### PR TITLE
Homepage: add proper tabs

### DIFF
--- a/css/helpdesk_home.scss
+++ b/css/helpdesk_home.scss
@@ -101,23 +101,23 @@ header {
 
 // Hack to hide some columns until we can add proper display preferences for
 // this list.
-.home-tickets-list [data-searchopt-id="1"],
-.home-tickets-list  [data-searchopt-content-id="1"],
-.home-tickets-list [data-searchopt-id="2"],
-.home-tickets-list  [data-searchopt-content-id="2"],
-.home-tickets-list [data-searchopt-id="80"],
-.home-tickets-list  [data-searchopt-content-id="80"],
-.home-tickets-list [data-searchopt-id="12"],
-.home-tickets-list  [data-searchopt-content-id="12"],
-.home-tickets-list [data-searchopt-id="19"],
-.home-tickets-list  [data-searchopt-content-id="19"],
-.home-tickets-list [data-searchopt-id="15"],
-.home-tickets-list  [data-searchopt-content-id="15"] {
+.tickets-banner [data-searchopt-id="1"],
+.tickets-banner  [data-searchopt-content-id="1"],
+.tickets-banner [data-searchopt-id="2"],
+.tickets-banner  [data-searchopt-content-id="2"],
+.tickets-banner [data-searchopt-id="80"],
+.tickets-banner  [data-searchopt-content-id="80"],
+.tickets-banner [data-searchopt-id="12"],
+.tickets-banner  [data-searchopt-content-id="12"],
+.tickets-banner [data-searchopt-id="19"],
+.tickets-banner  [data-searchopt-content-id="19"],
+.tickets-banner [data-searchopt-id="15"],
+.tickets-banner  [data-searchopt-content-id="15"] {
     display: table-cell !important;
 }
 
-.home-tickets-list [data-searchopt-id],
-.home-tickets-list  [data-searchopt-content-id] {
+.tickets-banner [data-searchopt-id],
+.tickets-banner  [data-searchopt-content-id] {
     display: none;
 }
 
@@ -154,4 +154,44 @@ header {
     padding-top:70px;
     padding-bottom:70px;
     flex-grow: 1;
+}
+
+// Specific style for the tabs
+#tabspanel {
+    border-right: 0 !important;
+    border-bottom: 1px solid transparent;
+
+    .nav-link {
+        border-bottom: 0 !important;
+        border-bottom-color: unset !important;
+    }
+}
+
+.tab-content {
+    border-top-right-radius: 0 !important;
+    border: 0 !important;
+}
+
+.tab-pane {
+    // Cancel parent padding, can't be done in .tab-content because the p-2 class
+    // already use !important so we can't override it.
+    margin: -0.5rem !important;
+}
+
+.home-ticket-list {
+    .search-card {
+        border-top-left-radius: 0;
+        border-top-right-radius: 0;
+    }
+
+    td {
+        // Remove stripped rows
+        box-shadow: none !important;
+    }
+
+    .card-footer {
+        border-top: 0;
+        padding-top: 16px;
+        padding-bottom: 8px;
+    }
 }

--- a/phpunit/CommonDropdown.php
+++ b/phpunit/CommonDropdown.php
@@ -76,10 +76,7 @@ abstract class CommonDropdown extends DbTestCase
     public function testDefineTabs()
     {
         $instance = $this->newInstance();
-        $tabs = array_map(
-            fn($text) => strip_tags($text),
-            $instance->defineTabs(),
-        );
+        $tabs = array_map('strip_tags', $instance->defineTabs());
         $this->assertSame($this->getTabs(), $tabs);
     }
 

--- a/phpunit/CommonDropdown.php
+++ b/phpunit/CommonDropdown.php
@@ -76,7 +76,11 @@ abstract class CommonDropdown extends DbTestCase
     public function testDefineTabs()
     {
         $instance = $this->newInstance();
-        $this->assertSame($this->getTabs(), $instance->defineTabs());
+        $tabs = array_map(
+            fn($text) => strip_tags($text),
+            $instance->defineTabs(),
+        );
+        $this->assertSame($this->getTabs(), $tabs);
     }
 
     public function testPre_deleteItem()

--- a/phpunit/functional/AgentTest.php
+++ b/phpunit/functional/AgentTest.php
@@ -49,7 +49,7 @@ class AgentTest extends DbTestCase
         ];
 
         $agent = new \Agent();
-        $tabs = array_map(fn($text) => strip_tags($text), $agent->defineTabs());
+        $tabs = array_map('strip_tags', $agent->defineTabs());
         $this->assertSame($expected, $tabs);
     }
 

--- a/phpunit/functional/AgentTest.php
+++ b/phpunit/functional/AgentTest.php
@@ -44,12 +44,13 @@ class AgentTest extends DbTestCase
     public function testDefineTabs()
     {
         $expected = [
-            'Agent$main'       => "<span><i class='ti ti-robot me-2'></i>Agent</span>",
-            'RuleMatchedLog$0' => "<span><i class='ti ti-book me-2'></i>Import information</span>",
+            'Agent$main'       => "Agent",
+            'RuleMatchedLog$0' => "Import information",
         ];
 
         $agent = new \Agent();
-        $this->assertSame($expected, $agent->defineTabs());
+        $tabs = array_map(fn($text) => strip_tags($text), $agent->defineTabs());
+        $this->assertSame($expected, $tabs);
     }
 
     public function testHandleAgent()

