### PR TITLE
fix(document): display stored value

### DIFF
--- a/ajax/dropdownRubDocument.php
+++ b/ajax/dropdownRubDocument.php
@@ -81,7 +81,8 @@ if (isset($_POST["rubdoc"])) {
             'width'     => '50%',
             'entity'    => intval($_POST['entity']),
             'rand'      => intval($_POST['rand']),
-            'condition' => ['glpi_documents.documentcategories_id' => (int)$_POST["rubdoc"]]
+            'condition' => ['glpi_documents.documentcategories_id' => (int)$_POST["rubdoc"]],
+            'value'     => $_POST['value'] ?? -1,
         ]
     );
 }

--- a/ajax/dropdownRubDocument.php
+++ b/ajax/dropdownRubDocument.php
@@ -82,7 +82,7 @@ if (isset($_POST["rubdoc"])) {
             'entity'    => intval($_POST['entity']),
             'rand'      => intval($_POST['rand']),
             'condition' => ['glpi_documents.documentcategories_id' => (int)$_POST["rubdoc"]],
-            'value'     => $_POST['value'] ?? -1,
+            'value'     => (int)($_POST['value'] ?? -1),
         ]
     );
 }

--- a/src/Document.php
+++ b/src/Document.php
@@ -1677,6 +1677,12 @@ class Document extends CommonDBTM
             }
         }
 
+        if (isset($p['value']) && ($p['value'] > 0)) {
+            $document = new Document();
+            $document->getFromDB($p['value']);
+            $p['rubdoc'] = $document->fields['documentcategories_id'];
+        }
+
         $subwhere = [
             'glpi_documents.is_deleted'   => 0,
         ] + getEntitiesRestrictCriteria('glpi_documents', '', $p['entity'], true);
@@ -1711,7 +1717,8 @@ class Document extends CommonDBTM
         $out  = Dropdown::showFromArray('_rubdoc', $values, ['width'               => '30%',
             'rand'                => $rand,
             'display'             => false,
-            'display_emptychoice' => true
+            'display_emptychoice' => true,
+            'value'               => $p['rubdoc'] ?? 0,
         ]);
         $field_id = Html::cleanId("dropdown__rubdoc$rand");
 
@@ -1732,7 +1739,8 @@ class Document extends CommonDBTM
         $out .= "<span id='show_" . $p['name'] . "$rand'>";
         $out .= "</span>\n";
 
-        $params['rubdoc'] = 0;
+        $params['rubdoc'] = $p['rubdoc'] ?? 0;
+        $params['value'] = $p['value'] ?? 0;
         $out .= Ajax::updateItem(
             "show_" . $p['name'] . $rand,
             $CFG_GLPI["root_doc"] . "/ajax/dropdownRubDocument.php",


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !34700
- Here is a brief description of what this PR does
The document dropdown failed to load with an initial value (either the default or a previously saved value). This issue occurs with the Fields plugin, which allows adding a document-type field that leverages the core's dropdown functionality.

## Screenshots (if appropriate):


