### PR TITLE
refactor(forms): Store itemtype as extra data for item question types

### DIFF
--- a/js/modules/Forms/QuestionItem.js
+++ b/js/modules/Forms/QuestionItem.js
@@ -59,17 +59,17 @@ export class GlpiFormQuestionTypeItem {
 
     #updateItemsIdDropdownID(question_details) {
         const id = getUUID();
-        question_details.find('span[id^="show_default_value_items_id_"]')
-            .attr('id', `show_default_value_items_id_${id}`);
+        question_details.find('span[id^="show_default_value"]')
+            .attr('id', `show_default_value${id}`);
 
         // Replace all occurence of previous id by the new one in script tags
         question_details.find('div script').each((index, script) => {
             // Replace the old itemtype select id by the new one
-            const itemtype_select_id = question_details.find('select[name="default_value[itemtype]"]').attr('id');
-            script.text = script.text.replace(/dropdown_default_value_itemtype_[0-9]+/g, itemtype_select_id);
+            const itemtype_select_id = question_details.find('select[name="itemtype"]').attr('id');
+            script.text = script.text.replace(/dropdown_itemtype[0-9]+/g, itemtype_select_id);
 
             // Replace the old id by the new one
-            script.text = script.text.replace(/show_default_value_items_id_[0-9]+/g, `show_default_value_items_id_${id}`);
+            script.text = script.text.replace(/show_default_value[0-9]+/g, `show_default_value${id}`);
             script.text = script.text.replace(/rand:[0-9]+/g, `rand:'${id}'`);
 
             // Execute the script

--- a/phpunit/GLPITestCase.php
+++ b/phpunit/GLPITestCase.php
@@ -442,5 +442,6 @@ class GLPITestCase extends TestCase
         Log::$use_queue = false;
         CommonDBTM::clearSearchOptionCache();
         AssetDefinitionManager::unsetInstance();
+        Dropdown::resetItemtypesStaticCache();
     }
 }

--- a/phpunit/functional/CronTaskTest.php
+++ b/phpunit/functional/CronTaskTest.php
@@ -230,27 +230,31 @@ class CronTaskTest extends DbTestCase
         $plugins = new \Plugin();
         $plugins->init();
 
-        // Deactivate all registered tasks
-        $crontask = new \CronTask();
-        $this->assertTrue($DB->update(\CronTask::getTable(), ['state' => \CronTask::STATE_DISABLE], [1]));
-        $this->assertFalse($crontask->getNeedToRun());
+        try {
+            // Deactivate all registered tasks
+            $crontask = new \CronTask();
+            $this->assertTrue($DB->update(\CronTask::getTable(), ['state' => \CronTask::STATE_DISABLE], [1]));
+            $this->assertFalse($crontask->getNeedToRun());
 
-        // Register task for active plugin.
-        $plugin_task = \CronTask::register(
-            $itemtype,
-            $name,
-            30,
-            [
-                'state'   => \CronTask::STATE_WAITING,
-                'hourmin' => 0,
-                'hourmax' => 24,
-            ]
-        );
-        $this->assertNotFalse($plugin_task);
-        $this->assertEquals($should_run, $crontask->getNeedToRun());
-        if ($should_run) {
-            $this->assertEquals($itemtype, $crontask->fields['itemtype']);
-            $this->assertEquals($name, $crontask->fields['name']);
+            // Register task for active plugin.
+            $plugin_task = \CronTask::register(
+                $itemtype,
+                $name,
+                30,
+                [
+                    'state'   => \CronTask::STATE_WAITING,
+                    'hourmin' => 0,
+                    'hourmax' => 24,
+                ]
+            );
+            $this->assertNotFalse($plugin_task);
+            $this->assertEquals($should_run, $crontask->getNeedToRun());
+            if ($should_run) {
+                $this->assertEquals($itemtype, $crontask->fields['itemtype']);
+                $this->assertEquals($name, $crontask->fields['name']);
+            }
+        } finally {
+            $plugins->unactivateAll();
         }
     }
 

--- a/phpunit/functional/Glpi/Form/AnswersSetTest.php
+++ b/phpunit/functional/Glpi/Form/AnswersSetTest.php
@@ -211,14 +211,8 @@ class AnswersSetTest extends DbTestCase
                         123 => 'Dropdown 1'
                     ]
                 ]))
