### PR TITLE
Replace some exit/die/responses to exception in AJAX controllers

### DIFF
--- a/ajax/asset/customfield.php
+++ b/ajax/asset/customfield.php
@@ -33,6 +33,7 @@
  */
 
 use Glpi\Asset\CustomFieldDefinition;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 /** @var \Glpi\Controller\LegacyFileLoadController $this */
 $this->setAjax();
@@ -53,8 +54,8 @@ if (isset($_POST['action'])) {
             echo $option->getFormInput();
         }
     } else {
-        http_response_code(400);
+        throw new BadRequestHttpException();
     }
 } else {
-    http_response_code(400);
+    throw new BadRequestHttpException();
 }

--- a/ajax/central.php
+++ b/ajax/central.php
@@ -34,6 +34,9 @@
  */
 
 /** @var \Glpi\Controller\LegacyFileLoadController $this */
+
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+
 $this->setAjax();
 
 // Send UTF8 Headers
@@ -46,8 +49,7 @@ if (
     (!isset($_REQUEST['params']['_idor_token']) || empty($_REQUEST['params']['_idor_token'])) || !isset($_REQUEST['itemtype'])
     || !isset($_REQUEST['widget'])
 ) {
-    http_response_code(400);
-    die();
+    throw new BadRequestHttpException();
 }
 
 $idor = $_REQUEST['params']['_idor_token'];
@@ -59,8 +61,7 @@ if (
         '_idor_token'  => $idor
     ] + $_REQUEST['params'])
 ) {
-    http_response_code(400);
-    die();
+    throw new BadRequestHttpException();
 }
 
 /** @var class-string<CommonGLPI> $itemtype */

--- a/ajax/commonitilsatisfaction.php
+++ b/ajax/commonitilsatisfaction.php
@@ -40,6 +40,7 @@ header("Content-Type: text/html; charset=UTF-8");
 Html::header_nocache();
 
 use Glpi\Application\View\TemplateRenderer;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
 $itemtype = $_POST['itemtype'];
 $ent = new Entity();
