### PR TITLE
fix(rule ticket): delete SLA date

### DIFF
--- a/phpunit/functional/RuleTest.php
+++ b/phpunit/functional/RuleTest.php
@@ -273,7 +273,7 @@ class RuleTest extends DbTestCase
         $this->assertSame(1, $rule->maxActionsCount());
 
         $rule = new \RuleTicket();
-        $this->assertSame(36, $rule->maxActionsCount());
+        $this->assertSame(40, $rule->maxActionsCount());
 
         $rule = new \RuleDictionnarySoftware();
         $this->assertSame(7, $rule->maxActionsCount());

--- a/src/RuleAction.php
+++ b/src/RuleAction.php
@@ -440,6 +440,7 @@ class RuleAction extends CommonDBChild
             'affectbyfqdn'        => __('Assign: equipment by name + domain'),
             'affectbymac'         => __('Assign: equipment by MAC address'),
             'compute'             => __('Recalculate'),
+            'delete'              => __('Delete'),
             'do_not_compute'      => __('Do not calculate'),
             'send'                => __('Send'),
             'add_validation'      => __('Send'),

--- a/src/RuleTicket.php
+++ b/src/RuleTicket.php
@@ -200,6 +200,12 @@ class RuleTicket extends Rule
                         }
                         break;
 
+                    case "delete":
+                        if ($action->fields["field"]) {
+                            $output[$action->fields["field"]] = null;
+                        }
+                        break;
+
                     case "assign":
                         $output[$action->fields["field"]] = $action->fields["value"];
 
@@ -914,6 +920,10 @@ class RuleTicket extends Rule
         $actions['slas_id_ttr']['type']                       = 'dropdown';
         $actions['slas_id_ttr']['condition']                  = ['glpi_slas.type' => SLM::TTR];
 
+        $actions['time_to_resolve']['name']                   = __('Time to resolve');
+        $actions['time_to_resolve']['type']                   = 'yesno';
+        $actions['time_to_resolve']['force_actions']          = ['delete'];
+
         $actions['slas_id_tto']['table']                      = 'glpi_slas';
         $actions['slas_id_tto']['field']                      = 'name';
         $actions['slas_id_tto']['name']                       = sprintf(
@@ -924,6 +934,10 @@ class RuleTicket extends Rule
         $actions['slas_id_tto']['linkfield']                  = 'slas_id_tto';
         $actions['slas_id_tto']['type']                       = 'dropdown';
         $actions['slas_id_tto']['condition']                  = ['glpi_slas.type' => SLM::TTO];
+
+        $actions['time_to_own']['name']                       = __('Time to own');
+        $actions['time_to_own']['type']                       = 'yesno';
+        $actions['time_to_own']['force_actions']              = ['delete'];
 
         $actions['olas_id_ttr']['table']                      = 'glpi_olas';
         $actions['olas_id_ttr']['field']                      = 'name';
@@ -936,6 +950,10 @@ class RuleTicket extends Rule
         $actions['olas_id_ttr']['type']                       = 'dropdown';
         $actions['olas_id_ttr']['condition']                  = ['glpi_olas.type' => SLM::TTR];
 
+        $actions['internal_time_to_resolve']['name']          = __('Internal time to resolve');
+        $actions['internal_time_to_resolve']['type']          = 'yesno';
+        $actions['internal_time_to_resolve']['force_actions'] = ['delete'];
+
         $actions['olas_id_tto']['table']                      = 'glpi_olas';
         $actions['olas_id_tto']['field']                      = 'name';
         $actions['olas_id_tto']['name']                       = sprintf(
@@ -946,6 +964,10 @@ class RuleTicket extends Rule
         $actions['olas_id_tto']['linkfield']                  = 'olas_id_tto';
         $actions['olas_id_tto']['type']                       = 'dropdown';
         $actions['olas_id_tto']['condition']                  = ['glpi_olas.type' => SLM::TTO];
+
+        $actions['internal_time_to_own']['name']              = __('Internal Time to own');
+        $actions['internal_time_to_own']['type']              = 'yesno';
+        $actions['internal_time_to_own']['force_actions']     = ['delete'];
 
         $actions['users_id_validate']['name']                 = sprintf(
             __('%1$s - %2$s'),


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !34685
- Here is a brief description of what this PR does
In the business rules for tickets, it is possible to remove the SLA by assigning an empty value, but this does not remove the calculated date on the ticket. Just like in the interface, removing the SLA doesn't automatically delete the corresponding date (a confirmation message appears). I propose adding an action to also delete this date when the SLA is removed.

## Screenshots (if appropriate):


