### PR TITLE
Create default forms on installation or update

### DIFF
--- a/phpunit/functional/Glpi/Form/DefaultFormsManagerTest.php
+++ b/phpunit/functional/Glpi/Form/DefaultFormsManagerTest.php
@@ -145,8 +145,8 @@ final class DefaultFormsManagerTest extends DbTestCase
             ],
             'Urgency' => 5, // Very high
             'Watchers' => [
-                ['itemtype' => User::class, 'items_id' => $tech_user_id],
-                ['itemtype' => User::class, 'items_id' => $normal_user_id],
+                User::class . '-' . $tech_user_id,
+                User::class . '-' . $normal_user_id,
             ]
         ]);
 
@@ -194,8 +194,8 @@ final class DefaultFormsManagerTest extends DbTestCase
             ],
             'Urgency' => 5, // Very high
             'Watchers' => [
-                ['itemtype' => User::class, 'items_id' => $tech_user_id],
-                ['itemtype' => User::class, 'items_id' => $normal_user_id],
+                User::class . '-' . $tech_user_id,
+                User::class . '-' . $normal_user_id,
             ]
         ]);
 

--- a/phpunit/functional/Glpi/Form/DefaultFormsManagerTest.php
+++ b/phpunit/functional/Glpi/Form/DefaultFormsManagerTest.php
@@ -1,0 +1,251 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace test\units\Glpi\Form;
+
+use DbTestCase;
+use Glpi\Form\AccessControl\FormAccessControlManager;
+use Glpi\Form\AccessControl\FormAccessParameters;
+use Glpi\Form\DefaultFormsManager;
+use Glpi\Form\Form;
+use Glpi\Session\SessionInfo;
+use Glpi\Tests\FormTesterTrait;
+use ITILCategory;
+use Location;
+use Ticket;
+use User;
+
+final class DefaultFormsManagerTest extends DbTestCase
+{
+    use FormTesterTrait;
+
+    private function getManager(): DefaultFormsManager
+    {
+        return new DefaultFormsManager();
+    }
+
+    public function testsFormAreAddedAfterInstallation(): void
+    {
+        $this->assertEquals(2, countElementsInTable(Form::getTable()));
+    }
+
+    public function testNoFormAreCreatedWhenDatabaseIsNotEmpty(): void
+    {
+        // Arrange: count the number of forms that already exist in the database
+        $number_of_forms_before = countElementsInTable(Form::getTable());
+
+        // Act: create default forms
+        $this->getManager()->createDefaultForms();
+
+        // Assert: there must be not be any new forms
+        $number_of_forms_after = countElementsInTable(Form::getTable());
+        $number_of_new_forms = $number_of_forms_after - $number_of_forms_before;
+        $this->assertEquals(0, $number_of_new_forms);
+    }
+
+    public function testIncidentFormProperties(): void
+    {
+        // Arrange: Get default incident form
+        $rows = (new Form())->find(['name' => 'Incident']);
+
+        // Assert: there should be one single form with specific properties
+        $this->assertCount(1, $rows);
+        $row = current($rows);
+        $this->assertEquals(0, $row['entities_id']);
+        $this->assertEquals(true, $row['is_recursive']);
+        $this->assertEquals(true, $row['is_active']);
+        $this->assertEquals(false, $row['is_deleted']);
+        $this->assertEquals(false, $row['is_draft']);
+        $this->assertEmpty($row['header']);
+        $this->assertNotEmpty($row['icon']);
+        $this->assertNotEmpty($row['description']);
+    }
+
+    public function testRequestFormProperties(): void
+    {
+        // Arrange: Get default incident form
+        $rows = (new Form())->find(['name' => 'Request']);
+
+        // Assert: there should be one single form with specific properties
+        $this->assertCount(1, $rows);
+        $row = current($rows);
+        $this->assertEquals(0, $row['entities_id']);
+        $this->assertEquals(true, $row['is_recursive']);
+        $this->assertEquals(true, $row['is_active']);
+        $this->assertEquals(false, $row['is_deleted']);
+        $this->assertEquals(false, $row['is_draft']);
+        $this->assertEmpty($row['header']);
+        $this->assertNotEmpty($row['icon']);
+        $this->assertNotEmpty($row['description']);
+    }
+
+    public function testIncidentFormQuestions(): void
+    {
+        // Arrange: Get default incident form and fetch test data
+        $rows = (new Form())->find(['name' => 'Incident']);
+        $row = current($rows);
+        $form = Form::getById($row['id']);
+
+        // Create test categories and locations
+        $category = $this->createItem(ITILCategory::class, [
+            'name' => 'Test category',
+            'is_incident' => true,
+        ]);
+        $location = $this->createItem(Location::class, [
+            'name' => 'Test location',
+        ]);
+
+        // Fetch test users
+        $tech_user_id = getItemByTypeName(User::class, "tech", true);
+        $normal_user_id = getItemByTypeName(User::class, "normal", true);
+
+        // Act: submit the default incident form
+        $ticket = $this->sendFormAndGetCreatedTicket($form, [
+            'Title' => 'My ticket title',
+            'Description' => 'My ticket content',
+            'Category' => [
+                'itemtype' => ITILCategory::class,
+                'items_id' => $category->getID(),
+            ],
+            'Location' => [
+                'itemtype' => Location::class,
+                'items_id' => $location->getID(),
+            ],
+            'Urgency' => 5, // Very high
+            'Watchers' => [
+                ['itemtype' => User::class, 'items_id' => $tech_user_id],
+                ['itemtype' => User::class, 'items_id' => $normal_user_id],
+            ]
+        ]);
+
+        // Assert: check the created ticket properties
+        $this->assertEquals(Ticket::INCIDENT_TYPE, $ticket->fields['type']);
+        $this->assertEquals('My ticket title', $ticket->fields['name']);
+        $this->assertEquals('My ticket content', $ticket->fields['content']);
+        $this->assertEquals($category->getID(), $ticket->fields['itilcategories_id']);
+        $this->assertEquals($location->getID(), $ticket->fields['locations_id']);
+        $this->assertEquals(5, $ticket->fields['urgency']);
+        // TODO: check observers, not possible yet as there are not configurable.
+    }
+
+    public function testRequestFormQuestions(): void
+    {
+        // Arrange: Get default request form and fetch test data
+        $rows = (new Form())->find(['name' => 'Request']);
+        $row = current($rows);
+        $form = Form::getById($row['id']);
+
+        // Create test categories and locations
+        $category = $this->createItem(ITILCategory::class, [
+            'name' => 'Test category',
+            'is_incident' => true,
+        ]);
+        $location = $this->createItem(Location::class, [
+            'name' => 'Test location',
+        ]);
+
+        // Fetch test users
+        $tech_user_id = getItemByTypeName(User::class, "tech", true);
+        $normal_user_id = getItemByTypeName(User::class, "normal", true);
+
+        // Act: submit the default incident form
+        $ticket = $this->sendFormAndGetCreatedTicket($form, [
+            'Title' => 'My ticket title',
+            'Description' => 'My ticket content',
+            'Category' => [
+                'itemtype' => ITILCategory::class,
+                'items_id' => $category->getID(),
+            ],
+            'Location' => [
+                'itemtype' => Location::class,
+                'items_id' => $location->getID(),
+            ],
+            'Urgency' => 5, // Very high
+            'Watchers' => [
+                ['itemtype' => User::class, 'items_id' => $tech_user_id],
+                ['itemtype' => User::class, 'items_id' => $normal_user_id],
+            ]
+        ]);
+
+        // Assert: check the created ticket properties
+        $this->assertEquals(Ticket::DEMAND_TYPE, $ticket->fields['type']);
+        $this->assertEquals('My ticket title', $ticket->fields['name']);
+        $this->assertEquals('My ticket content', $ticket->fields['content']);
+        $this->assertEquals($category->getID(), $ticket->fields['itilcategories_id']);
+        $this->assertEquals($location->getID(), $ticket->fields['locations_id']);
+        $this->assertEquals(5, $ticket->fields['urgency']);
+        // TODO: check observers, not possible yet as there are not configurable.
+    }
+
+    public function testIncidentFormShouldBeAccessibleBySelfServiceUsers(): void
+    {
+        // Arrange: Get default incident form
+        $rows = (new Form())->find(['name' => 'Incident']);
+        $row = current($rows);
+        $form = Form::getById($row['id']);
+
+        // Act: check if the form can be answered by a self service user
+        $form_access_manager = FormAccessControlManager::getInstance();
+        $parameters = new FormAccessParameters(
+            session_info: new SessionInfo(
+                user_id: getItemByTypeName(User::class, "post-only", true)
+            )
+        );
+        $can_answer = $form_access_manager->canAnswerForm($form, $parameters);
+
+        // Assert: the user should be able to see the form
+        $this->assertEquals(true, $can_answer);
+    }
+
+    public function testRequestFormShouldBeAccessibleBySelfServiceUsers(): void
+    {
+        // Arrange: Get default request form
+        $rows = (new Form())->find(['name' => 'Request']);
+        $row = current($rows);
+        $form = Form::getById($row['id']);
+
+        // Act: check if the form can be answered by a self service user
+        $form_access_manager = FormAccessControlManager::getInstance();
+        $parameters = new FormAccessParameters(
+            session_info: new SessionInfo(
+                user_id: getItemByTypeName(User::class, "post-only", true)
+            )
+        );
+        $can_answer = $form_access_manager->canAnswerForm($form, $parameters);
+
+        // Assert: the user should be able to see the form
+        $this->assertEquals(true, $can_answer);
+    }
+}

