### PR TITLE
Prevent streamed response of legacy scripts to send a status header

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -18,6 +18,7 @@ parameters:
     ignoreErrors:
         - '/Instantiated class (DB|DBSlave) not found/'
         - '/Instantiated class XHProfRuns_Default not found/'
+        - '/Instantiation of deprecated class Glpi\\Http\\HeaderlessStreamedResponse/'
         - { message: '/Variable \$this might not be defined/', paths: [ 'inc/includes.php' ] }
         - { message: '/Call to protected method setAjax\(\) of class Glpi\\Controller\\LegacyFileLoadController./', paths: [ 'ajax/*', 'front/*', 'inc/includes.php' ] }
         - { message: '/Access to protected property/', paths: [ 'front/dropdown.common.php', 'front/dropdown.common.form.php' ] }

--- a/src/Glpi/Controller/ApiController.php
+++ b/src/Glpi/Controller/ApiController.php
@@ -37,13 +37,13 @@ namespace Glpi\Controller;
 use Glpi\Api\HL\Controller\AbstractController as ApiAbstractController;
 use Glpi\Api\HL\Router;
 use Glpi\Application\ErrorHandler;
+use Glpi\Http\HeaderlessStreamedResponse;
 use Glpi\Http\JSONResponse;
 use Glpi\Http\Request;
 use Glpi\Http\Response;
 use Glpi\Security\Attribute\SecurityStrategy;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
-use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\Routing\Attribute\Route;
 
 final class ApiController extends AbstractController
@@ -60,7 +60,7 @@ final class ApiController extends AbstractController
     {
         $_SERVER['PATH_INFO'] = $request->get('request_parameters');
 
-        return new StreamedResponse($this->call(...));
+        return new HeaderlessStreamedResponse($this->call(...));
     }
 
     private function call(): void

--- a/src/Glpi/Controller/ApiRestController.php
+++ b/src/Glpi/Controller/ApiRestController.php
@@ -36,10 +36,10 @@ namespace Glpi\Controller;
 
 use Glpi\Api\APIRest;
 use Glpi\Application\ErrorHandler;
+use Glpi\Http\HeaderlessStreamedResponse;
 use Glpi\Security\Attribute\SecurityStrategy;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\Routing\Attribute\Route;
 
 final class ApiRestController extends AbstractController
