### PR TITLE
Add WiFi 8 version

### DIFF
--- a/src/WifiNetwork.php
+++ b/src/WifiNetwork.php
@@ -62,6 +62,7 @@ class WifiNetwork extends CommonDropdown
             'ac'        => 'ac', // Wifi 5
             'ax'        => 'ax', // Wifi 6/6E
             'be'        => 'be', // Wifi 7
+            'bn'        => 'bn', // Wifi 8
         ];
     }
 
@@ -69,14 +70,15 @@ class WifiNetwork extends CommonDropdown
     public static function getWifiCardModes()
     {
 
-        return [''          => Dropdown::EMPTY_VALUE,
-            'ad-hoc'    => __('Ad-hoc'),
-            'managed'   => __('Managed'),
-            'master'    => __('Master'),
-            'repeater'  => __('Repeater'),
-            'secondary' => __('Secondary'),
-            'monitor'   => Monitor::getTypeName(1),
-            'auto'      => __('Automatic')
+        return [
+            ''          => Dropdown::EMPTY_VALUE,
+            'ad-hoc'    => _x('wifi_card_mode', 'Ad-hoc'),
+            'managed'   => _x('wifi_card_mode', 'Managed'),
+            'master'    => _x('wifi_card_mode', 'Master'),
+            'repeater'  => _x('wifi_card_mode', 'Repeater'),
+            'secondary' => _x('wifi_card_mode', 'Secondary'),
+            'monitor'   => _x('wifi_card_mode', 'Monitor'),
+            'auto'      => _x('wifi_card_mode', 'Automatic')
         ];
     }
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Not expected to be officially adopted until 2028. While I hope GLPI 11 is obsolete by then, there is no harm in adding the protocol version now as the IEEE designation shouldn't change.

Also fixed potential issue with the "Monitor" mode translation. It had been changed a few years ago to use the Monitor itemtype name (Computer displays) and that may be an issue with non-English locales. For consistency, I changed all WiFi card mode strings to use the "wifi_card_mode" context.

