### PR TITLE
Allow specific display preferences to be configured for the helpdesk

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -172,7 +172,7 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	// identifier: foreach.emptyArray
 	'message' => '#^Empty array passed to foreach\\.$#',
-	'count' => 2,
+	'count' => 3,
 	'path' => __DIR__ . '/install/migrations/update_10.0.x_to_11.0.0.php',
 ];
 $ignoreErrors[] = [

--- a/ajax/displaypreference.php
+++ b/ajax/displaypreference.php
@@ -57,7 +57,12 @@ if (isset($_POST["activate"])) {
     if (!isset($_POST['itemtype'], $_POST['users_id'], $_POST['opts'])) {
         throw new BadRequestHttpException();
     }
-    $setupdisplay->updateOrder($_POST['itemtype'], $_POST['users_id'], $_POST['opts']);
+    $setupdisplay->updateOrder(
+        $_POST['itemtype'],
+        $_POST['users_id'],
+        $_POST['opts'],
+        $_POST['interface'] ?? 'central'
+    );
 } else {
     throw new BadRequestHttpException();
 }

--- a/css/helpdesk_home.scss
+++ b/css/helpdesk_home.scss
@@ -84,28 +84,6 @@ header {
     }
 }
 
-// Hack to hide some columns until we can add proper display preferences for
-// this list.
-.tickets-banner [data-searchopt-id="1"],
-.tickets-banner  [data-searchopt-content-id="1"],
-.tickets-banner [data-searchopt-id="2"],
-.tickets-banner  [data-searchopt-content-id="2"],
-.tickets-banner [data-searchopt-id="80"],
-.tickets-banner  [data-searchopt-content-id="80"],
-.tickets-banner [data-searchopt-id="12"],
-.tickets-banner  [data-searchopt-content-id="12"],
-.tickets-banner [data-searchopt-id="19"],
-.tickets-banner  [data-searchopt-content-id="19"],
-.tickets-banner [data-searchopt-id="15"],
-.tickets-banner  [data-searchopt-content-id="15"] {
-    display: table-cell !important;
-}
-
-.tickets-banner [data-searchopt-id],
-.tickets-banner  [data-searchopt-content-id] {
-    display: none;
-}
-
 .helpdesk-home-container {
     height: 100vh;
 

--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -1985,6 +1985,13 @@ $empty_data_builder = new class
                 'rank' => '6',
             ],
         ];
+        // Set interface to previously defined values.
+        // TODO: the previous values should probably use $ADDTODISPLAYPREF to be
+        // more maintainable...
+        foreach ($tables['glpi_displaypreferences'] as &$row) {
+            $row['interface'] = 'central';
+        }
+        unset($row);
 
         $ADDTODISPLAYPREF['Glpi\Form\Form'] = [1, 80, 86, 3, 4];
         $ADDTODISPLAYPREF['Glpi\Form\AnswersSet'] = [1, 3, 4];
@@ -2006,6 +2013,11 @@ $empty_data_builder = new class
         $ADDTODISPLAYPREF[Webhook::class] = [3, 4, 5];
         $ADDTODISPLAYPREF[QueuedWebhook::class] = [80, 2, 22, 20, 21, 7, 30, 16];
         $ADDTODISPLAYPREF[Consumable::class] = [2, 8, 3, 4, 5, 6, 7];
+        $ADDTODISPLAYPREF_HELPDESK[\Ticket::class] = [
+            12, // Status
+            19, // Last update
+            15, // Opening date
+        ];
 
         foreach ($ADDTODISPLAYPREF as $type => $options) {
             $rank = 1;
@@ -2014,6 +2026,18 @@ $empty_data_builder = new class
                     'itemtype' => $type,
                     'num' => $newval,
                     'rank' => $rank++,
+                    'interface' => 'central',
+                ];
+            }
+        }
+        foreach ($ADDTODISPLAYPREF_HELPDESK as $type => $options) {
+            $rank = 1;
+            foreach ($options as $newval) {
+                $tables['glpi_displaypreferences'][] = [
+                    'itemtype' => $type,
+                    'num' => $newval,
+                    'rank' => $rank++,
+                    'interface' => 'helpdesk',
                 ];
             }
         }

--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -1988,10 +1988,9 @@ $empty_data_builder = new class
         // Set interface to previously defined values.
         // TODO: the previous values should probably use $ADDTODISPLAYPREF to be
         // more maintainable...
