### PR TITLE
fix: invalid session if count doesn't exists

### DIFF
--- a/src/Session.php
+++ b/src/Session.php
@@ -1093,7 +1093,7 @@ class Session
 
             $row = $result->current();
 
-            if (!isset($row['count']) || $row['count'] === 0) {
+            if ($row === null || $row['count'] === 0) {
                 $valid_user = false;
             } elseif (
                 $row['last_rights_update'] !== null

--- a/src/Session.php
+++ b/src/Session.php
@@ -1093,7 +1093,7 @@ class Session
 
             $row = $result->current();
 
-            if ($row['count'] === 0) {
+            if (!isset($row['count']) || $row['count'] === 0) {
                 $valid_user = false;
             } elseif (
                 $row['last_rights_update'] !== null


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Since ef93b740eb68e418692149c9991f9fc556febe42.

If the query does not return any rows, we do not enter the case ```$row['count'] === 0``` (because of the trying to access array offset on null error), and therefore the session is not destroyed.

```
glpiphplog.WARNING:   *** PHP Warning (2): Trying to access array offset on null in /home/francois/www/glpi-core/main/htdocs/src/Session.php at line 1096
  Backtrace :
  src/Session.php:1173                               Session::checkValidSessionId()
  src/Glpi/Http/Firewall.php:131                     Session::checkLoginUser()
  ...nt/ContainerITyWjcI/FirewallProxy683eb58.php:25 Glpi\Http\Firewall->applyStrategy()
  src/Glpi/Http/FirewallStrategyListener.php:73      ContainerITyWjcI\FirewallProxy683eb58->applyStrategy()
  .../event-dispatcher/Debug/WrappedListener.php:116 Glpi\Http\FirewallStrategyListener->onKernelController()
  ...ymfony/event-dispatcher/EventDispatcher.php:220 Symfony\Component\EventDispatcher\Debug\WrappedListener->__invoke()
  ...symfony/event-dispatcher/EventDispatcher.php:56 Symfony\Component\EventDispatcher\EventDispatcher->callListeners()
  ...spatcher/Debug/TraceableEventDispatcher.php:139 Symfony\Component\EventDispatcher\EventDispatcher->dispatch()
  vendor/symfony/http-kernel/HttpKernel.php:169      Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcher->dispatch()
  vendor/symfony/http-kernel/HttpKernel.php:76       Symfony\Component\HttpKernel\HttpKernel->handleRaw()
  vendor/symfony/http-kernel/Kernel.php:197          Symfony\Component\HttpKernel\HttpKernel->handle()
  public/index.php:56                                Symfony\Component\HttpKernel\Kernel->handle()
```