### PR TITLE
Improve search performances

### DIFF
--- a/phpunit/GLPITestCase.php
+++ b/phpunit/GLPITestCase.php
@@ -441,6 +441,7 @@ class GLPITestCase extends TestCase
         // Statics values
         Log::$use_queue = false;
         CommonDBTM::clearSearchOptionCache();
+        \Glpi\Search\SearchOption::clearSearchOptionCache();
         AssetDefinitionManager::unsetInstance();
         Dropdown::resetItemtypesStaticCache();
     }

--- a/phpunit/functional/DbUtilsTest.php
+++ b/phpunit/functional/DbUtilsTest.php
@@ -1563,8 +1563,9 @@ class DbUtilsTest extends DbTestCase
     #[dataProvider('fixItemtypeCaseProvider')]
     public function testGetItemtypeWithFixedCase($itemtype, $expected)
     {
+        $name = 'glpi' . mt_rand();
         vfsStream::setup(
-            'glpi',
+            $name,
             null,
             [
                 'src' => [
@@ -1598,7 +1599,7 @@ class DbUtilsTest extends DbTestCase
             ]
         );
         $instance = new \DbUtils();
-        $result = $instance->fixItemtypeCase($itemtype, vfsStream::url('glpi'), [vfsStream::url('glpi/plugins')]);
+        $result = $instance->fixItemtypeCase($itemtype, vfsStream::url($name), [vfsStream::url("$name/plugins")]);
         $this->assertEquals($expected, $result);
     }
 }

--- a/src/DbUtils.php
+++ b/src/DbUtils.php
@@ -391,6 +391,7 @@ final class DbUtils
         } else if (preg_match('/^' . preg_quote(NS_PLUG, '/') . '(?<plugin>[a-z]+)\\\/i', $itemtype, $plugin_matches)) {
             $context = strtolower($plugin_matches['plugin']);
         }
+        $unique_key = crc32($context . $root_dir . implode(',', $plugins_dirs));
 
         $namespace      = $context === 'glpi-core' ? NS_GLPI : NS_PLUG . ucfirst($context) . '\\';
         $uses_namespace = preg_match('/^(' . preg_quote($namespace, '/') . ')/i', $itemtype);
@@ -403,27 +404,24 @@ final class DbUtils
         $replacements['\\'] = DIRECTORY_SEPARATOR;
         $expected_lc_path = str_ireplace(array_keys($replacements), array_values($replacements), strtolower($itemtype) . '.php');
 
-        $cache_key = sprintf('itemtype-case-mapping-%s', $context);
+        $cache_key = sprintf('itemtype-case-mapping-%s', $unique_key);
 