-        foreach ($tables['glpi_displaypreferences'] as &$row) {
-            $row['interface'] = 'central';
+        foreach (array_keys($tables['glpi_displaypreferences']) as $index) {
+            $tables['glpi_displaypreferences'][$index]['interface'] = 'central';
         }
-        unset($row);
 
         $ADDTODISPLAYPREF['Glpi\Form\Form'] = [1, 80, 86, 3, 4];
         $ADDTODISPLAYPREF['Glpi\Form\AnswersSet'] = [1, 3, 4];

--- a/install/migrations/update_10.0.x_to_11.0.0.php
+++ b/install/migrations/update_10.0.x_to_11.0.0.php
@@ -46,10 +46,11 @@ function update100xto1100()
      */
     global $DB, $migration;
 
-    $updateresult       = true;
-    $ADDTODISPLAYPREF   = [];
-    $DELFROMDISPLAYPREF = [];
-    $update_dir = __DIR__ . '/update_10.0.x_to_11.0.0/';
+    $updateresult              = true;
+    $ADDTODISPLAYPREF          = [];
+    $ADDTODISPLAYPREF_HELPDESK = [];
+    $DELFROMDISPLAYPREF        = [];
+    $update_dir                = __DIR__ . '/update_10.0.x_to_11.0.0/';
 
     //TRANS: %s is the number of new version
     $migration->displayTitle(sprintf(__('Update to %s'), '11.0.0'));
@@ -76,6 +77,23 @@ function update100xto1100()
                     'users_id'  => '0',
                     'itemtype'  => $type,
                     'num'       => $newval,
+                ]
+            );
+        }
+    }
+    foreach ($ADDTODISPLAYPREF_HELPDESK as $type => $tab) {
+        $rank = 1;
+        foreach ($tab as $newval) {
+            $DB->updateOrInsert(
+                'glpi_displaypreferences',
+                [
+                    'rank'      => $rank++
+                ],
+                [
+                    'users_id'  => '0',
+                    'itemtype'  => $type,
+                    'num'       => $newval,
+                    'interface' => 'helpdesk',
                 ]
             );
         }

--- a/install/migrations/update_10.0.x_to_11.0.0/displaypreference.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/displaypreference.php
@@ -88,7 +88,7 @@ if (!$DB->fieldExists($table, 'interface')) {
         'itemtype',
         'num',
         'interface'
-    ], 'unicity', 'UNIQUE', index_type: 'HASH'); // Need hash because the index is too long for BTREE
+    ], 'unicity', 'UNIQUE');
 
     // Force the migration of this table to be executed immediately because new preferences
     // using the new column are added in the same update using $ADDTODISPLAYPREF_HELPDESK

--- a/install/migrations/update_10.0.x_to_11.0.0/displaypreference.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/displaypreference.php
@@ -69,3 +69,34 @@ foreach (
         $appliedPreferences[$dpref['users_id']][$num] = true;
     }
 }
