### PR TITLE
fix: do not log last_collect_date

### DIFF
--- a/src/MailCollector.php
+++ b/src/MailCollector.php
@@ -726,7 +726,7 @@ class MailCollector extends CommonDBTM
                 $this->update([
                     'id' => $this->getID(),
                     'last_collect_date' => $_SESSION["glpi_currenttime"],
-                ]);
+                ], false);
 
                 return;
             }
@@ -989,7 +989,7 @@ class MailCollector extends CommonDBTM
                 $this->update([
                     'id' => $this->getID(),
                     'last_collect_date' => $_SESSION["glpi_currenttime"],
-                ]);
+                ], false);
 
               //TRANS: %1$d, %2$d, %3$d, %4$d %5$d and %6$d are number of messages
                 $msg = sprintf(


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

In a normal production instance with email collection every minute (yes it happens), updating the "last_collect_date" field makes the collectors' history grow, while I don't think it's a good idea to keep the update history of this field.

![image](https://github.com/user-attachments/assets/628ba271-43fa-46d1-bcfe-879981fc092e)