--- a/phpunit/functional/ApplianceTest.php
+++ b/phpunit/functional/ApplianceTest.php
@@ -48,7 +48,7 @@ class ApplianceTest extends DbTestCase
         ];
 
         $appliance = new \Appliance();
-        $tabs = array_map(fn($text) => strip_tags($text), $appliance->defineTabs());
+        $tabs = array_map('strip_tags', $appliance->defineTabs());
         $this->assertSame($expected, $tabs);
     }
 

--- a/phpunit/functional/ApplianceTest.php
+++ b/phpunit/functional/ApplianceTest.php
@@ -42,13 +42,14 @@ class ApplianceTest extends DbTestCase
     public function testDefineTabs()
     {
         $expected = [
-            'Appliance$main'     => "<span><i class='ti ti-versions me-2'></i>Appliance</span>",
-            'Impact$1'           => "<span><i class='ti ti-affiliate me-2'></i>Impact analysis</span>",
-            'ManualLink$1'       => "<span><i class='fas fa-link me-2'></i>Links</span>",
+            'Appliance$main'     => "Appliance",
+            'Impact$1'           => "Impact analysis",
+            'ManualLink$1'       => "Links",
         ];
 
         $appliance = new \Appliance();
-        $this->assertSame($expected, $appliance->defineTabs());
+        $tabs = array_map(fn($text) => strip_tags($text), $appliance->defineTabs());
+        $this->assertSame($expected, $tabs);
     }
 
     public function testGetTypes()

--- a/phpunit/functional/ConfigTest.php
+++ b/phpunit/functional/ConfigTest.php
@@ -101,7 +101,7 @@ class ConfigTest extends DbTestCase
         ];
 
         $instance = new \Config();
-        $tabs = array_map(fn($text) => strip_tags($text), $instance->defineTabs());
+        $tabs = array_map('strip_tags', $instance->defineTabs());
         $this->assertSame($expected, $tabs);
 
         //Standards users do not have extra tabs
@@ -109,7 +109,7 @@ class ConfigTest extends DbTestCase
         $this->assertTrue((bool)$auth->login('tech', 'tech', true));
 
         $instance = new \Config();
-        $tabs = array_map(fn($text) => strip_tags($text), $instance->defineTabs());
+        $tabs = array_map('strip_tags', $instance->defineTabs());
         $this->assertSame($expected, $tabs);
 
         //check extra tabs from superadmin profile
@@ -132,7 +132,7 @@ class ConfigTest extends DbTestCase
         ];
 
         $instance = new \Config();
-        $tabs = array_map(fn($text) => strip_tags($text), $instance->defineTabs());
+        $tabs = array_map('strip_tags', $instance->defineTabs());
         $this->assertSame($expected, $tabs);
     }
 

