### PR TITLE
Prevent conflict between dev and test docker containers

### DIFF
--- a/.github/actions/docker-compose-app.yml
+++ b/.github/actions/docker-compose-app.yml
@@ -1,6 +1,6 @@
 services:
   app:
-    container_name: "app"
+    container_name: "glpi-test-app"
     image: "ghcr.io/glpi-project/${PHP_IMAGE:-githubactions-php}"
     environment:
       CODE_COVERAGE: "${CODE_COVERAGE:-false}"

--- a/.github/actions/docker-compose-services.yml
+++ b/.github/actions/docker-compose-services.yml
@@ -1,20 +1,20 @@
 services:
   db:
-    container_name: "db"
+    container_name: "glpi-test-db"
     image: "ghcr.io/glpi-project/${DB_IMAGE:-githubactions-mariadb}"
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
       MYSQL_DATABASE: "glpi"
     shm_size: '1gb'
   dovecot:
-    container_name: "dovecot"
+    container_name: "glpi-test-dovecot"
     image: "ghcr.io/glpi-project/githubactions-dovecot"
   memcached:
-    container_name: "memcached"
+    container_name: "glpi-test-memcached"
     image: "ghcr.io/glpi-project/githubactions-memcached"
   openldap:
-    container_name: "openldap"
+    container_name: "glpi-test-openldap"
     image: "ghcr.io/glpi-project/githubactions-openldap"
   redis:
-    container_name: "redis"
+    container_name: "glpi-test-redis"
     image: "ghcr.io/glpi-project/githubactions-redis"


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

On my new dev machine, I installed some containers for services that are shared between many applications, and named them `db`, `openldap`, `redis`, ...

When trying to execute the test suite using the `tests/run_tests.sh` script, I get the following error:
```
Error response from daemon: Conflict. The container name "/openldap" is already in use by container "bcd2135ba0c4a153aeb96cb87db7c097f904d618520d8ff98467c416986ab460". You have to remove (or rename) that container to be able to reuse that name.
```

I propose to rename the name of the containers used by this script.