### PR TITLE
fix: Add parameter to bypass right checking in Dropdown::getStandardDropdownItemTypes

### DIFF
--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -1130,7 +1130,7 @@ JAVASCRIPT;
      * @return array (group of dropdown) of array (itemtype => localized name)
      * @phpstan-return array<string, array<class-string<CommonDBTM>, string>>
      **/
-    public static function getStandardDropdownItemTypes()
+    public static function getStandardDropdownItemTypes(bool $check_rights = true)
     {
         if (self::$standard_itemtypes_options === null) {
             $optgroup = [
@@ -1337,7 +1337,7 @@ JAVASCRIPT;
             foreach ($optgroup as $label => &$dp) {
                 foreach ($dp as $key => &$val) {
                     if ($tmp = getItemForItemtype($key)) {
-                        if (!$tmp::canView()) {
+                        if ($check_rights && !$tmp::canView()) {
                             unset($optgroup[$label][$key]);
                         } else if ($val === null) {
                             $val = $key::getTypeName(Session::getPluralNumber());

--- a/src/Glpi/Form/DefaultFormsManager.php
+++ b/src/Glpi/Form/DefaultFormsManager.php
@@ -258,10 +258,8 @@ final class DefaultFormsManager
         return [
             'type' => QuestionTypeItemDropdown::class,
             'name' => _n('Category', 'Categories', 1),
-            'default_value' => ([
-                'itemtype' => ITILCategory::class,
-                'items_id' => 0,
-            ])
+            'default_value' => 0,
+            'extra_data' => json_encode(['itemtype' => ITILCategory::class]),
         ];
     }
 
@@ -270,10 +268,8 @@ final class DefaultFormsManager
         return [
             'type' => QuestionTypeItemDropdown::class,
             'name' => _n('Location', 'Locations', 1),
-            'default_value' => ([
-                'itemtype' => Location::class,
-                'items_id' => 0,
-            ])
+            'default_value' => 0,
+            'extra_data' => json_encode(['itemtype' => Location::class]),
         ];
     }
 

--- a/src/Glpi/Form/QuestionType/QuestionTypeItemDropdown.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeItemDropdown.php
@@ -52,7 +52,7 @@ final class QuestionTypeItemDropdown extends QuestionTypeItem
 
     public function getAllowedItemtypes(): array
     {
-        $dropdown_itemtypes = Dropdown::getStandardDropdownItemTypes();
+        $dropdown_itemtypes = Dropdown::getStandardDropdownItemTypes(check_rights: false);
 
         /**
          * It is necessary to replace the values with their corresponding keys


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

This PR adds a parameter to bypass right checking in the `Dropdown::getStandardDropdownItemTypes` function.
Without this parameter, we encounter issues with right verification at times when we cannot log in.
For example, when adding a default form during database installation, this form includes a question that checks if the itemtype is valid. It is impossible to log in in this case, but the itemtype is still valid.