+
+// Add new 'interface' column to glpi_displaypreferences
+$table = "glpi_displaypreferences";
+if (!$DB->fieldExists($table, 'interface')) {
+    $migration->addField($table, 'interface', 'string', [
+        'value' => 'central',
+        'null'  => false,
+    ]);
+
+    // The only way to update a key is to drop it then recreate it
+    // We have to execute the migration after the key is dropped or the addKey
+    // method will not create the ADD query because it will think the key already exists.
+    $migration->dropKey($table, 'unicity');
+    $migration->migrationOneTable($table);
+    $migration->addKey($table, [
+        'users_id',
+        'itemtype',
+        'num',
+        'interface'
+    ], 'unicity', 'UNIQUE', index_type: 'HASH'); // Need hash because the index is too long for BTREE
+
+    // Force the migration of this table to be executed immediately because new preferences
+    // using the new column are added in the same update using $ADDTODISPLAYPREF_HELPDESK
+    $migration->migrationOneTable($table);
+}
+
+$ADDTODISPLAYPREF_HELPDESK[\Ticket::class] = [
+    12, // Status
+    19, // Last update
+    15, // Opening date
+];

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -2545,8 +2545,9 @@ CREATE TABLE `glpi_displaypreferences` (
   `num` int NOT NULL DEFAULT '0',
   `rank` int NOT NULL DEFAULT '0',
   `users_id` int unsigned NOT NULL DEFAULT '0',
+  `interface` varchar(255) NOT NULL DEFAULT 'central',
   PRIMARY KEY (`id`),
-  UNIQUE KEY `unicity` (`users_id`,`itemtype`,`num`),
+  UNIQUE KEY `unicity` (`users_id`,`itemtype`,`num`,`interface`) USING HASH,
   KEY `rank` (`rank`),
   KEY `num` (`num`),
   KEY `itemtype` (`itemtype`)

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -2547,7 +2547,7 @@ CREATE TABLE `glpi_displaypreferences` (
   `users_id` int unsigned NOT NULL DEFAULT '0',
   `interface` varchar(255) NOT NULL DEFAULT 'central',
   PRIMARY KEY (`id`),
-  UNIQUE KEY `unicity` (`users_id`,`itemtype`,`num`,`interface`) USING HASH,
+  UNIQUE KEY `unicity` (`users_id`,`itemtype`,`num`,`interface`),
   KEY `rank` (`rank`),
   KEY `num` (`num`),
   KEY `itemtype` (`itemtype`)

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -197,6 +197,15 @@ class CommonDBTM extends CommonGLPI
     private static $search_options_cache = [];
 
     /**
+     * If this method return true, a third 'Helpdesk view' display preference
+     * will be configurable and used for the helpdesk interface.
+     */
+    public static function supportHelpdeskDisplayPreferences(): bool
+    {
+        return false;
+    }
+
+    /**
      * Return the table used to store this object
      *
      * @param string $classname Force class (to avoid late_binding on inheritance)

--- a/src/DBmysql.php
+++ b/src/DBmysql.php
@@ -1537,11 +1537,8 @@ class DBmysql
      */
     public function updateOrInsert($table, $params, $where, $onlyone = true)
     {
-        $req = $this->request(array_merge(['FROM' => $table], $where));
-        $data = array_merge($where, $params);
-
         try {
-            $query = $this->buildUpdateOrInsert($table, $data, $where, $onlyone);
+            $query = $this->buildUpdateOrInsert($table, $params, $where, $onlyone);
             return $this->doQueryOrDie($query, 'Unable to create new element or update existing one');
         } catch (\RuntimeException $e) {
             trigger_error($e->getMessage(), E_USER_WARNING);
@@ -1558,7 +1555,7 @@ class DBmysql
         } elseif ($req->count() == 1 || !$onlyone) {
             return $this->buildUpdate($table, $data, $where);
         } else {
-            throw new RuntimeException('Update would change too many rows!', E_USER_WARNING);
+            throw new RuntimeException('Update would change too many rows!');
         }
     }
 

--- a/src/DisplayPreference.php
+++ b/src/DisplayPreference.php
@@ -148,7 +148,7 @@ class DisplayPreference extends CommonDBTM
      *
      * @return array
      **/
-    public static function getForTypeUser($itemtype, $user_id)
+    public static function getForTypeUser($itemtype, $user_id, string $interface = 'central')
     {
         /** @var \DBmysql $DB */
         global $DB;
@@ -157,6 +157,7 @@ class DisplayPreference extends CommonDBTM
             'FROM'   => self::getTable(),
             'WHERE'  => [
                 'itemtype'  => $itemtype,
+                'interface' => $interface,
                 'OR'        => [
                     ['users_id' => $user_id],
                     ['users_id' => 0]
@@ -234,7 +235,7 @@ class DisplayPreference extends CommonDBTM
         }
     }
 
-    public function updateOrder(string $itemtype, int $users_id, array $order)
+    public function updateOrder(string $itemtype, int $users_id, array $order, string $interface = 'central')
     {
         /** @var \DBmysql $DB */
         global $DB;
@@ -252,6 +253,7 @@ class DisplayPreference extends CommonDBTM
             [
                 'itemtype' => $itemtype,
                 'users_id' => $users_id,
+                'interface' => $interface,
                 'NOT'      => [
                     'num' => $official_order
                 ]
@@ -265,7 +267,8 @@ class DisplayPreference extends CommonDBTM
                     'itemtype' => $itemtype,
                     'users_id' => $users_id,
                     'num'      => $num,
-                    'rank' => $rank
+                    'rank'     => $rank,
+                    'interface' => $interface,
                 ],
                 [
                     'itemtype' => $itemtype,
@@ -403,7 +406,7 @@ class DisplayPreference extends CommonDBTM
      * @param bool $global True if global config, false if personal config
      * @return void|false
      */
-    private function showConfigForm(string $itemtype, bool $global)
+    private function showConfigForm(string $itemtype, bool $global, string $interface = 'central')
     {
         /** @var \DBmysql $DB */
         global $DB;
@@ -438,7 +441,7 @@ class DisplayPreference extends CommonDBTM
         // Get fixed columns
         $fixed_columns = $this->getFixedColumns($itemtype);
         $group  = '';
-        $already_added = self::getForTypeUser($itemtype, $IDuser);
+        $already_added = self::getForTypeUser($itemtype, $IDuser, $interface);
         $available_to_add = [];
         foreach ($searchopt as $key => $val) {
             if (!is_array($val)) {
@@ -482,7 +485,8 @@ class DisplayPreference extends CommonDBTM
             'entries' => $entries,
             'has_personal' => $has_personal,
             'is_global' => $global,
-            'available_itemtype' => $available_itemtype
+            'available_itemtype' => $available_itemtype,
+            'interface' => $interface,
         ]);
     }
 
@@ -538,6 +542,11 @@ class DisplayPreference extends CommonDBTM
     public function showFormGlobal($itemtype)
     {
         return $this->showConfigForm($itemtype, true);
+    }
+
+    public function showFormHelpdesk($itemtype): void
+    {
+        $this->showConfigForm($itemtype, true, 'helpdesk');
     }
 
     /**
@@ -620,6 +629,15 @@ class DisplayPreference extends CommonDBTM
                 if (Session::haveRight(self::$rightname, self::PERSONAL)) {
                     $ong[2] = $global_only ? null : __('Personal View');
                 }
+
+                $itemtype = $_GET["itemtype"] ?? null;
+                if (
+                    is_a($itemtype, CommonDBTM::class, true)
+                    && $itemtype::supportHelpdeskDisplayPreferences()
+                ) {
+                    $ong[3] = __('Helpdesk View');
+                }
+
                 return $ong;
 
             case Config::class:
@@ -645,6 +663,18 @@ class DisplayPreference extends CommonDBTM
                     case 2:
                         Session::checkRight(self::$rightname, self::PERSONAL);
                         $item->showFormPerso($_GET["displaytype"]);
+                        return true;
+
+                    case 3:
+                        $itemtype = $_GET["displaytype"] ?? null;
+                        if (
+                            !is_a($itemtype, CommonDBTM::class, true)
+                            || !$itemtype::supportHelpdeskDisplayPreferences()
+                        ) {
+                            return false;
+                        }
+
+                        $item->showFormHelpdesk($itemtype);
                         return true;
                 }
                 break;

--- a/src/Glpi/Dashboard/Grid.php
+++ b/src/Glpi/Dashboard/Grid.php
@@ -467,7 +467,13 @@ HTML;
         ]);
         $js = <<<JAVASCRIPT
       $(function () {
-         new GLPIDashboard({$js_params})
+        // Sometimes GLPIDashboard is undefined and it messes with e2e tests
+        // by throwing a blocking error
+        // TODO: investigate why this happens
+        if (typeof GLPIDashboard === 'undefined') {
+          return;
+        }
+        new GLPIDashboard({$js_params})
       });
 JAVASCRIPT;
         $js = Html::scriptBlock($js);

--- a/src/Glpi/Search/SearchEngine.php
+++ b/src/Glpi/Search/SearchEngine.php
@@ -405,7 +405,7 @@ final class SearchEngine
         $data['meta_toview'] = [];
         if (!$forcetoview) {
             // Add items to display depending of personal prefs
-            $displaypref = \DisplayPreference::getForTypeUser($itemtype, \Session::getLoginUserID());
+            $displaypref = \DisplayPreference::getForTypeUser($itemtype, \Session::getLoginUserID(), \Session::getCurrentInterface());
             if (count($displaypref)) {
                 foreach ($displaypref as $val) {
                     array_push($data['toview'], $val);

--- a/src/Glpi/System/Diagnostic/DatabaseSchemaIntegrityChecker.php
+++ b/src/Glpi/System/Diagnostic/DatabaseSchemaIntegrityChecker.php
@@ -536,6 +536,10 @@ class DatabaseSchemaIntegrityChecker
             // Ignore length on indexes when value is `250`
             // MariaDB in some recent version (at least 10.11.7) seems to mention it on some indexes, but we do not know why.
             '/(`\w+`)\(250\)/' => '$1',
+            // Mysql and MariaDB does not always have the same default value for index type depending on the index
+            // for example, the create query might return "UNIQUE KEY `unicity` USING HASH (`users_id`)" one one side
+            // and "UNIQUE KEY `unicity` (`users_id`)" on the other side, despite being the same index.
+            '/(UNIQUE KEY|FULLTEXT KEY|KEY) (.*) USING (\w+)/i' => '$1 $2',
         ];
         $indexes = preg_replace(array_keys($indexes_replacements), array_values($indexes_replacements), $indexes);
         if (!$this->strict) {

--- a/src/Migration.php
+++ b/src/Migration.php
@@ -558,11 +558,10 @@ class Migration
      * @param string       $indexname Index name, $fields if empty, defaults to empty
      * @param string       $type      Index type (index or unique - default 'INDEX')
      * @param integer      $len       Field length (default 0)
-     * @param string|null  $index_type Specify the index type (HASH or BTREE).
      *
      * @return void
      **/
-    public function addKey($table, $fields, $indexname = '', $type = 'INDEX', $len = 0, ?string $index_type = null)
+    public function addKey($table, $fields, $indexname = '', $type = 'INDEX', $len = 0)
     {
         // if no index name, we take that of the field(s)
         if (!$indexname) {
@@ -571,16 +570,6 @@ class Migration
             } else {
                 $indexname = $fields;
             }
-        }
-
-        // Use index_type if specified.
-        // MySQl support HASH and BTREE.
-        // MariaDB support HASH, BTREE and RTREE.
-        // BTREE is the implicit default for both.
-        if ($index_type && in_array($index_type, ['HASH', 'BTREE'])) {
-            $index_type = "USING $index_type ";
-        } else {
-            $index_type = '';
         }
 
         if (!isIndex($table, $indexname)) {
@@ -599,9 +588,9 @@ class Migration
             if ($type === 'FULLTEXT') {
                 $this->fulltexts[$table][] = "ADD $type `$indexname` ($fields)";
             } else if ($type === 'UNIQUE') {
-                $this->uniques[$table][] = "ADD $type `$indexname` $index_type($fields)";
+                $this->uniques[$table][] = "ADD $type `$indexname` ($fields)";
             } else {
-                $this->change[$table][] = "ADD $type `$indexname` $index_type($fields)";
+                $this->change[$table][] = "ADD $type `$indexname` ($fields)";
             }
         }
     }

--- a/src/Migration.php
+++ b/src/Migration.php
@@ -558,10 +558,11 @@ class Migration
      * @param string       $indexname Index name, $fields if empty, defaults to empty
      * @param string       $type      Index type (index or unique - default 'INDEX')
      * @param integer      $len       Field length (default 0)
+     * @param string|null  $index_type Specify the index type (HASH or BTREE).
      *
      * @return void
      **/
-    public function addKey($table, $fields, $indexname = '', $type = 'INDEX', $len = 0)
+    public function addKey($table, $fields, $indexname = '', $type = 'INDEX', $len = 0, ?string $index_type = null)
     {
         // if no index name, we take that of the field(s)
         if (!$indexname) {
@@ -570,6 +571,16 @@ class Migration
             } else {
                 $indexname = $fields;
             }
+        }
+
+        // Use index_type if specified.
+        // MySQl support HASH and BTREE.
+        // MariaDB support HASH, BTREE and RTREE.
+        // BTREE is the implicit default for both.
+        if ($index_type && in_array($index_type, ['HASH', 'BTREE'])) {
+            $index_type = "USING $index_type ";
+        } else {
+            $index_type = '';
         }
 
         if (!isIndex($table, $indexname)) {
@@ -588,9 +599,9 @@ class Migration
             if ($type === 'FULLTEXT') {
                 $this->fulltexts[$table][] = "ADD $type `$indexname` ($fields)";
             } else if ($type === 'UNIQUE') {
-                $this->uniques[$table][] = "ADD $type `$indexname` ($fields)";
+                $this->uniques[$table][] = "ADD $type `$indexname` $index_type($fields)";
             } else {
-                $this->change[$table][] = "ADD $type `$indexname` ($fields)";
+                $this->change[$table][] = "ADD $type `$indexname` $index_type($fields)";
             }
         }
     }

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -87,6 +87,12 @@ class Ticket extends CommonITILObject
     const CHANGEPRIORITY   =  65536;
     const READNEWTICKET    = 262144;
 
+    #[Override]
+    public static function supportHelpdeskDisplayPreferences(): bool
+    {
+        return true;
+    }
+
     public function getForbiddenStandardMassiveAction()
     {
 
@@ -3171,7 +3177,7 @@ JAVASCRIPT;
             ],
         ];
 
-       // Filter search fields for helpdesk
+        // Filter search fields for helpdesk
         if (
             !Session::isCron() // no filter for cron
             && (Session::getCurrentInterface() != 'central')

--- a/templates/components/search/displaypreference_config.html.twig
+++ b/templates/components/search/displaypreference_config.html.twig
@@ -83,6 +83,7 @@
                             add_field_html: add_opt_btn,
                             templateResult: result_template_js,
                             mb: '',
+                            aria_label: __('Select an option to add'),
                         }) }}
 
                         {% if not is_global %}