-        if (!array_key_exists($context, $mapping)) {
+        if (!array_key_exists($unique_key, $mapping)) {
             // Initialize mapping from persistent cache if it has not been done yet in current request
-            $mapping[$context] = $GLPI_CACHE->get($cache_key);
+            $mapping[$unique_key] = $GLPI_CACHE->get($cache_key);
         }
 
-        if ($mapping[$context] !== null && array_key_exists($expected_lc_path, $mapping[$context])) {
+        if ($mapping[$unique_key] !== null && array_key_exists($expected_lc_path, $mapping[$unique_key])) {
             // Return known value, if any
-            return ($context !== 'glpi-core' && $uses_namespace ? $namespace : '') . $mapping[$context][$expected_lc_path];
+            return ($context !== 'glpi-core' && $uses_namespace ? $namespace : '') . $mapping[$unique_key][$expected_lc_path];
         }
 
         if (
-            !defined('TU_USER')
-            && (
-                (
-                    $mapping[$context] !== null
+            (
+                $mapping[$unique_key] !== null
                 && !in_array(GLPI_ENVIRONMENT_TYPE, [GLPI::ENV_DEVELOPMENT, GLPI::ENV_TESTING])
-                )
-                || in_array($context, $already_scanned)
             )
+            || in_array($unique_key, $already_scanned)
         ) {
             // Do not scan class files if mapping was already cached, unless current env is development/testing.
             //
@@ -437,7 +435,7 @@ final class DbUtils
         }
 
         // Fetch filenames from "src" directory of context (GLPI core or given plugin).
-        $mapping[$context] = [];
+        $mapping[$unique_key] = [];
 
         $srcdirs = [];
         if ($context === 'glpi-core') {
@@ -463,7 +461,7 @@ final class DbUtils
                     // Store entry into mapping:
                     // - key is the lowercased filepath;
                     // - value is the classname with correct case.
-                    $mapping[$context][strtolower($relative_path)] = str_replace(
+                    $mapping[$unique_key][strtolower($relative_path)] = str_replace(
                         [DIRECTORY_SEPARATOR, '.php'],
                         ['\\',                ''],
                         $relative_path
@@ -472,12 +470,12 @@ final class DbUtils
             }
         }
 
-        $already_scanned[] = $context;
+        $already_scanned[] = $unique_key;
 
-        $GLPI_CACHE->set($cache_key, $mapping[$context]);
+        $GLPI_CACHE->set($cache_key, $mapping[$unique_key]);
 
-        return array_key_exists($expected_lc_path, $mapping[$context])
-            ? ($context !== 'glpi-core' && $uses_namespace ? $namespace : '') . $mapping[$context][$expected_lc_path]
+        return array_key_exists($expected_lc_path, $mapping[$unique_key])
+            ? ($context !== 'glpi-core' && $uses_namespace ? $namespace : '') . $mapping[$unique_key][$expected_lc_path]
             : $itemtype;
     }
 

--- a/src/DbUtils.php
+++ b/src/DbUtils.php
@@ -438,10 +438,16 @@ final class DbUtils
 
         // Fetch filenames from "src" directory of context (GLPI core or given plugin).
         $mapping[$context] = [];
-        foreach ($plugins_dirs as $plugins_dir) {
-            $srcdir = $context === 'glpi-core'
-                ? $root_dir . '/src'
-                : $plugins_dir . '/' . $context . '/src';
+
+        $srcdirs = [];
+        if ($context === 'glpi-core') {
+            $srcdirs[] = $root_dir . '/src';
+        } else {
+            foreach ($plugins_dirs as $plugins_dir) {
+                $srcdirs[] = $plugins_dir . '/' . $context . '/src';
+            }
+        }
+        foreach ($srcdirs as $srcdir) {
             if (is_dir($srcdir)) {
                 $files_iterator = new RecursiveIteratorIterator(
                     new RecursiveDirectoryIterator($srcdir),

--- a/src/DbUtils.php
+++ b/src/DbUtils.php
@@ -391,7 +391,17 @@ final class DbUtils
         } else if (preg_match('/^' . preg_quote(NS_PLUG, '/') . '(?<plugin>[a-z]+)\\\/i', $itemtype, $plugin_matches)) {
             $context = strtolower($plugin_matches['plugin']);
         }
-        $unique_key = crc32($context . $root_dir . implode(',', $plugins_dirs));
+
+        // Our cache key must take into account the requested directories
+        if ($context == 'glpi-core') {
+            // Only $root_dir will be used, we don't need to take plugins directories into account
+            // The "root=" prefix make sure we don't have any collision if $root_dir and $plugins_dirs are equals
+            $unique_key = crc32($context . 'root=' . $root_dir);
+        } else {
+            // Only $plugins_dirs will be used, we don't need to take the root dir
+            // The "plugins=" prefix make sure we don't have any collision if $root_dir and $plugins_dirs are equals
+            $unique_key = crc32($context . 'plugins=' . implode(',', $plugins_dirs));
+        }
 
         $namespace      = $context === 'glpi-core' ? NS_GLPI : NS_PLUG . ucfirst($context) . '\\';
         $uses_namespace = preg_match('/^(' . preg_quote($namespace, '/') . ')/i', $itemtype);

--- a/src/Glpi/Search/SearchOption.php
+++ b/src/Glpi/Search/SearchOption.php
@@ -55,6 +55,7 @@ final class SearchOption implements \ArrayAccess
      * @var array{id: int, name: string, field: string, table: string}
      */
     private array $search_opt_array;
+    private static $search_options_cache = [];
 
     public function __construct(array $search_opt_array)
     {
@@ -133,6 +134,10 @@ final class SearchOption implements \ArrayAccess
 
         $search = [];
 
+        $cache_key = $itemtype . '_' . $withplugins;
+        if (isset(self::$search_options_cache[$cache_key])) {
+            return self::$search_options_cache[$cache_key];
+        }
 
         $fn_append_options = static function ($new_options) use (&$search, $itemtype) {
             // Check duplicate keys between new options and existing options
@@ -373,6 +378,7 @@ final class SearchOption implements \ArrayAccess
             }
         }
 
+        self::$search_options_cache[$cache_key] = $search[$itemtype];
         return $search[$itemtype];
     }
 
@@ -775,5 +781,10 @@ final class SearchOption implements \ArrayAccess
         }
 
         return $generated_id;
+    }
+
+    public static function clearSearchOptionCache(): void
+    {
+        self::$search_options_cache = [];
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.

## Description

We are having github runner shortages so I am taking a (very quick) look on how we could reduce our tests run time.
This optimisation reduce the `SearchTest.php` execution from 18 minutes to 12 minutes on my dev env.

Note: this is a "bad" static cache that we would avoid in a perfect world.
However, it does the works for now and we already have similar caches for others search methods.

## Screenshots

Before:
![image](https://github.com/user-attachments/assets/fd864fed-7236-4dc8-a933-e10dce1bea3e)


After (edited after new commits):
![image](https://github.com/user-attachments/assets/3bb33b4a-967f-4dfe-be03-f85814ade07e)


