### PR TITLE
Fix "Calendar" Dropdown translation

### DIFF
--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -1199,7 +1199,7 @@ JAVASCRIPT;
                     'KnowbaseItemCategory' => null
                 ],
 
-                _n('Calendar', 'Calendars', 1) => [
+                _n('Calendar', 'Calendars', Session::getPluralNumber()) => [
                     'Calendar' => null,
                     'Holiday' => null
                 ],


### PR DESCRIPTION
The translation wasn't being rendered ("Calendar" was being shown instead of "Calendário" in PT-BR).

<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does

## Screenshots (if appropriate):