--- a/phpunit/functional/ConfigTest.php
+++ b/phpunit/functional/ConfigTest.php
@@ -91,46 +91,49 @@ class ConfigTest extends DbTestCase
     public function testDefineTabs()
     {
         $expected = [
-            'Config$1'      => "<span><i class='ti ti-adjustments me-2'></i>General setup</span>",
-            'Config$2'      => "<span><i class='ti ti-adjustments me-2'></i>Default values</span>",
-            'Config$3'      => "<span><i class='ti ti-package me-2'></i>Assets</span>",
-            'Config$4'      => "<span><i class='ti ti-headset me-2'></i>Assistance</span>",
-            'Config$12'     => "<span><i class='ti ti-wallet me-2'></i>Management</span>",
-            'DisplayPreference$1' => "<span><i class='ti ti-columns-3 me-2'></i>Search result display</span>",
-            'GLPINetwork$1' => "<span><i class='ti ti-headset me-2'></i>GLPI Network</span>",
+            'Config$1'      => "General setup",
+            'Config$2'      => "Default values",
+            'Config$3'      => "Assets",
+            'Config$4'      => "Assistance",
+            'Config$12'     => "Management",
+            'DisplayPreference$1' => "Search result display",
+            'GLPINetwork$1' => "GLPI Network",
         ];
 
         $instance = new \Config();
-        $this->assertSame($expected, $instance->defineTabs());
+        $tabs = array_map(fn($text) => strip_tags($text), $instance->defineTabs());
+        $this->assertSame($expected, $tabs);
 
         //Standards users do not have extra tabs
         $auth = new \Auth();
         $this->assertTrue((bool)$auth->login('tech', 'tech', true));
 
         $instance = new \Config();
-        $this->assertSame($expected, $instance->defineTabs());
+        $tabs = array_map(fn($text) => strip_tags($text), $instance->defineTabs());
+        $this->assertSame($expected, $tabs);
 
         //check extra tabs from superadmin profile
         $this->login();
         $expected = [
-            'Config$1'      => "<span><i class='ti ti-adjustments me-2'></i>General setup</span>",
-            'Config$2'      => "<span><i class='ti ti-adjustments me-2'></i>Default values</span>",
-            'Config$3'      => "<span><i class='ti ti-package me-2'></i>Assets</span>",
-            'Config$4'      => "<span><i class='ti ti-headset me-2'></i>Assistance</span>",
-            'Config$12'     => "<span><i class='ti ti-wallet me-2'></i>Management</span>",
-            'Config$9'      => "<span><i class='ti ti-news me-2'></i>Logs purge</span>",
-            'Config$5'      => "<span><i class='ti ti-adjustments me-2'></i>System</span>",
-            'Config$10'     => "<span><i class='ti ti-shield-lock me-2'></i>Security</span>",
-            'Config$7'      => "<span><i class='ti ti-dashboard me-2'></i>Performance</span>",
-            'Config$8'      => "<span><i class='ti ti-api-app me-2'></i>API</span>",
-            'Config$11'      => "<span><i class='ti ti-affiliate me-2'></i>Impact analysis</span>",
-            'DisplayPreference$1' => "<span><i class='ti ti-columns-3 me-2'></i>Search result display</span>",
-            'GLPINetwork$1' => "<span><i class='ti ti-headset me-2'></i>GLPI Network</span>",
-            'Log$1'         => "<span><i class='ti ti-history me-2'></i>Historical</span>",
+            'Config$1'      => "General setup",
+            'Config$2'      => "Default values",
+            'Config$3'      => "Assets",
+            'Config$4'      => "Assistance",
+            'Config$12'     => "Management",
+            'Config$9'      => "Logs purge",
+            'Config$5'      => "System",
+            'Config$10'     => "Security",
+            'Config$7'      => "Performance",
+            'Config$8'      => "API",
+            'Config$11'      => "Impact analysis",
+            'DisplayPreference$1' => "Search result display",
+            'GLPINetwork$1' => "GLPI Network",
+            'Log$1'         => "Historical",
         ];
 
         $instance = new \Config();
-        $this->assertSame($expected, $instance->defineTabs());
+        $tabs = array_map(fn($text) => strip_tags($text), $instance->defineTabs());
+        $this->assertSame($expected, $tabs);
     }
 
     public function testUnsetUndisclosedFields()

--- a/phpunit/functional/DocumentTest.php
+++ b/phpunit/functional/DocumentTest.php
@@ -92,12 +92,13 @@ class DocumentTest extends DbTestCase
     public function testDefineTabs()
     {
         $expected = [
-            'Document$main'   => "<span><i class='ti ti-files me-2'></i>Document</span>",
-            'Document_Item$1' => "<span><i class='ti ti-package me-2'></i>Associated items</span>",
-            'Document_Item$2' => "<span><i class='ti ti-files me-2'></i>Documents</span>",
+            'Document$main'   => "Document",
+            'Document_Item$1' => "Associated items",
+            'Document_Item$2' => "Documents",
         ];
         $doc = new \Document();
-        $this->assertSame($expected, $doc->defineTabs());
+        $tabs = array_map(fn($text) => strip_tags($text), $doc->defineTabs());
+        $this->assertSame($expected, $tabs);
     }
 
     public function testPrepareInputForAdd()

--- a/phpunit/functional/DocumentTest.php
+++ b/phpunit/functional/DocumentTest.php
@@ -97,7 +97,7 @@ class DocumentTest extends DbTestCase
             'Document_Item$2' => "Documents",
         ];
         $doc = new \Document();
-        $tabs = array_map(fn($text) => strip_tags($text), $doc->defineTabs());
+        $tabs = array_map('strip_tags', $doc->defineTabs());
         $this->assertSame($expected, $tabs);
     }
 

--- a/phpunit/functional/ImpactTest.php
+++ b/phpunit/functional/ImpactTest.php
@@ -147,7 +147,7 @@ class ImpactTest extends \DbTestCase
         $tab_name = $impact->getTabNameForItem($computer);
         $_SESSION['glpishow_count_on_tabs'] = $old_session;
 
-        $this->assertEquals("<span><i class='ti ti-affiliate me-2'></i>Impact analysis</span>", $tab_name);
+        $this->assertEquals("Impact analysis", strip_tags($tab_name));
     }
 
     public function testGetTabNameForItem_enabledAsset()
@@ -168,7 +168,7 @@ class ImpactTest extends \DbTestCase
         $tab_name = $impact->getTabNameForItem($computer2);
         $_SESSION['glpishow_count_on_tabs'] = $old_session;
 
-        $this->assertEquals("<span><i class='ti ti-affiliate me-2'></i>Impact analysis</span> <span class='badge glpi-badge'>2</span>", $tab_name);
+        $this->assertEquals("Impact analysis 2", strip_tags($tab_name));
     }
 
     public function testGetTabNameForItem_ITILObject()
@@ -208,7 +208,7 @@ class ImpactTest extends \DbTestCase
         $tab_name = $impact->getTabNameForItem($ticket);
         $_SESSION['glpishow_count_on_tabs'] = $old_session;
 
-        $this->assertEquals("<span><i class='ti ti-affiliate me-2'></i>Impact analysis</span>", $tab_name);
+        $this->assertEquals("Impact analysis", strip_tags($tab_name));
     }
 
     public function testBuildGraph_empty()

