### PR TITLE
fix notcontains search option operator

### DIFF
--- a/phpunit/functional/SearchTest.php
+++ b/phpunit/functional/SearchTest.php
@@ -2355,6 +2355,26 @@ class SearchTest extends DbTestCase
                 'meta' => false,
                 'expected' => "AND (INET_ATON(`glpi_ipaddresses`.`name`) > INET_ATON('192.168.1.10'))",
             ],
+            [
+                'link' => ' AND ',
+                'nott' => 0,
+                'itemtype' => \Computer::class,
+                'ID' => 2, // Search ID 2 (ID field)
+                'searchtype' => 'notequals',
+                'val' => 42,
+                'meta' => false,
+                'expected' => "AND (`glpi_computers`.`id` <> 42)",
+            ],
+            [
+                'link' => ' AND ',
+                'nott' => 0,
+                'itemtype' => \Printer::class,
+                'ID' => 12, // Search ID 12 (last pages counter field)
+                'searchtype' => 'notcontains',
+                'val' => 42,
+                'meta' => false,
+                'expected' => "AND (`glpi_printers`.`last_pages_counter` <> 42)",
+            ],
         ];
     }
 


### PR DESCRIPTION
SQL requests are wrong when using a search criteria with the operator notcontains.

It seems there is no unit tests for this, then I added them. 

## To reproduce

Need to find a search option having datatype = number without min nor max boundaries. Printer current count of page is an easy to test candidate.

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

The variable ```$nott``` is used later in Search::addWhere() leading to a double negation. I de-factorized the code to fix the issue to stick in the same design as equals / notequals operators implementation.

## Screenshots (if appropriate):


