### PR TITLE
Mutualize translatable string

### DIFF
--- a/templates/components/datatable.html.twig
+++ b/templates/components/datatable.html.twig
@@ -308,7 +308,7 @@
 
     {% if not nopager %}
         <div class="ms-auto d-inline-flex align-items-center d-none d-md-block my-2">
-            {{ __('Entries to show: ') }}
+            {{ __('Entries to show:') }}
             {% include 'components/dropdown/limit.html.twig' %}
         </div>
     {% endif %}


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

There are 2 occurences of `Entries to show:` and 1 occurence of `Entries to show: `. The ending space could probably be removed to use the same translatable string.