--- a/phpunit/functional/Item_OperatingSystemTest.php
+++ b/phpunit/functional/Item_OperatingSystemTest.php
@@ -96,8 +96,8 @@ class Item_OperatingSystemTest extends DbTestCase
         $this->assertTrue($ios->getFromDB($ios->getID()));
 
         $this->assertSame(
-            "<span><i class='ti ti-device-desktop-cog me-2'></i>Operating systems</span> <span class='badge glpi-badge'>1</span>",
-            $ios->getTabNameForItem($computer)
+            "Operating systems 1",
+            strip_tags($ios->getTabNameForItem($computer))
         );
         $this->assertSame(
             1,
@@ -132,8 +132,8 @@ class Item_OperatingSystemTest extends DbTestCase
         $this->assertTrue($ios->getFromDB($ios->getID()));
 
         $this->assertSame(
-            "<span><i class='ti ti-device-desktop-cog me-2'></i>Operating systems</span> <span class='badge glpi-badge'>2</span>",
-            $ios->getTabNameForItem($computer)
+            "Operating systems 2",
+            strip_tags($ios->getTabNameForItem($computer))
         );
         $this->assertSame(
             2,

--- a/phpunit/functional/Item_SoftwareLicenseTest.php
+++ b/phpunit/functional/Item_SoftwareLicenseTest.php
@@ -224,22 +224,25 @@ class Item_SoftwareLicenseTest extends DbTestCase
 
         $_SESSION['glpishow_count_on_tabs'] = 0;
         $expected = [
-            1 => "<span><i class='ti ti-key me-2'></i>Summary</span>",
-            2 => "<span><i class='ti ti-package me-2'></i>" . _n('Item', 'Items', \Session::getPluralNumber()) . "</span>"
+            1 => "Summary",
+            2 => "Items",
         ];
-        $this->assertSame($expected, $cSoftwareLicense->getTabNameForItem($license, 0));
+        $tabs = array_map(
+            fn($text) => strip_tags($text),
+            $cSoftwareLicense->getTabNameForItem($license, 0)
+        );
+        $this->assertSame($expected, $tabs);
 
         $_SESSION['glpishow_count_on_tabs'] = 1;
         $expected = [
-            1 => "<span><i class='ti ti-key me-2'></i>Summary</span>",
-            2 => \Item_SoftwareLicense::createTabEntry(
-                _n('Item', 'Items', \Session::getPluralNumber()),
-                2,
-                $license::getType(),
-                'ti ti-package'
-            )
+            1 => "Summary",
+            2 => "Items 2"
         ];
-        $this->assertSame($expected, $cSoftwareLicense->getTabNameForItem($license, 0));
+        $tabs = array_map(
+            fn($text) => strip_tags($text),
+            $cSoftwareLicense->getTabNameForItem($license, 0)
+        );
+        $this->assertSame($expected, $tabs);
     }
 
     public function testCountLicenses()

--- a/phpunit/functional/Item_SoftwareLicenseTest.php
+++ b/phpunit/functional/Item_SoftwareLicenseTest.php
@@ -228,7 +228,7 @@ class Item_SoftwareLicenseTest extends DbTestCase
             2 => "Items",
         ];
         $tabs = array_map(
-            fn($text) => strip_tags($text),
+            'strip_tags',
             $cSoftwareLicense->getTabNameForItem($license, 0)
         );
         $this->assertSame($expected, $tabs);
@@ -239,7 +239,7 @@ class Item_SoftwareLicenseTest extends DbTestCase
             2 => "Items 2"
         ];
         $tabs = array_map(
-            fn($text) => strip_tags($text),
+            'strip_tags',
             $cSoftwareLicense->getTabNameForItem($license, 0)
         );
         $this->assertSame($expected, $tabs);

--- a/phpunit/functional/Itil_ProjectTest.php
+++ b/phpunit/functional/Itil_ProjectTest.php
@@ -88,8 +88,8 @@ class Itil_ProjectTest extends DbTestCase
             // Count displayed in tab name should be equal to count of ITIL items linked to project
             $item_count = count($items);
             $this->assertSame(
-                "<span><i class='ti ti-alert-circle me-2'></i>Itil items</span> <span class='badge glpi-badge'>{$item_count}</span>",
-                $itil_project->getTabNameForItem($project)
+                "Itil items {$item_count}",
+                strip_tags($itil_project->getTabNameForItem($project))
             );
         }
 

--- a/phpunit/functional/KnowbaseItem_CommentTest.php
+++ b/phpunit/functional/KnowbaseItem_CommentTest.php
@@ -145,15 +145,15 @@ class KnowbaseItem_CommentTest extends DbTestCase
         $kbcom = new \KnowbaseItem_Comment();
 
         $name = $kbcom->getTabNameForItem($kb1, true);
-        $this->assertSame("<span><i class='ti ti-message-circle me-2'></i>Comments</span> <span class='badge glpi-badge'>5</span>", $name);
+        $this->assertSame("Comments 5", strip_tags($name));
 
         $_SESSION['glpishow_count_on_tabs'] = 1;
         $name = $kbcom->getTabNameForItem($kb1);
