### PR TITLE
Remove some `http_response_code()`/`exit()`/`die()` usages

### DIFF
--- a/ajax/map.php
+++ b/ajax/map.php
@@ -33,6 +33,8 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Exception\Http\BadRequestHttpException;
+
 header("Content-Type: application/json; charset=UTF-8");
 Html::header_nocache();
 
@@ -40,11 +42,7 @@ Session::checkLoginUser();
 
 $result = [];
 if (!isset($_POST['itemtype']) || !isset($_POST['params'])) {
-    http_response_code(500);
-    $result = [
-        'success'   => false,
-        'message'   => __('Required argument missing!')
-    ];
+    throw new BadRequestHttpException();
 } else {
     $itemtype = $_POST['itemtype'];
     $params   = $_POST['params'];

--- a/front/central.php
+++ b/front/central.php
@@ -45,7 +45,7 @@ if (isset($_GET["embed"]) && isset($_GET["dashboard"])) {
     Html::zeroSecurityIframedHeader($grid->getDashboard()->getTitle(), 'central', 'central');
     $grid->embed($_REQUEST);
     Html::popFooter();
-    exit;
+    return;
 }
 
 // Change profile system

--- a/front/crontask.form.php
+++ b/front/crontask.form.php
@@ -33,6 +33,8 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Exception\Http\BadRequestHttpException;
+
 /**
  * Form to edit Cron Task
  */
@@ -79,7 +81,7 @@ if (isset($_POST['execute'])) {
     Html::back();
 } else {
     if (!isset($_GET["id"]) || empty($_GET["id"])) {
-        exit();
+        throw new BadRequestHttpException();
     }
     $menus = ['config', 'crontask'];
     CronTask::displayFullPageForItem($_GET['id'], $menus);

--- a/front/initpassword.php
+++ b/front/initpassword.php
@@ -54,7 +54,7 @@ if (
         'title'         => __('Forgotten initialization'),
         'messages_only' => true,
     ]);
-    exit();
+    return;
 }
 
 $user = new User();
@@ -74,5 +74,3 @@ if (isset($_REQUEST['password_forget_token'])) {
         User::showPasswordInitRequestForm();
     }
 }
-
-exit();

