### PR TITLE
Fix Catalan locale in Flatpickr component

### DIFF
--- a/.webpack.config.js
+++ b/.webpack.config.js
@@ -181,6 +181,14 @@ var filesToCopy = [
 ];
 
 let copyPatterns = [];
+
+// See https://github.com/glpi-project/glpi/issues/17745
+copyPatterns.push({
+    from:    path.resolve(__dirname, 'node_modules/flatpickr/dist/l10n/cat.js'),
+    to:      path.resolve(__dirname, libOutputPath + '/flatpickr/l10n/ca.js'),
+    toType:  'file',
+});
+
 for (let s = 0; s < filesToCopy.length; s++) {
     let specs = filesToCopy[s];
     let to = (specs.to || libOutputPath) + '/' + specs.package.replace(/^@/, ''); // remove leading @ in case of prefixed package


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Fixes #17745.

The Catalan locale file is not named according to the corresponding iso code in the `flatpickr` dist archive, and therefore the component translations are not loaded correctly by GLPI in this language.

Using a specific copy instruction to fix the file name fixes this issue.