-        $this->assertSame("<span><i class='ti ti-message-circle me-2'></i>Comments</span> <span class='badge glpi-badge'>5</span>", $name);
+        $this->assertSame("Comments 5", strip_tags($name));
 
         $_SESSION['glpishow_count_on_tabs'] = 0;
         $name = $kbcom->getTabNameForItem($kb1);
-        $this->assertSame("<span><i class='ti ti-message-circle me-2'></i>Comments</span>", $name);
+        $this->assertSame("Comments", strip_tags($name));
 
         // Change knowbase rights to be empty
         $_SESSION['glpiactiveprofile']['knowbase'] = 0;
@@ -163,7 +163,7 @@ class KnowbaseItem_CommentTest extends DbTestCase
         // Add comment and read right
         $_SESSION['glpiactiveprofile']['knowbase'] = READ | \KnowbaseItem::COMMENTS;
         // Tab name should be filled
-        $this->assertSame("<span><i class='ti ti-message-circle me-2'></i>Comments</span>", $name);
+        $this->assertSame("Comments", strip_tags($name));
     }
 
     public function testDisplayComments()

--- a/phpunit/functional/KnowbaseItem_ItemTest.php
+++ b/phpunit/functional/KnowbaseItem_ItemTest.php
@@ -194,23 +194,23 @@ class KnowbaseItem_ItemTest extends DbTestCase
 
         $_SESSION['glpishow_count_on_tabs'] = 1;
         $name = $kb_item->getTabNameForItem($kb1);
-        $this->assertSame("<span><i class='ti ti-lifebuoy me-2'></i>Associated elements</span> <span class='badge glpi-badge'>3</span>", $name);
+        $this->assertSame("Associated elements 3", strip_tags($name));
 
         $_SESSION['glpishow_count_on_tabs'] = 0;
         $name = $kb_item->getTabNameForItem($kb1);
-        $this->assertSame("<span><i class='ti ti-lifebuoy me-2'></i>Associated elements</span>", $name);
+        $this->assertSame("Associated elements", strip_tags($name));
 
         $ticket3 = getItemByTypeName(\Ticket::getType(), '_ticket03');
 
         $_SESSION['glpishow_count_on_tabs'] = 1;
         $name = $kb_item->getTabNameForItem($ticket3, true);
-        $this->assertSame("<span><i class='ti ti-lifebuoy me-2'></i>Knowledge base</span> <span class='badge glpi-badge'>2</span>", $name);
+        $this->assertSame("Knowledge base 2", strip_tags($name));
 
         $name = $kb_item->getTabNameForItem($ticket3);
-        $this->assertSame("<span><i class='ti ti-lifebuoy me-2'></i>Knowledge base</span> <span class='badge glpi-badge'>2</span>", $name);
+        $this->assertSame("Knowledge base 2", strip_tags($name));
 
         $_SESSION['glpishow_count_on_tabs'] = 0;
         $name = $kb_item->getTabNameForItem($ticket3);
-        $this->assertSame("<span><i class='ti ti-lifebuoy me-2'></i>Knowledge base</span>", $name);
+        $this->assertSame("Knowledge base", strip_tags($name));
     }
 }

--- a/phpunit/functional/KnowbaseItem_RevisionTest.php
+++ b/phpunit/functional/KnowbaseItem_RevisionTest.php
@@ -178,7 +178,7 @@ class KnowbaseItem_RevisionTest extends DbTestCase
 
         $_SESSION['glpishow_count_on_tabs'] = 1;
         $name = $kb_rev->getTabNameForItem($kb1);
-        $this->assertSame("<span><i class='ti ti-history me-2'></i>Revision</span> <span class='badge glpi-badge'>1</span>", $name);
+        $this->assertSame("Revision 1", strip_tags($name));
 
         $this->assertTrue(
             $kb1->update(
@@ -190,11 +190,11 @@ class KnowbaseItem_RevisionTest extends DbTestCase
         );
 
         $name = $kb_rev->getTabNameForItem($kb1);
-        $this->assertSame("<span><i class='ti ti-history me-2'></i>Revisions</span> <span class='badge glpi-badge'>2</span>", $name);
+        $this->assertSame("Revisions 2", strip_tags($name));
 
         $_SESSION['glpishow_count_on_tabs'] = 0;
         $name = $kb_rev->getTabNameForItem($kb1);
-        $this->assertSame("<span><i class='ti ti-history me-2'></i>Revisions</span>", $name);
+        $this->assertSame("Revisions", strip_tags($name));
     }
 
     private function getNewKbItem()

--- a/phpunit/functional/Notification_NotificationTemplateTest.php
+++ b/phpunit/functional/Notification_NotificationTemplateTest.php
@@ -65,11 +65,11 @@ class Notification_NotificationTemplateTest extends DbTestCase
 
         $this->login();
         $name = $n_nt->getTabNameForItem($notif);
-        $this->assertSame("<span><i class='ti ti-template me-2'></i>Templates</span> <span class='badge glpi-badge'>1</span>", $name);
+        $this->assertSame("Templates 1", strip_tags($name));
 
         $_SESSION['glpishow_count_on_tabs'] = 0;
         $name = $n_nt->getTabNameForItem($notif);