--- a/front/locale.php
+++ b/front/locale.php
@@ -83,7 +83,8 @@ try {
 if (!($messages instanceof \Laminas\I18n\Translator\TextDomain)) {
    // No TextDomain found means that there is no translations for given domain.
    // It is mostly related to plugins that does not provide any translations.
-    exit($default_response);
+    echo $default_response;
+    return;
 }
 
 // Extract headers from main po file
@@ -98,7 +99,8 @@ $po_file_handle = fopen(
 );
 if (false === $po_file_handle) {
     trigger_error(sprintf('Unable to extract locales data from "%s".', $po_file), E_USER_WARNING);
-    exit($default_response);
+    echo $default_response;
+    return;
 }
 $in_headers = false;
 $headers = [];
@@ -122,7 +124,8 @@ while (false !== ($line = fgets($po_file_handle))) {
 }
 if (count(array_diff($header_keys, array_keys($headers))) > 0) {
     trigger_error(sprintf('Missing mandatory locale headers in "%s".', $po_file), E_USER_WARNING);
-    exit($default_response);
+    echo $default_response;
+    return;
 }
 
 // Output messages and headers

--- a/front/login.php
+++ b/front/login.php
@@ -33,11 +33,11 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Exception\AuthenticationFailedException;
+
 /**
  * @since 0.85
  */
-
-use Glpi\Exception\Http\AuthenticationFailedHttpException;
 
 /**
  * @var array $CFG_GLPI
@@ -94,7 +94,5 @@ if (!empty($_POST['totp_code'])) {
 if ($auth->login($login, $password, (isset($_REQUEST["noAUTO"]) ? $_REQUEST["noAUTO"] : false), $remember, $login_auth, $mfa_params)) {
     Auth::redirectIfAuthenticated();
 } else {
-    $exception = new AuthenticationFailedHttpException();
-    $exception->setMessageToDisplay(implode(' ', $auth->getErrors()));
-    throw $exception;
+    throw new AuthenticationFailedException(authentication_errors: $auth->getErrors());
 }

--- a/front/login.php
+++ b/front/login.php
@@ -37,7 +37,7 @@
  * @since 0.85
  */
 
-use Glpi\Application\View\TemplateRenderer;
+use Glpi\Exception\Http\AuthenticationFailedHttpException;
 
 /**
  * @var array $CFG_GLPI
@@ -77,14 +77,6 @@ if (isset($_POST['auth'])) {
 
 $remember = isset($_SESSION['rmbfield']) && isset($_POST[$_SESSION['rmbfield']]) && $CFG_GLPI["login_remember_time"];
 
-// Redirect management
-$REDIRECT = "";
-if (isset($_POST['redirect']) && (strlen($_POST['redirect']) > 0)) {
-    $REDIRECT = "?redirect=" . rawurlencode($_POST['redirect']);
-} else if (isset($_GET['redirect']) && strlen($_GET['redirect']) > 0) {
-    $REDIRECT = "?redirect=" . rawurlencode($_GET['redirect']);
-}
-
 $auth = new Auth();
 
 
@@ -102,10 +94,7 @@ if (!empty($_POST['totp_code'])) {
 if ($auth->login($login, $password, (isset($_REQUEST["noAUTO"]) ? $_REQUEST["noAUTO"] : false), $remember, $login_auth, $mfa_params)) {
     Auth::redirectIfAuthenticated();
 } else {
-    http_response_code(401);
-    TemplateRenderer::getInstance()->display('pages/login_error.html.twig', [
-        'errors'    => $auth->getErrors(),
-        'login_url' => $CFG_GLPI["root_doc"] . '/front/logout.php?noAUTO=1' . str_replace("?", "&", $REDIRECT),
-    ]);
-    exit();
+    $exception = new AuthenticationFailedHttpException();
+    $exception->setMessageToDisplay(implode(' ', $auth->getErrors()));
+    throw $exception;
 }

--- a/front/logout.php
+++ b/front/logout.php
@@ -71,9 +71,9 @@ $toADD = "";
 
 // Redirect management
 if (isset($_POST['redirect']) && (strlen($_POST['redirect']) > 0)) {
-    $toADD = "?redirect=" . $_POST['redirect'];
+    $toADD = "?redirect=" . rawurlencode($_POST['redirect']);
 } else if (isset($_GET['redirect']) && (strlen($_GET['redirect']) > 0)) {
-    $toADD = "?redirect=" . $_GET['redirect'];
+    $toADD = "?redirect=" . rawurlencode($_GET['redirect']);
 }
 
 if (isset($_SESSION["noAUTO"]) || isset($_GET['noAUTO'])) {

--- a/front/lostpassword.php
+++ b/front/lostpassword.php
@@ -55,7 +55,7 @@ if (
     TemplateRenderer::getInstance()->display('forgotpassword.html.twig', [
         'messages_only' => true,
     ]);
-    exit();
+    return;
 }
 
 $user = new User();
@@ -75,5 +75,3 @@ if (isset($_REQUEST['password_forget_token'])) {
         User::showPasswordForgetRequestForm();
     }
 }
-
-exit();

--- a/front/massiveaction.php
+++ b/front/massiveaction.php
@@ -53,7 +53,7 @@ try {
     echo "</div>";
 
     Html::popFooter();
-    exit();
+    return;
 }
 Html::popHeader(__('Bulk modification'), $_SERVER['PHP_SELF']);
 

--- a/front/palette_preview.php
+++ b/front/palette_preview.php
@@ -52,7 +52,7 @@ if ($preview === null) {
     $blank = base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=');
     header(sprintf('Content-Length: %s', strlen($blank)));
     echo $blank;
-    exit();
+    return;
 }
 
 header('Cache-Control: public, max-age=2592000, must-revalidate'); // 1 month cache

--- a/front/pluginimage.send.php
+++ b/front/pluginimage.send.php
@@ -43,6 +43,7 @@
  */
 
 use Glpi\Event;
+use Glpi\Exception\Http\AccessDeniedHttpException;
 
 /** @var array $CFG_GLPI */
 global $CFG_GLPI;
@@ -56,7 +57,7 @@ if (!isset($_GET["name"]) || !isset($_GET["plugin"]) || !Plugin::isPluginActive(
         //TRANS: %s is user name
         sprintf(__('%s makes a bad usage.'), $_SESSION["glpiname"])
     );
-    die("security");
+    throw new AccessDeniedHttpException();
 }
 
 $dir = GLPI_PLUGIN_DOC_DIR . "/" . $_GET["plugin"] . "/";
@@ -78,7 +79,7 @@ if (
         "security",
         sprintf(__('%s tries to use a non standard path.'), $_SESSION["glpiname"])
     );
-    die("security");
+    throw new AccessDeniedHttpException();
 }
 
 // Now send the file with header() magic

