### PR TITLE
refactor(forms): Remove redundant getKey() methods and use the default one

### DIFF
--- a/phpunit/functional/Glpi/Form/Destination/CommonITILField/AssociatedItemsFieldTest.php
+++ b/phpunit/functional/Glpi/Form/Destination/CommonITILField/AssociatedItemsFieldTest.php
@@ -295,8 +295,6 @@ final class AssociatedItemsFieldTest extends DbTestCase
         array $answers,
         array $expected_associated_items
     ): void {
-        $field = new AssociatedItemsField();
-
         // Insert config
         $destinations = $form->getDestinations();
         $this->assertCount(1, $destinations);
@@ -304,7 +302,7 @@ final class AssociatedItemsFieldTest extends DbTestCase
         $this->updateItem(
             $destination::getType(),
             $destination->getId(),
-            ['config' => [$field->getKey() => $config->jsonSerialize()]],
+            ['config' => [AssociatedItemsField::getKey() => $config->jsonSerialize()]],
             ["config"],
         );
 

--- a/phpunit/functional/Glpi/Form/Destination/CommonITILField/ContentFieldTest.php
+++ b/phpunit/functional/Glpi/Form/Destination/CommonITILField/ContentFieldTest.php
@@ -122,8 +122,6 @@ final class ContentFieldTest extends DbTestCase
         ?SimpleValueConfig $config,
         array $answers,
     ): Ticket {
-        $content_field = new ContentField();
-
         // Insert config
         if ($config !== null) {
             $destinations = $form->getDestinations();
@@ -134,8 +132,8 @@ final class ContentFieldTest extends DbTestCase
                 $destination->getId(),
                 [
                     'config' => [
-                        $content_field->getKey() => $config->jsonSerialize(),
-                        $content_field->getAutoConfigKey() => false,
+                        ContentField::getKey() => $config->jsonSerialize(),
+                        ContentField::getAutoConfigKey() => false,
                     ]
                 ],
                 ["config"],

--- a/phpunit/functional/Glpi/Form/Destination/CommonITILField/EntityFieldTest.php
+++ b/phpunit/functional/Glpi/Form/Destination/CommonITILField/EntityFieldTest.php
@@ -38,6 +38,7 @@ namespace tests\units\Glpi\Form\Destination\CommonITILField;
 use DbTestCase;
 use Entity;
 use Glpi\Form\AnswersHandler\AnswersHandler;
+use Glpi\Form\Destination\CommonITILField\EntityField;
 use Glpi\Form\Destination\CommonITILField\EntityFieldConfig;
 use Glpi\Form\Destination\CommonITILField\EntityFieldStrategy;
 use Glpi\Form\Destination\FormDestinationTicket;
@@ -234,7 +235,7 @@ final class EntityFieldTest extends DbTestCase
         $this->updateItem(
             $destination::getType(),
             $destination->getId(),
-            ['config' => ['entity' => $config->jsonSerialize()]],
+            ['config' => [EntityField::getKey() => $config->jsonSerialize()]],
             ["config"],
         );
 

--- a/phpunit/functional/Glpi/Form/Destination/CommonITILField/ITILCategoryFieldTest.php
+++ b/phpunit/functional/Glpi/Form/Destination/CommonITILField/ITILCategoryFieldTest.php
@@ -37,6 +37,7 @@ namespace tests\units\Glpi\Form\Destination\CommonITILField;
 
 use DbTestCase;
 use Glpi\Form\AnswersHandler\AnswersHandler;
+use Glpi\Form\Destination\CommonITILField\ITILCategoryField;
 use Glpi\Form\Destination\CommonITILField\ITILCategoryFieldConfig;
 use Glpi\Form\Destination\CommonITILField\ITILCategoryFieldStrategy;
 use Glpi\Form\Destination\FormDestinationTicket;
@@ -255,7 +256,7 @@ final class ITILCategoryFieldTest extends DbTestCase
         $this->updateItem(
             $destination::getType(),
             $destination->getId(),
-            ['config' => ['itilcategory' => $config->jsonSerialize()]],
+            ['config' => [ITILCategoryField::getKey() => $config->jsonSerialize()]],
             ["config"],
         );
 

--- a/phpunit/functional/Glpi/Form/Destination/CommonITILField/ITILFollowupFieldTest.php
+++ b/phpunit/functional/Glpi/Form/Destination/CommonITILField/ITILFollowupFieldTest.php
@@ -94,8 +94,6 @@ final class ITILFollowupFieldTest extends DbTestCase
         ITILFollowupFieldConfig $config,
         array $expected_itilfollowups
     ): void {
-        $field = new ITILFollowupField();
-
         // Insert config
         $destinations = $form->getDestinations();
         $this->assertCount(1, $destinations);
@@ -103,7 +101,7 @@ final class ITILFollowupFieldTest extends DbTestCase
         $this->updateItem(
             $destination::getType(),
             $destination->getId(),
-            ['config' => [$field->getKey() => $config->jsonSerialize()]],
+            ['config' => [ITILFollowupField::getKey() => $config->jsonSerialize()]],
             ["config"],
         );
 

--- a/phpunit/functional/Glpi/Form/Destination/CommonITILField/ITILTaskFieldTest.php
+++ b/phpunit/functional/Glpi/Form/Destination/CommonITILField/ITILTaskFieldTest.php
@@ -92,8 +92,6 @@ final class ITILTaskFieldTest extends DbTestCase
         ITILTaskFieldConfig $config,
         array $expected_itiltasks
     ): void {
-        $field = new ITILTaskField();
-
         // Insert config
         $destinations = $form->getDestinations();
         $this->assertCount(1, $destinations);
@@ -101,7 +99,7 @@ final class ITILTaskFieldTest extends DbTestCase
         $this->updateItem(
             $destination::getType(),
             $destination->getId(),
-            ['config' => [$field->getKey() => $config->jsonSerialize()]],
+            ['config' => [ITILTaskField::getKey() => $config->jsonSerialize()]],
             ["config"],
         );
 

--- a/phpunit/functional/Glpi/Form/Destination/CommonITILField/LocationFieldTest.php
+++ b/phpunit/functional/Glpi/Form/Destination/CommonITILField/LocationFieldTest.php
@@ -37,6 +37,7 @@ namespace tests\units\Glpi\Form\Destination\CommonITILField;
 
 use DbTestCase;
 use Glpi\Form\AnswersHandler\AnswersHandler;
+use Glpi\Form\Destination\CommonITILField\LocationField;
 use Glpi\Form\Destination\CommonITILField\LocationFieldConfig;
 use Glpi\Form\Destination\CommonITILField\LocationFieldStrategy;
 use Glpi\Form\Destination\FormDestinationTicket;
@@ -258,7 +259,7 @@ final class LocationFieldTest extends DbTestCase
         $this->updateItem(
             $destination::getType(),
             $destination->getId(),
-            ['config' => ['location' => $config->jsonSerialize()]],
+            ['config' => [LocationField::getKey() => $config->jsonSerialize()]],
             ["config"],
         );
 

--- a/phpunit/functional/Glpi/Form/Destination/CommonITILField/OLATTOFieldTest.php
+++ b/phpunit/functional/Glpi/Form/Destination/CommonITILField/OLATTOFieldTest.php
@@ -37,6 +37,7 @@ namespace tests\units\Glpi\Form\Destination\CommonITILField;
 
 use DbTestCase;
 use Glpi\Form\AnswersHandler\AnswersHandler;
+use Glpi\Form\Destination\CommonITILField\OLATTOField;
 use Glpi\Form\Destination\CommonITILField\SLMFieldConfig;
 use Glpi\Form\Destination\CommonITILField\SLMFieldStrategy;
 use Glpi\Form\Destination\FormDestinationTicket;
@@ -165,7 +166,7 @@ final class OLATTOFieldTest extends DbTestCase
         $this->updateItem(
             $destination::getType(),
             $destination->getId(),
-            ['config' => ['ola_tto' => $config->jsonSerialize()]],
+            ['config' => [OLATTOField::getKey() => $config->jsonSerialize()]],
             ["config"],
         );
 

--- a/phpunit/functional/Glpi/Form/Destination/CommonITILField/OLATTRFieldTest.php
+++ b/phpunit/functional/Glpi/Form/Destination/CommonITILField/OLATTRFieldTest.php
@@ -37,6 +37,7 @@ namespace tests\units\Glpi\Form\Destination\CommonITILField;
 
 use DbTestCase;
 use Glpi\Form\AnswersHandler\AnswersHandler;
+use Glpi\Form\Destination\CommonITILField\OLATTRField;
 use Glpi\Form\Destination\CommonITILField\SLMFieldConfig;
 use Glpi\Form\Destination\CommonITILField\SLMFieldStrategy;
 use Glpi\Form\Destination\FormDestinationTicket;
@@ -165,7 +166,7 @@ final class OLATTRFieldTest extends DbTestCase
         $this->updateItem(
             $destination::getType(),
             $destination->getId(),
-            ['config' => ['ola_ttr' => $config->jsonSerialize()]],
+            ['config' => [OLATTRField::getKey() => $config->jsonSerialize()]],
             ["config"],
         );
 

--- a/phpunit/functional/Glpi/Form/Destination/CommonITILField/RequestSourceFieldTest.php
+++ b/phpunit/functional/Glpi/Form/Destination/CommonITILField/RequestSourceFieldTest.php
@@ -37,6 +37,7 @@ namespace tests\units\Glpi\Form\Destination\CommonITILField;
 
 use DbTestCase;
 use Glpi\Form\AnswersHandler\AnswersHandler;
+use Glpi\Form\Destination\CommonITILField\RequestSourceField;
 use Glpi\Form\Destination\CommonITILField\RequestSourceFieldConfig;
 use Glpi\Form\Destination\CommonITILField\RequestSourceFieldStrategy;
 use Glpi\Form\Destination\FormDestinationTicket;
@@ -118,7 +119,7 @@ final class RequestSourceFieldTest extends DbTestCase
         $this->updateItem(
             $destination::getType(),
             $destination->getId(),
-            ['config' => ['request_source' => $config->jsonSerialize()]],
+            ['config' => [RequestSourceField::getKey() => $config->jsonSerialize()]],
             ["config"],
         );
 

--- a/phpunit/functional/Glpi/Form/Destination/CommonITILField/RequestTypeFieldTest.php
+++ b/phpunit/functional/Glpi/Form/Destination/CommonITILField/RequestTypeFieldTest.php
@@ -207,8 +207,6 @@ final class RequestTypeFieldTest extends DbTestCase
         array $answers,
         int $expected_request_type,
     ): void {
-        $field = new RequestTypeField();
-
         // Insert config
         $destinations = $form->getDestinations();
         $this->assertCount(1, $destinations);
@@ -216,7 +214,7 @@ final class RequestTypeFieldTest extends DbTestCase
         $this->updateItem(
             $destination::getType(),
             $destination->getId(),
-            ['config' => [$field->getKey() => $config->jsonSerialize()]],
+            ['config' => [RequestTypeField::getKey() => $config->jsonSerialize()]],
             ["config"],
         );
 

--- a/phpunit/functional/Glpi/Form/Destination/CommonITILField/SLATTOFieldTest.php
+++ b/phpunit/functional/Glpi/Form/Destination/CommonITILField/SLATTOFieldTest.php
@@ -37,6 +37,7 @@ namespace tests\units\Glpi\Form\Destination\CommonITILField;
 
 use DbTestCase;
 use Glpi\Form\AnswersHandler\AnswersHandler;
+use Glpi\Form\Destination\CommonITILField\SLATTOField;
 use Glpi\Form\Destination\CommonITILField\SLMFieldConfig;
 use Glpi\Form\Destination\CommonITILField\SLMFieldStrategy;
 use Glpi\Form\Destination\FormDestinationTicket;
@@ -165,7 +166,7 @@ final class SLATTOFieldTest extends DbTestCase
         $this->updateItem(
             $destination::getType(),
             $destination->getId(),
-            ['config' => ['sla_tto' => $config->jsonSerialize()]],
+            ['config' => [SLATTOField::getKey() => $config->jsonSerialize()]],
             ["config"],
         );
 

--- a/phpunit/functional/Glpi/Form/Destination/CommonITILField/SLATTRFieldTest.php
+++ b/phpunit/functional/Glpi/Form/Destination/CommonITILField/SLATTRFieldTest.php
@@ -37,6 +37,7 @@ namespace tests\units\Glpi\Form\Destination\CommonITILField;
 
 use DbTestCase;
 use Glpi\Form\AnswersHandler\AnswersHandler;
+use Glpi\Form\Destination\CommonITILField\SLATTRField;
 use Glpi\Form\Destination\CommonITILField\SLMFieldConfig;
 use Glpi\Form\Destination\CommonITILField\SLMFieldStrategy;
 use Glpi\Form\Destination\FormDestinationTicket;
@@ -165,7 +166,7 @@ final class SLATTRFieldTest extends DbTestCase
         $this->updateItem(
             $destination::getType(),
             $destination->getId(),
-            ['config' => ['sla_ttr' => $config->jsonSerialize()]],
+            ['config' => [SLATTRField::getKey() => $config->jsonSerialize()]],
             ["config"],
         );
 

--- a/phpunit/functional/Glpi/Form/Destination/CommonITILField/TemplateFieldTest.php
+++ b/phpunit/functional/Glpi/Form/Destination/CommonITILField/TemplateFieldTest.php
@@ -37,6 +37,7 @@ namespace tests\units\Glpi\Form\Destination\CommonITILField;
 
 use DbTestCase;
 use Glpi\Form\AnswersHandler\AnswersHandler;
+use Glpi\Form\Destination\CommonITILField\TemplateField;
 use Glpi\Form\Destination\CommonITILField\TemplateFieldConfig;
 use Glpi\Form\Destination\CommonITILField\TemplateFieldStrategy;
 use Glpi\Form\Destination\FormDestinationTicket;
@@ -161,6 +162,7 @@ final class TemplateFieldTest extends DbTestCase
         TemplateFieldConfig $config,
         int $expected_tickettemplates_id
     ): Ticket {
+
         // Insert config
         $destinations = $form->getDestinations();
         $this->assertCount(1, $destinations);
@@ -168,7 +170,7 @@ final class TemplateFieldTest extends DbTestCase
         $this->updateItem(
             $destination::getType(),
             $destination->getId(),
-            ['config' => ['template' => $config->jsonSerialize()]],
+            ['config' => [TemplateField::getKey() => $config->jsonSerialize()]],
             ["config"],
         );
 

--- a/phpunit/functional/Glpi/Form/Destination/CommonITILField/TitleFieldTest.php
+++ b/phpunit/functional/Glpi/Form/Destination/CommonITILField/TitleFieldTest.php
@@ -72,8 +72,6 @@ final class TitleFieldTest extends DbTestCase
         Form $form,
         ?SimpleValueConfig $config,
     ): void {
-        $title_field = new TitleField();
-
         // Insert config
         if ($config !== null) {
             $destinations = $form->getDestinations();
@@ -82,7 +80,7 @@ final class TitleFieldTest extends DbTestCase
             $this->updateItem(
                 $destination::getType(),
                 $destination->getId(),
-                ['config' => [$title_field->getKey() => $config->jsonSerialize()]],
+                ['config' => [TitleField::getKey() => $config->jsonSerialize()]],
                 ["config"],
             );
         }

--- a/phpunit/functional/Glpi/Form/Destination/CommonITILField/UrgencyFieldTest.php
+++ b/phpunit/functional/Glpi/Form/Destination/CommonITILField/UrgencyFieldTest.php
@@ -254,8 +254,6 @@ final class UrgencyFieldTest extends DbTestCase
         Form $form,
         UrgencyFieldConfig $config,
     ): void {
-        $field = new UrgencyField();
-
         // Insert config
         $destinations = $form->getDestinations();
         $this->assertCount(1, $destinations);
@@ -263,7 +261,7 @@ final class UrgencyFieldTest extends DbTestCase
         $this->updateItem(
             $destination::getType(),
             $destination->getId(),
-            ['config' => [$field->getKey() => $config->jsonSerialize()]],
+            ['config' => [UrgencyField::getKey() => $config->jsonSerialize()]],
             ["config"],
         );
     }

--- a/phpunit/functional/Glpi/Form/Destination/CommonITILField/ValidationFieldTest.php
+++ b/phpunit/functional/Glpi/Form/Destination/CommonITILField/ValidationFieldTest.php
@@ -264,8 +264,6 @@ final class ValidationFieldTest extends DbTestCase
         array $expected_validations,
         array $keys_to_be_considered
     ): void {
-        $field = new ValidationField();
-
         // Insert config
         $destinations = $form->getDestinations();
         $this->assertCount(1, $destinations);
@@ -273,7 +271,7 @@ final class ValidationFieldTest extends DbTestCase
         $this->updateItem(
             $destination::getType(),
             $destination->getId(),
-            ['config' => [$field->getKey() => $config->jsonSerialize()]],
+            ['config' => [ValidationField::getKey() => $config->jsonSerialize()]],
             ["config"],
         );
 

--- a/src/Glpi/Form/Destination/AbstractConfigField.php
+++ b/src/Glpi/Form/Destination/AbstractConfigField.php
@@ -44,7 +44,7 @@ use Toolbox;
 abstract class AbstractConfigField implements ConfigFieldInterface
 {
     #[Override]
-    public static function getKey(): string
+    final public static function getKey(): string
     {
         return Toolbox::slugify(static::class);
     }

--- a/src/Glpi/Form/Destination/CommonITILField/AssociatedItemsField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/AssociatedItemsField.php
@@ -49,12 +49,6 @@ use Ticket;
 class AssociatedItemsField extends AbstractConfigField
 {
     #[Override]
-    public static function getKey(): string
-    {
-        return 'associated_items';
-    }
-
-    #[Override]
     public function getLabel(): string
     {
         return __("Associated items");

--- a/src/Glpi/Form/Destination/CommonITILField/EntityField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/EntityField.php
@@ -48,12 +48,6 @@ use Override;
 class EntityField extends AbstractConfigField
 {
     #[Override]
-    public static function getKey(): string
-    {
-        return 'entity';
-    }
-
-    #[Override]
     public function getLabel(): string
     {
         return _n("Entity", "Entities", 1);

--- a/src/Glpi/Form/Destination/CommonITILField/ITILCategoryField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ITILCategoryField.php
@@ -50,12 +50,6 @@ use Override;
 class ITILCategoryField extends AbstractConfigField
 {
     #[Override]
-    public static function getKey(): string
-    {
-        return 'itilcategory';
-    }
-
-    #[Override]
     public function getLabel(): string
     {
         return _n('ITIL category', 'ITIL categories', 1);

--- a/src/Glpi/Form/Destination/CommonITILField/LocationField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/LocationField.php
@@ -48,12 +48,6 @@ use Override;
 class LocationField extends AbstractConfigField
 {
     #[Override]
-    public static function getKey(): string
-    {
-        return 'location';
-    }
-
-    #[Override]
     public function getLabel(): string
     {
         return _n('Location', 'Locations', 1);

--- a/src/Glpi/Form/Destination/CommonITILField/OLATTOField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/OLATTOField.php
@@ -42,12 +42,6 @@ use SLM;
 final class OLATTOField extends SLMField
 {
     #[Override]
-    public static function getKey(): string
-    {
-        return 'ola_tto';
-    }
-
-    #[Override]
     public function getLabel(): string
     {
         return __("OLA TTO");

--- a/src/Glpi/Form/Destination/CommonITILField/OLATTRField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/OLATTRField.php
@@ -42,12 +42,6 @@ use SLM;
 final class OLATTRField extends SLMField
 {
     #[Override]
-    public static function getKey(): string
-    {
-        return 'ola_ttr';
-    }
-
-    #[Override]
     public function getLabel(): string
     {
         return __("OLA TTR");

--- a/src/Glpi/Form/Destination/CommonITILField/RequestSourceField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/RequestSourceField.php
@@ -47,12 +47,6 @@ use RequestType;
 class RequestSourceField extends AbstractConfigField
 {
     #[Override]
-    public static function getKey(): string
-    {
-        return 'request_source';
-    }
-
-    #[Override]
     public function getLabel(): string
     {
         return RequestType::getTypeName(1);

--- a/src/Glpi/Form/Destination/CommonITILField/SLATTOField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/SLATTOField.php
@@ -42,12 +42,6 @@ use SLM;
 final class SLATTOField extends SLMField
 {
     #[Override]
-    public static function getKey(): string
-    {
-        return 'sla_tto';
-    }
-
-    #[Override]
     public function getLabel(): string
     {
         return __("SLA TTO");

--- a/src/Glpi/Form/Destination/CommonITILField/SLATTRField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/SLATTRField.php
@@ -42,12 +42,6 @@ use SLM;
 final class SLATTRField extends SLMField
 {
     #[Override]
-    public static function getKey(): string
-    {
-        return 'sla_ttr';
-    }
-
-    #[Override]
     public function getLabel(): string
     {
         return __("SLA TTR");

--- a/src/Glpi/Form/Destination/CommonITILField/TemplateField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/TemplateField.php
@@ -58,12 +58,6 @@ class TemplateField extends AbstractConfigField
     }
 
     #[Override]
-    public static function getKey(): string
-    {
-        return 'template';
-    }
-
-    #[Override]
     public function getLabel(): string
     {
         return _n('Template', 'Templates', 1);


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description
Remove specific `getKey` methods from form destination fields classes.
Use parent method to determine key.