### PR TITLE
Remove useless automatic MySQL connection closing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,7 @@ The present file will list all changes made to the project; according to the
 - `linkoption` option has been removed from `CommonDBTM::getLink()`.
 - `comments` and `icon` options have been removed from `CommonDBTM::getName()`.
 - `comments` and `icon` options have been removed from `CommonDBTM::getNameID()`.
+- The `$keepDb` parameter has been removed from `Html::footer()`.
 
 #### Deprecated
 - Usage of the `/marketplace` path for plugins URLs. All plugins URLs should now start with `/plugins`.
@@ -300,6 +301,7 @@ The present file will list all changes made to the project; according to the
 - Logging within the `mail-debug.log` log file.
 - `X-GLPI-Sanitized-Content` REST API header support.
 - Handling of encoded/escaped value in `autoName()`.
+- `closeDBConnections`
 - `regenerateTreeCompleteName()`
 - `Cartridge::getNotificationParameters()`
 - `CartridgeItem::showDebug()`
@@ -341,6 +343,7 @@ The present file will list all changes made to the project; according to the
 - `Contract::getContractRenewalIDByName()`
 - `Contract::showDebug()`
 - `Contract::showShort()`
+- `DbUtils::closeDBConnections()`
 - `DbUtils::regenerateTreeCompleteName()`
 - `Document::uploadDocument()`
 - `Document::showUploadedFilesDropdown()`

--- a/front/rule.common.php
+++ b/front/rule.common.php
@@ -142,7 +142,7 @@ if (isset($_POST["action"])) {
                      "$manufacturer");
     }
 
-    Html::footer(true);
+    Html::footer();
     exit();
 }
 

--- a/src/DbUtils.php
+++ b/src/DbUtils.php
@@ -2041,22 +2041,6 @@ final class DbUtils
     }
 
     /**
-     * Close active DB connections
-     *
-     * @return void
-     */
-    public function closeDBConnections()
-    {
-        /** @var \DBmysql $DB */
-        global $DB;
-
-       // Case of not init $DB object
-        if ($DB !== null && method_exists($DB, "close")) {
-            $DB->close();
-        }
-    }
-
-    /**
      * Get dates conditions to use in 'WHERE' clause
      *
      * @param string $field table.field to request

--- a/src/Glpi/Controller/ErrorController.php
+++ b/src/Glpi/Controller/ErrorController.php
@@ -94,7 +94,7 @@ class ErrorController extends AbstractController
             'link'    => \Html::getBackUrl(),
         ]);
 
-        \Html::footer(true);
+        \Html::footer();
     }
 
     private function getTraceAsString(\Throwable $exception): string

--- a/src/Html.php
+++ b/src/Html.php
@@ -1737,9 +1737,9 @@ HTML;
     /**
      * Print footer for every page
      *
-     * @param boolean $keepDB closeDBConnections if false (false by default)
-     **/
-    public static function footer($keepDB = false)
+     * @since 11.0.0 The `$keepDB` parameter has been removed.
+     */
+    public static function footer()
     {
         /**
          * @var array $CFG_GLPI
@@ -1860,10 +1860,6 @@ HTML;
         if ($_SESSION['glpi_use_mode'] === Session::DEBUG_MODE && !str_starts_with($_SERVER['PHP_SELF'], $CFG_GLPI['root_doc'] . '/install/')) {
             \Glpi\Debug\Profiler::getInstance()->stopAll();
             (new Glpi\Debug\Toolbar())->show();
-        }
-
-        if (!$keepDB && function_exists('closeDBConnections')) {
-            closeDBConnections();
         }
     }
 

--- a/src/autoload/dbutils-aliases.php
+++ b/src/autoload/dbutils-aliases.php
@@ -535,18 +535,6 @@ function autoName($objectName, $field, $isTemplate, $itemtype, $entities_id = -1
     return $dbu->autoName($objectName, $field, $isTemplate, $itemtype, $entities_id);
 }
 
-
-/**
- * Close active DB connections
- *
- * @return void
- **/
-function closeDBConnections()
-{
-    $dbu = new DbUtils();
-    $dbu->closeDBConnections();
-}
-
 /**
  * Add dates for request
  *


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Closing the MySQL connection automatically when calling the `Html::footer()` method is probably useless, as this is most of the time one of the lastest instruction called from our front scripts and controllers, and at the end of scripts execution, PHP is automatically closing connections. Also, if the `Html::footer()` il called in any PHPUnit script, it will make all other test fail, see https://github.com/glpi-project/glpi/actions/runs/11328891928/job/31503153946?pr=18046.

I propose to remove this behaviour.