--- a/front/report.dynamic.php
+++ b/front/report.dynamic.php
@@ -112,7 +112,7 @@ if (isset($_GET["display_type"])) {
            // Plugin case
             if ($plug = isPluginItemType($itemtype)) {
                 if (Plugin::doOneHook($plug['plugin'], 'dynamicReport', $_GET)) {
-                    exit();
+                    return;
                 }
             }
             $params = Search::manageParams($itemtype, $_GET);

--- a/front/rule.common.php
+++ b/front/rule.common.php
@@ -95,7 +95,7 @@ if (isset($_POST["action"])) {
         && $rulecollection->warningBeforeReplayRulesOnExistingDB($_SERVER['PHP_SELF'])
     ) {
         Html::footer();
-        exit();
+        return;
     }
 
     echo "<table class='tab_cadrehov'>";
@@ -143,7 +143,7 @@ if (isset($_POST["action"])) {
     }
 
     Html::footer();
-    exit();
+    return;
 }
 
 Html::header(

--- a/front/rule.test.php
+++ b/front/rule.test.php
@@ -33,6 +33,8 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Exception\Http\BadRequestHttpException;
+
 Session::checkCentralAccess();
 
 if (isset($_POST["sub_type"])) {
@@ -53,7 +55,7 @@ if (isset($_POST["rules_id"])) {
 
 /** @var Rule $rule */
 if (!$rule = getItemForItemtype($sub_type)) {
-    exit;
+    throw new BadRequestHttpException();
 }
 $rule->checkGlobal(READ);
 

--- a/front/smtp_oauth2_callback.php
+++ b/front/smtp_oauth2_callback.php
@@ -56,7 +56,7 @@ if (!array_key_exists('cookie_refresh', $_GET)) {
     <body></body>
 </html>
 HTML;
-    exit;
+    return;
 }
 
 Session::checkRight("config", UPDATE);

--- a/front/stat.global.php
+++ b/front/stat.global.php
@@ -33,6 +33,7 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Exception\Http\BadRequestHttpException;
 use Glpi\Stat\Data\Sglobal\StatDataAverageSatisfaction;
 use Glpi\Stat\Data\Sglobal\StatDataSatisfaction;
 use Glpi\Stat\Data\Sglobal\StatDataTicketAverageTime;
@@ -67,7 +68,7 @@ if (
 Stat::title();
 
 if (!$item = getItemForItemtype($_GET['itemtype'])) {
-    exit;
+    throw new BadRequestHttpException();
 }
 
 $stat = new Stat();

--- a/front/stat.graph.php
+++ b/front/stat.graph.php
@@ -34,6 +34,7 @@
  */
 
 use Glpi\Application\View\TemplateRenderer;
+use Glpi\Exception\Http\BadRequestHttpException;
 use Glpi\Stat\Data\Graph\StatDataSatisfaction;
 use Glpi\Stat\Data\Graph\StatDataSatisfactionSurvey;
 use Glpi\Stat\Data\Graph\StatDataTicketAverageTime;
@@ -50,7 +51,7 @@ Session::checkRight("statistic", READ);
 
 /** @var CommonITILObject $item */
 if (!$item = getItemForItemtype($_GET['itemtype'])) {
-    exit;
+    throw new BadRequestHttpException();
 }
 
 //sanitize dates

--- a/front/stat.location.php
+++ b/front/stat.location.php
@@ -116,7 +116,7 @@ if (
 ) {
    // Do nothing
     Html::footer();
-    exit();
+    return;
 }
 
 

--- a/front/stat.tracking.php
+++ b/front/stat.tracking.php
@@ -34,6 +34,7 @@
  */
 
 use Glpi\Application\View\TemplateRenderer;
+use Glpi\Exception\Http\BadRequestHttpException;
 use Glpi\Stat\Data\Location\StatDataClosed;
 use Glpi\Stat\Data\Location\StatDataLate;
 use Glpi\Stat\Data\Location\StatDataOpened;
@@ -48,7 +49,7 @@ Html::header(__('Statistics'), '', "helpdesk", "stat");
 Session::checkRight("statistic", READ);
 
 if (!$item = getItemForItemtype($_GET['itemtype'])) {
-    exit;
+    throw new BadRequestHttpException();
 }
 
 //sanitize dates

--- a/front/transfer.action.php
+++ b/front/transfer.action.php
@@ -51,7 +51,7 @@ if (isset($_POST['transfer'])) {
         echo "<div class='fw-bold text-center'>" . __s('Operation successful') . "<br>";
         echo "<a href='central.php' role='button' class='btn btn-primary'>" . __s('Back') . "</a></div>";
         Html::footer();
-        exit();
+        return;
     }
 } else if (isset($_POST['clear'])) {
     unset($_SESSION['glpitransfer_list']);
@@ -59,7 +59,7 @@ if (isset($_POST['transfer'])) {
     echo "<a href='central.php' role='button' class='btn btn-primary'>" . __s('Back') . "</a></div>";
     echo "</div>";
     Html::footer();
-    exit();
+    return;
 }
 
 unset($_SESSION['glpimassiveactionselected']);

--- a/install/update.php
+++ b/install/update.php
@@ -226,7 +226,7 @@ if (empty($_POST["continuer"]) && empty($_POST["from_update"])) {
         $result = Config::displayCheckDbEngine(true);
         echo "</p>";
         if ($result > 0) {
-            die(1);
+            return;
         }
         if (
             $update->isExpectedSecurityKeyFileMissing()

--- a/src/Glpi/Controller/ApiController.php
+++ b/src/Glpi/Controller/ApiController.php
@@ -82,7 +82,7 @@ final class ApiController extends AbstractController
             // Include the legacy API entrypoint and then die
             $api = new \Glpi\Api\APIRest();
             $api->call();
-            die();
+            return;
         }
 
         $supported_versions = Router::getAPIVersions();

--- a/src/Glpi/Controller/IndexController.php
+++ b/src/Glpi/Controller/IndexController.php
@@ -104,15 +104,15 @@ final class IndexController extends AbstractController
                 echo '</div>';
                 echo '</div>';
                 Html::nullFooter();
+                return;
             }
-            die();
         }
 
         //Try to detect GLPI agent calls
         $rawdata = file_get_contents("php://input");
         if (!isset($_POST['totp_code']) && !empty($rawdata) && $_SERVER['REQUEST_METHOD'] === 'POST') {
             include_once(GLPI_ROOT . '/front/inventory.php');
-            die();
+            return;
         }
 
         Session::checkCookieSecureConfig();

--- a/src/Glpi/Controller/IndexController.php
+++ b/src/Glpi/Controller/IndexController.php
@@ -132,34 +132,33 @@ final class IndexController extends AbstractController
 
         Auth::checkAlternateAuthSystems(true, $redirect);
 
-        $errors = [];
+        $error = null;
         if (isset($_GET['error']) && $redirect !== '') {
             switch ($_GET['error']) {
                 case 1: // cookie error
-                    $errors[] = __('You must accept cookies to reach this application');
+                    $error = __('You must accept cookies to reach this application');
                     break;
 
                 case 2: // GLPI_SESSION_DIR not writable
-                    $errors[] = __('Logins are not possible at this time. Please contact your administrator.');
+                    $error = __('Logins are not possible at this time. Please contact your administrator.');
                     break;
 
                 case 3:
-                    $errors[] = __('Your session has expired. Please log in again.');
+                    $error = __('Your session has expired. Please log in again.');
                     break;
             }
         }
 
-        // redirect to ticket
-        if ($redirect !== '') {
-            Toolbox::manageRedirect($redirect);
-        }
-
-        if (count($errors)) {
+        if ($error !== null) {
             TemplateRenderer::getInstance()->display('pages/login_error.html.twig', [
-                'errors'    => $errors,
-                'login_url' => $CFG_GLPI["root_doc"] . '/front/logout.php?noAUTO=1&redirect=' . str_replace("?", "&", $redirect),
+                'error'     => $error,
+                'login_url' => $CFG_GLPI["root_doc"] . '/front/logout.php?noAUTO=1&redirect=' . \rawurlencode(str_replace("?", "&", $redirect)),
             ]);
         } else {
+            if ($redirect !== '') {
+                Toolbox::manageRedirect($redirect);
+            }
+
             if (isset($_SESSION['mfa_pre_auth'], $_POST['skip_mfa'])) {
                 Html::redirect($CFG_GLPI['root_doc'] . '/front/login.php?skip_mfa=1');
             }

--- a/src/Glpi/Controller/IndexController.php
+++ b/src/Glpi/Controller/IndexController.php
@@ -152,7 +152,7 @@ final class IndexController extends AbstractController
         if ($error !== null) {
             TemplateRenderer::getInstance()->display('pages/login_error.html.twig', [
                 'error'     => $error,
-                'login_url' => $CFG_GLPI["root_doc"] . '/front/logout.php?noAUTO=1&redirect=' . \rawurlencode(str_replace("?", "&", $redirect)),
+                'login_url' => $CFG_GLPI["root_doc"] . '/front/logout.php?noAUTO=1&redirect=' . \rawurlencode($redirect),
             ]);
         } else {
             if ($redirect !== '') {

--- a/src/Glpi/Controller/IndexController.php
+++ b/src/Glpi/Controller/IndexController.php
@@ -132,26 +132,26 @@ final class IndexController extends AbstractController
 
         Auth::checkAlternateAuthSystems(true, $redirect);
 
-        $error = null;
+        $errors = [];
         if (isset($_GET['error']) && $redirect !== '') {
             switch ($_GET['error']) {
                 case 1: // cookie error
-                    $error = __('You must accept cookies to reach this application');
+                    $errors[] = __('You must accept cookies to reach this application');
                     break;
 
                 case 2: // GLPI_SESSION_DIR not writable
-                    $error = __('Logins are not possible at this time. Please contact your administrator.');
+                    $errors[] = __('Logins are not possible at this time. Please contact your administrator.');
                     break;
 
                 case 3:
-                    $error = __('Your session has expired. Please log in again.');
+                    $errors[] = __('Your session has expired. Please log in again.');
                     break;
             }
         }
 
-        if ($error !== null) {
+        if (count($errors) > 0) {
             TemplateRenderer::getInstance()->display('pages/login_error.html.twig', [
-                'error'     => $error,
+                'errors'    => $errors,
                 'login_url' => $CFG_GLPI["root_doc"] . '/front/logout.php?noAUTO=1&redirect=' . \rawurlencode($redirect),
             ]);
         } else {

--- a/src/Glpi/Exception/AuthenticationFailedException.php
+++ b/src/Glpi/Exception/AuthenticationFailedException.php
@@ -32,16 +32,21 @@
  * ---------------------------------------------------------------------
  */
 
-namespace Glpi\Exception\Http;
+namespace Glpi\Exception;
 
-use Symfony\Component\HttpKernel\Exception\HttpException;
-
-class AuthenticationFailedHttpException extends HttpException
+class AuthenticationFailedException extends \Exception
 {
-    use HttpExceptionTrait;
+    public function __construct(
+        string $message = '""',
+        int $code = null,
+        ?\Throwable $previous = null,
+        private array $authentication_errors = []
+    ) {
+        parent::__construct($message, $code, $previous);
+    }
 
-    public function __construct(string $message = '', ?\Throwable $previous = null, int $code = 0, array $headers = [])
+    public function getAuthenticationErrors(): array
     {
-        parent::__construct(401, $message, $previous, $headers, $code);
+        return $this->authentication_errors;
     }
 }

--- a/src/Glpi/Exception/Http/AuthenticationFailedHttpException.php
+++ b/src/Glpi/Exception/Http/AuthenticationFailedHttpException.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Exception\Http;
+
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+class AuthenticationFailedHttpException extends HttpException
+{
+    use HttpExceptionTrait;
+
+    public function __construct(string $message = '', ?\Throwable $previous = null, int $code = 0, array $headers = [])
+    {
+        parent::__construct(401, $message, $previous, $headers, $code);
+    }
+}

--- a/src/Glpi/Exception/SessionExpiredException.php
+++ b/src/Glpi/Exception/SessionExpiredException.php
@@ -32,16 +32,8 @@
  * ---------------------------------------------------------------------
  */
 
-namespace Glpi\Exception\Http;
+namespace Glpi\Exception;
 
-use Symfony\Component\HttpKernel\Exception\HttpException;
-
-class SessionExpiredHttpException extends HttpException
+class SessionExpiredException extends \Exception
 {
-    use HttpExceptionTrait;
-
-    public function __construct(string $message = '', ?\Throwable $previous = null, int $code = 0, array $headers = [])
-    {
-        parent::__construct(401, $message, $previous, $headers, $code);
-    }
 }

--- a/src/Glpi/Http/AccessErrorListener.php
+++ b/src/Glpi/Http/AccessErrorListener.php
@@ -36,8 +36,8 @@ namespace Glpi\Http;
 
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\Exception\Http\AccessDeniedHttpException;
-use Glpi\Exception\Http\AuthenticationFailedHttpException;
-use Glpi\Exception\Http\SessionExpiredHttpException;
+use Glpi\Exception\AuthenticationFailedException;
+use Glpi\Exception\SessionExpiredException;
 use Session;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -67,7 +67,7 @@ final class AccessErrorListener implements EventSubscriberInterface
 
         $response = null;
 
-        if ($throwable instanceof SessionExpiredHttpException) {
+        if ($throwable instanceof SessionExpiredException) {
             Session::destroy(); // destroy the session to prevent pesistence of unexcpected data
 
             $response = new RedirectResponse(
@@ -90,7 +90,7 @@ final class AccessErrorListener implements EventSubscriberInterface
                     $request->getBasePath()
                 )
             );
-        } elseif ($throwable instanceof AuthenticationFailedHttpException) {
+        } elseif ($throwable instanceof AuthenticationFailedException) {
             $login_url = sprintf(
                 '%s/front/logout.php?noAUTO=1',
                 $request->getBasePath()
@@ -103,11 +103,10 @@ final class AccessErrorListener implements EventSubscriberInterface
                 content: TemplateRenderer::getInstance()->render(
                     'pages/login_error.html.twig',
                     [
-                        'error'     => $throwable->getMessageToDisplay(),
+                        'errors'    => $throwable->getAuthenticationErrors(),
                         'login_url' => $login_url,
                     ]
-                ),
-                status: 401
+                )
             );
         }
 

--- a/src/Glpi/Http/AccessErrorListener.php
+++ b/src/Glpi/Http/AccessErrorListener.php
@@ -34,11 +34,14 @@
 
 namespace Glpi\Http;
 
+use Glpi\Application\View\TemplateRenderer;
 use Glpi\Exception\Http\AccessDeniedHttpException;
+use Glpi\Exception\Http\AuthenticationFailedHttpException;
 use Glpi\Exception\Http\SessionExpiredHttpException;
 use Session;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
@@ -59,6 +62,7 @@ final class AccessErrorListener implements EventSubscriberInterface
             return;
         }
 
+        $request = $event->getRequest();
         $throwable = $event->getThrowable();
 
         $response = null;
@@ -66,7 +70,6 @@ final class AccessErrorListener implements EventSubscriberInterface
         if ($throwable instanceof SessionExpiredHttpException) {
             Session::destroy(); // destroy the session to prevent pesistence of unexcpected data
 
-            $request = $event->getRequest();
             $response = new RedirectResponse(
                 sprintf(
                     '%s/?redirect=%s&error=3',
@@ -86,6 +89,25 @@ final class AccessErrorListener implements EventSubscriberInterface
                     '%s/front/central.php',
                     $request->getBasePath()
                 )
+            );
+        } elseif ($throwable instanceof AuthenticationFailedHttpException) {
+            $login_url = sprintf(
+                '%s/front/logout.php?noAUTO=1',
+                $request->getBasePath()
+            );
+            $redirect = $request->request->get('redirect') ?: $request->query->get('redirect') ?: null;
+            if ($redirect !== null) {
+                $login_url .= '&redirect=' . \rawurlencode($redirect);
+            }
+            $response = new Response(
+                content: TemplateRenderer::getInstance()->render(
+                    'pages/login_error.html.twig',
+                    [
+                        'error'     => $throwable->getMessageToDisplay(),
+                        'login_url' => $login_url,
+                    ]
+                ),
+                status: 401
             );
         }
 

--- a/src/Glpi/Http/AccessErrorListener.php
+++ b/src/Glpi/Http/AccessErrorListener.php
@@ -106,7 +106,8 @@ final class AccessErrorListener implements EventSubscriberInterface
                         'errors'    => $throwable->getAuthenticationErrors(),
                         'login_url' => $login_url,
                     ]
-                )
+                ),
+                400
             );
         }
 

--- a/src/Glpi/Http/AccessErrorListener.php
+++ b/src/Glpi/Http/AccessErrorListener.php
@@ -107,7 +107,7 @@ final class AccessErrorListener implements EventSubscriberInterface
                         'login_url' => $login_url,
                     ]
                 ),
