### PR TITLE
Block saving webhook responses

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -2336,12 +2336,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Application/ErrorHandler.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Offset \'GLPI_AJAX_DASHBOARD\'\\|\'GLPI_ALLOW_IFRAME…\'\\|\'GLPI_CACHE_DIR\'\\|\'GLPI_CALDAV_IMPORT…\'\\|\'GLPI_CENTRAL…\'\\|\'GLPI_CONFIG_DIR\'\\|\'GLPI_CRON_DIR\'\\|\'GLPI_DISABLE_ONLY…\'\\|\'GLPI_DOC_DIR\'\\|\'GLPI_DOCUMENTATION…\'\\|\'GLPI_ENVIRONMENT…\'\\|\'GLPI_GRAPH_DIR\'\\|\'GLPI_INSTALL_MODE\'\\|\'GLPI_INVENTORY_DIR\'\\|\'GLPI_LOCAL_I18N_DIR\'\\|\'GLPI_LOCK_DIR\'\\|\'GLPI_LOG_DIR\'\\|\'GLPI_MARKETPLACE…\'\\|\'GLPI_MARKETPLACE_DIR\'\\|\'GLPI_NETWORK_MAIL\'\\|\'GLPI_NETWORK…\'\\|\'GLPI_PICTURE_DIR\'\\|\'GLPI_PLUGIN_DOC_DIR\'\\|\'GLPI_RSS_DIR\'\\|\'GLPI_SERVERSIDE_URL…\'\\|\'GLPI_SESSION_DIR\'\\|\'GLPI_TELEMETRY_URI\'\\|\'GLPI_TEXT_MAXSIZE\'\\|\'GLPI_THEMES_DIR\'\\|\'GLPI_TMP_DIR\'\\|\'GLPI_UPLOAD_DIR\'\\|\'GLPI_USER_AGENT…\'\\|\'GLPI_VAR_DIR\'\\|\'PLUGINS_DIRECTORIES\' on array\\{\\} on left side of \\?\\? does not exist\\.$#',
-	'identifier' => 'nullCoalesce.offset',
-	'count' => 2,
-	'path' => __DIR__ . '/src/Glpi/Application/SystemConfigurator.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Instanceof between DBmysql and DBmysql will always evaluate to true\\.$#',
 	'identifier' => 'instanceof.alwaysTrue',
 	'count' => 1,

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -24,6 +24,7 @@ parameters:
         - GLPI_DISABLE_ONLY_FULL_GROUP_BY_SQL_MODE
         - GLPI_DOC_DIR
         - GLPI_DOCUMENTATION_ROOT_URL
+        - GLPI_ENVIRONMENT_TYPE
         - GLPI_FORCE_MAIL
         - GLPI_GRAPH_DIR
         - GLPI_INSTALL_MODE
@@ -53,10 +54,9 @@ parameters:
         - GLPI_THEMES_DIR
         - GLPI_TMP_DIR
         - GLPI_UPLOAD_DIR
-        - GLPI_USE_CSRF_CHECK
-        - GLPI_USE_IDOR_CHECK
         - GLPI_USER_AGENT_EXTRA_COMMENTS
         - GLPI_VAR_DIR
+        - GLPI_WEBHOOK_ALLOW_RESPONSE_SAVING
         - PLUGINS_DIRECTORIES
         - TU_USER
     ignoreErrors:

--- a/src/Glpi/Application/SystemConfigurator.php
+++ b/src/Glpi/Application/SystemConfigurator.php
@@ -122,7 +122,8 @@ final class SystemConfigurator
                 'GLPI_AJAX_DASHBOARD'         => '1', // 1 for "multi ajax mode" 0 for "single ajax mode" (see Glpi\Dashboard\Grid::getCards)
                 'GLPI_CALDAV_IMPORT_STATE'    => 0, // external events created from a caldav client will take this state by default (0 = Planning::INFO)
                 'GLPI_CENTRAL_WARNINGS'       => '1', // display (1), or not (0), warnings on GLPI Central page