-        $this->assertSame("<span><i class='ti ti-template me-2'></i>Templates</span>", $name);
+        $this->assertSame("Templates", strip_tags($name));
 
         $toadd = $n_nt->fields;
         unset($toadd['id']);
@@ -78,7 +78,7 @@ class Notification_NotificationTemplateTest extends DbTestCase
 
         $_SESSION['glpishow_count_on_tabs'] = 1;
         $name = $n_nt->getTabNameForItem($notif);
-        $this->assertSame("<span><i class='ti ti-template me-2'></i>Templates</span> <span class='badge glpi-badge'>2</span>", $name);
+        $this->assertSame("Templates 2", strip_tags($name));
     }
 
 

--- a/phpunit/functional/OperatingSystemArchitectureTest.php
+++ b/phpunit/functional/OperatingSystemArchitectureTest.php
@@ -57,7 +57,7 @@ class OperatingSystemArchitectureTest extends CommonDropdown
     protected function getTabs()
     {
         return [
-            'OperatingSystemArchitecture$main'  => "<span><i class='ti ti-edit me-2'></i>Operating system architecture</span>",
+            'OperatingSystemArchitecture$main'  => "Operating system architecture",
         ];
     }
 

--- a/phpunit/functional/OperatingSystemEditionTest.php
+++ b/phpunit/functional/OperatingSystemEditionTest.php
@@ -63,8 +63,8 @@ class OperatingSystemEditionTest extends CommonDropdown
     protected function getTabs()
     {
         return [
-            'OperatingSystemEdition$main' => "<span><i class='ti ti-edit me-2'></i>Edition</span>",
-            'DropdownTranslation$1' => "<span><i class='ti ti-language me-2'></i>Translations</span>"
+            'OperatingSystemEdition$main' => "Edition",
+            'DropdownTranslation$1' => "Translations",
         ];
     }
 

--- a/phpunit/functional/OperatingSystemKernelTest.php
+++ b/phpunit/functional/OperatingSystemKernelTest.php
@@ -57,7 +57,7 @@ class OperatingSystemKernelTest extends CommonDropdown
     protected function getTabs()
     {
         return [
-            'OperatingSystemKernel$main'  => "<span><i class='ti ti-edit me-2'></i>Kernel</span>",
+            'OperatingSystemKernel$main'  => "Kernel",
         ];
     }
 

--- a/phpunit/functional/OperatingSystemKernelVersionTest.php
+++ b/phpunit/functional/OperatingSystemKernelVersionTest.php
@@ -73,7 +73,7 @@ class OperatingSystemKernelVersionTest extends CommonDropdown
     protected function getTabs()
     {
         return [
-            'OperatingSystemKernelVersion$main' => "<span><i class='ti ti-edit me-2'></i>Kernel version</span>",
+            'OperatingSystemKernelVersion$main' => "Kernel version",
         ];
     }
 

--- a/phpunit/functional/OperatingSystemTest.php
+++ b/phpunit/functional/OperatingSystemTest.php
@@ -57,7 +57,7 @@ class OperatingSystemTest extends CommonDropdown
     protected function getTabs()
     {
         return [
-            'OperatingSystem$main'  => "<span><i class='ti ti-device-desktop-cog me-2'></i>Operating system</span>",
+            'OperatingSystem$main'  => "Operating system",
         ];
     }
 

--- a/src/Ajax.php
+++ b/src/Ajax.php
@@ -357,6 +357,8 @@ JAVASCRIPT;
                 $direct_link_url = $_SERVER['REQUEST_URI'];
                 if (count($_GET)) {
                     $direct_link_url .= count($_GET) ? '&' : '?';
+                } elseif (!str_contains($direct_link_url, "?")) {
+                    $direct_link_url .= "?";
                 }
                 $direct_link_url .= "forcetab=$tab_key";
 

--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -723,7 +723,7 @@ class CommonGLPI implements CommonGLPIInterface
         }
         $icon = !empty($icon) ? "<i class='$icon me-2'></i>" : '';
         if (!empty($icon)) {
-            $text = '<span>' . $icon . $text . '</span>';
+            $text = '<span class="d-flex align-items-center">' . $icon . $text . '</span>';
         }
         if ($nb) {
            //TRANS: %1$s is the name of the tab, $2$d is number of items in the tab between ()

--- a/src/Glpi/Controller/SelfService/HomeController.php
+++ b/src/Glpi/Controller/SelfService/HomeController.php
@@ -38,6 +38,7 @@ use Glpi\Controller\AbstractController;
 use Glpi\Form\SelfService\TilesManager;
 use Glpi\Http\Firewall;
 use Glpi\Security\Attribute\SecurityStrategy;
+use Glpi\SelfService\HomePageTabs;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
@@ -59,41 +60,13 @@ final class HomeController extends AbstractController
     )]
     public function __invoke(Request $request): Response
     {
-        // Compute tabs, will be handled by a service in later iterations (with a proper Tab object).
-        $tabs = [
-            [
-                'id'    => 'open-tickets',
-                'label' => __("Ongoing tickets"),
-                'criteria' => [
-                    [
-                        'link'       => 'AND',
-                        'field'      => 12,
-                        'searchtype' => 'equals',
-                        'value'      => 'notold',
-                    ]
-                ]
-            ],
-            [
-                'id'    => 'solved-tickets',
-                'label' => __("Solved tickets"),
-                'criteria' => [
-                    [
-                        'link'       => 'AND',
-                        'field'      => 12,
-                        'searchtype' => 'equals',
-                        'value'      => 'old',
-                    ]
-                ]
-            ],
-        ];
-
         // Will rename the file to "home.html.twig" later, don't want to remove
         // the original file yet.
         return $this->render('pages/self-service/new_home.html.twig', [
             'title' => __("Home"),
             'menu'  => ['helpdesk-home'],
             'tiles' => $this->tiles_manager->getTiles(),
-            'tabs'  => $tabs,
+            'tabs'  => new HomePageTabs(),
         ]);
     }
 }