-                400
+                status: 400
             );
         }
 

--- a/src/Glpi/Marketplace/Controller.php
+++ b/src/Glpi/Marketplace/Controller.php
@@ -38,6 +38,7 @@ namespace Glpi\Marketplace;
 use CommonGLPI;
 use Config;
 use CronTask;
+use Glpi\Exception\Http\HttpException;
 use Glpi\Marketplace\Api\Plugins as PluginsApi;
 use GLPINetwork;
 use NotificationEvent;
@@ -288,9 +289,9 @@ class Controller extends CommonGLPI
         $dest     = GLPI_TMP_DIR . '/' . mt_rand() . '.' . $filename;
 
         if (!$api->downloadArchive($url, $dest, $this->plugin_key, false)) {
-            http_response_code(500);
-            echo(__('Unable to download plugin archive.'));
-            return;
+            $exception = new HttpException(502);
+            $exception->setMessageToDisplay(__('Unable to download plugin archive.'));
+            throw $exception;
         }
 
         Toolbox::sendFile($dest, $filename);

--- a/src/Glpi/Marketplace/Controller.php
+++ b/src/Glpi/Marketplace/Controller.php
@@ -289,7 +289,7 @@ class Controller extends CommonGLPI
         $dest     = GLPI_TMP_DIR . '/' . mt_rand() . '.' . $filename;
 
         if (!$api->downloadArchive($url, $dest, $this->plugin_key, false)) {
-            $exception = new HttpException(502);
+            $exception = new HttpException(500);
             $exception->setMessageToDisplay(__('Unable to download plugin archive.'));
             throw $exception;
         }

