### PR TITLE
Fix ticket own right label

### DIFF
--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -5511,7 +5511,7 @@ JAVASCRIPT;
                 'long'  => __('Steal a ticket')
             ];
                                                //TRANS: short for : To be in charge of a ticket
-            $values[self::OWN]            = ['short' => __('Beeing in charge'),
+            $values[self::OWN]            = ['short' => __('Be in charge'),
                 'long'  => __('To be in charge of a ticket')
             ];
             $values[self::CHANGEPRIORITY] = __('Change the priority');


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Originally was just going to fix a typo `Beeing -> Being`, but the label still didn't match the form used with the other rights like "See assigned" so it was changed to "Be in charge" instead. So "User can Be in charge" not "User can Being in charge".
