### PR TITLE
Ignore basic auth header in HLAPI

### DIFF
--- a/src/Glpi/Api/HL/Router.php
+++ b/src/Glpi/Api/HL/Router.php
@@ -707,6 +707,10 @@ EOT;
     private function handleAuth(Request $request): void
     {
         if ($request->hasHeader('Authorization')) {
+            // Ignore Basic auth because it is only supported when passing data in password flow to /token, not actual auth
+            if (str_starts_with($request->getHeaderLine('Authorization'), 'Basic ')) {
+                return;
+            }
             $this->startTemporarySession($request);
             if ($request->hasHeader('GLPI-Profile')) {
                 $requested_profile = $request->getHeaderLine('GLPI-Profile');


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

Authenticating with the password OAuth flow lets you specify the client ID and secret in the request body or the Authorization header. The HLAPI router was seeing the header and trying to authenticate even though the only legitimate Authorization header would be a Bearer type. Ignoring basic auth lets the data get passed to the `/token` endpoint properly.