### PR TITLE
Remove automatic flush of the header

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -1306,8 +1306,6 @@ HTML;
         } else {
             return TemplateRenderer::getInstance()->render('layout/parts/head.html.twig', $tpl_vars);
         }
-
-        self::glpi_flush();
     }
 
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

The automatic flush of the output at the end of the `Html::includeHeader()` method was done to permit to the browser to download the CSS/JS resources earlier, before the rest of the page content is computed. It was probably considered as a good idea when it has been done, but I am not sure it is still necessary to do this.
Indeed, for most of the pages, the computation of the content is pretty fast, and for the slow pages, as the JS/CSS resources are probably already in cache, trying to load them earlier will probably does not change much.

I propose to remove this behaviour as it is not compatible with the construction of a base `Symfony` response object and forces us to use streamed responses.
Also, it cannot prevent this output to be sent in the PHPUnit output, even using the `$this->expectOutputRegex('/.+/');` assertion.