### PR TITLE
Remove useless deduplication of web profiler config

### DIFF
--- a/dependency_injection/services.php
+++ b/dependency_injection/services.php
@@ -71,15 +71,4 @@ return static function (ContainerConfigurator $container): void {
      * @see \Symfony\Component\HttpKernel\DependencyInjection\LoggerPass
      */
     $services->set('logger', LegacyGlobalLogger::class);
-
-    // Development-only
-    if ($container->env() === 'development') {
-        $container->extension('web_profiler', [
-            'toolbar' => true,
-            'intercept_redirects' => true,
-        ]);
-        $container->extension('framework', [
-            'profiler' => ['only_exceptions' => false],
-        ]);
-    }
 };


### PR DESCRIPTION
Duplicating config has no impact anyway, but it's to avoid written redundancy