### PR TITLE
fix sql debugger data collector

### DIFF
--- a/src/DBmysql.php
+++ b/src/DBmysql.php
@@ -402,16 +402,15 @@ class DBmysql
             }
         }
 
+        $this->last_query_warnings = $this->fetchQueryWarnings();
         if ($is_debug && $CFG_GLPI["debug_sql"]) {
             $TIME = (float) $TIMER->getTime();
             $debug_data['time'] = (int) ($TIME * 1000);
             $debug_data['rows'] = $this->affectedRows();
             $DEBUG_SQL["times"][$SQL_TOTAL_REQUEST] = $TIME;
             $DEBUG_SQL['rows'][$SQL_TOTAL_REQUEST] = $this->affectedRows();
+            $DEBUG_SQL['warnings'][$SQL_TOTAL_REQUEST] = $this->last_query_warnings;
         }
-
-        $this->last_query_warnings = $this->fetchQueryWarnings();
-        $DEBUG_SQL['warnings'][$SQL_TOTAL_REQUEST] = $this->last_query_warnings;
 
         $warnings_string = implode(
             "\n",

--- a/src/DBmysql.php
+++ b/src/DBmysql.php
@@ -402,13 +402,17 @@ class DBmysql
             }
         }
 
-        $this->last_query_warnings = $this->fetchQueryWarnings();
         if ($is_debug && $CFG_GLPI["debug_sql"]) {
             $TIME = (float) $TIMER->getTime();
             $debug_data['time'] = (int) ($TIME * 1000);
             $debug_data['rows'] = $this->affectedRows();
             $DEBUG_SQL["times"][$SQL_TOTAL_REQUEST] = $TIME;
             $DEBUG_SQL['rows'][$SQL_TOTAL_REQUEST] = $this->affectedRows();
+        }
+
+        // Ensure that we collect warning after affected rows
+        $this->last_query_warnings = $this->fetchQueryWarnings();
+        if ($is_debug && $CFG_GLPI["debug_sql"]) {
             $DEBUG_SQL['warnings'][$SQL_TOTAL_REQUEST] = $this->last_query_warnings;
         }
 


### PR DESCRIPTION
I think that SQL warnings are not properly stored when debug mode is enabled.

$SQL_TOTAL_REQUEST is incremented on each ->doQuery() execution only when debug mode is enabled, then i assume that $DEBUG_SQL['warnings'][$SQL_TOTAL_REQUEST] should be populated only when debug mode is enabled

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does

## Screenshots (if appropriate):


