### PR TITLE
Fix kb revision overflowing content

### DIFF
--- a/src/KnowbaseItem_Revision.php
+++ b/src/KnowbaseItem_Revision.php
@@ -224,9 +224,9 @@ class KnowbaseItem_Revision extends CommonDBTM
                      title: __('Show revision %rev').replace(/%rev/, _this.data('rev')),
                      body: `<div>
                         <h2>\${__('Subject')}</h2>
-                        <div>\${data.name}</div>
+                        <div class='text-wrap text-break'>\${data.name}</div>
                         <h2>\${__('Content')}</h2>
-                        <div>\${data.answer}</div>
+                        <div class='text-wrap text-break'>\${data.answer}</div>
                      </div>`,
                   });
                })
@@ -271,18 +271,19 @@ class KnowbaseItem_Revision extends CommonDBTM
                            </tr>
                            <tr>
                               <th>\${__('Subject')}</th>
-                              <td class='original'>\${data['old']['name']}</td>
-                              <td class='changed'>\${data['diff']['name']}</td>
-                              <td class='diff'></td>
+                              <td class='original text-wrap text-break'>\${data['old']['name']}</td>
+                              <td class='changed text-wrap text-break'>\${data['diff']['name']}</td>
+                              <td class='diff text-wrap text-break'></td>
                            </tr>
                            <tr>
                               <th>\${__('Content')}</th>
-                              <td class='original'>\${data['old']['answer']}</td>
-                              <td class='changed'>\${data['diff']['answer']}</td>
-                              <td class='diff'></td>
+                              <td class='original text-wrap text-break'>\${data['old']['answer']}</td>
+                              <td class='changed text-wrap text-break'>\${data['diff']['answer']}</td>
+                              <td class='diff text-wrap text-break'></td>
                            </tr>
                         </table>
                      </div>`,
+                     dialogclass: 'modal-xl'
                   });
 
                   $('#compare_view tr').prettyTextDiff();


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes #17773
- Here is a brief description of what this PR does

When comparing two revisions the resulting change can overflow the modal-body

## Screenshots (if appropriate):
*Before*
![image](https://github.com/user-attachments/assets/f7a9bd9d-7f03-4da2-b294-dc1f849f42a2)

*After*
![image](https://github.com/user-attachments/assets/cf61d9ed-03c2-4106-845d-d9c7b01a1d5c)




