### PR TITLE
[11.0] Remove usages of Response::sendError and deprecate the function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -245,6 +245,7 @@ The present file will list all changes made to the project; according to the
 - `Glpi\Features\DCBreadcrumb::getDcBreadcrumbSpecificValueToDisplay()`
 - `Glpi\Features\DCBreadcrumb::isEnclosurePart()`
 - `Glpi\Features\DCBreadcrumb::isRackPart()`
+- `Glpi\Http\Response::sendError()`. Throw a `Glpi\Exception\Http\*HttpException` exception instead.
 - `Glpi\Toolbox\Sanitizer::dbEscape()`
 - `Glpi\Toolbox\Sanitizer::dbEscapeRecursive()`
 - `Glpi\Toolbox\Sanitizer::dbUnescape()`

--- a/ajax/agent.php
+++ b/ajax/agent.php
@@ -33,7 +33,8 @@
  * ---------------------------------------------------------------------
  */
 
-use Glpi\Http\Response;
+use Glpi\Exception\Http\AccessDeniedHttpException;
+use Glpi\Exception\Http\NotFoundHttpException;
 
 /** @var \Glpi\Controller\LegacyFileLoadController $this */
 $this->setAjax();
@@ -45,8 +46,11 @@ Session::checkLoginUser();
 
 if (isset($_POST['action']) && isset($_POST['id'])) {
     $agent = new Agent();
-    if (!$agent->getFromDB($_POST['id']) || !$agent->canView()) {
-        Response::sendError(404, 'Unable to load agent #' . $_POST['id']);
+    if (!$agent->getFromDB($_POST['id'])) {
+        throw new NotFoundHttpException('Unable to load agent #' . $_POST['id']);
+    }
+    if (!$agent::canView()) {
+        throw new AccessDeniedHttpException('Unable to load agent #' . $_POST['id']);
     }
     $answer = [];
 

--- a/ajax/agent.php
+++ b/ajax/agent.php
@@ -50,7 +50,7 @@ if (isset($_POST['action']) && isset($_POST['id'])) {
         throw new NotFoundHttpException('Unable to load agent #' . $_POST['id']);
     }
     if (!$agent::canView()) {
-        throw new AccessDeniedHttpException('Unable to load agent #' . $_POST['id']);
+        throw new AccessDeniedHttpException();
     }
     $answer = [];
 

--- a/ajax/commonitilobject_item.php
+++ b/ajax/commonitilobject_item.php
@@ -45,7 +45,7 @@ Session::checkLoginUser();
 $obj = $obj ?? null;
 $item_obj = $item_obj ?? null;
 if (!($obj instanceof CommonDBTM) || !($item_obj instanceof CommonItilObject_Item)) {
-    throw new BadRequestHttpException('Bad request');
+    throw new BadRequestHttpException();
 }
 
 switch ($_GET['action']) {

--- a/ajax/commonitilobject_item.php
+++ b/ajax/commonitilobject_item.php
@@ -33,7 +33,7 @@
  * ---------------------------------------------------------------------
  */
 
-use Glpi\Http\Response;
+use Glpi\Exception\Http\BadRequestHttpException;
 
 header("Content-Type: text/html; charset=UTF-8");
 Html::header_nocache();
@@ -45,7 +45,7 @@ Session::checkLoginUser();
 $obj = $obj ?? null;
 $item_obj = $item_obj ?? null;
 if (!($obj instanceof CommonDBTM) || !($item_obj instanceof CommonItilObject_Item)) {
-    Response::sendError(400, 'Bad request', Response::CONTENT_TYPE_TEXT_HTML);
+    throw new BadRequestHttpException('Bad request');
 }
 
 switch ($_GET['action']) {

--- a/ajax/criteria_filter.php
+++ b/ajax/criteria_filter.php
@@ -34,10 +34,11 @@
  */
 
 use Glpi\Exception\Http\AccessDeniedHttpException;
+use Glpi\Exception\Http\BadRequestHttpException;
 use Glpi\Exception\Http\NotFoundHttpException;
+use Glpi\Exception\Http\UnprocessableEntityHttpException;
 use Glpi\Http\Response;
 use Glpi\Search\FilterableInterface;
-use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 
 Session::checkLoginUser();
 
@@ -46,7 +47,7 @@ $action = $_POST['action'] ?? false;
 switch ($action) {
     default:
         // Invalid action
-        throw new NotFoundHttpException("Invalid or missing value: action");
+        throw new BadRequestHttpException("Invalid or missing value: action");
 
     case "save_filter":
         // Default values for this endpoint
@@ -59,11 +60,11 @@ switch ($action) {
             !is_a($itemtype, CommonDBTM::class, true)
             || !is_a($itemtype, FilterableInterface::class, true)
         ) {
-            throw new NotFoundHttpException('Invalid or missing value: item_itemtype');
+            throw new BadRequestHttpException('Invalid or missing value: item_itemtype');
         }
-        /** @var CommonDBTM&FilterableInterface $item */
 
         // Validate items_id
+        /** @var (CommonDBTM&FilterableInterface)|false $item */
         $item = $itemtype::getById($items_id);
         if (!$item) {
             throw new NotFoundHttpException('Invalid or missing value: item_items_id');
@@ -71,7 +72,7 @@ switch ($action) {
 
         // Validate search criteria
         if (!is_array($search_criteria)) {
-            throw new NotFoundHttpException('Invalid value: criteria');
+            throw new BadRequestHttpException('Invalid value: criteria');
         }
 
         // Check rights, must be able to update parent item
@@ -98,11 +99,11 @@ switch ($action) {
             !is_a($itemtype, CommonDBTM::class, true)
             || !is_a($itemtype, FilterableInterface::class, true)
         ) {
-            throw new NotFoundHttpException('Invalid or missing value: itemtype');
+            throw new BadRequestHttpException('Invalid or missing value: itemtype');
         }
-        /** @var CommonDBTM&FilterableInterface $item */
 
         // Validate items_id
+        /** @var (CommonDBTM&FilterableInterface)|false $item */
         $item = $itemtype::getById($items_id);
         if (!$item) {
             throw new NotFoundHttpException('Invalid or missing value: items_id');

--- a/ajax/criteria_filter.php
+++ b/ajax/criteria_filter.php
@@ -33,8 +33,11 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Exception\Http\AccessDeniedHttpException;
+use Glpi\Exception\Http\NotFoundHttpException;
 use Glpi\Http\Response;
 use Glpi\Search\FilterableInterface;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 
 Session::checkLoginUser();
 
@@ -43,7 +46,7 @@ $action = $_POST['action'] ?? false;
 switch ($action) {
     default:
         // Invalid action
-        Response::sendError(400, "Invalid or missing value: action");
+        throw new NotFoundHttpException("Invalid or missing value: action");
 
     case "save_filter":
         // Default values for this endpoint
@@ -56,28 +59,29 @@ switch ($action) {
             !is_a($itemtype, CommonDBTM::class, true)
             || !is_a($itemtype, FilterableInterface::class, true)
         ) {
-            Response::sendError(400, 'Invalid or missing value: item_itemtype');
+            throw new NotFoundHttpException('Invalid or missing value: item_itemtype');
         }
+        /** @var CommonDBTM&FilterableInterface $item */
 
         // Validate items_id
         $item = $itemtype::getById($items_id);
         if (!$item) {
-            Response::sendError(400, 'Invalid or missing value: item_items_id');
+            throw new NotFoundHttpException('Invalid or missing value: item_items_id');
         }
 
         // Validate search criteria
         if (!is_array($search_criteria)) {
-            Response::sendError(400, 'Invalid value: criteria');
+            throw new NotFoundHttpException('Invalid value: criteria');
         }
 
         // Check rights, must be able to update parent item
         if (!$item->canUpdateItem()) {
-            Response::sendError(403, 'You are not allowed to update this item');
+            throw new AccessDeniedHttpException('You are not allowed to update this item');
         }
 
         // Save filters
         if (!$item->saveFilter($search_criteria)) {
-            Response::sendError(422, 'Unable to process data');
+            throw new UnprocessableEntityHttpException('Unable to process data');
         }
 
         // OK
@@ -94,23 +98,24 @@ switch ($action) {
             !is_a($itemtype, CommonDBTM::class, true)
             || !is_a($itemtype, FilterableInterface::class, true)
         ) {
-            Response::sendError(400, 'Invalid or missing value: itemtype');
+            throw new NotFoundHttpException('Invalid or missing value: itemtype');
         }
+        /** @var CommonDBTM&FilterableInterface $item */
 
         // Validate items_id
         $item = $itemtype::getById($items_id);
         if (!$item) {
-            Response::sendError(400, 'Invalid or missing value: items_id');
+            throw new NotFoundHttpException('Invalid or missing value: items_id');
         }
 
         // Check rights, must be able to update parent item
         if (!$item->canUpdateItem()) {
-            Response::sendError(403, 'You are not allowed to update this item');
+            throw new AccessDeniedHttpException('You are not allowed to update this item');
         }
 
         // Delete filters
         if (!$item->deleteFilter()) {
-            Response::sendError(422, 'Unable to process data');
+            throw new UnprocessableEntityHttpException('Unable to process data');
         }
 
         // OK

--- a/ajax/dropdownTrackingDeviceType.php
+++ b/ajax/dropdownTrackingDeviceType.php
@@ -33,7 +33,7 @@
  * ---------------------------------------------------------------------
  */
 
-use Glpi\Http\Response;
+use Glpi\Exception\Http\BadRequestHttpException;
 
 /** @var array $CFG_GLPI */
 global $CFG_GLPI;
@@ -49,7 +49,7 @@ $itemtype = $_POST["itemtype"] ?? '';
 
 // Check for required params
 if (empty($itemtype)) {
-    Response::sendError(400, "Bad request: itemtype cannot be empty", Response::CONTENT_TYPE_TEXT_HTML);
+    throw new BadRequestHttpException("Bad request: itemtype cannot be empty");
 }
 
 // Check if itemtype is valid in the given context

--- a/ajax/getUserPicture.php
+++ b/ajax/getUserPicture.php
@@ -33,7 +33,7 @@
  * ---------------------------------------------------------------------
  */
 
-use Glpi\Http\Response;
+use Glpi\Exception\Http\BadRequestHttpException;
 
 /** @var \Glpi\Controller\LegacyFileLoadController $this */
 $this->setAjax();
@@ -44,7 +44,7 @@ Html::header_nocache();
 Session::checkLoginUser();
 
 if (!isset($_REQUEST['users_id'])) {
-    Response::sendError(400, "Missing users_id parameter");
+    throw new BadRequestHttpException("Missing users_id parameter");
 } else if (!is_array($_REQUEST['users_id'])) {
     $_REQUEST['users_id'] = [$_REQUEST['users_id']];
 }

--- a/ajax/get_item_content.php
+++ b/ajax/get_item_content.php
@@ -33,7 +33,8 @@
  * ---------------------------------------------------------------------
  */
 
-use Glpi\Http\Response;
+use Glpi\Exception\Http\BadRequestHttpException;
+use Glpi\Exception\Http\NotFoundHttpException;
 use Glpi\RichText\RichText;
 
 /*
@@ -48,12 +49,12 @@ $items_id = $_GET['items_id'] ?? null;
 
 // Validate mandatory parameters
 if (is_null($itemtype) || is_null($items_id)) {
-    Response::sendError(400, "Missing required parameters");
+    throw new BadRequestHttpException("Missing required parameters");
 }
 
 // Validate itemtype (only CommonITILObject allowed for now)
 if (!is_a($itemtype, CommonITILObject::class, true)) {
-    Response::sendError(400, "Invalid itemtype");
+    throw new BadRequestHttpException("Invalid itemtype");
 }
 $item = new $itemtype();
 
@@ -63,7 +64,7 @@ if (
     || !$item->canViewItem()
     || !$item->isField('content')
 ) {
-    Response::sendError(404, "Item not found");
+    throw new NotFoundHttpException(404, "Item not found");
 }
 
 // Display content

--- a/ajax/impact.php
+++ b/ajax/impact.php
@@ -33,7 +33,8 @@
  * ---------------------------------------------------------------------
  */
 
-use Glpi\Http\Response;
+use Glpi\Exception\Http\AccessDeniedHttpException;
+use Glpi\Exception\Http\BadRequestHttpException;
 use Glpi\Plugin\Hooks;
 
 const DELTA_ACTION_ADD    = 1;
@@ -68,7 +69,7 @@ switch ($_SERVER['REQUEST_METHOD']) {
 
                 // Check required params
                 if (empty($itemtype)) {
-                    Response::sendError(400, "Missing itemtype");
+                    throw new BadRequestHttpException("Missing itemtype");
                 }
                 $icon = $CFG_GLPI["impact_asset_types"][$itemtype];
                 // Execute search
@@ -96,12 +97,12 @@ switch ($_SERVER['REQUEST_METHOD']) {
 
                // Check required params
                 if (empty($itemtype) || empty($items_id)) {
-                    Response::sendError(400, "Missing itemtype or items_id");
+                    throw new BadRequestHttpException("Missing itemtype or items_id");
                 }
 
                // Check that the target asset exist
                 if (!Impact::assetExist($itemtype, $items_id)) {
-                    Response::sendError(400, "Object[class=$itemtype, id=$items_id] doesn't exist");
+                    throw new BadRequestHttpException("Object[class=$itemtype, id=$items_id] doesn't exist");
                 }
 
                // Prepare graph
@@ -127,7 +128,7 @@ switch ($_SERVER['REQUEST_METHOD']) {
                 break;
 
             default:
-                Response::sendError(400, "Missing or invalid 'action' parameter");
+                throw new BadRequestHttpException("Missing or invalid 'action' parameter");
         }
         break;
 
@@ -135,13 +136,13 @@ switch ($_SERVER['REQUEST_METHOD']) {
     case 'POST':
        // Check required params
         if (!isset($_POST['impacts'])) {
-            Response::sendError(400, "Missing 'impacts' payload");
+            throw new BadRequestHttpException("Missing 'impacts' payload");
         }
 
        // Decode data (should be json)
         $data = Toolbox::jsonDecode($_POST['impacts'], true);
         if (!is_array($data)) {
-            Response::sendError(400, "Payload should be an array");
+            throw new BadRequestHttpException("Payload should be an array");
         }
 
         $readonly = true;
@@ -162,7 +163,7 @@ switch ($_SERVER['REQUEST_METHOD']) {
 
        // Stop here if readonly graph
         if ($readonly) {
-            Response::sendError(403, "Missing rights");
+            throw new AccessDeniedHttpException("Missing rights");
         }
 
         $context_id = 0;

--- a/ajax/itilfollowup.php
+++ b/ajax/itilfollowup.php
@@ -37,7 +37,7 @@
  * @since 9.5
  */
 
-use Glpi\Http\Response;
+use Glpi\Exception\Http\BadRequestHttpException;
 
 /** @var \Glpi\Controller\LegacyFileLoadController $this */
 $this->setAjax();
@@ -50,7 +50,7 @@ Session::checkLoginUser();
 // Mandatory parameter: itilfollowuptemplates_id
 $itilfollowuptemplates_id = $_POST['itilfollowuptemplates_id'] ?? null;
 if ($itilfollowuptemplates_id === null) {
-    Response::sendError(400, "Missing or invalid parameter: 'itilfollowuptemplates_id'");
+    throw new BadRequestHttpException("Missing or invalid parameter: 'itilfollowuptemplates_id'");
 } else if ($itilfollowuptemplates_id == 0) {
    // Reset form
     echo json_encode([
@@ -62,25 +62,25 @@ if ($itilfollowuptemplates_id === null) {
 // Mandatory parameter: items_id
 $parents_id = $_POST['items_id'] ?? 0;
 if (!$parents_id) {
-    Response::sendError(400, "Missing or invalid parameter: 'items_id'");
+    throw new BadRequestHttpException("Missing or invalid parameter: 'items_id'");
 }
 
 // Mandatory parameter: itemtype
 $parents_itemtype = $_POST['itemtype'] ?? '';
 if (empty($parents_itemtype) || !is_subclass_of($parents_itemtype, CommonITILObject::class)) {
-    Response::sendError(400, "Missing or invalid parameter: 'itemtype'");
+    throw new BadRequestHttpException("Missing or invalid parameter: 'itemtype'");
 }
 
 // Load followup template
 $template = new ITILFollowupTemplate();
 if (!$template->getFromDB($itilfollowuptemplates_id)) {
-    Response::sendError(400, "Unable to load template: $itilfollowuptemplates_id");
+    throw new BadRequestHttpException("Unable to load template: $itilfollowuptemplates_id");
 }
 
 // Load parent item
 $parent = new $parents_itemtype();
 if (!$parent->getFromDB($parents_id)) {
-    Response::sendError(400, "Unable to load parent item: $parents_itemtype $parents_id");
+    throw new BadRequestHttpException("Unable to load parent item: $parents_itemtype $parents_id");
 }
 
 // Render template content using twig

--- a/ajax/itilvalidation.php
+++ b/ajax/itilvalidation.php
@@ -37,7 +37,7 @@
  * @since 9.1
  */
 
-use Glpi\Http\Response;
+use Glpi\Exception\Http\BadRequestHttpException;
 
 /** @var \Glpi\Controller\LegacyFileLoadController $this */
 $this->setAjax();
@@ -50,7 +50,7 @@ Session::checkLoginUser();
 // Mandatory parameter: validationtemplates_id
 $validationtemplates_id = $_POST['validationtemplates_id'] ?? null;
 if ($validationtemplates_id === null) {
-    Response::sendError(400, "Missing or invalid parameter: 'validationtemplates_id'");
+    throw new BadRequestHttpException("Missing or invalid parameter: 'validationtemplates_id'");
 } else if ($validationtemplates_id == 0) {
     // Reset form
     echo json_encode([
@@ -62,25 +62,25 @@ if ($validationtemplates_id === null) {
 // Mandatory parameter: items_id
 $parents_id = $_POST['items_id'] ?? 0;
 if (!$parents_id) {
-    Response::sendError(400, "Missing or invalid parameter: 'items_id'");
+    throw new BadRequestHttpException("Missing or invalid parameter: 'items_id'");
 }
 
 // Mandatory parameter: itemtype
 $parents_itemtype = $_POST['itemtype'] ?? '';
 if (empty($parents_itemtype) || !is_subclass_of($parents_itemtype, CommonITILObject::class)) {
-    Response::sendError(400, "Missing or invalid parameter: 'itemtype'");
+    throw new BadRequestHttpException("Missing or invalid parameter: 'itemtype'");
 }
 
 // Load validation template
 $template = new ITILValidationTemplate();
 if (!$template->getFromDB($validationtemplates_id)) {
-    Response::sendError(400, "Unable to load template: $validationtemplates_id");
+    throw new BadRequestHttpException("Unable to load template: $validationtemplates_id");
 }
 
 // Load parent item
 $parent = new $parents_itemtype();
 if (!$parent->getFromDB($parents_id)) {
-    Response::sendError(400, "Unable to load parent item: $parents_itemtype $parents_id");
+    throw new BadRequestHttpException("Unable to load parent item: $parents_itemtype $parents_id");
 }
 
 $targets = ITILValidationTemplate_Target::getTargets($template->getID());

--- a/ajax/kanban.php
+++ b/ajax/kanban.php
@@ -39,7 +39,6 @@ use Glpi\Exception\Http\BadRequestHttpException;
 use Glpi\Exception\Http\HttpException;
 use Glpi\Features\Kanban;
 use Glpi\Features\Teamwork;
-use Glpi\Http\Response;
 
 /** @var \Glpi\Controller\LegacyFileLoadController $this */
 $this->setAjax();
@@ -50,7 +49,7 @@ Html::header_nocache();
 Session::checkLoginUser();
 
 if (!isset($_REQUEST['action'])) {
-    Response::sendError(400, "Missing action parameter", Response::CONTENT_TYPE_TEXT_HTML);
+    throw new BadRequestHttpException("Missing action parameter");
 }
 $action = $_REQUEST['action'];
 
@@ -64,7 +63,7 @@ if (isset($_REQUEST['itemtype'])) {
     if (!in_array($_REQUEST['action'], $nonkanban_actions) && !Toolbox::hasTrait($_REQUEST['itemtype'], Kanban::class)) {
        // Bad request
        // For all actions, except those in $nonkanban_actions, we expect to be manipulating the Kanban itself.
-        Response::sendError(400, "Invalid itemtype parameter", Response::CONTENT_TYPE_TEXT_HTML);
+        throw new BadRequestHttpException("Invalid itemtype parameter");
     }
     /** @var CommonDBTM $item */
     $itemtype = $_REQUEST['itemtype'];
@@ -119,7 +118,7 @@ if ($item !== null) {
 $checkParams = static function ($required) {
     foreach ($required as $param) {
         if (!isset($_REQUEST[$param])) {
-            Response::sendError(400, "Missing $param parameter");
+            throw new BadRequestHttpException("Missing $param parameter");
         }
     }
 };

--- a/ajax/solution.php
+++ b/ajax/solution.php
@@ -33,7 +33,7 @@
  * ---------------------------------------------------------------------
  */
 
-use Glpi\Http\Response;
+use Glpi\Exception\Http\BadRequestHttpException;
 use Glpi\RichText\RichText;
 
 /** @var \Glpi\Controller\LegacyFileLoadController $this */
@@ -47,7 +47,7 @@ Session::checkLoginUser();
 // Mandatory parameter: solutiontemplates_id
 $solutiontemplates_id = $_POST['solutiontemplates_id'] ?? null;
 if ($solutiontemplates_id === null) {
-    Response::sendError(400, "Missing or invalid parameter: 'solutiontemplates_id'");
+    throw new BadRequestHttpException("Missing or invalid parameter: 'solutiontemplates_id'");
 } else if ($solutiontemplates_id == 0) {
    // Reset form
     echo json_encode([
@@ -76,14 +76,14 @@ if (empty($parents_itemtype) || !is_subclass_of($parents_itemtype, CommonITILObj
 // Load solution template
 $template = new SolutionTemplate();
 if (!$template->getFromDB($solutiontemplates_id)) {
-    Response::sendError(400, "Unable to load template: $solutiontemplates_id");
+    throw new BadRequestHttpException("Unable to load template: $solutiontemplates_id");
 }
 
 if ($apply_twig) {
    // Load parent item
     $parent = new $parents_itemtype();
     if (!$parent->getFromDB($parents_id)) {
-        Response::sendError(400, "Unable to load parent item: $parents_itemtype $parents_id");
+        throw new BadRequestHttpException("Unable to load parent item: $parents_itemtype $parents_id");
     }
 
    // Render template content using twig

--- a/ajax/stencil.php
+++ b/ajax/stencil.php
@@ -33,6 +33,7 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Exception\Http\NotFoundHttpException;
 use Glpi\Http\Response;
 
 Session::checkLoginUser();
@@ -41,7 +42,7 @@ if (isset($_POST['id'])) {
     $stencil = Stencil::getStencilFromID($_POST['id']);
 
     if (!$stencil) {
-        Response::sendError(404, 'Stencil not found');
+        throw new NotFoundHttpException('Stencil not found');
     }
 
     $stencil->check($_POST['id'], READ);

--- a/ajax/task.php
+++ b/ajax/task.php
@@ -37,6 +37,7 @@
  * @since 9.1
  */
 
+use Glpi\Exception\Http\BadRequestHttpException;
 use Glpi\Http\Response;
 
 /** @var \Glpi\Controller\LegacyFileLoadController $this */
@@ -50,7 +51,7 @@ Session::checkLoginUser();
 // Mandatory parameter: tasktemplates_id
 $tasktemplates_id = $_POST['tasktemplates_id'] ?? null;
 if ($tasktemplates_id === null) {
-    Response::sendError(400, "Missing or invalid parameter: 'tasktemplates_id'");
+    throw new BadRequestHttpException("Missing or invalid parameter: 'tasktemplates_id'");
 } else if ($tasktemplates_id == 0) {
    // Reset form
     echo json_encode([
@@ -62,25 +63,25 @@ if ($tasktemplates_id === null) {
 // Mandatory parameter: items_id
 $parents_id = $_POST['items_id'] ?? 0;
 if (!$parents_id) {
-    Response::sendError(400, "Missing or invalid parameter: 'items_id'");
+    throw new BadRequestHttpException("Missing or invalid parameter: 'items_id'");
 }
 
 // Mandatory parameter: itemtype
 $parents_itemtype = $_POST['itemtype'] ?? '';
 if (empty($parents_itemtype) || !is_subclass_of($parents_itemtype, CommonITILObject::class)) {
-    Response::sendError(400, "Missing or invalid parameter: 'itemtype'");
+    throw new BadRequestHttpException("Missing or invalid parameter: 'itemtype'");
 }
 
 // Load task template
 $template = new TaskTemplate();
 if (!$template->getFromDB($tasktemplates_id)) {
-    Response::sendError(400, "Unable to load template: $tasktemplates_id");
+    throw new BadRequestHttpException("Unable to load template: $tasktemplates_id");
 }
 
 // Load parent item
 $parent = new $parents_itemtype();
 if (!$parent->getFromDB($parents_id)) {
-    Response::sendError(400, "Unable to load parent item: $parents_itemtype $parents_id");
+    throw new BadRequestHttpException("Unable to load parent item: $parents_itemtype $parents_id");
 }
 
 // Render template content using twig

--- a/front/asset/asset.form.php
+++ b/front/asset/asset.form.php
@@ -40,7 +40,7 @@
 use Glpi\Asset\Asset;
 use Glpi\Asset\AssetDefinition;
 use Glpi\Event;
-use Glpi\Http\Response;
+use Glpi\Exception\Http\BadRequestHttpException;
 
 if (array_key_exists('id', $_REQUEST) && !Asset::isNewId($_REQUEST['id'])) {
     $asset = Asset::getById($_REQUEST['id']);
@@ -58,7 +58,7 @@ if (array_key_exists('id', $_REQUEST) && !Asset::isNewId($_REQUEST['id'])) {
 }
 
 if ($asset === null) {
-    Response::sendError(400, 'Bad request', Response::CONTENT_TYPE_TEXT_HTML);
+    throw new BadRequestHttpException('Bad request');
 }
 
 Session::checkRightsOr($asset::$rightname, [READ, READ_ASSIGNED, READ_OWNED]);

--- a/front/asset/asset.php
+++ b/front/asset/asset.php
@@ -34,7 +34,7 @@
  */
 
 use Glpi\Asset\AssetDefinition;
-use Glpi\Http\Response;
+use Glpi\Exception\Http\BadRequestHttpException;
 use Glpi\Search\SearchEngine;
 
 $definition = new AssetDefinition();
@@ -43,7 +43,7 @@ $classname  = array_key_exists('class', $_GET) && $definition->getFromDBBySystem
     : null;
 
 if ($classname === null || !class_exists($classname)) {
-    Response::sendError(400, 'Bad request', Response::CONTENT_TYPE_TEXT_HTML);
+    throw new BadRequestHttpException('Bad request');
 }
 
 Session::checkRightsOr($classname::$rightname, [READ, READ_ASSIGNED, READ_OWNED]);

--- a/front/asset/ruledictionarymodel.form.php
+++ b/front/asset/ruledictionarymodel.form.php
@@ -34,7 +34,7 @@
  */
 
 use Glpi\Asset\AssetDefinition;
-use Glpi\Http\Response;
+use Glpi\Exception\Http\BadRequestHttpException;
 
 $definition = new AssetDefinition();
 $classname  = array_key_exists('class', $_GET) && $definition->getFromDBBySystemName((string)$_GET['class'])
@@ -42,7 +42,7 @@ $classname  = array_key_exists('class', $_GET) && $definition->getFromDBBySystem
     : null;
 
 if ($classname === null || !class_exists($classname)) {
-    Response::sendError(400, 'Bad request', Response::CONTENT_TYPE_TEXT_HTML);
+    throw new BadRequestHttpException('Bad request');
 }
 
 $rulecollection_class = $definition->getAssetModelDictionaryCollectionClassName();

--- a/front/asset/ruledictionarymodel.php
+++ b/front/asset/ruledictionarymodel.php
@@ -34,7 +34,7 @@
  */
 
 use Glpi\Asset\AssetDefinition;
-use Glpi\Http\Response;
+use Glpi\Exception\Http\BadRequestHttpException;
 
 $definition = new AssetDefinition();
 $classname  = array_key_exists('class', $_GET) && $definition->getFromDBBySystemName((string)$_GET['class'])
@@ -42,7 +42,7 @@ $classname  = array_key_exists('class', $_GET) && $definition->getFromDBBySystem
     : null;
 
 if ($classname === null || !class_exists($classname)) {
-    Response::sendError(400, 'Bad request', Response::CONTENT_TYPE_TEXT_HTML);
+    throw new BadRequestHttpException('Bad request');
 }
 
 $rulecollection_class = $definition->getAssetModelDictionaryCollectionClassName();

--- a/front/asset/ruledictionarytype.form.php
+++ b/front/asset/ruledictionarytype.form.php
@@ -34,7 +34,7 @@
  */
 
 use Glpi\Asset\AssetDefinition;
-use Glpi\Http\Response;
+use Glpi\Exception\Http\BadRequestHttpException;
 
 $definition = new AssetDefinition();
 $classname  = array_key_exists('class', $_GET) && $definition->getFromDBBySystemName((string)$_GET['class'])
@@ -42,7 +42,7 @@ $classname  = array_key_exists('class', $_GET) && $definition->getFromDBBySystem
     : null;
 
 if ($classname === null || !class_exists($classname)) {
-    Response::sendError(400, 'Bad request', Response::CONTENT_TYPE_TEXT_HTML);
+    throw new BadRequestHttpException('Bad request');
 }
 
 $rulecollection_class = $definition->getAssetTypeDictionaryCollectionClassName();

--- a/front/asset/ruledictionarytype.php
+++ b/front/asset/ruledictionarytype.php
@@ -34,7 +34,7 @@
  */
 
 use Glpi\Asset\AssetDefinition;
-use Glpi\Http\Response;
+use Glpi\Exception\Http\BadRequestHttpException;
 
 $definition = new AssetDefinition();
 $classname  = array_key_exists('class', $_GET) && $definition->getFromDBBySystemName((string)$_GET['class'])
@@ -42,7 +42,7 @@ $classname  = array_key_exists('class', $_GET) && $definition->getFromDBBySystem
     : null;
 
 if ($classname === null || !class_exists($classname)) {
-    Response::sendError(400, 'Bad request', Response::CONTENT_TYPE_TEXT_HTML);
+    throw new BadRequestHttpException('Bad request');
 }
 
 $rulecollection_class = $definition->getAssetTypeDictionaryCollectionClassName();

--- a/front/commonitilobject_item.form.php
+++ b/front/commonitilobject_item.form.php
@@ -34,7 +34,6 @@
  */
 
 use Glpi\Event;
-use Glpi\Http\Response;
 use Glpi\Exception\Http\BadRequestHttpException;
 
 /**
@@ -45,7 +44,7 @@ use Glpi\Exception\Http\BadRequestHttpException;
 Session::checkLoginUser();
 
 if (!($obj instanceof CommonDBTM) || !($item_obj instanceof CommonItilObject_Item)) {
-    Response::sendError(400, 'Bad request', Response::CONTENT_TYPE_TEXT_HTML);
+    throw new BadRequestHttpException('Bad request');
 }
 
 $obj_fkey = $obj->getForeignKeyField();

--- a/front/contenttemplates/documentation.php
+++ b/front/contenttemplates/documentation.php
@@ -34,13 +34,13 @@
  */
 
 use Glpi\ContentTemplates\TemplateManager;
-use Glpi\Http\Response;
+use Glpi\Exception\Http\BadRequestHttpException;
 use Glpi\Toolbox\MarkdownRenderer;
 
 // Check mandatory parameter
 $preset = $_GET['preset'] ?? null;
 if (is_null($preset)) {
-    Response::sendError(400, "Missing mandatory 'preset' parameter", Response::CONTENT_TYPE_TEXT_HTML);
+    throw new BadRequestHttpException("Missing mandatory 'preset' parameter");
 }
 
 Html::includeHeader(__("Template variables documentation"));

--- a/front/graph.send.php
+++ b/front/graph.send.php
@@ -35,7 +35,7 @@
 
 use Glpi\Csv\CsvResponse;
 use Glpi\Csv\StatCsvExport;
-use Glpi\Http\Response;
+use Glpi\Exception\Http\BadRequestHttpException;
 use Glpi\Stat\StatData;
 
 // Check rights
@@ -46,7 +46,7 @@ $statdata_itemtype = $_GET['statdata_itemtype'] ?? null;
 
 // Validate stats itemtype
 if (!is_a($statdata_itemtype, StatData::class, true)) {
-    Response::sendError(400, "Invalid stats itemtype", Response::CONTENT_TYPE_TEXT_PLAIN);
+    throw new BadRequestHttpException("Invalid stats itemtype");
 }
 
 // Get data and output csv

--- a/front/impactitem.form.php
+++ b/front/impactitem.form.php
@@ -33,7 +33,7 @@
  * ---------------------------------------------------------------------
  */
 
-use Glpi\Http\Response;
+use Glpi\Exception\Http\BadRequestHttpException;
 
 $impact_item = new ImpactItem();
 
@@ -42,7 +42,7 @@ if (isset($_POST["update"])) {
 
    // Can't update, id is missing
     if ($id === 0) {
-        Response::sendError(400, "Can't update the target impact item, id is missing", Response::CONTENT_TYPE_TEXT_HTML);
+        throw new BadRequestHttpException("Can't update the target impact item, id is missing");
     }
 
    // Load item and check rights

--- a/front/log/export.php
+++ b/front/log/export.php
@@ -35,7 +35,7 @@
 
 use Glpi\Csv\CsvResponse;
 use Glpi\Csv\LogCsvExport;
-use Glpi\Http\Response;
+use Glpi\Exception\Http\BadRequestHttpException;
 
 // Read params
 $itemtype = $_GET['itemtype']   ?? null;
@@ -46,18 +46,18 @@ Session::checkRight(Log::$rightname, READ);
 
 // Validate itemtype
 if (!is_a($itemtype, CommonDBTM::class, true)) {
-    Response::sendError(400, "Invalid itemtype", Response::CONTENT_TYPE_TEXT_PLAIN);
+    throw new BadRequestHttpException("Invalid itemtype");
 }
 
 // Validate id
 $item = $itemtype::getById($id);
 if (!$item || !$item->canViewItem()) {
-    Response::sendError(400, "No item found for given id", Response::CONTENT_TYPE_TEXT_PLAIN);
+    throw new BadRequestHttpException("No item found for given id");
 }
 
 // Validate filter
 if (!is_array($filter)) {
-    Response::sendError(400, "Invalid filter", Response::CONTENT_TYPE_TEXT_PLAIN);
+    throw new BadRequestHttpException("Invalid filter");
 }
 
 CsvResponse::output(new LogCsvExport($item, $filter));

--- a/front/logviewer.php
+++ b/front/logviewer.php
@@ -33,7 +33,7 @@
  * ---------------------------------------------------------------------
  */
 
-use Glpi\Http\Response;
+use Glpi\Exception\Http\NotFoundHttpException;
 use Glpi\System\Log\LogParser;
 use Glpi\System\Log\LogViewer;
 
@@ -49,7 +49,7 @@ if ($filepath === null) {
 }
 
 if (!file_exists(GLPI_LOG_DIR . '/' . $filepath) || is_dir(GLPI_LOG_DIR . '/' . $filepath)) {
-    Response::sendError(404, 'Not found', Response::CONTENT_TYPE_TEXT_HTML);
+    throw new NotFoundHttpException('Not found');
 }
 
 if (($_GET['action'] ?? '') === 'download') {

--- a/front/manuallink.form.php
+++ b/front/manuallink.form.php
@@ -35,13 +35,13 @@
 
 use Glpi\Event;
 use Glpi\Exception\Http\BadRequestHttpException;
-use Glpi\Http\Response;
+use Glpi\Exception\Http\NotFoundHttpException;
 
 Session::checkValidSessionId();
 
 $link = new ManualLink();
 if (array_key_exists('id', $_REQUEST) && !$link->getFromDB($_REQUEST['id'])) {
-    Response::sendError(404, 'No item found for given id', Response::CONTENT_TYPE_TEXT_HTML);
+    throw new NotFoundHttpException('No item found for given id');
 }
 
 if (array_key_exists('purge', $_POST) || array_key_exists('delete', $_POST)) {

--- a/front/stencil.form.php
+++ b/front/stencil.form.php
@@ -34,7 +34,7 @@
  */
 
 use Glpi\Exception\Http\AccessDeniedHttpException;
-use Glpi\Http\Response;
+use Glpi\Exception\Http\NotFoundHttpException;
 
 Session::checkLoginUser();
 
@@ -42,7 +42,7 @@ if (isset($_POST['id'])) {
     $stencil = Stencil::getStencilFromID($_POST['id']);
 
     if (!$stencil) {
-        Response::sendError(404, 'Stencil not found');
+        throw new NotFoundHttpException('Stencil not found');
     }
 
     $stencil->check($_POST['id'], READ);

--- a/src/Glpi/Exception/Http/UnprocessableEntityHttpException.php
+++ b/src/Glpi/Exception/Http/UnprocessableEntityHttpException.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2024 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -33,42 +32,11 @@
  * ---------------------------------------------------------------------
  */
 
-use Glpi\Exception\Http\BadRequestHttpException;
-use Glpi\Exception\Http\NotFoundHttpException;
-use Glpi\RichText\RichText;
+namespace Glpi\Exception\Http;
 
-/*
- * Ajax tooltip endpoint for CommonITILObjects
- */
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException as BaseException;
 
-Session::checkLoginUser();
-
-// Read parameters
-$itemtype = $_GET['itemtype'] ?? null;
-$items_id = $_GET['items_id'] ?? null;
-
-// Validate mandatory parameters
-if (is_null($itemtype) || is_null($items_id)) {
-    throw new BadRequestHttpException("Missing required parameters");
+class UnprocessableEntityHttpException extends BaseException implements HttpExceptionInterface
+{
+    use HttpExceptionTrait;
 }
-
-// Validate itemtype (only CommonITILObject allowed for now)
-if (!is_a($itemtype, CommonITILObject::class, true)) {
-    throw new BadRequestHttpException("Invalid itemtype");
-}
-$item = new $itemtype();
-
-// Validate item
-if (
-    !$item->getFromDB($items_id)
-    || !$item->canViewItem()
-    || !$item->isField('content')
-) {
-    throw new NotFoundHttpException("Item not found");
-}
-
-// Display content
-header('Content-type: text/html');
-echo RichText::getEnhancedHtml($item->fields['content'], [
-    'images_gallery' => false, // Don't show photoswipe gallery
-]);

--- a/src/Glpi/Features/Kanban.php
+++ b/src/Glpi/Features/Kanban.php
@@ -35,7 +35,7 @@
 
 namespace Glpi\Features;
 
-use Glpi\Http\Response;
+use Glpi\Exception\Http\BadRequestHttpException;
 use Glpi\Plugin\Hooks;
 
 /**
@@ -178,7 +178,7 @@ trait Kanban
             }
         }
         if (false === $tab_id || is_null($tab_id)) {
-            Response::sendError(400, "Itemtype does not have a Kanban tab!", Response::CONTENT_TYPE_TEXT_HTML);
+            throw new BadRequestHttpException("Itemtype does not have a Kanban tab!");
         }
         return static::getFormURLWithID($items_id, $full) . "&forcetab={$tab_id}";
     }

--- a/src/Glpi/Http/Response.php
+++ b/src/Glpi/Http/Response.php
@@ -65,10 +65,12 @@ class Response extends \GuzzleHttp\Psr7\Response
      * @param string  $content_type  Response content type
      *
      * @return never
+     *
+     * @deprecated 11.0.0
      */
     public static function sendError(int $code, string $message, string $content_type = self::CONTENT_TYPE_JSON): never
     {
-        Toolbox::deprecated('Response::sendError() is deprecated. Please throw HttpException objects instead.');
+        Toolbox::deprecated('Response::sendError() is deprecated. Throw a `Glpi\Exception\Http\*HttpException` exception instead.');
 
         switch ($content_type) {
             case self::CONTENT_TYPE_JSON:

--- a/src/Glpi/Http/Response.php
+++ b/src/Glpi/Http/Response.php
@@ -68,6 +68,7 @@ class Response extends \GuzzleHttp\Psr7\Response
      */
     public static function sendError(int $code, string $message, string $content_type = self::CONTENT_TYPE_JSON): never
     {
+        Toolbox::deprecated('Response::sendError() is deprecated. Please throw HttpException objects instead.');
 
         switch ($content_type) {
             case self::CONTENT_TYPE_JSON:


### PR DESCRIPTION
The goal is to follow the new error handling system and remove all occurrences of `die` and `exit` throughout the codebase