### PR TITLE
Fix findID method for entity

### DIFF
--- a/src/CommonTreeDropdown.php
+++ b/src/CommonTreeDropdown.php
@@ -916,7 +916,7 @@ abstract class CommonTreeDropdown extends CommonDropdown
                     $fk      => (isset($input[$fk]) ? $input[$fk] : 0)
                 ]
             ];
-            if ($this->isEntityAssign()) {
+            if ($this->isEntityAssign() && $this->getTable() != 'glpi_entities') {
                 $criteria['WHERE'] = $criteria['WHERE'] + getEntitiesRestrictCriteria(
                     $this->getTable(),
                     '',


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !34752 and linked with [datainjection/433](https://github.com/pluginsGLPI/datainjection/pull/433)
- Here is a brief description of what this PR does

The findId method added a new condition in the WHERE, for example glpi_entities.id = 0. However, even when the method searches for an entity in the glpi_entities table, it continues to add this condition, which prevents the entity being found, as the condition becomes incorrect.

## Screenshots (if appropriate):


