### PR TITLE
Fix - Verification of adding follow-ups for users who are in a ticket…

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -977,7 +977,16 @@ abstract class CommonITILObject extends CommonDBTM
          || (
             Session::haveRight('followup', ITILFollowup::ADDGROUPTICKET)
             && isset($_SESSION["glpigroups"])
-            && $this->haveAGroup(CommonITILActor::REQUESTER, $_SESSION['glpigroups'])
+            && (
+                (
+                    $this->haveAGroup(CommonITILActor::REQUESTER, $_SESSION['glpigroups'])
+                    && Session::haveRight("followup", ITILFollowup::ADDMYTICKET)
+                )
+                || (
+                    $this->haveAGroup(CommonITILActor::OBSERVER, $_SESSION['glpigroups'])
+                    && Session::haveRight("followup", ITILFollowup::ADD_AS_OBSERVER)
+                )
+            )
          )
          || $this->isUser(CommonITILActor::ASSIGN, Session::getLoginUserID())
          || (

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -2520,7 +2520,17 @@ class Ticket extends CommonITILObject
          || Profile::haveUserRight($user_id, $rightname, ITILFollowup::ADDALLTICKET, $entity_id)
          || (
             Profile::haveUserRight($user_id, $rightname, ITILFollowup::ADDGROUPTICKET, $entity_id)
-            && $this->haveAGroup(CommonITILActor::REQUESTER, $user_groups_ids)
+            && isset($user_groups_ids)
+            && (
+                (
+                    $this->haveAGroup(CommonITILActor::REQUESTER, $user_groups_ids)
+                    && Profile::haveUserRight($user_id, $rightname, ITILFollowup::ADDMYTICKET, $entity_id)
+                )
+                || (
+                    $this->haveAGroup(CommonITILActor::OBSERVER, $user_groups_ids)
+                    && Profile::haveUserRight($user_id, $rightname, ITILFollowup::ADD_AS_OBSERVER, $entity_id)
+                )
+            )
          )
          || $this->isUser(CommonITILActor::ASSIGN, $user_id)
          || $this->haveAGroup(CommonITILActor::ASSIGN, $user_groups_ids);

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -2520,7 +2520,7 @@ class Ticket extends CommonITILObject
          || Profile::haveUserRight($user_id, $rightname, ITILFollowup::ADDALLTICKET, $entity_id)
          || (
             Profile::haveUserRight($user_id, $rightname, ITILFollowup::ADDGROUPTICKET, $entity_id)
-            && isset($user_groups_ids)
+            && !empty($user_groups_ids)
             && (
                 (
                     $this->haveAGroup(CommonITILActor::REQUESTER, $user_groups_ids)


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !34517
- Here is a brief description of what this PR does

If a user is part of a group defined as an observer in a ticket, they cannot add a follow-up to this ticket. 

If the user is added directly as an individual observer, adding follow-up works correctly.

The problem occurs even if the following options are checked in the user's profile:

- Add follow-up (associated groups)
- Add follow-up (observer)

The same problem occurs with the self-service profile

