### PR TITLE
Helpdesk: remove breadcrumbs and use reduced container

### DIFF
--- a/css/helpdesk_home.scss
+++ b/css/helpdesk_home.scss
@@ -30,12 +30,6 @@
  * ---------------------------------------------------------------------
  */
 
-// We do not display the navigation menu and the breadcrumbs for this page.
-#navbar-menu,
-.secondary-bar {
-    display: none !important;
-}
-
 // Remove padding as we have a custom illustration as a background that should
 // be displayed in full width.
 .page-body {
@@ -49,15 +43,6 @@ header {
     &.sticky-lg-top {
         // Same as removing 'sticky-lg-top' class.
         position: relative !important;
-    }
-
-    // Limit the width on the header to the same width as the content.
-    .header-container {
-        // Same as adding 'container-xl' class.
-        max-width: 1320px;
-
-        --tblr-gutter-x: calc(var(--tblr-page-padding) * 2) !important;
-        --tblr-gutter-y: 0 !important;
     }
 
     // Disable "right slide" effect on the user info dropdown as it is not on the

--- a/templates/layout/parts/page_header.html.twig
+++ b/templates/layout/parts/page_header.html.twig
@@ -35,6 +35,7 @@
 
 {% set is_vertical = get_page_layout() == 'vertical' %}
 {% set is_horizontal = not is_vertical %}
+{% set is_helpdesk = get_current_interface() == 'helpdesk' %}
 
 <body class="{{ user_pref('fold_menu') and is_vertical ? 'navbar-collapsed' : '' }} {{ is_vertical ? 'vertical-layout' : 'horizontal-layout' }} {{ is_debug_active ? 'debug-active' : '' }}">
    {% if call('DBConnection::isDbAvailable') and constant('SKIP_UPDATES') is defined and not call('Update::isDbUpToDate') %}
@@ -92,7 +93,8 @@
       {% endif %}
 
       <header class="navbar d-print-none sticky-lg-top shadow-sm {{ is_vertical ? 'navbar-light navbar-expand-md' : 'navbar-dark navbar-expand-xl topbar' }}">
-         <div class="header-container container-fluid flex-xl-nowrap pe-xl-0">
+         {# On the helpdesk interface, the container will be displayed with a reduced width #}
+         <div class="header-container container-fluid flex-xl-nowrap pe-xl-0 {{ is_helpdesk ? 'container-xl' : '' }}">
             {% if is_vertical %}
                {{ include('layout/parts/breadcrumbs.html.twig') }}
 
@@ -128,7 +130,8 @@
          </div>
       </header>
 
-      {% if is_horizontal %}
+      {# Breadcrumbs are not needed on the helpdesk as we have only a few pages #}
+      {% if is_horizontal and not is_helpdesk %}
       <div class="navbar navbar-expand-md navbar-light secondary-bar sticky-md-top shadow-sm">
          <div class="container-fluid justify-content-start">
             {{ include('layout/parts/breadcrumbs.html.twig') }}


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.

## Description

For the helpdesk interface:
* Remove breadcrumbs
* Reduce the menu's container size

We don't need breadcrumbs on the helpdesk as we have 5 pages that are all available using the top menu.
Reducing the menu's container size allow it to match the container used for the content (which is what most applications do when possible).

## Screenshots

Before:
![image](https://github.com/user-attachments/assets/b782588f-ec48-45ff-9f81-c538be8a8145)

After:
![image](https://github.com/user-attachments/assets/5612fb80-9099-4820-8379-64d35fceb490)