-                'GLPI_TEXT_MAXSIZE'           => '4000' // character threshold for displaying read more button
+                'GLPI_TEXT_MAXSIZE'           => '4000', // character threshold for displaying read more button
+                'GLPI_WEBHOOK_ALLOW_RESPONSE_SAVING' => '0', // allow (1) or not (0) to save webhook response in database
             ],
             'production' => [
             ],
@@ -141,6 +142,7 @@ final class SystemConfigurator
                 ],
             ],
             'development' => [
+                'GLPI_WEBHOOK_ALLOW_RESPONSE_SAVING' => '1'
             ],
         ];
 

--- a/stubs/glpi_constants.php
+++ b/stubs/glpi_constants.php
@@ -35,6 +35,7 @@
 
 // This file contains stubs for GLPI constants.
 // Please try to keep them alphabetically ordered.
+// Keep in sync with the dynamicConstantNames config option in the PHPStan config file
 
 // Directories constants
 define('GLPI_CACHE_DIR', null);
@@ -83,4 +84,5 @@ define('GLPI_SERVERSIDE_URL_ALLOWLIST', []);
 define('GLPI_TELEMETRY_URI', null);
 define('GLPI_TEXT_MAXSIZE', null);
 define('GLPI_USER_AGENT_EXTRA_COMMENTS', null);
+define('GLPI_WEBHOOK_ALLOW_RESPONSE_SAVING', 0);
 define('PLUGINS_DIRECTORIES', ['/a', '/b', '/c']);

--- a/templates/pages/setup/webhook/queuedwebhook.html.twig
+++ b/templates/pages/setup/webhook/queuedwebhook.html.twig
@@ -37,68 +37,70 @@
 {% set rand_field = rand|default(random()) %}
 
 {% set params = params|merge({
-   addbuttons: {
-      send: {
-         icon: 'ti ti-send',
-         text: item.fields['last_status_code'] is null or item.fields['last_status_code'] >= 300 ? __('Send') : __('Resend'),
-         type: 'button'
-      }
-   }
+    addbuttons: {
+        send: {
+            icon: 'ti ti-send',
+            text: item.fields['last_status_code'] is null or item.fields['last_status_code'] >= 300 ? __('Send') : __('Resend'),
+            type: 'button'
+        }
+    }
 }) %}
 
 {% block form_fields %}
-   {{ fields.htmlField('itemtype', item.fields['itemtype'], _n('Type', 'Types', 1)) }}
-   {{ fields.htmlField('items_id', get_item_link(item.fields['itemtype'], item.fields['items_id']), _n('Item', 'Items', 1)) }}
-   {{ fields.htmlField('webhooks_id', get_item_link(webhook), 'Webhook'|itemtype_name) }}
-   {{ fields.nullField() }}
-   {{ fields.htmlField('create_time', item.fields['create_time'], __('Creation date')) }}
-   {{ fields.htmlField('send_time', item.fields['send_time'], __('Expected send date')) }}
-   {{ fields.htmlField('sent_time', item.fields['sent_time'], __('Send date')) }}
-   {{ fields.htmlField('sent_try', item.fields['sent_try'], __('Number of tries of sent')) }}
-   {{ fields.htmlField('last_status_code', item.getStatusCodeBadge(item.fields['last_status_code']), __('Last status code')) }}
+    {{ fields.htmlField('itemtype', item.fields['itemtype'], _n('Type', 'Types', 1)) }}
+    {{ fields.htmlField('items_id', get_item_link(item.fields['itemtype'], item.fields['items_id']), _n('Item', 'Items', 1)) }}
+    {{ fields.htmlField('webhooks_id', get_item_link(webhook), 'Webhook'|itemtype_name) }}
+    {{ fields.nullField() }}
+    {{ fields.htmlField('create_time', item.fields['create_time'], __('Creation date')) }}
+    {{ fields.htmlField('send_time', item.fields['send_time'], __('Expected send date')) }}
+    {{ fields.htmlField('sent_time', item.fields['sent_time'], __('Send date')) }}
+    {{ fields.htmlField('sent_try', item.fields['sent_try'], __('Number of tries of sent')) }}
+    {{ fields.htmlField('last_status_code', item.getStatusCodeBadge(item.fields['last_status_code']), __('Last status code')) }}
 
