### PR TITLE
fix: Bad session handling for GLPI mode cron

### DIFF
--- a/front/cron.php
+++ b/front/cron.php
@@ -54,9 +54,6 @@ global $CFG_GLPI;
 // Ensure current directory when run from crontab
 chdir(__DIR__);
 
-// Ensure that session is not used
-ini_set('session.use_cookies', 0);
-
 // Try detecting if we are running with the root user (Not available on Windows)
 if (function_exists('posix_geteuid') && posix_geteuid() === 0) {
     // Translation functions not available here

--- a/src/Glpi/Config/LegacyConfigurators/SessionStart.php
+++ b/src/Glpi/Config/LegacyConfigurators/SessionStart.php
@@ -49,6 +49,7 @@ final class SessionStart implements LegacyConfigProviderInterface, ConfigProvide
     private const NO_COOKIE_PATHS = [
         '/api(rest)?\.php.*',
         '/caldav\.php.*',
+        '/front/cron\.php.*',
     ];
 
     private const NO_SESSION_PATHS = [


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.

## Description

Fixed issue #17961 
The use of `ini_set('session.use_cookies', 0);` cause warnings due to the fact that the session was already active.

The addition of tests would be relevant, but I can't see how to test this layer.