### PR TITLE
Fix webhook itemtype list when itemtype has no schema

### DIFF
--- a/src/Webhook.php
+++ b/src/Webhook.php
@@ -330,7 +330,7 @@ class Webhook extends CommonDBTM implements FilterableInterface
         }
     }
 
-    private static function getAPIItemtypeData(): array
+    public static function getAPIItemtypeData(): array
     {
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
@@ -399,8 +399,8 @@ class Webhook extends CommonDBTM implements FilterableInterface
                                 $supported[$controller][$category][$supported_itemtype] = [
                                     'name' => $schema['name'],
                                 ];
-                                unset($supported[$controller][$category][$i]);
                             }
+                            unset($supported[$controller][$category][$i]);
                         }
                     } else if ($category === 'subtypes' && $controller === ITILController::class) {
                         /** @phpstan-var class-string<ITILController> $controller */

--- a/tests/functional/Webhook.php
+++ b/tests/functional/Webhook.php
@@ -35,8 +35,7 @@
 
 namespace tests\units;
 
-/* Test for inc/user.class.php */
-
+use Glpi\Api\HL\Controller\AbstractController;
 use Glpi\Search\SearchOption;
 
 class Webhook extends \DbTestCase
@@ -243,5 +242,23 @@ JSON;
         // Make sure we get at least something as a response.
         // The main purpose is to test the internal authentication middleware.
         $this->variable($webhook->getResultForPath('/Administration/User/' . $users_id, 'new', 'User', $users_id))->isNotNull();
+    }
+
+    public function testGetAPIItemtypeData()
+    {
+        $this->login();
+        $this->initAssetDefinition();
+
+        $supported_types = \Webhook::getAPIItemtypeData();
+        foreach ($supported_types as $controller => $type_data) {
+            $this->boolean(is_subclass_of($controller, AbstractController::class))->isTrue();
+            foreach ($type_data as $category => $types) {
+                $this->string($category)->matches('/main|subtypes/');
+                foreach ($types as $type_key => $type) {
+                    $this->boolean(class_exists($type_key))->isTrue();
+                    $this->array($type)->isNotEmpty();
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

Fixes issue when there are itemtypes that have no API schema associated causing invalid options to remain in the list and cause a PHP error when trying to access getTypeName on an invalid class. Issue noted when custom assets from the `asset_types` config list are added since there is no HLAPI support for them yet.