### PR TITLE
Ensure SCSS compilation does not reach max execution time

### DIFF
--- a/front/css.php
+++ b/front/css.php
@@ -56,6 +56,13 @@ if (Toolbox::getMemoryLimit() < ($max_memory * 1024 * 1024)) {
     ini_set('memory_limit', sprintf('%dM', $max_memory));
 }
 
+// Main CSS compilation can be quiet long on dev environments that have xdebug loaded.
+$max_execution_time    = 180;
+$current_max_exec_time = (int) ini_get('max_execution_time');
+if ($current_max_exec_time !== 0 && $current_max_exec_time < $max_execution_time) {
+    ini_set('max_execution_time', $max_execution_time);
+}
+
 // Ensure warnings will not break CSS output.
 ErrorHandler::getInstance()->disableOutput();
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

On my new development machine, that uses the default docker environment provided in the `docker-compose.yaml` file, the SCSS compilation timeouts after 30 seconds (at least on the `main` branch). I propose to increase the max execution time to 180 seconds for SCSS compilations.