### PR TITLE
Fix post login redirection

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -456,6 +456,20 @@ class Html
         exit();
     }
 
+    public static function getCurrentUrlForRedirect(): string
+    {
+        /**
+         * @var array $CFG_GLPI
+         */
+        global $CFG_GLPI;
+
+        return preg_replace(
+            '/^' . preg_quote($CFG_GLPI["root_doc"], '/') . '/',
+            '',
+            $_SERVER['REQUEST_URI']
+        );
+    }
+
     /**
      * Redirection to Login page
      *
@@ -474,11 +488,7 @@ class Html
         $dest = $CFG_GLPI["root_doc"] . "/index.php";
 
         if (!self::$is_ajax_request) {
-            $url_dest = preg_replace(
-                '/^' . preg_quote($CFG_GLPI["root_doc"], '/') . '/',
-                '',
-                $_SERVER['REQUEST_URI']
-            );
+            $url_dest = self::getCurrentUrlForRedirect();
             $dest .= "?redirect=" . rawurlencode($url_dest);
         }
 

--- a/tests/cypress/e2e/login.cy.js
+++ b/tests/cypress/e2e/login.cy.js
@@ -1,5 +1,3 @@
-<?php
-
 /**
  * ---------------------------------------------------------------------
  *
@@ -32,20 +30,23 @@
  * ---------------------------------------------------------------------
  */
 
-namespace Glpi\Exception\Access;
+describe("Login", () => {
+    it("redirect to requested page after login", () => {
+        // Must visit twice because glpi doens't support redirect on the first
+        // ever visit due to some cookies checks...
+        cy.visit('/front/ticket.form.php');
+        cy.visit('/front/ticket.form.php', {
+            failOnStatusCode: false
+        });
+        cy.findByRole('link', {'name': "Log in again"}).click();
 
-use Html;
-use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\HttpFoundation\Response;
+        // Login as e2e_tests
+        cy.findByRole('textbox', {'name': "Login"}).type('e2e_tests');
+        cy.findByLabelText("Password").type('glpi');
+        cy.findByRole('button', {name: "Sign in"}).click();
 
-/**
- * Used when there is no session, or session cookies have expired.
- */
-class SessionExpiredException extends AbstractHttpException
-{
-    public function asResponse(): Response
-    {
-        $redirect = Html::getCurrentUrlForRedirect();
-        return new RedirectResponse("/front/login.php?redirect=$redirect");
-    }
-}
+        // Should be redirected to requested page
+        cy.url().should('contains', "/front/ticket.form.php");
+    });
+});
+


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Post login redirection didn't work anymore (not sure since when).

The new method `getCurrentUrlForRedirect` probably shouldn't be in the Html class but not sure where to put it for now.