--- a/phpunit/functional/Glpi/Form/ServiceCatalog/ServiceCatalogManagerTest.php
+++ b/phpunit/functional/Glpi/Form/ServiceCatalog/ServiceCatalogManagerTest.php
@@ -44,6 +44,7 @@ use Glpi\Form\Form;
 use Glpi\Session\SessionInfo;
 use Glpi\Tests\FormBuilder;
 use Glpi\Tests\FormTesterTrait;
+use Override;
 use PHPUnit\Framework\Attributes\DataProvider;
 use User;
 
@@ -57,6 +58,15 @@ final class ServiceCatalogManagerTest extends \DbTestCase
     {
         self::$manager = new ServiceCatalogManager();
         parent::setUpBeforeClass();
+    }
+
+    #[Override]
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        // Disable default forms to not pollute the tests of this file
+        $this->disableExistingForms();
     }
 
     public function testOnlyActiveFormsAreDisplayed(): void

--- a/src/Glpi/Form/DefaultFormsManager.php
+++ b/src/Glpi/Form/DefaultFormsManager.php
@@ -1,0 +1,328 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Form;
+
+use AbstractRightsDropdown;
+use Glpi\Form\AccessControl\ControlType\AllowList;
+use Glpi\Form\AccessControl\ControlType\AllowListConfig;
+use Glpi\Form\AccessControl\FormAccessControl;
+use Glpi\Form\Destination\CommonITILField\ContentField;
+use Glpi\Form\Destination\CommonITILField\RequestTypeField;
+use Glpi\Form\Destination\CommonITILField\RequestTypeFieldConfig;
+use Glpi\Form\Destination\CommonITILField\RequestTypeFieldStrategy;
+use Glpi\Form\Destination\CommonITILField\SimpleValueConfig;
+use Glpi\Form\Destination\CommonITILField\TitleField;
+use Glpi\Form\Destination\FormDestination;
+use Glpi\Form\Destination\FormDestinationTicket;
+use Glpi\Form\QuestionType\QuestionTypeItemDropdown;
+use Glpi\Form\QuestionType\QuestionTypeLongText;
+use Glpi\Form\QuestionType\QuestionTypeObserver;
+use Glpi\Form\QuestionType\QuestionTypeShortText;
+use Glpi\Form\QuestionType\QuestionTypeUrgency;
+use Glpi\Form\Tag\AnswerTagProvider;
+use ITILCategory;
+use Location;
+use Ticket;
+
+final class DefaultFormsManager
+{
+    private AnswerTagProvider $answer_tag_provider;
+
+    public function __construct()
+    {
+        $this->answer_tag_provider = new AnswerTagProvider();
+    }
+
+    public function createDefaultForms(): void
+    {
+        if (countElementsInTable(Form::getTable()) > 0) {
+            return;
+        }
+
+        $this->createIncidentForm();
+        $this->createRequestForm();
+    }
+
+    private function createIncidentForm(): void
+    {
+        // Create form
+        $form = $this->createForm(
+            name: __('Incident'),
+            description: __("Declare an incident"),
+            icon: 'ti ti-exclamation-circle',
+        );
+
+        // Get first section
+        $sections = $form->getSections();
+        $section = array_pop($sections);
+
+        // Add questions
+        $this->addQuestion($section, $this->getUrgencyQuestionData());
+        $this->addQuestion($section, $this->getCategoryQuestionData());
+        // TODO: associated items (not possible yet)
+        $this->addQuestion($section, $this->getWatchersQuestionData());
+        $this->addQuestion($section, $this->getLocationQuestionData());
+        $title_question = $this->addQuestion($section, $this->getTitleQuestionData());
+        $description_question = $this->addQuestion($section, $this->getDescriptionQuestionData());
+
+        // Find title and description question tags, needed to configure the created ticket
+        $title_tag = $this->answer_tag_provider->getTagForQuestion(
+            $title_question
+        );
+        $description_tag = $this->answer_tag_provider->getTagForQuestion(
+            $description_question
+        );
+
+        // Prepare ticket destination config
+        $config = [
+            // Set title using an answer
+            TitleField::getKey() => (new SimpleValueConfig(
+                $title_tag->html,
+            ))->jsonSerialize(),
+
+            // Set manual description using an answer
+            ContentField::getAutoConfigKey() => false,
+            ContentField::getKey() => (new SimpleValueConfig(
+                $description_tag->html,
+            ))->jsonSerialize(),
+
+            // Force incident type
+            RequestTypeField::getKey() => (new RequestTypeFieldConfig(
+                strategy: RequestTypeFieldStrategy::SPECIFIC_VALUE,
+                specific_request_type: Ticket::INCIDENT_TYPE,
+            ))->jsonSerialize()
+        ];
+
+        // Add ticket destination
+        $this->addTicketDestination($form, $config);
+
+        // Allow all users
+        $this->allowAllUsers($form);
+    }
+
+    private function createRequestForm(): void
+    {
+        $form = $this->createForm(
+            name: __('Request'),
+            description: __("Request a service"),
+            icon: 'ti ti-devices-up',
+        );
+
+        // Get first section
+        $sections = $form->getSections();
+        $section = array_pop($sections);
+
+        // Add questions
+        $this->addQuestion($section, $this->getUrgencyQuestionData());
+        $this->addQuestion($section, $this->getCategoryQuestionData());
+        // TODO: associated items (not possible yet)
+        $this->addQuestion($section, $this->getWatchersQuestionData());
+        $this->addQuestion($section, $this->getLocationQuestionData());
+        $title_question = $this->addQuestion($section, $this->getTitleQuestionData());
+        $description_question = $this->addQuestion($section, $this->getDescriptionQuestionData());
+
+        // Find title and description question tags, needed to configure the created ticket
+        $title_tag = $this->answer_tag_provider->getTagForQuestion(
+            $title_question
+        );
+        $description_tag = $this->answer_tag_provider->getTagForQuestion(
+            $description_question
+        );
+
+        // Prepare ticket destination config
+        $config = [
+            // Set title using an answer
+            TitleField::getKey() => (new SimpleValueConfig(
+                $title_tag->html,
+            ))->jsonSerialize(),
+
+            // Set manual description using an answer
+            ContentField::getAutoConfigKey() => false,
+            ContentField::getKey() => (new SimpleValueConfig(
+                $description_tag->html,
+            ))->jsonSerialize(),
+
+            // Force incident type
+            RequestTypeField::getKey() => (new RequestTypeFieldConfig(
+                strategy: RequestTypeFieldStrategy::SPECIFIC_VALUE,
+                specific_request_type: Ticket::DEMAND_TYPE,
+            ))->jsonSerialize()
+        ];
+
+        // Add ticket destination
+        $this->addTicketDestination($form, $config);
+
+        // Allow all users
+        $this->allowAllUsers($form);
+    }
+
+    private function createForm(
+        string $name,
+        string $description,
+        string $icon,
+    ): Form {
+        $form = new Form();
+        $form_id = $form->add([
+            // Specific properties
+            'name'         => $name,
+            'description'  => $description,
+            'icon'         => $icon,
+            // Common properties
+            'is_active'    => true,
+            'is_recursive' => true,
+            'entities_id'  => 0,
+        ]);
+
+        if (!$form_id) {
+            throw new \RuntimeException("Failed to create form");
+        }
+
+        $form = Form::getById($form_id);
+        return $form;
+    }
+
+    private function addQuestion(
+        Section $section,
+        array $question_data,
+    ): Question {
+        // Refresh data
+        $section->getFromDB($section->getID());
+
+        // Set common values
+        $question_data['rank'] = count($section->getQuestions());
+        $question_data[Section::getForeignKeyField()] = $section->getID();
+
+        // Create question
+        $question = new Question();
+        if (!$question->add($question_data)) {
+            throw new \RuntimeException(
+                "Failed to create question: " . json_encode($question_data)
+            );
+        }
+
+        return $question;
+    }
+
+    private function getTitleQuestionData(): array
+    {
+        return [
+            'type' => QuestionTypeShortText::class,
+            'name' => __("Title"),
+        ];
+    }
+
+    private function getDescriptionQuestionData(): array
+    {
+        return [
+            'type' => QuestionTypeLongText::class,
+            'name' => __("Description"),
+            'is_mandatory' => true,
+        ];
+    }
+
+    private function getCategoryQuestionData(): array
+    {
+        return [
+            'type' => QuestionTypeItemDropdown::class,
+            'name' => _n('Category', 'Categories', 1),
+            'default_value' => ([
+                'itemtype' => ITILCategory::class,
+                'items_id' => 0,
+            ])
+        ];
+    }
+
+    private function getLocationQuestionData(): array
+    {
+        return [
+            'type' => QuestionTypeItemDropdown::class,
+            'name' => _n('Location', 'Locations', 1),
+            'default_value' => ([
+                'itemtype' => Location::class,
+                'items_id' => 0,
+            ])
+        ];
+    }
+
+    private function getUrgencyQuestionData(): array
+    {
+        return [
+            'type' => QuestionTypeUrgency::class,
+            'name' => __("Urgency"),
+        ];
+    }
+
+    private function getWatchersQuestionData(): array
+    {
+        return [
+            'type' => QuestionTypeObserver::class,
+            'name' => __("Watchers"),
+            'extra_data' => json_encode(['is_multiple_actors' => true]),
+        ];
+    }
+
+    private function addTicketDestination(Form $form, array $config): void
+    {
+        $destination = new FormDestination();
+        $id = $destination->add([
+            Form::getForeignKeyField() => $form->getID(),
+            'itemtype' => FormDestinationTicket::class,
+            'name'     => _n('Ticket', 'Tickets', 1),
+            'config'   => $config,
+        ]);
+
+        if (!$id) {
+            throw new \RunTimeException("Failed to create destination");
+        }
+    }
+
+    private function allowAllUsers(Form $form): void
+    {
+        $form_access_control = new FormAccessControl();
+        $id = $form_access_control->add([
+            Form::getForeignKeyField() => $form->getID(),
+            'strategy' => AllowList::class,
+            '_config'   => new AllowListConfig(
+                user_ids: [AbstractRightsDropdown::ALL_USERS]
+            ),
+            'is_active' => 1,
+        ]);
+
+        if (!$id) {
+            throw new \RunTimeException("Failed to create access policy");
+        }
+    }
+}