@@ -148,6 +149,7 @@
                     'action': 'update_order',
                     'itemtype': config_forms.find(`input[name="itemtype"]`).val(),
                     'users_id': config_forms.find(`input[name="users_id"]`).val(),
+                    'interface': '{{ interface }}',
                     'opts': opts,
                 },
             }).then(() => {

--- a/templates/components/search/displaypreference_modal.html.twig
+++ b/templates/components/search/displaypreference_modal.html.twig
@@ -46,7 +46,7 @@
          </div>
          <div class="modal-body">
             <div class="ratio ratio-1x1">
-               <iframe src="{{ path('/front/displaypreference.form.php?itemtype=' ~ itemtype|escape('url')) }}"></iframe>
+               <iframe data-testid="display-preference-iframe" src="{{ path('/front/displaypreference.form.php?itemtype=' ~ itemtype|escape('url')) }}"></iframe>
             </div>
          </div>
       </div>

--- a/tests/cypress/e2e/search/display_preferences.cy.js
+++ b/tests/cypress/e2e/search/display_preferences.cy.js
@@ -31,6 +31,14 @@
  */
 
 describe('Display preferences', () => {
+    before(() => {
+        // Create at least one ticket as we will be displaying the ticket list
+        // to validate that the right columns are displayed
+        cy.createWithAPI('Ticket', {
+            'name': 'Open ticket',
+            'content': 'Open ticket',
+        });
+    });
 
     it('can add a column to the global view', () => {
         cy.login();

--- a/tests/cypress/e2e/search/display_preferences.cy.js
+++ b/tests/cypress/e2e/search/display_preferences.cy.js
@@ -1,0 +1,173 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+describe('Display preferences', () => {
+
+    it('can add a column to the global view', () => {
+        cy.login();
+        cy.changeProfile('Super-Admin', true);
+        cy.visit('/front/ticket.php');
+        openDisplayPreferences();
+
+        // Add a new column to the global view
+        goToTab('Global View');
+        addDisplayPeference('Pending reason');
+
+        // Refresh page
+        cy.reload();
+
+        // Make sure the column was added to the ticket list (still as admin)
+        cy.findByRole('columnheader', {'name': 'Pending reason'}).should('be.visible');
+
+        // Switch to helpdesk and make sure the column was not added
+        cy.changeProfile('Self-Service', true);
+        cy.visit('/front/ticket.php');
+        cy.findByRole('columnheader', {'name': 'Pending reason'}).should('not.exist');
+
+        // Go back to super admin
+        cy.changeProfile('Super-Admin', true);
+        cy.visit('/front/ticket.php');
+
+        // Validate that the column was added to the global view config
+        openDisplayPreferences();
+        goToTab('Global View');
+        validateThatDisplayPreferenceExist('Pending reason');
+
+        // Make sure the column is not in the helpdesk view config
+        goToTab('Helpdesk View');
+        validateThatDisplayPreferenceDoNotExist('Pending reason');
+
+        // Return to global view and remove the new column to avoid changing the state for the next test
+        goToTab('Global View');
+        deletePreference('Pending reason');
+    });
+
+    it('can add a column to the helpesk view', () => {
+        cy.login();
+        cy.changeProfile('Super-Admin', true);
+        cy.visit('/front/ticket.php');
+        openDisplayPreferences();
+
+        // Add a new column to the global view
+        goToTab('Helpdesk View');
+        addDisplayPeference('Pending reason');
+
+        // Refresh page
+        cy.reload();
+
+        // Make sure the column was not added to the central ticket list
+        cy.findByRole('columnheader', {'name': 'Pending reason'}).should('not.exist');
+
+        // Switch to helpdesk and make sure the column was added
+        cy.changeProfile('Self-Service', true);
+        cy.visit('/front/ticket.php');
+        cy.findByRole('columnheader', {'name': 'Pending reason'}).should('be.visible');
+
+        // Go back to super admin
+        cy.changeProfile('Super-Admin', true);
+        cy.visit('/front/ticket.php');
+
+        // Validate that the column was added to the helpdesk view
+        openDisplayPreferences();
+        goToTab('Helpdesk View');
+        validateThatDisplayPreferenceExist('Pending reason');
+
+        // Make sure the column is not in the global view
+        goToTab('Global View');
+        validateThatDisplayPreferenceDoNotExist('Pending reason');
+
+        // Return to helpdesk view and remove the new column to avoid changing the state for the next test
+        goToTab('Helpdesk View');
+        deletePreference('Pending reason');
+    });
+
+    function openDisplayPreferences() {
+        cy.findByRole('button', {'name': 'Select default items to show'}).click();
+        cy.findByRole('dialog').should('be.visible');
+        createIframeBodyAlias();
+    }
+
+    function createIframeBodyAlias() {
+        // Special code needed because the display preferences modal use an iframe
+        // see: https://www.cypress.io/blog/working-with-iframes-in-cypress
+        cy.findByTestId('display-preference-iframe')
+            .its('0.contentDocument')
+            .its('body')
+            .then(cy.wrap)
+            .as('iframeBody')
+        ;
+    }
+
+    function goToTab(name) {
+        cy.get('@iframeBody').find('#tabspanel-select').select(name);
+    }
+
+    function addDisplayPeference(name) {
+        cy.get('@iframeBody')
+            .getDropdownByLabelText('Select an option to add')
+            .click()
+        ;
+        cy.get('@iframeBody')
+            .findByRole('option', {'name': name})
+            .click()
+        ;
+        cy.get('@iframeBody')
+            .findByRole('button', {'name': 'Add'})
+            .click()
+        ;
+    }
+
+    function deletePreference(name) {
+        cy.get('@iframeBody')
+            .findByRole('list')
+            .findByRole('option', {'name': name}) // Should be listitem instead of option, our DOM is wrong
+            .findByRole('button', {'name': "Delete permanently"})
+            .click()
+        ;
+    }
+
+    function validateThatDisplayPreferenceExist(name) {
+        cy.get('@iframeBody')
+            .findByRole('list')
+            .findByRole('option', {'name': name}) // Should be listitem instead of option, our DOM is wrong
+            .should('be.visible')
+        ;
+    }
+
+    function validateThatDisplayPreferenceDoNotExist(name) {
+        cy.get('@iframeBody')
+            .findByRole('list')
+            .findByRole('option', {'name': name}) // Should be listitem instead of option, our DOM is wrong
+            .should('not.exist')
+        ;
+    }
+});

--- a/tests/cypress/e2e/self-service/home.cy.js
+++ b/tests/cypress/e2e/self-service/home.cy.js
@@ -93,16 +93,40 @@ describe('Helpdesk home page', () => {
         cy.findAllByText('Open ticket 1').should('be.visible');
         cy.findAllByText('Open ticket 2').should('be.visible');
         cy.findAllByText('Closed ticket 1').should('not.exist');
+        cy.findByRole('tabpanel').within(() => {
+            // Validate the default columns are displayed
+            cy.findAllByRole('columnheader').should('have.length', 6);
+            cy.findByRole('columnheader', {'name': 'ID'}).should('be.visible');
+            cy.findByRole('columnheader', {'name': 'Title'}).should('be.visible');
+            cy.findByRole('columnheader', {'name': 'Entity'}).should('be.visible');
+            cy.findByRole('columnheader', {'name': 'Status'}).should('be.visible');
+            cy.findByRole('columnheader', {'name': 'Last update'}).should('be.visible');
+            cy.findByRole('columnheader', {'name': 'Opening date'}).should('be.visible');
+        });
 
         // Got to closed tickets tab
         cy.findByRole('tab', {'name': 'Solved tickets'}).click();
         cy.findAllByText('Open ticket 1').should('not.be.visible');
         cy.findAllByText('Open ticket 2').should('not.be.visible');
         cy.findAllByText('Closed ticket 1').should('be.visible');
+        cy.findByRole('tabpanel').within(() => {
+            // Validate the default columns are displayed
+            cy.findAllByRole('columnheader').should('have.length', 6);
+            cy.findByRole('columnheader', {'name': 'ID'}).should('be.visible');
+            cy.findByRole('columnheader', {'name': 'Title'}).should('be.visible');
+            cy.findByRole('columnheader', {'name': 'Entity'}).should('be.visible');
+            cy.findByRole('columnheader', {'name': 'Status'}).should('be.visible');
+            cy.findByRole('columnheader', {'name': 'Last update'}).should('be.visible');
+            cy.findByRole('columnheader', {'name': 'Opening date'}).should('be.visible');
+        });
 
         // Got to Reminder Feed tab
         cy.findByRole('tab', {'name': 'Reminders'}).click();
         cy.findAllByRole('link', {'name': 'Public reminder 1'}).should('be.visible');
+
+        // Return to main tab, make it easier to re-run the test as the last tab
+        // is kept in the session
+        cy.findByRole('tab', {'name': 'Ongoing tickets'}).click();
 
         // RSS feeds are not tested as they are only displayed if a real feed
         // is configurated. Since the query to the feed is done on the backend,

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -77,7 +77,7 @@ Cypress.Commands.add('logout', () => {
 
 Cypress.Commands.add('getCsrfToken', () => {
     // Load any light page that have a form
-    return cy.request('/front/computer.php').its('body').then((body) => {
+    return cy.request('/front/preference.php').its('body').then((body) => {
         // Parse page
         const $html = Cypress.$(body);
         const csrf = $html.find('input[name=_glpi_csrf_token]').val();

--- a/tests/functional/Glpi/System/Diagnostic/DatabaseSchemaIntegrityChecker.php
+++ b/tests/functional/Glpi/System/Diagnostic/DatabaseSchemaIntegrityChecker.php
@@ -2207,4 +2207,42 @@ DIFF);
 
         return $db;
     }
+
+    public function testIndexTypesAreNormalized(): void
+    {
+        // Arrange: get the SQL of a table that uses index types
+        $sql = <<<SQL
+CREATE TABLE `glpi_displaypreferences` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  UNIQUE KEY `unicity` (`users_id`,`itemtype`,`num`,`interface`),
+  UNIQUE KEY `unicity2` (`users_id`,`itemtype`,`num`,`interface`) USING BTREE,
+  UNIQUE KEY `unicity3` (`users_id`,`itemtype`,`num`,`interface`) USING HASH,
+  UNIQUE KEY `unicity4` (`users_id`,`itemtype`,`num`,`interface`)
+) COLLATE=utf8mb4_unicode_ci DEFAULT CHARSET=utf8mb4 ENGINE=InnoDB ROW_FORMAT=DYNAMIC
+SQL;
+
+        // Act: normalize the SQL
+        // TODO: the sql should be normalized by an independent service to
+        // make testing easier and promote the single responsibility principle
+        $db = $this->geDbMock();
+        $integrity_checker = new \Glpi\System\Diagnostic\DatabaseSchemaIntegrityChecker(
+            $db,
+        );
+        $normalized_sql = $this->callPrivateMethod(
+            $integrity_checker,
+            'getNormalizedSql',
+            $sql
+        );
+
+        // Assert: the index types should be removed are normalized
+        $this->string($normalized_sql)->isEqualTo(<<<SQL
+CREATE TABLE `glpi_displaypreferences` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  UNIQUE KEY `unicity` (`users_id`,`itemtype`,`num`,`interface`),
+  UNIQUE KEY `unicity2` (`users_id`,`itemtype`,`num`,`interface`),
+  UNIQUE KEY `unicity3` (`users_id`,`itemtype`,`num`,`interface`),
+  UNIQUE KEY `unicity4` (`users_id`,`itemtype`,`num`,`interface`)
+) COLLATE=utf8mb4_unicode_ci DEFAULT CHARSET=utf8mb4 ENGINE=InnoDB ROW_FORMAT=DYNAMIC
+SQL);
+    }
 }

--- a/tests/functional/Glpi/System/Diagnostic/DatabaseSchemaIntegrityChecker.php
+++ b/tests/functional/Glpi/System/Diagnostic/DatabaseSchemaIntegrityChecker.php
@@ -94,7 +94,7 @@ CREATE TABLE `table_{$table_increment}` (
   KEY`is_deleted`(`is_deleted`),
   KEY `values` (
     `value`,
-    `steps`,    
+    `steps`,
     `max`
   )
 ) ENGINE=MyISAM


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

- Allow specific display preferences to be configured for the `helpdesk` interface.
- This view is only added for itemtypes that define a `supportHelpdeskDisplayPreferences()` method that return `true` (so only ticket for now).
- There are no restrictions on the criteria that can be selected, despite some ticket's search criteria being disabled for the helpdesk interface (see `Ticket::rawSearchOption()`).
   This is because:
   * It is hard to filter the selectable criteria depending on the interface because of bad session management in the code.
    We would need a proper service that accept a given interface and then return the available search options.
    Instead, we have a direct call to `Session::getCurrentInterface()` deeply nested into the stack trace, which mean passing a specific interface value would require adding new parameters to every method in the call stack until we reach `Ticket::rawSearchOption()`.
   * `Ticket::rawSearchOption()` do not actually remove search options for the helpdesk, it set them as `nosearch = true`.
   This mean they can't be used to search data but are actually valid to be used as display preferences.
   Thus, it is the administrator responsibility to not add columns that may contain sensitive informations in the helpdesk view.

## Screenshots 

![image](https://github.com/user-attachments/assets/10097705-1e44-4414-80b9-68ec244f3696)

