### PR TITLE
Refactor dropdown comments handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -231,6 +231,7 @@ The present file will list all changes made to the project; according to the
 - Usage of the `front/dropdown.common.php` and the `dropdown.common.form.php` files. There is now a generic controller that will serve the search and form pages of any `Dropdown` class.
 - Usage of the `$link` parameter in `formatUserName()` and `DbUtils::formatUserName()`. Use `formatUserLink()` or `DbUtils::formatUserLink()` instead.
 - Usage of the `$link` parameter in `getUserName()` and `DbUtils::getUserName()`. Use `getUserLink()`, `DbUtils::getUserLink()`, or `User::getInfoCard()` instead.
+- Usage of the `$withcomment` parameter in `getTreeValueCompleteName()`, `DbUtils::getTreeValueCompleteName()` and `Dropdown::getDropdownName()`. Use `Dropdown::getDropdownComments()` instead.
 - `Auth::getErr()`
 - `AuthLDAP::dropdownUserDeletedActions()`
 - `AuthLDAP::getOptions()`

--- a/ajax/comments.php
+++ b/ajax/comments.php
@@ -121,10 +121,8 @@ if (
                 } else {
                     $table = getTableForItemType($_POST['itemtype']);
                 }
-                $tmpname = Dropdown::getDropdownName($table, $_POST["value"], 1);
-                if (is_array($tmpname) && isset($tmpname["comment"])) {
-                    echo htmlescape($tmpname["comment"]);
-                }
+
+                echo Dropdown::getDropdownComments($table, (int) $_POST["value"]);
 
                 if (isset($_POST['withlink'])) {
                     echo "<script type='text/javascript' >";

--- a/phpunit/functional/CableTest.php
+++ b/phpunit/functional/CableTest.php
@@ -43,27 +43,6 @@ use Glpi\SocketModel;
 
 class CableTest extends DbTestCase
 {
-    public function testAddSocket()
-    {
-
-        $socket = getItemByTypeName(Socket::class, '_socket01');
-        $location = getItemByTypeName('Location', '_location01');
-        $expected = $socket->getName() . " (" . $location->getName() . ")";
-        $ret = \Dropdown::getDropdownName('glpi_sockets', $socket->getID());
-        $this->assertSame($expected, $ret);
-
-        // test of return with comments
-        $expected = ['name'    => $expected,
-            'comment' => "Comment for socket _socket01"
-        ];
-        $ret = \Dropdown::getDropdownName('glpi_sockets', $socket->getID(), true);
-        $this->assertSame($expected, $ret);
-
-        // test of return without $tooltip
-        $ret = \Dropdown::getDropdownName('glpi_sockets', $socket->getID(), true, true, false);
-        $this->assertSame($expected, $ret);
-    }
-
     public function testAddNetworkPortThenSocket()
     {
         $this->login();

--- a/phpunit/functional/DropdownTest.php
+++ b/phpunit/functional/DropdownTest.php
@@ -134,51 +134,62 @@ class DropdownTest extends DbTestCase
 
     public function testGetDropdownNameAndComment()
     {
-        $separator         = ' > ';
-        $encoded_separator = ' &gt; ';
-
         $ret = \Dropdown::getDropdownName('not_a_known_table', 1);
         $this->assertSame('', $ret);
 
-        $cat = getItemByTypeName('TaskCategory', '_cat_1');
-
-        $subCat = getItemByTypeName('TaskCategory', '_subcat_1');
+        $subcat_id = getItemByTypeName('TaskCategory', '_subcat_1', true);
 
         // basic test returns string only
-        $expected_name = $cat->fields['name'] . $separator . $subCat->fields['name'];
-        $ret = \Dropdown::getDropdownName('glpi_taskcategories', $subCat->getID());
+        $expected_name = '_cat_1 > _subcat_1';
+        $ret = \Dropdown::getDropdownName('glpi_taskcategories', $subcat_id);
         $this->assertSame($expected_name, $ret);
 
         // test of return with comments
-        $expected_comments = '<span class="b">Complete name: </span>' . $cat->fields['name'] . $encoded_separator . $subCat->fields['name'] . '<br />'
-                . '<span class="b">Comments: </span>' . $subCat->fields['comment'];
-        $ret = @\Dropdown::getDropdownName('glpi_taskcategories', $subCat->getID(), withcomment: true);
+        $expected_comments = <<<HTML
+
+            <span class="b">Complete name: </span>_cat_1 &gt; _subcat_1<br />
+                <span class="b">Comments: </span>
+    
+Comment for sub-category _subcat_1
+
+HTML;
+        $ret = @\Dropdown::getDropdownName('glpi_taskcategories', $subcat_id, withcomment: true);
         $this->assertSame(['name' => $expected_name, 'comment' => $expected_comments], $ret);
 
-        $ret = \Dropdown::getDropdownComments('glpi_taskcategories', $subCat->getID());
+        $ret = \Dropdown::getDropdownComments('glpi_taskcategories', $subcat_id);
         $this->assertSame($expected_comments, $ret);
 
         // test of return without $tooltip
-        $expected_comments = $subCat->fields['comment'];
-        $ret = @\Dropdown::getDropdownName('glpi_taskcategories', $subCat->getID(), withcomment: true, tooltip: false);
+        $expected_comments = <<<HTML
+
+
+Comment for sub-category _subcat_1
+
+HTML;
+        $ret = @\Dropdown::getDropdownName('glpi_taskcategories', $subcat_id, withcomment: true, tooltip: false);
         $this->assertSame(['name' => $expected_name, 'comment' => $expected_comments], $ret);
 
-        $ret = \Dropdown::getDropdownComments('glpi_taskcategories', $subCat->getID(), tooltip: false);
+        $ret = \Dropdown::getDropdownComments('glpi_taskcategories', $subcat_id, tooltip: false);
         $this->assertSame($expected_comments, $ret);
 
         // test of return with translations
         $_SESSION["glpilanguage"] = \Session::loadLanguage('fr_FR');
         $_SESSION['glpi_dropdowntranslations'] = \DropdownTranslation::getAvailableTranslations($_SESSION["glpilanguage"]);
-        $expected_name = 'FR - _cat_1' . $separator . 'FR - _subcat_1';
-        $expected_comments = 'FR - Commentaire pour sous-catégorie _subcat_1';
+        $expected_name = 'FR - _cat_1 > FR - _subcat_1';
+        $expected_comments = <<<HTML
 
-        $ret = \Dropdown::getDropdownName('glpi_taskcategories', $subCat->getID());
+
+FR - Commentaire pour sous-catégorie _subcat_1
+
+HTML;
+
+        $ret = \Dropdown::getDropdownName('glpi_taskcategories', $subcat_id);
         $this->assertSame($expected_name, $ret);
 
-        $ret = @\Dropdown::getDropdownName('glpi_taskcategories', $subCat->getID(), withcomment: true, tooltip: false);
+        $ret = @\Dropdown::getDropdownName('glpi_taskcategories', $subcat_id, withcomment: true, tooltip: false);
         $this->assertSame(['name' => $expected_name, 'comment' => $expected_comments], $ret);
 
-        $ret = \Dropdown::getDropdownComments('glpi_taskcategories', $subCat->getID(), tooltip: false);
+        $ret = \Dropdown::getDropdownComments('glpi_taskcategories', $subcat_id, tooltip: false);
         $this->assertSame($expected_comments, $ret);
 
         // switch back to default language
@@ -190,202 +201,284 @@ class DropdownTest extends DbTestCase
 
         ///////////
         // Computer
-        $computer = getItemByTypeName('Computer', '_test_pc01');
+        $computer_id = getItemByTypeName('Computer', '_test_pc01', true);
 
-        $expected_name = $computer->getName();
-        $ret = \Dropdown::getDropdownName('glpi_computers', $computer->getID());
+        $expected_name = '_test_pc01';
+        $ret = \Dropdown::getDropdownName('glpi_computers', $computer_id);
         $this->assertSame($expected_name, $ret);
 
-        $expected_comments = $computer->fields['comment'];
-        $ret = @\Dropdown::getDropdownName('glpi_computers', $computer->getID(), withcomment: true);
+        $expected_comments = <<<HTML
+
+
+Comment for computer _test_pc01
+
+HTML;
+        $ret = @\Dropdown::getDropdownName('glpi_computers', $computer_id, withcomment: true);
         $this->assertSame(['name' => $expected_name, 'comment' => $expected_comments], $ret);
 
-        $ret = \Dropdown::getDropdownComments('glpi_computers', $computer->getID());
+        $ret = \Dropdown::getDropdownComments('glpi_computers', $computer_id);
         $this->assertSame($expected_comments, $ret);
 
         //////////
         // Contact
-        $contact = getItemByTypeName('Contact', '_contact01_name');
+        $contact_id = getItemByTypeName('Contact', '_contact01_name', true);
 
-        $expected_name = $contact->getName();
-        $ret = \Dropdown::getDropdownName('glpi_contacts', $contact->getID());
+        $expected_name = '_contact01_name _contact01_firstname';
+        $ret = \Dropdown::getDropdownName('glpi_contacts', $contact_id);
         $this->assertSame($expected_name, $ret);
 
         // test of return with comments
-        $expected_comments = '<span class="b">Phone: </span>0123456789<br />'
-            . '<span class="b">Phone 2: </span>0123456788<br />'
-            . '<span class="b">Mobile phone: </span>0623456789<br />'
-            . '<span class="b">Fax: </span>0123456787<br />'
-            . '<span class="b">Email: </span>_contact01_firstname._contact01_name@glpi.com<br />'
-            . '<span class="b">Comments: </span>Comment for contact _contact01_name';
-        $ret = @\Dropdown::getDropdownName('glpi_contacts', $contact->getID(), withcomment: true);
+        $expected_comments = <<<HTML
+
+            <span class="b">Phone: </span>0123456789<br />
+            <span class="b">Phone 2: </span>0123456788<br />
+            <span class="b">Mobile phone: </span>0623456789<br />
+            <span class="b">Fax: </span>0123456787<br />
+            <span class="b">Email: </span>_contact01_firstname._contact01_name@glpi.com<br />
+                <span class="b">Comments: </span>
+    
+Comment for contact _contact01_name
+
+HTML;
+        $ret = @\Dropdown::getDropdownName('glpi_contacts', $contact_id, withcomment: true);
         $this->assertSame(['name' => $expected_name, 'comment' => $expected_comments], $ret);
 
-        $ret = \Dropdown::getDropdownComments('glpi_contacts', $contact->getID());
+        $ret = \Dropdown::getDropdownComments('glpi_contacts', $contact_id);
         $this->assertSame($expected_comments, $ret);
 
         // test of return without $tooltip
-        $expected_comments = $contact->fields['comment'];
-        $ret = @\Dropdown::getDropdownName('glpi_contacts', $contact->getID(), withcomment: true, tooltip: false);
+        $expected_comments = <<<HTML
+
+
+Comment for contact _contact01_name
+
+HTML;
+        $ret = @\Dropdown::getDropdownName('glpi_contacts', $contact_id, withcomment: true, tooltip: false);
         $this->assertSame(['name' => $expected_name, 'comment' => $expected_comments], $ret);
 
-        $ret = \Dropdown::getDropdownComments('glpi_contacts', $contact->getID(), tooltip: false);
+        $ret = \Dropdown::getDropdownComments('glpi_contacts', $contact_id, tooltip: false);
         $this->assertSame($expected_comments, $ret);
 
         ///////////
         // Supplier
-        $supplier = getItemByTypeName('Supplier', '_suplier01_name');
+        $supplier_id = getItemByTypeName('Supplier', '_suplier01_name', true);
 
-        $expected_name = $supplier->getName();
-        $ret = \Dropdown::getDropdownName('glpi_suppliers', $supplier->getID());
+        $expected_name = '_suplier01_name';
+        $ret = \Dropdown::getDropdownName('glpi_suppliers', $supplier_id);
         $this->assertSame($expected_name, $ret);
 
         // test of return with comments
-        $expected_comments = '<span class="b">Phone: </span>0123456789<br />'
-            . '<span class="b">Fax: </span>0123456787<br />'
-            . '<span class="b">Email: </span>info@_supplier01_name.com<br />'
-            . '<span class="b">Comments: </span>Comment for supplier _suplier01_name';
-        $ret = @\Dropdown::getDropdownName('glpi_suppliers', $supplier->getID(), withcomment: true);
+        $expected_comments = <<<HTML
+
+            <span class="b">Phone: </span>0123456789<br />
+            <span class="b">Fax: </span>0123456787<br />
+            <span class="b">Email: </span>info@_supplier01_name.com<br />
+                <span class="b">Comments: </span>
+    
+Comment for supplier _suplier01_name
+
+HTML;
+        $ret = @\Dropdown::getDropdownName('glpi_suppliers', $supplier_id, withcomment: true);
         $this->assertSame(['name' => $expected_name, 'comment' => $expected_comments], $ret);
 
-        $ret = \Dropdown::getDropdownComments('glpi_suppliers', $supplier->getID());
+        $ret = \Dropdown::getDropdownComments('glpi_suppliers', $supplier_id);
         $this->assertSame($expected_comments, $ret);
 
         // test of return without $tooltip
-        $expected_comments = $supplier->fields['comment'];
-        $ret = @\Dropdown::getDropdownName('glpi_suppliers', $supplier->getID(), withcomment: true, tooltip: false);
+        $expected_comments = <<<HTML
+
+
+Comment for supplier _suplier01_name
+
+HTML;
+        $ret = @\Dropdown::getDropdownName('glpi_suppliers', $supplier_id, withcomment: true, tooltip: false);
         $this->assertSame(['name' => $expected_name, 'comment' => $expected_comments], $ret);
 
-        $ret = \Dropdown::getDropdownComments('glpi_suppliers', $supplier->getID(), tooltip: false);
+        $ret = \Dropdown::getDropdownComments('glpi_suppliers', $supplier_id, tooltip: false);
         $this->assertSame($expected_comments, $ret);
 
         ///////////
         // Budget
-        $budget = getItemByTypeName('Budget', '_budget01');
+        $budget_id = getItemByTypeName('Budget', '_budget01', true);
 
-        $expected_name = $budget->getName();
-        $ret = \Dropdown::getDropdownName('glpi_budgets', $budget->getID());
+        $expected_name = '_budget01';
+        $ret = \Dropdown::getDropdownName('glpi_budgets', $budget_id);
         $this->assertSame($expected_name, $ret);
 
         // test of return with comments
-        $expected_comments = '<span class="b">Location: </span>_location01<br />'
-            . '<span class="b">Type: </span>_budgettype01<br />'
-            . '<span class="b">Start date: </span>2016-10-18 <br />'
-            . '<span class="b">End date: </span>2016-12-31 <br />'
-            . '<span class="b">Comments: </span>Comment for budget _budget01';
-        $ret = @\Dropdown::getDropdownName('glpi_budgets', $budget->getID(), withcomment: true);
+        $expected_comments = <<<HTML
+
+            <span class="b">Location: </span>_location01<br />
+            <span class="b">Type: </span>_budgettype01<br />
+            <span class="b">Start date: </span>2016-10-18 <br />
+            <span class="b">End date: </span>2016-12-31 <br />
+                <span class="b">Comments: </span>
+    
+Comment for budget _budget01
+
+HTML;
+        $ret = @\Dropdown::getDropdownName('glpi_budgets', $budget_id, withcomment: true);
         $this->assertSame(['name' => $expected_name, 'comment' => $expected_comments], $ret);
 
-        $ret = \Dropdown::getDropdownComments('glpi_budgets', $budget->getID());
+        $ret = \Dropdown::getDropdownComments('glpi_budgets', $budget_id);
         $this->assertSame($expected_comments, $ret);
 
         // test of return without $tooltip
-        $expected_comments = $budget->fields['comment'];
-        $ret = @\Dropdown::getDropdownName('glpi_budgets', $budget->getID(), withcomment: true, tooltip: false);
+        $expected_comments = <<<HTML
+
+
+Comment for budget _budget01
+
+HTML;
+        $ret = @\Dropdown::getDropdownName('glpi_budgets', $budget_id, withcomment: true, tooltip: false);
         $this->assertSame(['name' => $expected_name, 'comment' => $expected_comments], $ret);
 
-        $ret = \Dropdown::getDropdownComments('glpi_budgets', $budget->getID(), tooltip: false);
+        $ret = \Dropdown::getDropdownComments('glpi_budgets', $budget_id, tooltip: false);
         $this->assertSame($expected_comments, $ret);
 
         ///////////
         // Location
-        $location = getItemByTypeName('Location', '_location01');
+        $location_id = getItemByTypeName('Location', '_location01', true);
 
-        $expected_name = $location->getName();
-        $ret = \Dropdown::getDropdownName('glpi_locations', $location->getID());
+        $expected_name = '_location01';
+        $ret = \Dropdown::getDropdownName('glpi_locations', $location_id);
         $this->assertSame($expected_name, $ret);
 
          // test of return with comments
-        $expected_comments = '<span class="b">Complete name: </span>_location01<br />'
-            . '<span class="b">Comments: </span>Comment for location _location01';
-        $ret = @\Dropdown::getDropdownName('glpi_locations', $location->getID(), withcomment: true);
+        $expected_comments = <<<HTML
+
+            <span class="b">Complete name: </span>_location01<br />
+                <span class="b">Comments: </span>
+    
+Comment for location _location01
+
+HTML;
+        $ret = @\Dropdown::getDropdownName('glpi_locations', $location_id, withcomment: true);
         $this->assertSame(['name' => $expected_name, 'comment' => $expected_comments], $ret);
 
-        $ret = \Dropdown::getDropdownComments('glpi_locations', $location->getID());
+        $ret = \Dropdown::getDropdownComments('glpi_locations', $location_id);
         $this->assertSame($expected_comments, $ret);
 
         // test of return without $tooltip
-        $expected_comments = $location->fields['comment'];
-        $ret = @\Dropdown::getDropdownName('glpi_locations', $location->getID(), withcomment: true, tooltip: false);
+        $expected_comments = <<<HTML
+
+
+Comment for location _location01
+
+HTML;
+        $ret = @\Dropdown::getDropdownName('glpi_locations', $location_id, withcomment: true, tooltip: false);
         $this->assertSame(['name' => $expected_name, 'comment' => $expected_comments], $ret);
 
-        $ret = \Dropdown::getDropdownComments('glpi_locations', $location->getID(), tooltip: false);
+        $ret = \Dropdown::getDropdownComments('glpi_locations', $location_id, tooltip: false);
         $this->assertSame($expected_comments, $ret);
 
         //Location with code only:
-        $location = getItemByTypeName('Location', '_location02 > _sublocation02');
+        $location_id = getItemByTypeName('Location', '_location02 > _sublocation02', true);
 
         $expected_name = "_location02 > _sublocation02 - code_sublocation02";
-        $ret = \Dropdown::getDropdownName('glpi_locations', $location->getID());
+        $ret = \Dropdown::getDropdownName('glpi_locations', $location_id);
         $this->assertSame($expected_name, $ret);
 
          // test of return with comments
-        $expected_comments = '<span class="b">Complete name: </span>_location02 &gt; _sublocation02<br />'
-            . '<span class="b">Code: </span>code_sublocation02<br />'
-            . '<span class="b">Comments: </span>Comment for location _sublocation02';
-        $ret = @\Dropdown::getDropdownName('glpi_locations', $location->getID(), withcomment: true);
+        $expected_comments = <<<HTML
+
+            <span class="b">Complete name: </span>_location02 &gt; _sublocation02<br />
+            <span class="b">Code: </span>code_sublocation02<br />
+                <span class="b">Comments: </span>
+    
+Comment for location _sublocation02
+
+HTML;
+        $ret = @\Dropdown::getDropdownName('glpi_locations', $location_id, withcomment: true);
         $this->assertSame(['name' => $expected_name, 'comment' => $expected_comments], $ret);
 
-        $ret = \Dropdown::getDropdownComments('glpi_locations', $location->getID());
+        $ret = \Dropdown::getDropdownComments('glpi_locations', $location_id);
         $this->assertSame($expected_comments, $ret);
 
         // test of return without $tooltip
-        $expected_comments = $location->fields['comment'];
-        $ret = @\Dropdown::getDropdownName('glpi_locations', $location->getID(), withcomment: true, tooltip: false);
+        $expected_comments = <<<HTML
+
+
+Comment for location _sublocation02
+
+HTML;
+        $ret = @\Dropdown::getDropdownName('glpi_locations', $location_id, withcomment: true, tooltip: false);
         $this->assertSame(['name' => $expected_name, 'comment' => $expected_comments], $ret);
 
-        $ret = \Dropdown::getDropdownComments('glpi_locations', $location->getID(), tooltip: false);
+        $ret = \Dropdown::getDropdownComments('glpi_locations', $location_id, tooltip: false);
         $this->assertSame($expected_comments, $ret);
 
         //Location with alias only:
-        $location = getItemByTypeName('Location', '_location02 > _sublocation03');
+        $location_id = getItemByTypeName('Location', '_location02 > _sublocation03', true);
 
         $expected_name = "alias_sublocation03";
-        $ret = \Dropdown::getDropdownName('glpi_locations', $location->getID());
+        $ret = \Dropdown::getDropdownName('glpi_locations', $location_id);
         $this->assertSame($expected_name, $ret);
 
          // test of return with comments
-        $expected_comments = '<span class="b">Complete name: </span>_location02 &gt; _sublocation03<br />'
-            . '<span class="b">Alias: </span>alias_sublocation03<br />'
-            . '<span class="b">Comments: </span>Comment for location _sublocation03';
-        $ret = @\Dropdown::getDropdownName('glpi_locations', $location->getID(), withcomment: true);
+        $expected_comments = <<<HTML
+
+            <span class="b">Complete name: </span>_location02 &gt; _sublocation03<br />
+            <span class="b">Alias: </span>alias_sublocation03<br />
+                <span class="b">Comments: </span>
+    
+Comment for location _sublocation03
+
+HTML;
+        $ret = @\Dropdown::getDropdownName('glpi_locations', $location_id, withcomment: true);
         $this->assertSame(['name' => $expected_name, 'comment' => $expected_comments], $ret);
 
-        $ret = \Dropdown::getDropdownComments('glpi_locations', $location->getID());
+        $ret = \Dropdown::getDropdownComments('glpi_locations', $location_id);
         $this->assertSame($expected_comments, $ret);
 
         // test of return without $tooltip
-        $expected_comments = $location->fields['comment'];
-        $ret = @\Dropdown::getDropdownName('glpi_locations', $location->getID(), withcomment: true, tooltip: false);
+        $expected_comments = <<<HTML
+
+
+Comment for location _sublocation03
+
+HTML;
+        $ret = @\Dropdown::getDropdownName('glpi_locations', $location_id, withcomment: true, tooltip: false);
         $this->assertSame(['name' => $expected_name, 'comment' => $expected_comments], $ret);
 
-        $ret = \Dropdown::getDropdownComments('glpi_locations', $location->getID(), tooltip: false);
+        $ret = \Dropdown::getDropdownComments('glpi_locations', $location_id, tooltip: false);
         $this->assertSame($expected_comments, $ret);
 
         //Location with alias and code:
-        $location = getItemByTypeName('Location', '_location02 > _sublocation04');
+        $location_id = getItemByTypeName('Location', '_location02 > _sublocation04', true);
 
         $expected_name = "alias_sublocation04 - code_sublocation04";
-        $ret = \Dropdown::getDropdownName('glpi_locations', $location->getID());
+        $ret = \Dropdown::getDropdownName('glpi_locations', $location_id);
         $this->assertSame($expected_name, $ret);
 
          // test of return with comments
-        $expected_comments = '<span class="b">Complete name: </span>_location02 &gt; _sublocation04<br />'
-            . '<span class="b">Alias: </span>alias_sublocation04<br />'
-            . '<span class="b">Code: </span>code_sublocation04<br />'
-            . '<span class="b">Comments: </span>Comment for location _sublocation04';
-        $ret = @\Dropdown::getDropdownName('glpi_locations', $location->getID(), withcomment: true);
+        $expected_comments = <<<HTML
+
+            <span class="b">Complete name: </span>_location02 &gt; _sublocation04<br />
+            <span class="b">Alias: </span>alias_sublocation04<br />
+            <span class="b">Code: </span>code_sublocation04<br />
+                <span class="b">Comments: </span>
+    
+Comment for location _sublocation04
+
+HTML;
+        $ret = @\Dropdown::getDropdownName('glpi_locations', $location_id, withcomment: true);
         $this->assertSame(['name' => $expected_name, 'comment' => $expected_comments], $ret);
 
-        $ret = \Dropdown::getDropdownComments('glpi_locations', $location->getID());
+        $ret = \Dropdown::getDropdownComments('glpi_locations', $location_id);
         $this->assertSame($expected_comments, $ret);
 
         // test of return without $tooltip
-        $expected_comments = $location->fields['comment'];
-        $ret = @\Dropdown::getDropdownName('glpi_locations', $location->getID(), withcomment: true, tooltip: false);
+        $expected_comments = <<<HTML
+
+
+Comment for location _sublocation04
+
+HTML;
+        $ret = @\Dropdown::getDropdownName('glpi_locations', $location_id, withcomment: true, tooltip: false);
         $this->assertSame(['name' => $expected_name, 'comment' => $expected_comments], $ret);
 
-        $ret = \Dropdown::getDropdownComments('glpi_locations', $location->getID(), tooltip: false);
+        $ret = \Dropdown::getDropdownComments('glpi_locations', $location_id, tooltip: false);
         $this->assertSame($expected_comments, $ret);
     }
 

--- a/phpunit/functional/DropdownTranslationTest.php
+++ b/phpunit/functional/DropdownTranslationTest.php
@@ -168,8 +168,7 @@ class DropdownTranslationTest extends DbTestCase
 
     public function testgetTranslatedCompletename(): void
     {
-        global $CFG_GLPI, $DB;
-        $CFG_GLPI['translate_dropdowns'] = 1;
+        global $DB;
 
         $values = $this->completenameGenerationFakeProvider();
         foreach ($values as $value) {

--- a/phpunit/functional/NotificationTargetTicketTest.php
+++ b/phpunit/functional/NotificationTargetTicketTest.php
@@ -174,14 +174,6 @@ class NotificationTargetTicketTest extends DbTestCase
         );
 
         // test of the getDataForObject for default language fr_FR
-        $CFG_GLPI['translate_dropdowns'] = 1;
-        // Force generation of completename that was not done on dataset bootstrap
-        // because `translate_dropdowns` is false by default.
-        (new \DropdownTranslation())->generateCompletename([
-            'itemtype' => \TaskCategory::class,
-            'items_id' => getItemByTypeName(\TaskCategory::class, '_cat_1', true),
-            'language' => 'fr_FR'
-        ]);
         $_SESSION["glpilanguage"] = \Session::loadLanguage('fr_FR');
         $_SESSION['glpi_dropdowntranslations'] = \DropdownTranslation::getAvailableTranslations($_SESSION["glpilanguage"]);
 

--- a/phpunit/functional/NotificationTargetTicketTest.php
+++ b/phpunit/functional/NotificationTargetTicketTest.php
@@ -111,7 +111,12 @@ class NotificationTargetTicketTest extends DbTestCase
                 '##task.author##'          => '_test_user',
                 '##task.categoryid##'      => $taskcat->getID(),
                 '##task.category##'        => '_cat_1 > _subcat_1',
-                '##task.categorycomment##' => 'Comment for sub-category _subcat_1',
+                '##task.categorycomment##' => <<<HTML
+
+
+Comment for sub-category _subcat_1
+
+HTML,
                 '##task.date##'            => '2016-10-19 11:50',
                 '##task.description##'     => 'Task to be done',
                 '##task.time##'            => '0 seconds',
@@ -186,7 +191,12 @@ class NotificationTargetTicketTest extends DbTestCase
                 '##task.author##'          => '_test_user',
                 '##task.categoryid##'      => $taskcat->getID(),
                 '##task.category##'        => 'FR - _cat_1 > FR - _subcat_1',
-                '##task.categorycomment##' => 'FR - Commentaire pour sous-catégorie _subcat_1',
+                '##task.categorycomment##' => <<<HTML
+
+
+FR - Commentaire pour sous-catégorie _subcat_1
+
+HTML,
                 '##task.date##'            => '2016-10-19 11:50',
                 '##task.description##'     => 'Task to be done',
                 '##task.time##'            => '0 seconde',

--- a/phpunit/functional/SearchTest.php
+++ b/phpunit/functional/SearchTest.php
@@ -2186,12 +2186,7 @@ class SearchTest extends DbTestCase
 
     public function testSearchDdTranslation()
     {
-        global $CFG_GLPI;
-
         $this->login();
-        $conf = new \Config();
-        $conf->setConfigurationValues('core', ['translate_dropdowns' => 1]);
-        $CFG_GLPI['translate_dropdowns'] = 1;
 
         $state = new \State();
         $this->assertTrue($state->maybeTranslated());
@@ -2233,8 +2228,6 @@ class SearchTest extends DbTestCase
 
         $this->assertSame(1, $data['data']['totalcount']);
 
-        $conf->setConfigurationValues('core', ['translate_dropdowns' => 0]);
-        $CFG_GLPI['translate_dropdowns'] = 0;
         unset($_SESSION['glpi_dropdowntranslations']);
     }
 

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -4937,14 +4937,15 @@ class CommonDBTM extends CommonGLPI
                             }
                             return getUserName($value);
                         }
+                        $name = Dropdown::getDropdownName($searchoptions['table'], $value);
                         if ($param['comments']) {
-                            $tmp = Dropdown::getDropdownName($searchoptions['table'], $value, 1);
-                            return $tmp['name'] . '&nbsp;' . Html::showToolTip(
-                                $tmp['comment'],
+                            $comments = Dropdown::getDropdownComments($searchoptions['table'], (int) $value);
+                            return htmlescape($name) . '&nbsp;' . Html::showToolTip(
+                                $comments,
                                 ['display' => false]
                             );
                         }
-                        return Dropdown::getDropdownName($searchoptions['table'], $value);
+                        return htmlescape($name);
 
                     case "itemtypename":
                         if ($obj = getItemForItemtype($value)) {

--- a/src/CommonDBVisible.php
+++ b/src/CommonDBVisible.php
@@ -311,11 +311,12 @@ abstract class CommonDBVisible extends CommonDBTM
                     }
                     echo "<td>" . htmlescape(Group::getTypeName(1)) . "</td>";
 
-                    $names   = Dropdown::getDropdownName('glpi_groups', $data['groups_id'], 1);
+                    $name    = Dropdown::getDropdownName('glpi_groups', $data['groups_id']);
+                    $tooltip = Dropdown::getDropdownComments('glpi_groups', (int) $data['groups_id']);
                     $entname = sprintf(
                         __s('%1$s %2$s'),
-                        htmlescape($names["name"]),
-                        Html::showToolTip($names["comment"], ['display' => false])
+                        htmlescape($name),
+                        Html::showToolTip($tooltip, ['display' => false])
                     );
                     if ($data['entities_id'] !== null) {
                         $entname = sprintf(
@@ -354,9 +355,13 @@ abstract class CommonDBVisible extends CommonDBTM
                         echo "</td>";
                     }
                     echo "<td>" . htmlescape(Entity::getTypeName(1)) . "</td>";
-                    $names   = Dropdown::getDropdownName('glpi_entities', $data['entities_id'], 1);
-                    $tooltip = Html::showToolTip($names["comment"], ['display' => false]);
-                    $entname = sprintf(__s('%1$s %2$s'), htmlescape($names["name"]), $tooltip);
+                    $name    = Dropdown::getDropdownName('glpi_entities', $data['entities_id']);
+                    $tooltip = Dropdown::getDropdownComments('glpi_entities', (int) $data['entities_id']);
+                    $entname = sprintf(
+                        __s('%1$s %2$s'),
+                        htmlescape($name),
+                        Html::showToolTip($tooltip, ['display' => false])
+                    );
                     if ($data['is_recursive']) {
                         $entname = sprintf(
                             __s('%1$s %2$s'),
@@ -387,9 +392,13 @@ abstract class CommonDBVisible extends CommonDBTM
                     }
                     echo "<td>" . _sn('Profile', 'Profiles', 1) . "</td>";
 
-                    $names   = Dropdown::getDropdownName('glpi_profiles', $data['profiles_id'], 1);
-                    $tooltip = Html::showToolTip($names["comment"], ['display' => false]);
-                    $entname = sprintf(__s('%1$s %2$s'), htmlescape($names["name"]), $tooltip);
+                    $name    = Dropdown::getDropdownName('glpi_profiles', $data['profiles_id']);
+                    $tooltip = Dropdown::getDropdownComments('glpi_profiles', (int) $data['profiles_id']);
+                    $entname = sprintf(
+                        __s('%1$s %2$s'),
+                        htmlescape($name),
+                        Html::showToolTip($tooltip, ['display' => false])
+                    );
                     if ($data['entities_id'] !== null) {
                         $entname = sprintf(
                             __s('%1$s / %2$s'),

--- a/src/CommonItilObject_Item.php
+++ b/src/CommonItilObject_Item.php
@@ -1561,22 +1561,18 @@ abstract class CommonItilObject_Item extends CommonDBRelation
                 }
 
                 if (isset($values['itemtype'])) {
+                    $table = getTableForItemType($values['itemtype']);
+                    $value = (int) $values[$field];
+                    $name = Dropdown::getDropdownName($table, $value);
                     if (isset($options['comments']) && $options['comments']) {
-                        $tmp = Dropdown::getDropdownName(
-                            getTableForItemType($values['itemtype']),
-                            $values[$field],
-                            1
-                        );
+                        $comments = Dropdown::getDropdownComments($table, $value);
                          return sprintf(
                              __('%1$s %2$s'),
-                             $tmp['name'],
-                             Html::showToolTip($tmp['comment'], ['display' => false])
+                             htmlescape($name),
+                             Html::showToolTip($comments, ['display' => false])
                          );
                     }
-                    return Dropdown::getDropdownName(
-                        getTableForItemType($values['itemtype']),
-                        $values[$field]
-                    );
+                    return htmlescape($name);
                 }
                 break;
         }

--- a/src/Contract_Item.php
+++ b/src/Contract_Item.php
@@ -95,22 +95,18 @@ class Contract_Item extends CommonDBRelation
         switch ($field) {
             case 'items_id':
                 if (isset($values['itemtype'])) {
+                    $table = getTableForItemType($values['itemtype']);
+                    $value = (int) $values[$field];
+                    $name = Dropdown::getDropdownName($table, $value);
                     if (isset($options['comments']) && $options['comments']) {
-                        $tmp = Dropdown::getDropdownName(
-                            getTableForItemType($values['itemtype']),
-                            $values[$field],
-                            1
-                        );
-                        return sprintf(
-                            __('%1$s %2$s'),
-                            $tmp['name'],
-                            Html::showToolTip($tmp['comment'], ['display' => false])
-                        );
+                        $comments = Dropdown::getDropdownComments($table, $value);
+                         return sprintf(
+                             __('%1$s %2$s'),
+                             htmlescape($name),
+                             Html::showToolTip($comments, ['display' => false])
+                         );
                     }
-                    return Dropdown::getDropdownName(
-                        getTableForItemType($values['itemtype']),
-                        $values[$field]
-                    );
+                    return htmlescape($name);
                 }
                 break;
         }

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -705,17 +705,11 @@ class Dropdown
 
         $data = $iterator->current();
 
-        $comment = '';
+        $extra_rows = [];
 
         if ($tooltip) {
-            $comment_rows = [];
-
             if (is_a($itemtype, CommonTreeDropdown::class, true)) {
-                $comment_rows[] = sprintf(
-                    __s('%1$s: %2$s'),
-                    '<span class="b">' . __s('Complete name'),
-                    '</span>' . htmlescape($data['translated_completename'] ?: $data['completename'])
-                );
+                $extra_rows[__('Complete name')] = $data['translated_completename'] ?: $data['completename'];
             }
 
             $fields = [];
@@ -730,11 +724,7 @@ class Dropdown
                     ];
                     foreach ($fields as $key => $label) {
                         if (!empty($data[$key])) {
-                            $comment_rows[] = sprintf(
-                                __s('%1$s: %2$s'),
-                                '<span class="b">' . htmlescape($label),
-                                '</span>' . htmlescape($data[$key])
-                            );
+                            $extra_rows[$label] = $data[$key];
                         }
                     }
                     break;
@@ -747,104 +737,74 @@ class Dropdown
                     ];
                     foreach ($fields as $key => $label) {
                         if (!empty($data[$key])) {
-                            $comment_rows[] = sprintf(
-                                __s('%1$s: %2$s'),
-                                '<span class="b">' . htmlescape($label),
-                                '</span>' . htmlescape($data[$key])
-                            );
+                            $extra_rows[$label] = $data[$key];
                         }
                     }
                     break;
 
                 case Budget::class:
                     if (!empty($data['locations_id'])) {
-                        $comment_rows[] = sprintf(
-                            __s('%1$s: %2$s'),
-                            '<span class="b">' . htmlescape(Location::getTypeName(1)),
-                            '</span>' . htmlescape(self::getDropdownName('glpi_locations', $data['locations_id'], translate: $translate))
+                        $extra_rows[Location::getTypeName(1)] = self::getDropdownName(
+                            'glpi_locations',
+                            $data['locations_id'],
+                            translate: $translate
                         );
                     }
                     if (!empty($data['budgettypes_id'])) {
-                        $comment_rows[] = sprintf(
-                            __s('%1$s: %2$s'),
-                            '<span class="b">' . _sn('Type', 'Types', 1),
-                            '</span>' . htmlescape(self::getDropdownName('glpi_budgettypes', $data['budgettypes_id'], translate: $translate))
+                        $extra_rows[_n('Type', 'Types', 1)] = self::getDropdownName(
+                            'glpi_budgettypes',
+                            $data['budgettypes_id'],
+                            translate: $translate
                         );
                     }
                     if (!empty($data['begin_date'])) {
-                        $comment_rows[] = sprintf(
-                            __s('%1$s: %2$s'),
-                            '<span class="b">' . __s('Start date'),
-                            '</span>' . Html::convDateTime($data['begin_date'])
-                        );
+                        $extra_rows[__('Start date')] = Html::convDateTime($data['begin_date']);
                     }
                     if (!empty($data['end_date'])) {
-                        $comment_rows[] = sprintf(
-                            __s('%1$s: %2$s'),
-                            '<span class="b">' . __s('End date'),
-                            '</span>' . Html::convDateTime($data['end_date'])
-                        );
+                        $extra_rows[__('End date')] = Html::convDateTime($data['end_date']);
                     }
                     break;
 
                 case Location::class:
                     if (!empty($data['alias'])) {
-                        $comment_rows[] = sprintf(
-                            __s('%1$s: %2$s'),
-                            '<span class="b">' . __s('Alias'),
-                            '</span>' . htmlescape($data['alias'])
-                        );
+                        $extra_rows[__('Alias')] = $data['alias'];
                     }
                     if (!empty($data['code'])) {
-                        $comment_rows[] = sprintf(
-                            __s('%1$s: %2$s'),
-                            '<span class="b">' . __s('Code'),
-                            '</span>' . htmlescape($data['code'])
-                        );
+                        $extra_rows[__('Code')] = $data['code'];
                     }
                     $address_comment = '';
                     $address = $data['address'];
                     $town    = $data['town'];
                     $country = $data['country'];
                     if (!empty($address)) {
-                        $address_comment .= htmlescape($address);
+                        $address_comment .= $address;
                     }
                     if (!empty($address) && (!empty($town) || !empty($country))) {
-                        $address_comment .= '<br/>';
+                        $address_comment .= "\n";
                     }
                     if (!empty($town)) {
-                        $address_comment .= htmlescape($town);
+                        $address_comment .= $town;
                     }
                     if (!empty($country)) {
                         if (!empty($town)) {
                             $address_comment .= ' - ';
                         }
-                        $address_comment .= htmlescape($country);
+                        $address_comment .= $country;
                     }
                     if (trim($address_comment) !== '') {
-                        $comment_rows[] = sprintf(
-                            __s('%1$s: %2$s'),
-                            '<span class="b">' . __s('Address'),
-                            '</span>' . $address_comment
-                        );
+                        $extra_rows[__('Address')] = $address_comment;
                     }
                     break;
             }
-
-            if (count($comment_rows) > 0) {
-                $comment = implode('<br />', $comment_rows);
-                $comment .= '<br />';
-                $comment .= sprintf(
-                    __s('%1$s: %2$s'),
-                    '<span class="b">' . __s('Comments'),
-                    '</span>'
-                );
-            }
         }
 
-        $comment .= nl2br(htmlescape($data['translated_comment'] ?: $data['comment']));
-
-        return $comment;
+        return TemplateRenderer::getInstance()->render(
+            'components/dropdown/comments.html.twig',
+            [
+                'comment'    => $data['translated_comment'] ?: $data['comment'],
+                'extra_rows' => $extra_rows,
+            ]
+        );
     }
 
 

--- a/src/Glpi/Application/View/Extension/ItemtypeExtension.php
+++ b/src/Glpi/Application/View/Extension/ItemtypeExtension.php
@@ -67,7 +67,7 @@ class ItemtypeExtension extends AbstractExtension
     {
         return [
             new TwigFunction('get_item', [$this, 'getItem']),
-            new TwigFunction('get_item_comment', [$this, 'getItemComment']),
+            new TwigFunction('get_item_comment', [$this, 'getItemComment'], ['is_safe' => ['html']]),
             new TwigFunction('get_item_link', [$this, 'getItemLink'], ['is_safe' => ['html']]),
             new TwigFunction('get_item_name', [$this, 'getItemName']),
         ];
@@ -205,8 +205,7 @@ class ItemtypeExtension extends AbstractExtension
     {
         if (is_a($item, CommonDropdown::class, true)) {
             $items_id = $item instanceof CommonDBTM ? $item->fields[$item->getIndexName()] : $id;
-            $texts = Dropdown::getDropdownName($item::getTable(), $items_id, true, true, false, '');
-            return $texts['comment'];
+            return Dropdown::getDropdownComments($item::getTable(), $items_id, tooltip: false);
         }
 
         if (($instance = $this->getItemInstance($item, $id)) === null) {
@@ -215,7 +214,7 @@ class ItemtypeExtension extends AbstractExtension
 
         $comment = $instance->isField('comment') ? $instance->fields['comment'] : null;
 
-        return $comment;
+        return htmlescape($comment);
     }
 
     /**

--- a/src/Item_Devices.php
+++ b/src/Item_Devices.php
@@ -305,22 +305,18 @@ class Item_Devices extends CommonDBRelation
         switch ($field) {
             case 'items_id':
                 if (isset($values['itemtype'])) {
+                    $table = getTableForItemType($values['itemtype']);
+                    $value = (int) $values[$field];
+                    $name = Dropdown::getDropdownName($table, $value);
                     if (isset($options['comments']) && $options['comments']) {
-                        $valueData = Dropdown::getDropdownName(
-                            getTableForItemType($values['itemtype']),
-                            $values[$field],
-                            1
-                        );
-                        return sprintf(
-                            __('%1$s %2$s'),
-                            $valueData['name'],
-                            Html::showToolTip($valueData['comment'], ['display' => false])
-                        );
+                        $comments = Dropdown::getDropdownComments($table, $value);
+                         return sprintf(
+                             __('%1$s %2$s'),
+                             htmlescape($name),
+                             Html::showToolTip($comments, ['display' => false])
+                         );
                     }
-                    return Dropdown::getDropdownName(
-                        getTableForItemType($values['itemtype']),
-                        $values[$field]
-                    );
+                    return htmlescape($name);
                 }
                 break;
         }

--- a/src/NotificationTargetCommonITILObject.php
+++ b/src/NotificationTargetCommonITILObject.php
@@ -1694,17 +1694,16 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
                 }
                  $tmp['##task.author##']       = getUserName($task['users_id']);
 
-                 $tmp_taskcatinfo = Dropdown::getDropdownName(
+                 $tmp['##task.categoryid##']      = $task['taskcategories_id'];
+                 $tmp['##task.category##']        = Dropdown::getDropdownName(
                      'glpi_taskcategories',
                      $task['taskcategories_id'],
-                     true,
-                     true,
-                     false,
-                     ''
                  );
-                 $tmp['##task.categoryid##']      = $task['taskcategories_id'];
-                 $tmp['##task.category##']        = $tmp_taskcatinfo['name'];
-                 $tmp['##task.categorycomment##'] = $tmp_taskcatinfo['comment'];
+                 $tmp['##task.categorycomment##'] = Dropdown::getDropdownComments(
+                     'glpi_taskcategories',
+                     $task['taskcategories_id'],
+                     tooltip: false
+                 );
 
                  $tmp['##task.date##']         = Html::convDateTime($task['date']);
                  $tmp['##task.description##']  = $task['content'];

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -2658,9 +2658,7 @@ JS
             $crit = $this->getCriteria($ID);
             if (isset($crit['type'])) {
                 return match ($crit['type']) {
-                    'dropdown' => ($result = Dropdown::getDropdownName($crit["table"], $value, false, false)) === '&nbsp;'
-                        ? ''
-                        : $result,
+                    'dropdown' => Dropdown::getDropdownName($crit["table"], $value, translate: false),
                     'dropdown_assign', 'dropdown_users' => getUserName($value),
                     'yesonly', 'yesno' => Dropdown::getYesNo($value),
                     'dropdown_impact' => CommonITILObject::getImpactName($value),

--- a/src/autoload/dbutils-aliases.php
+++ b/src/autoload/dbutils-aliases.php
@@ -286,9 +286,15 @@ function getTreeLeafValueName($table, $ID, $withcomment = false, $translate = tr
  * @return string : completename of the element
  *
  * @see getTreeLeafValueName()
+ *
+ * @since 11.0.0 Usage of the `$withcomment` parameter is deprecated.
  **/
 function getTreeValueCompleteName($table, $ID, $withcomment = false, $translate = true, $tooltip = true, string $default = '&nbsp;')
 {
+    if ($withcomment) {
+        Toolbox::deprecated('Usage of the `$withcomment` parameter is deprecated. Use `Dropdown::getDropdownComments()` instead.');
+    }
+
     $dbu = new DbUtils();
     return $dbu->getTreeValueCompleteName($table, $ID, $withcomment, $translate, $tooltip, $default);
 }

--- a/templates/components/dropdown/comments.html.twig
+++ b/templates/components/dropdown/comments.html.twig
@@ -1,0 +1,42 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2024 Teclib' and contributors.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+{% if extra_rows|length > 0 %}
+    {% for label, value in extra_rows %}
+        <span class="b">{{ __('%1$s: %2$s')|format(label, '') }}</span>{{ value|nl2br }}<br />
+    {% endfor %}
+    {% if comment is not empty %}
+        <span class="b">{{ __('%1$s: %2$s')|format(__('Comments'), '') }}</span>
+    {% endif %}
+{% endif %}
+
+{{ comment|nl2br }}

--- a/tests/functional/Glpi/Api/HL/Controller/AssetController.php
+++ b/tests/functional/Glpi/Api/HL/Controller/AssetController.php
@@ -389,8 +389,6 @@ class AssetController extends \HLAPITestCase
 
     public function testDropdownTranslations()
     {
-        global $CFG_GLPI;
-
         $this->login();
         $state = new \State();
         $this->integer($state_id = $state->add([
@@ -412,7 +410,6 @@ class AssetController extends \HLAPITestCase
             'value'     => 'Essai',
         ]))->isGreaterThan(0);
 
-        $CFG_GLPI['translate_dropdowns'] = true;
         // Get and verify
         $this->api->call(new Request('GET', '/Assets/Computer/' . $computer_id), function ($call) use ($state_id) {
             /** @var \HLAPICallAsserter $call */
@@ -442,8 +439,6 @@ class AssetController extends \HLAPITestCase
 
     public function testMissingDropdownTranslation()
     {
-        global $CFG_GLPI;
-
         $this->login();
         $state = new \State();
         $this->integer($state_id = $state->add([
@@ -457,7 +452,6 @@ class AssetController extends \HLAPITestCase
             'states_id' => $state_id,
         ]))->isGreaterThan(0);
 
-        $CFG_GLPI['translate_dropdowns'] = true;
         // Get and verify
         $this->api->call(new Request('GET', '/Assets/Computer/' . $computer_id), function ($call) use ($state_id) {
             /** @var \HLAPICallAsserter $call */


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

I extracted the `comments` computation from the `Dropdown::getDropdownName()` method and move it into a `Dropdown::getDropdownComments()` in order to not have a mix between raw data and HTML encoded data in the same method result.
- `Dropdown::getDropdownName()` will now always return a raw value.
- `Dropdown::getDropdownComments()` will always return a safe HTML string.