@@ -49,8 +50,7 @@ $config_suffix = $itemtype::getType() === 'Ticket' ? '' : ('_' . strtolower($ite
 if (isset($_POST['inquest_config' . $config_suffix], $_POST['entities_id'])) {
     if ($ent->getFromDB($_POST['entities_id'])) {
         if (!$ent->canViewItem()) {
-            http_response_code(403);
-            die();
+            throw new AccessDeniedHttpException();
         }
         $inquest_delay             = $ent->getfield('inquest_delay' . $config_suffix);
         $inquest_rate              = $ent->getfield('inquest_rate' . $config_suffix);

--- a/ajax/dashboard.php
+++ b/ajax/dashboard.php
@@ -35,6 +35,7 @@
 
 use Glpi\Application\ErrorHandler;
 use Glpi\Dashboard\Grid;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
 if (!isset($_REQUEST["action"])) {
     exit;
@@ -51,8 +52,7 @@ if (
     && (bool)$request_data['embed']
 ) {
     if (Grid::checkToken($request_data) === false) {
-        http_response_code(403);
-        exit;
+        throw new AccessDeniedHttpException();
     }
     $embed = true;
 } else {
@@ -64,8 +64,7 @@ $dashboard = new Glpi\Dashboard\Dashboard($_REQUEST['dashboard'] ?? "");
 switch ($_POST['action'] ?? null) {
     case 'save_new_dashboard':
         if (!Session::haveRight('dashboard', CREATE)) {
-            http_response_code(403);
-            exit();
+            throw new AccessDeniedHttpException();
         }
 
         echo $dashboard->saveNew(
@@ -76,8 +75,7 @@ switch ($_POST['action'] ?? null) {
 
     case 'save_items':
         if (!$dashboard->canUpdateCurrent()) {
-            http_response_code(403);
-            exit();
+            throw new AccessDeniedHttpException();
         }
 
         $dashboard->saveitems($_POST['items'] ?? []);
@@ -86,8 +84,7 @@ switch ($_POST['action'] ?? null) {
 
     case 'save_rights':
         if (!$dashboard->canUpdateCurrent()) {
-            http_response_code(403);
-            exit();
+            throw new AccessDeniedHttpException();
         }
 
         $dashboard->setPrivate($_POST['is_private'] != '0');
@@ -96,8 +93,7 @@ switch ($_POST['action'] ?? null) {
 
     case 'save_filter_data':
         if (!$dashboard->canViewCurrent()) {
-            http_response_code(403);
-            exit();
+            throw new AccessDeniedHttpException();
         }
 
         $dashboard->saveFilter($_POST['filters'] ?? []);
@@ -105,8 +101,7 @@ switch ($_POST['action'] ?? null) {
 
     case 'delete_dashboard':
         if (!$dashboard->canDeleteCurrent()) {
-            http_response_code(403);
-            exit();
+            throw new AccessDeniedHttpException();
         }
 
         echo $dashboard->delete(['key' => $_POST['dashboard']]);
@@ -119,8 +114,7 @@ switch ($_POST['action'] ?? null) {
 
     case 'clone_dashboard':
         if (!Session::haveRight('dashboard', CREATE) || !$dashboard->canViewCurrent()) {
-            http_response_code(403);
-            exit();
+            throw new AccessDeniedHttpException();
         }
 
         $new_dashboard = $dashboard->cloneCurrent();
@@ -129,8 +123,7 @@ switch ($_POST['action'] ?? null) {
 
     case 'disable_placeholders':
         if (!Session::haveRight(Config::$rightname, UPDATE)) {
-            http_response_code(403);
-            exit();
+            throw new AccessDeniedHttpException();
         }
         Config::setConfigurationValues('core', ['is_demo_dashboards' => 0]);
         exit();
@@ -139,8 +132,7 @@ switch ($_POST['action'] ?? null) {
 switch ($_GET['action'] ?? null) {
     case 'get_filter_data':
         if (!$dashboard->canViewCurrent()) {
-            http_response_code(403);
-            exit();
+            throw new AccessDeniedHttpException();
         }
 
         echo $dashboard->getFilter();
@@ -155,8 +147,7 @@ header("Content-Type: text/html; charset=UTF-8");
 switch ($_REQUEST['action']) {
     case 'add_new':
         if (!Session::haveRight('dashboard', CREATE)) {
-            http_response_code(403);
-            exit();
+            throw new AccessDeniedHttpException();
         }
 
         $grid->displayAddDashboardForm();
@@ -165,8 +156,7 @@ switch ($_REQUEST['action']) {
     case 'edit_rights':
         // FIXME This endpoint does not seems to be used.
         if (!Session::haveRight('dashboard', UPDATE)) {
-            http_response_code(403);
-            exit();
+            throw new AccessDeniedHttpException();
         }
 
         $grid->displayEditRightsForm();
@@ -175,8 +165,7 @@ switch ($_REQUEST['action']) {
     case 'display_edit_widget':
     case 'display_add_widget':
         if (!$dashboard->canUpdateCurrent()) {
-            http_response_code(403);
-            exit();
+            throw new AccessDeniedHttpException();
         }
 
         $grid->displayWidgetForm($_REQUEST);
@@ -184,8 +173,7 @@ switch ($_REQUEST['action']) {
 
     case 'display_embed_form':
         if (!Session::haveRight('dashboard', UPDATE)) {
-            http_response_code(403);
-            exit();
+            throw new AccessDeniedHttpException();
         }
 
         $grid->displayEmbedForm();
@@ -193,8 +181,7 @@ switch ($_REQUEST['action']) {
 
     case 'get_card':
         if (!$dashboard->canViewCurrent() && !$embed) {
-            http_response_code(403);
-            exit();
+            throw new AccessDeniedHttpException();
         }
 
         Session::writeClose();
@@ -205,8 +192,7 @@ switch ($_REQUEST['action']) {
 
     case 'get_cards':
         if (!$dashboard->canViewCurrent() && !$embed) {
-            http_response_code(403);
-            exit();
+            throw new AccessDeniedHttpException();
         }
 
         Session::writeClose();
@@ -230,24 +216,21 @@ switch ($_REQUEST['action']) {
 
     case 'display_add_filter':
         if (!$dashboard->canUpdateCurrent()) {
-            http_response_code(403);
-            exit();
+            throw new AccessDeniedHttpException();
         }
 
         $grid->displayFilterForm($_REQUEST);
         break;
     case 'get_dashboard_filters':
         if (!Session::haveRight('dashboard', READ)) {
-            http_response_code(403);
-            exit();
+            throw new AccessDeniedHttpException();
         }
 
         echo $grid->getFiltersSetHtml($_REQUEST['filters'] ?? []);
         break;
     case 'get_filter':
         if (!Session::haveRight('dashboard', READ)) {
-            http_response_code(403);
-            exit();
+            throw new AccessDeniedHttpException();
         }
 
         echo $grid->getFilterHtml($_REQUEST['filter_id']);
@@ -255,8 +238,7 @@ switch ($_REQUEST['action']) {
 
     case 'get_dashboard_items':
         if (!$dashboard->canViewCurrent() && !$embed) {
-            http_response_code(403);
-            exit();
+            throw new AccessDeniedHttpException();
         }
 
         echo $grid->getGridItemsHtml(true, $_REQUEST['embed'] ?? false);

--- a/ajax/debug.php
+++ b/ajax/debug.php
@@ -34,14 +34,16 @@
  */
 
 use Glpi\Application\ErrorHandler;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 Html::header_nocache();
 
 Session::checkLoginUser();
 
 if ($_SESSION['glpi_use_mode'] !== Session::DEBUG_MODE) {
-    http_response_code(403);
-    die();
+    throw new AccessDeniedHttpException();
 }
 
 \Glpi\Debug\Profiler::getInstance()->disable();
@@ -64,8 +66,7 @@ if (isset($_GET['ajax_id'])) {
             die();
         }
     }
-    http_response_code(404);
-    die();
+    throw new NotFoundHttpException();
 }
 
 if (isset($_GET['action'])) {
@@ -124,5 +125,4 @@ if (isset($_GET['action'])) {
     }
 }
 
-http_response_code(400);
-die();
+throw new BadRequestHttpException();

--- a/ajax/displaypreference.php
+++ b/ajax/displaypreference.php
@@ -33,6 +33,8 @@
  * ---------------------------------------------------------------------
  */
 
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+
 Html::header_nocache();
 
 Session::checkLoginUser();
@@ -53,9 +55,9 @@ if (isset($_POST["activate"])) {
     }
 } else if (isset($_POST['action']) && $_POST['action'] === 'update_order') {
     if (!isset($_POST['itemtype'], $_POST['users_id'], $_POST['opts'])) {
-        die(400);
+        throw new BadRequestHttpException('Missing input keys');
     }
     $setupdisplay->updateOrder($_POST['itemtype'], $_POST['users_id'], $_POST['opts']);
 } else {
-    die(400);
+    throw new BadRequestHttpException('No input data');
 }

--- a/ajax/displaypreference.php
+++ b/ajax/displaypreference.php
@@ -55,9 +55,9 @@ if (isset($_POST["activate"])) {
     }
 } else if (isset($_POST['action']) && $_POST['action'] === 'update_order') {
     if (!isset($_POST['itemtype'], $_POST['users_id'], $_POST['opts'])) {
-        throw new BadRequestHttpException('Missing input keys');
+        throw new BadRequestHttpException();
     }
     $setupdisplay->updateOrder($_POST['itemtype'], $_POST['users_id'], $_POST['opts']);
 } else {
-    throw new BadRequestHttpException('No input data');
+    throw new BadRequestHttpException();
 }

--- a/ajax/fuzzysearch.php
+++ b/ajax/fuzzysearch.php
@@ -34,7 +34,6 @@
  */
 
 /** @var \Glpi\Controller\LegacyFileLoadController $this */
-
 $this->setAjax();
 
 header("Content-Type: text/html; charset=UTF-8");

--- a/ajax/fuzzysearch.php
+++ b/ajax/fuzzysearch.php
@@ -34,6 +34,9 @@
  */
 
 /** @var \Glpi\Controller\LegacyFileLoadController $this */
+
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
 $this->setAjax();
 
 header("Content-Type: text/html; charset=UTF-8");
@@ -44,5 +47,5 @@ Session::checkLoginUser();
 try {
     echo json_encode(Html::getMenuFuzzySearchList(), JSON_THROW_ON_ERROR);
 } catch (JsonException $e) {
-    die(500);
+    throw new HttpException(500, 'Error encoding JSON.', $e);
 }

--- a/ajax/fuzzysearch.php
+++ b/ajax/fuzzysearch.php
@@ -35,8 +35,6 @@
 
 /** @var \Glpi\Controller\LegacyFileLoadController $this */
 
-use Symfony\Component\HttpKernel\Exception\HttpException;
-
 $this->setAjax();
 
 header("Content-Type: text/html; charset=UTF-8");
@@ -44,8 +42,4 @@ Html::header_nocache();
 
 Session::checkLoginUser();
 
-try {
-    echo json_encode(Html::getMenuFuzzySearchList(), JSON_THROW_ON_ERROR);
-} catch (JsonException $e) {
-    throw new HttpException(500, 'Error encoding JSON.', $e);
-}
+echo json_encode(Html::getMenuFuzzySearchList(), JSON_THROW_ON_ERROR);

--- a/ajax/getFormQuestionActorsDropdownValue.php
+++ b/ajax/getFormQuestionActorsDropdownValue.php
@@ -38,6 +38,7 @@ use Glpi\Form\Question;
 use Glpi\Form\QuestionType\QuestionTypeAssignee;
 use Glpi\Form\QuestionType\QuestionTypeObserver;
 use Glpi\Form\QuestionType\QuestionTypeRequester;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
 include(__DIR__ . '/getAbstractRightDropdownValue.php');
 
@@ -54,8 +55,7 @@ if (Session::getCurrentInterface() !== 'central') {
 
     // Check if the user can view at least one question
     if (array_reduce($questions, fn($acc, $question) => $acc || $question->canViewItem(), false) === false) {
-        http_response_code(403);
-        exit();
+        throw new AccessDeniedHttpException();
     }
 }
 

--- a/ajax/impact.php
+++ b/ajax/impact.php
@@ -276,6 +276,5 @@ switch ($_SERVER['REQUEST_METHOD']) {
         }
 
         header('Content-Type: application/javascript');
-        http_response_code(200);
         break;
 }

--- a/ajax/kanban.php
+++ b/ajax/kanban.php
@@ -37,6 +37,9 @@ use Glpi\Application\View\TemplateRenderer;
 use Glpi\Features\Kanban;
 use Glpi\Features\Teamwork;
 use Glpi\Http\Response;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 
 /** @var \Glpi\Controller\LegacyFileLoadController $this */
 $this->setAjax();
@@ -73,15 +76,13 @@ if ($item !== null) {
     if (in_array($action, ['refresh', 'get_switcher_dropdown', 'get_column', 'load_item_panel'])) {
         if (!$item->canView()) {
            // Missing rights
-            http_response_code(403);
-            return;
+            throw new AccessDeniedHttpException();
         }
     }
     if (in_array($action, ['update', 'load_item_panel', 'delete_teammember'])) {
         if (!$item->can($_REQUEST['items_id'], UPDATE)) {
             // Missing rights
-            http_response_code(403);
-            return;
+            throw new AccessDeniedHttpException();
         }
     }
     if (in_array($action, ['load_teammember_form', 'add_teammember'])) {
@@ -89,31 +90,27 @@ if ($item !== null) {
         $can_assign = method_exists($item, 'canAssign') ? $item->canAssign() : $item->can($_REQUEST['items_id'], UPDATE);
         if (!$can_assign) {
            // Missing rights
-            http_response_code(403);
-            return;
+            throw new AccessDeniedHttpException();
         }
     }
     if (in_array($action, ['bulk_add_item', 'add_item'])) {
         if (!$item->canCreate()) {
            // Missing rights
-            http_response_code(403);
-            return;
+            throw new AccessDeniedHttpException();
         }
     }
     if (in_array($action, ['delete_item'])) {
         $maybe_deleted = $item->maybeDeleted();
         if (($maybe_deleted && !$item::canDelete()) && (!$maybe_deleted && $item::canPurge())) {
            // Missing rights
-            http_response_code(403);
-            return;
+            throw new AccessDeniedHttpException();
         }
     }
     if ($action === 'restore_item') {
         $maybe_deleted = $item->maybeDeleted();
         if (($maybe_deleted && !$item::canDelete())) {
             // Missing rights
-            http_response_code(403);
-            return;
+            throw new AccessDeniedHttpException();
         }
     }
 }
@@ -140,29 +137,25 @@ if (($_POST['action'] ?? null) === 'update') {
 
     $item = getItemForItemtype($itemtype);
     if (!$item) {
-        http_response_code(400);
-        return;
+        throw new BadRequestHttpException();
     }
 
     $inputs = $_POST['inputs'];
 
     if (!$item->can(-1, CREATE, $inputs)) {
-        http_response_code(403);
-        return;
+        throw new AccessDeniedHttpException();
     }
 
     $result = $item->add($inputs);
     if (!$result) {
-        http_response_code(400);
-        return;
+        throw new BadRequestHttpException();
     }
 } else if (($_POST['action'] ?? null) === 'bulk_add_item') {
     $checkParams(['inputs']);
 
     $item = getItemForItemtype($itemtype);
     if (!$item) {
-        http_response_code(400);
-        return;
+        throw new BadRequestHttpException('No item for this type');
     }
 
     $inputs = $_POST['inputs'];
@@ -240,8 +233,7 @@ if (($_POST['action'] ?? null) === 'update') {
     $column_itemtype = getItemtypeForForeignKeyField($column_field);
     if (!$column_itemtype::canCreate() || !$column_itemtype::canView()) {
        // Missing rights
-        http_response_code(403);
-        return;
+        throw new AccessDeniedHttpException();
     }
     $params = $_POST['params'] ?? [];
     $column_item = new $column_itemtype();
@@ -253,7 +245,6 @@ if (($_POST['action'] ?? null) === 'update') {
         // Do nothing with the state unless it isn't saved yet. Could be that no columns are shown or an error occured.
         // If the state is supposed to be cleared, it should come through as a clear_column_state request.
         if (Item_Kanban::hasStateForItem($_POST['itemtype'], $_POST['items_id'])) {
-            http_response_code(304);
             return;
         }
         Item_Kanban::saveStateForItem($_POST['itemtype'], $_POST['items_id'], []);
@@ -272,7 +263,10 @@ if (($_POST['action'] ?? null) === 'update') {
 } else if ($_REQUEST['action'] === 'clear_column_state') {
     $checkParams(['items_id']);
     $result = Item_Kanban::clearStateForItem($_REQUEST['itemtype'], $_REQUEST['items_id']);
-    http_response_code($result ? 200 : 500);
+    if (!$result) {
+        throw new HttpException(500);
+    }
+
     return;
 } else if ($_REQUEST['action'] === 'list_columns') {
     $checkParams(['column_field']);
@@ -297,8 +291,7 @@ if (($_POST['action'] ?? null) === 'update') {
             'purged' => $item->getFromDB($_POST['items_id']) === false,
         ]);
     } else {
-        http_response_code(403);
-        return;
+        throw new AccessDeniedHttpException();
     }
 } else if (($_POST['action'] ?? null) === 'restore_item') {
     $checkParams(['items_id']);
@@ -308,8 +301,7 @@ if (($_POST['action'] ?? null) === 'update') {
     if (($maybe_deleted && $item->canDeleteItem())) {
         $item->restore(['id' => $_POST['items_id']]);
     } else {
-        http_response_code(403);
-        return;
+        throw new AccessDeniedHttpException();
     }
 } else if (($_POST['action'] ?? null) === 'add_teammember') {
     $checkParams(['itemtype_teammember', 'items_id_teammember']);
@@ -329,17 +321,14 @@ if (($_POST['action'] ?? null) === 'update') {
             'team' => Toolbox::hasTrait($item, Teamwork::class) ? $item->getTeam() : []
         ]);
     } else {
-        http_response_code(400);
-        return;
+        throw new BadRequestHttpException();
     }
 } else if (($_REQUEST['action'] ?? null) === 'load_teammember_form') {
     if (isset($itemtype, $item) && Toolbox::hasTrait($_REQUEST['itemtype'], Teamwork::class)) {
         echo $item::getTeamMemberForm($item, $itemtype);
     } else {
-        http_response_code(400);
-        return;
+        throw new BadRequestHttpException();
     }
 } else {
-    http_response_code(400);
-    return;
+    throw new BadRequestHttpException();
 }

--- a/ajax/kanban.php
+++ b/ajax/kanban.php
@@ -155,7 +155,7 @@ if (($_POST['action'] ?? null) === 'update') {
 
     $item = getItemForItemtype($itemtype);
     if (!$item) {
-        throw new BadRequestHttpException('No item for this type');
+        throw new BadRequestHttpException();
     }
 
     $inputs = $_POST['inputs'];

--- a/ajax/pendingreason.php
+++ b/ajax/pendingreason.php
@@ -34,21 +34,22 @@
  */
 
 // Direct access to file
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+
 header("Content-Type: application/json; charset=UTF-8");
 
 Session::checkLoginUser();
 
 // Tech only
 if (Session::getCurrentInterface() !== "central") {
-    http_response_code(403);
-    die;
+    throw new AccessDeniedHttpException();
 }
 
 // Read parameter and load pending reason
 $pending_reason = PendingReason::getById($_REQUEST['pendingreasons_id'] ?? null);
 if (!$pending_reason) {
-    http_response_code(400);
-    die;
+    throw new BadRequestHttpException('Expected pending reason id');
 }
 
 echo json_encode([

--- a/ajax/pendingreason.php
+++ b/ajax/pendingreason.php
@@ -49,7 +49,7 @@ if (Session::getCurrentInterface() !== "central") {
 // Read parameter and load pending reason
 $pending_reason = PendingReason::getById($_REQUEST['pendingreasons_id'] ?? null);
 if (!$pending_reason) {
-    throw new BadRequestHttpException('Expected pending reason id');
+    throw new BadRequestHttpException();
 }
 
 echo json_encode([

--- a/ajax/rack.php
+++ b/ajax/rack.php
@@ -34,6 +34,9 @@
  */
 
 /** @var \Glpi\Controller\LegacyFileLoadController $this */
+
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+
 $this->setAjax();
 
 header("Content-Type: text/html; charset=UTF-8");
@@ -42,8 +45,7 @@ Html::header_nocache();
 Session::checkLoginUser();
 
 if (!Session::haveRight('datacenter', UPDATE)) {
-    http_response_code(403);
-    die;
+    throw new AccessDeniedHttpException();
 }
 if (!isset($_REQUEST['action'])) {
     exit();

--- a/ajax/rack.php
+++ b/ajax/rack.php
@@ -36,6 +36,7 @@
 /** @var \Glpi\Controller\LegacyFileLoadController $this */
 
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 $this->setAjax();
 
@@ -48,7 +49,7 @@ if (!Session::haveRight('datacenter', UPDATE)) {
     throw new AccessDeniedHttpException();
 }
 if (!isset($_REQUEST['action'])) {
-    exit();
+    throw new BadRequestHttpException();
 }
 
 $answer = [];

--- a/ajax/search.php
+++ b/ajax/search.php
@@ -55,7 +55,7 @@ if (!isset($_REQUEST['action'])) {
 switch ($_REQUEST['action']) {
     case 'display_results':
         if (!isset($_REQUEST['itemtype'])) {
-            throw new BadRequestHttpException('Missing item type in input');
+            throw new BadRequestHttpException();
         }
 
         /** @var class-string<CommonDBTM> $itemtype */

--- a/ajax/search.php
+++ b/ajax/search.php
@@ -34,6 +34,8 @@
  */
 
 use Glpi\Search\Input\QueryBuilder;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 // Direct access to file
 
@@ -53,15 +55,13 @@ if (!isset($_REQUEST['action'])) {
 switch ($_REQUEST['action']) {
     case 'display_results':
         if (!isset($_REQUEST['itemtype'])) {
-            http_response_code(400);
-            die;
+            throw new BadRequestHttpException('Missing item type in input');
         }
 
         /** @var class-string<CommonDBTM> $itemtype */
         $itemtype = $_REQUEST['itemtype'];
         if (!$itemtype::canView()) {
-            http_response_code(403);
-            die;
+            throw new AccessDeniedHttpException();
         }
 
         // Handle display params

--- a/ajax/timeline.php
+++ b/ajax/timeline.php
@@ -34,6 +34,7 @@
  */
 
 use Glpi\Application\View\TemplateRenderer;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
 Session::checkLoginUser();
 
@@ -50,8 +51,7 @@ if (($_POST['action'] ?? null) === 'change_task_state') {
     /** @var CommonITILTask $task */
     $task = new $taskClass();
     if (!$task->getFromDB((int) $_POST['tasks_id']) || !$task->canUpdateItem()) {
-        http_response_code(403);
-        die();
+        throw new AccessDeniedHttpException();
     }
     if (!in_array($task->fields['state'], [0, Planning::INFO])) {
         $new_state = ($task->fields['state'] == Planning::DONE)

--- a/ajax/treebrowse.php
+++ b/ajax/treebrowse.php
@@ -33,6 +33,8 @@
  * ---------------------------------------------------------------------
  */
 
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+
 header("Content-Type: text/html; charset=UTF-8");
 Html::header_nocache();
 
@@ -76,5 +78,5 @@ switch ($_REQUEST['action']) {
         Search::showList($itemtype, $params);
         return;
 }
-http_response_code(400);
-return;
+
+throw new BadRequestHttpException();

--- a/ajax/webhook.php
+++ b/ajax/webhook.php
@@ -33,6 +33,11 @@
  * ---------------------------------------------------------------------
  */
 
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
 header("Content-Type: text/html; charset=UTF-8");
 Html::header_nocache();
 
@@ -48,7 +53,7 @@ switch ($action) {
             header("Content-Type: application/json; charset=UTF-8");
             echo json_encode($response);
         } else {
-            die(404);
+            throw new NotFoundHttpException();
         }
         die();
     case 'get_events_from_itemtype':
@@ -137,8 +142,7 @@ switch ($action) {
         $webhook = new Webhook();
         if ($webhook->getFromDB($webhook_id)) {
             if (!$webhook->canUpdateItem()) {
-                http_response_code(403);
-                die();
+                throw new AccessDeniedHttpException();
             }
             if ($_POST['use_default_payload'] === 'true') {
                 $webhook->update([
@@ -153,16 +157,13 @@ switch ($action) {
                 ]);
             }
         } else {
-            http_response_code(404);
-            die();
+            throw new NotFoundHttpException();
         }
         die();
     case 'resend':
         $result = QueuedWebhook::sendById($_POST['id']);
-        if ($result) {
-            http_response_code(200);
-        } else {
-            http_response_code(400);
+        if (!$result) {
+            throw new BadRequestHttpException();
         }
         die();
     case 'get_monaco_suggestions':
@@ -170,8 +171,9 @@ switch ($action) {
         try {
             echo json_encode(Webhook::getMonacoSuggestions($_GET['itemtype']), JSON_THROW_ON_ERROR);
         } catch (JsonException $e) {
-            http_response_code(500);
+            throw new HttpException(500, 'Error encoding JSON.', $e);
         }
         die();
 }
-http_response_code(400);
+
+throw new BadRequestHttpException();

--- a/ajax/webhook.php
+++ b/ajax/webhook.php
@@ -169,6 +169,7 @@ switch ($action) {
     case 'get_monaco_suggestions':
         header("Content-Type: application/json; charset=UTF-8");
         echo json_encode(Webhook::getMonacoSuggestions($_GET['itemtype']), JSON_THROW_ON_ERROR);
+        return;
 }
 
 throw new BadRequestHttpException();

--- a/ajax/webhook.php
+++ b/ajax/webhook.php
@@ -168,12 +168,7 @@ switch ($action) {
         die();
     case 'get_monaco_suggestions':
         header("Content-Type: application/json; charset=UTF-8");
-        try {
-            echo json_encode(Webhook::getMonacoSuggestions($_GET['itemtype']), JSON_THROW_ON_ERROR);
-        } catch (JsonException $e) {
-            throw new HttpException(500, 'Error encoding JSON.', $e);
-        }
-        die();
+        echo json_encode(Webhook::getMonacoSuggestions($_GET['itemtype']), JSON_THROW_ON_ERROR);
 }
 
 throw new BadRequestHttpException();


### PR DESCRIPTION
Goals, in all `ajax/` files:

* Avoid using `http_response_code()` , and replace with proper exceptions or other kind of features
* Avoid using `exit/die` 