@@ -56,7 +56,7 @@ final class ApiRestController extends AbstractController
     {
         $_SERVER['PATH_INFO'] = $request->get('request_parameters');
 
-        return new StreamedResponse(function () {
+        return new HeaderlessStreamedResponse(function () {
             // Ensure errors will not break API output.
             ErrorHandler::getInstance()->disableOutput();
 

--- a/src/Glpi/Controller/DropdownController.php
+++ b/src/Glpi/Controller/DropdownController.php
@@ -35,12 +35,12 @@
 namespace Glpi\Controller;
 
 use CommonDropdown;
+use Glpi\Http\HeaderlessStreamedResponse;
 use Html;
 use Search;
 use Symfony\Component\HttpFoundation\Exception\BadRequestException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\Routing\Attribute\Route;
 
@@ -59,7 +59,7 @@ final class DropdownController extends AbstractController
             throw new BadRequestException('The "class" attribute is mandatory for dropdown routes.');
         }
 
-        return new StreamedResponse(function () use ($class, $request) {
+        return new HeaderlessStreamedResponse(function () use ($class, $request) {
             $dropdown = new $class();
             $this->loadDropdown($request, $dropdown);
         });

--- a/src/Glpi/Controller/DropdownFormController.php
+++ b/src/Glpi/Controller/DropdownFormController.php
@@ -38,10 +38,10 @@ use CommonDevice;
 use CommonDropdown;
 use Html;
 use Glpi\Event;
+use Glpi\Http\HeaderlessStreamedResponse;
 use Symfony\Component\HttpFoundation\Exception\BadRequestException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\Routing\Attribute\Route;
@@ -62,7 +62,7 @@ final class DropdownFormController extends AbstractController
             throw new BadRequestException('The "class" attribute must be a valid dropdown class.');
         }
 
-        return new StreamedResponse(function () use ($class, $request) {
+        return new HeaderlessStreamedResponse(function () use ($class, $request) {
             $dropdown = new $class();
             $this->loadDropdownForm($request, $dropdown);
         });

--- a/src/Glpi/Controller/IndexController.php
+++ b/src/Glpi/Controller/IndexController.php
@@ -42,11 +42,11 @@ use Preference;
 use Dropdown;
 use CronTask;
 use Glpi\Application\View\TemplateRenderer;
+use Glpi\Http\HeaderlessStreamedResponse;
 use Glpi\Plugin\Hooks;
 use Glpi\Security\Attribute\SecurityStrategy;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\Routing\Attribute\Route;
 
 final class IndexController extends AbstractController
@@ -61,7 +61,7 @@ final class IndexController extends AbstractController
     #[SecurityStrategy('no_check')]
     public function __invoke(Request $request): Response
     {
-        return new StreamedResponse($this->call(...));
+        return new HeaderlessStreamedResponse($this->call(...));
     }
 
     private function call(): void

--- a/src/Glpi/Controller/LegacyFileLoadController.php
+++ b/src/Glpi/Controller/LegacyFileLoadController.php
@@ -35,8 +35,9 @@
 namespace Glpi\Controller;
 
 use Glpi\DependencyInjection\PublicService;
+use Glpi\Http\HeaderlessStreamedResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\StreamedResponse;
+use Symfony\Component\HttpFoundation\Response;
 
 final class LegacyFileLoadController implements PublicService
 {
@@ -44,7 +45,7 @@ final class LegacyFileLoadController implements PublicService
 
     protected ?Request $request = null;
 
-    public function __invoke(Request $request): StreamedResponse
+    public function __invoke(Request $request): Response
     {
         $this->request = $request;
 
@@ -58,7 +59,7 @@ final class LegacyFileLoadController implements PublicService
             require $target_file;
         };
 
-        return new StreamedResponse($callback->bindTo($this, self::class));
+        return new HeaderlessStreamedResponse($callback->bindTo($this, self::class));
     }
 
     protected function setAjax(): void

--- a/src/Glpi/Controller/StatusController.php
+++ b/src/Glpi/Controller/StatusController.php
@@ -37,12 +37,12 @@ namespace Glpi\Controller;
 use Session;
 use Glpi\Api\HL\Router;
 use Glpi\Application\ErrorHandler;
+use Glpi\Http\HeaderlessStreamedResponse;
 use Glpi\Http\Request;
 use Glpi\Http\Response;
 use Glpi\Security\Attribute\SecurityStrategy;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
-use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\Routing\Attribute\Route;
 
 final class StatusController extends AbstractController
@@ -54,7 +54,7 @@ final class StatusController extends AbstractController
     #[SecurityStrategy('no_check')]
     public function __invoke(SymfonyRequest $request): SymfonyResponse
     {
-        return new StreamedResponse($this->call(...));
+        return new HeaderlessStreamedResponse($this->call(...));
     }
 
     private function call(): void


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Fixes #17940

Due to a PHP bug, the usage of `http_response_code()` is not working as expected on PHP-FPM as long as a `header('HTTP/X.X $status $text')` function call as been done. Many of our legacy scripts are using the  `http_response_code()` function and the `Symfony` base respons is calling the `header('HTTP/X.X $status $text')` function.
See https://bugs.php.net/bug.php?id=81451 and https://stackoverflow.com/a/69213593

As a quick fix, I propose to redefine our own `StreamedResponse` class and prevent it to send any headers (we do not use this feature anyway). All usages of the `http_response_code()` in our code will still have to be removed, but with this temporary solution, we can do it step by step, and we give some more time to plugins developpers to do it on their side.
