### PR TITLE
Improve e2e isolation

### DIFF
--- a/templates/layout/parts/profile_selector.html.twig
+++ b/templates/layout/parts/profile_selector.html.twig
@@ -34,7 +34,14 @@
 {% set rand = random() %}
 
 <div class="dropdown dropstart">
-    <button class="dropdown-item dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    <button
+        class="dropdown-item dropdown-toggle"
+        type="button"
+        data-bs-toggle="dropdown"
+        aria-haspopup="true"
+        aria-expanded="false"
+        aria-label="{{ __("Change profile") }}"
+    >
         <i class="ti ti-user-check"></i>
         {{ (session('glpiactiveprofile')['name'] ?? '') }}
     </button>

--- a/tests/cypress/e2e/DebugMode/debug_mode.cy.js
+++ b/tests/cypress/e2e/DebugMode/debug_mode.cy.js
@@ -39,13 +39,15 @@ describe("Debug Mode", () => {
         cy.disableDebugMode();
     });
     it('No debug mode for non super-admin', () => {
-        cy.changeProfile('Admin', true);
+        cy.changeProfile('Admin');
+        cy.visit('/front/computer.form.php');
         cy.get('#debug-toolbar-applet').should('not.exist', { timeout: 200 });
         cy.get('header a.user-menu-dropdown-toggle').click();
         cy.get('.dropdown-item[title="Change mode"]').should('not.exist', { timeout: 200 });
     });
     it('Debug mode for super-admin', () => {
         cy.changeProfile('Super-Admin');
+        cy.visit('/front/computer.form.php');
         cy.get('#debug-toolbar-applet').should('not.exist');
         cy.get('header a.user-menu-dropdown-toggle').click();
         cy.get('.dropdown-item[title="Change mode"]').should('exist').invoke('attr', 'href').should('include', '/ajax/switchdebug.php');

--- a/tests/cypress/e2e/ajax_controller.cy.js
+++ b/tests/cypress/e2e/ajax_controller.cy.js
@@ -34,7 +34,7 @@
 describe('Ajax Controller', () => {
     beforeEach(() => {
         cy.login();
-        cy.changeProfile('Super-Admin', true);
+        cy.changeProfile('Super-Admin');
     });
     it('refresh tabs on update', () => {
         cy.createWithAPI('Glpi\\Form\\Form', {

--- a/tests/cypress/e2e/entities_selector.cy.js
+++ b/tests/cypress/e2e/entities_selector.cy.js
@@ -33,14 +33,16 @@
 describe('Entities selector', () => {
     beforeEach(() => {
         cy.login();
-        cy.changeProfile('Super-Admin', true);
+        cy.changeProfile('Super-Admin');
 
         // Go to any page; force the entity to be E2ETestEntity
+        cy.blockGLPIDashboards();
         cy.visit('/front/central.php?active_entity=1');
         cy.get('header').findByTitle('Root entity > E2ETestEntity').should('exist');
     });
 
     after(() => {
+        cy.blockGLPIDashboards();
         cy.visit('/front/central.php?active_entity=1&is_recursive=1');
     });
 

--- a/tests/cypress/e2e/error_page.cy.js
+++ b/tests/cypress/e2e/error_page.cy.js
@@ -57,6 +57,9 @@ describe('Error page', () => {
                 cy.findByTestId('stack-trace').should('exist');
             });
         }
+
+        // eslint-disable-next-line
+        cy.wait(100); // The debug bar throw an error if we disable it immediately after loading a page...
         cy.disableDebugMode();
 
         // Check without debug mode (stack trace should NOT be displayed)

--- a/tests/cypress/e2e/error_page.cy.js
+++ b/tests/cypress/e2e/error_page.cy.js
@@ -35,7 +35,7 @@ describe('Error page', () => {
     });
 
     it('Displays a bad request error', () => {
-        cy.changeProfile('Super-Admin', true);
+        cy.changeProfile('Super-Admin');
 
         const urls = [
             '/front/impactcsv.php',       // streamed response
@@ -73,7 +73,7 @@ describe('Error page', () => {
     });
 
     it('Displays an access denied error', () => {
-        cy.changeProfile('Self-Service', true);
+        cy.changeProfile('Self-Service');
 
         const urls = [
             '/front/computer.php', // streamed response
@@ -99,7 +99,7 @@ describe('Error page', () => {
     });
 
     it('Displays a not found error', () => {
-        cy.changeProfile('Super-Admin', true);
+        cy.changeProfile('Super-Admin');
 
         const urls = [
             '/front/computer.form.php?id=999999', // streamed response

--- a/tests/cypress/e2e/fileupload.cy.js
+++ b/tests/cypress/e2e/fileupload.cy.js
@@ -33,7 +33,7 @@
 describe('File upload', () => {
     beforeEach(() => {
         cy.login();
-        cy.changeProfile('Super-Admin', true);
+        cy.changeProfile('Super-Admin');
         cy.visit('/front/document.form.php');
     });
 

--- a/tests/cypress/e2e/form/access_policies/access_control.cy.js
+++ b/tests/cypress/e2e/form/access_policies/access_control.cy.js
@@ -34,7 +34,7 @@
 describe('Access Control', () => {
     beforeEach(() => {
         cy.login();
-        cy.changeProfile('Super-Admin', true);
+        cy.changeProfile('Super-Admin');
 
         cy.createWithAPI('Glpi\\Form\\Form', {
             'name': '[Tests] Access Control',

--- a/tests/cypress/e2e/form/access_policies/direct_access.cy.js
+++ b/tests/cypress/e2e/form/access_policies/direct_access.cy.js
@@ -38,7 +38,7 @@ describe('Form access policy', () => {
         }).as('form_id');
 
         cy.login();
-        cy.changeProfile('Super-Admin', true);
+        cy.changeProfile('Super-Admin');
 
         cy.get('@form_id').then((form_id) => {
             const tab = 'Glpi\\Form\\AccessControl\\FormAccessControl$1';

--- a/tests/cypress/e2e/form/comment.cy.js
+++ b/tests/cypress/e2e/form/comment.cy.js
@@ -38,7 +38,7 @@ describe('Comment form', () => {
         }).as('form_id');
 
         cy.login();
-        cy.changeProfile('Super-Admin', true);
+        cy.changeProfile('Super-Admin');
 
         cy.get('@form_id').then((form_id) => {
             const tab = 'Glpi\\Form\\Form$main';

--- a/tests/cypress/e2e/form/destination_config_fields/associated_items.cy.js
+++ b/tests/cypress/e2e/form/destination_config_fields/associated_items.cy.js
@@ -34,7 +34,7 @@
 describe('Associated items configuration', () => {
     beforeEach(() => {
         cy.login();
-        cy.changeProfile('Super-Admin', true);
+        cy.changeProfile('Super-Admin');
 
         // Create form with a single "item" question
         cy.createFormWithAPI().as('form_id').visitFormTab('Form');

--- a/tests/cypress/e2e/form/destination_config_fields/content.cy.js
+++ b/tests/cypress/e2e/form/destination_config_fields/content.cy.js
@@ -34,7 +34,7 @@
 describe('Content configuration', () => {
     beforeEach(() => {
         cy.login();
-        cy.changeProfile('Super-Admin', true);
+        cy.changeProfile('Super-Admin');
 
         // Create form with a single "request type" question
         cy.createFormWithAPI({"name": "My form name"}).visitFormTab('Form');

--- a/tests/cypress/e2e/form/destination_config_fields/entity.cy.js
+++ b/tests/cypress/e2e/form/destination_config_fields/entity.cy.js
@@ -34,7 +34,7 @@
 describe('Entity configuration', () => {
     beforeEach(() => {
         cy.login();
-        cy.changeProfile('Super-Admin', true);
+        cy.changeProfile('Super-Admin');
 
         // Create form with a single "entity" question
         cy.createFormWithAPI().as('form_id').visitFormTab('Form');

--- a/tests/cypress/e2e/form/destination_config_fields/itilcategory.cy.js
+++ b/tests/cypress/e2e/form/destination_config_fields/itilcategory.cy.js
@@ -34,7 +34,7 @@
 describe('ITILCategory configuration', () => {
     beforeEach(() => {
         cy.login();
-        cy.changeProfile('Super-Admin', true);
+        cy.changeProfile('Super-Admin');
 
         // Create form with a single "request type" question
         cy.createFormWithAPI().as('form_id').visitFormTab('Form');

--- a/tests/cypress/e2e/form/destination_config_fields/itilfollowup.cy.js
+++ b/tests/cypress/e2e/form/destination_config_fields/itilfollowup.cy.js
@@ -34,7 +34,7 @@
 describe('ITILFollowup configuration', () => {
     beforeEach(() => {
         cy.login();
-        cy.changeProfile('Super-Admin', true);
+        cy.changeProfile('Super-Admin');
 
         // Create form
         cy.createFormWithAPI().as('form_id').visitFormTab('Form');

--- a/tests/cypress/e2e/form/destination_config_fields/itiltask.cy.js
+++ b/tests/cypress/e2e/form/destination_config_fields/itiltask.cy.js
@@ -34,7 +34,7 @@
 describe('ITILTask configuration', () => {
     beforeEach(() => {
         cy.login();
-        cy.changeProfile('Super-Admin', true);
+        cy.changeProfile('Super-Admin');
 
         // Create form
         cy.createFormWithAPI().as('form_id').visitFormTab('Form');

--- a/tests/cypress/e2e/form/destination_config_fields/location.cy.js
+++ b/tests/cypress/e2e/form/destination_config_fields/location.cy.js
@@ -34,7 +34,7 @@
 describe('Location configuration', () => {
     beforeEach(() => {
         cy.login();
-        cy.changeProfile('Super-Admin', true);
+        cy.changeProfile('Super-Admin');
 
         cy.createFormWithAPI().as('form_id').visitFormTab('Form');
 

--- a/tests/cypress/e2e/form/destination_config_fields/ola_tto.cy.js
+++ b/tests/cypress/e2e/form/destination_config_fields/ola_tto.cy.js
@@ -34,7 +34,7 @@
 describe('OLA TTO configuration', () => {
     beforeEach(() => {
         cy.login();
-        cy.changeProfile('Super-Admin', true);
+        cy.changeProfile('Super-Admin');
 
         // Create form
         cy.createFormWithAPI().visitFormTab('Form');

--- a/tests/cypress/e2e/form/destination_config_fields/ola_ttr.cy.js
+++ b/tests/cypress/e2e/form/destination_config_fields/ola_ttr.cy.js
@@ -34,7 +34,7 @@
 describe('OLA TTR configuration', () => {
     beforeEach(() => {
         cy.login();
-        cy.changeProfile('Super-Admin', true);
+        cy.changeProfile('Super-Admin');
 
         // Create form
         cy.createFormWithAPI().visitFormTab('Form');

--- a/tests/cypress/e2e/form/destination_config_fields/request_source.cy.js
+++ b/tests/cypress/e2e/form/destination_config_fields/request_source.cy.js
@@ -34,7 +34,7 @@
 describe('Request source configuration', () => {
     beforeEach(() => {
         cy.login();
-        cy.changeProfile('Super-Admin', true);
+        cy.changeProfile('Super-Admin');
 
         // Create form
         cy.createFormWithAPI().visitFormTab('Form');

--- a/tests/cypress/e2e/form/destination_config_fields/request_type.cy.js
+++ b/tests/cypress/e2e/form/destination_config_fields/request_type.cy.js
@@ -34,7 +34,7 @@
 describe('Request type configuration', () => {
     beforeEach(() => {
         cy.login();
-        cy.changeProfile('Super-Admin', true);
+        cy.changeProfile('Super-Admin');
 
         // Create form with a single "request type" question
         cy.createFormWithAPI().visitFormTab('Form');

--- a/tests/cypress/e2e/form/destination_config_fields/sla_tto.cy.js
+++ b/tests/cypress/e2e/form/destination_config_fields/sla_tto.cy.js
@@ -34,7 +34,7 @@
 describe('SLA TTO configuration', () => {
     beforeEach(() => {
         cy.login();
-        cy.changeProfile('Super-Admin', true);
+        cy.changeProfile('Super-Admin');
 
         // Create form
         cy.createFormWithAPI().visitFormTab('Form');

--- a/tests/cypress/e2e/form/destination_config_fields/sla_ttr.cy.js
+++ b/tests/cypress/e2e/form/destination_config_fields/sla_ttr.cy.js
@@ -34,7 +34,7 @@
 describe('SLA TTR configuration', () => {
     beforeEach(() => {
         cy.login();
-        cy.changeProfile('Super-Admin', true);
+        cy.changeProfile('Super-Admin');
 
         // Create form
         cy.createFormWithAPI().visitFormTab('Form');

--- a/tests/cypress/e2e/form/destination_config_fields/template.cy.js
+++ b/tests/cypress/e2e/form/destination_config_fields/template.cy.js
@@ -34,7 +34,7 @@
 describe('Template configuration', () => {
     beforeEach(() => {
         cy.login();
-        cy.changeProfile('Super-Admin', true);
+        cy.changeProfile('Super-Admin');
 
         // Create form
         cy.createFormWithAPI().as('form_id').visitFormTab('Form');

--- a/tests/cypress/e2e/form/destination_config_fields/title.cy.js
+++ b/tests/cypress/e2e/form/destination_config_fields/title.cy.js
@@ -34,7 +34,7 @@
 describe('Title configuration', () => {
     beforeEach(() => {
         cy.login();
-        cy.changeProfile('Super-Admin', true);
+        cy.changeProfile('Super-Admin');
 
         // Create form with a single "request type" question
         cy.createFormWithAPI({"name": "My form name"}).visitFormTab('Form');

--- a/tests/cypress/e2e/form/destination_config_fields/urgency.cy.js
+++ b/tests/cypress/e2e/form/destination_config_fields/urgency.cy.js
@@ -34,7 +34,7 @@
 describe('Urgency configuration', () => {
     beforeEach(() => {
         cy.login();
-        cy.changeProfile('Super-Admin', true);
+        cy.changeProfile('Super-Admin');
 
         // Create form with a single "urgency" question
         cy.createFormWithAPI().visitFormTab('Form');

--- a/tests/cypress/e2e/form/destination_config_fields/validation.cy.js
+++ b/tests/cypress/e2e/form/destination_config_fields/validation.cy.js
@@ -34,7 +34,7 @@
 describe('Validation configuration', () => {
     beforeEach(() => {
         cy.login();
-        cy.changeProfile('Super-Admin', true);
+        cy.changeProfile('Super-Admin');
 
         cy.createFormWithAPI().as('form_id').visitFormTab('Form');
 

--- a/tests/cypress/e2e/form/form_convert_default_values.cy.js
+++ b/tests/cypress/e2e/form/form_convert_default_values.cy.js
@@ -38,7 +38,7 @@ describe('Convert default value form', () => {
         }).as('form_id');
 
         cy.login();
-        cy.changeProfile('Super-Admin', true);
+        cy.changeProfile('Super-Admin');
 
         cy.get('@form_id').then((form_id) => {
             const tab = 'Glpi\\Form\\Form$main';

--- a/tests/cypress/e2e/form/form_destination.cy.js
+++ b/tests/cypress/e2e/form/form_destination.cy.js
@@ -38,7 +38,7 @@ describe('Form destination', () => {
         }).as('form_id');
 
         cy.login();
-        cy.changeProfile('Super-Admin', true);
+        cy.changeProfile('Super-Admin');
 
         cy.get('@form_id').then((form_id) => {
             const tab = 'Glpi\\Form\\Destination\\FormDestination$1';

--- a/tests/cypress/e2e/form/form_editor.cy.js
+++ b/tests/cypress/e2e/form/form_editor.cy.js
@@ -34,7 +34,7 @@
 describe ('Form editor', () => {
     beforeEach(() => {
         cy.login();
-        cy.changeProfile('Super-Admin', true);
+        cy.changeProfile('Super-Admin');
     });
 
     it('can create a form and fill its main details', () => {

--- a/tests/cypress/e2e/form/form_preview.cy.js
+++ b/tests/cypress/e2e/form/form_preview.cy.js
@@ -46,7 +46,7 @@ describe('Form preview', config, () => {
         }).as('form_id');
 
         cy.login();
-        cy.changeProfile('Super-Admin', true);
+        cy.changeProfile('Super-Admin');
 
         cy.get('@form_id').then((form_id) => {
             const tab = 'Glpi\\Form\\Form$1';

--- a/tests/cypress/e2e/form/form_tags.cy.js
+++ b/tests/cypress/e2e/form/form_tags.cy.js
@@ -69,7 +69,7 @@ describe('Form tags', () => {
         });
 
         cy.login();
-        cy.changeProfile('Super-Admin', true);
+        cy.changeProfile('Super-Admin');
 
         cy.get('@form_id').then((form_id) => {
             const tab = 'Glpi\\Form\\Destination\\FormDestination$1';

--- a/tests/cypress/e2e/form/question_types/actors.cy.js
+++ b/tests/cypress/e2e/form/question_types/actors.cy.js
@@ -38,7 +38,7 @@ describe('Actor form question type', () => {
         }).as('form_id');
 
         cy.login();
-        cy.changeProfile('Super-Admin', true);
+        cy.changeProfile('Super-Admin');
 
         cy.get('@form_id').then((form_id) => {
             const tab = 'Glpi\\Form\\Form$main';

--- a/tests/cypress/e2e/form/question_types/dropdown.cy.js
+++ b/tests/cypress/e2e/form/question_types/dropdown.cy.js
@@ -38,7 +38,7 @@ describe('Dropdown form question type', () => {
         }).as('form_id');
 
         cy.login();
-        cy.changeProfile('Super-Admin', true);
+        cy.changeProfile('Super-Admin');
 
         cy.get('@form_id').then((form_id) => {
             const tab = 'Glpi\\Form\\Form$main';

--- a/tests/cypress/e2e/form/question_types/item.cy.js
+++ b/tests/cypress/e2e/form/question_types/item.cy.js
@@ -42,7 +42,7 @@ describe('Item form question type', () => {
         }).as('ticket_id');
 
         cy.login();
-        cy.changeProfile('Super-Admin', true);
+        cy.changeProfile('Super-Admin');
 
         cy.get('@form_id').then((form_id) => {
             const tab = 'Glpi\\Form\\Form$main';

--- a/tests/cypress/e2e/form/question_types/selectables.cy.js
+++ b/tests/cypress/e2e/form/question_types/selectables.cy.js
@@ -38,7 +38,7 @@ describe('Selectable form question types', () => {
         }).as('form_id');
 
         cy.login();
-        cy.changeProfile('Super-Admin', true);
+        cy.changeProfile('Super-Admin');
 
         cy.get('@form_id').then((form_id) => {
             const tab = 'Glpi\\Form\\Form$main';

--- a/tests/cypress/e2e/form/serializer/export.cy.js
+++ b/tests/cypress/e2e/form/serializer/export.cy.js
@@ -34,7 +34,7 @@
 describe ('Export forms', () => {
     beforeEach(() => {
         cy.login();
-        cy.changeProfile('Super-Admin', true);
+        cy.changeProfile('Super-Admin');
     });
 
     it('Export single form', () => {

--- a/tests/cypress/e2e/form/serializer/import.cy.js
+++ b/tests/cypress/e2e/form/serializer/import.cy.js
@@ -35,7 +35,7 @@
 describe ('Import forms', () => {
     beforeEach(() => {
         cy.login();
-        cy.changeProfile('Super-Admin', true);
+        cy.changeProfile('Super-Admin');
     });
 
     it('can import forms', () => {

--- a/tests/cypress/e2e/form/service_catalog/service_catalog_page.cy.js
+++ b/tests/cypress/e2e/form/service_catalog/service_catalog_page.cy.js
@@ -44,7 +44,7 @@ describe('Service catalog page', () => {
 
         // Allow form to be displayed in the service catalog.
         cy.login();
-        cy.changeProfile('Super-Admin', true);
+        cy.changeProfile('Super-Admin');
         cy.get('@form_id').visitFormTab('Policies');
         cy.getDropdownByLabelText('Allow specifics users, groups or profiles').selectDropdownValue('All users');
         cy.findByRole('link', {'name': /There are \d+ user\(s\) matching these criteria\./}).should('exist');

--- a/tests/cypress/e2e/form/service_catalog/service_catalog_tab.cy.js
+++ b/tests/cypress/e2e/form/service_catalog/service_catalog_tab.cy.js
@@ -34,7 +34,7 @@
 describe('Service catalog tab', () => {
     beforeEach(() => {
         cy.login();
-        cy.changeProfile('Super-Admin', true);
+        cy.changeProfile('Super-Admin');
 
         cy.createFormWithAPI({
             'name': "Test form for service_catalog_tab.cy.js"

--- a/tests/cypress/e2e/general_config.cy.js
+++ b/tests/cypress/e2e/general_config.cy.js
@@ -33,7 +33,7 @@
 describe('Notifications', () => {
     beforeEach(() => {
         cy.login();
-        cy.changeProfile('Super-Admin', true);
+        cy.changeProfile('Super-Admin');
     });
 
     it('Change devices in menu', () => {

--- a/tests/cypress/e2e/notifications.cy.js
+++ b/tests/cypress/e2e/notifications.cy.js
@@ -33,7 +33,7 @@
 describe('Notifications', () => {
     beforeEach(() => {
         cy.login();
-        cy.changeProfile('Super-Admin', true);
+        cy.changeProfile('Super-Admin');
     });
     it('View Templates for a Notification', () => {
         // New Ticket notification

--- a/tests/cypress/e2e/search/filterable.cy.js
+++ b/tests/cypress/e2e/search/filterable.cy.js
@@ -34,7 +34,7 @@
 describe('Filterable', () => {
     beforeEach(() => {
         cy.login();
-        cy.changeProfile('Super-Admin', true);
+        cy.changeProfile('Super-Admin');
     });
 
     it('preview results are only loaded when explicitly requester', () => {

--- a/tests/cypress/e2e/self-service/home.cy.js
+++ b/tests/cypress/e2e/self-service/home.cy.js
@@ -34,7 +34,7 @@
 describe('Helpdesk home page', () => {
     beforeEach(() => {
         cy.login();
-        cy.changeProfile('Self-Service', true);
+        cy.changeProfile('Self-Service');
     });
     it('can use tiles', () => {
         cy.visit('/Home');

--- a/tests/cypress/e2e/session.cy.js
+++ b/tests/cypress/e2e/session.cy.js
@@ -1,0 +1,111 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+describe("Session", () => {
+    it('can login', () => {
+        cy.blockGLPIDashboards();
+
+        // Go to login page
+        cy.visit('/', {
+            headers: {
+                'Accept-Language': 'en-GB,en;q=0.9',
+            }
+        });
+        cy.title().should('eq', 'Authentication - GLPI');
+
+        // Fill form
+        cy.findByRole('textbox', {'name': "Login"}).type('e2e_tests');
+        cy.findByLabelText("Password").type('glpi');
+        cy.findByRole('checkbox', {name: "Remember me"}).check();
+        cy.getDropdownByLabelText("Login source").selectDropdownValue('GLPI internal database');
+
+        // Submit, the url should now contain /front/central.php or /front/helpdesk.public.php
+        cy.findByRole('button', {name: "Sign in"}).click();
+        cy.url().should('match', /\/front\/(central|helpdesk.public).php/);
+
+        // Validate cookies
+        cy.getCookies().should('have.length.gte', 2).then((cookies) => {
+            // Should be two cookies starting with 'glpi_' and one of them should end with '_rememberme'
+            expect(cookies.filter((cookie) => cookie.name.startsWith('glpi_'))).to.have.length(2);
+            expect(cookies.filter((cookie) => cookie.name.startsWith('glpi_') && cookie.name.endsWith('_rememberme'))).to.have.length(1);
+        });
+    });
+
+    it('can logout', () => {
+        // Login and go to any page
+        cy.login();
+        cy.visit('/front/computer.form.php');
+
+        // Logout
+        cy.findByRole('link', {name: 'User menu'}).click();
+        cy.findByRole('link', {name: 'Logout'}).click();
+
+        // Should be redirected to login page
+        cy.visit('/front/computer.form.php');
+        cy.findByText('Your session has expired. Please log in again.').should('exist');
+    });
+
+    it("redirect to requested page after login", () => {
+        // Must visit twice because glpi doens't support redirect on the first
+        // ever visit due to some cookies checks...
+        cy.visit('/front/ticket.form.php');
+        cy.visit('/front/ticket.form.php', {
+            failOnStatusCode: false
+        });
+        cy.findByRole('link', {'name': "Log in again"}).click();
+
+        // Login as e2e_tests
+        cy.findByRole('textbox', {'name': "Login"}).type('e2e_tests');
+        cy.findByLabelText("Password").type('glpi');
+        cy.findByRole('button', {name: "Sign in"}).click();
+
+        // Should be redirected to requested page
+        cy.url().should('contains', "/front/ticket.form.php");
+    });
+
+    it("can change profile", () => {
+        // Login and go to any page
+        cy.login();
+        cy.visit('/front/computer.form.php');
+        cy.findByRole('link', {'name': 'User menu'}).should('contain.text', 'Super-Admin');
+
+        // Change profile
+        cy.findByRole('link', {'name': 'User menu'}).click();
+        cy.findByRole('button', {'name': 'Change profile'}).click();
+        cy.findByRole('link', {'name': 'Observer'}).click();
+        cy.findByRole('link', {'name': 'User menu'}).should('contain.text', 'Observer');
+    });
+
+    // Note: testing that the current entity can be changed is done in the
+    // dedicated entities_selector.cy.js file
+});
+

--- a/tests/cypress/e2e/session.cy.js
+++ b/tests/cypress/e2e/session.cy.js
@@ -94,12 +94,14 @@ describe("Session", () => {
         cy.login();
         cy.visit('/front/computer.form.php');
         cy.findByRole('link', {'name': 'User menu'}).should('contain.text', 'Super-Admin');
+        cy.findByRole('listitem', {'name': 'Administration'}).should('exist');
 
         // Change profile
         cy.findByRole('link', {'name': 'User menu'}).click();
         cy.findByRole('button', {'name': 'Change profile'}).click();
-        cy.findByRole('link', {'name': 'Observer'}).click();
-        cy.findByRole('link', {'name': 'User menu'}).should('contain.text', 'Observer');
+        cy.findByRole('link', {'name': 'Self-Service'}).click();
+        cy.findByRole('link', {'name': 'User menu'}).should('contain.text', 'Self-Service');
+        cy.findByRole('listitem', {'name': 'Administration'}).should('not.exist');
     });
 
     // Note: testing that the current entity can be changed is done in the

--- a/tests/cypress/e2e/session.cy.js
+++ b/tests/cypress/e2e/session.cy.js
@@ -75,9 +75,6 @@ describe("Session", () => {
     });
 
     it("redirect to requested page after login", () => {
-        // Must visit twice because glpi doens't support redirect on the first
-        // ever visit due to some cookies checks...
-        cy.visit('/front/ticket.form.php');
         cy.visit('/front/ticket.form.php', {
             failOnStatusCode: false
         });

--- a/tests/cypress/e2e/tabs.cy.js
+++ b/tests/cypress/e2e/tabs.cy.js
@@ -33,7 +33,7 @@
 describe('Tabs', () => {
     beforeEach(() => {
         cy.login();
-        cy.changeProfile('Super-Admin', true);
+        cy.changeProfile('Super-Admin');
     });
     it('can use the "forcetab" URL parameter to land on a specific tab', () => {
         cy.visit("/front/user.form.php?id=2&forcetab=Change_Item$1");

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -31,8 +31,6 @@
  * ---------------------------------------------------------------------
  */
 
-import _ from 'lodash';
-
 let api_token = null;
 
 /**
@@ -44,39 +42,27 @@ let api_token = null;
  * @returns Chainable
  */
 Cypress.Commands.add('login', (username = 'e2e_tests', password = 'glpi') => {
-    cy.session(
-        username,
-        () => {
-            cy.blockGLPIDashboards();
-            cy.visit('/', {
-                headers: {
-                    'Accept-Language': 'en-GB,en;q=0.9',
-                }
-            });
-            cy.title().should('eq', 'Authentication - GLPI');
-            cy.findByRole('textbox', {'name': "Login"}).type(username);
-            cy.findByLabelText("Password", {exact: false}).type(password);
-            cy.findByRole('checkbox', {name: "Remember me"}).check();
-            // Select 'local' from the 'auth' dropdown
-            cy.findByLabelText("Login source").select('local', { force: true });
-            // TODO: should be
-            // cy.findByRole('combobox', {name: "Login source"}).select2('local', { force: true });
+    cy.clearAllCookies();
+    cy.request('index.php').its('body').then((body) => {
+        const $html = Cypress.$(body);
 
-            cy.findByRole('button', {name: "Sign in"}).click();
-            // After logging in, the url should contain /front/central.php or /front/helpdesk.public.php
-            cy.url().should('match', /\/front\/(central|helpdesk.public).php/);
-        },
-        {
-            validate: () => {
-                cy.getCookies().should('have.length.gte', 2).then((cookies) => {
-                    // Should be two cookies starting with 'glpi_' and one of them should end with '_rememberme'
-                    expect(cookies.filter((cookie) => cookie.name.startsWith('glpi_'))).to.have.length(2);
-                    expect(cookies.filter((cookie) => cookie.name.startsWith('glpi_') && cookie.name.endsWith('_rememberme'))).to.have.length(1);
-                });
-            },
-            cacheAcrossSpecs: true,
-        },
-    );
+        // Parse page
+        const csrf = $html.find('input[name=_glpi_csrf_token]').val();
+        const username_input = $html.find('#login_name').prop('name');
+        const password_input = $html.find('#login_password').prop('name');
+
+        // Send login request
+        cy.request({
+            method: 'POST',
+            url: '/front/login.php',
+            form: true,
+            body: {
+                [username_input]: username,
+                [password_input]: password,
+                _glpi_csrf_token: csrf,
+            }
+        });
+    });
 });
 
 /**
@@ -86,8 +72,7 @@ Cypress.Commands.add('login', (username = 'e2e_tests', password = 'glpi') => {
  * @returns Chainable
  */
 Cypress.Commands.add('logout', () => {
-    cy.findByRole('link', {name: 'User menu'}).click();
-    cy.findByRole('link', {name: 'Logout'}).click();
+    cy.request('/front/logout.php');
 });
 
 /**
@@ -95,40 +80,21 @@ Cypress.Commands.add('logout', () => {
  * @method changeProfile
  * @description Change the profile of the current user. Only supports the default GLPI profiles.
  * @param {string} profile - Profile to change to
- * @param {boolean} [verify=false] - Whether to verify that the profile was changed
  */
-Cypress.Commands.add('changeProfile', (profile, verify = false) => {
-    // If on about:blank, we need to get back to GLPI.
-    // Can happen at the start of a test if the login restored an existing session and therefore no redirect happened.
-    // With testIsolation, cypress starts each test on about:blank.
-    cy.url().then((url) => {
-        if (url === 'about:blank') {
-            cy.blockGLPIDashboards();
-            cy.visit('/');
-        }
-    });
-    // Pattern for the profile link text to match exactly except ignoring surrounding whitespace
-    const profile_pattern = new RegExp(`^\\s*${_.escapeRegExp(profile)}\\s*$`);
-    // Check if we are already on the desired profile
-    cy.get('header a.user-menu-dropdown-toggle').then(() => {
-        if (!Cypress.$('header a.user-menu-dropdown-toggle > div > div:nth-of-type(1)').text().match(profile_pattern)) {
-            // Look for all <a> with href containing 'newprofile=' and find the one with the text matching the desired profile
-            cy.get('div.user-menu a[href*="newprofile="]').contains(profile_pattern).first().invoke('attr', 'href').then((href) => {
-                cy.blockGLPIDashboards();
-                cy.visit(href, {
-                    headers: {
-                        // Cypress doesn't send this by default and it causes a real headache with GLPI since it is always used when redirecting back after a profile/entity change.
-                        // This causes e2e tests to randomly fail with the browser ending up on a /front/null page.
-                        Referer: Cypress.config('baseUrl'),
-                    }
-                }).then(() => {
-                    if (verify) {
-                        cy.get('header a.user-menu-dropdown-toggle > div > div:nth-of-type(1)').contains(profile_pattern);
-                    }
-                });
-            });
-        }
-    });
+Cypress.Commands.add('changeProfile', (profile) => {
+    const profiles = new Map([
+        ['Self-Service', 1],
+        ['Observer',     2],
+        ['Admin',        3],
+        ['Super-Admin',  4],
+        ['Hotliner',     5],
+        ['Technician',   6],
+        ['Supervisor',   7],
+        ['Read-Only',    8],
+    ]);
+    const profile_id = profiles.get(profile);
+
+    cy.request(`/front/central.php?newprofile=${profile_id}`);
 });
 
 /**


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.

## Description

We have had some session isolations issues when trying to add some tests to #18046.
These change simplify some cypress commands dealing with sessions to avoid these issues.

- Do not cache login between tests
- Replace `login` command by a direct HTTP request (no UI interaction, which is much faster) 
- Replace `logout` command by a direct HTTP request (no UI interaction) 
- Replace `changeProfile` command by a direct HTTP request (no UI interaction) 
- Add dedicated tests using the UI for login, logout and change profile.
- Add the test from #18046 that make sure login redirection is working