-                ->addQuestion("GLPI Objects", QuestionTypeItem::class, [
-                    'itemtype' => 'User',
-                    'items_id' => 0
-                ])
-                ->addQuestion("Dropdowns", QuestionTypeItemDropdown::class, [
-                    'itemtype' => 'Location',
-                    'items_id' => 0
-                ])
+                ->addQuestion("GLPI Objects", QuestionTypeItem::class, 0, json_encode(['itemtype' => 'User']))
+                ->addQuestion("Dropdowns", QuestionTypeItemDropdown::class, 0, json_encode(['itemtype' => 'Location']))
         );
 
         // File question type requires an uploaded file

--- a/phpunit/functional/Glpi/Form/Destination/CommonITILField/AssociatedItemsFieldTest.php
+++ b/phpunit/functional/Glpi/Form/Destination/CommonITILField/AssociatedItemsFieldTest.php
@@ -361,18 +361,15 @@ final class AssociatedItemsFieldTest extends DbTestCase
         $monitors = $this->createMonitors(3);
 
         $builder = new FormBuilder();
-        $builder->addQuestion("Computer 1", QuestionTypeItem::class, [
+        $builder->addQuestion("Computer 1", QuestionTypeItem::class, $computers[0]->getID(), json_encode([
             'itemtype' => Computer::getType(),
-            'items_id' => $computers[0]->getID(),
-        ]);
-        $builder->addQuestion("Monitor 1", QuestionTypeItem::class, [
+        ]));
+        $builder->addQuestion("Monitor 1", QuestionTypeItem::class, $monitors[0]->getID(), json_encode([
             'itemtype' => Monitor::getType(),
-            'items_id' => $monitors[0]->getID(),
-        ]);
-        $builder->addQuestion("Computer 2", QuestionTypeItem::class, [
+        ]));
+        $builder->addQuestion("Computer 2", QuestionTypeItem::class, $computers[1]->getID(), json_encode([
             'itemtype' => Computer::getType(),
-            'items_id' => $computers[1]->getID(),
-        ]);
+        ]));
 
         $builder->addDestination(
             FormDestinationTicket::class,

--- a/phpunit/functional/Glpi/Form/Destination/CommonITILField/EntityFieldTest.php
+++ b/phpunit/functional/Glpi/Form/Destination/CommonITILField/EntityFieldTest.php
@@ -266,12 +266,12 @@ final class EntityFieldTest extends DbTestCase
     private function createAndGetFormWithMultipleEntityAndRequesterQuestions(): Form
     {
         $builder = new FormBuilder();
-        $builder->addQuestion("Entity 1", QuestionTypeItem::class, [
+        $builder->addQuestion("Entity 1", QuestionTypeItem::class, 0, json_encode([
             'itemtype' => Entity::getType(),
-        ]);
-        $builder->addQuestion("Entity 2", QuestionTypeItem::class, [
+        ]));
+        $builder->addQuestion("Entity 2", QuestionTypeItem::class, 0, json_encode([
             'itemtype' => Entity::getType(),
-        ]);
+        ]));
         $builder->addDestination(
             FormDestinationTicket::class,
             "My ticket",

--- a/phpunit/functional/Glpi/Form/Destination/CommonITILField/ITILCategoryFieldTest.php
+++ b/phpunit/functional/Glpi/Form/Destination/CommonITILField/ITILCategoryFieldTest.php
@@ -290,12 +290,12 @@ final class ITILCategoryFieldTest extends DbTestCase
     private function createAndGetFormWithMultipleITILCategoryQuestions(): Form
     {
         $builder = new FormBuilder();
-        $builder->addQuestion("ITILCategory 1", QuestionTypeItemDropdown::class, [
+        $builder->addQuestion("ITILCategory 1", QuestionTypeItemDropdown::class, 0, json_encode([
             'itemtype' => ITILCategory::class,
-        ]);
-        $builder->addQuestion("ITILCategory 2", QuestionTypeItemDropdown::class, [
+        ]));
+        $builder->addQuestion("ITILCategory 2", QuestionTypeItemDropdown::class, 0, json_encode([
             'itemtype' => ITILCategory::class,
-        ]);
+        ]));
         $builder->addDestination(
             FormDestinationTicket::class,
             "My ticket",

--- a/phpunit/functional/Glpi/Form/Destination/CommonITILField/ITILCategoryFieldTest.php
+++ b/phpunit/functional/Glpi/Form/Destination/CommonITILField/ITILCategoryFieldTest.php
@@ -289,6 +289,8 @@ final class ITILCategoryFieldTest extends DbTestCase
 
     private function createAndGetFormWithMultipleITILCategoryQuestions(): Form
     {
+        $this->login();
+
         $builder = new FormBuilder();
         $builder->addQuestion("ITILCategory 1", QuestionTypeItemDropdown::class, 0, json_encode([
             'itemtype' => ITILCategory::class,

--- a/phpunit/functional/Glpi/Form/Destination/CommonITILField/LocationFieldTest.php
+++ b/phpunit/functional/Glpi/Form/Destination/CommonITILField/LocationFieldTest.php
@@ -289,6 +289,8 @@ final class LocationFieldTest extends DbTestCase
 
     private function createAndGetFormWithMultipleLocationQuestions(): Form
     {
+        $this->login();
+
         $builder = new FormBuilder();
         $builder->addQuestion("Location 1", QuestionTypeItemDropdown::class, 0, json_encode([
             'itemtype' => Location::getType(),

--- a/phpunit/functional/Glpi/Form/Destination/CommonITILField/LocationFieldTest.php
+++ b/phpunit/functional/Glpi/Form/Destination/CommonITILField/LocationFieldTest.php
@@ -290,12 +290,12 @@ final class LocationFieldTest extends DbTestCase
     private function createAndGetFormWithMultipleLocationQuestions(): Form
     {
         $builder = new FormBuilder();
-        $builder->addQuestion("Location 1", QuestionTypeItemDropdown::class, [
+        $builder->addQuestion("Location 1", QuestionTypeItemDropdown::class, 0, json_encode([
             'itemtype' => Location::getType(),
-        ]);
-        $builder->addQuestion("Location 2", QuestionTypeItemDropdown::class, [
+        ]));
+        $builder->addQuestion("Location 2", QuestionTypeItemDropdown::class, 0, json_encode([
             'itemtype' => Location::getType(),
-        ]);
+        ]));
         $builder->addDestination(
             FormDestinationTicket::class,
             "My ticket",

--- a/phpunit/functional/Glpi/Form/Destination/CommonITILField/ValidationFieldTest.php
+++ b/phpunit/functional/Glpi/Form/Destination/CommonITILField/ValidationFieldTest.php
@@ -323,7 +323,9 @@ final class ValidationFieldTest extends DbTestCase
     {
         $builder = new FormBuilder();
         $builder->addQuestion("Assignee", QuestionTypeAssignee::class);
-        $builder->addQuestion("GLPI User", QuestionTypeItem::class);
+        $builder->addQuestion("GLPI User", QuestionTypeItem::class, 0, json_encode([
+            'itemtype' => User::class,
+        ]));
         $builder->addDestination(
             FormDestinationTicket::class,
             "My ticket",

--- a/phpunit/functional/Glpi/Form/FormTest.php
+++ b/phpunit/functional/Glpi/Form/FormTest.php
@@ -106,6 +106,12 @@ class FormTest extends DbTestCase
                     123 => 'Dropdown 1',
                 ]
             ],
+            \Glpi\Form\QuestionType\QuestionTypeItem::class => [
+                'itemtype' => 'Computer',
+            ],
+            \Glpi\Form\QuestionType\QuestionTypeItemDropdown::class => [
+                'itemtype' => 'Location',
+            ],
         ];
 
         foreach ($questions as $type) {

--- a/phpunit/functional/Glpi/Form/QuestionType/QuestionTypeItemDropdownTest.php
+++ b/phpunit/functional/Glpi/Form/QuestionType/QuestionTypeItemDropdownTest.php
@@ -53,7 +53,9 @@ final class QuestionTypeItemDropdownTest extends DbTestCase
         ]);
 
         $builder = new FormBuilder();
-        $builder->addQuestion("Category", QuestionTypeItemDropdown::class);
+        $builder->addQuestion("Category", QuestionTypeItemDropdown::class, 0, json_encode(
+            ['itemtype' => ITILCategory::getType()]
+        ));
         $builder->addDestination(FormDestinationTicket::class, "My ticket");
         $form = $this->createForm($builder);
 

--- a/phpunit/functional/Glpi/Form/QuestionType/QuestionTypeItemDropdownTest.php
+++ b/phpunit/functional/Glpi/Form/QuestionType/QuestionTypeItemDropdownTest.php
@@ -48,6 +48,8 @@ final class QuestionTypeItemDropdownTest extends DbTestCase
 
     public function testItemDropdownAnswerIsDisplayedInTicketDescription(): void
     {
+        $this->login();
+
         $category = $this->createItem(ITILCategory::class, [
             'name' => 'My category',
         ]);

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -1619,6 +1619,7 @@ JAVASCRIPT;
         $params['width']               = '';
         $params['no_sort']             = false;
         $params['aria_label']          = '';
+        $params['add_data_attributes'] = '';
 
         if (is_array($options) && count($options)) {
             foreach ($options as $key => $val) {
@@ -1648,6 +1649,7 @@ JAVASCRIPT;
                 'init'                => $params['init'],
                 'width'               => $params['width'],
                 'aria_label'          => $params['aria_label'],
+                'add_data_attributes' => $params['add_data_attributes'],
             ]);
         }
         return 0;
@@ -1721,28 +1723,29 @@ JAVASCRIPT;
         global $CFG_GLPI;
 
         $params = [
-            'itemtype_name'                   => 'itemtype',
-            'items_id_name'                   => 'items_id',
-            'itemtypes'                       => '',
-            'default_itemtype'                => 0,
-            'default_items_id'                => -1,
-            'entity_restrict'                 => -1,
-            'onlyglobal'                      => false,
-            'checkright'                      => false,
-            'showItemSpecificity'             => '',
-            'emptylabel'                      => self::EMPTY_VALUE,
-            'display_emptychoice'             => true,
-            'used'                            => [],
-            'ajax_page'                       => $CFG_GLPI["root_doc"] . "/ajax/dropdownAllItems.php",
-            'display'                         => true,
-            'rand'                            => mt_rand(),
-            'itemtype_track_changes'          => false,
-            'init'                            => true,
-            'width'                           => '80%',
-            'container_css_class'             => '',
-            'no_sort'                         => false,
-            'aria_label'                      => '',
-            'specific_tags_items_id_dropdown' => [],
+            'itemtype_name'                         => 'itemtype',
+            'items_id_name'                         => 'items_id',
+            'itemtypes'                             => '',
+            'default_itemtype'                      => 0,
+            'default_items_id'                      => -1,
+            'entity_restrict'                       => -1,
+            'onlyglobal'                            => false,
+            'checkright'                            => false,
+            'showItemSpecificity'                   => '',
+            'emptylabel'                            => self::EMPTY_VALUE,
+            'display_emptychoice'                   => true,
+            'used'                                  => [],
+            'ajax_page'                             => $CFG_GLPI["root_doc"] . "/ajax/dropdownAllItems.php",
+            'display'                               => true,
+            'rand'                                  => mt_rand(),
+            'itemtype_track_changes'                => false,
+            'init'                                  => true,
+            'width'                                 => '80%',
+            'container_css_class'                   => '',
+            'no_sort'                               => false,
+            'aria_label'                            => '',
+            'specific_tags_items_id_dropdown'       => [],
+            'add_data_attributes_itemtype_dropdown' => '',
         ];
 
         if (is_array($options) && count($options)) {
@@ -1763,6 +1766,7 @@ JAVASCRIPT;
             'width'               => $params['width'],
             'no_sort'             => $params['no_sort'],
             'aria_label'          => $params['aria_label'],
+            'add_data_attributes' => $params['add_data_attributes_itemtype_dropdown'],
         ]);
 
         $p_ajax = [

--- a/src/Glpi/Form/QuestionType/QuestionTypeItem.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeItem.php
@@ -104,14 +104,11 @@ class QuestionTypeItem extends AbstractQuestionType
      */
     public function getDefaultValueItemtype(?Question $question): ?string
     {
-        if (
-            $question !== null
-            && isset($question->fields['default_value'])
-        ) {
-            return json_decode($question->fields['default_value'], true)['itemtype'] ?? null;
+        if ($question === null) {
+            return null;
         }
 
-        return null;
+        return $question->getExtraDatas()['itemtype'] ?? null;
     }
 
     /**
@@ -122,24 +119,30 @@ class QuestionTypeItem extends AbstractQuestionType
      */
     public function getDefaultValueItemId(?Question $question): int
     {
-        if (
-            $question !== null
-            && isset($question->fields['default_value'])
-        ) {
-            return json_decode($question->fields['default_value'], true)['items_id'] ?? 0;
+        if ($question === null) {
+            return 0;
         }
 
-        return 0;
+        return (int) $question->fields['default_value'] ?? 0;
     }
 
     #[Override]
-    public function formatDefaultValueForDB(mixed $value): ?string
+    public function validateExtraDataInput(array $input): bool
     {
-        if (is_array($value)) {
-            return json_encode($value);
+        // Check if the itemtype is set
+        if (!isset($input['itemtype'])) {
+            return false;
         }
 
-        return null;
+        // Check if the itemtype is allowed
+        if (
+            $input['itemtype'] != '0'
+            && !in_array($input['itemtype'], array_merge(...array_values($this->getAllowedItemtypes())))
+        ) {
+            return false;
+        }
+
+        return true;
     }
 
     #[Override]
@@ -160,14 +163,17 @@ class QuestionTypeItem extends AbstractQuestionType
                     'display_emptychoice'            : true,
                     'default_itemtype'               : default_itemtype,
                     'default_items_id'               : default_items_id,
-                    'itemtype_name'                  : 'default_value[itemtype]',
-                    'items_id_name'                  : 'default_value[items_id]',
+                    'itemtype_name'                  : 'itemtype',
+                    'items_id_name'                  : 'default_value',
                     'width'                          : '100%',
                     'container_css_class'            : 'mt-2',
                     'no_sort'                        : true,
                     'aria_label'                     : itemtype_aria_label,
                     'specific_tags_items_id_dropdown': {
                         'aria-label': items_id_aria_label,
+                    },
+                    'add_data_attributes_itemtype_dropdown' : {
+                        'glpi-form-editor-specific-question-extra-data': '',
                     },
                 }
             ) }}

--- a/src/Glpi/Form/QuestionType/QuestionTypeItem.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeItem.php
@@ -123,7 +123,7 @@ class QuestionTypeItem extends AbstractQuestionType
             return 0;
         }
 
-        return (int) $question->fields['default_value'] ?? 0;
+        return (int) ($question->fields['default_value'] ?? 0);
     }
 
     #[Override]


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Store itemtype as extra data instead of default value for item question types.