### PR TITLE
Avoid using sleep() in tests

### DIFF
--- a/phpunit/GLPITestCase.php
+++ b/phpunit/GLPITestCase.php
@@ -444,4 +444,18 @@ class GLPITestCase extends TestCase
         AssetDefinitionManager::unsetInstance();
         Dropdown::resetItemtypesStaticCache();
     }
+
+    /**
+     * Apply a DateTime modification using the given string.
+     * Examples:
+     * - $this->modifyCurrentTime('+1 second');
+     * - $this->modifyCurrentTime('+5 hours');
+     * - $this->modifyCurrentTime('-2 years');
+     */
+    protected function modifyCurrentTime(string $modification): void
+    {
+        $date = new DateTime(Session::getCurrentTime());
+        $date->modify($modification);
+        $_SESSION['glpi_currenttime'] = $date->format("Y-m-d H:i:s");
+    }
 }

--- a/phpunit/functional/TicketTest.php
+++ b/phpunit/functional/TicketTest.php
@@ -3059,7 +3059,7 @@ class TicketTest extends DbTestCase
         $this->assertEquals($expected, $ticket->canTakeIntoAccount());
 
         // Check that computation of "takeintoaccount_delay_stat" can be prevented
-        sleep(1); // be sure to wait at least one second before updating
+        $this->modifyCurrentTime('+1 second'); // be sure to wait at least one second before updating
         $this->assertTrue(
             $ticket->update(
                 [
@@ -3386,7 +3386,7 @@ class TicketTest extends DbTestCase
             // Login with tech to be sure to be have rights to take into account
             $this->login('tech', 'tech');
 
-            sleep(1); // be sure to wait at least one second before updating
+            $this->modifyCurrentTime('+1 second'); // be sure to wait at least one second before updating
             $this->assertTrue(
                 $ticket->update(
                     $input + [


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.

## Description

Add a new helper method to avoid wasting time with `sleep()` during our tests.
