### PR TITLE
Do not intercept redirects on dev env

### DIFF
--- a/dependency_injection/web_profiler.php
+++ b/dependency_injection/web_profiler.php
@@ -42,7 +42,6 @@ return static function (ContainerConfigurator $container): void {
 
     $container->extension('web_profiler', [
         'toolbar' => true,
-        'intercept_redirects' => true,
     ]);
     $container->extension('framework', [
         'profiler' => ['only_exceptions' => false],


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Now that session expirations are generating a redirection that can be intercepted by the Symfony profiler, it is a pain to have this feature enabled everytime. I think it is useful only for specific debugging and developers can activate it when they need it.