--- a/src/Glpi/System/Diagnostic/DatabaseSchemaIntegrityChecker.php
+++ b/src/Glpi/System/Diagnostic/DatabaseSchemaIntegrityChecker.php
@@ -674,7 +674,6 @@ class DatabaseSchemaIntegrityChecker
                 $is_quoted = !$is_quoted;
                 continue;
             } else if ($is_quoted) {
-                //exit();
                 continue;
             }
 

--- a/src/Session.php
+++ b/src/Session.php
@@ -38,7 +38,7 @@ use Glpi\Cache\I18nCache;
 use Glpi\Event;
 use Glpi\Exception\Http\AccessDeniedHttpException;
 use Glpi\Exception\Http\BadRequestHttpException;
-use Glpi\Exception\Http\SessionExpiredHttpException;
+use Glpi\Exception\SessionExpiredException;
 use Glpi\Plugin\Hooks;
 use Glpi\Session\SessionInfo;
 
@@ -1045,7 +1045,7 @@ class Session
             !isset($_SESSION['valid_id'])
             || ($_SESSION['valid_id'] !== session_id())
         ) {
-            throw new SessionExpiredHttpException();
+            throw new SessionExpiredException();
         }
 
         $user_id    = self::getLoginUserID();

--- a/templates/components/search/map.html.twig
+++ b/templates/components/search/map.html.twig
@@ -141,11 +141,7 @@
                       }
                   );
               }).fail((response) => {
-                  const _data = response.responseJSON;
                   let _message = escapeMarkupText(__('An error occurred loading data :('));
-                  if (_data.message) {
-                      _message = _data.message;
-                  }
                   const fail_info = L.control();
                   fail_info.onAdd = function (map) {
                       this._div = L.DomUtil.create('div', 'fail_info');

--- a/templates/pages/login_error.html.twig
+++ b/templates/pages/login_error.html.twig
@@ -44,9 +44,7 @@
                 {{ _n('Error', 'Errors', 1) }}
             </h4>
             <div>
-                {% for error in errors %}
-                    {{ error }}<br />
-                {% endfor %}
+                {{ error }}
             </div>
 
             <a href="{{ login_url }}" class="btn btn-primary mt-3">

--- a/templates/pages/login_error.html.twig
+++ b/templates/pages/login_error.html.twig
@@ -44,7 +44,9 @@
                 {{ _n('Error', 'Errors', 1) }}
             </h4>
             <div>
-                {{ error }}
+                {% for error in errors %}
+                    {{ error }}<br />
+                {% endfor %}
             </div>
 
             <a href="{{ login_url }}" class="btn btn-primary mt-3">

--- a/tests/functional/Session.php
+++ b/tests/functional/Session.php
@@ -37,7 +37,7 @@ namespace tests\units;
 
 use Computer;
 use Glpi\Exception\Http\AccessDeniedHttpException;
-use Glpi\Exception\Http\SessionExpiredHttpException;
+use Glpi\Exception\SessionExpiredException;
 use ReflectionClass;
 
 /* Test for inc/session.class.php */
@@ -1242,7 +1242,7 @@ class Session extends \DbTestCase
             function () {
                 \Session::checkValidSessionId();
             }
-        )->isInstanceOf(SessionExpiredHttpException::class);
+        )->isInstanceOf(SessionExpiredException::class);
     }
 
     protected function checkCentralAccessProvider(): iterable


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Follows #18046 .

Usage of the `http_response_code()` method is not compatible with many `Symfony` features (as explained in #18014) and usage of the `exit()`/`die()` methods prevents some `Symfony` features to be used (e.g. kernel events listeners).

I replace some usages of these methods to make the corresponding code fully compatible with the `Symfony` framework.