--- a/src/Glpi/SelfService/HomePageTabs.php
+++ b/src/Glpi/SelfService/HomePageTabs.php
@@ -1,0 +1,185 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\SelfService;
+
+use CommonGLPI;
+use Override;
+use Reminder;
+use RSSFeed;
+use Search;
+use Session;
+use Ticket;
+
+final class HomePageTabs extends CommonGLPI
+{
+    private const ONGOING_TICKETS_TAB = 1;
+    private const SOLVED_TICKETS_TAB = 2;
+    private const PUBLIC_REMINDER_TAB = 3;
+    private const RSS_FEED_PUBLIC = 4;
+
+    #[Override]
+    public function defineTabs($options = []): array
+    {
+        $tabs = [];
+        $this->addStandardTab(__CLASS__, $tabs, $options);
+        $tabs['no_all_tab'] = true;
+
+        return $tabs;
+    }
+
+    #[Override]
+    public function getTabNameForItem(
+        CommonGLPI $item,
+        $withtemplate = 0
+    ): array|string {
+        // Only available on self
+        if (!($item instanceof self)) {
+            return '';
+        }
+
+        $tabs = [
+            self::ONGOING_TICKETS_TAB => self::createTabEntry(
+                text: __('Ongoing tickets'),
+                icon: Ticket::getIcon()
+            ),
+            self::SOLVED_TICKETS_TAB  => self::createTabEntry(
+                text: __('Solved tickets'),
+                icon: 'ti ti-check'
+            ),
+        ];
+
+        if (Session::haveRight("reminder_public", READ)) {
+            // TODO: only show if at least one reminder is visible
+            $tabs[self::PUBLIC_REMINDER_TAB] = self::createTabEntry(
+                text: Reminder::getTypeName(),
+                icon: Reminder::getIcon()
+            );
+        }
+
+        if (Session::haveRight("rssfeed_public", READ)) {
+            // TODO: only show if at least one RSS feed is visible
+            $tabs[self::RSS_FEED_PUBLIC] = self::createTabEntry(
+                text: RSSFeed::getTypeName(),
+                icon: RSSFeed::getIcon()
+            );
+        }
+
+        return $tabs;
+    }
+
+    #[Override]
+    public static function displayTabContentForItem(
+        CommonGLPI $item,
+        $tabnum = 1,
+        $withtemplate = 0
+    ): bool {
+        if (!($item instanceof self)) {
+            return false;
+        }
+
+        $tabs = new self();
+
+        if ($tabnum == self::ONGOING_TICKETS_TAB) {
+            $tabs->displayOngoingTicketsTabs();
+            return true;
+        }
+
+        if ($tabnum == self::SOLVED_TICKETS_TAB) {
+            $tabs->displaySolvedTicketsTabs();
+            return true;
+        }
+
+        if ($tabnum == self::PUBLIC_REMINDER_TAB) {
+            if (!Session::haveRight("reminder_public", READ)) {
+                return false;
+            }
+
+            // TODO: improve display
+            echo Reminder::showListForCentral(false, false);
+            return true;
+        }
+
+        if ($tabnum == self::RSS_FEED_PUBLIC) {
+            if (!Session::haveRight("rssfeed_public", READ)) {
+                return false;
+            }
+
+            // TODO: improve display
+            echo RSSFeed::showListForCentral(false, false);
+            return true;
+        }
+
+        return false;
+    }
+
+    private function displayOngoingTicketsTabs(): void
+    {
+        $this->showTicketList([
+            [
+                'link'       => 'AND',
+                'field'      => 12,
+                'searchtype' => 'equals',
+                'value'      => 'notold',
+            ]
+        ]);
+    }
+
+    private function displaySolvedTicketsTabs(): void
+    {
+        $this->showTicketList([
+            [
+                'link'       => 'AND',
+                'field'      => 12,
+                'searchtype' => 'equals',
+                'value'      => 'old',
+            ]
+        ]);
+    }
+
+    private function showTicketList(array $criteria): void
+    {
+        echo '<div class="home-ticket-list">';
+        Search::showList(Ticket::class, [
+            'criteria'           => $criteria,
+            'showmassiveactions' => false,
+            'hide_controls'      => true,
+            'as_map'             => false,
+            'push_history'       => false,
+            'sort'               => [19],
+            'order'              => ['DESC'],
+        ]);
+        echo '</div>';
+    }
+}

