### PR TITLE
Do not forward to dropdown controller if a front script exists

### DIFF
--- a/src/Glpi/Http/LegacyAssetsListener.php
+++ b/src/Glpi/Http/LegacyAssetsListener.php
@@ -69,6 +69,14 @@ final readonly class LegacyAssetsListener implements EventSubscriberInterface
     {
         $request = $event->getRequest();
 
+        if (
+            $request->attributes->get('_controller') !== null
+            || $event->getResponse() !== null
+        ) {
+            // A controller or a response has already been defined for this request, do not override them.
+            return;
+        }
+
         $response = $this->serveLegacyAssets($request);
 
         if ($response) {

--- a/src/Glpi/Http/LegacyDropdownRouteListener.php
+++ b/src/Glpi/Http/LegacyDropdownRouteListener.php
@@ -62,6 +62,14 @@ final readonly class LegacyDropdownRouteListener implements EventSubscriberInter
         }
         $request = $event->getRequest();
 
+        if (
+            $request->attributes->get('_controller') !== null
+            || $event->getResponse() !== null
+        ) {
+            // A controller or a response has already been defined for this request, do not override them.
+            return;
+        }
+
         if ($class = $this->findDropdownClass($request)) {
             $is_form = \str_ends_with($request->getPathInfo(), '.form.php');
 

--- a/src/Glpi/Http/LegacyRouterListener.php
+++ b/src/Glpi/Http/LegacyRouterListener.php
@@ -74,6 +74,14 @@ final readonly class LegacyRouterListener implements EventSubscriberInterface
 
         $request = $event->getRequest();
 
+        if (
+            $request->attributes->get('_controller') !== null
+            || $event->getResponse() !== null
+        ) {
+            // A controller or a response has already been defined for this request, do not override them.
+            return;
+        }
+
         $response = $this->runLegacyRouter($request);
 
         if ($response) {

--- a/src/Glpi/Http/ListenersPriority.php
+++ b/src/Glpi/Http/ListenersPriority.php
@@ -50,6 +50,8 @@ final class ListenersPriority
         LegacyConfigProviderListener::class => 350,
 
         // Plugins dropdowns requires plugins to be initialized, therefore config must be already set.
+        // Also, keep it after the `LegacyRouterListener` to not map to the generic dropdown controller if a
+        // legacy script exists for the requested URI.
         LegacyDropdownRouteListener::class => 300,
     ];
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Fixes #17781.

`Group` extends `CommonDropdown` but has its own custom `/front/group.php` script. The generic `DropdownController` should not be used in this case.