-   {{ fields.smallTitle(__('Request')) }}
+    {{ fields.smallTitle(__('Request')) }}
 
-   {{ fields.htmlField('url', item.fields['url'], __('URL')) }}
-   {{ fields.textareaField('body', item.fields['body'], '', {
-      full_width: true,
-      readonly: true,
-      rows: 10,
-      no_label: true,
-   }) }}
+    {{ fields.htmlField('url', item.fields['url'], __('URL')) }}
+    {{ fields.textareaField('body', item.fields['body'], '', {
+        full_width: true,
+        readonly: true,
+        rows: 10,
+        no_label: true,
+    }) }}
 
-   {{ fields.smallTitle(__('Headers')) }}
-   {% for header_name, header_value in headers %}
-      {{ fields.htmlField('headers_' ~ header_name, header_value, header_name) }}
-   {% endfor %}
+    {{ fields.smallTitle(__('Headers')) }}
+    {% for header_name, header_value in headers %}
+        {{ fields.htmlField('headers_' ~ header_name, header_value, header_name) }}
+    {% endfor %}
 
-   {{ fields.smallTitle(__('Last response')) }}
-   {{ fields.textareaField('response_body', item.fields['response_body'], '', {
-      full_width: true,
-      readonly: true,
-      rows: 10,
-      no_label: true,
-   }) }}
+    {% if constant('GLPI_WEBHOOK_ALLOW_RESPONSE_SAVING') %}
+        {{ fields.smallTitle(__('Last response')) }}
+        {{ fields.textareaField('response_body', item.fields['response_body'], '', {
+            full_width: true,
+            readonly: true,
+            rows: 10,
+            no_label: true,
+        }) }}
+    {% endif %}
 
-   <script>
-      $(() => {
-          $('button[name="send"]').click((e) => {
-              const btn = $(e.target);
-              $.ajax({
-                  url: '{{ path('/ajax/webhook.php') }}',
-                  type: 'POST',
-                  data: {
-                      'action': 'resend',
-                      'id': {{ item.fields['id'] }}
-                  },
-                  beforeSend: () => {
-                      btn.attr('disabled', true);
-                  },
-                  complete: () => {
-                      window.location.reload();
-                  }
-              });
-          });
-      })
-   </script>
+    <script>
+        $(() => {
+            $('button[name="send"]').click((e) => {
+                const btn = $(e.target);
+                $.ajax({
+                    url: '{{ path('/ajax/webhook.php') }}',
+                    type: 'POST',
+                    data: {
+                        'action': 'resend',
+                        'id': {{ item.fields['id'] }}
+                    },
+                    beforeSend: () => {
+                        btn.attr('disabled', true);
+                    },
+                    complete: () => {
+                        window.location.reload();
+                    }
+                });
+            });
+        })
+    </script>
 {% endblock %}

--- a/templates/pages/setup/webhook/webhook.html.twig
+++ b/templates/pages/setup/webhook/webhook.html.twig
@@ -134,7 +134,9 @@
         field_options
     ) }}
 
-    {{ fields.dropdownYesNo('save_response_body', item.fields['save_response_body'], __('Save response body')) }}
+    {% if constant('GLPI_WEBHOOK_ALLOW_RESPONSE_SAVING') %}
+        {{ fields.dropdownYesNo('save_response_body', item.fields['save_response_body'], __('Save response body')) }}
+    {% endif %}
 
     {{ fields.dropdownYesNo('log_in_item_history', item.fields['log_in_item_history'], __('Log in item history')) }}
 


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Saving responses from webhooks isn't very useful except very rare cases where a service actually sends a response body and you want to view it for debug reasons. By default the ability to save webhook responses will be disabled except in development environments.

Need to make sure the `hookparser` plugin (also not useful for 90% of regular webhook use cases) can still access the responses regardless of this setting.
