### PR TITLE
fix(ITIL template): predefined fields not set

### DIFF
--- a/phpunit/functional/ITILTemplateTest.php
+++ b/phpunit/functional/ITILTemplateTest.php
@@ -530,6 +530,25 @@ class ITILTemplateTest extends DbTestCase
         $this->assertSame($category_tpl_id, (int)$tt->fields['id']);
     }
 
+    /**
+     * Check that all predefined fields are set in the default values
+     *
+     * @dataProvider itilProvider
+     */
+    public function testGetDefaultValues($itiltype)
+    {
+        $itemtype       = '\\' . $itiltype;
+        $default_values = $itemtype::getDefaultValues();
+        $tt_class       = $itiltype . 'Template';
+        $tt             = new $tt_class();
+        $fields         = $tt->getAllowedFields(true, true);
+        $tt_predefined  = $tt_class . 'PredefinedField';
+        $fields         = array_diff_key($fields, $tt_predefined::getExcludedFields());
+        foreach ($fields as $field) {
+            $this->assertArrayHasKey($field, $default_values);
+        }
+    }
+
     private function createTemplate($itiltype)
     {
         //create template

--- a/src/Change.php
+++ b/src/Change.php
@@ -903,7 +903,7 @@ class Change extends CommonITILObject
             'name'                       => '',
             'itilcategories_id'          => 0,
             'actiontime'                 => 0,
-            'date'                      => 'NULL',
+            'date'                       => 'NULL',
             '_add_validation'            => 0,
             'users_id_validate'          => [],
             '_tasktemplates_id'          => [],
@@ -913,7 +913,11 @@ class Change extends CommonITILObject
             'backoutplancontent'         => '',
             'checklistcontent'           => '',
             'items_id'                   => 0,
-            '_actors'                     => [],
+            '_actors'                    => [],
+            'status'                     => self::INCOMING,
+            'time_to_resolve'            => 'NULL',
+            'itemtype'                   => '',
+            'locations_id'               => 0,
         ];
     }
 

--- a/src/Problem.php
+++ b/src/Problem.php
@@ -1551,12 +1551,19 @@ class Problem extends CommonITILObject
             'entities_id'                => $_SESSION['glpiactive_entity'],
             'itilcategories_id'          => 0,
             'actiontime'                 => 0,
-            'date'                      => 'NULL',
+            'date'                       => 'NULL',
             '_add_validation'            => 0,
             'users_id_validate'          => [],
             '_tasktemplates_id'          => [],
             'items_id'                   => 0,
-            '_actors'                     => [],
+            '_actors'                    => [],
+            'status'                     => self::INCOMING,
+            'time_to_resolve'            => 'NULL',
+            'itemtype'                   => '',
+            'locations_id'               => 0,
+            'impactcontent'              => '',
+            'causecontent'               => '',
+            'symptomcontent'             => '',
         ];
     }
 


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !34638
- Here is a brief description of what this PR does
Some predefined fields from templates were not populated when creating a Problem or Change.

## Screenshots (if appropriate):


