### PR TITLE
Ensure that container cache is correctly refreshed on testing env

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -2636,14 +2636,14 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Inventory/Inventory.php',
 ];
 $ignoreErrors[] = [
-	// identifier: return.type
-	'message' => '#^Method Glpi\\\\Kernel\\\\Kernel\\:\\:getLogDir\\(\\) should return string but returns null\\.$#',
+	// identifier: function.impossibleType
+	'message' => '#^Call to function in_array\\(\\) with arguments null, array\\{\'development\', \'testing\'\\} and true will always evaluate to false\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Glpi/Kernel/Kernel.php',
 ];
 $ignoreErrors[] = [
-	// identifier: identical.alwaysFalse
-	'message' => '#^Strict comparison using \\=\\=\\= between null and \'development\' will always evaluate to false\\.$#',
+	// identifier: return.type
+	'message' => '#^Method Glpi\\\\Kernel\\\\Kernel\\:\\:getLogDir\\(\\) should return string but returns null\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Glpi/Kernel/Kernel.php',
 ];

--- a/src/Glpi/Kernel/Kernel.php
+++ b/src/Glpi/Kernel/Kernel.php
@@ -34,6 +34,7 @@
 
 namespace Glpi\Kernel;
 
+use GLPI;
 use Glpi\Application\ConfigurationConstants;
 use Glpi\Config\ConfigProviderConsoleExclusiveInterface;
 use Glpi\Config\ConfigProviderWithRequestInterface;
@@ -58,12 +59,17 @@ final class Kernel extends BaseKernel
         (new ConfigurationConstants($this->getProjectDir()))->computeConstants($env);
 
         // TODO: refactor the GLPI class.
-        $glpi = (new \GLPI());
+        $glpi = (new GLPI());
         $glpi->initLogger();
         $glpi->initErrorHandler();
 
         $env = GLPI_ENVIRONMENT_TYPE;
-        parent::__construct($env, $env === 'development');
+        parent::__construct(
+            $env,
+            // `debug: true` will ensure that cache is recompiled everytime a corresponding resource is updated.
+            // Reserved for dev/test environments as it consumes many disk I/O.
+            debug: in_array($env, [GLPI::ENV_DEVELOPMENT, GLPI::ENV_TESTING], true)
+        );
     }
 
     public function __destruct()


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

When the kernel is instanciated without the `debug: true` parameter, DI container cache freshness is not checked at runtime. See https://github.com/symfony/http-kernel/blob/c227b1a922703bfbc7c1d5b52c76d6beceb67753/Kernel.php#L413-L421

It causes issues on the `testing` environment, as a change in class/method signatures can make the cached container incompatible with the GLPI code and result in a fatal error.

Instanciating the kernel with the `debug: true` parameter in the `testing` environment will prevent this kind of issues.