### PR TITLE
Use a custom `htmlescape()` function to handle unexpected null values

### DIFF
--- a/ajax/comments.php
+++ b/ajax/comments.php
@@ -83,7 +83,7 @@ if (
 
             if (isset($_POST['withlink']) && $link !== null) {
                 echo "<script type='text/javascript' >";
-                echo Html::jsGetElementbyID($_POST['withlink']) . ".attr('href', '" . htmlspecialchars($link) . "');";
+                echo Html::jsGetElementbyID($_POST['withlink']) . ".attr('href', '" . htmlescape($link) . "');";
                 echo "</script>";
             }
             break;
@@ -123,7 +123,7 @@ if (
                 }
                 $tmpname = Dropdown::getDropdownName($table, $_POST["value"], 1);
                 if (is_array($tmpname) && isset($tmpname["comment"])) {
-                    echo htmlspecialchars($tmpname["comment"]);
+                    echo htmlescape($tmpname["comment"]);
                 }
 
                 if (isset($_POST['withlink'])) {

--- a/ajax/dropdownAllItems.php
+++ b/ajax/dropdownAllItems.php
@@ -115,7 +115,7 @@ if ($_POST["idtable"] && class_exists($_POST["idtable"])) {
             $params['entity_restrict'] = $_POST['entity_restrict'];
         }
 
-        $name = htmlspecialchars($_POST["name"]);
+        $name = htmlescape($_POST["name"]);
         Ajax::updateItemOnSelectEvent(
             $field_id,
             "showItemSpecificity_" . $name . "$rand",

--- a/ajax/dropdownShowIPNetwork.php
+++ b/ajax/dropdownShowIPNetwork.php
@@ -40,7 +40,7 @@ $network = new IPNetwork();
 
 if ($_POST['ipnetworks_id'] && $network->can($_POST['ipnetworks_id'], READ)) {
     echo "<br>";
-    echo "<a href='" . $network->getLinkURL() . "'>" . htmlspecialchars($network->fields['completename']) . "</a><br>";
+    echo "<a href='" . $network->getLinkURL() . "'>" . htmlescape($network->fields['completename']) . "</a><br>";
 
     $address = $network->getAddress()->getTextual();
     $netmask = $network->getNetmask()->getTextual();

--- a/ajax/dropdownTrackingDeviceType.php
+++ b/ajax/dropdownTrackingDeviceType.php
@@ -103,7 +103,7 @@ if ($isValidItemtype) {
 
     // Auto update summary of active or just solved tickets
     if (($_POST['source_itemtype'] ?? null) === Ticket::class) {
-        $myname = htmlspecialchars($_POST["myname"]);
+        $myname = htmlescape($_POST["myname"]);
         echo "<span id='item_ticket_selection_information{$myname}_$rand' class='ms-1'></span>";
         Ajax::updateItemOnSelectEvent(
             $field_id,

--- a/ajax/inputtext.php
+++ b/ajax/inputtext.php
@@ -42,7 +42,7 @@ Html::header_nocache();
 if (isset($_POST['name'])) {
     echo "<input type='text' " . (isset($_POST["size"]) ? " size='" . (int) $_POST["size"] . "' " : "") . " " .
          (isset($_POST["maxlength"]) ? "maxlength='" . (int) $_POST["maxlength"] . "' " : "") . " name='" .
-         htmlspecialchars($_POST['name']) . "' value=\"" .
-         htmlspecialchars(rawurldecode($_POST["data"])) .
+         htmlescape($_POST['name']) . "' value=\"" .
+         htmlescape(rawurldecode($_POST["data"])) .
         "\">";
 }

--- a/ajax/searchoptionvalue.php
+++ b/ajax/searchoptionvalue.php
@@ -160,6 +160,6 @@ if (isset($_POST['searchtype'])) {
    // Default case : text field
     if (!$display) {
         echo "<input type='text' size='13' name='$inputname' value=\"" .
-               htmlspecialchars($_POST['value']) . "\">";
+               htmlescape($_POST['value']) . "\">";
     }
 }

--- a/ajax/subvisibility.php
+++ b/ajax/subvisibility.php
@@ -60,7 +60,7 @@ if (!empty($_POST['type']) && isset($_POST['items_id']) && ($_POST['items_id'] >
                 $params['toadd'] = [-1 => __('No restriction')];
             }
             echo "<table class='tab_format'><tr><td>";
-            echo htmlspecialchars(Entity::getTypeName(1));
+            echo htmlescape(Entity::getTypeName(1));
             echo "</td><td>";
             Entity::dropdown($params);
             echo "</td><td>";

--- a/ajax/textarea.php
+++ b/ajax/textarea.php
@@ -42,6 +42,6 @@ Html::header_nocache();
 if (isset($_POST['name'])) {
     echo "<textarea " . (isset($_POST['rows']) ? " rows='" . $_POST['rows'] . "' " : "") . " " .
          (isset($_POST['cols']) ? " cols='" . $_POST['cols'] . "' " : "") . "  name='" . $_POST['name'] . "'>";
-    echo htmlspecialchars(rawurldecode(($_POST["data"])));
+    echo htmlescape(rawurldecode(($_POST["data"])));
     echo "</textarea>";
 }

--- a/ajax/uemailUpdate.php
+++ b/ajax/uemailUpdate.php
@@ -123,7 +123,7 @@ if (
         );
     } else {
         $email_string = "<input type='mail' class='form-control' name='" . $_POST['field'] . "[alternative_email][]'
-                        value='" . htmlspecialchars($default_email) . "'>";
+                        value='" . htmlescape($default_email) . "'>";
     }
 
     echo "$email_string";

--- a/front/change_ticket.form.php
+++ b/front/change_ticket.form.php
@@ -43,7 +43,7 @@ if (isset($_POST["add"])) {
             __('Mandatory fields are not filled. Please correct: %s'),
             Change::getTypeName(1)
         );
-        Session::addMessageAfterRedirect(htmlspecialchars($message), false, ERROR);
+        Session::addMessageAfterRedirect(htmlescape($message), false, ERROR);
         Html::back();
     }
     if (empty($_POST['tickets_id']) && !empty($_POST['changes_id'])) {
@@ -51,7 +51,7 @@ if (isset($_POST["add"])) {
             __('Mandatory fields are not filled. Please correct: %s'),
             Ticket::getTypeName(1)
         );
-        Session::addMessageAfterRedirect(htmlspecialchars($message), false, ERROR);
+        Session::addMessageAfterRedirect(htmlescape($message), false, ERROR);
         Html::back();
     }
     $item->check(-1, CREATE, $_POST);

--- a/front/commonitilobject_item.form.php
+++ b/front/commonitilobject_item.form.php
@@ -61,7 +61,7 @@ if (isset($_POST["add"])) {
             __('Mandatory fields are not filled. Please correct: %s'),
             _n('Associated element', 'Associated elements', 1)
         );
-        Session::addMessageAfterRedirect(htmlspecialchars($message), false, ERROR);
+        Session::addMessageAfterRedirect(htmlescape($message), false, ERROR);
         Html::back();
     }
 

--- a/front/config.form.php
+++ b/front/config.form.php
@@ -39,7 +39,7 @@ Session::checkRight("config", READ);
 
 if (isset($_GET['check_version'])) {
     Session::addMessageAfterRedirect(
-        htmlspecialchars(Toolbox::checkNewVersionAvailable())
+        htmlescape(Toolbox::checkNewVersionAvailable())
     );
     Html::back();
 }

--- a/front/contract_item.form.php
+++ b/front/contract_item.form.php
@@ -50,7 +50,7 @@ if (isset($_POST["add"])) {
             __('Mandatory fields are not filled. Please correct: %s'),
             Contract::getTypeName(1)
         );
-        Session::addMessageAfterRedirect(htmlspecialchars($message), false, ERROR);
+        Session::addMessageAfterRedirect(htmlescape($message), false, ERROR);
         Html::back();
     }
 

--- a/front/contract_supplier.form.php
+++ b/front/contract_supplier.form.php
@@ -48,7 +48,7 @@ if (isset($_POST["add"])) {
             __('Mandatory fields are not filled. Please correct: %s'),
             _n('Contract', 'Contracts', 1)
         );
-        Session::addMessageAfterRedirect(htmlspecialchars($message), false, ERROR);
+        Session::addMessageAfterRedirect(htmlescape($message), false, ERROR);
         Html::back();
     }
     $contractsupplier->check(-1, CREATE, $_POST);

--- a/front/crontask.form.php
+++ b/front/crontask.form.php
@@ -54,7 +54,7 @@ if (isset($_POST['execute'])) {
     }
     if ($name) {
        //TRANS: %s is a task name
-        Session::addMessageAfterRedirect(htmlspecialchars(sprintf(__('Task %s executed'), $name)));
+        Session::addMessageAfterRedirect(htmlescape(sprintf(__('Task %s executed'), $name)));
     }
     Html::back();
 } else if (isset($_POST["update"])) {

--- a/front/item_softwarelicense.form.php
+++ b/front/item_softwarelicense.form.php
@@ -45,7 +45,7 @@ if (isset($_POST["add"])) {
             __('Mandatory fields are not filled. Please correct: %s'),
             _n('Item', 'Items', 1)
         );
-        Session::addMessageAfterRedirect(htmlspecialchars($message), false, ERROR);
+        Session::addMessageAfterRedirect(htmlescape($message), false, ERROR);
         Html::back();
     }
     if ($_POST['softwarelicenses_id'] > 0) {

--- a/front/knowbaseitem.form.php
+++ b/front/knowbaseitem.form.php
@@ -148,14 +148,14 @@ if (isset($_POST["add"])) {
     $kb->check($_GET["id"], UPDATE);
     if ($kb->revertTo($_GET['to_rev'])) {
         Session::addMessageAfterRedirect(
-            htmlspecialchars(sprintf(
+            htmlescape(sprintf(
                 __('Knowledge base item has been reverted to revision %s'),
                 $_GET['to_rev']
             ))
         );
     } else {
         Session::addMessageAfterRedirect(
-            htmlspecialchars(sprintf(
+            htmlescape(sprintf(
                 __('Knowledge base item has not been reverted to revision %s'),
                 $_GET['to_rev']
             )),

--- a/front/knowbaseitemtranslation.form.php
+++ b/front/knowbaseitemtranslation.form.php
@@ -54,14 +54,14 @@ if (isset($_POST['add'])) {
     $translation->check($_GET["id"], UPDATE);
     if ($translation->revertTo($_GET['to_rev'])) {
         Session::addMessageAfterRedirect(
-            htmlspecialchars(sprintf(
+            htmlescape(sprintf(
                 __('Knowledge base item translation has been reverted to revision %s'),
                 $_GET['to_rev']
             ))
         );
     } else {
         Session::addMessageAfterRedirect(
-            htmlspecialchars(sprintf(
+            htmlescape(sprintf(
                 __('Knowledge base item translation has not been reverted to revision %s'),
                 $_GET['to_rev']
             )),

--- a/front/ldap.group.import.php
+++ b/front/ldap.group.import.php
@@ -71,7 +71,7 @@ if (isset($_GET['next']) || !isset($_SESSION['ldap_server']) && !isset($_POST['l
         if (!AuthLDAP::testLDAPConnection($_SESSION["ldap_server"])) {
             unset($_SESSION["ldap_server"]);
             echo "<div class='center b'>" . __s('Unable to connect to the LDAP directory') . "<br>";
-            echo "<a href='" . htmlspecialchars($_SERVER['PHP_SELF']) . "?next=listservers'>" . __s('Back') . "</a></div>";
+            echo "<a href='" . htmlescape($_SERVER['PHP_SELF']) . "?next=listservers'>" . __s('Back') . "</a></div>";
         } else {
             if (!isset($_SESSION["ldap_group_filter"])) {
                 $_SESSION["ldap_group_filter"] = '';

--- a/front/lock.form.php
+++ b/front/lock.form.php
@@ -56,7 +56,7 @@ if (isset($_POST['itemtype'])) {
                     foreach (array_keys($_POST[$type]) as $key) {
                         if (!$item->can($key, UPDATE)) {
                             Session::addMessageAfterRedirect(
-                                htmlspecialchars(sprintf(
+                                htmlescape(sprintf(
                                     __('You do not have rights to restore %s item.'),
                                     $type
                                 )),
@@ -81,7 +81,7 @@ if (isset($_POST['itemtype'])) {
                     foreach (array_keys($_POST[$type]) as $key) {
                         if (!$item->can($key, PURGE)) {
                              Session::addMessageAfterRedirect(
-                                 htmlspecialchars(sprintf(
+                                 htmlescape(sprintf(
                                      __('You do not have rights to delete %s item.'),
                                      $type
                                  )),

--- a/front/massiveaction.php
+++ b/front/massiveaction.php
@@ -74,12 +74,12 @@ if ($nbnoaction > 0 && $nbok === 0 && $nbko === 0 && $nbnoright === 0) {
 } else {
     $message = __s('Operation successful');
     if ($nbnoaction > 0) {
-        $message .= "<br>" . htmlspecialchars(sprintf(__('(%1$d items required no action)'), $nbnoaction));
+        $message .= "<br>" . htmlescape(sprintf(__('(%1$d items required no action)'), $nbnoaction));
     }
 }
 if ($nbnoright || $nbko) {
    //TRANS: %$1d and %$2d are numbers
-    $message .= "<br>" . htmlspecialchars(sprintf(
+    $message .= "<br>" . htmlescape(sprintf(
         __('(%1$d authorizations problems, %2$d failures)'),
         $nbnoright,
         $nbko

--- a/front/notificationmailingsetting.form.php
+++ b/front/notificationmailingsetting.form.php
@@ -60,7 +60,7 @@ if (isset($_POST["update"])) {
             } catch (\Throwable $e) {
                 ErrorHandler::getInstance()->handleException($e, true);
                 Session::addMessageAfterRedirect(
-                    htmlspecialchars(sprintf(_x('oauth', 'Authorization failed with error: %s'), $e->getMessage())),
+                    htmlescape(sprintf(_x('oauth', 'Authorization failed with error: %s'), $e->getMessage())),
                     false,
                     ERROR
                 );

--- a/front/problem_ticket.form.php
+++ b/front/problem_ticket.form.php
@@ -44,7 +44,7 @@ if (isset($_POST["add"])) {
             __('Mandatory fields are not filled. Please correct: %s'),
             Problem::getTypeName(1)
         );
-        Session::addMessageAfterRedirect(htmlspecialchars($message), false, ERROR);
+        Session::addMessageAfterRedirect(htmlescape($message), false, ERROR);
         Html::back();
     }
     if (empty($_POST['tickets_id']) && !empty($_POST['problems_id'])) {
@@ -52,7 +52,7 @@ if (isset($_POST["add"])) {
             __('Mandatory fields are not filled. Please correct: %s'),
             Ticket::getTypeName(1)
         );
-        Session::addMessageAfterRedirect(htmlspecialchars($message), false, ERROR);
+        Session::addMessageAfterRedirect(htmlescape($message), false, ERROR);
         Html::back();
     }
     $item->check(-1, CREATE, $_POST);

--- a/front/rule.backup.php
+++ b/front/rule.backup.php
@@ -81,7 +81,7 @@ switch ($action) {
     case "download":
         echo "<div class='center'>";
         $itemtype = $_REQUEST['itemtype'];
-        echo "<a href='" . htmlspecialchars($itemtype::getSearchURL()) . "'>" . __s('Back') . "</a>";
+        echo "<a href='" . htmlescape($itemtype::getSearchURL()) . "'>" . __s('Back') . "</a>";
         echo "</div>";
         Html::redirect("rule.backup.php?action=export&itemtype=" . urlencode($_REQUEST['itemtype']));
         // phpcs doesn't understand that the script will exit here so we need a comment to avoid the fallthrough warning

--- a/front/rule.common.php
+++ b/front/rule.common.php
@@ -53,7 +53,7 @@ if (isset($_POST["action"])) {
     $ruleclass = $rulecollection->getRuleClass();
     if ($ruleclass->initRules()) {
         Session::addMessageAfterRedirect(
-            htmlspecialchars(sprintf(
+            htmlescape(sprintf(
             //TRANS: first parameter is the rule type name
                 __('%1$s has been reset.'),
                 $rulecollection->getTitle()
@@ -61,7 +61,7 @@ if (isset($_POST["action"])) {
         );
     } else {
         Session::addMessageAfterRedirect(
-            htmlspecialchars(sprintf(
+            htmlescape(sprintf(
                 //TRANS: first parameter is the rule type name
                 __('%1$s reset failed.'),
                 $rulecollection->getTitle()
@@ -100,7 +100,7 @@ if (isset($_POST["action"])) {
 
     echo "<table class='tab_cadrehov'>";
 
-    echo "<tr><th><div class='relative b'>" . htmlspecialchars($rulecollection->getTitle()) . "<br>" .
+    echo "<tr><th><div class='relative b'>" . htmlescape($rulecollection->getTitle()) . "<br>" .
          __s('Replay the rules dictionary') . "</div></th></tr>";
     echo "<tr><td class='center'>";
     Html::progressBar('doaction_progress', [

--- a/front/smtp_oauth2_callback.php
+++ b/front/smtp_oauth2_callback.php
@@ -42,7 +42,7 @@ if (!array_key_exists('cookie_refresh', $_GET)) {
     // Session cookie will not be accessible when user will be redirected from provider website
     // if `session.cookie_samesite` configuration value is `strict`.
     // Redirecting on self using `http-equiv="refresh"` will get around this limitation.
-    $url = htmlspecialchars(
+    $url = htmlescape(
         $_SERVER['REQUEST_URI']
         . (strpos($_SERVER['REQUEST_URI'], '?') !== false ? '&' : '?')
         . 'cookie_refresh'
@@ -67,7 +67,7 @@ if (
 ) {
     // Got an error, probably user denied access
     Session::addMessageAfterRedirect(
-        htmlspecialchars(sprintf(_x('oauth', 'Authorization failed with error: %s'), $_GET['error_description'] ?? $_GET['error'])),
+        htmlescape(sprintf(_x('oauth', 'Authorization failed with error: %s'), $_GET['error_description'] ?? $_GET['error'])),
         false,
         ERROR
     );
@@ -122,7 +122,7 @@ if (
                 E_USER_WARNING
             );
             Session::addMessageAfterRedirect(
-                htmlspecialchars(sprintf(_x('oauth', 'Unable to fetch authorization code. Error is: %s'), $e->getMessage())),
+                htmlescape(sprintf(_x('oauth', 'Unable to fetch authorization code. Error is: %s'), $e->getMessage())),
                 false,
                 ERROR
             );

--- a/front/stat.graph.php
+++ b/front/stat.graph.php
@@ -139,7 +139,7 @@ switch ($_GET["type"]) {
             _n('Category', 'Categories', 1),
             Dropdown::getDropdownName("glpi_itilcategories", $_GET["id"])
         );
-        $title   = htmlspecialchars($title);
+        $title   = htmlescape($title);
         break;
 
     case 'locations_tree':
@@ -161,7 +161,7 @@ switch ($_GET["type"]) {
             Location::getTypeName(1),
             Dropdown::getDropdownName('glpi_locations', $_GET['id'])
         );
-        $title   = htmlspecialchars($title);
+        $title   = htmlescape($title);
         break;
 
     case "type":
@@ -169,7 +169,7 @@ switch ($_GET["type"]) {
         $val2    = "";
         $values  = Stat::getItems($_GET["itemtype"], $_GET["date1"], $_GET["date2"], $_GET["type"]);
         $title   = sprintf(__('%1$s: %2$s'), _n('Type', 'Types', 1), Ticket::getTicketTypeName($_GET["id"]));
-        $title   = htmlspecialchars($title);
+        $title   = htmlescape($title);
         break;
 
     case 'group_tree':
@@ -192,7 +192,7 @@ switch ($_GET["type"]) {
             Group::getTypeName(1),
             Dropdown::getDropdownName("glpi_groups", $_GET["id"])
         );
-        $title   = htmlspecialchars($title);
+        $title   = htmlescape($title);
         break;
 
     case "groups_id_assign":
@@ -204,7 +204,7 @@ switch ($_GET["type"]) {
             Group::getTypeName(1),
             Dropdown::getDropdownName("glpi_groups", $_GET["id"])
         );
-        $title   = htmlspecialchars($title);
+        $title   = htmlescape($title);
         break;
 
     case "priority":
@@ -218,7 +218,7 @@ switch ($_GET["type"]) {
             'urgency'  => sprintf(__('%1$s: %2$s'), __('Urgency'), $item::getUrgencyName($_GET["id"])),
             'impact'   => sprintf(__('%1$s: %2$s'), __('Impact'), $item->getImpactName($_GET["id"])),
         };
-        $title   = htmlspecialchars($title);
+        $title   = htmlescape($title);
         break;
 
     case "usertitles_id":
@@ -230,7 +230,7 @@ switch ($_GET["type"]) {
             _x('person', 'Title'),
             Dropdown::getDropdownName("glpi_usertitles", $_GET["id"])
         );
-        $title   = htmlspecialchars($title);
+        $title   = htmlescape($title);
         break;
 
     case "solutiontypes_id":
@@ -242,7 +242,7 @@ switch ($_GET["type"]) {
             SolutionType::getTypeName(1),
             Dropdown::getDropdownName("glpi_solutiontypes", $_GET["id"])
         );
-        $title   = htmlspecialchars($title);
+        $title   = htmlescape($title);
         break;
 
     case "usercategories_id":
@@ -254,7 +254,7 @@ switch ($_GET["type"]) {
             _n('Category', 'Categories', 1),
             Dropdown::getDropdownName("glpi_usercategories", $_GET["id"])
         );
-        $title   = htmlspecialchars($title);
+        $title   = htmlescape($title);
         break;
 
     case "requesttypes_id":
@@ -266,7 +266,7 @@ switch ($_GET["type"]) {
             RequestType::getTypeName(1),
             Dropdown::getDropdownName("glpi_requesttypes", $_GET["id"])
         );
-        $title   = htmlspecialchars($title);
+        $title   = htmlescape($title);
         break;
 
     case "device":
@@ -295,7 +295,7 @@ switch ($_GET["type"]) {
                 $item::getTypeName(),
                 $current['designation']
             );
-            $title   = htmlspecialchars($title);
+            $title   = htmlescape($title);
         }
         break;
 
@@ -315,7 +315,7 @@ switch ($_GET["type"]) {
                 $item::getTypeName(),
                 Dropdown::getDropdownName($table, $_GET["id"])
             );
-            $title   = htmlspecialchars($title);
+            $title   = htmlescape($title);
         }
         break;
 }

--- a/front/ticket_contract.form.php
+++ b/front/ticket_contract.form.php
@@ -43,7 +43,7 @@ if (isset($_POST["add"])) {
             __('Mandatory fields are not filled. Please correct: %s'),
             Contract::getTypeName(1)
         );
-        Session::addMessageAfterRedirect(htmlspecialchars($message), false, ERROR);
+        Session::addMessageAfterRedirect(htmlescape($message), false, ERROR);
         Html::back();
     }
     if (empty($_POST['tickets_id']) && !empty($_POST['contracts_id'])) {
@@ -51,7 +51,7 @@ if (isset($_POST["add"])) {
             __('Mandatory fields are not filled. Please correct: %s'),
             Ticket::getTypeName(1)
         );
-        Session::addMessageAfterRedirect(htmlspecialchars($message), false, ERROR);
+        Session::addMessageAfterRedirect(htmlescape($message), false, ERROR);
         Html::back();
     }
     $item->check(-1, CREATE, $_POST);

--- a/src/AbstractITILChildTemplate.php
+++ b/src/AbstractITILChildTemplate.php
@@ -103,7 +103,7 @@ abstract class AbstractITILChildTemplate extends CommonDropdown
         $err_msg = null;
         if (!TemplateManager::validate($input['content'], $err_msg)) {
             Session::addMessageAfterRedirect(
-                htmlspecialchars(sprintf('%s: %s', __('Content'), $err_msg)),
+                htmlescape(sprintf('%s: %s', __('Content'), $err_msg)),
                 false,
                 ERROR
             );

--- a/src/Appliance_Item_Relation.php
+++ b/src/Appliance_Item_Relation.php
@@ -194,8 +194,8 @@ class Appliance_Item_Relation extends CommonDBRelation
             $itemtype = $row['itemtype'];
             $item = new $itemtype();
             $item->getFromDB($row['items_id']);
-            $relations[$row['id']] = "<i class='" . $item->getIcon() . "' title='" . htmlspecialchars($item::getTypeName(1)) . "'></i>" .
-                        "&nbsp;" . htmlspecialchars($item::getTypeName(1)) .
+            $relations[$row['id']] = "<i class='" . $item->getIcon() . "' title='" . htmlescape($item::getTypeName(1)) . "'></i>" .
+                        "&nbsp;" . htmlescape($item::getTypeName(1)) .
                         "&nbsp;-&nbsp;" . $item->getLink();
         }
 

--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -3887,13 +3887,13 @@ TWIG, $twig_params);
                     }
 
                     echo "<tr><td style='width: 250px' class='text-end'><label for='basedn'>" . __('BaseDN') . "</label></td><td colspan='3'>";
-                    echo "<input type='text' class='form-control' id='basedn' name='basedn' value=\"" . htmlspecialchars($_SESSION['ldap_import']['basedn'], ENT_QUOTES) .
+                    echo "<input type='text' class='form-control' id='basedn' name='basedn' value=\"" . htmlescape($_SESSION['ldap_import']['basedn']) .
                      "\" " . (!$_SESSION['ldap_import']['basedn'] ? "disabled" : "") . ">";
                     echo "</td></tr>";
 
                     echo "<tr><td class='text-end'><label for='ldap_filter'>" . __('Search filter for users') . "</label></td><td colspan='3'>";
                     echo "<input type='text' class='form-control' id='ldap_filter' name='ldap_filter' value=\"" .
-                      htmlspecialchars($_SESSION['ldap_import']['ldap_filter'], ENT_QUOTES) . "\">";
+                      htmlescape($_SESSION['ldap_import']['ldap_filter']) . "\">";
                     echo "</td></tr>";
                 }
                 break;
@@ -3997,7 +3997,7 @@ TWIG, $twig_params);
                         $field_counter++;
                         $field_value = '';
                         if (isset($_SESSION['ldap_import']['criterias'][$field])) {
-                            $field_value = htmlspecialchars($_SESSION['ldap_import']['criterias'][$field]);
+                            $field_value = htmlescape($_SESSION['ldap_import']['criterias'][$field]);
                         }
                         echo "<input type='text' class='form-control' id='criterias$field' name='criterias[$field]' value='$field_value'>";
                         echo "</td>";

--- a/src/CableStrand.php
+++ b/src/CableStrand.php
@@ -149,13 +149,13 @@ class CableStrand extends CommonDropdown
 
             echo "<table class='tab_cadre_fixe'>";
             echo "<tr><th>" . _sn('Type', 'Types', 1) . "</th>";
-            echo "<th>" . htmlspecialchars(Entity::getTypeName(1)) . "</th>";
+            echo "<th>" . htmlescape(Entity::getTypeName(1)) . "</th>";
             echo "<th>" . __s('Name') . "</th>";
             echo "<th>" . __s('Inventory number') . "</th>";
             echo "<th>" . sprintf(__s('%s (%s)'), _sn('Associated item', 'Associated items', 1), __s('Endpoint B')) . "</th>";
-            echo "<th>" . sprintf(__s('%s (%s)'), htmlspecialchars(Socket::getTypeName(1)), __s('Endpoint B')) . "</th>";
+            echo "<th>" . sprintf(__s('%s (%s)'), htmlescape(Socket::getTypeName(1)), __s('Endpoint B')) . "</th>";
             echo "<th>" . sprintf(__s('%s (%s)'), _sn('Associated item', 'Associated items', 1), __s('Endpoint A')) . "</th>";
-            echo "<th>" . sprintf(__s('%s (%s)'), htmlspecialchars(Socket::getTypeName(1)), __s('Endpoint A')) . "</th>";
+            echo "<th>" . sprintf(__s('%s (%s)'), htmlescape(Socket::getTypeName(1)), __s('Endpoint A')) . "</th>";
             echo "</tr>";
 
             foreach ($iterator as $data) {
@@ -167,7 +167,7 @@ class CableStrand extends CommonDropdown
                 echo "<tr class='tab_bg_1'><td>" . $cable->getTypeName() . "</td>";
                 echo "<td>" . Dropdown::getDropdownName("glpi_entities", $cable->getEntityID()) . "</td>";
                 echo "<td>" . $cable->getLink() . "</td>";
-                echo "<td>" . (isset($cable->fields["otherserial"]) ? htmlspecialchars($cable->fields["otherserial"]) : "-") . "</td>";
+                echo "<td>" . (isset($cable->fields["otherserial"]) ? htmlescape($cable->fields["otherserial"]) : "-") . "</td>";
                 echo "<td>";
                 if ($cable->fields["items_id_endpoint_b"] > 0) {
                     $item_endpoint_b = getItemForItemtype($cable->fields["itemtype_endpoint_b"]);

--- a/src/Calendar_Holiday.php
+++ b/src/Calendar_Holiday.php
@@ -124,8 +124,8 @@ class Calendar_Holiday extends CommonDBRelation
                 'id' => $data['linkid'],
                 'name' => sprintf(
                     '<a href="%s">%s</a>',
-                    htmlspecialchars(Holiday::getFormURLWithID($data['id'])),
-                    htmlspecialchars($data['name'])
+                    htmlescape(Holiday::getFormURLWithID($data['id'])),
+                    htmlescape($data['name'])
                 ),
                 'begin' => $data['begin_date'],
                 'end' => $data['end_date'],

--- a/src/Cartridge.php
+++ b/src/Cartridge.php
@@ -838,7 +838,7 @@ TWIG, ['counts' => $counts, 'highlight' => $highlight]);
                     if ($_SESSION['glpiis_ids_visible'] || empty($printname)) {
                         $printname = sprintf(__('%1$s (%2$s)'), $printname, $data["printID"]);
                     }
-                    $printer_link = "<a href='" . htmlspecialchars(Printer::getFormURLWithID($data["printID"])) . "'><span class='fw-bold'>" . htmlspecialchars($printname) . "</span></a>";
+                    $printer_link = "<a href='" . htmlescape(Printer::getFormURLWithID($data["printID"])) . "'><span class='fw-bold'>" . htmlescape($printname) . "</span></a>";
                 } else {
                     $printer_link = NOT_AVAILABLE;
                 }
@@ -1135,8 +1135,8 @@ TWIG, ['printer_id' => $printer->getID()]);
 
         $entries = [];
         foreach ($iterator as $data) {
-            $model = '<a href="' . htmlspecialchars(CartridgeItem::getFormURLWithID($data["tID"])) . '">'
-                . htmlspecialchars(sprintf(__('%1$s - %2$s'), $data["type"], $data["ref"]))
+            $model = '<a href="' . htmlescape(CartridgeItem::getFormURLWithID($data["tID"])) . '">'
+                . htmlescape(sprintf(__('%1$s - %2$s'), $data["type"], $data["ref"]))
                 . '</a>';
 
             $tmp_dbeg       = explode("-", $data["date_in"]);

--- a/src/CartridgeItem.php
+++ b/src/CartridgeItem.php
@@ -476,7 +476,7 @@ class CartridgeItem extends CommonDBTM
                              $task->log(sprintf(__('%1$s: %2$s') . "\n", $entityname, $message));
                              $task->addVolume(1);
                         } else {
-                             Session::addMessageAfterRedirect(htmlspecialchars(sprintf(
+                             Session::addMessageAfterRedirect(htmlescape(sprintf(
                                  __('%1$s: %2$s'),
                                  $entityname,
                                  $message
@@ -501,7 +501,7 @@ class CartridgeItem extends CommonDBTM
                             $task->log($msg);
                         } else {
                            //TRANS: %s is the entity
-                            Session::addMessageAfterRedirect(htmlspecialchars($msg), false, ERROR);
+                            Session::addMessageAfterRedirect(htmlescape($msg), false, ERROR);
                         }
                     }
                 }

--- a/src/CartridgeItem_PrinterModel.php
+++ b/src/CartridgeItem_PrinterModel.php
@@ -175,7 +175,7 @@ class CartridgeItem_PrinterModel extends CommonDBRelation
                     ]
                 ];
                 $url = Printer::getSearchURL() . "?" . Toolbox::append_params($opt, '&amp;');
-                echo "<td class='center'><a href='" . $url . "'>" . htmlspecialchars($data["name"]) . "</a></td>";
+                echo "<td class='center'><a href='" . $url . "'>" . htmlescape($data["name"]) . "</a></td>";
                 echo "</tr>";
             }
             echo $header_begin . $header_bottom . $header_end;

--- a/src/Certificate.php
+++ b/src/Certificate.php
@@ -804,7 +804,7 @@ class Certificate extends CommonDBTM
                         $task->log($msg);
                         $task->addVolume(1);
                     } else {
-                        Session::addMessageAfterRedirect(htmlspecialchars($msg));
+                        Session::addMessageAfterRedirect(htmlescape($msg));
                     }
 
                     // Add alert
@@ -828,7 +828,7 @@ class Certificate extends CommonDBTM
                     if ($task) {
                         $task->log($msg);
                     } else {
-                        Session::addMessageAfterRedirect(htmlspecialchars($msg), false, ERROR);
+                        Session::addMessageAfterRedirect(htmlescape($msg), false, ERROR);
                     }
                 }
             }

--- a/src/Certificate_Item.php
+++ b/src/Certificate_Item.php
@@ -267,7 +267,7 @@ class Certificate_Item extends CommonDBRelation
         echo "<th>" . _sn('Type', 'Types', 1) . "</th>";
         echo "<th>" . __s('Name') . "</th>";
         if (Session::isMultiEntitiesMode()) {
-            echo "<th>" . htmlspecialchars(Entity::getTypeName(1)) . "</th>";
+            echo "<th>" . htmlescape(Entity::getTypeName(1)) . "</th>";
         }
         echo "<th>" . __s('Serial number') . "</th>";
         echo "<th>" . __s('Inventory number') . "</th>";
@@ -294,7 +294,7 @@ class Certificate_Item extends CommonDBRelation
                         }
 
                         $link = $itemtype::getFormURLWithID($data["id"]);
-                        $name = "<a href=\"" . $link . "\">" . htmlspecialchars($data["name"]) . "$ID</a>";
+                        $name = "<a href=\"" . $link . "\">" . htmlescape($data["name"]) . "$ID</a>";
 
                         echo "<tr class='tab_bg_1'>";
 
@@ -303,17 +303,17 @@ class Certificate_Item extends CommonDBRelation
                             Html::showMassiveActionCheckBox(__CLASS__, $data["linkid"]);
                             echo "</td>";
                         }
-                        echo "<td class='center'>" . htmlspecialchars($item->getTypeName(1)) . "</td>";
+                        echo "<td class='center'>" . htmlescape($item->getTypeName(1)) . "</td>";
                         echo "<td class='center' " . (isset($data['is_deleted']) && $data['is_deleted'] ? "class='tab_bg_2_2'" : "") .
                         ">" . $name . "</td>";
                         if (Session::isMultiEntitiesMode()) {
                             $entity = ($item->isEntityAssign() ?
                             Dropdown::getDropdownName("glpi_entities", $data['entity']) :
                             '-');
-                             echo "<td class='center'>" . htmlspecialchars($entity) . "</td>";
+                             echo "<td class='center'>" . htmlescape($entity) . "</td>";
                         }
-                        echo "<td class='center'>" . (isset($data["serial"]) ? htmlspecialchars($data["serial"]) : "-") . "</td>";
-                        echo "<td class='center'>" . (isset($data["otherserial"]) ? htmlspecialchars($data["otherserial"]) : "-") . "</td>";
+                        echo "<td class='center'>" . (isset($data["serial"]) ? htmlescape($data["serial"]) : "-") . "</td>";
+                        echo "<td class='center'>" . (isset($data["otherserial"]) ? htmlescape($data["otherserial"]) : "-") . "</td>";
                         echo "</tr>";
                     }
                 }
@@ -458,7 +458,7 @@ class Certificate_Item extends CommonDBRelation
         }
         echo "<th>" . __('Name') . "</th>";
         if (Session::isMultiEntitiesMode()) {
-            echo "<th>" . htmlspecialchars(Entity::getTypeName(1)) . "</th>";
+            echo "<th>" . htmlescape(Entity::getTypeName(1)) . "</th>";
         }
         echo "<th>" . _sn('Type', 'Types', 1) . "</th>";
         echo "<th>" . __s('DNS name') . "</th>";
@@ -509,8 +509,8 @@ class Certificate_Item extends CommonDBRelation
                     $data["certificatetypes_id"]
                 );
                  echo "</td>";
-                 echo "<td class='center'>" . htmlspecialchars($data["dns_name"]) . "</td>";
-                 echo "<td class='center'>" . htmlspecialchars($data["dns_suffix"]) . "</td>";
+                 echo "<td class='center'>" . htmlescape($data["dns_name"]) . "</td>";
+                 echo "<td class='center'>" . htmlescape($data["dns_suffix"]) . "</td>";
                  echo "<td class='center'>" . Html::convDate($data["date_creation"]) . "</td>";
                 if (
                     $data["date_expiration"] <= date('Y-m-d')

--- a/src/Change.php
+++ b/src/Change.php
@@ -1342,7 +1342,7 @@ class Change extends CommonITILObject
                             foreach ($change->users[CommonITILActor::REQUESTER] as $d) {
                                 if ($d["users_id"] > 0) {
                                     $name = '<i class="fas fa-sm fa-fw fa-user text-muted me-1"></i>' .
-                                        htmlspecialchars(getUserName($d["users_id"]));
+                                        htmlescape(getUserName($d["users_id"]));
                                     $requesters[] = $name;
                                 } else {
                                     $requesters[] = '<i class="fas fa-sm fa-fw fa-envelope text-muted me-1"></i>' .
@@ -1553,7 +1553,7 @@ class Change extends CommonITILObject
         $rand      = mt_rand();
         if ($change->getFromDBwithData($ID)) {
             $bgcolor = $_SESSION["glpipriority_" . $change->fields["priority"]];
-            $name    = htmlspecialchars(sprintf(__('%1$s: %2$s'), __('ID'), $change->fields["id"]));
+            $name    = htmlescape(sprintf(__('%1$s: %2$s'), __('ID'), $change->fields["id"]));
             echo "<tr class='tab_bg_2'>";
             echo "<td>
             <div class='badge_block' style='border-color: $bgcolor'>
@@ -1569,7 +1569,7 @@ class Change extends CommonITILObject
                 foreach ($change->users[CommonITILActor::REQUESTER] as $d) {
                     $user = new User();
                     if ($d["users_id"] > 0 && $user->getFromDB($d["users_id"])) {
-                         $name     = "<span class='b'>" . htmlspecialchars($user->getName()) . "</span>";
+                         $name     = "<span class='b'>" . htmlescape($user->getName()) . "</span>";
                         if ($viewusers) {
                             $name = sprintf(
                                 __s('%1$s %2$s'),
@@ -1585,7 +1585,7 @@ class Change extends CommonITILObject
                         }
                          echo $name;
                     } else {
-                        echo htmlspecialchars($d['alternative_email']) . "&nbsp;";
+                        echo htmlescape($d['alternative_email']) . "&nbsp;";
                     }
                     echo "<br>";
                 }
@@ -1604,13 +1604,13 @@ class Change extends CommonITILObject
             echo "</td>";
 
             echo "<td>";
-            $link = "<a id='change" . htmlspecialchars($change->fields["id"] . $rand) . "' href='" .
+            $link = "<a id='change" . htmlescape($change->fields["id"] . $rand) . "' href='" .
             Change::getFormURLWithID($change->fields["id"]);
             if ($forcetab != '') {
-                $link .= "&amp;forcetab=" . htmlspecialchars($forcetab);
+                $link .= "&amp;forcetab=" . htmlescape($forcetab);
             }
             $link .= "'>";
-            $link .= "<span class='b'>" . htmlspecialchars($change->fields["name"]) . "</span></a>";
+            $link .= "<span class='b'>" . htmlescape($change->fields["name"]) . "</span></a>";
             $link = sprintf(
                 __s('%1$s %2$s'),
                 $link,

--- a/src/CommonDBChild.php
+++ b/src/CommonDBChild.php
@@ -799,9 +799,9 @@ abstract class CommonDBChild extends CommonDBConnexity
         if ($this->isNewID($this->getID())) {
             $value = '';
         } else {
-            $value = htmlspecialchars($this->getName());
+            $value = htmlescape($this->getName());
         }
-        $field_name = htmlspecialchars($field_name . "[$id]");
+        $field_name = htmlescape($field_name . "[$id]");
 
         if ($canedit) {
             $out = "<input type='text' size='40' name='$field_name' value='$value' class='form-select'>";
@@ -863,8 +863,8 @@ abstract class CommonDBChild extends CommonDBConnexity
 
         if ($canedit) {
             $lower_name         = strtolower(get_called_class());
-            $child_count_js_var = htmlspecialchars('nb' . $lower_name . 's');
-            $div_id             = htmlspecialchars("add_" . $lower_name . "_to_" . $item->getType() . "_" . $items_id);
+            $child_count_js_var = htmlescape('nb' . $lower_name . 's');
+            $div_id             = htmlescape("add_" . $lower_name . "_to_" . $item->getType() . "_" . $items_id);
 
             // Beware : -1 is for the first element added ...
             $result = "&nbsp;<script type='text/javascript'>var $child_count_js_var=2; </script>";
@@ -923,7 +923,7 @@ abstract class CommonDBChild extends CommonDBConnexity
         }
 
         $lower_name = strtolower(get_called_class());
-        $div_id     = htmlspecialchars("add_" . $lower_name . "_to_" . $item->getType() . "_" . $items_id);
+        $div_id     = htmlescape("add_" . $lower_name . "_to_" . $item->getType() . "_" . $items_id);
 
         $query = [
             'FROM'   => static::getTable(),

--- a/src/CommonDBConnexity.php
+++ b/src/CommonDBConnexity.php
@@ -319,7 +319,7 @@ abstract class CommonDBConnexity extends CommonDBTM
             }
 
             Session::addMessageAfterRedirect(
-                htmlspecialchars(sprintf(
+                htmlescape(sprintf(
                     __('Cannot update item %s #%s: not enough right on the parent(s) item(s)'),
                     $new_item->getTypeName(),
                     $new_item->getID()
@@ -637,13 +637,13 @@ abstract class CommonDBConnexity extends CommonDBTM
                                 $itemtype_2 = $itemtype::$itemtype_2;
                                 $values[1]  = $itemtype_2::getTypeName(Session::getPluralNumber());
                             }
-                            echo htmlspecialchars(sprintf(__('Select a peer for %s:'), $itemtype::getTypeName()));
+                            echo htmlescape(sprintf(__('Select a peer for %s:'), $itemtype::getTypeName()));
                             Dropdown::showFromArray($peer_field, $values);
                             echo "<br>\n";
                         } else if (!$itemtype::$mustBeAttached_1) {
-                              echo "<input type='hidden' name='" . htmlspecialchars($peer_field) . "' value='0'>";
+                              echo "<input type='hidden' name='" . htmlescape($peer_field) . "' value='0'>";
                         } else if (!$itemtype::$mustBeAttached_2) {
-                            echo "<input type='hidden' name='" . htmlspecialchars($peer_field) . "' value='1'>";
+                            echo "<input type='hidden' name='" . htmlescape($peer_field) . "' value='1'>";
                         }
                     }
                 }

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -1449,18 +1449,18 @@ class CommonDBTM extends CommonGLPI
         if ($link_url !== '') {
             $html .= sprintf(
                 '<a href="%s" title="%s"%s>',
-                htmlspecialchars($link_url),
-                htmlspecialchars($link_title),
-                $p['class'] !== '' ? sprintf(' class="%s"', htmlspecialchars($p['class'])) : '',
+                htmlescape($link_url),
+                htmlescape($link_title),
+                $p['class'] !== '' ? sprintf(' class="%s"', htmlescape($p['class'])) : '',
             );
         }
         if ($icon !== '') {
             $html .= sprintf(
                 '<i class="%s"></i> ',
-                htmlspecialchars($icon)
+                htmlescape($icon)
             );
         }
-        $html .= htmlspecialchars($label);
+        $html .= htmlescape($label);
         if ($comment !== '') {
             $html .= ' - ' . $comment; // Comment tooltip is already HTML encoded.
         }
@@ -1522,7 +1522,7 @@ class CommonDBTM extends CommonGLPI
                 );
             }
             $opt = [ 'forceid' => $this instanceof CommonITILObject ];
-            $display = (isset($this->input['_no_message_link']) ? htmlspecialchars($this->getNameID($opt))
+            $display = (isset($this->input['_no_message_link']) ? htmlescape($this->getNameID($opt))
                                                             : $this->getLink($opt));
 
            // Do not display quotes
@@ -1952,12 +1952,12 @@ class CommonDBTM extends CommonGLPI
     final public function formatSessionMessageAfterAction(string $message): string
     {
         if (isset($this->input['_no_message_link'])) {
-            $display = htmlspecialchars($this->getNameID());
+            $display = htmlescape($this->getNameID());
         } else {
             $display = $this->getLink();
         }
 
-        return sprintf(__s('%1$s: %2$s'), htmlspecialchars($message), $display);
+        return sprintf(__s('%1$s: %2$s'), htmlescape($message), $display);
     }
 
     /**
@@ -3490,21 +3490,21 @@ class CommonDBTM extends CommonGLPI
         if ($this->isField('completename')) {
             $toadd[] = [
                 'name'  => __s('Complete name'),
-                'value' => htmlspecialchars((string) $this->getField('completename')),
+                'value' => htmlescape((string) $this->getField('completename')),
             ];
         }
 
         if ($this->isField('serial')) {
             $toadd[] = [
                 'name'  => __s('Serial number'),
-                'value' => htmlspecialchars((string) $this->getField('serial')),
+                'value' => htmlescape((string) $this->getField('serial')),
             ];
         }
 
         if ($this->isField('otherserial')) {
             $toadd[] = [
                 'name'  => __s('Inventory number'),
-                'value' => htmlspecialchars((string) $this->getField('otherserial')),
+                'value' => htmlescape((string) $this->getField('otherserial')),
             ];
         }
 
@@ -3513,7 +3513,7 @@ class CommonDBTM extends CommonGLPI
             if (strlen($name) > 0) {
                 $toadd[] = [
                     'name'  => __s('Status'),
-                    'value' => htmlspecialchars($name),
+                    'value' => htmlescape($name),
                 ];
             }
         }
@@ -3522,8 +3522,8 @@ class CommonDBTM extends CommonGLPI
             $name = Dropdown::getDropdownName("glpi_locations", $this->fields['locations_id']);
             if (strlen($name) > 0) {
                 $toadd[] = [
-                    'name'  => htmlspecialchars(Location::getTypeName(1)),
-                    'value' => htmlspecialchars($name),
+                    'name'  => htmlescape(Location::getTypeName(1)),
+                    'value' => htmlescape($name),
                 ];
             }
         }
@@ -3532,8 +3532,8 @@ class CommonDBTM extends CommonGLPI
             $name = getUserName($this->fields['users_id']);
             if (strlen($name) > 0) {
                 $toadd[] = [
-                    'name'  => htmlspecialchars(User::getTypeName(1)),
-                    'value' => htmlspecialchars($name),
+                    'name'  => htmlescape(User::getTypeName(1)),
+                    'value' => htmlescape($name),
                 ];
             }
         }
@@ -3547,8 +3547,8 @@ class CommonDBTM extends CommonGLPI
                 $name = Dropdown::getDropdownName("glpi_groups", $group);
                 if (strlen($name) > 0) {
                     $toadd[] = [
-                        'name'  => htmlspecialchars(Group::getTypeName(1)),
-                        'value' => htmlspecialchars($name),
+                        'name'  => htmlescape(Group::getTypeName(1)),
+                        'value' => htmlescape($name),
                     ];
                 }
             }
@@ -3558,8 +3558,8 @@ class CommonDBTM extends CommonGLPI
             $name = getUserName($this->fields['users_id_tech']);
             if (strlen($name) > 0) {
                 $toadd[] = [
-                    'name'  => htmlspecialchars(__('Technician in charge')),
-                    'value' => htmlspecialchars($name),
+                    'name'  => htmlescape(__('Technician in charge')),
+                    'value' => htmlescape($name),
                 ];
             }
         }
@@ -3567,14 +3567,14 @@ class CommonDBTM extends CommonGLPI
         if ($this->isField('contact')) {
             $toadd[] = [
                 'name'  => __s('Alternate username'),
-                'value' => htmlspecialchars((string) $this->getField('contact')),
+                'value' => htmlescape((string) $this->getField('contact')),
             ];
         }
 
         if ($this->isField('contact_num')) {
             $toadd[] = [
                 'name'  => __s('Alternate username number'),
-                'value' => htmlspecialchars((string) $this->getField('contact_num')),
+                'value' => htmlescape((string) $this->getField('contact_num')),
             ];
         }
 
@@ -3596,7 +3596,7 @@ class CommonDBTM extends CommonGLPI
         if ($this instanceof CommonDropdown && $this->isField('comment')) {
             $toadd[] = [
                 'name'  => __s('Comments'),
-                'value' => nl2br(htmlspecialchars((string) $this->getField('comment'))),
+                'value' => nl2br(htmlescape((string) $this->getField('comment'))),
             ];
         }
 
@@ -4382,7 +4382,7 @@ class CommonDBTM extends CommonGLPI
                 __('At least one field has an incorrect value'),
                 implode(',', $fails)
             );
-            Session::addMessageAfterRedirect(htmlspecialchars($message), INFO, true);
+            Session::addMessageAfterRedirect(htmlescape($message), INFO, true);
         }
     }
 
@@ -4446,12 +4446,12 @@ class CommonDBTM extends CommonGLPI
         }
 
         if ($unicity['action_refuse']) {
-            $message_text = htmlspecialchars(sprintf(
+            $message_text = htmlescape(sprintf(
                 __('Impossible record for %s'),
                 implode(' & ', $message)
             ));
         } else {
-            $message_text = htmlspecialchars(sprintf(
+            $message_text = htmlescape(sprintf(
                 __('Item successfully added but duplicate record on %s'),
                 implode(' & ', $message)
             ));
@@ -4486,7 +4486,7 @@ class CommonDBTM extends CommonGLPI
                             $field_value
                         );
                     }
-                    $new_text = htmlspecialchars(sprintf(__('%1$s: %2$s'), $value, $field_value));
+                    $new_text = htmlescape(sprintf(__('%1$s: %2$s'), $value, $field_value));
                     if (empty($double_text)) {
                         $double_text = $new_text;
                     } else {
@@ -5322,7 +5322,7 @@ class CommonDBTM extends CommonGLPI
 
         if ($add) {
             $entries[] = [
-                'template' => '<a href="' . htmlspecialchars($target_blank) . '">' . __('Blank Template') . '</a>'
+                'template' => '<a href="' . htmlescape($target_blank) . '">' . __('Blank Template') . '</a>'
             ];
         }
 
@@ -5336,7 +5336,7 @@ class CommonDBTM extends CommonGLPI
                 $modify_params = (strpos($target, '?') ? '&' : '?') . "id=" . $data['id'] . "&withtemplate=1";
                 $target_modify = $target . $modify_params;
 
-                $entry['template'] = '<a href="' . htmlspecialchars($target_modify) . '">' . htmlspecialchars($templname) . '</a>';
+                $entry['template'] = '<a href="' . htmlescape($target_modify) . '">' . htmlescape($templname) . '</a>';
                 if (Session::isMultiEntitiesMode()) {
                     if (!isset($entity_cache[$data['entities_id']])) {
                         $entity_cache[$data['entities_id']] = Dropdown::getDropdownName('glpi_entities', $data['entities_id']);
@@ -5347,7 +5347,7 @@ class CommonDBTM extends CommonGLPI
             } else {
                 $add_params = (strpos($target, '?') ? '&' : '?') . "id=" . $data['id'] . "&withtemplate=2";
                 $target_add = $target . $add_params;
-                $entry['template'] = '<a href="' . htmlspecialchars($target_add) . '">' . htmlspecialchars($templname) . '</a>';
+                $entry['template'] = '<a href="' . htmlescape($target_add) . '">' . htmlescape($templname) . '</a>';
             }
             $entries[] = $entry;
         }

--- a/src/CommonDBVisible.php
+++ b/src/CommonDBVisible.php
@@ -214,11 +214,11 @@ abstract class CommonDBVisible extends CommonDBTM
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $ID      = htmlspecialchars($this->fields['id']);
+        $ID      = htmlescape($this->fields['id']);
         $canedit = $this->canEdit($ID);
         $rand    = mt_rand();
         $nb      = $this->countVisibilities();
-        $str_type = htmlspecialchars(strtolower($this::getType()));
+        $str_type = htmlescape(strtolower($this::getType()));
         $fk = static::getForeignKeyField();
 
         if ($canedit) {
@@ -292,8 +292,8 @@ abstract class CommonDBVisible extends CommonDBTM
                         Html::showMassiveActionCheckBox($this::getType() . '_User', $data["id"]);
                         echo "</td>";
                     }
-                    echo "<td>" . htmlspecialchars(User::getTypeName(1)) . "</td>";
-                    echo "<td>" . htmlspecialchars(getUserName($data['users_id'])) . "</td>";
+                    echo "<td>" . htmlescape(User::getTypeName(1)) . "</td>";
+                    echo "<td>" . htmlescape(getUserName($data['users_id'])) . "</td>";
                     echo "</tr>";
                 }
             }
@@ -309,19 +309,19 @@ abstract class CommonDBVisible extends CommonDBTM
                         Html::showMassiveActionCheckBox('Group_' . $this::getType(), $data["id"]);
                         echo "</td>";
                     }
-                    echo "<td>" . htmlspecialchars(Group::getTypeName(1)) . "</td>";
+                    echo "<td>" . htmlescape(Group::getTypeName(1)) . "</td>";
 
                     $names   = Dropdown::getDropdownName('glpi_groups', $data['groups_id'], 1);
                     $entname = sprintf(
                         __s('%1$s %2$s'),
-                        htmlspecialchars($names["name"]),
+                        htmlescape($names["name"]),
                         Html::showToolTip($names["comment"], ['display' => false])
                     );
                     if ($data['entities_id'] !== null) {
                         $entname = sprintf(
                             __s('%1$s / %2$s'),
                             $entname,
-                            htmlspecialchars(
+                            htmlescape(
                                 Dropdown::getDropdownName(
                                     'glpi_entities',
                                     $data['entities_id']
@@ -353,10 +353,10 @@ abstract class CommonDBVisible extends CommonDBTM
                         Html::showMassiveActionCheckBox('Entity_' . $this::getType(), $data["id"]);
                         echo "</td>";
                     }
-                    echo "<td>" . htmlspecialchars(Entity::getTypeName(1)) . "</td>";
+                    echo "<td>" . htmlescape(Entity::getTypeName(1)) . "</td>";
                     $names   = Dropdown::getDropdownName('glpi_entities', $data['entities_id'], 1);
                     $tooltip = Html::showToolTip($names["comment"], ['display' => false]);
-                    $entname = sprintf(__s('%1$s %2$s'), htmlspecialchars($names["name"]), $tooltip);
+                    $entname = sprintf(__s('%1$s %2$s'), htmlescape($names["name"]), $tooltip);
                     if ($data['is_recursive']) {
                         $entname = sprintf(
                             __s('%1$s %2$s'),
@@ -389,12 +389,12 @@ abstract class CommonDBVisible extends CommonDBTM
 
                     $names   = Dropdown::getDropdownName('glpi_profiles', $data['profiles_id'], 1);
                     $tooltip = Html::showToolTip($names["comment"], ['display' => false]);
-                    $entname = sprintf(__s('%1$s %2$s'), htmlspecialchars($names["name"]), $tooltip);
+                    $entname = sprintf(__s('%1$s %2$s'), htmlescape($names["name"]), $tooltip);
                     if ($data['entities_id'] !== null) {
                         $entname = sprintf(
                             __s('%1$s / %2$s'),
                             $entname,
-                            htmlspecialchars(
+                            htmlescape(
                                 Dropdown::getDropdownName(
                                     'glpi_entities',
                                     $data['entities_id']

--- a/src/CommonDropdown.php
+++ b/src/CommonDropdown.php
@@ -616,7 +616,7 @@ abstract class CommonDropdown extends CommonDBTM
             return false;
         }
 
-        $ID = htmlspecialchars($this->fields['id']);
+        $ID = htmlescape($this->fields['id']);
 
         echo "<div class='center'><p class='red'>";
         echo __s("Caution: you're about to remove a heading used for one or more items.");
@@ -626,10 +626,10 @@ abstract class CommonDropdown extends CommonDBTM
            // Delete form (set to 0)
             echo "<p>" . __s('If you confirm the deletion, all uses of this dropdown will be blanked.') .
               "</p>";
-            echo "<form action='" . htmlspecialchars($target) . "' method='post'>";
+            echo "<form action='" . htmlescape($target) . "' method='post'>";
             echo "<table class='tab_cadre'><tr>";
             echo "<td><input type='hidden' name='id' value='$ID'>";
-            echo "<input type='hidden' name='itemtype' value='" . htmlspecialchars($this->getType()) . "' />";
+            echo "<input type='hidden' name='itemtype' value='" . htmlescape($this->getType()) . "' />";
             echo "<input type='hidden' name='forcepurge' value='1'>";
             echo "<input class='btn btn-primary' type='submit' name='purge'
                 value=\"" . _sx('button', 'Confirm') . "\">";
@@ -666,7 +666,7 @@ abstract class CommonDropdown extends CommonDBTM
             $replacement_options
         );
         echo "<input type='hidden' name='id' value='$ID' />";
-        echo "<input type='hidden' name='itemtype' value='" . htmlspecialchars($this->getType()) . "' />";
+        echo "<input type='hidden' name='itemtype' value='" . htmlescape($this->getType()) . "' />";
         echo "</td><td>";
         echo "<input class='btn btn-primary' type='submit' name='replace' value=\"" . _sx('button', 'Replace') . "\">";
         echo "</td><td>";
@@ -843,7 +843,7 @@ abstract class CommonDropdown extends CommonDBTM
 
         switch ($ma->getAction()) {
             case 'merge':
-                echo "&nbsp;" . htmlspecialchars($_SESSION['glpiactive_entity_shortname']);
+                echo "&nbsp;" . htmlescape($_SESSION['glpiactive_entity_shortname']);
                 echo "<br><br>" . Html::submit(_x('button', 'Merge'), ['name' => 'massiveaction']);
                 return true;
         }

--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -738,13 +738,13 @@ class CommonGLPI implements CommonGLPIInterface
             $icon = '';
         }
 
-        $icon_html = $icon !== '' ? sprintf('<i class="%s me-2"></i>', htmlspecialchars($icon)) : '';
+        $icon_html = $icon !== '' ? sprintf('<i class="%s me-2"></i>', htmlescape($icon)) : '';
         $counter_html = $nb !== 0 ? sprintf(' <span class="badge glpi-badge">%d</span>', $nb) : '';
 
         return sprintf(
             '<span class="d-flex align-items-center">%s%s%s</span>',
             $icon_html,
-            htmlspecialchars($text),
+            htmlescape($text),
             $counter_html
         );
     }
@@ -1059,7 +1059,7 @@ class CommonGLPI implements CommonGLPIInterface
             if (!$glpilisttitle) {
                 $glpilisttitle = __('List');
             }
-            $list = "<a href='$glpilisturl' title=\"" . htmlspecialchars($glpilisttitle) . "\"
+            $list = "<a href='$glpilisturl' title=\"" . htmlescape($glpilisttitle) . "\"
                   class='btn btn-sm btn-icon btn-ghost-secondary me-2'
                   data-bs-toggle='tooltip' data-bs-placement='bottom'>
                   <i class='ti ti-list-search fa-lg'></i>
@@ -1111,7 +1111,7 @@ class CommonGLPI implements CommonGLPIInterface
                 if (method_exists($this, 'getStatusIcon') && $this->isField('status')) {
                     echo "<span class='me-1'>" . $this->getStatusIcon($this->fields['status']) . '</span>';
                 }
-                echo htmlspecialchars($this->getNameID([
+                echo htmlescape($this->getNameID([
                     'forceid' => $this instanceof CommonITILObject
                 ]));
                 if ($this->isField('is_deleted') && $this->fields['is_deleted']) {

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -1914,7 +1914,7 @@ abstract class CommonITILObject extends CommonDBTM
                     __('Mandatory fields are not filled. Please correct: %s'),
                     implode(", ", $mandatory_missing)
                 );
-                Session::addMessageAfterRedirect(htmlspecialchars($message), false, ERROR);
+                Session::addMessageAfterRedirect(htmlescape($message), false, ERROR);
                 return false;
             }
         }
@@ -3016,7 +3016,7 @@ abstract class CommonITILObject extends CommonDBTM
                                 __('Mandatory fields are not filled. Please correct: %s'),
                                 implode(", ", $mandatory_missing)
                             );
-                            Session::addMessageAfterRedirect(htmlspecialchars($message), false, ERROR);
+                            Session::addMessageAfterRedirect(htmlescape($message), false, ERROR);
                             return false;
                         }
                     }
@@ -5130,7 +5130,7 @@ abstract class CommonITILObject extends CommonDBTM
     public static function getStatusIcon($status)
     {
         $class = static::getStatusClass($status);
-        $label = htmlspecialchars(static::getStatus($status));
+        $label = htmlescape(static::getStatus($status));
         return "<i class='$class me-1' title='$label' data-bs-toggle='tooltip'></i>";
     }
 
@@ -5354,7 +5354,7 @@ abstract class CommonITILObject extends CommonDBTM
             $CFG_GLPI["root_doc"] . "/ajax/dropdownItilActors.php",
             $params
         );
-        echo "<span id='showitilactor" . htmlspecialchars($typename) . "_$rand' class='actor-dropdown'>&nbsp;</span>";
+        echo "<span id='showitilactor" . htmlescape($typename) . "_$rand' class='actor-dropdown'>&nbsp;</span>";
         if ($inobject) {
             echo "<hr>";
         }
@@ -5523,14 +5523,14 @@ abstract class CommonITILObject extends CommonDBTM
                     "countassign_$rand",
                     $CFG_GLPI["root_doc"] . "/ajax/actorinformation.php",
                     ['users_id_assign' => '__VALUE__'],
-                    "dropdown__users_id_" . htmlspecialchars($typename . $rand)
+                    "dropdown__users_id_" . htmlescape($typename . $rand)
                 );
                 echo "});</script>";
             }
         }
 
         if ($CFG_GLPI['notifications_mailing']) {
-            echo "<div id='notif_" . htmlspecialchars($typename) . "_$rand' class='mt-2'>";
+            echo "<div id='notif_" . htmlescape($typename) . "_$rand' class='mt-2'>";
             echo "</div>";
 
             echo "<script type='text/javascript'>";
@@ -6891,7 +6891,7 @@ abstract class CommonITILObject extends CommonDBTM
                 if ($user->getFromDB($d["users_id"])) {
                     $eighth_col .= sprintf(
                         __('%1$s %2$s'),
-                        "<span class='b'>" . htmlspecialchars($user->getName()) . "</span>",
+                        "<span class='b'>" . htmlescape($user->getName()) . "</span>",
                         Html::showToolTip(
                             $user->getInfoCard(),
                             [
@@ -6926,7 +6926,7 @@ abstract class CommonITILObject extends CommonDBTM
                 } elseif ($user->getFromDB($d["users_id"])) {
                     $ninth_col .= sprintf(
                         __('%1$s %2$s'),
-                        "<span class='b'>" . htmlspecialchars($user->getName()) . "</span>",
+                        "<span class='b'>" . htmlescape($user->getName()) . "</span>",
                         Html::showToolTip(
                             $user->getInfoCard(),
                             [
@@ -7256,11 +7256,11 @@ abstract class CommonITILObject extends CommonDBTM
                 $showprivate_task[$itemtype] = Session::haveRight($taskclass::$rightname, CommonITILTask::SEEPRIVATE);
             }
 
-            $name = '<span class="fw-bold">' . htmlspecialchars($item->getName()) . '</span>';
+            $name = '<span class="fw-bold">' . htmlescape($item->getName()) . '</span>';
             if ($item->canViewItem()) {
                 $name  = sprintf(
                     __s('%1$s (%2$s)'),
-                    '<a id="' . $name_link_id . '" href="' . htmlspecialchars($item->getLinkURL()) . '">' . $name . '</a><br>',
+                    '<a id="' . $name_link_id . '" href="' . htmlescape($item->getLinkURL()) . '">' . $name . '</a><br>',
                     sprintf(
                         __s('%1$s - %2$s'),
                         $item->numberOfFollowups($showprivate_fup),
@@ -7319,7 +7319,7 @@ abstract class CommonITILObject extends CommonDBTM
 
             $priority_name = static::getPriorityName($item->fields["priority"]);
             $priority_color = $_SESSION["glpipriority_" . $item->fields["priority"]];
-            $entry['priority'] = '<span class="fw-bold badge text-body" style="background-color: ' . htmlspecialchars($priority_color) . '">' . htmlspecialchars($priority_name) . '</span>';
+            $entry['priority'] = '<span class="fw-bold badge text-body" style="background-color: ' . htmlescape($priority_color) . '">' . htmlescape($priority_name) . '</span>';
 
             $entry['requester'] = '';
             foreach ($item->getUsers(CommonITILActor::REQUESTER) as $d) {
@@ -7327,7 +7327,7 @@ abstract class CommonITILObject extends CommonDBTM
                 if (!isset($user_cache[$d["users_id"]]) && $user->getFromDB($d["users_id"])) {
                     $user_value = sprintf(
                         __s('%1$s %2$s'),
-                        htmlspecialchars($user->getName()),
+                        htmlescape($user->getName()),
                         Html::showToolTip(
                             $user->getInfoCard(),
                             [
@@ -7344,19 +7344,19 @@ abstract class CommonITILObject extends CommonDBTM
                 if (!isset($group_cache[$d['groups_id']])) {
                     $group_cache[$d['groups_id']] = Dropdown::getDropdownName(table: 'glpi_groups', id: $d['groups_id'], default: '');
                 }
-                $entry['requester'] .= htmlspecialchars($group_cache[$d['groups_id']]) . '<br>';
+                $entry['requester'] .= htmlescape($group_cache[$d['groups_id']]) . '<br>';
             }
 
             $entry['assigned'] = '';
             foreach ($item->getUsers(CommonITILActor::ASSIGN) as $d) {
                 if (Session::getCurrentInterface() === 'helpdesk' && !empty($anon_name = User::getAnonymizedNameForUser($d['users_id'], $item->getEntityID()))) {
-                    $entry['assigned'] .= htmlspecialchars($anon_name) . '<br>';
+                    $entry['assigned'] .= htmlescape($anon_name) . '<br>';
                 } else {
                     $user = new User();
                     if (!isset($user_cache[$d["users_id"]]) && $user->getFromDB($d["users_id"])) {
                         $user_value = sprintf(
                             __s('%1$s %2$s'),
-                            htmlspecialchars($user->getName()),
+                            htmlescape($user->getName()),
                             Html::showToolTip(
                                 $user->getInfoCard(),
                                 [
@@ -7372,19 +7372,19 @@ abstract class CommonITILObject extends CommonDBTM
             }
             foreach ($item->getGroups(CommonITILActor::ASSIGN) as $d) {
                 if (Session::getCurrentInterface() === 'helpdesk' && !empty($anon_name = Group::getAnonymizedName($item->getEntityID()))) {
-                    $entry['assigned'] .= htmlspecialchars($anon_name) . '<br>';
+                    $entry['assigned'] .= htmlescape($anon_name) . '<br>';
                 } else {
                     if (!isset($group_cache[$d['groups_id']])) {
                         $group_cache[$d['groups_id']] = Dropdown::getDropdownName(table: 'glpi_groups', id: $d['groups_id'], default: '');
                     }
-                    $entry['assigned'] .= htmlspecialchars($group_cache[$d['groups_id']]) . '<br>';
+                    $entry['assigned'] .= htmlescape($group_cache[$d['groups_id']]) . '<br>';
                 }
             }
             foreach ($item->getSuppliers(CommonITILActor::ASSIGN) as $d) {
                 if (!isset($supplier_cache[$d['suppliers_id']])) {
                     $supplier_cache[$d['suppliers_id']] = Dropdown::getDropdownName(table: 'glpi_suppliers', id: $d['suppliers_id'], default: '');
                 }
-                $entry['assigned'] .= htmlspecialchars($supplier_cache[$d['suppliers_id']]) . '<br>';
+                $entry['assigned'] .= htmlescape($supplier_cache[$d['suppliers_id']]) . '<br>';
             }
 
             if (!$params['ticket_stats']) {
@@ -7397,7 +7397,7 @@ abstract class CommonITILObject extends CommonDBTM
                     if (!isset($asset_cache[$val['itemtype']][$val['items_id']])) {
                         $object = getItemForItemtype($val["itemtype"]);
                         if ($object && $object->getFromDB($val["items_id"])) {
-                            $asset_cache[$val['itemtype']][$val['items_id']] = $object::canView() ? $object->getLink() : htmlspecialchars($object->getNameID());
+                            $asset_cache[$val['itemtype']][$val['items_id']] = $object::canView() ? $object->getLink() : htmlescape($object->getNameID());
                         }
                     }
                     if (isset($asset_cache[$val['itemtype']][$val['items_id']])) {
@@ -7433,14 +7433,14 @@ abstract class CommonITILObject extends CommonDBTM
                 foreach ($result as $plan) {
                     if (isset($plan['begin']) && $plan['begin']) {
                         $items[$plan['id']] = $plan['id'];
-                        $planned_infos .= htmlspecialchars(sprintf(__('From %s'), Html::convDateTime($plan['begin'])));
-                        $planned_infos .= htmlspecialchars(sprintf(__('To %s'), Html::convDateTime($plan['end'])));
+                        $planned_infos .= htmlescape(sprintf(__('From %s'), Html::convDateTime($plan['begin'])));
+                        $planned_infos .= htmlescape(sprintf(__('To %s'), Html::convDateTime($plan['end'])));
                         if ($plan['users_id_tech']) {
                             $user = new User();
                             if (!isset($user_cache[$plan["users_id_tech"]]) && $user->getFromDB($plan["users_id_tech"])) {
                                 $user_value = sprintf(
                                     __s('%1$s %2$s'),
-                                    htmlspecialchars($user->getName()),
+                                    htmlescape($user->getName()),
                                     Html::showToolTip(
                                         $user->getInfoCard(),
                                         [
@@ -7451,7 +7451,7 @@ abstract class CommonITILObject extends CommonDBTM
                                 );
                                 $user_cache[$plan['users_id']] = $user_value;
                             }
-                            $planned_infos .= htmlspecialchars(sprintf(__s('By %s'), $user_cache[$plan['users_id_tech']]));
+                            $planned_infos .= htmlescape(sprintf(__s('By %s'), $user_cache[$plan['users_id_tech']]));
                         }
                         $planned_infos .= "<br>";
                     }
@@ -8063,7 +8063,7 @@ abstract class CommonITILObject extends CommonDBTM
 
                 $content = $log_row['change'];
                 if (strlen($log_row['field']) > 0) {
-                    $content = sprintf(__s("%s: %s"), htmlspecialchars($log_row['field']), $content);
+                    $content = sprintf(__s("%s: %s"), htmlescape($log_row['field']), $content);
                 }
                 $content = "<i class='fas fa-history me-1' title='" . __s("Log entry") . "' data-bs-toggle='tooltip'></i>" . $content;
                 $user_id = 0;

--- a/src/CommonITILObject_CommonITILObject.php
+++ b/src/CommonITILObject_CommonITILObject.php
@@ -448,8 +448,8 @@ abstract class CommonITILObject_CommonITILObject extends CommonDBRelation
             $resolved_value['name'] = __('Duplicated by');
         }
         return !$with_icon
-            ? htmlspecialchars($resolved_value['name'])
-            : sprintf($icon_tag, htmlspecialchars($resolved_value['icon']), htmlspecialchars($resolved_value['name']));
+            ? htmlescape($resolved_value['name'])
+            : sprintf($icon_tag, htmlescape($resolved_value['icon']), htmlescape($resolved_value['name']));
     }
 
     /**

--- a/src/CommonITILSatisfaction.php
+++ b/src/CommonITILSatisfaction.php
@@ -185,7 +185,7 @@ abstract class CommonITILSatisfaction extends CommonDBTM
             $inquest_mandatory_comment = Entity::getUsedConfig('inquest_config' . $config_suffix, $entities_id, 'inquest_mandatory_comment' . $config_suffix);
             if ($inquest_mandatory_comment && ($satisfaction <= $inquest_mandatory_comment) && empty($comment)) {
                 Session::addMessageAfterRedirect(
-                    htmlspecialchars(sprintf(__('Comment is required if score is less than or equal to %d'), $inquest_mandatory_comment)),
+                    htmlescape(sprintf(__('Comment is required if score is less than or equal to %d'), $inquest_mandatory_comment)),
                     false,
                     ERROR
                 );

--- a/src/CommonITILTask.php
+++ b/src/CommonITILTask.php
@@ -1595,7 +1595,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
         }
 
         $html .= "<img src='" . $CFG_GLPI["root_doc"] . "/pics/rdv_interv.png' alt='' title=\"" .
-             htmlspecialchars($parent->getTypeName(1)) . "\">&nbsp;&nbsp;";
+             htmlescape($parent->getTypeName(1)) . "\">&nbsp;&nbsp;";
         $html .= $parent->getStatusIcon($val['status']);
         $html .= "&nbsp;<a id='content_tracking_" . $val["id"] . $rand . "'
                    href='" . $parenttype::getFormURLWithID($val[$parenttype_fk]) . "'
@@ -1640,12 +1640,12 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
             $html .= "</span>";
         }
         $html .= "<div>";
-        $html .= htmlspecialchars(sprintf(__('%1$s: %2$s'), __('Priority'), $parent->getPriorityName($val["priority"])));
+        $html .= htmlescape(sprintf(__('%1$s: %2$s'), __('Priority'), $parent->getPriorityName($val["priority"])));
         $html .= "</div>";
 
        // $val['content'] has already been sanitized and decoded by self::populatePlanning()
         $content = $val['content'];
-        $html .= "<div class='event-description rich_text_container'>" . htmlspecialchars($content) . "</div>";
+        $html .= "<div class='event-description rich_text_container'>" . htmlescape($content) . "</div>";
         $html .= $recall;
 
         $parent->getFromDB($val[$parent->getForeignKeyField()]);
@@ -1945,13 +1945,13 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
          </td>";
 
             echo "<td>";
-            echo htmlspecialchars($item_link->fields['name']);
+            echo htmlescape($item_link->fields['name']);
             echo "</td>";
 
             echo "<td>";
-            $link = "<a id='" . htmlspecialchars(strtolower($item_link->getType())) . "ticket" . htmlspecialchars($item_link->fields["id"] . $rand) . "' href='" .
+            $link = "<a id='" . htmlescape(strtolower($item_link->getType())) . "ticket" . htmlescape($item_link->fields["id"] . $rand) . "' href='" .
                    $item_link->getFormURLWithID($item_link->fields["id"]);
-            $link .= "&amp;forcetab=" . htmlspecialchars($tab_name) . "$1";
+            $link .= "&amp;forcetab=" . htmlescape($tab_name) . "$1";
             $link   .= "'>";
             $link = sprintf(
                 __s('%1$s %2$s'),

--- a/src/CommonITILValidation.php
+++ b/src/CommonITILValidation.php
@@ -367,10 +367,10 @@ abstract class CommonITILValidation extends CommonDBChild
                     $user->getFromDB($this->fields["items_id_target"]);
                     $email   = $user->getDefaultEmail();
                     if (!empty($email)) {
-                        Session::addMessageAfterRedirect(htmlspecialchars(sprintf(__('Approval request sent to %s'), $user->getName())));
+                        Session::addMessageAfterRedirect(htmlescape(sprintf(__('Approval request sent to %s'), $user->getName())));
                     } else {
                         Session::addMessageAfterRedirect(
-                            htmlspecialchars(sprintf(
+                            htmlescape(sprintf(
                                 __('The selected user (%s) has no valid email address. The request has been created, without email confirmation.'),
                                 $user->getName()
                             )),
@@ -381,7 +381,7 @@ abstract class CommonITILValidation extends CommonDBChild
                 } elseif (is_a($this->fields["itemtype_target"], CommonDBTM::class, true)) {
                     $target = new $this->fields["itemtype_target"]();
                     if ($target->getFromDB($this->fields["items_id_target"])) {
-                        Session::addMessageAfterRedirect(htmlspecialchars(sprintf(__('Approval request sent to %s'), $target->getName())));
+                        Session::addMessageAfterRedirect(htmlescape(sprintf(__('Approval request sent to %s'), $target->getName())));
                     }
                 }
             }
@@ -989,8 +989,8 @@ abstract class CommonITILValidation extends CommonDBChild
             Session::addToNavigateListItems($this->getType(), $row["id"]);
             $status  = sprintf(
                 '<div class="badge fw-normal fs-4 text-wrap" style="border-color: %s;border-width: 2px;">%s</div>',
-                htmlspecialchars(self::getStatusColor($row['status'])),
-                htmlspecialchars(self::getStatus($row['status']))
+                htmlescape(self::getStatusColor($row['status'])),
+                htmlescape(self::getStatus($row['status']))
             );
 
             $comment_submission = RichText::getEnhancedHtml($this->fields['comment_submission'], ['images_gallery' => true]);
@@ -1022,8 +1022,8 @@ abstract class CommonITILValidation extends CommonDBChild
                 if ($doc->getFromDB($docs_values['documents_id'])) {
                     $document .= sprintf(
                         '<a href="%s">%s</a><br />',
-                        htmlspecialchars($doc->getLinkURL()),
-                        htmlspecialchars($doc->getName())
+                        htmlescape($doc->getLinkURL()),
+                        htmlescape($doc->getName())
                     );
                 }
             }
@@ -1031,11 +1031,11 @@ abstract class CommonITILValidation extends CommonDBChild
             $script = "";
             if ($canedit) {
                 $edit_title = __s('Edit');
-                $item_id = htmlspecialchars($item->fields['id']);
-                $row_id = htmlspecialchars($row["id"]);
-                $rand = htmlspecialchars($rand);
-                $view_validation_id = htmlspecialchars($this->fields[static::$items_id]);
-                $root_doc = htmlspecialchars($CFG_GLPI["root_doc"]);
+                $item_id = htmlescape($item->fields['id']);
+                $row_id = htmlescape($row["id"]);
+                $rand = htmlescape($rand);
+                $view_validation_id = htmlescape($this->fields[static::$items_id]);
+                $root_doc = htmlescape($CFG_GLPI["root_doc"]);
                 $params_json = json_encode([
                     'type'             => static::class,
                     'parenttype'       => static::$itemtype,

--- a/src/CommonItilObject_Item.php
+++ b/src/CommonItilObject_Item.php
@@ -429,13 +429,13 @@ abstract class CommonItilObject_Item extends CommonDBRelation
             $header_bottom .= "</th>";
         }
         $header_end .= "<th>" . _sn('Type', 'Types', 1) . "</th>";
-        $header_end .= "<th>" . htmlspecialchars(Entity::getTypeName(1)) . "</th>";
+        $header_end .= "<th>" . htmlescape(Entity::getTypeName(1)) . "</th>";
         $header_end .= "<th>" . __s('Name') . "</th>";
         $header_end .= "<th>" . __s('Serial number') . "</th>";
         $header_end .= "<th>" . __s('Inventory number') . "</th>";
         $header_end .= "<th>" . __s('Knowledge base entries') . "</th>";
-        $header_end .= "<th>" . htmlspecialchars(State::getTypeName(1)) . "</th>";
-        $header_end .= "<th>" . htmlspecialchars(Location::getTypeName(1)) . "</th>";
+        $header_end .= "<th>" . htmlescape(State::getTypeName(1)) . "</th>";
+        $header_end .= "<th>" . htmlescape(Location::getTypeName(1)) . "</th>";
         echo "<tr>";
         echo $header_begin . $header_top . $header_end;
 
@@ -452,7 +452,7 @@ abstract class CommonItilObject_Item extends CommonDBRelation
 
                 $prem = true;
                 foreach ($iterator as $data) {
-                    $name = htmlspecialchars($data["name"] ?? '');
+                    $name = htmlescape($data["name"]);
                     if (
                         $_SESSION["glpiis_ids_visible"]
                         || empty($data["name"])
@@ -473,7 +473,7 @@ abstract class CommonItilObject_Item extends CommonDBRelation
                         echo "</td>";
                     }
                     if ($prem) {
-                        $typename = htmlspecialchars($item->getTypeName($nb));
+                        $typename = htmlescape($item->getTypeName($nb));
                         echo "<td class='center top' rowspan='$nb'>" .
                             (($nb > 1) ? sprintf(__s('%1$s: %2$s'), $typename, $nb) : $typename) . "</td>";
                         $prem = false;
@@ -483,10 +483,10 @@ abstract class CommonItilObject_Item extends CommonDBRelation
                     echo "<td class='center" .
                             (isset($data['is_deleted']) && $data['is_deleted'] ? " tab_bg_2_2'" : "'");
                     echo ">" . $namelink . "</td>";
-                    echo "<td class='center'>" . (isset($data["serial"]) ?  htmlspecialchars($data["serial"]) : "-") .
+                    echo "<td class='center'>" . (isset($data["serial"]) ?  htmlescape($data["serial"]) : "-") .
                         "</td>";
                     echo "<td class='center'>" .
-                        (isset($data["otherserial"]) ? htmlspecialchars($data["otherserial"]) : "-") . "</td>";
+                        (isset($data["otherserial"]) ? htmlescape($data["otherserial"]) : "-") . "</td>";
                     $item->getFromDB($data["id"]);
                     echo "<td class='center'>" . $item->getKBLinks() . "</td>";
                     echo "<td class='center'>";
@@ -648,7 +648,7 @@ abstract class CommonItilObject_Item extends CommonDBRelation
                     sprintf(__('%1$s = %2$s'), $item->getTypeName(1), $item->getName())
                 );
                 echo "<tr class='noHover'><th colspan='$colspan'>";
-                $title = htmlspecialchars(sprintf(__('%d linked %s'), $number, static::$itemtype_1::getTypeName($number)));
+                $title = htmlescape(sprintf(__('%d linked %s'), $number, static::$itemtype_1::getTypeName($number)));
                 $link = "<a href='" . static::$itemtype_1::getSearchURL() . "?" .
                         Toolbox::append_params($params, '&amp;') . "'>" . __s('Show all') . "</a>";
                 $title = sprintf(__s('%1$s (%2$s)'), $title, $link);
@@ -661,7 +661,7 @@ abstract class CommonItilObject_Item extends CommonDBRelation
         } else {
             echo "<table class='tab_cadre_fixehov'>";
             echo "<tr class='noHover'><th colspan='$colspan'>";
-            echo htmlspecialchars(sprintf(__('No %s on this item'), static::$itemtype_1::getTypeName($number)));
+            echo htmlescape(sprintf(__('No %s on this item'), static::$itemtype_1::getTypeName($number)));
         }
 
         // object list
@@ -700,7 +700,7 @@ abstract class CommonItilObject_Item extends CommonDBRelation
 
             echo "<div class='spaced'><table class='tab_cadre_fixehov'>";
             echo "<tr class='noHover'><th colspan='$colspan'>";
-            echo htmlspecialchars(sprintf(__('%s on linked items'), static::$itemtype_1::getTypeName($number)));
+            echo htmlescape(sprintf(__('%s on linked items'), static::$itemtype_1::getTypeName($number)));
             echo "</th></tr>";
             if ($number > 0) {
                 static::$itemtype_1::commonListHeader(Search::HTML_OUTPUT);
@@ -1498,7 +1498,7 @@ abstract class CommonItilObject_Item extends CommonDBRelation
                 );
             }
 
-            $display = (isset($this->input['_no_message_link']) ? htmlspecialchars($item->getNameID())
+            $display = (isset($this->input['_no_message_link']) ? htmlescape($item->getNameID())
                                                             : $item->getLink());
 
            //TRANS : %s is the description of the added item
@@ -1537,7 +1537,7 @@ abstract class CommonItilObject_Item extends CommonDBRelation
             $item->getFromDB($this->fields['items_id']);
 
             if (isset($this->input['_no_message_link'])) {
-                $display = htmlspecialchars($item->getNameID());
+                $display = htmlescape($item->getNameID());
             } else {
                 $display = $item->getLink();
             }
@@ -1628,7 +1628,7 @@ abstract class CommonItilObject_Item extends CommonDBRelation
         $rand = $params['rand'];
 
         if ($_SESSION["glpiactiveprofile"]["helpdesk_hardware"] == 0) {
-            echo "<input type='hidden' name='" . htmlspecialchars($myname) . "' value=''>";
+            echo "<input type='hidden' name='" . htmlescape($myname) . "' value=''>";
             echo "<input type='hidden' name='items_id' value='0'>";
         } else {
             echo "<div id='tracking_all_devices$rand' class='input-group mb-1'>";
@@ -1689,7 +1689,7 @@ abstract class CommonItilObject_Item extends CommonDBRelation
                     $CFG_GLPI["root_doc"] . "/ajax/dropdownTrackingDeviceType.php",
                     $p
                 );
-                echo "<span id='" . Html::cleanId("results_" . htmlspecialchars($myname) . "$rand") . "'>\n";
+                echo "<span id='" . Html::cleanId("results_" . htmlescape($myname) . "$rand") . "'>\n";
 
                // Display default value if itemtype is displayed
                 if (
@@ -1713,7 +1713,7 @@ abstract class CommonItilObject_Item extends CommonDBRelation
                         echo "<script type='text/javascript' >\n";
                         echo "$(function() {";
                         Ajax::updateItemJsCode(
-                            "results_" . htmlspecialchars($myname) . "$rand",
+                            "results_" . htmlescape($myname) . "$rand",
                             $CFG_GLPI["root_doc"] .
                                       "/ajax/dropdownTrackingDeviceType.php",
                             $p

--- a/src/CommonTreeDropdown.php
+++ b/src/CommonTreeDropdown.php
@@ -588,7 +588,7 @@ TWIG, $twig_params);
                 'itemtype' => static::class,
                 'id'       => $data['id'],
             ];
-            $name = htmlspecialchars($data['name']);
+            $name = htmlescape($data['name']);
             if (
                 (($fk === 'entities_id') && in_array($data['id'], $_SESSION['glpiactiveentities'], true))
                 || !$entity_assign
@@ -596,7 +596,7 @@ TWIG, $twig_params);
             ) {
                 $entry['name'] = sprintf(
                     '<a href="%s">%s</a>',
-                    htmlspecialchars(static::getFormURLWithID($data['id'])),
+                    htmlescape(static::getFormURLWithID($data['id'])),
                     $name
                 );
             } else {

--- a/src/Config.php
+++ b/src/Config.php
@@ -274,7 +274,7 @@ class Config extends CommonDBTM
        // Add skipMaintenance if maintenance mode update
         if (isset($input['maintenance_mode']) && $input['maintenance_mode']) {
             $_SESSION['glpiskipMaintenance'] = 1;
-            $url = htmlspecialchars($CFG_GLPI['root_doc'] . "/index.php?skipMaintenance=1");
+            $url = htmlescape($CFG_GLPI['root_doc'] . "/index.php?skipMaintenance=1");
             Session::addMessageAfterRedirect(
                 sprintf(
                     __s('Maintenance mode activated. Backdoor using: %s'),
@@ -1522,7 +1522,7 @@ class Config extends CommonDBTM
             echo $message . "\n";
         } else {
             $img = "<img src='" . $CFG_GLPI['root_doc'] . "/pics/";
-            $img .= ($error > 0 ? "ko_min" : "ok_min") . ".png' alt='" . htmlspecialchars($message) . "' title='" . htmlspecialchars($message) . "'/>";
+            $img .= ($error > 0 ? "ko_min" : "ok_min") . ".png' alt='" . htmlescape($message) . "' title='" . htmlescape($message) . "'/>";
 
             if ($fordebug) {
                 echo $img . $message . "\n";
@@ -1996,7 +1996,7 @@ class Config extends CommonDBTM
             'class'   => 'purgelog_interval'
         ], $options);
 
-        $out = "<div class='" . htmlspecialchars($options['class']) . "'>";
+        $out = "<div class='" . htmlescape($options['class']) . "'>";
         $out .= Dropdown::showFromArray($name, $values, $options);
         $out .= "</div>";
 

--- a/src/Consumable.php
+++ b/src/Consumable.php
@@ -446,7 +446,7 @@ class Consumable extends CommonDBChild
             if ($nohtml) {
                 $out = $tmptxt;
             } else {
-                $out = "<div $highlight>" . htmlspecialchars($tmptxt) . "</div>";
+                $out = "<div $highlight>" . htmlescape($tmptxt) . "</div>";
             }
         } else {
             if ($nohtml) {

--- a/src/ConsumableItem.php
+++ b/src/ConsumableItem.php
@@ -424,7 +424,7 @@ class ConsumableItem extends CommonDBTM
                              ) . " :  $message\n");
                                $task->addVolume(1);
                         } else {
-                             Session::addMessageAfterRedirect(htmlspecialchars(Dropdown::getDropdownName(
+                             Session::addMessageAfterRedirect(htmlescape(Dropdown::getDropdownName(
                                  "glpi_entities",
                                  $entity
                              ) . " :  $message"));
@@ -448,7 +448,7 @@ class ConsumableItem extends CommonDBTM
                         if ($task) {
                             $task->log($msg);
                         } else {
-                            Session::addMessageAfterRedirect(htmlspecialchars($msg), false, ERROR);
+                            Session::addMessageAfterRedirect(htmlescape($msg), false, ERROR);
                         }
                     }
                 }

--- a/src/Contact_Supplier.php
+++ b/src/Contact_Supplier.php
@@ -166,10 +166,10 @@ class Contact_Supplier extends CommonDBRelation
             $header_bottom .= "<th width='10'>" . Html::getCheckAllAsCheckbox('mass' . __CLASS__ . $rand);
             $header_bottom .= "</th>";
         }
-        $header_end .= "<th>" . htmlspecialchars(Supplier::getTypeName(1)) . "</th>";
-        $header_end .= "<th>" . htmlspecialchars(Entity::getTypeName(1)) . "</th>";
-        $header_end .= "<th>" . htmlspecialchars(SupplierType::getTypeName(1)) . "</th>";
-        $header_end .= "<th>" . htmlspecialchars(Phone::getTypeName(1)) . "</th>";
+        $header_end .= "<th>" . htmlescape(Supplier::getTypeName(1)) . "</th>";
+        $header_end .= "<th>" . htmlescape(Entity::getTypeName(1)) . "</th>";
+        $header_end .= "<th>" . htmlescape(SupplierType::getTypeName(1)) . "</th>";
+        $header_end .= "<th>" . htmlescape(Phone::getTypeName(1)) . "</th>";
         $header_end .= "<th>" . __s('Fax') . "</th>";
         $header_end .= "<th>" . __s('Website') . "</th>";
         $header_end .= "</tr>";
@@ -207,13 +207,13 @@ class Contact_Supplier extends CommonDBRelation
                 }
                 echo "<td class='center'>";
                 echo "<a href='" . Supplier::getFormURLWithID($data["id"]) . "'>" .
-                   htmlspecialchars(Dropdown::getDropdownName("glpi_suppliers", $data["id"])) . "</a></td>";
-                echo "<td class='center'>" . htmlspecialchars(Dropdown::getDropdownName("glpi_entities", $data["entity"]));
+                   htmlescape(Dropdown::getDropdownName("glpi_suppliers", $data["id"])) . "</a></td>";
+                echo "<td class='center'>" . htmlescape(Dropdown::getDropdownName("glpi_entities", $data["entity"]));
                 echo "</td>";
-                echo "<td class='center'>" . htmlspecialchars(Dropdown::getDropdownName("glpi_suppliertypes", $data["suppliertypes_id"]));
+                echo "<td class='center'>" . htmlescape(Dropdown::getDropdownName("glpi_suppliertypes", $data["suppliertypes_id"]));
                 echo "</td>";
-                echo "<td class='center' width='80'>" . htmlspecialchars($data["phonenumber"]) . "</td>";
-                echo "<td class='center' width='80'>" . htmlspecialchars($data["fax"]) . "</td>";
+                echo "<td class='center' width='80'>" . htmlescape($data["phonenumber"]) . "</td>";
+                echo "<td class='center' width='80'>" . htmlescape($data["fax"]) . "</td>";
                 echo "<td class='center'>" . $website . "</td>";
                 echo "</tr>";
             }
@@ -302,8 +302,8 @@ class Contact_Supplier extends CommonDBRelation
             $header_bottom .= "</th>";
         }
         $header_end .= "<th>" . __s('Name') . "</th>";
-        $header_end .= "<th>" . htmlspecialchars(Entity::getTypeName(1)) . "</th>";
-        $header_end .= "<th>" . htmlspecialchars(Phone::getTypeName(1)) . "</th>";
+        $header_end .= "<th>" . htmlescape(Entity::getTypeName(1)) . "</th>";
+        $header_end .= "<th>" . htmlescape(Phone::getTypeName(1)) . "</th>";
         $header_end .= "<th>" . __s('Phone 2') . "</th>";
         $header_end .= "<th>" . __s('Mobile phone') . "</th>";
         $header_end .= "<th>" . __s('Fax') . "</th>";
@@ -333,18 +333,18 @@ class Contact_Supplier extends CommonDBRelation
                 }
                 echo "<td class='center'>";
                 echo "<a href='" . Contact::getFormURLWithID($data["id"]) . "'>" .
-                   htmlspecialchars(sprintf(__('%1$s %2$s'), $data["name"], $data["firstname"])) . "</a></td>";
+                   htmlescape(sprintf(__('%1$s %2$s'), $data["name"], $data["firstname"])) . "</a></td>";
                 echo "<td class='center' width='100'>" . Dropdown::getDropdownName(
                     "glpi_entities",
                     $data["entity"]
                 );
                  echo "</td>";
-                 echo "<td class='center' width='100'>" . htmlspecialchars($data["phone"]) . "</td>";
-                 echo "<td class='center' width='100'>" . htmlspecialchars($data["phone2"]) . "</td>";
-                 echo "<td class='center' width='100'>" . htmlspecialchars($data["mobile"]) . "</td>";
-                 echo "<td class='center' width='100'>" . htmlspecialchars($data["fax"]) . "</td>";
+                 echo "<td class='center' width='100'>" . htmlescape($data["phone"]) . "</td>";
+                 echo "<td class='center' width='100'>" . htmlescape($data["phone2"]) . "</td>";
+                 echo "<td class='center' width='100'>" . htmlescape($data["mobile"]) . "</td>";
+                 echo "<td class='center' width='100'>" . htmlescape($data["fax"]) . "</td>";
                  echo "<td class='center'>";
-                 echo "<a href='mailto:" . htmlspecialchars($data["email"]) . "'>" . htmlspecialchars($data["email"]) . "</a></td>";
+                 echo "<a href='mailto:" . htmlescape($data["email"]) . "'>" . htmlescape($data["email"]) . "</a></td>";
                  echo "<td class='center'>" . Dropdown::getDropdownName(
                      "glpi_contacttypes",
                      $data["contacttypes_id"]

--- a/src/Contract.php
+++ b/src/Contract.php
@@ -1065,7 +1065,7 @@ class Contract extends CommonDBTM
         ]);
         $out    = "";
         foreach ($iterator as $data) {
-            $out .= htmlspecialchars(Dropdown::getDropdownName("glpi_suppliers", $data['id'])) . "<br>";
+            $out .= htmlescape(Dropdown::getDropdownName("glpi_suppliers", $data['id'])) . "<br>";
         }
         return $out;
     }
@@ -1346,7 +1346,7 @@ class Contract extends CommonDBTM
                             $task->log(sprintf(__('%1$s: %2$s') . "\n", $entityname, $message));
                             $task->addVolume(1);
                         } else {
-                            Session::addMessageAfterRedirect(htmlspecialchars(sprintf(
+                            Session::addMessageAfterRedirect(htmlescape(sprintf(
                                 __('%1$s: %2$s'),
                                 $entityname,
                                 $message
@@ -1371,7 +1371,7 @@ class Contract extends CommonDBTM
                         if ($task) {
                             $task->log($msg);
                         } else {
-                            Session::addMessageAfterRedirect(htmlspecialchars($msg), false, ERROR);
+                            Session::addMessageAfterRedirect(htmlescape($msg), false, ERROR);
                         }
                     }
                 }

--- a/src/ContractCost.php
+++ b/src/ContractCost.php
@@ -363,8 +363,8 @@ TWIG, $twig_params);
             ) : $data['name'];
             $name = sprintf(
                 __('%1$s %2$s'),
-                htmlspecialchars($name),
-                Html::showToolTip(htmlspecialchars($data['comment']), ['display' => false])
+                htmlescape($name),
+                Html::showToolTip(htmlescape($data['comment']), ['display' => false])
             );
             if (!isset($budget_cache[$data['budgets_id']])) {
                 $budget_cache[$data['budgets_id']] = Dropdown::getDropdownName(table: 'glpi_budgets', id: $data['budgets_id'], default: '');

--- a/src/CronTask.php
+++ b/src/CronTask.php
@@ -1164,7 +1164,7 @@ class CronTask extends CommonDBTM
                 'date'     => sprintf(
                     '<a href="javascript:reloadTab(\'crontasklogs_id=%s\');">%s</a>',
                     $data['id'],
-                    htmlspecialchars(Html::convDateTime($data['date']))
+                    htmlescape(Html::convDateTime($data['date']))
                 ),
                 'elapsed'  => $data['elapsed'],
                 'volume'   => $data['volume'],
@@ -1955,7 +1955,7 @@ TWIG, ['msg' => __('Last run list')]);
             $msg = __('Automatic actions may not be running as expected');
             $params = [
                 'msg' => $msg,
-                'warnings' => '<ul>' . implode('', array_map(static fn ($warning) => '<li>' . htmlspecialchars($warning) . '</li>', $warnings)) . '</ul>'
+                'warnings' => '<ul>' . implode('', array_map(static fn ($warning) => '<li>' . htmlescape($warning) . '</li>', $warnings)) . '</ul>'
             ];
             echo TemplateRenderer::getInstance()->renderFromStringTemplate(<<<TWIG
                 <span class="alert alert-warning p-1 ps-2">

--- a/src/Database.php
+++ b/src/Database.php
@@ -382,7 +382,7 @@ class Database extends CommonDBChild
 
         if ($canedit) {
             echo "<div class='center firstbloc'>" .
-            "<a class='btn btn-primary' href='" . htmlspecialchars(static::getFormURL()) . "?databaseinstances_id=$ID'>";
+            "<a class='btn btn-primary' href='" . htmlescape(static::getFormURL()) . "?databaseinstances_id=$ID'>";
             echo __s('Add a database');
             echo "</a></div>\n";
         }
@@ -413,7 +413,7 @@ class Database extends CommonDBChild
         if (empty($databases)) {
             echo "<tr><th>" . __s('No database') . "</th></tr>";
         } else {
-            echo "<tr class='noHover'><th colspan='10'>" . htmlspecialchars(self::getTypeName(Session::getPluralNumber())) . "</th></tr>";
+            echo "<tr class='noHover'><th colspan='10'>" . htmlescape(self::getTypeName(Session::getPluralNumber())) . "</th></tr>";
 
             $header = "<tr><th>" . __s('Name') . "</th>";
             $header .= "<th>" . sprintf(__('%1$s (%2$s)'), __s('Size'), __s('Mio')) . "</th>";
@@ -457,7 +457,7 @@ class Database extends CommonDBChild
     public static function getAdditionalMenuLinks()
     {
         $links = [];
-        $label = htmlspecialchars(DatabaseInstance::getTypeName(Session::getPluralNumber()));
+        $label = htmlescape(DatabaseInstance::getTypeName(Session::getPluralNumber()));
         if (static::canView()) {
             $insts = "<i class=\"ti ti-database-import\" title=\"$label\"" .
             "></i><span class='d-none d-xxl-block'>$label</span>";

--- a/src/DatabaseInstance.php
+++ b/src/DatabaseInstance.php
@@ -346,7 +346,7 @@ class DatabaseInstance extends CommonDBTM
                     if ($values[$field] > 0) {
                         $item = new $itemtype();
                         if ($item->getFromDB($values[$field])) {
-                            return "<a href='" . htmlspecialchars($item->getLinkURL()) . "'>" . htmlspecialchars($item->fields['name']) . "</a>";
+                            return "<a href='" . htmlescape($item->getLinkURL()) . "'>" . htmlescape($item->fields['name']) . "</a>";
                         } else {
                             return ' ';
                         }

--- a/src/Datacenter.php
+++ b/src/Datacenter.php
@@ -200,7 +200,7 @@ class Datacenter extends CommonDBTM
     public static function getAdditionalMenuLinks()
     {
         $links = [];
-        $label = htmlspecialchars(DCRoom::getTypeName(Session::getPluralNumber()));
+        $label = htmlescape(DCRoom::getTypeName(Session::getPluralNumber()));
         if (static::canView()) {
             $rooms = "<i class='ti ti-building pointer'
                       title=\"$label\"></i>

--- a/src/DbUtils.php
+++ b/src/DbUtils.php
@@ -1479,7 +1479,7 @@ final class DbUtils
                 $comment  = sprintf(
                     __('%1$s: %2$s') . "<br>",
                     "<span class='b'>" . __('Complete name') . "</span>",
-                    htmlspecialchars($name)
+                    htmlescape($name)
                 );
                 if ($table == Location::getTable()) {
                     $acomment = '';
@@ -1490,14 +1490,14 @@ final class DbUtils
                     $alias   = $result['alias'];
                     if (!empty($alias)) {
                         $name = $alias;
-                        $comment .= "<span class='b'>" . __s('Alias:') . "</span> " . htmlspecialchars($alias) . "<br/>";
+                        $comment .= "<span class='b'>" . __s('Alias:') . "</span> " . htmlescape($alias) . "<br/>";
                     }
                     if (!empty($code)) {
                         $name .= ' - ' . $code;
-                        $comment .= "<span class='b'>" . __s('Code:') . "</span> " . htmlspecialchars($code) . "<br/>";
+                        $comment .= "<span class='b'>" . __s('Code:') . "</span> " . htmlescape($code) . "<br/>";
                     }
                     if (!empty($address)) {
-                        $acomment .= htmlspecialchars($address);
+                        $acomment .= htmlescape($address);
                     }
                     if (
                         !empty($address) &&
@@ -1506,13 +1506,13 @@ final class DbUtils
                         $acomment .= '<br/>';
                     }
                     if (!empty($town)) {
-                        $acomment .= htmlspecialchars($town);
+                        $acomment .= htmlescape($town);
                     }
                     if (!empty($country)) {
                         if (!empty($town)) {
                             $acomment .= ' - ';
                         }
-                        $acomment .= htmlspecialchars($country);
+                        $acomment .= htmlescape($country);
                     }
                     if (trim($acomment) != '') {
                         $comment .= "<span class='b'>&nbsp;" . __s('Address:') . "</span> " . $acomment . "<br/>";
@@ -1783,14 +1783,14 @@ final class DbUtils
         $username = $this->formatUserName($id, $login, $realname, $firstname);
 
         if ($id <= 0 || !User::canView()) {
-            return htmlspecialchars($username);
+            return htmlescape($username);
         }
 
         return sprintf(
             '<a title="%s" href="%s">%s</a>',
-            htmlspecialchars($username),
+            htmlescape($username),
             User::getFormURLWithID($id),
-            htmlspecialchars($username)
+            htmlescape($username)
         );
     }
 
@@ -1833,8 +1833,8 @@ final class DbUtils
         if ($link == 1) {
             Toolbox::deprecated('Usage of `$link` parameter is deprecated. Use `getUserLink()` instead.');
             return $valid_user
-                ? sprintf('<a title="%s" href="%s">%s</a>', htmlspecialchars($username), User::getFormURLWithID($ID), htmlspecialchars($username))
-                : htmlspecialchars($username);
+                ? sprintf('<a title="%s" href="%s">%s</a>', htmlescape($username), User::getFormURLWithID($ID), htmlescape($username))
+                : htmlescape($username);
         }
 
         if ($link == 2) {
@@ -1862,14 +1862,14 @@ final class DbUtils
         $username = $this->getUserName($id);
 
         if (!is_int($id) || $id <= 0 || !User::canView()) {
-            return htmlspecialchars($username);
+            return htmlescape($username);
         }
 
         return sprintf(
             '<a title="%s" href="%s">%s</a>',
-            htmlspecialchars($username),
+            htmlescape($username),
             User::getFormURLWithID($id),
-            htmlspecialchars($username)
+            htmlescape($username)
         );
     }
 

--- a/src/DefaultFilter.php
+++ b/src/DefaultFilter.php
@@ -182,7 +182,7 @@ class DefaultFilter extends CommonDBTM implements FilterableInterface
 
         if ($this->getFromDBByCrit($criteria)) {
             Session::addMessageAfterRedirect(
-                htmlspecialchars(sprintf(
+                htmlescape(sprintf(
                     __('Itemtype %s is already in use'),
                     $input['itemtype']
                 )),

--- a/src/Document.php
+++ b/src/Document.php
@@ -160,7 +160,7 @@ class Document extends CommonDBTM
                 ) <= 1)
             ) {
                 if (unlink(GLPI_DOC_DIR . "/" . $this->fields["filepath"])) {
-                    Session::addMessageAfterRedirect(htmlspecialchars(sprintf(
+                    Session::addMessageAfterRedirect(htmlescape(sprintf(
                         __('Successful deletion of the file %s'),
                         $this->fields["filepath"]
                     )));
@@ -173,7 +173,7 @@ class Document extends CommonDBTM
                         E_USER_WARNING
                     );
                     Session::addMessageAfterRedirect(
-                        htmlspecialchars(sprintf(
+                        htmlescape(sprintf(
                             __('Failed to delete the file %s'),
                             $this->fields["filepath"]
                         )),
@@ -447,10 +447,10 @@ class Document extends CommonDBTM
 
         $initfileout = null;
         if ($fileout !== null) {
-            $initfileout = htmlspecialchars($fileout);
+            $initfileout = htmlescape($fileout);
             $fileout     = Toolbox::strlen($fileout) > $len
-                ? htmlspecialchars(Toolbox::substr($fileout, 0, $len)) . "&hellip;"
-                : htmlspecialchars($fileout);
+                ? htmlescape(Toolbox::substr($fileout, 0, $len)) . "&hellip;"
+                : htmlescape($fileout);
         }
 
         $out   = '';
@@ -1043,7 +1043,7 @@ class Document extends CommonDBTM
                 E_USER_WARNING
             );
             Session::addMessageAfterRedirect(
-                htmlspecialchars(sprintf(__('File %s not found.'), $filename)),
+                htmlescape(sprintf(__('File %s not found.'), $filename)),
                 false,
                 ERROR
             );
@@ -1070,7 +1070,7 @@ class Document extends CommonDBTM
             ) <= 1)
         ) {
             if (unlink(GLPI_DOC_DIR . "/" . $input['current_filepath'])) {
-                Session::addMessageAfterRedirect(htmlspecialchars(sprintf(
+                Session::addMessageAfterRedirect(htmlescape(sprintf(
                     __('Successful deletion of the file %s'),
                     $input['current_filename']
                 )));
@@ -1085,7 +1085,7 @@ class Document extends CommonDBTM
                     E_USER_WARNING
                 );
                 Session::addMessageAfterRedirect(
-                    htmlspecialchars(sprintf(
+                    htmlescape(sprintf(
                         __('Failed to delete the file %1$s'),
                         $input['current_filename']
                     )),

--- a/src/DocumentType.php
+++ b/src/DocumentType.php
@@ -130,7 +130,7 @@ class DocumentType extends CommonDropdown
             case 'icon':
                 if (!empty($values[$field])) {
                     return "&nbsp;<img style='vertical-align:middle;' alt='' src='" .
-                      htmlspecialchars($CFG_GLPI["typedoc_icon_dir"] . "/" . $values[$field]) . "'>";
+                      htmlescape($CFG_GLPI["typedoc_icon_dir"] . "/" . $values[$field]) . "'>";
                 }
         }
         return parent::getSpecificValueToDisplay($field, $values, $options);

--- a/src/Document_Item.php
+++ b/src/Document_Item.php
@@ -188,7 +188,7 @@ class Document_Item extends CommonDBRelation
                         __('Mandatory fields are not filled. Please correct: %s'),
                         Document::getTypeName(Session::getPluralNumber())
                     );
-                    Session::addMessageAfterRedirect(htmlspecialchars($message), false, ERROR);
+                    Session::addMessageAfterRedirect(htmlescape($message), false, ERROR);
                     return false;
                 }
             }
@@ -443,7 +443,7 @@ TWIG, $twig_params);
                     }
 
                     $link     = $itemtype::getFormURLWithID($data['id']);
-                    $name = '<a href="' . htmlspecialchars($link) . '">' . htmlspecialchars($linkname) . ' ' . htmlspecialchars($linkname_extra) . "</a>";
+                    $name = '<a href="' . htmlescape($link) . '">' . htmlescape($linkname) . ' ' . htmlescape($linkname_extra) . "</a>";
 
                     $entity_name = '-';
                     if (isset($data['entity'])) {
@@ -698,7 +698,7 @@ TWIG, $twig_params);
             }
 
             $link = !empty($data["link"])
-                ? '<a target="_blank" href="' . htmlspecialchars(Toolbox::formatOutputWebLink($data["link"])) . '">' . htmlspecialchars($data["link"]) . "</a>"
+                ? '<a target="_blank" href="' . htmlescape(Toolbox::formatOutputWebLink($data["link"])) . '">' . htmlescape($data["link"]) . "</a>"
                 : '';
 
             if (!isset($category_names[$data["documentcategories_id"]])) {

--- a/src/Domain.php
+++ b/src/Domain.php
@@ -743,7 +743,7 @@ class Domain extends CommonDBTM
                             $task->log($msg);
                             $task->addVolume(1);
                         } else {
-                            Session::addMessageAfterRedirect(htmlspecialchars($msg));
+                            Session::addMessageAfterRedirect(htmlescape($msg));
                         }
 
                         // Add alert
@@ -767,7 +767,7 @@ class Domain extends CommonDBTM
                         if ($task) {
                             $task->log($msg);
                         } else {
-                            Session::addMessageAfterRedirect(htmlspecialchars($msg), false, ERROR);
+                            Session::addMessageAfterRedirect(htmlescape($msg), false, ERROR);
                         }
                     }
                 }
@@ -850,7 +850,7 @@ class Domain extends CommonDBTM
     {
         $links = [];
         if (static::canManageRecords()) {
-            $label = htmlspecialchars(DomainRecord::getTypeName(Session::getPluralNumber()));
+            $label = htmlescape(DomainRecord::getTypeName(Session::getPluralNumber()));
             $rooms = "<i class='fa fa-clipboard-list pointer' title=\"$label\"></i>
             <span class='d-none d-xxl-block ps-1'>$label</span>";
             $links[$rooms] = DomainRecord::getSearchURL(false);

--- a/src/DomainRecord.php
+++ b/src/DomainRecord.php
@@ -485,8 +485,8 @@ TWIG, $twig_params);
                 'type'     => Dropdown::getDropdownName(DomainRecordType::getTable(), $data['domainrecordtypes_id']),
                 'name'     => sprintf(
                     '<a href="%s">%s</a>',
-                    htmlspecialchars(DomainRecord::getFormURLWithID($data['id'])),
-                    htmlspecialchars($name)
+                    htmlescape(DomainRecord::getFormURLWithID($data['id'])),
+                    htmlescape($name)
                 ),
                 'ttl'      => $data['ttl'],
                 'data'     => $data['data']

--- a/src/DomainRecordType.php
+++ b/src/DomainRecordType.php
@@ -222,7 +222,7 @@ class DomainRecordType extends CommonDropdown
         switch ($field_type) {
             case 'fields':
                 $printable = json_encode(json_decode($field_value), JSON_PRETTY_PRINT);
-                echo '<textarea name="' . $field_name . '" cols="75" rows="25">' . htmlspecialchars($printable) . '</textarea >';
+                echo '<textarea name="' . $field_name . '" cols="75" rows="25">' . htmlescape($printable) . '</textarea >';
                 break;
         }
     }

--- a/src/Domain_Item.php
+++ b/src/Domain_Item.php
@@ -295,8 +295,8 @@ TWIG, $twig_params);
                     'type'     => $itemtype_name,
                     'name'     => sprintf(
                         '<a href="%s">%s</a>',
-                        htmlspecialchars($itemtype::getFormURLWithID($linked_data['id'])),
-                        htmlspecialchars($name)
+                        htmlescape($itemtype::getFormURLWithID($linked_data['id'])),
+                        htmlescape($name)
                     ),
                     'serial'   => $linked_data["serial"] ?? '-',
                     'otherserial' => $linked_data["otherserial"] ?? '-',
@@ -549,7 +549,7 @@ TWIG, $twig_params);
                 $relation_names[$data['domainrelations_id']] = Dropdown::getDropdownName(table: "glpi_domainrelations", id: $data['domainrelations_id'], default: '');
             }
 
-            $expiration = htmlspecialchars(Html::convDate($data["date_expiration"]));
+            $expiration = htmlescape(Html::convDate($data["date_expiration"]));
             if (
                 !empty($data["date_expiration"])
                 && $data["date_expiration"] <= date('Y-m-d')

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -624,36 +624,36 @@ class Dropdown
                             if (!empty($data["phone"])) {
                                 $comment .= "<br>" . sprintf(
                                     __('%1$s: %2$s'),
-                                    "<span class='b'>" . htmlspecialchars(Phone::getTypeName(1)),
-                                    "</span>" . htmlspecialchars($data['phone'])
+                                    "<span class='b'>" . htmlescape(Phone::getTypeName(1)),
+                                    "</span>" . htmlescape($data['phone'])
                                 );
                             }
                             if (!empty($data["phone2"])) {
                                 $comment .= "<br>" . sprintf(
                                     __('%1$s: %2$s'),
                                     "<span class='b'>" . __s('Phone 2'),
-                                    "</span>" . htmlspecialchars($data['phone2'])
+                                    "</span>" . htmlescape($data['phone2'])
                                 );
                             }
                             if (!empty($data["mobile"])) {
                                 $comment .= "<br>" . sprintf(
                                     __('%1$s: %2$s'),
                                     "<span class='b'>" . __s('Mobile phone'),
-                                    "</span>" . htmlspecialchars($data['mobile'])
+                                    "</span>" . htmlescape($data['mobile'])
                                 );
                             }
                             if (!empty($data["fax"])) {
                                 $comment .= "<br>" . sprintf(
                                     __('%1$s: %2$s'),
                                     "<span class='b'>" . __s('Fax'),
-                                    "</span>" . htmlspecialchars($data['fax'])
+                                    "</span>" . htmlescape($data['fax'])
                                 );
                             }
                             if (!empty($data["email"])) {
                                 $comment .= "<br>" . sprintf(
                                     __('%1$s: %2$s'),
                                     "<span class='b'>" . _n('Email', 'Emails', 1),
-                                    "</span>" . htmlspecialchars($data['email'])
+                                    "</span>" . htmlescape($data['email'])
                                 );
                             }
                         }
@@ -664,22 +664,22 @@ class Dropdown
                             if (!empty($data["phonenumber"])) {
                                  $comment .= "<br>" . sprintf(
                                      __('%1$s: %2$s'),
-                                     "<span class='b'>" . htmlspecialchars(Phone::getTypeName(1)),
-                                     "</span>" . htmlspecialchars($data['phonenumber'])
+                                     "<span class='b'>" . htmlescape(Phone::getTypeName(1)),
+                                     "</span>" . htmlescape($data['phonenumber'])
                                  );
                             }
                             if (!empty($data["fax"])) {
                                 $comment .= "<br>" . sprintf(
                                     __('%1$s: %2$s'),
                                     "<span class='b'>" . __s('Fax'),
-                                    "</span>" . htmlspecialchars($data['fax'])
+                                    "</span>" . htmlescape($data['fax'])
                                 );
                             }
                             if (!empty($data["email"])) {
                                 $comment .= "<br>" . sprintf(
                                     __('%1$s: %2$s'),
                                     "<span class='b'>" . _sn('Email', 'Emails', 1),
-                                    "</span>" . htmlspecialchars($data['email'])
+                                    "</span>" . htmlescape($data['email'])
                                 );
                             }
                         }
@@ -703,7 +703,7 @@ class Dropdown
                             if (!empty($data['locations_id'])) {
                                  $comment .= "<br>" . sprintf(
                                      __('%1$s: %2$s'),
-                                     "<span class='b'>" . htmlspecialchars(Location::getTypeName(1)) . "</span>",
+                                     "<span class='b'>" . htmlescape(Location::getTypeName(1)) . "</span>",
                                      self::getDropdownName(
                                          "glpi_locations",
                                          $data["locations_id"],
@@ -1380,7 +1380,7 @@ JAVASCRIPT;
         echo "<div class='container-fluid text-start'>";
         echo "<div class='mb-3 row'>";
 
-        $title = htmlspecialchars($title);
+        $title = htmlescape($title);
         echo "<label class='col-sm-1 col-form-label'>$title</label>";
         $selected = '';
 
@@ -2298,37 +2298,37 @@ JAVASCRIPT;
         if ($param['readonly']) {
             $to_display = [];
             foreach ($param['values'] as $value) {
-                $output .= "<input type='hidden' name='" . htmlspecialchars($field_name) . "' value='" . htmlspecialchars($value) . "'>";
+                $output .= "<input type='hidden' name='" . htmlescape($field_name) . "' value='" . htmlescape($value) . "'>";
                 if (isset($elements[$value])) {
-                    $to_display[] = htmlspecialchars($elements[$value]);
+                    $to_display[] = htmlescape($elements[$value]);
                 }
             }
-            $output .= '<span class="form-control" readonly style="width: ' . htmlspecialchars($param["width"]) . '">' . implode(', ', $to_display) . '</span>';
+            $output .= '<span class="form-control" readonly style="width: ' . htmlescape($param["width"]) . '">' . implode(', ', $to_display) . '</span>';
         } else {
             if ($param['multiple']) {
                 // Fix for multiple select not sending any form data when no option is selected
-                $output .= "<input type='hidden' name='" . htmlspecialchars($original_field_name) . "' value=''>";
+                $output .= "<input type='hidden' name='" . htmlescape($original_field_name) . "' value=''>";
             }
-            $output  .= "<select name='" . htmlspecialchars($field_name) . "' id='" . htmlspecialchars($field_id) . "'";
+            $output  .= "<select name='" . htmlescape($field_name) . "' id='" . htmlescape($field_id) . "'";
 
             if ($param['width'] !== '') {
-                $output .= " style='width: " . htmlspecialchars($param['width']) . "'";
+                $output .= " style='width: " . htmlescape($param['width']) . "'";
             }
 
             if ($param['tooltip']) {
-                $output .= ' title="' . htmlspecialchars($param['tooltip']) . '"';
+                $output .= ' title="' . htmlescape($param['tooltip']) . '"';
             }
 
             if ($param['class']) {
-                $output .= ' class="' . htmlspecialchars($param['class']) . '"';
+                $output .= ' class="' . htmlescape($param['class']) . '"';
             }
 
             if (!empty($param["on_change"])) {
-                $output .= " onChange='" . htmlspecialchars($param["on_change"]) . "'";
+                $output .= " onChange='" . htmlescape($param["on_change"]) . "'";
             }
 
             if ((is_int($param["size"])) && ($param["size"] > 0)) {
-                $output .= " size='" . htmlspecialchars($param["size"]) . "'";
+                $output .= " size='" . htmlescape($param["size"]) . "'";
             }
 
             if ($param["multiple"]) {
@@ -2348,14 +2348,14 @@ JAVASCRIPT;
             }
 
             if ($param['aria_label'] !== '') {
-                $output .= " aria-label='" . htmlspecialchars($param['aria_label']) . "'";
+                $output .= " aria-label='" . htmlescape($param['aria_label']) . "'";
             }
 
             if (!empty($param['add_data_attributes'])) {
                 if (is_array($param['add_data_attributes'])) {
                     $output .= implode(' ', array_map(
                         function ($key, $value) {
-                            return htmlspecialchars('data-' . $key) . '="' . htmlspecialchars($value) . '"';
+                            return htmlescape('data-' . $key) . '="' . htmlescape($value) . '"';
                         },
                         array_keys($param['add_data_attributes']),
                         $param['add_data_attributes']
@@ -2368,7 +2368,7 @@ JAVASCRIPT;
             foreach ($elements as $key => $val) {
                // optgroup management
                 if (is_array($val)) {
-                    $opt_goup = htmlspecialchars($key);
+                    $opt_goup = htmlescape($key);
                     if ($max_option_size < strlen($opt_goup)) {
                         $max_option_size = strlen($opt_goup);
                     }
@@ -2378,18 +2378,18 @@ JAVASCRIPT;
                     if (isset($param['option_tooltips'][$key])) {
                         if (is_array($param['option_tooltips'][$key])) {
                             if (isset($param['option_tooltips'][$key]['__optgroup_label'])) {
-                                $output .= ' title="' . htmlspecialchars($param['option_tooltips'][$key]['__optgroup_label']) . '"';
+                                $output .= ' title="' . htmlescape($param['option_tooltips'][$key]['__optgroup_label']) . '"';
                             }
                             $optgroup_tooltips = $param['option_tooltips'][$key];
                         } else {
-                            $output .= ' title="' . htmlspecialchars($param['option_tooltips'][$key]) . '"';
+                            $output .= ' title="' . htmlescape($param['option_tooltips'][$key]) . '"';
                         }
                     }
                     $output .= ">";
 
                     foreach ($val as $key2 => $val2) {
                         if (!isset($param['used'][$key2])) {
-                            $output .= "<option value='" . htmlspecialchars($key2) . "'";
+                            $output .= "<option value='" . htmlescape($key2) . "'";
                            // Do not use in_array : trouble with 0 and empty value
                             foreach ($param['values'] as $value) {
                                 if (strcmp($key2, $value) === 0) {
@@ -2398,9 +2398,9 @@ JAVASCRIPT;
                                 }
                             }
                             if ($optgroup_tooltips && isset($optgroup_tooltips[$key2])) {
-                                $output .= ' title="' . htmlspecialchars($optgroup_tooltips[$key2]) . '"';
+                                $output .= ' title="' . htmlescape($optgroup_tooltips[$key2]) . '"';
                             }
-                            $output .= ">" .  htmlspecialchars($val2) . "</option>";
+                            $output .= ">" .  htmlescape($val2) . "</option>";
                             if ($max_option_size < strlen($val2)) {
                                 $max_option_size = strlen($val2);
                             }
@@ -2409,7 +2409,7 @@ JAVASCRIPT;
                     $output .= "</optgroup>";
                 } else {
                     if (!isset($param['used'][$key])) {
-                        $output .= "<option value='" . htmlspecialchars($key) . "'";
+                        $output .= "<option value='" . htmlescape($key) . "'";
                        // Do not use in_array : trouble with 0 and empty value
                         foreach ($param['values'] as $value) {
                             if (strcmp($key, $value) === 0) {
@@ -2418,9 +2418,9 @@ JAVASCRIPT;
                             }
                         }
                         if (isset($param['option_tooltips'][$key])) {
-                            $output .= ' title="' . htmlspecialchars($param['option_tooltips'][$key]) . '"';
+                            $output .= ' title="' . htmlescape($param['option_tooltips'][$key]) . '"';
                         }
-                        $output .= ">" . htmlspecialchars($val) . "</option>";
+                        $output .= ">" . htmlescape($val) . "</option>";
                         if (!is_null($val) && ($max_option_size < strlen($val))) {
                             $max_option_size = strlen($val);
                         }
@@ -2429,7 +2429,7 @@ JAVASCRIPT;
             }
 
             if ($param['other'] !== false) {
-                $output .= "<option value='" . htmlspecialchars($other_select_option) . "'";
+                $output .= "<option value='" . htmlescape($other_select_option) . "'";
                 if (is_string($param['other'])) {
                     $output .= " selected";
                 }
@@ -2438,9 +2438,9 @@ JAVASCRIPT;
 
             $output .= "</select>";
             if ($param['other'] !== false) {
-                $output .= "<input name='" . htmlspecialchars($other_select_option) . "' id='" . htmlspecialchars($other_select_option) . "' type='text'";
+                $output .= "<input name='" . htmlescape($other_select_option) . "' id='" . htmlescape($other_select_option) . "' type='text'";
                 if (is_string($param['other'])) {
-                    $output .= " value=\"" . htmlspecialchars($param['other']) . "\"";
+                    $output .= " value=\"" . htmlescape($param['other']) . "\"";
                 } else {
                     $output .= " style=\"display: none\"";
                 }
@@ -2463,7 +2463,7 @@ JAVASCRIPT;
            // Hack for All / None because select2 does not provide it
             $select   = __('All');
             $deselect = __('None');
-            $output  .= "<div class='invisible' id='selectallbuttons_" . htmlspecialchars($field_id) . "'>";
+            $output  .= "<div class='invisible' id='selectallbuttons_" . htmlescape($field_id) . "'>";
             $output  .= "<div class='d-flex justify-content-around p-1'>";
             $output  .= "<a class='btn btn-sm' " .
                       "onclick=\"selectAll('$field_id');$('#$field_id').select2('close');\">$select" .
@@ -2604,7 +2604,7 @@ JAVASCRIPT;
                // Templates edition
                 if (!empty($params['withtemplate'])) {
                     echo "<input type='hidden' name='is_global' value='" .
-                        htmlspecialchars($params['management_restrict']) . "'>";
+                        htmlescape($params['management_restrict']) . "'>";
                     echo (!$params['management_restrict'] ? __s('Unit management') : __s('Global management'));
                 } else {
                     echo (!$params['value'] ? __s('Unit management') : __s('Global management'));

--- a/src/DropdownTranslation.php
+++ b/src/DropdownTranslation.php
@@ -415,7 +415,7 @@ TWIG, $twig_params);
             if (($matching_field['type'] ?? null) === 'tinymce') {
                 $entry['value'] = '<div class="rich_text_container">' . RichText::getSafeHtml($data['value']) . '</div>';
             } else {
-                $entry['value'] = htmlspecialchars($data['value']);
+                $entry['value'] = htmlescape($data['value']);
             }
             $entries[] = $entry;
         }

--- a/src/Entity.php
+++ b/src/Entity.php
@@ -2879,7 +2879,7 @@ class Entity extends CommonTreeDropdown
         if ($this->fields[$field] == self::CONFIG_PARENT) {
             $tid = self::getUsedConfig(str_replace('_id', '_strategy', $field), $this->getID(), $field, $default_value);
             if (!$tid) {
-                return self::inheritedValue(htmlspecialchars($empty_value), true, false);
+                return self::inheritedValue(htmlescape($empty_value), true, false);
             }
             if ($item->getFromDB($tid)) {
                 return self::inheritedValue($item->getLink(), true, false);
@@ -2936,12 +2936,12 @@ class Entity extends CommonTreeDropdown
 
         // Construct HTML with special chars encoded.
         if ($title === null) {
-            $title = htmlspecialchars(implode(' > ', $names));
+            $title = htmlescape(implode(' > ', $names));
         }
         $breadcrumbs = implode(
             '<i class="fas fa-caret-right mx-1"></i>',
             array_map(
-                static fn (string $name) => '<span class="text-nowrap">' . htmlspecialchars($name) . '</span>',
+                static fn (string $name) => '<span class="text-nowrap">' . htmlescape($name) . '</span>',
                 $names
             )
         );
@@ -2977,17 +2977,17 @@ class Entity extends CommonTreeDropdown
         $names = explode(' > ', trim($entity->fields['completename']));
 
         // Construct HTML with special chars encoded.
-        $title       = htmlspecialchars(implode(' > ', $names));
+        $title       = htmlescape(implode(' > ', $names));
         $last_name   = array_pop($names);
         $breadcrumbs = implode(
             '<i class="fas fa-caret-right mx-1"></i>',
             array_map(
-                static fn (string $name) => '<span class="text-nowrap text-muted">' . htmlspecialchars($name) . '</span>',
+                static fn (string $name) => '<span class="text-nowrap text-muted">' . htmlescape($name) . '</span>',
                 $names
             )
         );
 
-        $last_url  = '<i class="fas fa-caret-right mx-1"></i>' . '<a href="' . $entity->getLinkURL() . '" title="' . $title . '">' . htmlspecialchars($last_name) . '</a>';
+        $last_url  = '<i class="fas fa-caret-right mx-1"></i>' . '<a href="' . $entity->getLinkURL() . '" title="' . $title . '">' . htmlescape($last_name) . '</a>';
 
         return '<span class="glpi-badge" title="' . $title . '">' . $breadcrumbs . $last_url . '</span>';
     }

--- a/src/FQDNLabel.php
+++ b/src/FQDNLabel.php
@@ -120,7 +120,7 @@ abstract class FQDNLabel extends CommonDBChild
 
            // Before adding a name, we must unsure its is valid : it conforms to RFC
             if (!self::checkFQDNLabel($input['name'])) {
-                Session::addMessageAfterRedirect(htmlspecialchars(sprintf(
+                Session::addMessageAfterRedirect(htmlescape(sprintf(
                     __('Invalid internet name: %s'),
                     $input['name']
                 )), false, ERROR);

--- a/src/FieldUnicity.php
+++ b/src/FieldUnicity.php
@@ -158,7 +158,7 @@ class FieldUnicity extends CommonDropdown
             if ($item = getItemForItemtype($this->fields['itemtype'])) {
                 echo $item::getTypeName();
             }
-            echo "<input type='hidden' name='itemtype' value='" . htmlspecialchars($this->fields['itemtype']) . "'>";
+            echo "<input type='hidden' name='itemtype' value='" . htmlescape($this->fields['itemtype']) . "'>";
         } else {
             $options = [];
            //Add criteria : display dropdown

--- a/src/Glpi/Api/HL/Middleware/DebugResponseMiddleware.php
+++ b/src/Glpi/Api/HL/Middleware/DebugResponseMiddleware.php
@@ -79,7 +79,7 @@ class DebugResponseMiddleware extends AbstractMiddleware implements ResponseMidd
             $header_value = '';
             foreach ($debug_messages as $debug_message) {
                 // escape quotes in the message, quote the message, and add it to the header value, and append a comma to the end
-                $msg = htmlspecialchars($debug_message);
+                $msg = htmlescape($debug_message);
                 $header_value .= '"' . $msg . '",';
             }
             // remove the last comma from the header value

--- a/src/Glpi/Application/ErrorHandler.php
+++ b/src/Glpi/Application/ErrorHandler.php
@@ -506,7 +506,7 @@ class ErrorHandler
             $this->output_handler->writeln($message, $verbosity);
         } else if (!isCommandLine()) {
             echo '<div class="alert alert-important alert-danger glpi-debug-alert" style="z-index:10000">'
-            . '<span class="b">' . \htmlspecialchars($error_type) . ': </span>' . \htmlspecialchars($message) . '</div>';
+            . '<span class="b">' . \htmlescape($error_type) . ': </span>' . \htmlescape($message) . '</div>';
         } else {
             echo $error_type . ': ' . $message . "\n";
         }

--- a/src/Glpi/Asset/AssetDefinition.php
+++ b/src/Glpi/Asset/AssetDefinition.php
@@ -296,7 +296,7 @@ final class AssetDefinition extends AbstractDefinition
         if (array_key_exists('capacities', $input)) {
             if (!$this->validateCapacityArray($input['capacities'])) {
                 Session::addMessageAfterRedirect(
-                    htmlspecialchars(sprintf(
+                    htmlescape(sprintf(
                         __('The following field has an incorrect value: "%s".'),
                         __('Capacities')
                     )),

--- a/src/Glpi/Asset/Asset_PeripheralAsset.php
+++ b/src/Glpi/Asset/Asset_PeripheralAsset.php
@@ -405,8 +405,8 @@ TWIG, $twig_params);
                 $linkname = sprintf(__('%1$s (%2$s)'), $linkname, $data["id"]);
             }
             $link = $itemtype::getFormURLWithID($data["id"]);
-            $label = sprintf('<i class="%s"></i> %s', htmlspecialchars($itemtype::getIcon()), htmlspecialchars($linkname));
-            $name = '<a href="' . htmlspecialchars($link) . '">' . $label . '</a>';
+            $label = sprintf('<i class="%s"></i> %s', htmlescape($itemtype::getIcon()), htmlescape($linkname));
+            $name = '<a href="' . htmlescape($link) . '">' . $label . '</a>';
             $entry['name'] = $name;
 
             if (!isset($entity_cache[$data['entities_id']])) {
@@ -562,7 +562,7 @@ TWIG, $twig_params);
                 $linkname = sprintf(__('%1$s (%2$s)'), $linkname, $data["id"]);
             }
             $link = $itemtype::getFormURLWithID($data["id"]);
-            $name = '<a href="' . htmlspecialchars($link) . '">' . htmlspecialchars($linkname) . '</a>';
+            $name = '<a href="' . htmlescape($link) . '">' . htmlescape($linkname) . '</a>';
             $entry['name'] = $name;
 
             if (!isset($entity_cache[$data['entities_id']])) {

--- a/src/Glpi/CalDAV/Traits/VobjectConverterTrait.php
+++ b/src/Glpi/CalDAV/Traits/VobjectConverterTrait.php
@@ -285,7 +285,7 @@ trait VobjectConverterTrait
 
         // Content is handled as plain text in CalDAV client and will be handled as rich text on GLPI side,
         // so special chars have to be encoded in html entities.
-        $content = htmlspecialchars($content);
+        $content = htmlescape($content);
 
         return $content;
     }

--- a/src/Glpi/CustomObject/AbstractDefinition.php
+++ b/src/Glpi/CustomObject/AbstractDefinition.php
@@ -364,7 +364,7 @@ abstract class AbstractDefinition extends CommonDBTM
         if (array_key_exists('system_name', $input)) {
             if (!is_string($input['system_name']) || preg_match('/^[A-Za-z]+$/i', $input['system_name']) !== 1) {
                 Session::addMessageAfterRedirect(
-                    htmlspecialchars(sprintf(
+                    htmlescape(sprintf(
                         __('The following field has an incorrect value: "%s".'),
                         __('System name')
                     )),
@@ -374,7 +374,7 @@ abstract class AbstractDefinition extends CommonDBTM
                 $has_errors = true;
             } else if (in_array($input['system_name'], static::getDefinitionManagerClass()::getInstance()->getReservedSystemNames(), true)) {
                 Session::addMessageAfterRedirect(
-                    htmlspecialchars(sprintf(
+                    htmlescape(sprintf(
                         __('The system name must not be the reserved word "%s".'),
                         $input['system_name']
                     )),
@@ -395,7 +395,7 @@ abstract class AbstractDefinition extends CommonDBTM
         if (array_key_exists('profiles', $input)) {
             if (!$this->validateProfileArray($input['profiles'])) {
                 Session::addMessageAfterRedirect(
-                    htmlspecialchars(sprintf(
+                    htmlescape(sprintf(
                         __('The following field has an incorrect value: "%s".'),
                         _n('Profile', 'Profiles', Session::getPluralNumber())
                     )),
@@ -411,7 +411,7 @@ abstract class AbstractDefinition extends CommonDBTM
         if (array_key_exists('translations', $input)) {
             if (!$this->validateTranslationsArray($input['translations'])) {
                 Session::addMessageAfterRedirect(
-                    htmlspecialchars(sprintf(
+                    htmlescape(sprintf(
                         __('The following field has an incorrect value: "%s".'),
                         _n('Translation', 'Translations', Session::getPluralNumber())
                     )),
@@ -644,7 +644,7 @@ abstract class AbstractDefinition extends CommonDBTM
 
         switch ($field) {
             case 'icon':
-                $value = htmlspecialchars($values[$field]);
+                $value = htmlescape($values[$field]);
                 return sprintf('<i class="ti %s"></i>', $value);
             case 'translations':
                 $translations = json_decode($values[$field], associative: true);
@@ -681,7 +681,7 @@ TWIG,
 
         switch ($field) {
             case 'icon':
-                $value = htmlspecialchars($values[$field] ?? '');
+                $value = htmlescape($values[$field]);
                 return TemplateRenderer::getInstance()->renderFromStringTemplate(<<<TWIG
                     {% import 'components/form/fields_macros.html.twig' as fields %}
                     {{ fields.dropdownWebIcons(name, value, '', {no_label: true, width: '200px'}) }}

--- a/src/Glpi/Dashboard/Grid.php
+++ b/src/Glpi/Dashboard/Grid.php
@@ -658,7 +658,7 @@ HTML;
         $edit_label    = __("Edit this card");
         $delete_label  = __("Delete this card");
 
-        $gridstack_id = htmlspecialchars($gridstack_id);
+        $gridstack_id = htmlescape($gridstack_id);
 
         $this->items[] = <<<HTML
          <div class="grid-stack-item"

--- a/src/Glpi/Dashboard/Widget.php
+++ b/src/Glpi/Dashboard/Widget.php
@@ -1657,7 +1657,7 @@ HTML;
         ];
         $p = array_merge($default, $params);
 
-        $p['label'] = \htmlspecialchars($p['label'] ?? '');
+        $p['label'] = \htmlescape($p['label']);
 
         $id = "search-table-" . $p['rand'];
 
@@ -1668,7 +1668,7 @@ HTML;
         $fg_color2 = Toolbox::getFgColor($p['color'], 5);
 
         $href = strlen($p['url'])
-            ? \sprintf('href="%s"', \htmlspecialchars($p['url']))
+            ? \sprintf('href="%s"', \htmlescape($p['url']))
             : "";
 
         $class = count($p['filters']) > 0 ? " filter-" . implode(' filter-', $p['filters']) : "";

--- a/src/Glpi/Features/Inventoriable.php
+++ b/src/Glpi/Features/Inventoriable.php
@@ -125,13 +125,13 @@ trait Inventoriable
             $title = sprintf(
              //TRANS: parameter is the name of the asset
                 __s('Download "%1$s" inventory file'),
-                htmlspecialchars($this->getName())
+                htmlescape($this->getName())
             );
 
             echo sprintf(
                 "<a href='%s' style='float: right;' target='_blank'><i class='fas fa-download' title='%s'></i></a>",
-                \htmlspecialchars($href),
-                \htmlspecialchars($title)
+                \htmlescape($href),
+                \htmlescape($title)
             );
 
             if (static::class == RefusedEquipment::class) {
@@ -179,16 +179,16 @@ trait Inventoriable
         global $CFG_GLPI;
 
         echo '<tr class="tab_bg_1">';
-        echo '<td>' . htmlspecialchars(Agent::getTypeName(1)) . '</td>';
+        echo '<td>' . htmlescape(Agent::getTypeName(1)) . '</td>';
         echo '<td>' . $this->agent->getLink() . '</td>';
 
         echo '<td>' . __s('Useragent') . '</td>';
-        echo '<td>' . htmlspecialchars($this->agent->fields['useragent']) . '</td>';
+        echo '<td>' . htmlescape($this->agent->fields['useragent']) . '</td>';
         echo '</tr>';
 
         echo '<tr class="tab_bg_1">';
         echo '<td>' . __s('Inventory tag') . '</td>';
-        echo '<td>' . htmlspecialchars($this->agent->fields['tag']) . '</td>';
+        echo '<td>' . htmlescape($this->agent->fields['tag']) . '</td>';
         echo '<td>' . __s('Last inventory') . '</td>';
         echo '<td>' . Html::convDateTime($this->agent->fields['last_contact']) . '</td>';
         echo '</tr>';

--- a/src/Glpi/Form/Tag/Tag.php
+++ b/src/Glpi/Form/Tag/Tag.php
@@ -62,10 +62,10 @@ final readonly class Tag
             "class"                  => "border-$color border-start border-3 bg-dark-lt",
         ];
         $properties = implode(" ", array_map(
-            fn($key, $value) => sprintf('%s="%s"', htmlspecialchars($key), htmlspecialchars($value)),
+            fn($key, $value) => sprintf('%s="%s"', htmlescape($key), htmlescape($value)),
             array_keys($properties),
             array_values($properties),
         ));
-        $this->html = sprintf('<span %s>%s</span>', $properties, htmlspecialchars($label));
+        $this->html = sprintf('<span %s>%s</span>', $properties, htmlescape($label));
     }
 }

--- a/src/Glpi/Inventory/Conf.php
+++ b/src/Glpi/Inventory/Conf.php
@@ -739,7 +739,7 @@ class Conf extends CommonGLPI
 
             echo "<tr class='tab_bg_1'>";
             echo "<th colspan='4'>";
-            echo htmlspecialchars(CommonDevice::getTypeName(Session::getPluralNumber()));
+            echo htmlescape(CommonDevice::getTypeName(Session::getPluralNumber()));
             echo "</th>";
             echo "</tr>";
 
@@ -1089,7 +1089,7 @@ class Conf extends CommonGLPI
             );
             trigger_error($msg, E_USER_WARNING);
             Session::addMessageAfterRedirect(
-                htmlspecialchars($msg),
+                htmlescape($msg),
                 false,
                 WARNING
             );
@@ -1143,7 +1143,7 @@ class Conf extends CommonGLPI
             );
             trigger_error($msg, E_USER_WARNING);
             Session::addMessageAfterRedirect(
-                htmlspecialchars($msg),
+                htmlescape($msg),
                 false,
                 WARNING
             );

--- a/src/Glpi/Inventory/Inventory.php
+++ b/src/Glpi/Inventory/Inventory.php
@@ -314,7 +314,7 @@ class Inventory
             $unhandled_data = array_diff_key($all_props, $data);
             if (count($unhandled_data)) {
                 Session::addMessageAfterRedirect(
-                    htmlspecialchars(sprintf(
+                    htmlescape(sprintf(
                         __('Following keys has been ignored during process: %1$s'),
                         implode(
                             ', ',
@@ -885,7 +885,7 @@ class Inventory
                     $task->log($message);
                     $task->addVolume(1);
                 } else {
-                    Session::addMessageAfterRedirect(htmlspecialchars($message));
+                    Session::addMessageAfterRedirect(htmlescape($message));
                 }
             }
         }
@@ -972,7 +972,7 @@ class Inventory
                     $task->log($message);
                     $task->addVolume(1);
                 } else {
-                    Session::addMessageAfterRedirect(htmlspecialchars($message));
+                    Session::addMessageAfterRedirect(htmlescape($message));
                 }
             }
         }

--- a/src/Glpi/Marketplace/Controller.php
+++ b/src/Glpi/Marketplace/Controller.php
@@ -201,7 +201,7 @@ class Controller extends CommonGLPI
         if (!UnifiedArchive::canOpen($dest)) {
             $type = Formats::detectArchiveFormat($dest);
             Session::addMessageAfterRedirect(
-                htmlspecialchars(sprintf(__('Plugin archive format is not supported by your system : %s.'), $type)),
+                htmlescape(sprintf(__('Plugin archive format is not supported by your system : %s.'), $type)),
                 false,
                 ERROR
             );

--- a/src/Glpi/Marketplace/View.php
+++ b/src/Glpi/Marketplace/View.php
@@ -531,7 +531,7 @@ JS;
         $description = Toolbox::stripTags($plugin['description']);
 
         $authors = Toolbox::stripTags(implode(', ', array_column($plugin['authors'] ?? [], 'name', 'id')));
-        $authors_title = htmlspecialchars($authors);
+        $authors_title = htmlescape($authors);
         $authors = strlen($authors)
             ? "<i class='fa-fw ti ti-users'></i>{$authors}"
             : "";
@@ -550,28 +550,28 @@ JS;
             ? self::getStarsHtml($plugin['note'])
             : "";
 
-        $home_url = htmlspecialchars($plugin['homepage_url'] ?? "");
+        $home_url = htmlescape($plugin['homepage_url']);
         $home_url = strlen($home_url)
             ? "<a href='{$home_url}' target='_blank' >
                <i class='ti ti-home-2 add_tooltip' title='" . __s("Homepage") . "'></i>
                </a>"
             : "";
 
-        $issues_url = htmlspecialchars($plugin['issues_url'] ?? "");
+        $issues_url = htmlescape($plugin['issues_url']);
         $issues_url = strlen($issues_url)
             ? "<a href='{$issues_url}' target='_blank' >
                <i class='ti ti-bug add_tooltip' title='" . __s("Get help") . "'></i>
                </a>"
             : "";
 
-        $readme_url = htmlspecialchars($plugin['readme_url'] ?? "");
+        $readme_url = htmlescape($plugin['readme_url']);
         $readme_url = strlen($readme_url)
             ? "<a href='{$readme_url}' target='_blank' >
                <i class='ti ti-book add_tooltip' title='" . __s("Readme") . "'></i>
                </a>"
             : "";
 
-        $changelog_url = htmlspecialchars($plugin['changelog_url'] ?? "");
+        $changelog_url = htmlescape($plugin['changelog_url']);
         $changelog_url = strlen($changelog_url)
             ? "<a href='{$changelog_url}' target='_blank' >
                <i class='ti ti-news add_tooltip' title='" . __s("Changelog") . "'></i>
@@ -809,7 +809,7 @@ HTML;
             } else if ($can_be_updated) {
                 $update_title = sprintf(
                     __s("A new version (%s) is available, update?", 'marketplace'),
-                    htmlspecialchars($web_update_version)
+                    htmlescape($web_update_version)
                 );
 
                 $buttons .= TemplateRenderer::getInstance()->render('components/plugin_update_modal.html.twig', [
@@ -907,7 +907,7 @@ HTML;
                                    </a>',
                 'content' => sprintf(
                     __s('By uninstalling the "%s" plugin you will lose all the data of the plugin.'),
-                    htmlspecialchars($plugin_inst->getField('name'))
+                    htmlescape($plugin_inst->getField('name'))
                 )
             ]);
 
@@ -938,7 +938,7 @@ HTML;
     {
         $icon = "";
 
-        $logo_url = htmlspecialchars($plugin['logo_url'] ?? "");
+        $logo_url = htmlescape($plugin['logo_url']);
         if (strlen($logo_url)) {
             $icon = "<img src='{$logo_url}'>";
         } else {

--- a/src/Glpi/RichText/RichText.php
+++ b/src/Glpi/RichText/RichText.php
@@ -68,7 +68,7 @@ final class RichText
         $content = trim($content, "\r\n");
 
         if ($encode_output) {
-            $content = htmlspecialchars($content);
+            $content = htmlescape($content);
         }
 
         return $content;
@@ -152,7 +152,7 @@ final class RichText
         $content = trim($content, "\r\n");
 
         if ($encode_output) {
-            $content = htmlspecialchars($content);
+            $content = htmlescape($content);
         }
 
         return $content;
@@ -235,7 +235,7 @@ final class RichText
             if (preg_match('/(<|>)/', $content)) {
                 // Input was not HTML, and special chars were not saved as HTML entities.
                 // We have to encode them into HTML entities.
-                $content = htmlspecialchars($content);
+                $content = htmlescape($content);
             }
 
             // Plain text line breaks have to be transformed into <br /> tags.
@@ -453,7 +453,7 @@ HTML;
             $out .= "<a href='{$img['src']}' itemprop='contentUrl' data-index='0'>";
             $width_attr = isset($img['thumbnail_w']) ? "width='{$img['thumbnail_w']}'" : "";
             $height_attr = isset($img['thumbnail_h']) ? "height='{$img['thumbnail_h']}'" : "";
-            $out .= "<img src='" . htmlspecialchars($img['thumbnail_src'], ENT_QUOTES) . "' itemprop='thumbnail' loading='lazy' {$width_attr} {$height_attr}>";
+            $out .= "<img src='" . htmlescape($img['thumbnail_src']) . "' itemprop='thumbnail' loading='lazy' {$width_attr} {$height_attr}>";
             $out .= "</a>";
             $out .= "</figure>";
         }

--- a/src/Glpi/RichText/UserMention.php
+++ b/src/Glpi/RichText/UserMention.php
@@ -254,7 +254,7 @@ final class UserMention
             $replacement = sprintf(
                 '<a class="user-mention" href="%s">@%s</a>',
                 $user->getLinkURL(),
-                \htmlspecialchars($user->getFriendlyName())
+                \htmlescape($user->getFriendlyName())
             );
             $content = preg_replace($pattern, $replacement, $content);
         }

--- a/src/Glpi/Search/Input/QueryBuilder.php
+++ b/src/Glpi/Search/Input/QueryBuilder.php
@@ -169,7 +169,7 @@ final class QueryBuilder implements SearchInputInterface
 
         $p      = $request['p'];
         $num    = (int) $request['num'];
-        $prefix = isset($p['prefix_crit']) ? htmlspecialchars($p['prefix_crit']) : '';
+        $prefix = isset($p['prefix_crit']) ? htmlescape($p['prefix_crit']) : '';
 
         if (!is_subclass_of($request['itemtype'], 'CommonDBTM')) {
             throw new \RuntimeException('Invalid itemtype provided!');
@@ -241,7 +241,7 @@ final class QueryBuilder implements SearchInputInterface
         }
 
         $p                 = $request['p'];
-        $prefix            = isset($p['prefix_crit']) ? htmlspecialchars($p['prefix_crit']) : '';
+        $prefix            = isset($p['prefix_crit']) ? htmlescape($p['prefix_crit']) : '';
         $searchopt         = $request['searchopt'] ?? [];
         $request['value']  = rawurldecode($request['value']);
         $fieldname         = isset($request['meta']) && $request['meta']
@@ -359,8 +359,8 @@ final class QueryBuilder implements SearchInputInterface
             $message = $fieldpattern['validation_message'];
 
             echo "<input type='text' class='form-control' size='13' name='$inputname' value=\"" .
-                htmlspecialchars($request['value']) . "\" pattern=\"" . htmlspecialchars($pattern) . "\">" .
-                "<span class='invalid-tooltip'>" . htmlspecialchars($message) . "</span>";
+                htmlescape($request['value']) . "\" pattern=\"" . htmlescape($pattern) . "\">" .
+                "<span class='invalid-tooltip'>" . htmlescape($message) . "</span>";
         }
     }
 
@@ -399,7 +399,7 @@ final class QueryBuilder implements SearchInputInterface
         $randrow     = mt_rand();
         $normalized_itemtype = Toolbox::getNormalizedItemtype($request["itemtype"]);
         $rowid       = 'searchrow' . $normalized_itemtype . $randrow;
-        $prefix      = isset($p['prefix_crit']) ? htmlspecialchars($p['prefix_crit']) : '';
+        $prefix      = isset($p['prefix_crit']) ? htmlescape($p['prefix_crit']) : '';
         $parents_num = isset($p['parents_num']) ? $p['parents_num'] : [];
         $criteria    = [];
         $from_meta   = isset($request['from_meta']) && $request['from_meta'];
@@ -489,7 +489,7 @@ final class QueryBuilder implements SearchInputInterface
 
         $p            = $request['p'];
         $num          = (int) $request['num'];
-        $prefix       = isset($p['prefix_crit']) ? htmlspecialchars($p['prefix_crit']) : '';
+        $prefix       = isset($p['prefix_crit']) ? htmlescape($p['prefix_crit']) : '';
         $parents_num  = isset($p['parents_num']) ? $p['parents_num'] : [];
         $itemtype     = $request["itemtype"];
         $metacriteria = self::findCriteriaInSession($itemtype, $num, $parents_num);
@@ -611,7 +611,7 @@ final class QueryBuilder implements SearchInputInterface
         $p           = $request['p'];
         $randrow     = mt_rand();
         $rowid       = 'searchrow' . Toolbox::getNormalizedItemtype($request['itemtype']) . $randrow;
-        $prefix      = isset($p['prefix_crit']) ? htmlspecialchars($p['prefix_crit']) : '';
+        $prefix      = isset($p['prefix_crit']) ? htmlescape($p['prefix_crit']) : '';
         $parents_num = isset($p['parents_num']) ? $p['parents_num'] : [];
 
         if (!$criteria = self::findCriteriaInSession($request['itemtype'], $num, $parents_num)) {

--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -5130,7 +5130,7 @@ final class SQLProvider implements SearchProviderInterface
                                                         ]
                                                     );
                                                 }
-                                                $out .= sprintf(__s('%1$s %2$s'), htmlspecialchars($user->getName()), $tooltip);
+                                                $out .= sprintf(__s('%1$s %2$s'), htmlescape($user->getName()), $tooltip);
                                             }
                                         }
 
@@ -5154,7 +5154,7 @@ final class SQLProvider implements SearchProviderInterface
                                                 $out .= \Search::LBBR;
                                             }
                                             $count_display++;
-                                            $out .= "<a href='mailto:" . \htmlspecialchars($split2[1]) . "'>" . \htmlspecialchars($split2[1]) . "</a>";
+                                            $out .= "<a href='mailto:" . \htmlescape($split2[1]) . "'>" . \htmlescape($split2[1]) . "</a>";
                                         }
                                     }
                                 }
@@ -5360,7 +5360,7 @@ final class SQLProvider implements SearchProviderInterface
                             }
                             $text  = "<a ";
                             $text .= "href=\"" . \Ticket::getFormURLWithID($linkid) . "\">";
-                            $text .= \htmlspecialchars($link_text) . "</a>";
+                            $text .= \htmlescape($link_text) . "</a>";
                             if (count($displayed)) {
                                 $out .= \Search::LBBR;
                             }
@@ -5402,7 +5402,7 @@ final class SQLProvider implements SearchProviderInterface
                             $out  = "<a id='problem$itemtype" . $data['id'] . "' ";
                             $out .= "href=\"" . $CFG_GLPI["root_doc"] . "/front/problem.php?" .
                                 \Toolbox::append_params($options, '&amp;') . "\">";
-                            $out .= \htmlspecialchars($data[$ID][0]['name']) . "</a>";
+                            $out .= \htmlescape($data[$ID][0]['name']) . "</a>";
                             return $out;
                         }
                     }
@@ -5463,7 +5463,7 @@ final class SQLProvider implements SearchProviderInterface
                             $out  = "<a id='ticket$itemtype" . $data['id'] . "' ";
                             $out .= "href=\"" . $CFG_GLPI["root_doc"] . "/front/ticket.php?" .
                                 \Toolbox::append_params($options, '&amp;') . "\">";
-                            $out .= \htmlspecialchars($data[$ID][0]['name']) . "</a>";
+                            $out .= \htmlescape($data[$ID][0]['name']) . "</a>";
                             return $out;
                         }
                     }
@@ -5676,7 +5676,7 @@ final class SQLProvider implements SearchProviderInterface
                         $name = $data[$ID][0]['trans'];
                     }
                     if ($itemtype == 'ProjectState') {
-                        $out =   "<a href='" . \ProjectState::getFormURLWithID($data[$ID][0]["id"]) . "'>" . \htmlspecialchars($name) . "</a></div>";
+                        $out =   "<a href='" . \ProjectState::getFormURLWithID($data[$ID][0]["id"]) . "'>" . \htmlescape($name) . "</a></div>";
                     } else {
                         $out = $name;
                     }
@@ -5755,7 +5755,7 @@ final class SQLProvider implements SearchProviderInterface
                         ) {
                             $name = sprintf(__('%1$s (%2$s)'), $name, $data[$ID][0]['id']);
                         }
-                        $out    .= \htmlspecialchars($name) . "</a>";
+                        $out    .= \htmlescape($name) . "</a>";
 
                         // Add tooltip
                         $id = $data[$ID][0]['id'];
@@ -5908,7 +5908,7 @@ final class SQLProvider implements SearchProviderInterface
                     $color = $_SESSION["glpipriority_$index"];
                     $name  = \CommonITILObject::getPriorityName($index);
                     return "<div class='badge_block' style='border-color: $color'>
-                        <span style='background: $color'></span>&nbsp;" . \htmlspecialchars($name) . "
+                        <span style='background: $color'></span>&nbsp;" . \htmlescape($name) . "
                        </div>";
 
                 case "glpi_knowbaseitems.name":
@@ -5971,7 +5971,7 @@ final class SQLProvider implements SearchProviderInterface
                         $fa_class = "fa-eye-slash not-published";
                         $fa_title = __s("This item is not published yet");
                     }
-                    return "<div class='kb'> <i class='fa fa-fw $fa_class' title='$fa_title'></i> <a href='$href'>" . \htmlspecialchars($name) . "</a></div>";
+                    return "<div class='kb'> <i class='fa fa-fw $fa_class' title='$fa_title'></i> <a href='$href'>" . \htmlescape($name) . "</a></div>";
             }
         }
 
@@ -6043,11 +6043,11 @@ final class SQLProvider implements SearchProviderInterface
                                 foreach ($chunks as $key => $element_name) {
                                     $class = $key === array_key_last($chunks) ? '' : 'class="text-muted"';
                                     $separator = $key === array_key_last($chunks) ? '' : ' &gt; ';
-                                    $completename .= sprintf('<span %s>%s</span>%s', $class, \htmlspecialchars($element_name), $separator);
+                                    $completename .= sprintf('<span %s>%s</span>%s', $class, \htmlescape($element_name), $separator);
                                 }
                                 $name = $completename;
                             } else {
-                                $name = \htmlspecialchars($name);
+                                $name = \htmlescape($name);
                             }
 
                             $out  .= "<a id='" . $linkitemtype . "_" . $data['id'] . "_" .
@@ -6100,7 +6100,7 @@ final class SQLProvider implements SearchProviderInterface
                                     )
                                 );
                             } else {
-                                $out .= \htmlspecialchars($plaintext);
+                                $out .= \htmlescape($plaintext);
                             }
                         }
                     }
@@ -6167,7 +6167,7 @@ final class SQLProvider implements SearchProviderInterface
                         }
                         $count_display++;
                         if (!empty($data[$ID][$k]['name'])) {
-                            $mail = \htmlspecialchars($data[$ID][$k]['name']);
+                            $mail = \htmlescape($data[$ID][$k]['name']);
                             $out .= (empty($out) ? '' : \Search::LBBR);
                             $out .= "<a href='mailto:" . $mail . "'>" . $mail;
                             $out .= "</a>";
@@ -6184,7 +6184,7 @@ final class SQLProvider implements SearchProviderInterface
                         if (\Toolbox::strlen($link) > $CFG_GLPI["url_maxlength"]) {
                             $link = \Toolbox::substr($link, 0, $CFG_GLPI["url_maxlength"]) . "...";
                         }
-                        return "<a href=\"" . \htmlspecialchars(\Toolbox::formatOutputWebLink($orig_link)) . "\" target='_blank'>" . \htmlspecialchars($link) . "</a>";
+                        return "<a href=\"" . \htmlescape(\Toolbox::formatOutputWebLink($orig_link)) . "\" target='_blank'>" . \htmlescape($link) . "</a>";
                     }
                     return '';
 
@@ -6267,7 +6267,7 @@ final class SQLProvider implements SearchProviderInterface
                             $out .= $itemtype_name;
                         }
                     }
-                    return \htmlspecialchars($out);
+                    return \htmlescape($out);
 
                 case "language":
                     if (isset($CFG_GLPI['languages'][$data[$ID][0]['name']])) {
@@ -6327,7 +6327,7 @@ HTML;
                     isset($so['toadd'])
                     && isset($so['toadd'][$field_data['name']])
                 ) {
-                    $out .= \htmlspecialchars($so['toadd'][$field_data['name']]);
+                    $out .= \htmlescape($so['toadd'][$field_data['name']]);
                 } else {
                     // Trans field exists
                     if (isset($field_data['trans']) && !empty($field_data['trans'])) {
@@ -6338,7 +6338,7 @@ HTML;
                         $out .= $field_data['trans_name'];
                     } else {
                         $value = $field_data['name'];
-                        $out .= \htmlspecialchars($value ?: '');
+                        $out .= \htmlescape($value ?: '');
                     }
                 }
             }

--- a/src/Glpi/Socket.php
+++ b/src/Glpi/Socket.php
@@ -685,16 +685,16 @@ class Socket extends CommonDBChild
             $socket_name = $canedit
                 ? sprintf(
                     '<a href="%s">%s</a>',
-                    htmlspecialchars($socket->getLinkURL()),
-                    htmlspecialchars($socket->fields['name'])
+                    htmlescape($socket->getLinkURL()),
+                    htmlescape($socket->fields['name'])
                 )
-                : htmlspecialchars($socket->fields['name']);
+                : htmlescape($socket->fields['name']);
             $netport_name = '';
             if ($networkport->getFromDB($socket->fields["networkports_id"])) {
                 $netport_name = sprintf(
                     '<a href="%s">%s</a>',
-                    htmlspecialchars($networkport->getLinkURL()),
-                    htmlspecialchars($networkport->fields['name'])
+                    htmlescape($networkport->getLinkURL()),
+                    htmlescape($networkport->fields['name'])
                 );
             }
             $has_cable = $cable->getFromDBByCrit([
@@ -707,8 +707,8 @@ class Socket extends CommonDBChild
             $cable_name = $has_cable
                 ? sprintf(
                     '<a href="%s">%s</a>',
-                    htmlspecialchars($cable->getLinkURL()),
-                    htmlspecialchars($cable->getName())
+                    htmlescape($cable->getLinkURL()),
+                    htmlescape($cable->getName())
                 )
                 : '';
             $itemtype = '';
@@ -730,8 +730,8 @@ class Socket extends CommonDBChild
                 $itemtype_label = $endpoint::getType();
                 $item_label = sprintf(
                     '<a href="%s">%s</a>',
-                    htmlspecialchars($endpoint->getLinkURL()),
-                    htmlspecialchars($endpoint->getName())
+                    htmlescape($endpoint->getLinkURL()),
+                    htmlescape($endpoint->getName())
                 );
             } else {
                 $itemtype_label = '';
@@ -837,13 +837,13 @@ class Socket extends CommonDBChild
             'START' => $start,
             'LIMIT' => $_SESSION['glpilist_limit']
         ]);
-        $socket_form_url = htmlspecialchars(self::getFormURL());
+        $socket_form_url = htmlescape(self::getFormURL());
 
         foreach ($it as $data) {
             $name = sprintf(
                 '<a href="%s">%s</a>',
-                htmlspecialchars(self::getFormURLWithID($data['id'])),
-                htmlspecialchars($data['name'])
+                htmlescape(self::getFormURLWithID($data['id'])),
+                htmlescape($data['name'])
             );
 
             $socketmodel = new SocketModel();

--- a/src/HTMLTableEntity.php
+++ b/src/HTMLTableEntity.php
@@ -114,7 +114,7 @@ abstract class HTMLTableEntity
     {
         $id = $options['id'] ?? $this->html_id;
         if (!empty($id)) {
-            echo ' id="' . htmlspecialchars($id) . '"';
+            echo ' id="' . htmlescape($id) . '"';
         }
 
         $style = $this->html_style;
@@ -126,7 +126,7 @@ abstract class HTMLTableEntity
             }
         }
         if (count($style) > 0) {
-            echo " style='" . htmlspecialchars(implode(';', $style)) . "'";
+            echo " style='" . htmlescape(implode(';', $style)) . "'";
         }
 
         $class = $this->html_class;
@@ -138,7 +138,7 @@ abstract class HTMLTableEntity
             }
         }
         if (count($class) > 0) {
-            echo " class='" . htmlspecialchars(implode(' ', $class)) . "'";
+            echo " class='" . htmlescape(implode(' ', $class)) . "'";
         }
     }
 

--- a/src/HTMLTableGroup.php
+++ b/src/HTMLTableGroup.php
@@ -206,7 +206,7 @@ class HTMLTableGroup extends HTMLTableBase
                 $p['display_title_for_each_group']
                 && !empty($this->content)
             ) {
-                echo "\t<tbody><tr><th colspan='$totalNumberOfColumn'>" . htmlspecialchars($this->content) .
+                echo "\t<tbody><tr><th colspan='$totalNumberOfColumn'>" . htmlescape($this->content) .
                  "</th></tr></tbody>\n";
             }
 

--- a/src/HTMLTableMain.php
+++ b/src/HTMLTableMain.php
@@ -240,7 +240,7 @@ class HTMLTableMain extends HTMLTableBase
 
         echo "\n<table class='tab_cadre_fixehov'";
         if (!empty($p['html_id'])) {
-            echo " id='" . htmlspecialchars($p['html_id']) . "'";
+            echo " id='" . htmlescape($p['html_id']) . "'";
         }
         echo ">\n";
 
@@ -250,7 +250,7 @@ class HTMLTableMain extends HTMLTableBase
         }
 
         if (!empty($this->title)) {
-            echo "\t\t<tr class='noHover'><th colspan='$totalNumberOfColumn'>" . htmlspecialchars($this->title) .
+            echo "\t\t<tr class='noHover'><th colspan='$totalNumberOfColumn'>" . htmlescape($this->title) .
               "</th></tr>\n";
         }
 

--- a/src/Html.php
+++ b/src/Html.php
@@ -135,7 +135,7 @@ class Html
         } catch (\Throwable $e) {
             ErrorHandler::getInstance()->handleException($e, false);
             Session::addMessageAfterRedirect(
-                htmlspecialchars(sprintf(
+                htmlescape(sprintf(
                     __('%1$s %2$s'),
                     $time,
                     _x('adjective', 'Invalid')
@@ -186,7 +186,7 @@ class Html
         if (!is_string($string)) {
             return $string;
         }
-        return htmlspecialchars($string);
+        return htmlescape($string);
     }
 
     /**
@@ -219,7 +219,7 @@ class Html
             $append = '&nbsp;(...)';
         }
 
-        return \htmlspecialchars($string) . $append;
+        return \htmlescape($string) . $append;
     }
 
     /**
@@ -557,13 +557,13 @@ class Html
 
         if ($ref_title != "") {
             echo "<span class='btn bg-blue-lt pe-none' aria-disabled='true'>
-            " . htmlspecialchars($ref_title) . "
+            " . htmlescape($ref_title) . "
          </span>";
         }
 
         if (is_array($ref_btts) && count($ref_btts)) {
             foreach ($ref_btts as $key => $val) {
-                echo "<a class='btn btn-outline-secondary' href='" . htmlspecialchars($key) . "'>" . htmlspecialchars($val) . "</a>";
+                echo "<a class='btn btn-outline-secondary' href='" . htmlescape($key) . "'>" . htmlescape($val) . "</a>";
             }
         }
         echo "</div>";
@@ -616,7 +616,7 @@ class Html
      **/
     public static function displayBackLink()
     {
-        echo '<a href="' . htmlspecialchars(self::getBackUrl()) . '">' . __s('Back') . "</a>";
+        echo '<a href="' . htmlescape(self::getBackUrl()) . '">' . __s('Back') . "</a>";
     }
 
     /**
@@ -708,7 +708,7 @@ class Html
      **/
     public static function addConfirmationOnAction($string, $additionalactions = '')
     {
-        return "onclick=\"" . htmlspecialchars(Html::getConfirmationOnActionScript($string, $additionalactions)) . "\"";
+        return "onclick=\"" . htmlescape(Html::getConfirmationOnActionScript($string, $additionalactions)) . "\"";
     }
 
 
@@ -2255,7 +2255,7 @@ HTML;
 
         $out .= "<input type='checkbox' class='form-check-input " . $params['class'] . "' title=\"" . $params['title'] . "\" ";
         if (isset($params['onclick'])) {
-            $params['onclick'] = htmlspecialchars($params['onclick'], ENT_QUOTES);
+            $params['onclick'] = htmlescape($params['onclick']);
             $out .= " onclick='{$params['onclick']}'";
         }
 
@@ -2338,7 +2338,7 @@ HTML;
 
         if (empty($options['name'])) {
             // encode quotes and brackets to prevent maformed name attribute
-            $id = htmlspecialchars($id, ENT_QUOTES);
+            $id = htmlescape($id);
             $id = str_replace(['[', ']'], ['&amp;#91;', '&amp;#93;'], $id);
             $options['name'] = "item[$itemtype][" . $id . "]";
         }
@@ -2563,11 +2563,11 @@ HTML;
             } else {
                 $out .= "onclick='modal_massiveaction_window$identifier.show();'";
             }
-            $out .= " href='#modal_massaction_content$identifier' title=\"" . htmlspecialchars($p['title']) . "\">";
+            $out .= " href='#modal_massaction_content$identifier' title=\"" . htmlescape($p['title']) . "\">";
             if ($p['display_arrow']) {
                 $out .= "<i class='ti ti-corner-left-" . ($p['ontop'] ? 'down' : 'up') . " mt-1' style='margin-left: -2px;'></i>";
             }
-            $out .= "<span>" . htmlspecialchars($p['title']) . "</span>";
+            $out .= "<span>" . htmlescape($p['title']) . "</span>";
             $out .= "</a>";
 
             if (
@@ -3911,7 +3911,7 @@ JAVASCRIPT
        // Print it
         $out .= "<div><table class='tab_cadre_pager'>";
         if (!empty($title)) {
-            $out .= "<tr><th colspan='6'>" . htmlspecialchars($title) . "</th></tr>";
+            $out .= "<tr><th colspan='6'>" . htmlescape($title) . "</th></tr>";
         }
         $out .= "<tr>\n";
 
@@ -3976,7 +3976,7 @@ JAVASCRIPT
             echo "<tr><th>KEY</th><th>=></th><th>VALUE</th></tr>";
 
             foreach ($tab as $key => $val) {
-                $key = htmlspecialchars($key);
+                $key = htmlescape($key);
                 echo "<tr><td>";
                 echo $key;
                 echo "</td><td>";
@@ -4009,7 +4009,7 @@ JAVASCRIPT
                                 echo "(object) " . get_class($val);
                             }
                         } else {
-                            echo htmlspecialchars($val ?? "");
+                            echo htmlescape($val);
                         }
                     }
                 }
@@ -4224,13 +4224,13 @@ JAVASCRIPT
         if (($num > 0) && ($num < $tot)) {
            // TRANS %1$d %2$d are numbers (displayed, total)
             $cpt = "<span class='primary-bg primary-fg count'>" .
-            htmlspecialchars(sprintf(__('%1$d on %2$d'), $num, $tot)) . "</span>";
+            htmlescape(sprintf(__('%1$d on %2$d'), $num, $tot)) . "</span>";
         } else {
            // $num is 0, so means configured to display nothing
            // or $num == $tot
             $cpt = "<span class='primary-bg primary-fg count'>$tot</span>";
         }
-        return sprintf(__s('%1$s %2$s'), htmlspecialchars($string), $cpt);
+        return sprintf(__s('%1$s %2$s'), htmlescape($string), $cpt);
     }
 
 
@@ -4280,7 +4280,7 @@ JAVASCRIPT
                 $link .= " class='pointer' ";
             }
         }
-        $action  = " submitGetLink('$action', " . htmlspecialchars(json_encode($fields)) . ");";
+        $action  = " submitGetLink('$action', " . htmlescape(json_encode($fields)) . ");";
 
         if (is_array($confirm) || strlen($confirm)) {
             $link .= self::addConfirmationOnAction($confirm, $action);
@@ -4289,7 +4289,7 @@ JAVASCRIPT
         }
 
         // Ensure $btlabel is properly escaped
-        $btlabel = htmlspecialchars($btlabel);
+        $btlabel = htmlescape($btlabel);
         $link .= '>';
         if (empty($btimage)) {
             $link .= $btlabel;
@@ -4691,12 +4691,12 @@ JS;
         }
        // Do not escape title if it is an image or a i tag (fontawesome)
         if (!preg_match('/<i(mg)?.*/', $text)) {
-            $text = htmlspecialchars($text);
+            $text = htmlescape($text);
         }
 
         return sprintf(
             '<a href="%1$s" %2$s>%3$s</a>',
-            htmlspecialchars($url),
+            htmlescape($url),
             Html::parseAttributes($options),
             $text
         );
@@ -4730,7 +4730,7 @@ JS;
         }
         return sprintf(
             '<input type="hidden" name="%1$s" %2$s />',
-            htmlspecialchars($fieldName),
+            htmlescape($fieldName),
             Html::parseAttributes($options)
         );
     }
@@ -4759,7 +4759,7 @@ JS;
         return sprintf(
             '<input type="%1$s" name="%2$s" %3$s />',
             $type,
-            htmlspecialchars($fieldName),
+            htmlescape($fieldName),
             Html::parseAttributes($options)
         );
     }
@@ -4790,7 +4790,7 @@ JS;
             }
 
             $original_field_name = str_ends_with($name, '[]') ? substr($name, 0, -2) : $name;
-            $original_field_name = htmlspecialchars($original_field_name);
+            $original_field_name = htmlescape($original_field_name);
 
             $select .= sprintf(
                 '<input type="hidden" name="%1$s" value="" %2$s>',
@@ -4800,18 +4800,18 @@ JS;
         }
         $select .= sprintf(
             '<select name="%1$s" %2$s>',
-            htmlspecialchars($name),
+            htmlescape($name),
             self::parseAttributes($options)
         );
         foreach ($values as $key => $value) {
             $select .= sprintf(
                 '<option value="%1$s"%2$s>%3$s</option>',
-                htmlspecialchars($key),
+                htmlescape($key),
                 ($selected != false && (
                 $key == $selected
                 || is_array($selected) && in_array($key, $selected))
                 ) ? ' selected="selected"' : '',
-                htmlspecialchars($value)
+                htmlescape($value)
             );
         }
         $select .= '</select>';
@@ -4870,7 +4870,7 @@ JS;
             $options['alt']   = $caption;
             return sprintf(
                 '<input type="image" src="%s" %s />',
-                htmlspecialchars($image),
+                htmlescape($image),
                 Html::parseAttributes($options)
             );
         }
@@ -4885,7 +4885,7 @@ JS;
                <span>$caption</span>
             </button>&nbsp;";
 
-        return sprintf($button, htmlspecialchars(strip_tags($caption)), Html::parseAttributes($options));
+        return sprintf($button, htmlescape(strip_tags($caption)), Html::parseAttributes($options));
     }
 
 
@@ -4986,7 +4986,7 @@ HTML;
             $value = implode(' ', $value);
         }
 
-        return sprintf('%1$s="%2$s"', htmlspecialchars($key), htmlspecialchars($value));
+        return sprintf('%1$s="%2$s"', htmlescape($key), htmlescape($value));
     }
 
 
@@ -5199,7 +5199,7 @@ HTML;
         if ($p['only_uploaded_files']) {
             $display .= "<div class='fileupload only-uploaded-files'>";
         } else {
-            $display .= "<div class='fileupload draghoverable' id='" . htmlspecialchars($p['dropZone']) . "'>";
+            $display .= "<div class='fileupload draghoverable' id='" . htmlescape($p['dropZone']) . "'>";
 
             if ($p['showtitle']) {
                 $display .= "<b>";
@@ -5242,8 +5242,8 @@ HTML;
         $display .= "<input id='fileupload{$rand_id}' type='file' name='_uploader_{$name}[]'
                       class='form-control'
                       $required
-                      data-uploader-name=\"" . htmlspecialchars($p['name']) . "\"
-                      data-url='" . htmlspecialchars($CFG_GLPI["root_doc"]) . "/ajax/fileupload.php'
+                      data-uploader-name=\"" . htmlescape($p['name']) . "\"
+                      data-url='" . htmlescape($CFG_GLPI["root_doc"]) . "/ajax/fileupload.php'
                       data-form-data='{\"name\": \"_uploader_{$name}\", \"showfilesize\": " . ($p['showfilesize'] ? 'true' : 'false') . "}'"
                       . ($p['multiple'] ? " multiple='multiple'" : "")
                       . ($p['onlyimages'] ? " accept='.gif,.png,.jpg,.jpeg'" : "") . ">";
@@ -5445,7 +5445,7 @@ HTML;
         $p = array_merge($p, $options);
 
        // div who will receive and display file list
-        $display = "<div id='" . htmlspecialchars($p['filecontainer']) . "' class='fileupload_info'>";
+        $display = "<div id='" . htmlescape($p['filecontainer']) . "' class='fileupload_info'>";
         if (isset($p['uploads']['_' . $p['name']])) {
             foreach ($p['uploads']['_' . $p['name']] as $uploadId => $upload) {
                 $prefix  = substr($upload, 0, 23);
@@ -5474,9 +5474,9 @@ HTML;
                 ];
 
                 // Show the name and size of the upload
-                $display .= "<p id='" . htmlspecialchars($upload['id']) . "'>&nbsp;";
-                $display .= "<img src='" . htmlspecialchars($extensionIcon) . "' title='" . htmlspecialchars($extension) . "'>&nbsp;";
-                $display .= "<b>" . htmlspecialchars($upload['display']) . "</b>&nbsp;(" . htmlspecialchars(Toolbox::getSize($upload['size'])) . ")";
+                $display .= "<p id='" . htmlescape($upload['id']) . "'>&nbsp;";
+                $display .= "<img src='" . htmlescape($extensionIcon) . "' title='" . htmlescape($extension) . "'>&nbsp;";
+                $display .= "<b>" . htmlescape($upload['display']) . "</b>&nbsp;(" . htmlescape(Toolbox::getSize($upload['size'])) . ")";
 
                 $name = '_' . $p['name'] . '[' . $uploadId . ']';
                 $display .= Html::hidden($name, ['value' => $upload['name']]);
@@ -5498,7 +5498,7 @@ HTML;
                     1 => $upload['id'] . '2',
                 ]);
                 $deleteUpload = "deleteImagePasted({$domItems}, {$textTag}, {$getEditor})";
-                $display .= '<span class="fas fa-times-circle pointer" onclick="' . htmlspecialchars($deleteUpload) . '"></span>';
+                $display .= '<span class="fas fa-times-circle pointer" onclick="' . htmlescape($deleteUpload) . '"></span>';
 
                 $display .= "</p>";
             }

--- a/src/IPAddress.php
+++ b/src/IPAddress.php
@@ -157,7 +157,7 @@ class IPAddress extends CommonDBChild
                 }
                 //TRANS: %s is the invalid address
                 $msg = sprintf(__('%1$s: %2$s'), __('Invalid IP address'), $input['name']);
-                Session::addMessageAfterRedirect(htmlspecialchars($msg), false, ERROR);
+                Session::addMessageAfterRedirect(htmlescape($msg), false, ERROR);
                 return false;
             }
         }

--- a/src/IPNetwork.php
+++ b/src/IPNetwork.php
@@ -470,7 +470,7 @@ class IPNetwork extends CommonImplicitTreeDropdown
         $preparedInput = $this->prepareInput($input);
 
         if (isset($preparedInput['error']) && !isset($input['_no_message'])) {
-            Session::addMessageAfterRedirect(htmlspecialchars($preparedInput['error']), false, ERROR);
+            Session::addMessageAfterRedirect(htmlescape($preparedInput['error']), false, ERROR);
         }
 
         $input = $preparedInput['input'];
@@ -488,7 +488,7 @@ class IPNetwork extends CommonImplicitTreeDropdown
         $preparedInput = $this->prepareInput($input);
 
         if (isset($preparedInput['error']) && !isset($input['_no_message'])) {
-            Session::addMessageAfterRedirect(htmlspecialchars($preparedInput['error']), false, ERROR);
+            Session::addMessageAfterRedirect(htmlescape($preparedInput['error']), false, ERROR);
         }
 
         $input = $preparedInput['input'];

--- a/src/IPNetwork_Vlan.php
+++ b/src/IPNetwork_Vlan.php
@@ -170,7 +170,7 @@ class IPNetwork_Vlan extends CommonDBRelation
             $header_bottom .= "</th>";
         }
         $header_end .= "<th>" . __s('Name') . "</th>";
-        $header_end .= "<th>" . htmlspecialchars(Entity::getTypeName(1)) . "</th>";
+        $header_end .= "<th>" . htmlescape(Entity::getTypeName(1)) . "</th>";
         $header_end .= "<th>" . __s('ID TAG') . "</th>";
         $header_end .= "</tr>";
         echo $header_begin . $header_top . $header_end;
@@ -183,16 +183,16 @@ class IPNetwork_Vlan extends CommonDBRelation
                 Html::showMassiveActionCheckBox(__CLASS__, $data["assocID"]);
                 echo "</td>";
             }
-            $name = htmlspecialchars($data["name"]);
+            $name = htmlescape($data["name"]);
             if ($_SESSION["glpiis_ids_visible"] || empty($data["name"])) {
                 $name = sprintf(__('%1$s (%2$s)'), $name, $data["id"]);
             }
             echo "<td class='center b'>
-               <a href='" . htmlspecialchars($CFG_GLPI["root_doc"]) . "/front/vlan.form.php?id=" . $data["id"] . "'>" . $name .
+               <a href='" . htmlescape($CFG_GLPI["root_doc"]) . "/front/vlan.form.php?id=" . $data["id"] . "'>" . $name .
               "</a>";
             echo "</td>";
             echo "<td class='center'>" . Dropdown::getDropdownName("glpi_entities", $data["entities_id"]);
-            echo "<td class='numeric'>" . htmlspecialchars($data["tag"]) . "</td>";
+            echo "<td class='numeric'>" . htmlescape($data["tag"]) . "</td>";
             echo "</tr>";
         }
         if ($number) {

--- a/src/ITILCategory.php
+++ b/src/ITILCategory.php
@@ -478,8 +478,8 @@ class ITILCategory extends CommonTreeDropdown
             echo "<th>" . __s('Name') . "</th>";
             echo "<th>" . __s('Incident') . "</th>";
             echo "<th>" . __s('Request') . "</th>";
-            echo "<th>" . htmlspecialchars(Change::getTypeName(1)) . "</th>";
-            echo "<th>" . htmlspecialchars(Problem::getTypeName(1)) . "</th>";
+            echo "<th>" . htmlescape(Change::getTypeName(1)) . "</th>";
+            echo "<th>" . htmlescape(Problem::getTypeName(1)) . "</th>";
             echo "</tr>";
 
             foreach ($iterator as $data) {
@@ -488,7 +488,7 @@ class ITILCategory extends CommonTreeDropdown
                 echo "<td>" . $itilcategory->getLink(['comments' => true]) . "</td>";
                 if ($data['tickettemplates_id_incident'] == $ID) {
                     echo "<td class='center'>
-                     <img src='" . htmlspecialchars($CFG_GLPI["root_doc"]) . "/pics/ok.png' alt=\"" . __s('OK') .
+                     <img src='" . htmlescape($CFG_GLPI["root_doc"]) . "/pics/ok.png' alt=\"" . __s('OK') .
                         "\" width='14' height='14'>
                      </td>";
                 } else {
@@ -496,7 +496,7 @@ class ITILCategory extends CommonTreeDropdown
                 }
                 if ($data['tickettemplates_id_demand'] == $ID) {
                     echo "<td class='center'>
-                     <img src='" . htmlspecialchars($CFG_GLPI["root_doc"]) . "/pics/ok.png' alt=\"" . __s('OK') .
+                     <img src='" . htmlescape($CFG_GLPI["root_doc"]) . "/pics/ok.png' alt=\"" . __s('OK') .
                         "\" width='14' height='14'>
                      </td>";
                 } else {
@@ -504,7 +504,7 @@ class ITILCategory extends CommonTreeDropdown
                 }
                 if ($data['changetemplates_id'] == $ID) {
                     echo "<td class='center'>
-                     <img src='" . htmlspecialchars($CFG_GLPI["root_doc"]) . "/pics/ok.png' alt=\"" . __s('OK') .
+                     <img src='" . htmlescape($CFG_GLPI["root_doc"]) . "/pics/ok.png' alt=\"" . __s('OK') .
                         "\" width='14' height='14'>
                      </td>";
                 } else {
@@ -512,7 +512,7 @@ class ITILCategory extends CommonTreeDropdown
                 }
                 if ($data['problemtemplates_id'] == $ID) {
                     echo "<td class='center'>
-                     <img src='" . htmlspecialchars($CFG_GLPI["root_doc"]) . "/pics/ok.png' alt=\"" . __s('OK') .
+                     <img src='" . htmlescape($CFG_GLPI["root_doc"]) . "/pics/ok.png' alt=\"" . __s('OK') .
                         "\" width='14' height='14'>
                      </td>";
                 } else {

--- a/src/Impact.php
+++ b/src/Impact.php
@@ -290,15 +290,15 @@ JS);
            // Header
             echo '<thead>';
             echo '<tr class="noHover">';
-            echo '<th class="impact-list-header" colspan="6" width="90%"><h3>' . htmlspecialchars($label) . '';
+            echo '<th class="impact-list-header" colspan="6" width="90%"><h3>' . htmlescape($label) . '';
             echo '<i class="fas fa-2x fa-caret-down impact-toggle-subitems-master impact-pointer"></i></h3></th>';
             echo '</tr>';
             echo '<tr class="noHover">';
             echo '<th>' . _sn('Item', 'Items', 1) . '</th>';
             echo '<th>' . __s('Relation') . '</th>';
-            echo '<th>' . htmlspecialchars(Ticket::getTypeName(Session::getPluralNumber())) . '</th>';
-            echo '<th>' . htmlspecialchars(Problem::getTypeName(Session::getPluralNumber())) . '</th>';
-            echo '<th>' . htmlspecialchars(Change::getTypeName(Session::getPluralNumber())) . '</th>';
+            echo '<th>' . htmlescape(Ticket::getTypeName(Session::getPluralNumber())) . '</th>';
+            echo '<th>' . htmlescape(Problem::getTypeName(Session::getPluralNumber())) . '</th>';
+            echo '<th>' . htmlescape(Change::getTypeName(Session::getPluralNumber())) . '</th>';
             echo '<th width="50px"></th>';
             echo '</tr>';
             echo '</thead>';
@@ -311,7 +311,7 @@ JS);
                 echo '<tr class="tab_bg_1">';
                 echo '<td class="left subheader impact-left" colspan="6">';
                 $total = count($items);
-                echo '<a>' . htmlspecialchars($itemtype::getTypeName()) . '</a>' . ' (' . $total . ')';
+                echo '<a>' . htmlescape($itemtype::getTypeName()) . '</a>' . ' (' . $total . ')';
                 echo '<i class="fas fa-2x fa-caret-down impact-toggle-subitems impact-pointer"></i>';
                 echo '</td>';
                 echo '</tr>';
@@ -322,16 +322,16 @@ JS);
                     echo '<td class="impact-left" width="15%">';
                     echo '<div><a target="_blank" href="' .
                     $itemtype_item['stored']->getLinkURL() . '">' .
-                    htmlspecialchars($itemtype_item['stored']->getFriendlyName()) . '</a></div>';
+                    htmlescape($itemtype_item['stored']->getFriendlyName()) . '</a></div>';
                     echo '</td>';
                     echo '<td width="40%"><div>';
 
                     $path = [];
                     foreach ($itemtype_item['node']['path'] as $node) {
                         if ($node['id'] == $start_node_id) {
-                            $path[] = '<b>' . htmlspecialchars($node['label']) . '</b>';
+                            $path[] = '<b>' . htmlescape($node['label']) . '</b>';
                         } else {
-                            $path[] = htmlspecialchars($node['label']);
+                            $path[] = htmlescape($node['label']);
                         }
                     }
                     $separator = '<i class="fas fa-angle-right"></i>';
@@ -376,7 +376,7 @@ JS);
        // Toolbar
         echo '<div class="impact-list-toolbar">';
         if ($has_impact) {
-            echo '<a target="_blank" href="' . htmlspecialchars($CFG_GLPI['root_doc']) . '/front/impactcsv.php?itemtype=' . htmlspecialchars($impact_item->fields['itemtype']) . '&items_id=' . htmlspecialchars($impact_item->fields['items_id']) . '">';
+            echo '<a target="_blank" href="' . htmlescape($CFG_GLPI['root_doc']) . '/front/impactcsv.php?itemtype=' . htmlescape($impact_item->fields['itemtype']) . '&items_id=' . htmlescape($impact_item->fields['items_id']) . '">';
             echo '<i class="fas fa-download impact-pointer impact-list-tools" title="' . __s('Export to csv') . '"></i>';
             echo '</a>';
         }
@@ -390,7 +390,7 @@ JS);
         if ($can_update && $impact_context) {
             $rand = mt_rand();
 
-            $setting_dialog .= '<form id="list_depth_form" action="' . htmlspecialchars($CFG_GLPI['root_doc']) . '/front/impactitem.form.php" method="POST">';
+            $setting_dialog .= '<form id="list_depth_form" action="' . htmlescape($CFG_GLPI['root_doc']) . '/front/impactitem.form.php" method="POST">';
             $setting_dialog .= '<table class="tab_cadre_fixe">';
             $setting_dialog .= '<tr>';
             $setting_dialog .= '<td><label for="impact_max_depth_' . $rand . '">' . __s("Max depth") . '</label></td>';
@@ -468,9 +468,9 @@ JS);
          $(document).on("impactUpdated", function() {
             $.ajax({
                type: "GET",
-               url: "' . htmlspecialchars($CFG_GLPI['root_doc']) . '/ajax/impact.php",
+               url: "' . htmlescape($CFG_GLPI['root_doc']) . '/ajax/impact.php",
                data: {
-                  itemtype: "' . htmlspecialchars(get_class($item)) . '",
+                  itemtype: "' . htmlescape(get_class($item)) . '",
                   items_id: "' . $item->fields['id'] . '",
                   action  : "load",
                   view    : "list",
@@ -560,7 +560,7 @@ JS);
                     $priority = $itil_object['priority'];
                 }
             }
-            $extra = 'id="' . $id . '" style="background-color:' .  htmlspecialchars($user->fields["priority_$priority"]) . '; cursor:pointer;"';
+            $extra = 'id="' . $id . '" style="background-color:' .  htmlescape($user->fields["priority_$priority"]) . '; cursor:pointer;"';
 
             echo Html::scriptBlock(<<<JS
                 $(document).on("click", "#$id", () => {
@@ -853,7 +853,7 @@ JS);
 
                $.ajax({
                   type: "GET",
-                  url: "' . htmlspecialchars($CFG_GLPI['root_doc']) . '/ajax/impact.php",
+                  url: "' . htmlescape($CFG_GLPI['root_doc']) . '/ajax/impact.php",
                   data: {
                      itemtype: values[0],
                      items_id: values[1],
@@ -986,7 +986,7 @@ JS);
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $action = htmlspecialchars($CFG_GLPI['root_doc']) . '/ajax/impact.php';
+        $action = htmlescape($CFG_GLPI['root_doc']) . '/ajax/impact.php';
         $formName = "form_impact_network";
 
         echo "<form name=\"$formName\" action=\"$action\" method=\"post\" class='no-track'>";
@@ -1041,8 +1041,8 @@ JS);
             $icon = self::checkIcon($icon);
 
             echo '<div class="impact-side-filter-itemtypes-item">';
-            echo '<h4><img class="impact-side-icon" src="' . htmlspecialchars($CFG_GLPI['root_doc']) . '/' . htmlspecialchars($icon) . '" title="' . htmlspecialchars($itemtype::getTypeName()) . '" data-itemtype="' . htmlspecialchars($itemtype) . '">';
-            echo "<span>" . htmlspecialchars($itemtype::getTypeName()) . "</span></h4>";
+            echo '<h4><img class="impact-side-icon" src="' . htmlescape($CFG_GLPI['root_doc']) . '/' . htmlescape($icon) . '" title="' . htmlescape($itemtype::getTypeName()) . '" data-itemtype="' . htmlescape($itemtype) . '">';
+            echo "<span>" . htmlescape($itemtype::getTypeName()) . "</span></h4>";
             echo '</div>'; // impact-side-filter-itemtypes-item
         }
         echo '</div>'; // impact-side-filter-itemtypes-items
@@ -1796,7 +1796,7 @@ JS);
         global $CFG_GLPI;
 
        // Form head
-        $action = htmlspecialchars(Toolbox::getItemTypeFormURL(Config::getType()));
+        $action = htmlescape(Toolbox::getItemTypeFormURL(Config::getType()));
         echo "<form name='form' action='$action' method='post'>";
 
        // Table head

--- a/src/Infocom.php
+++ b/src/Infocom.php
@@ -611,7 +611,7 @@ class Infocom extends CommonDBChild
                     Html::convDate($budget->fields['begin_date']),
                     Html::convDate($budget->fields['end_date'])
                 );
-                Session::addMessageAfterRedirect(htmlspecialchars($msg), false, ERROR);
+                Session::addMessageAfterRedirect(htmlescape($msg), false, ERROR);
             }
         }
     }
@@ -745,7 +745,7 @@ class Infocom extends CommonDBChild
                     ));
                     $task->addVolume(1);
                 } else {
-                    Session::addMessageAfterRedirect(htmlspecialchars(sprintf(
+                    Session::addMessageAfterRedirect(htmlescape(sprintf(
                         __('%1$s: %2$s'),
                         Dropdown::getDropdownName(
                             "glpi_entities",
@@ -770,7 +770,7 @@ class Infocom extends CommonDBChild
                 if ($task) {
                     $task->log($msg);
                 } else {
-                    Session::addMessageAfterRedirect(htmlspecialchars($msg), false, ERROR);
+                    Session::addMessageAfterRedirect(htmlescape($msg), false, ERROR);
                 }
             }
         }

--- a/src/ItemVirtualMachine.php
+++ b/src/ItemVirtualMachine.php
@@ -214,7 +214,7 @@ class ItemVirtualMachine extends CommonDBChild
                         ];
                     } else {
                         $entries[] = [
-                            'name' => htmlspecialchars($computer->fields['name']),
+                            'name' => htmlescape($computer->fields['name']),
                             'serial' => NOT_AVAILABLE,
                             'comment' => NOT_AVAILABLE,
                             'entity' => Dropdown::getDropdownName('glpi_entities', $computer->fields['entities_id'])

--- a/src/Item_Devices.php
+++ b/src/Item_Devices.php
@@ -636,7 +636,7 @@ class Item_Devices extends CommonDBRelation
             echo "\n<form id='form_device_add$rand' name='form_device_add$rand'
                   action='" . Toolbox::getItemTypeFormURL(__CLASS__) . "' method='post'>\n";
             echo "\t<input type='hidden' name='items_id' value='$ID'>\n";
-            echo "\t<input type='hidden' name='itemtype' value='" . htmlspecialchars($item->getType()) . "'>\n";
+            echo "\t<input type='hidden' name='itemtype' value='" . htmlescape($item->getType()) . "'>\n";
         }
 
         $table = new HTMLTableMain();
@@ -763,7 +763,7 @@ class Item_Devices extends CommonDBRelation
             echo "\n<form id='form_device_action$rand' name='form_device_action$rand'
                   action='" . Toolbox::getItemTypeFormURL(__CLASS__) . "' method='post'>\n";
             echo "\t<input type='hidden' name='items_id' value='$ID'>\n";
-            echo "\t<input type='hidden' name='itemtype' value='" . htmlspecialchars($item->getType()) . "'>\n";
+            echo "\t<input type='hidden' name='itemtype' value='" . htmlescape($item->getType()) . "'>\n";
         }
 
         $table->display(['display_super_for_each_group' => false,
@@ -1078,7 +1078,7 @@ class Item_Devices extends CommonDBRelation
                                 $content = Html::progressBar("percent" . mt_rand(), [
                                     'create'  => true,
                                     'percent' => $percent,
-                                    'message' => htmlspecialchars($message),
+                                    'message' => htmlescape($message),
                                     'display' => false
                                 ]);
                                 break;
@@ -1543,7 +1543,7 @@ class Item_Devices extends CommonDBRelation
 
         if (!isset($input[static::$items_id_2]) || !$input[static::$items_id_2]) {
             Session::addMessageAfterRedirect(
-                htmlspecialchars(sprintf(
+                htmlescape(sprintf(
                     __('%1$s: %2$s'),
                     static::getTypeName(),
                     __('A device ID is mandatory')
@@ -1596,7 +1596,7 @@ class Item_Devices extends CommonDBRelation
             }
             if (isset($input[$field]) && !$canUpdate) {
                 unset($input[$field]);
-                Session::addMessageAfterRedirect(htmlspecialchars(__('Update of ' . $attributs['short name'] . ' denied')));
+                Session::addMessageAfterRedirect(htmlescape(__('Update of ' . $attributs['short name'] . ' denied')));
             }
         }
 

--- a/src/Item_Disk.php
+++ b/src/Item_Disk.php
@@ -229,7 +229,7 @@ class Item_Disk extends CommonDBChild
             && !(!empty($withtemplate) && ($withtemplate == 2))
         ) {
             echo "<div class='mt-1 mb-3 text-center'>" .
-               "<a class='btn btn-primary' href='" . self::getFormURL() . "?itemtype=" . htmlspecialchars($itemtype) . "&items_id=$ID&amp;withtemplate=" .
+               "<a class='btn btn-primary' href='" . self::getFormURL() . "?itemtype=" . htmlescape($itemtype) . "&items_id=$ID&amp;withtemplate=" .
                   $withtemplate . "'>";
             echo __s('Add a volume');
             echo "</a></div>\n";

--- a/src/Item_Enclosure.php
+++ b/src/Item_Enclosure.php
@@ -243,11 +243,11 @@ class Item_Enclosure extends CommonDBRelation
         echo "</tr>";
 
         echo "<tr class='tab_bg_1'>";
-        echo "<td><label for='dropdown_enclosures_id$rand'>" . htmlspecialchars(Enclosure::getTypeName(1)) . "</label></td>";
+        echo "<td><label for='dropdown_enclosures_id$rand'>" . htmlescape(Enclosure::getTypeName(1)) . "</label></td>";
         echo "<td>";
         Enclosure::dropdown(['value' => $this->fields["enclosures_id"], 'rand' => $rand]);
         echo "</td>";
-        echo "<td><label for='dropdown_position$rand'>" . htmlspecialchars(__('Position')) . "</label></td>";
+        echo "<td><label for='dropdown_position$rand'>" . htmlescape(__('Position')) . "</label></td>";
         echo "<td>";
         Dropdown::showNumber(
             'position',

--- a/src/Item_Line.php
+++ b/src/Item_Line.php
@@ -204,7 +204,7 @@ class Item_Line extends CommonDBRelation
         } else {
             echo "<table class='tab_cadre_fixehov'>";
             $header = "<tr>";
-            $header .= "<th>" . htmlspecialchars(Item_DeviceSimcard::getTypeName(1)) . "</th>";
+            $header .= "<th>" . htmlescape(Item_DeviceSimcard::getTypeName(1)) . "</th>";
             $header .= "</tr>";
 
             echo $header;
@@ -372,7 +372,7 @@ class Item_Line extends CommonDBRelation
         } else {
             echo "<table class='tab_cadre_fixehov'>";
             $header = "<tr>";
-            $header .= "<th>" . htmlspecialchars(Item_DeviceSimcard::getTypeName(1)) . "</th>";
+            $header .= "<th>" . htmlescape(Item_DeviceSimcard::getTypeName(1)) . "</th>";
             $header .= "</tr>";
 
             echo $header;
@@ -394,7 +394,7 @@ class Item_Line extends CommonDBRelation
             echo '<tr class="tab_bg_2"><th colspan="3">' . __s('Add a line') . '</th></tr>';
 
             echo '<tr class="tab_bg_1">';
-            echo '<td><label for="dropdown_items_id' . $rand . '">' . htmlspecialchars(Line::getTypeName(1)) . '</label></td>';
+            echo '<td><label for="dropdown_items_id' . $rand . '">' . htmlescape(Line::getTypeName(1)) . '</label></td>';
             echo '<td>';
             //get all used items
             $used = [];
@@ -447,7 +447,7 @@ class Item_Line extends CommonDBRelation
                 $header .= Html::getCheckAllAsCheckbox('mass' . __CLASS__ . $rand);
                 $header .= "</th>";
             }
-            $header .= "<th>" . htmlspecialchars(Line::getTypeName(1)) . "</th>";
+            $header .= "<th>" . htmlescape(Line::getTypeName(1)) . "</th>";
             $header .= "</tr>";
 
             echo $header;

--- a/src/Item_OperatingSystem.php
+++ b/src/Item_OperatingSystem.php
@@ -250,7 +250,7 @@ class Item_OperatingSystem extends CommonDBRelation
         }
 
         foreach ($columns as $key => $val) {
-            $val = htmlspecialchars($val);
+            $val = htmlescape($val);
             $header_end .= "<th" . ($sort == $key ? " class='order_$order'" : '') . ">" .
                         "<a href='javascript:reloadTab(\"sort=$key&amp;order=" .
                           (($order == "ASC") ? "DESC" : "ASC") . "&amp;start=0\");'>$val</a></th>";
@@ -266,7 +266,7 @@ class Item_OperatingSystem extends CommonDBRelation
                     $linkname = sprintf(__('%1$s (%2$s)'), $linkname, $data["assocID"]);
                 }
                 $link = Toolbox::getItemTypeFormURL(self::getType());
-                $name = "<a href=\"" . $link . "?id=" . $data["assocID"] . "\">" . htmlspecialchars($linkname) . "</a>";
+                $name = "<a href=\"" . $link . "?id=" . $data["assocID"] . "\">" . htmlescape($linkname) . "</a>";
 
                 echo "<tr class='tab_bg_1'>";
                 if (
@@ -277,9 +277,9 @@ class Item_OperatingSystem extends CommonDBRelation
                     Html::showMassiveActionCheckBox(__CLASS__, $data["assocID"]);
                     echo "</td>";
                 }
-                $version = htmlspecialchars($data['version'] ?? "");
-                $architecture = htmlspecialchars($data['architecture'] ?? "");
-                $servicepack = htmlspecialchars($data['servicepack'] ?? "");
+                $version = htmlescape($data['version']);
+                $architecture = htmlescape($data['architecture']);
+                $servicepack = htmlescape($data['servicepack']);
                 echo "<td class='center'>{$name}</td>";
                 echo "<td class='center'>{$version}</td>";
                 echo "<td class='center'>{$architecture}</td>";

--- a/src/Item_Plug.php
+++ b/src/Item_Plug.php
@@ -102,7 +102,7 @@ class Item_Plug extends CommonDBRelation
         if ($canedit) {
             $rand = mt_rand();
             echo "\n<form id='form_device_add$rand' name='form_device_add$rand'
-               action='" . htmlspecialchars(Toolbox::getItemTypeFormURL(__CLASS__)) . "' method='post'>\n";
+               action='" . htmlescape(Toolbox::getItemTypeFormURL(__CLASS__)) . "' method='post'>\n";
             echo "\t<input type='hidden' name='" . static::$items_id_1 . "' value='$ID'>\n";
             echo "\t<input type='hidden' name='itemtype' value='" . $item::class . "'>\n";
             echo "<table class='tab_cadre_fixe'><tr class='tab_bg_1'><td>";

--- a/src/Item_Project.php
+++ b/src/Item_Project.php
@@ -106,7 +106,7 @@ class Item_Project extends CommonDBRelation
         if ($canedit) {
             echo "<div class='firstbloc'>";
             echo "<form name='projectitem_form$rand' id='projectitem_form$rand' method='post'
-                action='" . htmlspecialchars(Toolbox::getItemTypeFormURL(__CLASS__)) . "'>";
+                action='" . htmlescape(Toolbox::getItemTypeFormURL(__CLASS__)) . "'>";
 
             echo "<table class='tab_cadre_fixe'>";
             echo "<tr class='tab_bg_2'><th colspan='2'>" . __s('Add an item') . "</th></tr>";
@@ -149,7 +149,7 @@ class Item_Project extends CommonDBRelation
             $header_bottom .= "</th>";
         }
         $header_end .= "<th>" . _sn('Type', 'Types', 1) . "</th>";
-        $header_end .= "<th>" . htmlspecialchars(Entity::getTypeName(1)) . "</th>";
+        $header_end .= "<th>" . htmlescape(Entity::getTypeName(1)) . "</th>";
         $header_end .= "<th>" . __s('Name') . "</th>";
         $header_end .= "<th>" . __s('Serial number') . "</th>";
         $header_end .= "<th>" . __s('Inventory number') . "</th></tr>";
@@ -176,7 +176,7 @@ class Item_Project extends CommonDBRelation
                         $name = sprintf(__('%1$s (%2$s)'), $name, $data["id"]);
                     }
                     $link     = $item::getFormURLWithID($data['id']);
-                    $namelink = "<a href=\"" . $link . "\">" . htmlspecialchars($name) . "</a>";
+                    $namelink = "<a href=\"" . $link . "\">" . htmlescape($name) . "</a>";
 
                     echo "<tr class='tab_bg_1'>";
                     if ($canedit) {
@@ -185,7 +185,7 @@ class Item_Project extends CommonDBRelation
                         echo "</td>";
                     }
                     if ($prem) {
-                        $typename = htmlspecialchars($item->getTypeName($nb));
+                        $typename = htmlescape($item->getTypeName($nb));
                         echo "<td class='center top' rowspan='$nb'>" .
                          (($nb > 1) ? sprintf(__('%1$s: %2$s'), $typename, $nb) : $typename) . "</td>";
                         $prem = false;
@@ -195,10 +195,10 @@ class Item_Project extends CommonDBRelation
                     echo "<td class='center" .
                         (isset($data['is_deleted']) && $data['is_deleted'] ? " tab_bg_2_2'" : "'");
                     echo ">" . $namelink . "</td>";
-                    echo "<td class='center'>" . (isset($data["serial"]) ? "" . htmlspecialchars($data["serial"]) . "" : "-") .
+                    echo "<td class='center'>" . (isset($data["serial"]) ? "" . htmlescape($data["serial"]) . "" : "-") .
                     "</td>";
                     echo "<td class='center'>" .
-                      (isset($data["otherserial"]) ? "" . htmlspecialchars($data["otherserial"]) . "" : "-") . "</td>";
+                      (isset($data["otherserial"]) ? "" . htmlescape($data["otherserial"]) . "" : "-") . "</td>";
                     echo "</tr>";
                 }
                 $totalnb += $nb;

--- a/src/Item_Rack.php
+++ b/src/Item_Rack.php
@@ -304,7 +304,7 @@ class Item_Rack extends CommonDBRelation
             <div class="grid-stack grid-stack-2 grid-rack"
                  id="grid-front"
                  gs-column="2"
-                 gs-max-row="' . htmlspecialchars($rack->fields['number_units'] + 1) . '">';
+                 gs-max-row="' . htmlescape($rack->fields['number_units'] + 1) . '">';
 
         if ($link->canCreate()) {
             echo '<div class="racks_add"></div>';
@@ -315,7 +315,7 @@ class Item_Rack extends CommonDBRelation
         }
         echo '   <div class="grid-stack-item lock-bottom"
                     gs-no-resize="true" gs-no-move="true"
-                    gs-h="1" gs-w="2" gs-x="0" gs-y="' . htmlspecialchars($rack->fields['number_units']) . '"></div>
+                    gs-h="1" gs-w="2" gs-x="0" gs-y="' . htmlescape($rack->fields['number_units']) . '"></div>
             </div>
             <ul class="indexes"></ul>';
         // append some spaces on bottom for having symetrical view between front and rear
@@ -333,7 +333,7 @@ class Item_Rack extends CommonDBRelation
             <div class="grid-stack grid-stack-2 grid-rack"
                  id="grid2-rear"
                  gs-column="2"
-                 gs-max-row="' . htmlspecialchars($rack->fields['number_units'] + 1) . '">';
+                 gs-max-row="' . htmlescape($rack->fields['number_units'] + 1) . '">';
 
         if ($link->canCreate()) {
             echo '<div class="racks_add"></div>';
@@ -344,7 +344,7 @@ class Item_Rack extends CommonDBRelation
         }
         echo '   <div class="grid-stack-item lock-bottom"
                     gs-no-resize="true" gs-no-move="true"
-                    gs-h="1" gs-w="2" gs-x="0" gs-y="' . htmlspecialchars($rack->fields['number_units']) . '">
+                    gs-h="1" gs-w="2" gs-x="0" gs-y="' . htmlescape($rack->fields['number_units']) . '">
                </div>
             </div>
             <ul class="indexes"></ul>';
@@ -512,21 +512,21 @@ JAVASCRIPT;
         Html::progressBar('rack_space', [
             'create' => true,
             'percent' => $space_prct,
-            'message' => htmlspecialchars($space_prct . "%"),
+            'message' => htmlescape($space_prct . "%"),
         ]);
 
         echo "<h3>" . __s("Weight") . "</h3>";
         Html::progressBar('rack_weight', [
             'create' => true,
             'percent' => $weight_prct,
-            'message' => htmlspecialchars($weight . " / " . $rack->fields['max_weight'])
+            'message' => htmlescape($weight . " / " . $rack->fields['max_weight'])
         ]);
 
         echo "<h3>" . __s("Power") . "</h3>";
         Html::progressBar('rack_power', [
             'create' => true,
             'percent' => $power_prct,
-            'message' => htmlspecialchars($power . " / " . $rack->fields['max_power'])
+            'message' => htmlescape($power . " / " . $rack->fields['max_power'])
         ]);
         echo "</div>";
         echo "</div>";
@@ -647,7 +647,7 @@ JAVASCRIPT;
         echo "</tr>";
 
         echo "<tr class='tab_bg_1'>";
-        echo "<td><label for='dropdown_racks_id$rand'>" . htmlspecialchars(Rack::getTypeName(1)) . "</label></td>";
+        echo "<td><label for='dropdown_racks_id$rand'>" . htmlescape(Rack::getTypeName(1)) . "</label></td>";
         echo "<td>";
         Rack::dropdown(['value' => $this->fields["racks_id"], 'rand' => $rand]);
         echo "</td>";
@@ -1085,7 +1085,7 @@ JAVASCRIPT;
         if (count($error_detected)) {
             foreach ($error_detected as $error) {
                 Session::addMessageAfterRedirect(
-                    htmlspecialchars($error),
+                    htmlescape($error),
                     true,
                     ERROR
                 );

--- a/src/Item_RemoteManagement.php
+++ b/src/Item_RemoteManagement.php
@@ -155,7 +155,7 @@ class Item_RemoteManagement extends CommonDBChild
     public function getRemoteLink(): string
     {
         $link = '<a href="%s" target="_blank">%s</a>';
-        $id = htmlspecialchars($this->fields['remoteid'] ?? '');
+        $id = htmlescape($this->fields['remoteid']);
         $href = null;
         switch ($this->fields['type']) {
             case self::TEAMVIEWER:

--- a/src/Item_SoftwareLicense.php
+++ b/src/Item_SoftwareLicense.php
@@ -484,7 +484,7 @@ class Item_SoftwareLicense extends CommonDBRelation
                 echo "<tr class='tab_bg_2'><td colspan='2'>{$data["completename"]}</td></tr>";
                 foreach ($target_types as $itemtype) {
                     $nb = self::countForLicense($softwarelicense_id, $data['id'], $itemtype);
-                    $typename = htmlspecialchars($itemtype::getTypeName());
+                    $typename = htmlescape($itemtype::getTypeName());
                     echo "<tr class='tab_bg_2'><td>$tab$tab$typename</td>";
                     echo "<td class='numeric'>{$nb}</td></tr>\n";
                     $tot += $nb;
@@ -822,7 +822,7 @@ JAVASCRIPT;
             }
 
             foreach ($columns as $key => $val) {
-                $val = htmlspecialchars($val);
+                $val = htmlescape($val);
                // Non order column
                 if ($key[0] == '_') {
                     $header_end .= "<th>$val</th>";
@@ -850,7 +850,7 @@ JAVASCRIPT;
                     $itemname = sprintf(__('%1$s (%2$s)'), $itemname, $data['iID']);
                 }
 
-                $itemname = htmlspecialchars($itemname);
+                $itemname = htmlescape($itemname);
                 if ($canshowitems[$data['item_type']]) {
                     echo "<td><a href='" . $data['item_type']::getFormURLWithID($data['iID']) . "'>$itemname</a></td>";
                 } else {
@@ -860,11 +860,11 @@ JAVASCRIPT;
                 if ($showEntity) {
                     echo "<td>" . $data['entity'] . "</td>";
                 }
-                echo "<td>" . htmlspecialchars($data['serial']) . "</td>";
-                echo "<td>" . htmlspecialchars($data['otherserial']) . "</td>";
-                echo "<td>" . htmlspecialchars($data['location']) . "</td>";
-                echo "<td>" . htmlspecialchars($data['state']) . "</td>";
-                echo "<td>" . htmlspecialchars($data['groupe']) . "</td>";
+                echo "<td>" . htmlescape($data['serial']) . "</td>";
+                echo "<td>" . htmlescape($data['otherserial']) . "</td>";
+                echo "<td>" . htmlescape($data['location']) . "</td>";
+                echo "<td>" . htmlescape($data['state']) . "</td>";
+                echo "<td>" . htmlescape($data['groupe']) . "</td>";
                 echo "<td>" . formatUserLink(
                     $data['userid'],
                     $data['username'],

--- a/src/Item_SoftwareVersion.php
+++ b/src/Item_SoftwareVersion.php
@@ -748,7 +748,7 @@ class Item_SoftwareVersion extends CommonDBRelation
 
                 echo "<td>{$data['item_type']}</td>";
 
-                $itemname = htmlspecialchars($itemname);
+                $itemname = htmlescape($itemname);
                 if ($canshowitems[$data['item_type']]) {
                     echo "<td><a href='" . $data['item_type']::getFormURLWithID($data['iID']) . "'>$itemname</a></td>";
                 } else {
@@ -756,13 +756,13 @@ class Item_SoftwareVersion extends CommonDBRelation
                 }
 
                 if ($showEntity) {
-                    echo "<td>" . htmlspecialchars($data['entity']) . "</td>";
+                    echo "<td>" . htmlescape($data['entity']) . "</td>";
                 }
-                echo "<td>" . htmlspecialchars($data['serial']) . "</td>";
-                echo "<td>" . htmlspecialchars($data['otherserial']) . "</td>";
-                echo "<td>" . htmlspecialchars($data['location']) . "</td>";
-                echo "<td>" . htmlspecialchars($data['state']) . "</td>";
-                echo "<td>" . htmlspecialchars($data['groupe']) . "</td>";
+                echo "<td>" . htmlescape($data['serial']) . "</td>";
+                echo "<td>" . htmlescape($data['otherserial']) . "</td>";
+                echo "<td>" . htmlescape($data['location']) . "</td>";
+                echo "<td>" . htmlescape($data['state']) . "</td>";
+                echo "<td>" . htmlescape($data['groupe']) . "</td>";
                 echo "<td>" . formatUserLink(
                     $data['userid'],
                     $data['username'],
@@ -836,8 +836,8 @@ class Item_SoftwareVersion extends CommonDBRelation
 
         echo "<div class='center'>";
         echo "<table class='tab_cadre'><tr>";
-        echo "<th>" . htmlspecialchars(Entity::getTypeName(1)) . "</th>";
-        echo "<th>" . htmlspecialchars(self::getTypeName(Session::getPluralNumber())) . "</th>";
+        echo "<th>" . htmlescape(Entity::getTypeName(1)) . "</th>";
+        echo "<th>" . htmlescape(self::getTypeName(Session::getPluralNumber())) . "</th>";
         echo "</tr>\n";
 
         $tot = 0;
@@ -852,7 +852,7 @@ class Item_SoftwareVersion extends CommonDBRelation
         foreach ($iterator as $data) {
             $nb = self::countForVersion($softwareversions_id, $data['id']);
             if ($nb > 0) {
-                echo "<tr class='tab_bg_2'><td>" . htmlspecialchars($data["completename"]) . "</td>";
+                echo "<tr class='tab_bg_2'><td>" . htmlescape($data["completename"]) . "</td>";
                 echo "<td class='numeric'>" . $nb . "</td></tr>\n";
                 $tot += $nb;
             }
@@ -1043,7 +1043,7 @@ class Item_SoftwareVersion extends CommonDBRelation
 
        // Mini Search engine
         echo "<table class='tab_cadre_fixe'>";
-        echo "<tr class='tab_bg_1'><th colspan='2'>" . htmlspecialchars(Software::getTypeName(Session::getPluralNumber())) . "</th></tr>";
+        echo "<tr class='tab_bg_1'><th colspan='2'>" . htmlescape(Software::getTypeName(Session::getPluralNumber())) . "</th></tr>";
         echo "<tr class='tab_bg_1'><td>";
         echo _sn('Category', 'Categories', 1) . "</td><td>";
         SoftwareCategory::dropdown(['value'      => $crit,
@@ -1094,11 +1094,11 @@ class Item_SoftwareVersion extends CommonDBRelation
             $header_end .= "<th>" . __s('Name') . "</th>";
             $header_end .= "<th>" . __s('Status') . "</th>";
             $header_end .= "<th>" . _sn('Version', 'Versions', 1) . "</th>";
-            $header_end .= "<th>" . htmlspecialchars(SoftwareLicense::getTypeName(1)) . "</th>";
+            $header_end .= "<th>" . htmlescape(SoftwareLicense::getTypeName(1)) . "</th>";
             $header_end .= "<th>" . __s('Installation date') . "</th>";
             $header_end .= "<th>" . _sn('Architecture', 'Architectures', 1) . "</th>";
             $header_end .= "<th>" . __s('Automatic inventory') . "</th>";
-            $header_end .= "<th>" . htmlspecialchars(SoftwareCategory::getTypeName(1)) . "</th>";
+            $header_end .= "<th>" . htmlescape(SoftwareCategory::getTypeName(1)) . "</th>";
             $header_end .= "<th>" . __s('Valid license') . "</th>";
             $header_end .= "<th>
                 <button class='btn btn-sm show_filters " . ($is_filtered ? "btn-secondary" : "btn-outline-secondary") . "'>
@@ -1114,13 +1114,13 @@ class Item_SoftwareVersion extends CommonDBRelation
                         <input type='hidden' name='filters[active]' value='1'>
                     </td>
                     <td>
-                        <input type='text' class='form-control' name='filters[name]' value='" . htmlspecialchars($filters['name'] ?? '') . "'>
+                        <input type='text' class='form-control' name='filters[name]' value='" . htmlescape($filters['name']) . "'>
                     </td>
                     <td>
-                        <input type='text' class='form-control' name='filters[state]' value='" . htmlspecialchars($filters['state'] ?? '') . "'>
+                        <input type='text' class='form-control' name='filters[state]' value='" . htmlescape($filters['state']) . "'>
                     </td>
                     <td>
-                        <input type='text' class='form-control' name='filters[version]' value='" . htmlspecialchars($filters['version'] ?? '') . "'>
+                        <input type='text' class='form-control' name='filters[version]' value='" . htmlescape($filters['version']) . "'>
                     </td>
                     <td></td>
                     <td>
@@ -1133,7 +1133,7 @@ class Item_SoftwareVersion extends CommonDBRelation
                         ) . "
                     </td>
                     <td>
-                        <input type='text' class='form-control' name='filters[arch]' value='" . htmlspecialchars($filters['arch'] ?? '') . "'>
+                        <input type='text' class='form-control' name='filters[arch]' value='" . htmlescape($filters['arch']) . "'>
                     </td>
                     <td>" . Dropdown::showFromArray(
                             "filters[is_dynamic]",
@@ -1206,11 +1206,11 @@ class Item_SoftwareVersion extends CommonDBRelation
         ) {
             echo "<form method='post' action='" . Item_SoftwareLicense::getFormURL() . "'>";
             echo "<div class='spaced'><table class='tab_cadre_fixe'>";
-            echo "<tr class='tab_bg_1'><th colspan='2'>" . htmlspecialchars(SoftwareLicense::getTypeName(Session::getPluralNumber())) . "</th></tr>";
+            echo "<tr class='tab_bg_1'><th colspan='2'>" . htmlescape(SoftwareLicense::getTypeName(Session::getPluralNumber())) . "</th></tr>";
             echo "<tr class='tab_bg_1'>";
             echo "<td class='center'>";
-            echo htmlspecialchars(SoftwareLicense::getTypeName(Session::getPluralNumber())) . "&nbsp;&nbsp;";
-            echo "<input type='hidden' name='itemtype' value='" . htmlspecialchars($itemtype) . "'>";
+            echo htmlescape(SoftwareLicense::getTypeName(Session::getPluralNumber())) . "&nbsp;&nbsp;";
+            echo "<input type='hidden' name='itemtype' value='" . htmlescape($itemtype) . "'>";
             echo "<input type='hidden' name='items_id' value='$items_id'>";
             Software::dropdownLicenseToInstall("softwarelicenses_id", $entities_id);
             echo "</td><td width='20%'>";
@@ -1312,7 +1312,7 @@ class Item_SoftwareVersion extends CommonDBRelation
                 $header_end    .= "</th>";
             }
             $header_end .= "<th>" . __s('Name') . "</th><th>" . __s('Status') . "</th>";
-            $header_end .= "<th>" . _sn('Version', 'Versions', 1) . "</th><th>" . htmlspecialchars(SoftwareLicense::getTypeName(1)) . "</th>";
+            $header_end .= "<th>" . _sn('Version', 'Versions', 1) . "</th><th>" . htmlescape(SoftwareLicense::getTypeName(1)) . "</th>";
             $header_end .= "<th>" . __s('Installation date') . "</th>";
             $header_end .= "</tr>\n";
             echo $header_begin . $header_top . $header_end;
@@ -1379,9 +1379,9 @@ class Item_SoftwareVersion extends CommonDBRelation
             )
                                                : $data["softname"]);
             echo "</a></td>";
-            echo "<td>" . htmlspecialchars($data["state"]) . "</td>";
+            echo "<td>" . htmlescape($data["state"]) . "</td>";
 
-            echo "<td>" . htmlspecialchars($data["version"]);
+            echo "<td>" . htmlescape($data["version"]);
             echo "</td><td>";
         }
 
@@ -1430,13 +1430,13 @@ class Item_SoftwareVersion extends CommonDBRelation
             }
 
             if ($display) {
-                echo "<span class='b'>" . htmlspecialchars($licdata['name']) . "</span> - " . htmlspecialchars($licserial);
+                echo "<span class='b'>" . htmlescape($licdata['name']) . "</span> - " . htmlescape($licserial);
 
                 $link_item = Toolbox::getItemTypeFormURL('SoftwareLicense');
                 $link      = $link_item . "?id=" . $licdata['id'];
-                $comment   = "<table><tr><td>" . __s('Name') . "</td><td>" . htmlspecialchars($licdata['name']) . "</td></tr>" .
-                         "<tr><td>" . __s('Serial number') . "</td><td>" . htmlspecialchars($licdata['serial']) . "</td></tr>" .
-                         "<tr><td>" . __s('Comments') . '</td><td>' . htmlspecialchars($licdata['comment']) . "</td></tr>" .
+                $comment   = "<table><tr><td>" . __s('Name') . "</td><td>" . htmlescape($licdata['name']) . "</td></tr>" .
+                         "<tr><td>" . __s('Serial number') . "</td><td>" . htmlescape($licdata['serial']) . "</td></tr>" .
+                         "<tr><td>" . __s('Comments') . '</td><td>' . htmlescape($licdata['comment']) . "</td></tr>" .
                          "</table>";
 
                 Html::showToolTip($comment, ['link' => $link]);
@@ -1506,9 +1506,9 @@ class Item_SoftwareVersion extends CommonDBRelation
         )
                                             : $data["softname"]);
         echo "</a></td>";
-        echo "<td>" . htmlspecialchars($data["state"]) . "</td>";
+        echo "<td>" . htmlescape($data["state"]) . "</td>";
 
-        echo "<td>" . htmlspecialchars($data["version"]);
+        echo "<td>" . htmlescape($data["version"]);
 
         $serial = $data["serial"];
 
@@ -1527,9 +1527,9 @@ class Item_SoftwareVersion extends CommonDBRelation
             echo " - " . $serial;
         }
 
-        $comment = "<table><tr><td>" . __s('Name') . "</td>" . "<td>" . htmlspecialchars($data['name']) . "</td></tr>" .
-                 "<tr><td>" . __s('Serial number') . "</td><td>" . htmlspecialchars($data['serial']) . "</td></tr>" .
-                 "<tr><td>" . __s('Comments') . "</td><td>" . htmlspecialchars($data['comment']) . "</td></tr></table>";
+        $comment = "<table><tr><td>" . __s('Name') . "</td>" . "<td>" . htmlescape($data['name']) . "</td></tr>" .
+                 "<tr><td>" . __s('Serial number') . "</td><td>" . htmlescape($data['serial']) . "</td></tr>" .
+                 "<tr><td>" . __s('Comments') . "</td><td>" . htmlescape($data['comment']) . "</td></tr></table>";
 
         Html::showToolTip($comment, ['link' => $link]);
         echo "</td></tr>\n";

--- a/src/Itil_Project.php
+++ b/src/Itil_Project.php
@@ -317,7 +317,7 @@ TWIG, $twig_params);
             echo '<tr class="tab_bg_2"><th colspan="2">' . __s('Add a project') . '</th></tr>';
             echo '<tr class="tab_bg_2">';
             echo '<td>';
-            echo '<input type="hidden" name="itemtype" value="' . htmlspecialchars($itil->getType()) . '" />';
+            echo '<input type="hidden" name="itemtype" value="' . htmlescape($itil->getType()) . '" />';
             echo '<input type="hidden" name="items_id" value="' . $ID . '" />';
             Project::dropdown(
                 [
@@ -348,7 +348,7 @@ TWIG, $twig_params);
 
         echo '<table class="tab_cadre_fixehov">';
         echo '<tr class="noHover">';
-        echo '<th colspan="12">' . htmlspecialchars(Project::getTypeName($numrows)) . '</th>';
+        echo '<th colspan="12">' . htmlescape(Project::getTypeName($numrows)) . '</th>';
         echo '</tr>';
         if ($numrows) {
             Project::commonListHeader(Search::HTML_OUTPUT, $massContainerId);

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -1600,8 +1600,8 @@ TWIG, $twig_params);
                         $row_num
                     );
                 } else {
-                    echo Search::showItem($output_type, htmlspecialchars($name), $item_num, $row_num);
-                    echo Search::showItem($output_type, htmlspecialchars(RichText::getTextFromHtml($answer, true, false, true)), $item_num, $row_num);
+                    echo Search::showItem($output_type, htmlescape($name), $item_num, $row_num);
+                    echo Search::showItem($output_type, htmlescape(RichText::getTextFromHtml($answer, true, false, true)), $item_num, $row_num);
                 }
 
                 if ($showwriter) {
@@ -1628,9 +1628,9 @@ TWIG, $twig_params);
                         $categories_names[] = "<a class='kb-category'"
                             . " href='$cathref'"
                             . " data-category-id='" . $knowbaseitemcategories_id . "'"
-                            . ">" . htmlspecialchars($fullcategoryname) . '</a>';
+                            . ">" . htmlescape($fullcategoryname) . '</a>';
                     } else {
-                        $categories_names[] = htmlspecialchars($fullcategoryname);
+                        $categories_names[] = htmlescape($fullcategoryname);
                     }
                 }
                 echo Search::showItem($output_type, implode(', ', $categories_names), $item_num, $row_num);
@@ -2102,7 +2102,7 @@ TWIG, $twig_params);
                     $matches[1],
                     $matches[2],
                     Toolbox::slugify($matches[3]),
-                    htmlspecialchars($matches[3]),
+                    htmlescape($matches[3]),
                     '<svg aria-hidden="true" height="16" version="1.1" viewBox="0 0 16 16" width="16"><path d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"/></svg>'
                 ],
                 $tpl

--- a/src/KnowbaseItemTranslation.php
+++ b/src/KnowbaseItemTranslation.php
@@ -204,9 +204,9 @@ TWIG, $twig_params);
 
         $entries = [];
         foreach ($found as $data) {
-            $name = htmlspecialchars($data["name"]);
+            $name = htmlescape($data["name"]);
             if ($canedit) {
-                $name = "<a href=\"" . htmlspecialchars(self::getFormURLWithID($data["id"])) . "\">{$name}</a>";
+                $name = "<a href=\"" . htmlescape(self::getFormURLWithID($data["id"])) . "\">{$name}</a>";
             }
             if (!empty($data['answer'])) {
                 $name .= Html::showToolTip(RichText::getEnhancedHtml($data['answer']), [

--- a/src/KnowbaseItem_Item.php
+++ b/src/KnowbaseItem_Item.php
@@ -331,7 +331,7 @@ class KnowbaseItem_Item extends CommonDBRelation
                     if ($values[$field] > 0) {
                         $item = new $values['itemtype']();
                         $item->getFromDB($values[$field]);
-                        return "<a href='" . htmlspecialchars($item->getLinkURL()) . "'>" . htmlspecialchars($item->fields['name']) . "</a>";
+                        return "<a href='" . htmlescape($item->getLinkURL()) . "'>" . htmlescape($item->fields['name']) . "</a>";
                     }
                 }
                 return ' ';

--- a/src/LevelAgreement.php
+++ b/src/LevelAgreement.php
@@ -167,7 +167,7 @@ abstract class LevelAgreement extends CommonDBChild
         echo Html::input("name", ['value' => $this->fields["name"]]);
         echo "<td rowspan='" . $rowspan . "'>" . __s('Comments') . "</td>";
         echo "<td rowspan='" . $rowspan . "'>
-            <textarea class='form-control' rows='8' name='comment' >" . htmlspecialchars($this->fields["comment"]) . "</textarea>";
+            <textarea class='form-control' rows='8' name='comment' >" . htmlescape($this->fields["comment"]) . "</textarea>";
         echo "</td></tr>";
 
         echo "<tr class='tab_bg_1'>";
@@ -448,7 +448,7 @@ TWIG, $twig_params);
             $entries[] = [
                 'itemtype' => RuleTicket::class,
                 'id'       => $rule->getID(),
-                'rule'     => $canedit ? $rule->getLink() : htmlspecialchars($rule->fields["name"]),
+                'rule'     => $canedit ? $rule->getLink() : htmlescape($rule->fields["name"]),
                 'active'   => Dropdown::getYesNo($rule->fields["is_active"]),
                 'description' => $rule->fields["description"]
             ];

--- a/src/Link.php
+++ b/src/Link.php
@@ -600,7 +600,7 @@ TWIG, $buttons_params);
                 $actions = '';
 
                 if ($manuallink->canUpdateItem()) {
-                    $actions .= '<a href="' . htmlspecialchars(ManualLink::getFormURLWithID($row[$item->getIndexName()])) . '" title="' . _sx('button', 'Update') . '">';
+                    $actions .= '<a href="' . htmlescape(ManualLink::getFormURLWithID($row[$item->getIndexName()])) . '" title="' . _sx('button', 'Update') . '">';
                     $actions .= '<i class="fas fa-edit"></i>';
                     $actions .= '<span class="sr-only">' . _x('button', 'Update') . '</span>';
                     $actions .= '</a>';
@@ -690,13 +690,13 @@ TWIG, $buttons_params);
             $i     = 1;
             foreach ($links as $key => $val) {
                 $name    = ($names[$key] ?? reset($names));
-                $newlink = '<a href="' . htmlspecialchars($val) . '"';
+                $newlink = '<a href="' . htmlescape($val) . '"';
                 if ($params['open_window']) {
                     $newlink .= " target='_blank'";
                 }
                 $newlink          .= ">";
-                $linkname          = htmlspecialchars(sprintf(__('%1$s #%2$s'), $name, $i));
-                $newlink          .= htmlspecialchars(sprintf(__('%1$s: %2$s'), $linkname, $val));
+                $linkname          = htmlescape(sprintf(__('%1$s #%2$s'), $name, $i));
+                $newlink          .= htmlescape(sprintf(__('%1$s: %2$s'), $linkname, $val));
                 $newlink          .= "</a>";
                 $computedlinks[]   = $newlink;
                 $i++;
@@ -718,10 +718,10 @@ TWIG, $buttons_params);
                 $url             = $CFG_GLPI["root_doc"] . "/front/link.send.php?lID=" . $params['id'] .
                                  "&itemtype=" . $item::class .
                                  "&id=" . $item->getID() . "&rank=$key";
-                $newlink         = '<a href="' . htmlspecialchars($url) . '" target="_blank">';
+                $newlink         = '<a href="' . htmlescape($url) . '" target="_blank">';
                 $newlink        .= "<i class='fa-lg fa-fw fas fa-link me-2'></i>";
-                $linkname        = htmlspecialchars(sprintf(__('%1$s #%2$s'), $name, $i));
-                $newlink        .= htmlspecialchars(sprintf(__('%1$s: %2$s'), $linkname, $val));
+                $linkname        = htmlescape(sprintf(__('%1$s #%2$s'), $name, $i));
+                $newlink        .= htmlescape(sprintf(__('%1$s: %2$s'), $linkname, $val));
                 $newlink        .= "</a>";
                 $computedlinks[] = $newlink;
                 $i++;
@@ -842,7 +842,7 @@ TWIG, $buttons_params);
             || (isset($input['data']) && !TemplateManager::validate($input['data'], $err_msg))
         ) {
             if ($err_msg !== null) {
-                Session::addMessageAfterRedirect(htmlspecialchars($err_msg), false, ERROR);
+                Session::addMessageAfterRedirect(htmlescape($err_msg), false, ERROR);
             }
             return false;
         }

--- a/src/Lock.php
+++ b/src/Lock.php
@@ -278,7 +278,7 @@ TWIG;
                 if ($default_items_id !== null && is_a($row['itemtype'], CommonDBRelation::class, true)) {
                     $related_object = new $default_itemtype();
                     $related_object->getFromDB($object->fields[$default_items_id]);
-                    $name = htmlspecialchars($related_object->getName());
+                    $name = htmlescape($related_object->getName());
                     $default_object_link = "<a href='" . $object->getLinkURL() . "'" . $name . ">" . $name . "</a>";
                 }
 
@@ -489,22 +489,22 @@ TWIG, $twig_params);
                 $item = new $itemtype();
                 if ($item->can($link_item, READ)) {
                     $url  = "<a href='" . $item->getFormURLWithID($link_item) . "'>";
-                    $url .= htmlspecialchars($item->fields["name"]) . "</a>";
+                    $url .= htmlescape($item->fields["name"]) . "</a>";
 
-                    $tooltip = "<table><tr><td>" . __s('Name') . "</td><td>" . htmlspecialchars($item->fields['name']) .
+                    $tooltip = "<table><tr><td>" . __s('Name') . "</td><td>" . htmlescape($item->fields['name']) .
                         '</td></tr>';
                     if (isset($item->fields['serial'])) {
-                        $tooltip .= "<tr><td>" . __s('Serial number') . "</td><td>" . htmlspecialchars($item->fields['serial']) .
+                        $tooltip .= "<tr><td>" . __s('Serial number') . "</td><td>" . htmlescape($item->fields['serial']) .
                             '</td></tr>';
                     }
                     if (isset($item->fields['comment'])) {
-                        $tooltip .= "<tr><td>" . __s('Comments') . "</td><td>" . htmlspecialchars($item->fields['comment']) .
+                        $tooltip .= "<tr><td>" . __s('Comments') . "</td><td>" . htmlescape($item->fields['comment']) .
                             '</td></tr></table>';
                     }
 
                     $url .= "&nbsp; " . Html::showToolTip($tooltip, ['display' => false]);
                 } else {
-                    $url = htmlspecialchars($item->fields['name']);
+                    $url = htmlescape($item->fields['name']);
                 }
             }
             $subtable['entries'][] = [
@@ -868,7 +868,7 @@ TWIG, $twig_params);
                     $show_checkbox = $type_item->can($data['id'], UPDATE) || $type_item->can($data['id'], PURGE);
                     $object_item_type = new $type();
                     $object_item_type->getFromDB($data['id']);
-                    $object_name = htmlspecialchars($data['name']);
+                    $object_name = htmlescape($data['name']);
                     $object_link = "<a href='" . $object_item_type->getLinkURL() . "'>{$object_name}</a>";
 
                     $subtable['entries'][] = [

--- a/src/Log.php
+++ b/src/Log.php
@@ -418,7 +418,7 @@ class Log extends CommonDBTM
                     case self::HISTORY_LOCK_ITEM:
                     case self::HISTORY_UNLOCK_ITEM:
                     case self::HISTORY_RESTORE_ITEM:
-                        $tmp['change'] = htmlspecialchars($action_label);
+                        $tmp['change'] = htmlescape($action_label);
                         break;
 
                     case self::HISTORY_ADD_DEVICE:
@@ -433,8 +433,8 @@ class Log extends CommonDBTM
                      //TRANS: %s is the component name
                         $tmp['change'] = sprintf(
                             __s('%1$s: %2$s'),
-                            htmlspecialchars($action_label),
-                            htmlspecialchars($data["new_value"])
+                            htmlescape($action_label),
+                            htmlescape($data["new_value"])
                         );
                         break;
 
@@ -455,13 +455,13 @@ class Log extends CommonDBTM
                              __s('%1$s: %2$s'),
                              sprintf(
                                  __s('%1$s (%2$s)'),
-                                 htmlspecialchars($action_label),
-                                 htmlspecialchars($tmp['field'])
+                                 htmlescape($action_label),
+                                 htmlescape($tmp['field'])
                              ),
                              sprintf(
                                  __s('%1$s by %2$s'),
-                                 htmlspecialchars($data["old_value"]),
-                                 htmlspecialchars($data[ "new_value"])
+                                 htmlescape($data["old_value"]),
+                                 htmlescape($data[ "new_value"])
                              )
                          );
                         break;
@@ -478,8 +478,8 @@ class Log extends CommonDBTM
                        //TRANS: %s is the component name
                         $tmp['change'] = sprintf(
                             __s('%1$s: %2$s'),
-                            htmlspecialchars($action_label),
-                            htmlspecialchars($data["old_value"])
+                            htmlescape($action_label),
+                            htmlescape($data["old_value"])
                         );
                         break;
 
@@ -495,8 +495,8 @@ class Log extends CommonDBTM
                         //TRANS: %s is the component name
                         $tmp['change'] = sprintf(
                             __s('%1$s: %2$s'),
-                            htmlspecialchars($action_label),
-                            htmlspecialchars($data["old_value"])
+                            htmlescape($action_label),
+                            htmlescape($data["old_value"])
                         );
                         break;
 
@@ -512,8 +512,8 @@ class Log extends CommonDBTM
                         //TRANS: %s is the component name
                         $tmp['change'] = sprintf(
                             __s('%1$s: %2$s'),
-                            htmlspecialchars($action_label),
-                            htmlspecialchars($data["new_value"])
+                            htmlescape($action_label),
+                            htmlescape($data["new_value"])
                         );
                         break;
 
@@ -522,8 +522,8 @@ class Log extends CommonDBTM
                         //TRANS: %s is the software name
                         $tmp['change'] = sprintf(
                             __s('%1$s: %2$s'),
-                            htmlspecialchars($action_label),
-                            htmlspecialchars($data["new_value"])
+                            htmlescape($action_label),
+                            htmlescape($data["new_value"])
                         );
                         break;
 
@@ -532,8 +532,8 @@ class Log extends CommonDBTM
                         //TRANS: %s is the software name
                         $tmp['change'] = sprintf(
                             __s('%1$s: %2$s'),
-                            htmlspecialchars($action_label),
-                            htmlspecialchars($data["old_value"])
+                            htmlescape($action_label),
+                            htmlescape($data["old_value"])
                         );
                         break;
 
@@ -549,8 +549,8 @@ class Log extends CommonDBTM
                         //TRANS: %s is the item name
                         $tmp['change'] = sprintf(
                             __s('%1$s: %2$s'),
-                            htmlspecialchars($action_label),
-                            htmlspecialchars($data["old_value"])
+                            htmlescape($action_label),
+                            htmlescape($data["old_value"])
                         );
                         break;
 
@@ -566,14 +566,14 @@ class Log extends CommonDBTM
                         //TRANS: %s is the item name
                         $tmp['change'] = sprintf(
                             __s('%1$s: %2$s'),
-                            htmlspecialchars($action_label),
-                            htmlspecialchars($data["new_value"])
+                            htmlescape($action_label),
+                            htmlescape($data["new_value"])
                         );
                         break;
 
                     case self::HISTORY_LOG_SIMPLE_MESSAGE:
                         $tmp['field']  = "";
-                        $tmp['change'] = htmlspecialchars($data["new_value"]);
+                        $tmp['change'] = htmlescape($data["new_value"]);
                         break;
 
                     case self::HISTORY_ADD_RELATION:
@@ -583,8 +583,8 @@ class Log extends CommonDBTM
                         }
                         $tmp['change'] = sprintf(
                             __s('%1$s: %2$s'),
-                            htmlspecialchars($action_label),
-                            htmlspecialchars($data["new_value"])
+                            htmlescape($action_label),
+                            htmlescape($data["new_value"])
                         );
 
                         if ($data['itemtype'] == 'Ticket') {
@@ -626,18 +626,18 @@ class Log extends CommonDBTM
                             if ($as) {
                                 $tmp['change'] = sprintf(
                                     __s('%1$s: %2$s'),
-                                    htmlspecialchars($action_label),
+                                    htmlescape($action_label),
                                     sprintf(
                                         __s('%1$s (%2$s)'),
-                                        htmlspecialchars($data["new_value"]),
-                                        htmlspecialchars($as)
+                                        htmlescape($data["new_value"]),
+                                        htmlescape($as)
                                     )
                                 );
                             } else {
                                 $tmp['change'] = sprintf(
                                     __s('%1$s: %2$s'),
-                                    htmlspecialchars($action_label),
-                                    htmlspecialchars($data["new_value"])
+                                    htmlescape($action_label),
+                                    htmlescape($data["new_value"])
                                 );
                             }
                         }
@@ -651,11 +651,11 @@ class Log extends CommonDBTM
                         }
                         $tmp['change'] = sprintf(
                             __s('%1$s: %2$s'),
-                            htmlspecialchars($action_label),
+                            htmlescape($action_label),
                             sprintf(
                                 __s('%1$s (%2$s)'),
-                                htmlspecialchars($data["old_value"]),
-                                htmlspecialchars($data["new_value"])
+                                htmlescape($data["old_value"]),
+                                htmlescape($data["new_value"])
                             )
                         );
                         break;
@@ -667,8 +667,8 @@ class Log extends CommonDBTM
                         }
                         $tmp['change'] = sprintf(
                             __s('%1$s: %2$s'),
-                            htmlspecialchars($action_label),
-                            htmlspecialchars($data["old_value"])
+                            htmlescape($action_label),
+                            htmlescape($data["old_value"])
                         );
                         break;
 
@@ -679,8 +679,8 @@ class Log extends CommonDBTM
                         }
                         $tmp['change'] = sprintf(
                             __s('%1$s: %2$s'),
-                            htmlspecialchars($action_label),
-                            htmlspecialchars($data["old_value"])
+                            htmlescape($action_label),
+                            htmlescape($data["old_value"])
                         );
                         break;
 
@@ -691,8 +691,8 @@ class Log extends CommonDBTM
                         }
                         $tmp['change'] = sprintf(
                             __s('%1$s: %2$s'),
-                            htmlspecialchars($action_label),
-                            htmlspecialchars($data["new_value"])
+                            htmlescape($action_label),
+                            htmlescape($data["new_value"])
                         );
                         break;
 
@@ -703,11 +703,11 @@ class Log extends CommonDBTM
                         }
                         $tmp['change'] = sprintf(
                             __s('%1$s: %2$s'),
-                            htmlspecialchars($action_label),
+                            htmlescape($action_label),
                             sprintf(
                                 __s('%1$s (%2$s)'),
-                                htmlspecialchars($tmp['field']),
-                                htmlspecialchars($data["new_value"])
+                                htmlescape($tmp['field']),
+                                htmlescape($data["new_value"])
                             )
                         );
 
@@ -720,11 +720,11 @@ class Log extends CommonDBTM
                         }
                         $tmp['change'] = sprintf(
                             __s('%1$s: %2$s'),
-                            htmlspecialchars($action_label),
+                            htmlescape($action_label),
                             sprintf(
                                 __s('%1$s (%2$s)'),
-                                htmlspecialchars($tmp['field']),
-                                htmlspecialchars($data["new_value"])
+                                htmlescape($tmp['field']),
+                                htmlescape($data["new_value"])
                             )
                         );
                         break;
@@ -736,11 +736,11 @@ class Log extends CommonDBTM
                         }
                         $tmp['change'] = sprintf(
                             __s('%1$s: %2$s'),
-                            htmlspecialchars($action_label),
+                            htmlescape($action_label),
                             sprintf(
                                 __s('%1$s (%2$s)'),
-                                htmlspecialchars($tmp['field']),
-                                htmlspecialchars($data["old_value"])
+                                htmlescape($tmp['field']),
+                                htmlescape($data["old_value"])
                             )
                         );
                         break;
@@ -752,11 +752,11 @@ class Log extends CommonDBTM
                         }
                         $tmp['change'] = sprintf(
                             __s('%1$s: %2$s'),
-                            htmlspecialchars($action_label),
+                            htmlescape($action_label),
                             sprintf(
                                 __s('%1$s (%2$s)'),
-                                htmlspecialchars($tmp['field']),
-                                htmlspecialchars($data["old_value"])
+                                htmlescape($tmp['field']),
+                                htmlescape($data["old_value"])
                             )
                         );
                         break;
@@ -768,11 +768,11 @@ class Log extends CommonDBTM
                         }
                         $tmp['change'] = sprintf(
                             __s('%1$s: %2$s'),
-                            htmlspecialchars($action_label),
+                            htmlescape($action_label),
                             sprintf(
                                 __s('%1$s (%2$s)'),
-                                htmlspecialchars($tmp['field']),
-                                htmlspecialchars($data["new_value"])
+                                htmlescape($tmp['field']),
+                                htmlescape($data["new_value"])
                             )
                         );
                         break;
@@ -780,12 +780,12 @@ class Log extends CommonDBTM
                     case self::HISTORY_SEND_WEBHOOK:
                         $tmp['change'] = sprintf(
                             __s('%1$s: %2$s'),
-                            htmlspecialchars($action_label),
+                            htmlescape($action_label),
                             sprintf(
                                 __s('%1$s (Status %2$s -> %3$s)'),
-                                htmlspecialchars($data["itemtype_link"]),
-                                htmlspecialchars($data["old_value"]),
-                                htmlspecialchars($data["new_value"])
+                                htmlescape($data["itemtype_link"]),
+                                htmlescape($data["old_value"]),
+                                htmlescape($data["new_value"])
                             )
                         );
                         break;
@@ -882,8 +882,8 @@ class Log extends CommonDBTM
                     }
                     $tmp['change'] = sprintf(
                         __s('Change %1$s to %2$s'),
-                        '<del>' . htmlspecialchars($oldval) . '</del>',
-                        '<ins>' . htmlspecialchars($newval) . '</ins>'
+                        '<del>' . htmlescape($oldval) . '</del>',
+                        '<ins>' . htmlescape($newval) . '</ins>'
                     );
                 }
             }

--- a/src/MailCollector.php
+++ b/src/MailCollector.php
@@ -469,7 +469,7 @@ class MailCollector extends CommonDBTM
                     foreach ($rejected as $id => $data) {
                         if ($action == 1) {
                             Session::addMessageAfterRedirect(
-                                htmlspecialchars(sprintf(
+                                htmlescape(sprintf(
                                     __('Email %s not found. Impossible import.'),
                                     strtr($id, $clean)
                                 )),
@@ -511,7 +511,7 @@ class MailCollector extends CommonDBTM
             } catch (\Throwable $e) {
                 ErrorHandler::getInstance()->handleException($e, true);
                 Session::addMessageAfterRedirect(
-                    __s('An error occurred trying to connect to collector.') . "<br/>" . htmlspecialchars($e->getMessage()),
+                    __s('An error occurred trying to connect to collector.') . "<br/>" . htmlescape($e->getMessage()),
                     false,
                     ERROR
                 );
@@ -798,14 +798,14 @@ class MailCollector extends CommonDBTM
                     $blacklisted
                 );
                 if ($display) {
-                     Session::addMessageAfterRedirect(htmlspecialchars($msg), false, ($error ? ERROR : INFO));
+                     Session::addMessageAfterRedirect(htmlescape($msg), false, ($error ? ERROR : INFO));
                 } else {
                     return $msg;
                 }
             } else {
                 $msg = __('Could not connect to mailgate server');
                 if ($display) {
-                    Session::addMessageAfterRedirect(htmlspecialchars($msg), false, ERROR);
+                    Session::addMessageAfterRedirect(htmlescape($msg), false, ERROR);
                     GLPINetwork::addErrorMessageAfterRedirect();
                 } else {
                     return $msg;
@@ -815,7 +815,7 @@ class MailCollector extends CommonDBTM
            //TRANS: %s is the ID of the mailgate
             $msg = sprintf(__('Could not find mailgate %d'), $mailgateID);
             if ($display) {
-                Session::addMessageAfterRedirect(htmlspecialchars($msg), false, ERROR);
+                Session::addMessageAfterRedirect(htmlescape($msg), false, ERROR);
                 GLPINetwork::addErrorMessageAfterRedirect();
             } else {
                 return $msg;
@@ -1885,8 +1885,8 @@ class MailCollector extends CommonDBTM
             foreach ($errors as $data) {
                 $collector->getFromDB($data['id']);
                 $servers[] = [
-                    'link' => htmlspecialchars($collector->getLinkURL()),
-                    'name' => htmlspecialchars($collector->getName(['complete' => true]))
+                    'link' => htmlescape($collector->getLinkURL()),
+                    'name' => htmlescape($collector->getName(['complete' => true]))
                 ];
             }
         }

--- a/src/ManualLink.php
+++ b/src/ManualLink.php
@@ -223,13 +223,13 @@ class ManualLink extends CommonDBChild
         $html = '';
 
         $target = $fields['open_window'] == 1 ? '_blank' : '_self';
-        $html .= '<a href="' . htmlspecialchars($fields['url']) . '" target="' . $target . '">';
+        $html .= '<a href="' . htmlescape($fields['url']) . '" target="' . $target . '">';
         if (!empty($fields['icon'])) {
             // Forces font family values to fallback on ".fab" family font if char is not available in ".fas" family.
-            $html .= '<i class="fa-lg fa-fw fa ' . htmlspecialchars($fields['icon']) . '"'
+            $html .= '<i class="fa-lg fa-fw fa ' . htmlescape($fields['icon']) . '"'
             . ' style="font-family:\'Font Awesome 6 Free\', \'Font Awesome 6 Brands\';"></i>&nbsp;';
         }
-        $html .= htmlspecialchars(!empty($fields['name']) ? $fields['name'] : $fields['url']);
+        $html .= htmlescape(!empty($fields['name']) ? $fields['name'] : $fields['url']);
         $html .= '</a>';
 
         return $html;

--- a/src/MassiveAction.php
+++ b/src/MassiveAction.php
@@ -1341,7 +1341,7 @@ class MassiveAction
         if ($this->display_progress_bars) {
             if ($this->progress_bar_displayed !== true) {
                 Html::progressBar('main_' . $this->identifier, ['create'  => true,
-                    'message' => htmlspecialchars($this->action_name)
+                    'message' => htmlescape($this->action_name)
                 ]);
                 $this->progress_bar_displayed         = true;
                 $this->fields_to_remove_when_reload[] = 'progress_bar_displayed';
@@ -1363,7 +1363,7 @@ class MassiveAction
                     Html::progressBar(
                         'itemtype_' . $this->identifier,
                         [
-                            'message' => htmlspecialchars($itemtype::getTypeName(Session::getPluralNumber())),
+                            'message' => htmlescape($itemtype::getTypeName(Session::getPluralNumber())),
                             'percent' => $percent
                         ]
                     );

--- a/src/Migration.php
+++ b/src/Migration.php
@@ -126,7 +126,7 @@ class Migration
     {
         if (!isCommandLine() && $id != $this->current_message_area_id) {
             $this->current_message_area_id = $id;
-            echo "<div id='" . htmlspecialchars($this->current_message_area_id) . "'></div>";
+            echo "<div id='" . htmlescape($this->current_message_area_id) . "'></div>";
         }
 
         $this->displayMessage(__('Work in progress...'));
@@ -683,7 +683,7 @@ class Migration
             if (isCommandLine()) {
                 throw new \RuntimeException($message);
             } else {
-                echo htmlspecialchars($message) . "\n";
+                echo htmlescape($message) . "\n";
                 die(1);
             }
         }
@@ -1605,7 +1605,7 @@ class Migration
      */
     private function outputMessageToHtml(string $msg, ?string $style = null, ?string $area_id = null): void
     {
-        $msg = htmlspecialchars($msg);
+        $msg = htmlescape($msg);
 
         $msg = match ($style) {
             'title' => '<h3>' . $msg . '</h3>',

--- a/src/NetworkAlias.php
+++ b/src/NetworkAlias.php
@@ -117,7 +117,7 @@ class NetworkAlias extends FQDNLabel
         );
         echo "</td>";
         echo "<td>" . __s('Comments') . "</td>";
-        echo "<td><textarea class='form-control' rows='4' name='comment' >" . htmlspecialchars($this->fields["comment"]);
+        echo "<td><textarea class='form-control' rows='4' name='comment' >" . htmlescape($this->fields["comment"]);
         echo "</textarea></td>";
         echo "</tr>";
 
@@ -151,9 +151,9 @@ class NetworkAlias extends FQDNLabel
             return;
         }
 
-        $content = htmlspecialchars(self::getTypeName());
+        $content = htmlescape(self::getTypeName());
         if (isset($options['column_links'][$column_name])) {
-            $content = "<a href='" . htmlspecialchars($options['column_links'][$column_name]) . "'>$content</a>";
+            $content = "<a href='" . htmlescape($options['column_links'][$column_name]) . "'>$content</a>";
         }
         $this_header = $base->addHeader($column_name, $content, $super, $father);
         $this_header->setItemType('NetworkAlias');
@@ -212,8 +212,8 @@ class NetworkAlias extends FQDNLabel
                     $row = $row->createRow();
                 }
 
-                $content = '<a href="' . htmlspecialchars($alias->getLinkURL()) . '">'
-                    . htmlspecialchars($alias->getInternetName())
+                $content = '<a href="' . htmlescape($alias->getLinkURL()) . '">'
+                    . htmlescape($alias->getInternetName())
                     . '</a>';
                 $row->addCell($header, $content, $father, $alias);
             }
@@ -302,7 +302,7 @@ class NetworkAlias extends FQDNLabel
         }
         $header_end .= "<th>" . __s('Name') . "</th>";
         $header_end .= "<th>" . _sn('Internet domain', 'Internet domains', 1) . "</th>";
-        $header_end .= "<th>" . htmlspecialchars(Entity::getTypeName(1)) . "</th>";
+        $header_end .= "<th>" . htmlescape(Entity::getTypeName(1)) . "</th>";
         $header_end .= "</tr>";
         echo $header_begin . $header_top . $header_end;
 
@@ -337,7 +337,7 @@ class NetworkAlias extends FQDNLabel
                 echo "};";
                 echo "</script>";
             }
-            echo "<a href='" . static::getFormURLWithID($data["id"]) . "'>" . htmlspecialchars($name) . "</a>";
+            echo "<a href='" . static::getFormURLWithID($data["id"]) . "'>" . htmlescape($name) . "</a>";
             echo "</td>";
             echo "<td class='center' $showviewjs>" . Dropdown::getDropdownName(
                 "glpi_fqdns",
@@ -393,7 +393,7 @@ class NetworkAlias extends FQDNLabel
 
         if ($number < 1) {
             echo "<table class='tab_cadre_fixe'>";
-            echo "<tr><th>" . htmlspecialchars(self::getTypeName(1)) . "</th><th>" . __s('No item found') . "</th></tr>";
+            echo "<tr><th>" . htmlescape(self::getTypeName(1)) . "</th><th>" . __s('No item found') . "</th></tr>";
             echo "</table>";
         } else {
             Html::printAjaxPager(self::getTypeName($number), $start, $number);
@@ -444,10 +444,10 @@ class NetworkAlias extends FQDNLabel
                 if ($address->getFromDB($data["address_id"])) {
                     echo "<tr class='tab_bg_1'>";
                     echo "<td><a href='" . $alias->getFormURLWithID($data['alias_id']) . "'>" .
-                          htmlspecialchars($data['alias']) . "</a></td>";
-                    echo "<td><a href='" . $address->getLinkURL() . "'>" . htmlspecialchars($address->getInternetName()) .
+                          htmlescape($data['alias']) . "</a></td>";
+                    echo "<td><a href='" . $address->getLinkURL() . "'>" . htmlescape($address->getInternetName()) .
                     "</a></td>";
-                    echo "<td>" . htmlspecialchars($data['comment']) . "</td>";
+                    echo "<td>" . htmlescape($data['comment']) . "</td>";
                     echo "</tr>";
                 }
             }

--- a/src/NetworkName.php
+++ b/src/NetworkName.php
@@ -452,9 +452,9 @@ TWIG, ['alert' => __("Several network names available! Go to the tab 'Network Na
             $delete_all_column->setHTMLClass('center');
         }
         if (!isset($options['dont_display'][$column_name])) {
-            $content = htmlspecialchars(self::getTypeName());
+            $content = htmlescape(self::getTypeName());
             if (isset($options['column_links'][$column_name])) {
-                $content = '<a href="' . htmlspecialchars($options['column_links'][$column_name]) . '">'
+                $content = '<a href="' . htmlescape($options['column_links'][$column_name]) . '">'
                     . $content
                     . '</a>';
             }
@@ -620,10 +620,10 @@ TWIG, ['alert' => __("Several network names available! Go to the tab 'Network Na
                 if (empty($internetName)) {
                     $internetName = "(" . $line["id"] . ")";
                 }
-                $content  = htmlspecialchars($internetName);
+                $content  = htmlescape($internetName);
                 if (Session::haveRight('internet', READ)) {
                     $content  = '<a href="' . $address->getLinkURL() . '">'
-                        . htmlspecialchars($internetName)
+                        . htmlescape($internetName)
                         . '</a>';
                 }
 
@@ -756,7 +756,7 @@ TWIG, $twig_params);
         $table                                     = new HTMLTableMain();
         $column                                    = $table->addHeader(
             'Internet',
-            htmlspecialchars(self::getTypeName(Session::getPluralNumber()))
+            htmlescape(self::getTypeName(Session::getPluralNumber()))
         );
         $t_group                                   = $table->createGroup('Main', '');
 

--- a/src/NetworkPort.php
+++ b/src/NetworkPort.php
@@ -765,7 +765,7 @@ class NetworkPort extends CommonDBChild
         echo "</td></tr>";
 
         echo "<tr><th colspan='$colspan'>";
-        echo htmlspecialchars(sprintf(
+        echo htmlescape(sprintf(
             __('%s %s'),
             count($ports_iterator),
             NetworkPort::getTypeName(count($ports_iterator))
@@ -839,7 +839,7 @@ class NetworkPort extends CommonDBChild
             ];
 
             echo "<thead><tr><th colspan='" . count($dprefs) . "'>";
-            echo htmlspecialchars(sprintf(
+            echo htmlescape(sprintf(
                 __('%s %s'),
                 count($mports_iterator),
                 _n('Management port', 'Management ports', count($mports_iterator))
@@ -852,7 +852,7 @@ class NetworkPort extends CommonDBChild
                 echo "<th>";
                 foreach ($so as $option) {
                     if ($option['id'] == $dpref) {
-                        echo htmlspecialchars($option['name']);
+                        echo htmlescape($option['name']);
                         continue;
                     }
                 }
@@ -931,7 +931,7 @@ class NetworkPort extends CommonDBChild
                                 $name = sprintf(__('%1$s (%2$s)'), $name, $port['id']);
                             }
 
-                            $output .= '<a href="' . htmlspecialchars($url) . '">' . htmlspecialchars($name) . '</a>';
+                            $output .= '<a href="' . htmlescape($url) . '">' . htmlescape($name) . '</a>';
                             break;
                         case 31:
                             $speed = $port[$option['field']];
@@ -945,7 +945,7 @@ class NetworkPort extends CommonDBChild
                                 }
                             }
                             //TRANS: %1$s is a number maybe float or string and %2$s the unit
-                            $output .= htmlspecialchars(sprintf(__('%1$s %2$s'), round($speed, 2), $val));
+                            $output .= htmlescape(sprintf(__('%1$s %2$s'), round($speed, 2), $val));
                             break;
                         case 32:
                             $state_class = '';
@@ -966,9 +966,9 @@ class NetworkPort extends CommonDBChild
                             }
                             $output .= sprintf(
                                 '<i class="fas fa-circle %s" title="%s"></i> <span class="sr-only">%s</span>',
-                                htmlspecialchars($state_class),
-                                htmlspecialchars($state_title),
-                                htmlspecialchars($state_title)
+                                htmlescape($state_class),
+                                htmlescape($state_title),
+                                htmlescape($state_title)
                             );
                             break;
                         case 34:
@@ -1166,9 +1166,9 @@ class NetworkPort extends CommonDBChild
                             }
                             $output .= sprintf(
                                 '<i class="fas %s" title="%s"></i> <span class="sr-only">%s</span>',
-                                htmlspecialchars($co_class),
-                                htmlspecialchars($title),
-                                htmlspecialchars($title)
+                                htmlescape($co_class),
+                                htmlescape($title),
+                                htmlescape($title)
                             );
                             break;
                         case 41:
@@ -1273,13 +1273,13 @@ class NetworkPort extends CommonDBChild
         $link = $port->getLink();
 
         if (!empty($port->fields['mac'])) {
-            $link .= '<br/>' . htmlspecialchars($port->fields['mac']);
+            $link .= '<br/>' . htmlescape($port->fields['mac']);
         }
 
         $ips_iterator = $this->getIpsForPort($port::class, $port->getID());
         $ips = '';
         foreach ($ips_iterator as $ipa) {
-            $ips .= ' ' . htmlspecialchars($ipa['name']);
+            $ips .= ' ' . htmlescape($ipa['name']);
         }
         if (!empty($ips)) {
             $link .= '<br/>' . $ips;

--- a/src/NetworkPortConnectionLog.php
+++ b/src/NetworkPortConnectionLog.php
@@ -136,8 +136,8 @@ class NetworkPortConnectionLog extends CommonDBChild
 
                 $cport_link = sprintf(
                     '<a href="%1$s">%2$s</a>',
-                    htmlspecialchars($cport::getFormURLWithID($cport->fields['id'])),
-                    htmlspecialchars(trim($cport->fields['name']) === '' ? __('Without name') : $cport->fields['name'])
+                    htmlescape($cport::getFormURLWithID($cport->fields['id'])),
+                    htmlescape(trim($cport->fields['name']) === '' ? __('Without name') : $cport->fields['name'])
                 );
 
                 $entries = [

--- a/src/NetworkPortInstantiation.php
+++ b/src/NetworkPortInstantiation.php
@@ -597,7 +597,7 @@ TWIG, $twig_params);
             if ($device2->can($device2->fields["id"], READ)) {
                 echo $oppositePort->getLink();
                 if ($device1->fields["entities_id"] !== $device2->fields["entities_id"]) {
-                     echo "<br>(" . htmlspecialchars(Dropdown::getDropdownName(
+                     echo "<br>(" . htmlescape(Dropdown::getDropdownName(
                          "glpi_entities",
                          $device2->getEntityID()
                      )) . ")";
@@ -626,7 +626,7 @@ TWIG, $twig_params);
                 }
                 printf(
                     __s('%1$s on %2$s'),
-                    "<span class='b'>" . htmlspecialchars($netname) . "</span>",
+                    "<span class='b'>" . htmlescape($netname) . "</span>",
                     "<span class='b'>" . $device2->getName() . "</span>"
                 );
                 echo "<br>(" . Dropdown::getDropdownName(
@@ -646,7 +646,7 @@ TWIG, $twig_params);
                             ]
                         );
                     } else {
-                        echo "<a href=\"" . htmlspecialchars($netport->getFormURLWithID($ID)) . "\">" . _sx('button', 'Connect') . "</a>";
+                        echo "<a href=\"" . htmlescape($netport->getFormURLWithID($ID)) . "\">" . _sx('button', 'Connect') . "</a>";
                     }
                 } else {
                     echo "&nbsp;";
@@ -716,7 +716,7 @@ TWIG, $twig_params);
             $params
         );
 
-        echo "<span id='show_" . htmlspecialchars($p['name']) . "$rand'>&nbsp;</span>";
+        echo "<span id='show_" . htmlescape($p['name']) . "$rand'>&nbsp;</span>";
 
         return $rand;
     }

--- a/src/NetworkPortWifi.php
+++ b/src/NetworkPortWifi.php
@@ -55,7 +55,7 @@ class NetworkPortWifi extends NetworkPortInstantiation
         if (!$options['several']) {
             echo "<tr class='tab_bg_1'>";
             $this->showNetworkCardField($netport, $options, $recursiveItems);
-            echo "<td>" . htmlspecialchars(WifiNetwork::getTypeName(1)) . "</td><td>";
+            echo "<td>" . htmlescape(WifiNetwork::getTypeName(1)) . "</td><td>";
             WifiNetwork::dropdown(['value'  => $this->fields["wifinetworks_id"]]);
             echo "</td>";
             echo "</tr>";

--- a/src/NotificationEvent.php
+++ b/src/NotificationEvent.php
@@ -214,7 +214,7 @@ class NotificationEvent extends CommonDBTM
                     );
                     $label = Notification_NotificationTemplate::getMode($data['mode'])['label'];
                     Session::addMessageAfterRedirect(
-                        htmlspecialchars(sprintf(__('Unable to send notification using %1$s'), $label)),
+                        htmlescape(sprintf(__('Unable to send notification using %1$s'), $label)),
                         true,
                         ERROR
                     );

--- a/src/NotificationEventAbstract.php
+++ b/src/NotificationEventAbstract.php
@@ -143,15 +143,15 @@ abstract class NotificationEventAbstract implements NotificationEventInterface
                                 } else {
                                     // This is only used in the debug tab of some forms
                                     $notificationtarget->getFromDB($target['id']);
-                                    echo "<tr class='tab_bg_2'><td>" . htmlspecialchars($label) . "</td>";
-                                    echo "<td>" . htmlspecialchars($notificationtarget->getNameID()) . "</td>";
+                                    echo "<tr class='tab_bg_2'><td>" . htmlescape($label) . "</td>";
+                                    echo "<td>" . htmlescape($notificationtarget->getNameID()) . "</td>";
                                     echo "<td>" . sprintf(
                                         __s('%1$s (%2$s)'),
                                         $template->getName(),
-                                        htmlspecialchars($users_infos['language'])
+                                        htmlescape($users_infos['language'])
                                     ) . "</td>";
-                                    echo "<td>" . htmlspecialchars($options['mode']) . "</td>";
-                                    echo "<td>" . htmlspecialchars($key) . "</td>";
+                                    echo "<td>" . htmlescape($options['mode']) . "</td>";
+                                    echo "<td>" . htmlescape($key) . "</td>";
                                     echo "</tr>";
                                 }
                                 $processed[$users_infos['language']][$key]

--- a/src/NotificationEventMailing.php
+++ b/src/NotificationEventMailing.php
@@ -456,7 +456,7 @@ class NotificationEventMailing extends NotificationEventAbstract
         global $CFG_GLPI;
 
         $messageerror = __s('Error in sending the email');
-        Session::addMessageAfterRedirect($messageerror . "<br/>" . htmlspecialchars($error), true, ERROR);
+        Session::addMessageAfterRedirect($messageerror . "<br/>" . htmlescape($error), true, ERROR);
 
         $retries = $CFG_GLPI['smtp_max_retries'] - $notification->fields['sent_try'];
         Toolbox::logInFile(

--- a/src/NotificationTemplate.php
+++ b/src/NotificationTemplate.php
@@ -278,7 +278,7 @@ class NotificationTemplate extends CommonDBTM
                      "<html>
                         <head>
                          <META http-equiv='Content-Type' content='text/html; charset=utf-8'>
-                         <title>" . htmlspecialchars($lang['subject']) . "</title>
+                         <title>" . htmlescape($lang['subject']) . "</title>
                          <style type='text/css'>
                            {$css}
                          </style>
@@ -501,7 +501,7 @@ class NotificationTemplate extends CommonDBTM
             }
             $data[$tag] = RichText::isRichTextHtmlContent($value)
                 ? RichText::getSafeHtml($value) // Value is rich text, make it safe
-                : nl2br(htmlspecialchars($value)); // Value is plain text, encode its entities
+                : nl2br(htmlescape($value)); // Value is plain text, encode its entities
         }
 
         return $data;

--- a/src/NotificationTemplateTranslation.php
+++ b/src/NotificationTemplateTranslation.php
@@ -154,7 +154,7 @@ TWIG, $twig_params);
                 $entries[] = [
                     'itemtype' => self::class,
                     'id' => $data['id'],
-                    'language' => '<a href="' . htmlspecialchars($href) . '">' . htmlspecialchars($lang) . '</a>',
+                    'language' => '<a href="' . htmlescape($href) . '">' . htmlescape($lang) . '</a>',
                 ];
             }
         }
@@ -357,11 +357,11 @@ TWIG, $twig_params);
             }
             $rows[] = [
                 'values' => [
-                    ['content' => htmlspecialchars($tag)],
-                    ['content' => htmlspecialchars($label)],
-                    ['content' => htmlspecialchars($event)],
-                    ['content' => htmlspecialchars($action)],
-                    ['content' => htmlspecialchars($allowed_values)],
+                    ['content' => htmlescape($tag)],
+                    ['content' => htmlescape($label)],
+                    ['content' => htmlescape($event)],
+                    ['content' => htmlescape($action)],
+                    ['content' => htmlescape($allowed_values)],
                 ]
             ];
         }

--- a/src/Notification_NotificationTemplate.php
+++ b/src/Notification_NotificationTemplate.php
@@ -163,7 +163,7 @@ TWIG, $twig_params);
             $tpl_link = $tpl->getLink();
             if (empty($tpl_link)) {
                 $tpl_link = "<i class='fa fa-exclamation-triangle red'></i>
-                        <a href='" . htmlspecialchars($notiftpl->getLinkUrl()) . "'>" .
+                        <a href='" . htmlescape($notiftpl->getLinkUrl()) . "'>" .
                          __s("No template selected") .
                       "</a>";
             }

--- a/src/PDU_Rack.php
+++ b/src/PDU_Rack.php
@@ -156,7 +156,7 @@ class PDU_Rack extends CommonDBRelation
         if (count($error_detected)) {
             foreach ($error_detected as $error) {
                 Session::addMessageAfterRedirect(
-                    htmlspecialchars($error),
+                    htmlescape($error),
                     true,
                     ERROR
                 );
@@ -239,7 +239,7 @@ class PDU_Rack extends CommonDBRelation
         $rand = mt_rand();
 
         echo "<tr class='tab_bg_1'>";
-        echo "<td><label for='dropdown_pdus_id$rand'>" . htmlspecialchars(PDU::getTypeName(1)) . "</label></td>";
+        echo "<td><label for='dropdown_pdus_id$rand'>" . htmlescape(PDU::getTypeName(1)) . "</label></td>";
         echo "<td>";
         PDU::dropdown([
             'value'       => $this->fields["pdus_id"],
@@ -263,7 +263,7 @@ class PDU_Rack extends CommonDBRelation
         echo "</tr>";
 
         echo "<tr class='tab_bg_1'>";
-        echo "<td><label for='dropdown_racks_id$rand'>" . htmlspecialchars(Rack::getTypeName(1)) . "</label></td>";
+        echo "<td><label for='dropdown_racks_id$rand'>" . htmlescape(Rack::getTypeName(1)) . "</label></td>";
         echo "<td>";
         Rack::dropdown(['value' => $this->fields["racks_id"], 'rand' => $rand]);
         echo "</td>";
@@ -573,13 +573,13 @@ JAVASCRIPT;
                     if (!empty($pdu->fields['serial'])) {
                         $tip .= "<span>
                            <label>" . __s('serial') . ":</label>" .
-                           htmlspecialchars($pdu->fields['serial']) . "
+                           htmlescape($pdu->fields['serial']) . "
                         </span>";
                     }
                     if (!empty($pdu->fields['otherserial'])) {
                         $tip .= "<span>
                            <label>" . __s('Inventory number') . ":</label>" .
-                           htmlspecialchars($pdu->fields['otherserial']) . "
+                           htmlescape($pdu->fields['otherserial']) . "
                         </span>";
                     }
                     if (!empty($model_name)) {

--- a/src/Planning.php
+++ b/src/Planning.php
@@ -113,7 +113,7 @@ class Planning extends CommonGLPI
         $links = [];
 
         if (self::canView()) {
-            $title     = htmlspecialchars(self::getTypeName(Session::getPluralNumber()));
+            $title     = htmlescape(self::getTypeName(Session::getPluralNumber()));
             $planning  = "<i class='fa far fa-calendar-alt pointer' title='$title'>
                         <span class='sr-only'>$title</span>
                        </i>";
@@ -122,7 +122,7 @@ class Planning extends CommonGLPI
         }
 
         if (PlanningExternalEvent::canView()) {
-            $ext_title = htmlspecialchars(PlanningExternalEvent::getTypeName(Session::getPluralNumber()));
+            $ext_title = htmlescape(PlanningExternalEvent::getTypeName(Session::getPluralNumber()));
             $external  = "<i class='fa fas fa-calendar-week pointer' title='$ext_title'>
                         <span class='sr-only'>$ext_title</span>
                        </i>";
@@ -227,7 +227,7 @@ class Planning extends CommonGLPI
      */
     public static function getStatusIcon($status): string
     {
-        $label = htmlspecialchars(self::getState($status), ENT_QUOTES);
+        $label = htmlescape(self::getState($status));
         if (empty($label)) {
             return '';
         }
@@ -372,7 +372,7 @@ JAVASCRIPT;
             Session::addMessageAfterRedirect(
                 sprintf(
                     __s('The user %1$s is busy at the selected timeframe.'),
-                    '<a href="' . htmlspecialchars($user::getFormURLWithID($users_id)) . '">' . htmlspecialchars($user->getName()) . '</a>'
+                    '<a href="' . htmlescape($user::getFormURLWithID($users_id)) . '">' . htmlescape($user->getName()) . '</a>'
                 ) . '<br/>' . $message,
                 false,
                 WARNING

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -889,7 +889,7 @@ class Plugin extends CommonDBTM
                 $function();
             } else {
                 Session::addMessageAfterRedirect(
-                    htmlspecialchars(sprintf(__('Plugin %1$s has no uninstall function!'), $this->fields['name'])),
+                    htmlescape(sprintf(__('Plugin %1$s has no uninstall function!'), $this->fields['name'])),
                     true,
                     WARNING
                 );
@@ -924,7 +924,7 @@ class Plugin extends CommonDBTM
         }
 
         Session::addMessageAfterRedirect(
-            htmlspecialchars($message),
+            htmlescape($message),
             true,
             $type
         );
@@ -967,7 +967,7 @@ class Plugin extends CommonDBTM
                         $this->update(['id'    => $ID,
                             'state' => self::NOTACTIVATED
                         ]);
-                        $message  = htmlspecialchars(sprintf(__('Plugin %1$s has been installed!'), $this->fields['name']));
+                        $message  = htmlescape(sprintf(__('Plugin %1$s has been installed!'), $this->fields['name']));
                         $message .= '<br/><br/>' . str_replace(
                             '%activate_link',
                             Html::getSimpleForm(
@@ -984,7 +984,7 @@ class Plugin extends CommonDBTM
                         $this->update(['id'    => $ID,
                             'state' => self::TOBECONFIGURED
                         ]);
-                        $message = htmlspecialchars(sprintf(__('Plugin %1$s has been installed and must be configured!'), $this->fields['name']));
+                        $message = htmlescape(sprintf(__('Plugin %1$s has been installed and must be configured!'), $this->fields['name']));
                     }
 
                     $this->resetHookableCacheEntries($this->fields['directory']);
@@ -1005,10 +1005,10 @@ class Plugin extends CommonDBTM
                 }
             } else {
                 $type = WARNING;
-                $message = htmlspecialchars(sprintf(__('Plugin %1$s has no install function!'), $this->fields['name']));
+                $message = htmlescape(sprintf(__('Plugin %1$s has no install function!'), $this->fields['name']));
             }
         } else {
-            $message = htmlspecialchars(sprintf(__('Plugin %1$s not found!'), $ID));
+            $message = htmlescape(sprintf(__('Plugin %1$s not found!'), $ID));
         }
 
         Session::addMessageAfterRedirect(
@@ -1049,7 +1049,7 @@ class Plugin extends CommonDBTM
                     $this->unload($this->fields['directory']);
 
                     Session::addMessageAfterRedirect(
-                        htmlspecialchars(sprintf(__('Plugin %1$s prerequisites are not matching, it cannot be activated.'), $this->fields['name'])) . ' ' . $msg,
+                        htmlescape(sprintf(__('Plugin %1$s prerequisites are not matching, it cannot be activated.'), $this->fields['name'])) . ' ' . $msg,
                         true,
                         ERROR
                     );
@@ -1093,7 +1093,7 @@ class Plugin extends CommonDBTM
                 self::doHook(Hooks::POST_PLUGIN_ENABLE, $this->fields['directory']);
 
                 Session::addMessageAfterRedirect(
-                    htmlspecialchars(sprintf(__('Plugin %1$s has been activated!'), $this->fields['name'])),
+                    htmlescape(sprintf(__('Plugin %1$s has been activated!'), $this->fields['name'])),
                     true,
                     INFO
                 );
@@ -1115,7 +1115,7 @@ class Plugin extends CommonDBTM
                 $this->unload($this->fields['directory']);
 
                 Session::addMessageAfterRedirect(
-                    htmlspecialchars(sprintf(__('Plugin %1$s configuration must be done, it cannot be activated.'), $this->fields['name'])),
+                    htmlescape(sprintf(__('Plugin %1$s configuration must be done, it cannot be activated.'), $this->fields['name'])),
                     true,
                     ERROR
                 );
@@ -1124,7 +1124,7 @@ class Plugin extends CommonDBTM
         }
 
         Session::addMessageAfterRedirect(
-            htmlspecialchars(sprintf(__('Plugin %1$s not found!'), $ID)),
+            htmlescape(sprintf(__('Plugin %1$s not found!'), $ID)),
             true,
             ERROR
         );
@@ -1206,7 +1206,7 @@ class Plugin extends CommonDBTM
         }
 
         Session::addMessageAfterRedirect(
-            htmlspecialchars(sprintf(__('Plugin %1$s not found!'), $ID)),
+            htmlescape(sprintf(__('Plugin %1$s not found!'), $ID)),
             true,
             ERROR
         );
@@ -2068,7 +2068,7 @@ class Plugin extends CommonDBTM
         }
 
         if (!$compat) {
-            echo htmlspecialchars(Plugin::messageIncompatible(
+            echo htmlescape(Plugin::messageIncompatible(
                 'core',
                 (isset($infos['min']) ? $infos['min'] : null),
                 (isset($infos['max']) ? $infos['max'] : null)
@@ -2105,7 +2105,7 @@ class Plugin extends CommonDBTM
         }
 
         if (!$compat) {
-            echo htmlspecialchars(Plugin::messageIncompatible(
+            echo htmlescape(Plugin::messageIncompatible(
                 'php',
                 (isset($infos['min']) ? $infos['min'] : null),
                 (isset($infos['max']) ? $infos['max'] : null)
@@ -2130,7 +2130,7 @@ class Plugin extends CommonDBTM
         $report = Config::checkExtensions($exts);
         if (count($report['missing'])) {
             foreach (array_keys($report['missing']) as $ext) {
-                echo htmlspecialchars(self::messageMissingRequirement('ext', $ext)) . '<br/>';
+                echo htmlescape(self::messageMissingRequirement('ext', $ext)) . '<br/>';
             }
             return false;
         }
@@ -2155,7 +2155,7 @@ class Plugin extends CommonDBTM
         $compat = true;
         foreach ($params as $param) {
             if (!isset($CFG_GLPI[$param]) || trim($CFG_GLPI[$param]) == '' || !$CFG_GLPI[$param]) {
-                echo htmlspecialchars(self::messageMissingRequirement('glpiparam', $param)) . '<br/>';
+                echo htmlescape(self::messageMissingRequirement('glpiparam', $param)) . '<br/>';
                 $compat = false;
             }
         }
@@ -2178,7 +2178,7 @@ class Plugin extends CommonDBTM
         $compat = true;
         foreach ($params as $param) {
             if (!ini_get($param) || trim(ini_get($param)) == '') {
-                echo htmlspecialchars(self::messageMissingRequirement('param', $param)) . '<br/>';
+                echo htmlescape(self::messageMissingRequirement('param', $param)) . '<br/>';
                 $compat = false;
             }
         }
@@ -2201,7 +2201,7 @@ class Plugin extends CommonDBTM
         $compat = true;
         foreach ($plugins as $plugin) {
             if (!$this->isActivated($plugin)) {
-                echo htmlspecialchars(self::messageMissingRequirement('plugin', $plugin)) . '<br/>';
+                echo htmlescape(self::messageMissingRequirement('plugin', $plugin)) . '<br/>';
                 $compat = false;
             }
         }
@@ -2620,7 +2620,7 @@ TWIG;
                             ),
                             'content' => sprintf(
                                 __s('By uninstalling the "%s" plugin you will lose all the data of the plugin.'),
-                                htmlspecialchars($plugin->getField('name'))
+                                htmlescape($plugin->getField('name'))
                             )
                         ]);
                     } else {
@@ -2649,7 +2649,7 @@ TWIG;
             case 'homepage':
                 $value = Toolbox::formatOutputWebLink($values[$field]);
                 if (!empty($value)) {
-                    $value = htmlspecialchars($value);
+                    $value = htmlescape($value);
                     return "<a href=\"" . $value . "\" target='_blank'>
                      <i class='fas fa-external-link-alt fa-2x'></i><span class='sr-only'>$value</span>
                   </a>";

--- a/src/Problem.php
+++ b/src/Problem.php
@@ -1039,7 +1039,7 @@ class Problem extends CommonITILObject
                             foreach ($problem->users[CommonITILActor::REQUESTER] as $d) {
                                 if ($d["users_id"] > 0) {
                                     $name = '<i class="fas fa-sm fa-fw fa-user text-muted me-1"></i>' .
-                                        htmlspecialchars(getUserName($d["users_id"]));
+                                        htmlescape(getUserName($d["users_id"]));
                                     $requesters[] = $name;
                                 } else {
                                     $requesters[] = '<i class="fas fa-sm fa-fw fa-envelope text-muted me-1"></i>' .
@@ -1251,7 +1251,7 @@ class Problem extends CommonITILObject
         $rand      = mt_rand();
         if ($problem->getFromDBwithData($ID)) {
             $bgcolor = $_SESSION["glpipriority_" . $problem->fields["priority"]];
-            $name    = htmlspecialchars(sprintf(__('%1$s: %2$s'), __('ID'), $problem->fields["id"]));
+            $name    = htmlescape(sprintf(__('%1$s: %2$s'), __('ID'), $problem->fields["id"]));
             echo "<tr class='tab_bg_2'>";
             echo "<td>
             <div class='badge_block' style='border-color: $bgcolor'>
@@ -1267,7 +1267,7 @@ class Problem extends CommonITILObject
                 foreach ($problem->users[CommonITILActor::REQUESTER] as $d) {
                     $user = new User();
                     if ($d["users_id"] > 0 && $user->getFromDB($d["users_id"])) {
-                        $name = "<span class='b'>" . htmlspecialchars($user->getName()) . "</span>";
+                        $name = "<span class='b'>" . htmlescape($user->getName()) . "</span>";
                         if ($viewusers) {
                             $name = sprintf(
                                 __('%1$s %2$s'),
@@ -1308,7 +1308,7 @@ class Problem extends CommonITILObject
                 $link .= "&amp;forcetab=" . $forcetab;
             }
             $link .= "'>";
-            $link .= "<span class='b'>" . htmlspecialchars($problem->fields["name"]) . "</span></a>";
+            $link .= "<span class='b'>" . htmlescape($problem->fields["name"]) . "</span></a>";
             $link = printf(
                 __('%1$s %2$s'),
                 $link,

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -3752,7 +3752,7 @@ class Profile extends CommonDBTM
         // without this, you can't have an empty dropdown
         // done to avoid define NORIGHT value
         if ($param['multiple']) {
-            echo "<input type='hidden' name='" . htmlspecialchars($name) . "[]' value='0'>";
+            echo "<input type='hidden' name='" . htmlescape($name) . "[]' value='0'>";
         }
         return Dropdown::showFromArray($name, $values, $param);
     }

--- a/src/Profile_User.php
+++ b/src/Profile_User.php
@@ -168,8 +168,8 @@ class Profile_User extends CommonDBRelation
             if ($canshowentity) {
                 $link = sprintf(
                     '<a href="%s">%s</a>',
-                    htmlspecialchars(Entity::getFormURLWithID($data["entities_id"])),
-                    htmlspecialchars($link)
+                    htmlescape(Entity::getFormURLWithID($data["entities_id"])),
+                    htmlescape($link)
                 );
             }
             $entry['entity'] = $link;
@@ -177,11 +177,11 @@ class Profile_User extends CommonDBRelation
             if (Profile::canView()) {
                 $profile_name = sprintf(
                     '<a href="%s">%s</a>',
-                    htmlspecialchars(Profile::getFormURLWithID($data['id'])),
-                    htmlspecialchars($data['name'])
+                    htmlescape(Profile::getFormURLWithID($data['id'])),
+                    htmlescape($data['name'])
                 );
             } else {
-                $profile_name = htmlspecialchars($data['name']);
+                $profile_name = htmlescape($data['name']);
             }
 
             if ($data['is_dynamic'] || $data['is_recursive']) {

--- a/src/Project.php
+++ b/src/Project.php
@@ -1297,7 +1297,7 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria
             if ($item->fields["users_id"] && $user->getFromDB($item->fields["users_id"])) {
                 $fourth_col .= sprintf(
                     __('%1$s %2$s'),
-                    "<span class='b'>" . htmlspecialchars($user->getName()) . "</span>",
+                    "<span class='b'>" . htmlescape($user->getName()) . "</span>",
                     Html::showToolTip(
                         $user->getInfoCard(),
                         [
@@ -1462,7 +1462,7 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria
 
         echo "<div class='spaced'>";
         echo "<table class='tab_cadre_fixehov'>";
-        echo "<tr class='noHover'><th colspan='12'>" . htmlspecialchars(Project::getTypeName($numrows)) . "</th></tr>";
+        echo "<tr class='noHover'><th colspan='12'>" . htmlescape(Project::getTypeName($numrows)) . "</th></tr>";
         if ($numrows) {
             Project::commonListHeader();
             Session::initNavigateListItems(
@@ -1630,7 +1630,7 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria
         echo "<tr><td colspan='4' class='subheader'>" . _sn('Manager', 'Managers', 1) . "</td></tr>";
 
         echo "<tr class='tab_bg_1'>";
-        echo "<td>" . htmlspecialchars(User::getTypeName(1)) . "</td>";
+        echo "<td>" . htmlescape(User::getTypeName(1)) . "</td>";
         echo "<td>";
         User::dropdown(['name'   => 'users_id',
             'value'  => $ID ? $this->fields["users_id"] : Session::getLoginUserID(),
@@ -1638,7 +1638,7 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria
             'entity' => $this->fields["entities_id"]
         ]);
         echo "</td>";
-        echo "<td>" . htmlspecialchars(Group::getTypeName(1)) . "</td>";
+        echo "<td>" . htmlescape(Group::getTypeName(1)) . "</td>";
         echo "<td>";
         Group::dropdown([
             'name'      => 'groups_id',
@@ -1825,7 +1825,7 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria
                              Html::showMassiveActionCheckBox('ProjectTeam', $data["id"]);
                              echo "</td>";
                         }
-                        echo "<td>" . htmlspecialchars($item->getTypeName(1)) . "</td>";
+                        echo "<td>" . htmlescape($item->getTypeName(1)) . "</td>";
                         echo "<td>" . $item->getLink() . "</td>";
                         echo "</tr>";
                     }
@@ -2238,7 +2238,7 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria
                 $parentname = $item['_parent_name'] ?? $item['_parents_id'];
 
                 $content .= "<div>";
-                $content .= Html::link(htmlspecialchars(sprintf(__('%s of %s'), $childref, $parentname)), Project::getFormURLWithID($item['_parents_id']));
+                $content .= Html::link(htmlescape(sprintf(__('%s of %s'), $childref, $parentname)), Project::getFormURLWithID($item['_parents_id']));
                 $content .= "</div>";
             }
             $content .= "<div class='flex-break'></div>";
@@ -2795,7 +2795,7 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria
                         'colspan' => 4,
                         'content' => sprintf(
                             '<a href="%s">%s</a>',
-                            htmlspecialchars(self::getSearchURL() . '?' . Toolbox::append_params($options)),
+                            htmlescape(self::getSearchURL() . '?' . Toolbox::append_params($options)),
                             Html::makeTitle(__('Ongoing projects'), $displayed_row_count, count($projects_id))
                         ),
                     ]
@@ -2840,16 +2840,16 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria
                         'content' => $state !== false
                             ? sprintf(
                                 '<div class="badge_block" style="border-color:%s"><span class="me-1" style="background:%s"></span>%s',
-                                htmlspecialchars($state->fields['color']),
-                                htmlspecialchars($state->fields['color']),
-                                htmlspecialchars($state->fields['name']),
+                                htmlescape($state->fields['color']),
+                                htmlescape($state->fields['color']),
+                                htmlescape($state->fields['name']),
                             )
                             : '',
                     ],
                     [
                         'content' => sprintf(
                             '<div class="badge_block" style="border-color: #ffcece"><span class="me-1" style="background: #ffcece"></span>%s',
-                            htmlspecialchars($priority)
+                            htmlescape($priority)
                         ),
                     ],
                     [

--- a/src/ProjectCost.php
+++ b/src/ProjectCost.php
@@ -276,7 +276,7 @@ class ProjectCost extends CommonDBChild
         Html::showDateField("end_date", ['value' => $this->fields['end_date']]);
         echo "</td></tr>";
 
-        echo "<tr class='tab_bg_1'><td>" . htmlspecialchars(Budget::getTypeName(1)) . "</td>";
+        echo "<tr class='tab_bg_1'><td>" . htmlescape(Budget::getTypeName(1)) . "</td>";
         echo "<td>";
         Budget::dropdown(['value' => $this->fields["budgets_id"]]);
         echo "</td></tr>";
@@ -344,14 +344,14 @@ class ProjectCost extends CommonDBChild
         }
         $total = 0;
         echo "<table class='tab_cadre_fixehov'>";
-        echo "<tr class='noHover'><th colspan='5'>" . htmlspecialchars(self::getTypeName(count($iterator))) .
+        echo "<tr class='noHover'><th colspan='5'>" . htmlescape(self::getTypeName(count($iterator))) .
             "</th></tr>";
 
         if (count($iterator)) {
             echo "<tr><th>" . __s('Name') . "</th>";
             echo "<th>" . __s('Begin date') . "</th>";
             echo "<th>" . __s('End date') . "</th>";
-            echo "<th>" . htmlspecialchars(Budget::getTypeName(1)) . "</th>";
+            echo "<th>" . htmlescape(Budget::getTypeName(1)) . "</th>";
             echo "<th>" . _sn('Cost', 'Costs', 1) . "</th>";
             echo "</tr>";
 

--- a/src/ProjectTask.php
+++ b/src/ProjectTask.php
@@ -1359,7 +1359,7 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
                 $header    .= "</th>";
             }
             foreach ($columns as $key => $val) {
-                $val = htmlspecialchars($val);
+                $val = htmlescape($val);
 
                 // Non order column
                 if ($key[0] == '_') {
@@ -1560,7 +1560,7 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
                              Html::showMassiveActionCheckBox('ProjectTaskTeam', $data["id"]);
                              echo "</td>";
                         }
-                        echo "<td>" . htmlspecialchars($item->getTypeName(1)) . "</td>";
+                        echo "<td>" . htmlescape($item->getTypeName(1)) . "</td>";
                         echo "<td>" . $item->getLink() . "</td>";
                         echo "</tr>";
                     }
@@ -1753,7 +1753,7 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
                         'colspan' => 4,
                         'content' => sprintf(
                             '<a href="%s">%s</a>',
-                            htmlspecialchars(self::getSearchURL() . '?' . Toolbox::append_params($options)),
+                            htmlescape(self::getSearchURL() . '?' . Toolbox::append_params($options)),
                             Html::makeTitle(__('Ongoing projects tasks'), $displayed_row_count, count($projecttasks_id))
                         ),
                     ]
@@ -1798,9 +1798,9 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
                         'content' => $state !== false
                             ? sprintf(
                                 '<div class="badge_block" style="border-color:%s"><span class="me-1" style="background:%s"></span>%s',
-                                htmlspecialchars($state->fields['color']),
-                                htmlspecialchars($state->fields['color']),
-                                htmlspecialchars($state->fields['name']),
+                                htmlescape($state->fields['color']),
+                                htmlescape($state->fields['color']),
+                                htmlescape($state->fields['name']),
                             )
                             : '',
                     ],

--- a/src/ProjectTask_Ticket.php
+++ b/src/ProjectTask_Ticket.php
@@ -414,10 +414,10 @@ class ProjectTask_Ticket extends CommonDBRelation
 
         $entries = [];
         foreach ($iterator as $data) {
-            $project_name = htmlspecialchars($data['projectname'] . (empty($data['projectname']) ? "({$data['projects_id']})" : ''));
-            $projectlink = "<a href='" . htmlspecialchars(Project::getFormURLWithID($data['projects_id'])) . "'>$project_name</a>";
-            $task_name = htmlspecialchars($data['name'] . (empty($data['name']) ? "({$data['id']})" : ''));
-            $tasklink = "<a href='" . htmlspecialchars(ProjectTask::getFormURLWithID($data['id'])) . "'>$task_name</a>";
+            $project_name = htmlescape($data['projectname'] . (empty($data['projectname']) ? "({$data['projects_id']})" : ''));
+            $projectlink = "<a href='" . htmlescape(Project::getFormURLWithID($data['projects_id'])) . "'>$project_name</a>";
+            $task_name = htmlescape($data['name'] . (empty($data['name']) ? "({$data['id']})" : ''));
+            $tasklink = "<a href='" . htmlescape(ProjectTask::getFormURLWithID($data['id'])) . "'>$task_name</a>";
 
             $father = '';
             if ($data['projecttasks_id'] > 0) {
@@ -434,7 +434,7 @@ class ProjectTask_Ticket extends CommonDBRelation
             if (!empty($status)) {
                 $fg_color = Toolbox::getFgColor($data['color']);
                 $status_badge_style = "background-color:{$data['color']}; color:{$fg_color};";
-                $status = '<span class="badge" style="' . $status_badge_style . '">' . htmlspecialchars($data['sname']) . '</span>';
+                $status = '<span class="badge" style="' . $status_badge_style . '">' . htmlescape($data['sname']) . '</span>';
             }
 
             $entries[] = [

--- a/src/RSSFeed.php
+++ b/src/RSSFeed.php
@@ -530,7 +530,7 @@ class RSSFeed extends CommonDBVisible implements ExtraVisibilityCriteria
 
         if (!Toolbox::isUrlSafe($url)) {
             Session::addMessageAfterRedirect(
-                htmlspecialchars(sprintf(__('URL "%s" is not allowed by your administrator.'), $url)),
+                htmlescape(sprintf(__('URL "%s" is not allowed by your administrator.'), $url)),
                 false,
                 ERROR
             );
@@ -644,7 +644,7 @@ TWIG, ['msg' => __('Check permissions to the directory: %s', GLPI_RSS_DIR)]);
                 ];
             }
         } else {
-            $rss_feed['error'] = htmlspecialchars(!Toolbox::isUrlSafe($this->fields['url'])
+            $rss_feed['error'] = htmlescape(!Toolbox::isUrlSafe($this->fields['url'])
                 ? sprintf(__('URL "%s" is not allowed by your administrator.'), $this->fields['url'])
                 : __('Error retrieving RSS feed'));
             $this->setError(true);
@@ -741,7 +741,7 @@ TWIG, ['msg' => __('Check permissions to the directory: %s', GLPI_RSS_DIR)]);
             $criteria['WHERE']["$table.users_id"] = $users_id;
             $criteria['WHERE']["$table.is_active"] = 1;
 
-            $titre = "<a href='" . htmlspecialchars(RSSFeed::getSearchURL()) . "'>" .
+            $titre = "<a href='" . htmlescape(RSSFeed::getSearchURL()) . "'>" .
                     _sn('Personal RSS feed', 'Personal RSS feeds', Session::getPluralNumber()) . "</a>";
         } else {
            // Show public rssfeeds / not mines : need to have access to public rssfeeds
@@ -757,7 +757,7 @@ TWIG, ['msg' => __('Check permissions to the directory: %s', GLPI_RSS_DIR)]);
             }
 
             if (Session::getCurrentInterface() === 'central') {
-                $titre = "<a href='" . htmlspecialchars(RSSFeed::getSearchURL()) . "'>" .
+                $titre = "<a href='" . htmlescape(RSSFeed::getSearchURL()) . "'>" .
                        _sn('Public RSS feed', 'Public RSS feeds', Session::getPluralNumber()) . "</a>";
             } else {
                 $titre = _sn('Public RSS feed', 'Public RSS feeds', Session::getPluralNumber());
@@ -809,14 +809,14 @@ TWIG, ['msg' => __('Check permissions to the directory: %s', GLPI_RSS_DIR)]);
                 if (empty($feed_link)) {
                     $output .= $item->feed->get_title();
                 } else {
-                    $output .= '<a target="_blank" href="' . htmlspecialchars($feed_link) . '">' . $item->feed->get_title() . '</a>';
+                    $output .= '<a target="_blank" href="' . htmlescape($feed_link) . '">' . $item->feed->get_title() . '</a>';
                 }
 
                 $item_link = URL::sanitizeURL($item->get_permalink());
                 $rand = mt_rand();
                 $output .= "<div id='rssitem$rand'>";
                 if (!empty($item_link)) {
-                    $output .= '<a target="_blank" href="' . htmlspecialchars($item_link) . '">';
+                    $output .= '<a target="_blank" href="' . htmlescape($item_link) . '">';
                 }
                 $output .= $item->get_title();
                 if (!empty($item_link)) {

--- a/src/Rack.php
+++ b/src/Rack.php
@@ -845,7 +845,7 @@ JAVASCRIPT;
 
         if ($existing > 0) {
             Session::addMessageAfterRedirect(
-                htmlspecialchars(sprintf(
+                htmlescape(sprintf(
                     __('%1$s position is not available'),
                     $input['position']
                 )),
@@ -977,33 +977,33 @@ JAVASCRIPT;
      */
     private static function getCell(Rack $rack, $cell)
     {
-        $bgcolor = htmlspecialchars($rack->getField('bgcolor'));
-        $fgcolor = htmlspecialchars(Html::getInvertedColor($bgcolor));
-        return "<div class='grid-stack-item room_orientation_" . htmlspecialchars($cell['room_orientation']) . "'
-                  gs-id='" . htmlspecialchars($cell['id']) . "'
+        $bgcolor = htmlescape($rack->getField('bgcolor'));
+        $fgcolor = htmlescape(Html::getInvertedColor($bgcolor));
+        return "<div class='grid-stack-item room_orientation_" . htmlescape($cell['room_orientation']) . "'
+                  gs-id='" . htmlescape($cell['id']) . "'
                   gs-locked='true'
                   gs-h='1'
                   gs-w='1'
-                  gs-x='" . htmlspecialchars($cell['_x']) . "'
-                  gs-y='" . htmlspecialchars($cell['_y']) . "'>
+                  gs-x='" . htmlescape($cell['_x']) . "'
+                  gs-y='" . htmlescape($cell['_y']) . "'>
             <div class='grid-stack-item-content'
                   style='background-color: $bgcolor;
                         color: $fgcolor;'>
                <a href='" . $rack->getLinkURL() . "'
                   style='color: $fgcolor'>" .
-                  htmlspecialchars($cell['name']) . "</a>
+                  htmlescape($cell['name']) . "</a>
                <span class='tipcontent'>
                   <span>
                      <label>" . __s('name') . ":</label>" .
-                     htmlspecialchars($cell['name']) . "
+                     htmlescape($cell['name']) . "
                   </span>
                   <span>
                      <label>" . __s('serial') . ":</label>" .
-                     htmlspecialchars($cell['serial']) . "
+                     htmlescape($cell['serial']) . "
                   </span>
                   <span>
                      <label>" . __s('Inventory number') . ":</label>" .
-                     htmlspecialchars($cell['otherserial']) . "
+                     htmlescape($cell['otherserial']) . "
                   </span>
                </span>
             </div><!-- // .grid-stack-item-content -->

--- a/src/RefusedEquipment.php
+++ b/src/RefusedEquipment.php
@@ -186,26 +186,26 @@ class RefusedEquipment extends CommonDBTM
 
         $itemtype = $this->fields['itemtype'];
         echo "<th>" .  __s('Item type') . "</th>";
-        echo "<td>" . htmlspecialchars($itemtype::getTypeName(1))  . "</td>";
+        echo "<td>" . htmlescape($itemtype::getTypeName(1))  . "</td>";
 
         echo "<th>" . __s('Name') . "</th>";
-        echo "<td>" . htmlspecialchars($this->getName())  . "</td>";
+        echo "<td>" . htmlescape($this->getName())  . "</td>";
 
         echo "</tr>";
         echo "<tr class='tab_bg_1'>";
 
         echo "<th>" .  __s('Serial') . "</th>";
-        echo "<td>" . htmlspecialchars($this->fields['serial'])  . "</td>";
+        echo "<td>" . htmlescape($this->fields['serial'])  . "</td>";
 
         echo "<th>" .  __s('UUID') . "</th>";
-        echo "<td>" . htmlspecialchars($this->fields['uuid'])  . "</td>";
+        echo "<td>" . htmlescape($this->fields['uuid'])  . "</td>";
 
         echo "</tr>";
         echo "<tr class='tab_bg_1'>";
 
         $rule = new RuleImportAsset();
         $rule->getFromDB($this->fields['rules_id']);
-        echo "<th>" .  htmlspecialchars(Rule::getTypeName(1)) . "</th>";
+        echo "<th>" .  htmlescape(Rule::getTypeName(1)) . "</th>";
         echo "<td>";
         echo $rule->getLink();
 
@@ -225,17 +225,17 @@ class RefusedEquipment extends CommonDBTM
 
         $entity = new Entity();
         $entity->getFromDB($this->fields['entities_id']);
-        echo "<th>" .  htmlspecialchars(Entity::getTypeName(1)) . "</th>";
+        echo "<th>" .  htmlescape(Entity::getTypeName(1)) . "</th>";
         echo "<td>" . $entity->getLink() . "</td>";
 
         echo "</tr>";
         echo "<tr class='tab_bg_1'>";
 
-        echo "<th>" .  htmlspecialchars(IPAddress::getTypeName(1)) . "</th>";
-        echo "<td>" . htmlspecialchars(implode(', ', importArrayFromDB($this->fields['ip']))) . "</td>";
+        echo "<th>" .  htmlescape(IPAddress::getTypeName(1)) . "</th>";
+        echo "<td>" . htmlescape(implode(', ', importArrayFromDB($this->fields['ip']))) . "</td>";
 
         echo "<th>" .  __s('MAC address') . "</th>";
-        echo "<td>" . htmlspecialchars(implode(', ', importArrayFromDB($this->fields['mac']))) . "</td>";
+        echo "<td>" . htmlescape(implode(', ', importArrayFromDB($this->fields['mac']))) . "</td>";
 
         echo "</tr>";
         $this->showInventoryInfo();

--- a/src/RegisteredID.php
+++ b/src/RegisteredID.php
@@ -70,13 +70,13 @@ class RegisteredID extends CommonDBChild
      **/
     public static function getJSCodeToAddForItemChild($field_name, $child_count_js_var): string
     {
-        $field_name = htmlspecialchars($field_name);
-        $child_count_js_var = htmlspecialchars($child_count_js_var);
+        $field_name = htmlescape($field_name);
+        $child_count_js_var = htmlescape($child_count_js_var);
         $result  = "<select name=\'" . $field_name . "_type[-'+$child_count_js_var+']\'>";
         $result .= "<option value=\'\'>" . Dropdown::EMPTY_VALUE . "</option>";
         foreach (self::getRegisteredIDTypes() as $name => $label) {
-            $name = htmlspecialchars($name);
-            $label = htmlspecialchars($label);
+            $name = htmlescape($name);
+            $label = htmlescape($label);
             $result .= "<option value=\'$name\'>$label</option>";
         }
         $result .= "</select> : ";
@@ -92,10 +92,10 @@ class RegisteredID extends CommonDBChild
         } else {
             $value = $this->getName();
         }
-        $value             = htmlspecialchars($value);
+        $value             = htmlescape($value);
         $result            = "";
-        $main_field        = htmlspecialchars($field_name . "[$id]");
-        $type_field        = htmlspecialchars($field_name . "_type[$id]");
+        $main_field        = htmlescape($field_name . "[$id]");
+        $type_field        = htmlescape($field_name . "_type[$id]");
         $registeredIDTypes = self::getRegisteredIDTypes();
 
         if ($canedit) {
@@ -104,9 +104,9 @@ class RegisteredID extends CommonDBChild
             foreach ($registeredIDTypes as $name => $label) {
                 $result .= sprintf(
                     "<option value='%s'%s>%s</option>",
-                    htmlspecialchars($name),
+                    htmlescape($name),
                     $this->fields['device_type'] === $name ? " selected" : "",
-                    htmlspecialchars($label)
+                    htmlescape($label)
                 );
             }
             $result .= "</select> : <input type='text' size='30' name='$main_field' value='$value' class='form-control'>\n";
@@ -115,7 +115,7 @@ class RegisteredID extends CommonDBChild
             if (!empty($this->fields['device_type'])) {
                 $result .= sprintf(
                     __s('%1$s: %2$s'),
-                    htmlspecialchars($registeredIDTypes[$this->fields['device_type']]),
+                    htmlescape($registeredIDTypes[$this->fields['device_type']]),
                     $value
                 );
             } else {

--- a/src/Reminder.php
+++ b/src/Reminder.php
@@ -736,9 +736,9 @@ class Reminder extends CommonDBVisible implements
                 }
                 $link = sprintf(
                     '<a id="content_reminder_%s" href="%s">%s</a>',
-                    htmlspecialchars($data["id"] . $rand),
-                    htmlspecialchars(self::getFormURLWithID($data["id"])),
-                    htmlspecialchars($name)
+                    htmlescape($data["id"] . $rand),
+                    htmlescape(self::getFormURLWithID($data["id"])),
+                    htmlescape($name)
                 );
                 $text = $data["text"];
                 if (!empty($data['transtext'])) {
@@ -763,8 +763,8 @@ class Reminder extends CommonDBVisible implements
                     );
                     $row['values'][] = sprintf(
                         '<a href="%s" class="pointer float-end" title="%s"><i class="ti ti-bell"></i><span class="sr-only">%s</span></a>',
-                        htmlspecialchars(sprintf('%s/front/planning.php?date=%s&type=day', $CFG_GLPI['root_doc'], $date_url)),
-                        htmlspecialchars($planning_text),
+                        htmlescape(sprintf('%s/front/planning.php?date=%s&type=day', $CFG_GLPI['root_doc'], $date_url)),
+                        htmlescape($planning_text),
                         __s('Planning')
                     );
                 } else {

--- a/src/ReminderTranslation.php
+++ b/src/ReminderTranslation.php
@@ -172,11 +172,11 @@ TWIG, $twig_params);
             if ($canedit) {
                 $entry['subject'] = sprintf(
                     '<a href="%s">%s</a>',
-                    htmlspecialchars(self::getFormURLWithID($data['id'])),
-                    htmlspecialchars($data['name'])
+                    htmlescape(self::getFormURLWithID($data['id'])),
+                    htmlescape($data['name'])
                 );
             } else {
-                $entry['subject'] = htmlspecialchars($data['name']);
+                $entry['subject'] = htmlescape($data['name']);
             }
             if (!empty($data['text'])) {
                 $entry['subject'] .= Html::showToolTip(RichText::getEnhancedHtml($data['text']), ['display' => false]);

--- a/src/Reservation.php
+++ b/src/Reservation.php
@@ -918,7 +918,7 @@ JAVASCRIPT;
         echo "<h1>" . __s('Reservations for this item') . "</h1>";
         echo "<div id='reservations_planning_$rand' class='reservations-planning tabbed'></div>";
 
-        $defaultDate = htmlspecialchars($_REQUEST['defaultDate'] ?? date('Y-m-d'));
+        $defaultDate = htmlescape($_REQUEST['defaultDate'] ?? date('Y-m-d'));
         $now = date("Y-m-d H:i:s");
         $js = <<<JAVASCRIPT
             $(() => {
@@ -1045,7 +1045,7 @@ JAVASCRIPT;
                 'item' => '',
                 'entity' => '',
                 'by' => getUserName($data["by"]),
-                'comments' => nl2br(htmlspecialchars($data["comments"])),
+                'comments' => nl2br(htmlescape($data["comments"])),
             ];
 
             $item = null;
@@ -1063,13 +1063,13 @@ JAVASCRIPT;
 
             if (!$is_old) {
                 [$annee, $mois] = explode("-", $data["start_date"]);
-                $href = htmlspecialchars($CFG_GLPI["root_doc"]) . "/front/reservation.php?reservationitems_id={$data["id"]}&mois_courant=$mois&annee_courante=$annee";
+                $href = htmlescape($CFG_GLPI["root_doc"]) . "/front/reservation.php?reservationitems_id={$data["id"]}&mois_courant=$mois&annee_courante=$annee";
                 $entry['planning'] = "<a href='$href' title='" . __s('See planning') . "'>";
                 $entry['planning'] .= "<i class='" . Planning::getIcon() . "'></i>";
                 $entry['planning'] .= "<span class='sr-only'>" . __s('See planning') . "</span>";
                 $entry['planning'] .= "</a>";
             } else if ($item instanceof CommonDBTM) {
-                $href = htmlspecialchars($item::getFormURLWithID($item->getID()) . "&forcetab=Reservation$1&tab_params[defaultDate]={$data["start_date"]}");
+                $href = htmlescape($item::getFormURLWithID($item->getID()) . "&forcetab=Reservation$1&tab_params[defaultDate]={$data["start_date"]}");
                 $entry['planning'] = "<a href='$href' title=\"" . __s('See planning') . "\">";
                 $entry['planning'] .= "<i class='" . Planning::getIcon() . "'></i>";
                 $entry['planning'] .= "<span class='sr-only'>" . __s('See planning') . "</span>";

--- a/src/ReservationItem.php
+++ b/src/ReservationItem.php
@@ -608,9 +608,9 @@ TWIG, $twig_params);
                         );
                     }
                 }
-                $item_link = htmlspecialchars(sprintf(__('%1$s - %2$s'), $typename, $row["name"]));
+                $item_link = htmlescape(sprintf(__('%1$s - %2$s'), $typename, $row["name"]));
                 if ($itemtype::canView()) {
-                    $item_link = "<a href='" . htmlspecialchars($itemtype::getFormURLWithId($row['items_id'])) . "&forcetab=Reservation$1'>" .
+                    $item_link = "<a href='" . htmlescape($itemtype::getFormURLWithId($row['items_id'])) . "&forcetab=Reservation$1'>" .
                         $item_link .
                         "</a>";
                 }
@@ -621,7 +621,7 @@ TWIG, $twig_params);
                 }
                 $entry['location'] = $location_cache[$row["location"]];
 
-                $entry['comment'] = nl2br(htmlspecialchars($row["comment"] ?? ""));
+                $entry['comment'] = nl2br(htmlescape($row["comment"]));
 
                 if ($showentity) {
                     if (!isset($entity_cache[$row["entities_id"]])) {
@@ -629,7 +629,7 @@ TWIG, $twig_params);
                     }
                     $entry['entity'] = $entity_cache[$row["entities_id"]];
                 }
-                $cal_href = htmlspecialchars(Reservation::getSearchURL() . "?reservationitems_id=" . $row['id']);
+                $cal_href = htmlescape(Reservation::getSearchURL() . "?reservationitems_id=" . $row['id']);
                 $entry['calendar'] = "<a href='$cal_href'>";
                 $entry['calendar'] .= "<i class='" . Planning::getIcon() . " fa-2x cursor-pointer' title=\"" . __s("Reserve this item") . "\"></i>";
 
@@ -803,7 +803,7 @@ TWIG, $twig_params);
                     ));
                 } else {
                    //TRANS: %1$s is a name, %2$s is text of message
-                    Session::addMessageAfterRedirect(htmlspecialchars(sprintf(
+                    Session::addMessageAfterRedirect(htmlescape(sprintf(
                         __('%1$s: %2$s'),
                         Dropdown::getDropdownName(
                             "glpi_entities",
@@ -828,7 +828,7 @@ TWIG, $twig_params);
                 if ($task) {
                     $task->log($msg);
                 } else {
-                    Session::addMessageAfterRedirect(htmlspecialchars($msg), false, ERROR);
+                    Session::addMessageAfterRedirect(htmlescape($msg), false, ERROR);
                 }
             }
         }

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -1929,7 +1929,7 @@ JS
             foreach ($RuleCriterias->getRuleCriterias($this->fields['id']) as $RuleCriteria) {
                 $to_display = $this->getMinimalCriteria($RuleCriteria->fields);
                 $data['criteria'] .= '<span class="glpi-badge mb-1">'
-                    . implode('<i class="ti ti-caret-right-filled mx-1"></i>', array_map('htmlspecialchars', $to_display))
+                    . implode('<i class="ti ti-caret-right-filled mx-1"></i>', array_map('htmlescape', $to_display))
                     . '</span><br />';
             }
         }
@@ -1941,7 +1941,7 @@ JS
             foreach ($RuleAction->getRuleActions($this->fields['id']) as $RuleAction) {
                 $to_display = $this->getMinimalAction($RuleAction->fields);
                 $data['actions'] .= '<span class="glpi-badge mb-1">'
-                    . implode('<i class="ti ti-caret-right-filled mx-1"></i>', array_map('htmlspecialchars', $to_display))
+                    . implode('<i class="ti ti-caret-right-filled mx-1"></i>', array_map('htmlescape', $to_display))
                     . '</span><br />';
             }
         }
@@ -1954,7 +1954,7 @@ JS
         );
 
         if ($display_entity) {
-            $entname = htmlspecialchars(Dropdown::getDropdownName('glpi_entities', $this->fields['entities_id']));
+            $entname = htmlescape(Dropdown::getDropdownName('glpi_entities', $this->fields['entities_id']));
             if ($this->maybeRecursive() && $this->fields['is_recursive']) {
                 $entname = sprintf(__s('%1$s %2$s'), $entname, "<span class='fw-bold'>(" . __s('R') . ")</span>");
             }
@@ -2134,7 +2134,7 @@ JS
         $entries = [
             [
                 'action' => __('Validation'),
-                'result' => htmlspecialchars(Dropdown::getYesNo($global_result)),
+                'result' => htmlescape(Dropdown::getYesNo($global_result)),
             ]
         ];
         $output = $this->preProcessPreviewResults($output);
@@ -2159,7 +2159,7 @@ JS
             foreach ($value as $v) {
                 $entries[] = [
                     'action' => $action_def["name"],
-                    'result' => htmlspecialchars($this->getActionValue($action_def_key, $actiontype, $v))
+                    'result' => htmlescape($this->getActionValue($action_def_key, $actiontype, $v))
                 ];
             }
         }
@@ -2171,7 +2171,7 @@ JS
                 $regex_results .= "<table class='table table-sm table-borderless table-striped'>";
                 $regex_results .= "<tr><th>" . __s('Key') . "</th><th>" . __s('Value') . "</th></tr>";
                 foreach ($this->regex_results[0] as $key => $value) {
-                    $regex_results .= "<tr><td>" . htmlspecialchars($key) . "</td><td>" . htmlspecialchars($value) . "</td></tr>";
+                    $regex_results .= "<tr><td>" . htmlescape($key) . "</td><td>" . htmlescape($value) . "</td></tr>";
                 }
                 $regex_results .= "</table>";
             }
@@ -2208,9 +2208,9 @@ JS
     public function getMinimalCriteriaText($fields, $addtotd = '')
     {
         $to_display = $this->getMinimalCriteria($fields);
-        $text  = "<td $addtotd>" . htmlspecialchars($to_display['criterion']) . "</td>";
-        $text .= "<td $addtotd>" . htmlspecialchars($to_display['condition']) . "</td>";
-        $text .= "<td $addtotd>" . htmlspecialchars($to_display['pattern']) . "</td>";
+        $text  = "<td $addtotd>" . htmlescape($to_display['criterion']) . "</td>";
+        $text .= "<td $addtotd>" . htmlescape($to_display['condition']) . "</td>";
+        $text .= "<td $addtotd>" . htmlescape($to_display['pattern']) . "</td>";
         return $text;
     }
 
@@ -2239,9 +2239,9 @@ JS
     public function getMinimalActionText($fields, $addtotd = '')
     {
         $to_display = $this->getMinimalAction($fields);
-        $text  = "<td $addtotd>" . htmlspecialchars($to_display['field']) . "</td>";
-        $text .= "<td $addtotd>" . htmlspecialchars($to_display['type']) . "</td>";
-        $text .= "<td $addtotd>" . htmlspecialchars($to_display['value']) . "</td>";
+        $text  = "<td $addtotd>" . htmlescape($to_display['field']) . "</td>";
+        $text .= "<td $addtotd>" . htmlescape($to_display['type']) . "</td>";
+        $text .= "<td $addtotd>" . htmlescape($to_display['value']) . "</td>";
         return $text;
     }
 
@@ -2962,9 +2962,9 @@ JS
 
         $entries = [];
         foreach ($rules as $rule) {
-            $name = htmlspecialchars($rule->fields["name"]);
+            $name = htmlescape($rule->fields["name"]);
             if ($canedit) {
-                $name = "<a href='" . htmlspecialchars(static::getFormURLWithID($rule->fields["id"]))
+                $name = "<a href='" . htmlescape(static::getFormURLWithID($rule->fields["id"]))
                     . "&amp;onglet=1'>" . $name . "</a>";
             }
 

--- a/src/SavedSearch.php
+++ b/src/SavedSearch.php
@@ -506,7 +506,7 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
                     && Session::getCurrentInterface() != "helpdesk"
                 ) {
                     Session::addMessageAfterRedirect(
-                        htmlspecialchars(sprintf(__('Partial load of the saved search: %s'), $this->getName())),
+                        htmlescape(sprintf(__('Partial load of the saved search: %s'), $this->getName())),
                         false,
                         ERROR
                     );

--- a/src/Software.php
+++ b/src/Software.php
@@ -729,7 +729,7 @@ class Software extends CommonDBTM
             $paramsselsoft
         );
 
-        echo "<span id='show_" . htmlspecialchars($myname . $rand) . "'>&nbsp;</span>\n";
+        echo "<span id='show_" . htmlescape($myname . $rand) . "'>&nbsp;</span>\n";
 
         return $rand;
     }

--- a/src/SoftwareLicense.php
+++ b/src/SoftwareLicense.php
@@ -810,7 +810,7 @@ class SoftwareLicense extends CommonTreeDropdown
             foreach ($iterator as $license) {
                 $name     = $license['softname'] . ' - ' . $license['name'] . ' - ' . $license['serial'];
                 //TRANS: %1$s the license name, %2$s is the expiration date
-                $message .= htmlspecialchars(sprintf(
+                $message .= htmlescape(sprintf(
                     __('License %1$s expired on %2$s'),
                     Html::convDate($license["expire"]),
                     $name
@@ -832,7 +832,7 @@ class SoftwareLicense extends CommonTreeDropdown
                     } else {
                         Session::addMessageAfterRedirect(sprintf(
                             __s('%1$s: %2$s'),
-                            htmlspecialchars($entityname),
+                            htmlescape($entityname),
                             $message
                         ));
                     }
@@ -849,7 +849,7 @@ class SoftwareLicense extends CommonTreeDropdown
                 } else {
                     $entityname = Dropdown::getDropdownName(Entity::getTable(), $entity);
                    //TRANS: %s is entity name
-                    $msg = htmlspecialchars(sprintf(__('%1$s: %2$s'), $entityname, __('Send licenses alert failed')));
+                    $msg = htmlescape(sprintf(__('%1$s: %2$s'), $entityname, __('Send licenses alert failed')));
                     if ($task) {
                         $task->log($msg);
                     } else {

--- a/src/SoftwareVersion.php
+++ b/src/SoftwareVersion.php
@@ -339,7 +339,7 @@ TWIG, $twig_params);
                 'os' => Dropdown::getDropdownName('glpi_operatingsystems', $data['operatingsystems_id']),
                 'arch' => $data['arch'],
                 'installations' => $nb,
-                'comments' => nl2br(htmlspecialchars($data['comment'] ?? ''))
+                'comments' => nl2br(htmlescape($data['comment']))
             ];
         }
 

--- a/src/Stat.php
+++ b/src/Stat.php
@@ -530,9 +530,9 @@ class Stat extends CommonGLPI
             $headers[] = __('Number of late tickets');
             $headers[] = __('Number of closed tickets');
         } else {
-            $html_output .= $output::showHeaderItem(htmlspecialchars(_nx('ticket', 'Opened', 'Opened', Session::getPluralNumber())), $header_num);
+            $html_output .= $output::showHeaderItem(htmlescape(_nx('ticket', 'Opened', 'Opened', Session::getPluralNumber())), $header_num);
             $html_output .= $output::showHeaderItem(
-                htmlspecialchars(_nx('ticket', 'Solved', 'Solved', Session::getPluralNumber())),
+                htmlescape(_nx('ticket', 'Solved', 'Solved', Session::getPluralNumber())),
                 $header_num
             );
             $html_output .= $output::showHeaderItem(__s('Late'), $header_num);
@@ -546,11 +546,11 @@ class Stat extends CommonGLPI
                 $headers[] = __('Average satisfaction');
             } else {
                 $html_output .= $output::showHeaderItem(
-                    htmlspecialchars(_nx('survey', 'Opened', 'Opened', Session::getPluralNumber())),
+                    htmlescape(_nx('survey', 'Opened', 'Opened', Session::getPluralNumber())),
                     $header_num
                 );
                 $html_output .= $output::showHeaderItem(
-                    htmlspecialchars(_nx('survey', 'Answered', 'Answered', Session::getPluralNumber())),
+                    htmlescape(_nx('survey', 'Answered', 'Answered', Session::getPluralNumber())),
                     $header_num
                 );
                 $html_output .= $output::showHeaderItem(__s('Average'), $header_num);
@@ -604,7 +604,7 @@ class Stat extends CommonGLPI
                     ],
                     '&amp;'
                 );
-                $html_output .= $output::showItem("<a href='$url'>" . htmlspecialchars($value[$i]['link']) . "</a>", $item_num, $row_num);
+                $html_output .= $output::showItem("<a href='$url'>" . htmlescape($value[$i]['link']) . "</a>", $item_num, $row_num);
             } else {
                 if ($is_html_output) {
                     $html_output .= $output::showItem($value[$i]['link'], $item_num, $row_num);
@@ -731,7 +731,7 @@ class Stat extends CommonGLPI
                     $timedisplay = Html::timestampToCsvString($timedisplay);
                 }
                 if ($is_html_output) {
-                    $timedisplay = htmlspecialchars($timedisplay);
+                    $timedisplay = htmlescape($timedisplay);
                 }
 
                 if ($is_html_output) {
@@ -766,7 +766,7 @@ class Stat extends CommonGLPI
                 $timedisplay = Html::timestampToCsvString($timedisplay);
             }
             if ($is_html_output) {
-                $timedisplay = htmlspecialchars($timedisplay);
+                $timedisplay = htmlescape($timedisplay);
             }
 
             if ($is_html_output) {
@@ -800,7 +800,7 @@ class Stat extends CommonGLPI
                 $timedisplay = Html::timestampToCsvString($timedisplay);
             }
             if ($is_html_output) {
-                $timedisplay = htmlspecialchars($timedisplay);
+                $timedisplay = htmlescape($timedisplay);
             }
 
             if ($is_html_output) {
@@ -852,7 +852,7 @@ class Stat extends CommonGLPI
                 $timedisplay = Html::timestampToCsvString($timedisplay);
             }
             if ($is_html_output) {
-                $timedisplay = htmlspecialchars($timedisplay);
+                $timedisplay = htmlescape($timedisplay);
             }
 
             if ($is_html_output) {
@@ -869,7 +869,7 @@ class Stat extends CommonGLPI
                 $timedisplay = Html::timestampToCsvString($timedisplay);
             }
             if ($is_html_output) {
-                $timedisplay = htmlspecialchars($timedisplay);
+                $timedisplay = htmlescape($timedisplay);
             }
 
             if ($is_html_output) {
@@ -1656,13 +1656,13 @@ class Stat extends CommonGLPI
             $header_num = 1;
             echo $output::showNewLine();
             $item_label = _n('Associated element', 'Associated elements', $numrows);
-            echo $output::showHeaderItem($is_html_output ? htmlspecialchars($item_label) : $item_label, $header_num);
+            echo $output::showHeaderItem($is_html_output ? htmlescape($item_label) : $item_label, $header_num);
             if ($view_entities) {
                 $entity_label = Entity::getTypeName(1);
-                echo $output::showHeaderItem($is_html_output ? htmlspecialchars($entity_label) : $entity_label, $header_num);
+                echo $output::showHeaderItem($is_html_output ? htmlescape($entity_label) : $entity_label, $header_num);
             }
             $nb_tickets_label = __('Number of tickets');
-            echo $output::showHeaderItem($is_html_output ? htmlspecialchars($nb_tickets_label) : $nb_tickets_label, $header_num);
+            echo $output::showHeaderItem($is_html_output ? htmlescape($nb_tickets_label) : $nb_tickets_label, $header_num);
             echo $output::showEndLine(false);
 
             $i = $start;
@@ -1676,7 +1676,7 @@ class Stat extends CommonGLPI
                // Get data and increment loop variables
                 echo $output::showNewLine($i % 2);
                 $link = $is_html_output
-                    ? sprintf(__s('%1$s - %2$s'), htmlspecialchars($data['itemtype']::getTypeName()), $data['link'])
+                    ? sprintf(__s('%1$s - %2$s'), htmlescape($data['itemtype']::getTypeName()), $data['link'])
                     : sprintf(__('%1$s - %2$s'), $data['itemtype']::getTypeName(), $data['link']);
                 echo $output::showItem(
                     $link,
@@ -1687,7 +1687,7 @@ class Stat extends CommonGLPI
                 );
                 if ($view_entities) {
                       echo $output::showItem(
-                          $is_html_output ? htmlspecialchars($data['entity_name']) : $data['entity_name'],
+                          $is_html_output ? htmlescape($data['entity_name']) : $data['entity_name'],
                           $item_num,
                           $i - $start + 1,
                           "class='text-center'" . " " . ($data['is_deleted'] ? " class='deleted' "
@@ -1695,7 +1695,7 @@ class Stat extends CommonGLPI
                       );
                 }
                 echo $output::showItem(
-                    $is_html_output ? htmlspecialchars($data["NB"]) : $data["NB"],
+                    $is_html_output ? htmlescape($data["NB"]) : $data["NB"],
                     $item_num,
                     $i - $start + 1,
                     "class='center'" . " " . ($data['is_deleted'] ? " class='deleted' "

--- a/src/State.php
+++ b/src/State.php
@@ -233,9 +233,9 @@ class State extends CommonTreeDropdown
             ];
 
 
-            $url = htmlspecialchars(AllAssets::getSearchURL()) . '?' . Toolbox::append_params($opt, '&amp;');
+            $url = htmlescape(AllAssets::getSearchURL()) . '?' . Toolbox::append_params($opt, '&amp;');
             $entry = [
-                'state' => '<a href="' . $url . '">' . htmlspecialchars($data["completename"]) . '</a>'
+                'state' => '<a href="' . $url . '">' . htmlescape($data["completename"]) . '</a>'
             ];
             foreach ($state_type as $itemtype) {
                 $count = $states[$data["id"]][$itemtype] ?? 0;
@@ -301,7 +301,7 @@ class State extends CommonTreeDropdown
         }
         if (!$this->isUnique($input)) {
             Session::addMessageAfterRedirect(
-                htmlspecialchars(sprintf(__s('%1$s must be unique!'), static::getTypeName(1))),
+                htmlescape(sprintf(__s('%1$s must be unique!'), static::getTypeName(1))),
                 false,
                 ERROR
             );
@@ -742,7 +742,7 @@ class State extends CommonTreeDropdown
     {
         if (!$this->isUnique($input)) {
             Session::addMessageAfterRedirect(
-                htmlspecialchars(sprintf(__s('%1$s must be unique per level!'), static::getTypeName(1))),
+                htmlescape(sprintf(__s('%1$s must be unique per level!'), static::getTypeName(1))),
                 false,
                 ERROR
             );

--- a/src/Supplier.php
+++ b/src/Supplier.php
@@ -376,7 +376,7 @@ class Supplier extends CommonDBTM
         $ret = '&nbsp;&nbsp;&nbsp;&nbsp;';
 
         if ($withname) {
-            $ret .= htmlspecialchars($this->fields["name"]);
+            $ret .= htmlescape($this->fields["name"]);
             $ret .= "&nbsp;&nbsp;";
         }
 
@@ -519,7 +519,7 @@ class Supplier extends CommonDBTM
                     if ($nb > 0) {
                         $title = sprintf(__('%1$s: %2$s'), $title, $nb);
                     }
-                    echo "<td class='center'>" . htmlspecialchars($title) . "</td>";
+                    echo "<td class='center'>" . htmlescape($title) . "</td>";
                     echo "<td class='center' colspan='2'>";
                     $opt = ['order'      => 'ASC',
                         'is_deleted' => 0,
@@ -547,7 +547,7 @@ class Supplier extends CommonDBTM
                             $name = sprintf(__('%1$s (%2$s)'), $name, $data["id"]);
                         }
                         $link = $linktype::getFormURLWithID($data[$linkfield]);
-                        $name = "<a href='$link'>" . htmlspecialchars($name) . "</a>";
+                        $name = "<a href='$link'>" . htmlescape($name) . "</a>";
 
                         echo "<tr class='tab_bg_1";
                         if (isset($data['is_template']) && $data['is_template'] == 1) {
@@ -560,7 +560,7 @@ class Supplier extends CommonDBTM
                             if ($nb > 0) {
                                 $title = sprintf(__('%1$s: %2$s'), $title, $nb);
                             }
-                            echo "<td class='center top' rowspan='$nb'>" . htmlspecialchars($title) . "</td>";
+                            echo "<td class='center top' rowspan='$nb'>" . htmlescape($title) . "</td>";
                         }
                         echo "<td class='center'>" . Dropdown::getDropdownName(
                             "glpi_entities",
@@ -570,9 +570,9 @@ class Supplier extends CommonDBTM
                         echo ((isset($data['is_deleted']) && $data['is_deleted']) ? " tab_bg_2_2'" : "'") . ">";
                         echo $name . "</td>";
                         echo "<td class='center'>" .
-                           (isset($data["serial"]) ? htmlspecialchars($data["serial"]) : "-") . "</td>";
+                           (isset($data["serial"]) ? htmlescape($data["serial"]) : "-") . "</td>";
                         echo "<td class='center'>" .
-                           (isset($data["otherserial"]) ? htmlspecialchars($data["otherserial"]) : "-") . "</td>";
+                           (isset($data["otherserial"]) ? htmlescape($data["otherserial"]) : "-") . "</td>";
                         echo "</tr>";
                     }
                 }

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -1582,7 +1582,7 @@ class Ticket extends CommonITILObject
             foreach ($input['_users_id_requester_notif']['alternative_email'] as $email) {
                 if ($email && !NotificationMailing::isUserAddressValid($email)) {
                     Session::addMessageAfterRedirect(
-                        htmlspecialchars(sprintf(__('Invalid email address %s'), $email)),
+                        htmlescape(sprintf(__('Invalid email address %s'), $email)),
                         false,
                         ERROR
                     );
@@ -2235,7 +2235,7 @@ class Ticket extends CommonITILObject
                     'rand'         => $rand
                 ];
                 echo "<table class='mx-auto'><tr>";
-                echo "<td><label for='dropdown__mergeticket$rand'>" . htmlspecialchars(Ticket::getTypeName(1)) . "</label></td><td colspan='3'>";
+                echo "<td><label for='dropdown__mergeticket$rand'>" . htmlescape(Ticket::getTypeName(1)) . "</label></td><td colspan='3'>";
                 Ticket::dropdown($mergeparam);
                 echo "</td></tr><tr><td><label for='with_followups'>" . __s('Merge followups') . "</label></td><td>";
                 Html::showCheckbox([
@@ -2296,7 +2296,7 @@ class Ticket extends CommonITILObject
                 echo '<div class="horizontal-form">';
 
                 echo '<div class="form-row">';
-                $label = htmlspecialchars(SolutionTemplate::getTypeName(1));
+                $label = htmlescape(SolutionTemplate::getTypeName(1));
                 echo "<label for='solution_template'>$label</label>";
                 SolutionTemplate::dropdown([
                     'name'     => "solution_template",
@@ -2328,7 +2328,7 @@ JAVASCRIPT;
                 echo '</div>'; // .form-row
 
                 echo '<div class="form-row">';
-                $label = htmlspecialchars(SolutionType::getTypeName(1));
+                $label = htmlescape(SolutionType::getTypeName(1));
                 echo "<label for='solutiontypes_id'>$label</label>";
                 SolutionType::dropdown([
                     'name'  => 'solutiontypes_id',
@@ -4675,7 +4675,7 @@ JAVASCRIPT;
                             foreach ($job->users[CommonITILActor::REQUESTER] as $d) {
                                 if ($d["users_id"] > 0) {
                                     $name = '<i class="fas fa-sm fa-fw fa-user text-muted me-1"></i>' .
-                                        htmlspecialchars(getUserName($d["users_id"]));
+                                        htmlescape(getUserName($d["users_id"]));
                                     $requesters[] = $name;
                                 } else {
                                     $requesters[] = '<i class="fas fa-sm fa-fw fa-envelope text-muted me-1"></i>' .
@@ -5063,7 +5063,7 @@ JAVASCRIPT;
         $rand = mt_rand();
         if ($job->getFromDBwithData($ID)) {
             $bgcolor = $_SESSION["glpipriority_" . $job->fields["priority"]];
-            $name    = htmlspecialchars(sprintf(__('%1$s: %2$s'), __('ID'), $job->fields["id"]));
+            $name    = htmlescape(sprintf(__('%1$s: %2$s'), __('ID'), $job->fields["id"]));
            // $rand    = mt_rand();
             echo "<tr class='tab_bg_2'>";
             echo "<td>
@@ -5080,7 +5080,7 @@ JAVASCRIPT;
                 foreach ($job->users[CommonITILActor::REQUESTER] as $d) {
                     $user = new User();
                     if ($d["users_id"] > 0 && $user->getFromDB($d["users_id"])) {
-                        $name     = "<span class='b'>" . htmlspecialchars($user->getName()) . "</span>";
+                        $name     = "<span class='b'>" . htmlescape($user->getName()) . "</span>";
                         $name     = sprintf(
                             __('%1$s %2$s'),
                             $name,
@@ -5094,7 +5094,7 @@ JAVASCRIPT;
                         );
                          echo $name;
                     } else {
-                        echo htmlspecialchars($d['alternative_email']) . "&nbsp;";
+                        echo htmlescape($d['alternative_email']) . "&nbsp;";
                     }
                     echo "<br>";
                 }
@@ -5128,12 +5128,12 @@ JAVASCRIPT;
             }
             echo "<td>";
 
-            $link = "<a id='ticket" . htmlspecialchars($job->fields["id"] . $rand) . "' href='" . Ticket::getFormURLWithID($job->fields["id"]);
+            $link = "<a id='ticket" . htmlescape($job->fields["id"] . $rand) . "' href='" . Ticket::getFormURLWithID($job->fields["id"]);
             if ($forcetab != '') {
                 $link .= "&amp;forcetab=" . $forcetab;
             }
             $link   .= "'>";
-            $link   .= "<span class='b'>" . htmlspecialchars($job->getNameID()) . "</span></a>";
+            $link   .= "<span class='b'>" . htmlescape($job->getNameID()) . "</span></a>";
             $link    = sprintf(
                 __s('%1$s (%2$s)'),
                 $link,

--- a/src/Ticket_Ticket.php
+++ b/src/Ticket_Ticket.php
@@ -58,7 +58,7 @@ class Ticket_Ticket extends CommonITILObject_CommonITILObject
             case 'add':
                 Toolbox::deprecated('Ticket_Ticket "add" massive action is deprecated. Use CommonITILObject_CommonITILObject "add" massive action.');
                 Ticket_Ticket::dropdownLinks('link');
-                printf(htmlspecialchars(__('%1$s: %2$s'), Ticket::getTypeName(1), __('ID')));
+                echo htmlescape(sprintf(__('%1$s: %2$s'), Ticket::getTypeName(1), __('ID')));
                 echo "&nbsp;<input type='text' name='tickets_id_1' value='' size='10'>\n";
                 echo "<br><br>";
                 echo "<br><br><input type='submit' name='massiveaction' class='btn btn-primary' value='" .

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -2868,7 +2868,7 @@ class Toolbox
             return null;
         }
 
-        return ($full ? $CFG_GLPI["root_doc"] : "") . '/front/document.send.php?file=_pictures/' . htmlspecialchars($path);
+        return ($full ? $CFG_GLPI["root_doc"] : "") . '/front/document.send.php?file=_pictures/' . htmlescape($path);
     }
 
     /**

--- a/src/User.php
+++ b/src/User.php
@@ -862,7 +862,7 @@ class User extends CommonDBTM
                         $input['password_last_update'] = $_SESSION['glpi_currenttime'];
                     } else {
                         Session::addMessagesAfterRedirect(
-                            array_map('htmlspecialchars', $password_errors),
+                            array_map('htmlescape', $password_errors),
                             false,
                             ERROR
                         );
@@ -986,7 +986,7 @@ class User extends CommonDBTM
             try {
                 $this->forgetPassword($email, true);
             } catch (\Glpi\Exception\ForgetPasswordException $e) {
-                Session::addMessageAfterRedirect(htmlspecialchars($e->getMessage()), false, ERROR);
+                Session::addMessageAfterRedirect(htmlescape($e->getMessage()), false, ERROR);
             }
         }
     }
@@ -1094,7 +1094,7 @@ class User extends CommonDBTM
                         $input['password_last_update'] = $_SESSION["glpi_currenttime"];
                     } else {
                         Session::addMessagesAfterRedirect(
-                            array_map('htmlspecialchars', $password_errors),
+                            array_map('htmlescape', $password_errors),
                             false,
                             ERROR
                         );
@@ -1281,7 +1281,7 @@ class User extends CommonDBTM
             try {
                 $this->forgetPassword($email, false);
             } catch (\Glpi\Exception\ForgetPasswordException $e) {
-                Session::addMessageAfterRedirect(htmlspecialchars($e->getMessage()), false, ERROR);
+                Session::addMessageAfterRedirect(htmlescape($e->getMessage()), false, ERROR);
             }
         } elseif (in_array('password', $this->updates)) {
             $alert = new Alert();
@@ -2578,7 +2578,7 @@ class User extends CommonDBTM
 
         if ($ID > 0) {
             $vcard_lbl = __s('Download user VCard');
-            $vcard_url = htmlspecialchars(self::getFormURLWithID($ID) . "&getvcard=1");
+            $vcard_url = htmlescape(self::getFormURLWithID($ID) . "&getvcard=1");
             $vcard_btn = <<<HTML
             <a href="{$vcard_url}" target="_blank"
                      class="btn btn-icon btn-sm btn-ghost-secondary"
@@ -2590,7 +2590,7 @@ HTML;
             $toolbar[] = $vcard_btn;
 
             $error_message = null;
-            $impersonate_form = htmlspecialchars(self::getFormURLWithID($ID));
+            $impersonate_form = htmlescape(self::getFormURLWithID($ID));
             if (Session::canImpersonate($ID, $error_message)) {
                 $impersonate_lbl = __s('Impersonate');
                 $csrf_token = Session::getNewCSRFToken();
@@ -2621,7 +2621,7 @@ HTML;
 JAVASCRIPT;
                 $toolbar[] = $impersonate_btn . Html::scriptBlock($impersonate_js);
             } elseif ($error_message !== null) {
-                $error_message = htmlspecialchars($error_message);
+                $error_message = htmlescape($error_message);
                 $impersonate_btn = <<<HTML
                <button type="button" name="impersonate" value="1"
                        class="btn btn-icon btn-sm  btn-ghost-danger btn-impersonate"
@@ -2699,10 +2699,10 @@ HTML;
             ($this->fields["authtype"] == Auth::DB_GLPI)
         ) {
            //display login field for new records, or if this is not external auth
-            echo "<td><input name='name' id='name' value=\"" . htmlspecialchars($this->fields["name"]) . "\" class='form-control'></td>";
+            echo "<td><input name='name' id='name' value=\"" . htmlescape($this->fields["name"]) . "\" class='form-control'></td>";
         } else {
             echo "<td class='b'>" . $this->fields["name"];
-            echo "<input type='hidden' name='name' value=\"" . htmlspecialchars($this->fields["name"]) . "\" class='form-control'></td>";
+            echo "<input type='hidden' name='name' value=\"" . htmlescape($this->fields["name"]) . "\" class='form-control'></td>";
         }
 
         if (!$simplified_form && !empty($this->fields["name"])) {
@@ -2882,7 +2882,7 @@ JAVASCRIPT;
 
         $phonerand = mt_rand();
         echo "<tr class='tab_bg_1'>";
-        echo "<td><label for='textfield_phone$phonerand'>" .  htmlspecialchars(Phone::getTypeName(1)) . "</label></td><td>";
+        echo "<td><label for='textfield_phone$phonerand'>" .  htmlescape(Phone::getTypeName(1)) . "</label></td><td>";
         echo Html::input(
             'phone',
             [
@@ -2906,7 +2906,7 @@ JAVASCRIPT;
                 }
                 if (!empty($this->fields["user_dn"])) {
                   //TRANS: %s is the user dn
-                    echo '<br>' . sprintf(__s('%1$s: %2$s'), __s('User DN'), htmlspecialchars($this->fields["user_dn"]));
+                    echo '<br>' . sprintf(__s('%1$s: %2$s'), __s('User DN'), htmlescape($this->fields["user_dn"]));
                 }
                 if ($this->fields['is_deleted_ldap']) {
                     echo '<br>' . __s('User missing in LDAP directory');
@@ -2964,7 +2964,7 @@ JAVASCRIPT;
             echo "</td>";
             echo "<td rowspan='4' class='middle'><label for='comment'>" . __s('Comments') . "</label></td>";
             echo "<td class='center middle' rowspan='4'>";
-            echo "<textarea class='form-control' id='comment' name='comment' >" . htmlspecialchars($this->fields["comment"] ?? '') . "</textarea>";
+            echo "<textarea class='form-control' id='comment' name='comment' >" . htmlescape($this->fields["comment"]) . "</textarea>";
             echo "</td></tr>";
 
             $admnumrand = mt_rand();
@@ -2987,7 +2987,7 @@ JAVASCRIPT;
         echo "<tr class='tab_bg_1'>";
         if (!empty($ID)) {
             $locrand = mt_rand();
-            echo "<td><label for='dropdown_locations_id$locrand'>" . htmlspecialchars(Location::getTypeName(1)) . "</label></td><td>";
+            echo "<td><label for='dropdown_locations_id$locrand'>" . htmlescape(Location::getTypeName(1)) . "</label></td><td>";
             $entities = $this->getEntities();
             if (count($entities) <= 0) {
                 $entities = -1;
@@ -3009,14 +3009,14 @@ JAVASCRIPT;
             echo "</td></tr>";
             $profilerand = mt_rand();
             echo "<tr class='tab_bg_1'>";
-            echo "<td><label for='dropdown__profiles_id$profilerand'>" .  htmlspecialchars(Profile::getTypeName(1)) . "</label></td><td>";
+            echo "<td><label for='dropdown__profiles_id$profilerand'>" .  htmlescape(Profile::getTypeName(1)) . "</label></td><td>";
             Profile::dropdownUnder(['name'  => '_profiles_id',
                 'rand'  => $profilerand,
                 'value' => Profile::getDefault()
             ]);
 
             $entrand = mt_rand();
-            echo "</td><td><label for='dropdown__entities_id$entrand'>" .  htmlspecialchars(Entity::getTypeName(1)) . "</label></td><td>";
+            echo "</td><td><label for='dropdown__entities_id$entrand'>" .  htmlescape(Entity::getTypeName(1)) . "</label></td><td>";
             Entity::dropdown(['name'                => '_entities_id',
                 'display_emptychoice' => false,
                 'rand'                => $entrand,
@@ -3187,11 +3187,11 @@ JAVASCRIPT;
                            && !empty($this->fields["password"])));
 
             echo "<div class='center'>";
-            echo "<form method='post' name='user_manager' enctype='multipart/form-data' action='" . htmlspecialchars($target) . "' autocomplete='off'>";
+            echo "<form method='post' name='user_manager' enctype='multipart/form-data' action='" . htmlescape($target) . "' autocomplete='off'>";
             echo "<table class='tab_cadre_fixe'>";
-            echo "<tr><th colspan='4'>" . sprintf(__s('%1$s: %2$s'), __s('Login'), htmlspecialchars($this->fields["name"]));
-            echo "<input type='hidden' name='name' value='" . htmlspecialchars($this->fields["name"]) . "'>";
-            echo "<input type='hidden' name='id' value='" . htmlspecialchars($this->fields["id"]) . "'>";
+            echo "<tr><th colspan='4'>" . sprintf(__s('%1$s: %2$s'), __s('Login'), htmlescape($this->fields["name"]));
+            echo "<input type='hidden' name='name' value='" . htmlescape($this->fields["name"]) . "'>";
+            echo "<input type='hidden' name='id' value='" . htmlescape($this->fields["id"]) . "'>";
             echo "</th></tr>";
 
             $surnamerand = mt_rand();
@@ -3236,7 +3236,7 @@ JAVASCRIPT;
                 && isset($authtype['firstname_field'])
                 && !empty($authtype['firstname_field'])
             ) {
-                echo htmlspecialchars($this->fields["firstname"]);
+                echo htmlescape($this->fields["firstname"]);
             } else {
                 echo Html::input(
                     'firstname',
@@ -3257,7 +3257,7 @@ JAVASCRIPT;
                 if (empty($this->fields['sync_field'])) {
                     echo Dropdown::EMPTY_VALUE;
                 } else {
-                    echo htmlspecialchars($this->fields['sync_field']);
+                    echo htmlescape($this->fields['sync_field']);
                 }
                 echo "</td></tr>";
             } else {
@@ -3346,13 +3346,13 @@ JAVASCRIPT;
             }
 
             $phonerand = mt_rand();
-            echo "<tr class='tab_bg_1'><td><label for='textfield_phone$phonerand'>" .  htmlspecialchars(Phone::getTypeName(1)) . "</label></td><td>";
+            echo "<tr class='tab_bg_1'><td><label for='textfield_phone$phonerand'>" .  htmlescape(Phone::getTypeName(1)) . "</label></td><td>";
 
             if (
                 $extauth
                 && isset($authtype['phone_field']) && !empty($authtype['phone_field'])
             ) {
-                echo htmlspecialchars($this->fields["phone"]);
+                echo htmlescape($this->fields["phone"]);
             } else {
                 echo Html::input(
                     'phone',
@@ -3377,7 +3377,7 @@ JAVASCRIPT;
                 $extauth
                 && isset($authtype['mobile_field']) && !empty($authtype['mobile_field'])
             ) {
-                echo htmlspecialchars($this->fields["mobile"]);
+                echo htmlescape($this->fields["mobile"]);
             } else {
                 echo Html::input(
                     'mobile',
@@ -3418,7 +3418,7 @@ JAVASCRIPT;
                 $extauth
                 && isset($authtype['phone2_field']) && !empty($authtype['phone2_field'])
             ) {
-                echo htmlspecialchars($this->fields["phone2"]);
+                echo htmlescape($this->fields["phone2"]);
             } else {
                 echo Html::input(
                     'phone2',
@@ -3467,7 +3467,7 @@ JAVASCRIPT;
             echo "</td><td colspan='2'></td></tr>";
 
             $locrand = mt_rand();
-            echo "<tr class='tab_bg_1'><td><label for='dropdown_locations_id$locrand'>" . htmlspecialchars(Location::getTypeName(1)) . "</label></td><td>";
+            echo "<tr class='tab_bg_1'><td><label for='dropdown_locations_id$locrand'>" . htmlescape(Location::getTypeName(1)) . "</label></td><td>";
             Location::dropdown(['value'  => $this->fields['locations_id'],
                 'rand'   => $locrand,
                 'entity' => $entities
@@ -4862,7 +4862,7 @@ JAVASCRIPT;
             }
 
             if ($p['readonly']) {
-                return '<span class="form-control" readonly>' . htmlspecialchars($user_name) . '</span>';
+                return '<span class="form-control" readonly>' . htmlescape($user_name) . '</span>';
             }
 
             if ($p['value'] === 'myself') {
@@ -5779,11 +5779,11 @@ JAVASCRIPT;
                 Session::addMessageAfterRedirect(__s('Reset password successful.'));
             }
         } catch (\Glpi\Exception\ForgetPasswordException $e) {
-            Session::addMessageAfterRedirect(htmlspecialchars($e->getMessage()), false, ERROR);
+            Session::addMessageAfterRedirect(htmlescape($e->getMessage()), false, ERROR);
         } catch (\Glpi\Exception\PasswordTooWeakException $e) {
            // Force display on error
             foreach ($e->getMessages() as $message) {
-                Session::addMessageAfteRredirect(htmlspecialchars($message), false, ERROR);
+                Session::addMessageAfteRredirect(htmlescape($message), false, ERROR);
             }
         }
 
@@ -5805,7 +5805,7 @@ JAVASCRIPT;
         try {
             $this->forgetPassword($email);
         } catch (\Glpi\Exception\ForgetPasswordException $e) {
-            Session::addMessageAfterRedirect(htmlspecialchars($e->getMessage()), false, ERROR);
+            Session::addMessageAfterRedirect(htmlescape($e->getMessage()), false, ERROR);
             return;
         }
         Session::addMessageAfteRredirect(__s('If the given email address match an existing GLPI user, you will receive an email containing the information required to reset your password. Please contact your administrator if you do not receive any email.'));
@@ -5827,7 +5827,7 @@ JAVASCRIPT;
         try {
             $this->forgetPassword($email, true);
         } catch (\Glpi\Exception\ForgetPasswordException $e) {
-            Session::addMessageAfterRedirect(htmlspecialchars($e->getMessage()), false, ERROR);
+            Session::addMessageAfterRedirect(htmlescape($e->getMessage()), false, ERROR);
             return;
         }
         Session::addMessageAfterRedirect(__s('The given email address will receive the information required to define password.'));
@@ -5950,10 +5950,10 @@ JAVASCRIPT;
 
         echo "<div class='spaced'>";
         echo "<table class='tab_cadre_fixe'>";
-        echo "<tr><th colspan='2'>" . htmlspecialchars(AuthLDAP::getTypeName(1)) . "</th></tr>";
+        echo "<tr><th colspan='2'>" . htmlescape(AuthLDAP::getTypeName(1)) . "</th></tr>";
 
         echo "<tr class='tab_bg_2'><td>" . __s('User DN') . "</td>";
-        echo "<td>" . htmlspecialchars($this->fields['user_dn']) . "</td></tr>";
+        echo "<td>" . htmlescape($this->fields['user_dn']) . "</td></tr>";
 
         if ($this->fields['user_dn']) {
             $config_ldap = new AuthLDAP();
@@ -5994,7 +5994,7 @@ JAVASCRIPT;
                             continue;
                         }
                         echo '<tr class="tab_bg_2">';
-                        echo '<td>' . htmlspecialchars($key) . '</td>';
+                        echo '<td>' . htmlescape($key) . '</td>';
                         echo '<td>';
                         unset($values['count']);
                         $printed_values = [];
@@ -6002,7 +6002,7 @@ JAVASCRIPT;
                             if (str_contains($key, 'password')) {
                                 $value = '********';
                             }
-                            $printed_values[] = htmlspecialchars($value);
+                            $printed_values[] = htmlescape($value);
                         }
                         echo implode(', ', $printed_values);
                         echo '</td>';

--- a/src/UserEmail.php
+++ b/src/UserEmail.php
@@ -154,9 +154,9 @@ class UserEmail extends CommonDBChild
     {
 
         return "<input title=\'" . __s('Default email') . "\' type=\'radio\' name=\'_default_email\'" .
-             " value=\'-'+" . htmlspecialchars($child_count_js_var) . "+'\'>&nbsp;" .
-             "<input type=\'text\' size=\'30\' class=\'form-control\' " . "name=\'" . htmlspecialchars($field_name) .
-             "[-'+" . htmlspecialchars($child_count_js_var) . "+']\'>";
+             " value=\'-'+" . htmlescape($child_count_js_var) . "+'\'>&nbsp;" .
+             "<input type=\'text\' size=\'30\' class=\'form-control\' " . "name=\'" . htmlescape($field_name) .
+             "[-'+" . htmlescape($child_count_js_var) . "+']\'>";
     }
 
 
@@ -173,13 +173,13 @@ class UserEmail extends CommonDBChild
         if ($this->isNewID($this->getID())) {
             $value = '';
         } else {
-            $value = htmlspecialchars($this->fields['email'] ?? '');
+            $value = htmlescape($this->fields['email']);
         }
         $result = "";
-        $field_name = htmlspecialchars($field_name . "[$id]");
+        $field_name = htmlescape($field_name . "[$id]");
         $result .= "<div class='d-flex align-items-center'>";
         $result .= "<input title='" . __s('Default email') . "' type='radio' name='_default_email'
-             value='" . htmlspecialchars($this->getID()) . "'";
+             value='" . htmlescape($this->getID()) . "'";
         if (!$canedit) {
             $result .= " disabled";
         }

--- a/src/Vlan.php
+++ b/src/Vlan.php
@@ -151,14 +151,14 @@ class Vlan extends CommonDropdown
 
             $vlan = new self();
             if ($vlan->getFromDB($options['items_id'])) {
-                $content = htmlspecialchars(sprintf(__('%1$s - %2$s'), $vlan->getName(), $tagged_msg));
+                $content = htmlescape(sprintf(__('%1$s - %2$s'), $vlan->getName(), $tagged_msg));
                 $content .= Html::showToolTip(
-                    htmlspecialchars(sprintf(
+                    htmlescape(sprintf(
                         __('%1$s: %2$s'),
                         __('ID TAG'),
                         $vlan->fields['tag']
                     )) . "<br>" .
-                    htmlspecialchars(sprintf(
+                    htmlescape(sprintf(
                         __('%1$s: %2$s'),
                         __('Comments'),
                         $vlan->fields['comment']

--- a/src/autoload/misc-functions.php
+++ b/src/autoload/misc-functions.php
@@ -86,3 +86,15 @@ function isPluginItemType($classname)
    // Standard case
     return false;
 }
+
+/**
+ * Escape a string to make it safe to be printed in an HTML page.
+ * This function is pretty similar to the `htmlspecialchars` function, but its signature is less strict.
+ *
+ * @param mixed $str
+ * @return string
+ */
+function htmlescape(mixed $str): string
+{
+    return htmlspecialchars((string) $str);
+}


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.

## Description

Fixes #17933.

There are many places in our code where `htmlspecialchars()` may be call for a null value (or even an integer, a float, ...). Instead of using the `?? ''` to fix occurences that triggers a deprecation notice, I propose to use a custom `htmlescape()` function that ensures that non-string legitimate values are correctly handled.