--- a/src/Glpi/Form/Destination/AbstractConfigField.php
+++ b/src/Glpi/Form/Destination/AbstractConfigField.php
@@ -44,7 +44,7 @@ use Toolbox;
 abstract class AbstractConfigField implements ConfigFieldInterface
 {
     #[Override]
-    public function getKey(): string
+    public static function getKey(): string
     {
         return Toolbox::slugify(static::class);
     }
@@ -89,9 +89,9 @@ abstract class AbstractConfigField implements ConfigFieldInterface
         return $config[$this->getAutoConfigKey()] ?? true;
     }
 
-    public function getAutoConfigKey(): string
+    public static function getAutoConfigKey(): string
     {
-        return $this->getKey() . '_auto';
+        return static::getKey() . '_auto';
     }
 
     #[Override]

--- a/src/Glpi/Form/Destination/CommonITILField/AssociatedItemsField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/AssociatedItemsField.php
@@ -49,7 +49,7 @@ use Ticket;
 class AssociatedItemsField extends AbstractConfigField
 {
     #[Override]
-    public function getKey(): string
+    public static function getKey(): string
     {
         return 'associated_items';
     }

--- a/src/Glpi/Form/Destination/CommonITILField/EntityField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/EntityField.php
@@ -48,7 +48,7 @@ use Override;
 class EntityField extends AbstractConfigField
 {
     #[Override]
-    public function getKey(): string
+    public static function getKey(): string
     {
         return 'entity';
     }

--- a/src/Glpi/Form/Destination/CommonITILField/ITILCategoryField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ITILCategoryField.php
@@ -50,7 +50,7 @@ use Override;
 class ITILCategoryField extends AbstractConfigField
 {
     #[Override]
-    public function getKey(): string
+    public static function getKey(): string
     {
         return 'itilcategory';
     }

--- a/src/Glpi/Form/Destination/CommonITILField/ITILCategoryFieldStrategy.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ITILCategoryFieldStrategy.php
@@ -35,10 +35,9 @@
 
 namespace Glpi\Form\Destination\CommonITILField;
 
-use atoum\atoum\php\tokenizer\iterator\value;
+use Glpi\Form\Answer;
 use Glpi\Form\AnswersSet;
 use Glpi\Form\QuestionType\QuestionTypeItemDropdown;
-use Glpi\Form\QuestionType\QuestionTypeITILCategory;
 use ITILCategory;
 
 enum ITILCategoryFieldStrategy: string
@@ -98,15 +97,25 @@ enum ITILCategoryFieldStrategy: string
             QuestionTypeItemDropdown::class
         );
 
+        // Filter by itemtype
+        $valid_answers = array_filter($valid_answers, function (Answer $answer) {
+            $value = $answer->getRawAnswer();
+            if (
+                $value['itemtype'] !== ITILCategory::getType()
+                || !is_numeric($value['items_id'])
+            ) {
+                return false;
+            }
+
+            return true;
+        });
+
         if (count($valid_answers) == 0) {
             return null;
         }
 
         $answer = end($valid_answers);
         $value = $answer->getRawAnswer();
-        if ($value['itemtype'] !== ITILCategory::getType() || !is_numeric($value['items_id'])) {
-            return null;
-        }
 
         return (int) $value['items_id'];
     }

--- a/src/Glpi/Form/Destination/CommonITILField/LocationField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/LocationField.php
@@ -48,7 +48,7 @@ use Override;
 class LocationField extends AbstractConfigField
 {
     #[Override]
-    public function getKey(): string
+    public static function getKey(): string
     {
         return 'location';
     }

--- a/src/Glpi/Form/Destination/CommonITILField/OLATTOField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/OLATTOField.php
@@ -42,7 +42,7 @@ use SLM;
 final class OLATTOField extends SLMField
 {
     #[Override]
-    public function getKey(): string
+    public static function getKey(): string
     {
         return 'ola_tto';
     }

--- a/src/Glpi/Form/Destination/CommonITILField/OLATTRField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/OLATTRField.php
@@ -42,7 +42,7 @@ use SLM;
 final class OLATTRField extends SLMField
 {
     #[Override]
-    public function getKey(): string
+    public static function getKey(): string
     {
         return 'ola_ttr';
     }

--- a/src/Glpi/Form/Destination/CommonITILField/RequestSourceField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/RequestSourceField.php
@@ -35,7 +35,6 @@
 
 namespace Glpi\Form\Destination\CommonITILField;
 
-use Dropdown;
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\JsonFieldInterface;
 use Glpi\Form\AnswersSet;
@@ -44,12 +43,11 @@ use Glpi\Form\Form;
 use InvalidArgumentException;
 use Override;
 use RequestType;
-use Ticket;
 
 class RequestSourceField extends AbstractConfigField
 {
     #[Override]
-    public function getKey(): string
+    public static function getKey(): string
     {
         return 'request_source';
     }

--- a/src/Glpi/Form/Destination/CommonITILField/SLATTOField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/SLATTOField.php
@@ -42,7 +42,7 @@ use SLM;
 final class SLATTOField extends SLMField
 {
     #[Override]
-    public function getKey(): string
+    public static function getKey(): string
     {
         return 'sla_tto';
     }

--- a/src/Glpi/Form/Destination/CommonITILField/SLATTRField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/SLATTRField.php
@@ -42,7 +42,7 @@ use SLM;
 final class SLATTRField extends SLMField
 {
     #[Override]
-    public function getKey(): string
+    public static function getKey(): string
     {
         return 'sla_ttr';
     }

--- a/src/Glpi/Form/Destination/CommonITILField/TemplateField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/TemplateField.php
@@ -58,7 +58,7 @@ class TemplateField extends AbstractConfigField
     }
 
     #[Override]
-    public function getKey(): string
+    public static function getKey(): string
     {
         return 'template';
     }

--- a/src/Glpi/Form/Destination/ConfigFieldInterface.php
+++ b/src/Glpi/Form/Destination/ConfigFieldInterface.php
@@ -47,7 +47,7 @@ interface ConfigFieldInterface
      *
      * @return string
      */
-    public function getKey(): string;
+    public static function getKey(): string;
 
     /**
      * Label to be displayed when configuring this field.

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -37,6 +37,7 @@ use Glpi\Application\View\TemplateRenderer;
 use Glpi\Console\Application;
 use Glpi\DBAL\QueryParam;
 use Glpi\Event;
+use Glpi\Form\DefaultFormsManager;
 use Glpi\Http\Response;
 use Glpi\Mail\Protocol\ProtocolInterface;
 use Glpi\Rules\RulesManager;
@@ -2154,6 +2155,10 @@ class Toolbox
                     }
                 }
             }
+
+            // Create default forms
+            $default_forms_manager = new DefaultFormsManager();
+            $default_forms_manager->createDefaultForms();
 
             // Initalize rules
             RulesManager::initializeRules();

--- a/src/Update.php
+++ b/src/Update.php
@@ -33,6 +33,7 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Form\DefaultFormsManager;
 use Glpi\Rules\RulesManager;
 use Glpi\System\Diagnostic\DatabaseSchemaIntegrityChecker;
 use Glpi\Toolbox\VersionParser;
@@ -274,6 +275,10 @@ class Update
                 );
             }
         }
+
+        // Create default forms
+        $default_forms_manager = new DefaultFormsManager();
+        $default_forms_manager->createDefaultForms();
 
         // Initalize rules
         $this->migration->displayTitle(__('Initializing rules...'));

--- a/tests/src/FormTesterTrait.php
+++ b/tests/src/FormTesterTrait.php
@@ -427,4 +427,16 @@ trait FormTesterTrait
 
         return $form_copy;
     }
+
+    protected function disableExistingForms(): void
+    {
+        $forms = (new Form())->find([]);
+        foreach ($forms as $row) {
+            $form = new Form();
+            $form->update([
+                'id' => $row['id'],
+                'is_active' => false
+            ]);
+        }
+    }
 }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Add two default forms when installing GLPI or updating to GLPI 11.
The goal is to copy the "old" helpdesk form:

![image](https://github.com/user-attachments/assets/30745fb5-589e-4e81-ac5e-888b4b15a535)

It is split into two Incident/Request forms which are almost identical.
Note that the "associated elements" question is missing because it isn't possible to implement it right now (we will work on that later) and that the picked "watchers" are also not applied into the ticket (not possible yet too).

The default forms themselves are subject to change later as we make the final adjustments before GLPI 11.
Right now, the goal is just to offer the same feature that in GLPI 10 but with two "real" forms.