--- a/templates/pages/self-service/new_home.html.twig
+++ b/templates/pages/self-service/new_home.html.twig
@@ -88,48 +88,7 @@
         </section>
         <div class="tickets-banner">
             <div class="container-xl">
-                <ul class="nav nav-tabs home-tickets-tabs" role="tablist">
-                    {% for tab in tabs %}
-                        <li class="nav-item">
-                            <a
-                                class="nav-link {{ loop.index0 == 0 ? 'active' : '' }}"
-                                aria-current="page"
-                                id="{{ tab.id }}-tab"
-                                href="#"
-                                data-bs-toggle="tab"
-                                data-bs-target="#{{ tab.id }}-pane"
-                                type="button"
-                                role="tab"
-                                aria-controls="{{ tab.id }}-pane"
-                                aria-selected="{{ loop.index0 == 0 ? 'true' : 'false' }}"
-                            >{{ tab.label }}</a>
-                        </li>
-                    {% endfor %}
-                </ul>
-
-                <div class="tab-content">
-                    {% for tab in tabs %}
-                        <div
-                            id="{{ tab.id }}-pane"
-                            class="tab-pane fade home-tickets-list {{ loop.index0 == 0 ? 'show active' : '' }}"
-                            role="tabpanel"
-                            aria-labelledby="{{ tab.id }}-tab"
-                            tabindex="{{ loop.index0 }}"
-                        >
-                            {% do call('Search::showList', [
-                                'Ticket',
-                                {
-                                    'criteria' : tab.criteria,
-                                    'showmassiveactions' : false,
-                                    'hide_controls'      : true,
-                                    'as_map'             : false,
-                                    'push_history'       : false,
-                                }
-                            ]) %}
-                        </div>
-                    {% endfor %}
-                </div>
-
+                {{ tabs.showTabsContent() }}
             </div>
         </div>
     </div>

--- a/tests/LDAP/AuthLdap.php
+++ b/tests/LDAP/AuthLdap.php
@@ -261,7 +261,7 @@ class AuthLDAP extends DbTestCase
         $expected = [
             'AuthLDAP$main' => "LDAP directory",
         ];
-        $tabs = array_map(fn($text) => strip_tags($text), $tabs);
+        $tabs = array_map('strip_tags', $tabs);
         $this->array($tabs)->isIdenticalTo($expected);
     }
 
@@ -549,10 +549,7 @@ class AuthLDAP extends DbTestCase
 
         $ldap   = getItemByTypeName('AuthLDAP', 'LDAP1');
         $result = $ldap->getTabNameForItem($ldap);
-        $result = array_map(
-            fn($text) => strip_tags($text),
-            $result,
-        );
+        $result = array_map('strip_tags', $result);
         $expected = [
             1 => "Test",
             2 => "Users",

--- a/tests/LDAP/AuthLdap.php
+++ b/tests/LDAP/AuthLdap.php
@@ -259,8 +259,9 @@ class AuthLDAP extends DbTestCase
         $ldap     = new \AuthLDAP();
         $tabs     = $ldap->defineTabs();
         $expected = [
-            'AuthLDAP$main' => "<span><i class='far fa-address-book me-2'></i>LDAP directory</span>",
+            'AuthLDAP$main' => "LDAP directory",
         ];
+        $tabs = array_map(fn($text) => strip_tags($text), $tabs);
         $this->array($tabs)->isIdenticalTo($expected);
     }
 
@@ -541,19 +542,23 @@ class AuthLDAP extends DbTestCase
         $this->array($result)->hasSize(3);
     }
 
-    public function testgetTabNameForItem()
+    public function testGetTabNameForItem()
     {
         $this->login();
         $this->addLdapServers();
 
         $ldap   = getItemByTypeName('AuthLDAP', 'LDAP1');
         $result = $ldap->getTabNameForItem($ldap);
+        $result = array_map(
+            fn($text) => strip_tags($text),
+            $result,
+        );
         $expected = [
-            1 => "<span><i class='ti ti-stethoscope me-2'></i>Test</span>",
-            2 => "<span><i class='ti ti-user me-2'></i>Users</span>",
-            3 => "<span><i class='ti ti-user me-2'></i>Groups</span>",
-            5 => "<span><i class='far fa-address-book me-2'></i>Advanced information</span>",
-            6 => "<span><i class='far fa-address-book me-2'></i>Replicates</span>"
+            1 => "Test",
+            2 => "Users",
+            3 => "Groups",
+            5 => "Advanced information",
+            6 => "Replicates"
         ];
         $this->array($result)->isIdenticalTo($expected);
 


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works. -> not much to test here

## Description

- Reuse GLPI's AJAX tabs
- Tweak display
- Add reminders and RSS feeds as default tabs (they were displayed on the old home page, we don't want to remove this feature)
- Display of the reminder and rss feed tables are not ideal, we probably need to tweak it but it is also used in some others parts of GLPI so it might be best to defer this to another PR

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/cad333e9-38ab-49e2-b072-b399b20b4831)

