### PR TITLE
Prevent Referer spoofing

### DIFF
--- a/front/central.php
+++ b/front/central.php
@@ -60,9 +60,9 @@ if (isset($_REQUEST['newprofile'])) {
             }
         }
         $_SESSION['_redirected_from_profile_selector'] = true;
-        Html::redirect($_SERVER['HTTP_REFERER']);
+        Html::back();
     }
-    Html::redirect(preg_replace("/entities_id.*/", "", $_SERVER['HTTP_REFERER']));
+    Html::redirect(preg_replace("/entities_id.*/", "", Html::getBackUrl()));
 }
 
 // Manage entity change
@@ -71,11 +71,8 @@ if (isset($_GET["active_entity"])) {
         $_GET["is_recursive"] = 0;
     }
     if (Session::changeActiveEntities($_GET["active_entity"], $_GET["is_recursive"])) {
-        if (
-            ($_GET["active_entity"] == $_SESSION["glpiactive_entity"])
-            && isset($_SERVER['HTTP_REFERER'])
-        ) {
-            Html::redirect(preg_replace("/(\?|&|" . urlencode('?') . "|" . urlencode('&') . ")?(entities_id|active_entity).*/", "", $_SERVER['HTTP_REFERER']));
+        if ($_GET["active_entity"] == $_SESSION["glpiactive_entity"]) {
+            Html::redirect(preg_replace("/(\?|&|" . urlencode('?') . "|" . urlencode('&') . ")?(entities_id|active_entity).*/", "", Html::getBackUrl()));
         }
     }
 }

--- a/front/helpdesk.public.php
+++ b/front/helpdesk.public.php
@@ -49,7 +49,7 @@ if (isset($_REQUEST['newprofile'])) {
             Html::redirect($_SERVER['PHP_SELF']);
         }
     } else {
-        Html::redirect(preg_replace("/entities_id=.*/", "", $_SERVER['HTTP_REFERER']));
+        Html::redirect(preg_replace("/entities_id=.*/", "", Html::getBackUrl()));
     }
 }
 
@@ -60,7 +60,7 @@ if (isset($_GET["active_entity"])) {
     }
     if (Session::changeActiveEntities($_GET["active_entity"], $_GET["is_recursive"])) {
         if ($_GET["active_entity"] == $_SESSION["glpiactive_entity"]) {
-            Html::redirect(preg_replace("/(\?|&|" . urlencode('?') . "|" . urlencode('&') . ")?(entities_id|active_entity).*/", "", $_SERVER['HTTP_REFERER']));
+            Html::redirect(preg_replace("/(\?|&|" . urlencode('?') . "|" . urlencode('&') . ")?(entities_id|active_entity).*/", "", Html::getBackUrl()));
         }
     }
 }

--- a/install/install.php
+++ b/install/install.php
@@ -430,7 +430,10 @@ function step8()
         );
     }
 
-    $url_base = str_replace("/install/install.php", "", $_SERVER['HTTP_REFERER']);
+    $referer_url = Html::getRefererUrl();
+    $url_base = $referer_url !== null
+        ? str_replace("/install/install.php", "", $referer_url)
+        : 'http://localhost';
     $DB->update(
         'glpi_configs',
         ['value' => $url_base],

--- a/src/MassiveAction.php
+++ b/src/MassiveAction.php
@@ -353,11 +353,7 @@ class MassiveAction
                         foreach ($POST['items'] as $itemtype => $ids) {
                             $this->nb_items += count($ids);
                         }
-                        if (isset($_SERVER['HTTP_REFERER'])) {
-                            $this->redirect = $_SERVER['HTTP_REFERER'];
-                        } else {
-                            $this->redirect = $CFG_GLPI['root_doc'] . "/front/central.php";
-                        }
+                        $this->redirect = Html::getBackUrl();
                     // Don't display progress bars if delay is less than 1 second
                         $this->display_progress_bars = false;
                         break;

--- a/src/Session.php
+++ b/src/Session.php
@@ -379,9 +379,7 @@ class Session
             $url = '';
 
             if (!isset($_SERVER['REQUEST_URI']) || (strpos($_SERVER['REQUEST_URI'], "tabs") > 0)) {
-                if (isset($_SERVER['HTTP_REFERER'])) {
-                    $url = $_SERVER['HTTP_REFERER'];
-                }
+                $url = Html::getRefererUrl();
             } else {
                 $url = $_SERVER['REQUEST_URI'];
             }

--- a/src/Transfer.php
+++ b/src/Transfer.php
@@ -3804,7 +3804,8 @@ final class Transfer extends CommonDBTM
     public function showForm($ID, array $options = [])
     {
         $edit_form = true;
-        if (!str_contains($_SERVER['HTTP_REFERER'], "transfer.form.php")) {
+        $referer_url = Html::getRefererUrl();
+        if ($referer_url === null || !str_contains($referer_url, "transfer.form.php")) {
             $edit_form = false;
         }
         TemplateRenderer::getInstance()->display('pages/admin/transfer.html.twig', [


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

Even if it does not seems possible to exploit it, we already had several issues opened related to lack of filtering of the referer header value.

I propose to add some filtering on it, and to generate back URLs based on the `$CFG_GLPI['url_base']` config entry when the referer is considered as invalid/unsafe.
