### PR TITLE
Use illustrations for helpdesk forms instead of icons

### DIFF
--- a/install/migrations/update_10.0.x_to_11.0.0/form.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/form.php
@@ -55,7 +55,7 @@ if (!$DB->tableExists('glpi_forms_forms')) {
             `is_draft` tinyint NOT NULL DEFAULT '0',
             `name` varchar(255) NOT NULL DEFAULT '',
             `header` longtext,
-            `icon` varchar(255) NOT NULL DEFAULT '',
+            `illustration` varchar(255) NOT NULL DEFAULT '',
             `description` longtext,
             `date_mod` timestamp NULL DEFAULT NULL,
             `date_creation` timestamp NULL DEFAULT NULL,
@@ -231,7 +231,7 @@ if (GLPI_VERSION == "11.0.0-dev") {
     $migration->addKey("glpi_forms_answerssets", "entities_id");
     $migration->addField("glpi_forms_destinations_formdestinations", "config", "JSON NOT NULL COMMENT 'Extra configuration field(s) depending on the destination type'");
 
-    $migration->addField("glpi_forms_forms", "icon", "string");
+    $migration->addField("glpi_forms_forms", "illustration", "string");
     $migration->addField("glpi_forms_forms", "description", "text");
 }
 

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -9413,7 +9413,7 @@ CREATE TABLE `glpi_forms_forms` (
     `is_draft` tinyint NOT NULL DEFAULT '0',
     `name` varchar(255) NOT NULL DEFAULT '',
     `header` longtext,
-    `icon` varchar(255) NOT NULL DEFAULT '',
+    `illustration` varchar(255) NOT NULL DEFAULT '',
     `description` longtext,
     `date_mod` timestamp NULL DEFAULT NULL,
     `date_creation` timestamp NULL DEFAULT NULL,

--- a/phpunit/functional/Glpi/Form/DefaultFormsManagerTest.php
+++ b/phpunit/functional/Glpi/Form/DefaultFormsManagerTest.php
@@ -78,7 +78,7 @@ final class DefaultFormsManagerTest extends DbTestCase
     public function testIncidentFormProperties(): void
     {
         // Arrange: Get default incident form
-        $rows = (new Form())->find(['name' => 'Incident']);
+        $rows = (new Form())->find(['name' => 'Report an issue']);
 
         // Assert: there should be one single form with specific properties
         $this->assertCount(1, $rows);
@@ -89,14 +89,14 @@ final class DefaultFormsManagerTest extends DbTestCase
         $this->assertEquals(false, $row['is_deleted']);
         $this->assertEquals(false, $row['is_draft']);
         $this->assertEmpty($row['header']);
-        $this->assertNotEmpty($row['icon']);
+        $this->assertNotEmpty($row['illustration']);
         $this->assertNotEmpty($row['description']);
     }
 
     public function testRequestFormProperties(): void
     {
         // Arrange: Get default incident form
-        $rows = (new Form())->find(['name' => 'Request']);
+        $rows = (new Form())->find(['name' => 'Request a service']);
 
         // Assert: there should be one single form with specific properties
         $this->assertCount(1, $rows);
@@ -107,14 +107,14 @@ final class DefaultFormsManagerTest extends DbTestCase
         $this->assertEquals(false, $row['is_deleted']);
         $this->assertEquals(false, $row['is_draft']);
         $this->assertEmpty($row['header']);
-        $this->assertNotEmpty($row['icon']);
+        $this->assertNotEmpty($row['illustration']);
         $this->assertNotEmpty($row['description']);
     }
 
     public function testIncidentFormQuestions(): void
     {
         // Arrange: Get default incident form and fetch test data
-        $rows = (new Form())->find(['name' => 'Incident']);
+        $rows = (new Form())->find(['name' => 'Report an issue']);
         $row = current($rows);
         $form = Form::getById($row['id']);
 
@@ -163,7 +163,7 @@ final class DefaultFormsManagerTest extends DbTestCase
     public function testRequestFormQuestions(): void
     {
         // Arrange: Get default request form and fetch test data
-        $rows = (new Form())->find(['name' => 'Request']);
+        $rows = (new Form())->find(['name' => 'Request a service']);
         $row = current($rows);
         $form = Form::getById($row['id']);
 
@@ -212,7 +212,7 @@ final class DefaultFormsManagerTest extends DbTestCase
     public function testIncidentFormShouldBeAccessibleBySelfServiceUsers(): void
     {
         // Arrange: Get default incident form
-        $rows = (new Form())->find(['name' => 'Incident']);
+        $rows = (new Form())->find(['name' => 'Report an issue']);
         $row = current($rows);
         $form = Form::getById($row['id']);
 
@@ -232,7 +232,7 @@ final class DefaultFormsManagerTest extends DbTestCase
     public function testRequestFormShouldBeAccessibleBySelfServiceUsers(): void
     {
         // Arrange: Get default request form
-        $rows = (new Form())->find(['name' => 'Request']);
+        $rows = (new Form())->find(['name' => 'Request a service']);
         $row = current($rows);
         $form = Form::getById($row['id']);
 

--- a/src/Glpi/Form/DefaultFormsManager.php
+++ b/src/Glpi/Form/DefaultFormsManager.php
@@ -80,9 +80,9 @@ final class DefaultFormsManager
     {
         // Create form
         $form = $this->createForm(
-            name: __('Incident'),
-            description: __("Declare an incident"),
-            icon: 'ti ti-exclamation-circle',
+            name: __('Report an issue'),
+            description: __("Ask for support from our helpdesk team."),
+            illustration: 'report-issue.svg',
         );
 
         // Get first section
@@ -136,9 +136,9 @@ final class DefaultFormsManager
     private function createRequestForm(): void
     {
         $form = $this->createForm(
-            name: __('Request'),
-            description: __("Request a service"),
-            icon: 'ti ti-devices-up',
+            name: __('Request a service'),
+            description: __("Ask for a service to be provided by our team."),
+            illustration: 'request-service.svg',
         );
 
         // Get first section
@@ -192,14 +192,14 @@ final class DefaultFormsManager
     private function createForm(
         string $name,
         string $description,
-        string $icon,
+        string $illustration,
     ): Form {
         $form = new Form();
         $form_id = $form->add([
             // Specific properties
             'name'         => $name,
             'description'  => $description,
-            'icon'         => $icon,
+            'illustration' => $illustration,
             // Common properties
             'is_active'    => true,
             'is_recursive' => true,

--- a/src/Glpi/Form/SelfService/FormTile.php
+++ b/src/Glpi/Form/SelfService/FormTile.php
@@ -60,7 +60,7 @@ final class FormTile implements TileInterface
 
     public function getIllustration(): string
     {
-        return $this->illustration ?: $this->form->fields['icon'];
+        return $this->illustration ?: $this->form->fields['illustration'];
     }
 
     public function getLink(): string

--- a/src/Glpi/Form/SelfService/TilesManager.php
+++ b/src/Glpi/Form/SelfService/TilesManager.php
@@ -54,13 +54,6 @@ final class TilesManager
         if ($incident_form !== null) {
             $tiles[] = new FormTile(
                 form: $incident_form,
-                // Overriding the form's title and description to get a more
-                // verbose tile for the home page.
-                title: __("Report an issue"),
-                description: __("Ask for support from our helpdesk team."),
-                // Override illustration as forms are still using tabler icons
-                // instead of the new illustrations.
-                illustration: "report-issue.svg",
             );
         }
 
@@ -102,7 +95,7 @@ final class TilesManager
     {
         // TODO: form will be loaded using its id later once default tiles are
         // created during GLPI's installation
-        $rows = (new Form())->find(['name' => 'Incident']);
+        $rows = (new Form())->find(['name' => 'Report an issue']);
 
         // TODO: once tile are saved to database, deleting a form should also
         // delete the associated tile.

--- a/templates/components/helpdesk_forms/forms_list.html.twig
+++ b/templates/components/helpdesk_forms/forms_list.html.twig
@@ -35,22 +35,18 @@
     <div class="col-12 col-sm-6 col-md-4 d-flex">
         <a
             class="card mx-1 my-2 flex-grow-1"
-            href=" {{ "/Form/Render/" ~ form.fields.id }}"
+            href="{{ path("/Form/Render/" ~ form.fields.id) }}"
         >
-            <section
-                class="card-body"
-                aria-labelledby="form-{{ form.fields.id }}"
-            >
+            <section class="card-body" aria-labelledby="form-{{ form.fields.id }}">
                 <div class="d-flex">
-                    <i
-                        class="ti {{ form.fields.icon ?? "ti-list-details" }} fa-fw"
-                        style="font-size: 5rem; color: var(--glpi-mainmenu-bg)"
-                    > </i>
+                    {{ render_illustration(form.fields.illustration ?? 'report-issue.svg', 100) }}
                     <div class="ms-4">
-                        <h2 id="form-{{ form.fields.id }}" class="card-title">
+                        <h2 id="form-{{ form.fields.id }}" class="card-title mb-2">
                             {{ form.fields.name }}
                         </h2>
-                        <div class="text-secondary">{{ form.fields.description|safe_html }}</div>
+                        <div class="text-secondary">
+                            {{ form.fields.description|safe_html }}
+                        </div>
                     </div>
                 </div>
             </section>

--- a/templates/pages/admin/form/service_catalog_tab.html.twig
+++ b/templates/pages/admin/form/service_catalog_tab.html.twig
@@ -44,10 +44,10 @@
         action="{{ form.getFormURL() }}"
         data-submit-once
     >
-        {{ fields.dropdownWebIcons(
-            'icon',
-            form.fields.icon,
-            __('Icon'),
+        {{ fields.textField(
+            'illustration',
+            form.fields.illustration,
+            __('Illustration'),
             {
                 'is_horizontal': false,
                 'full_width' : true,

--- a/tests/cypress/e2e/form/service_catalog/service_catalog_tab.cy.js
+++ b/tests/cypress/e2e/form/service_catalog/service_catalog_tab.cy.js
@@ -44,11 +44,11 @@ describe('Service catalog tab', () => {
     it('can configure service catalog', () => {
         // Make sure the values we are about to apply are are not already set to
         // prevent false negative.
-        cy.getDropdownByLabelText("Icon").should('not.contain.text', 'ti-dog');
+        cy.findByRole("textbox", {'name': 'Illustration'}).should('not.contain.text', 'request-service.svg');
         cy.findByLabelText("Description").awaitTinyMCE().should('not.contain.text', 'My description');
 
         // Set values
-        cy.getDropdownByLabelText("Icon").selectDropdownValue('ti-dog');
+        cy.findByRole("textbox", {'name': 'Illustration'}).type('request-service.svg');
         cy.findByLabelText("Description").awaitTinyMCE().type('My description');
 
         // Save changes
@@ -56,7 +56,7 @@ describe('Service catalog tab', () => {
         cy.findByRole('alert').should('contain.text', 'Item successfully updated');
 
         // Validate values
-        cy.getDropdownByLabelText("Icon").should('contain.text', 'ti-dog');
+        cy.findByRole("textbox", {'name': 'Illustration'}).should('have.value', 'request-service.svg');
         cy.findByLabelText("Description").awaitTinyMCE().should('contain.text', 'My description');
     });
 });


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Use our new illustrations instead of tabler icons in the service catalog.

Note that config is a raw text input, we will have to work on some kind of illustration selector.
This will be done in another PR as I suspect it will be a difficult task to get it right.

## Screenshots 

Service catalog:

![image](https://github.com/user-attachments/assets/c7340e86-b37a-4d7c-a917-a17adbfad35d)

Config:

![image](https://github.com/user-attachments/assets/c65a86a8-9610-4ba8-a170-24df536bd905)


