### PR TITLE
Less strict validation of the referer URL

### DIFF
--- a/phpunit/functional/HtmlTest.php
+++ b/phpunit/functional/HtmlTest.php
@@ -913,18 +913,6 @@ class HtmlTest extends \GLPITestCase
             'expected' => 'https://localhost/glpi/front/computer.form.php?id=1',
         ];
 
-        // Outside GLPI
-        yield 'http://localhost/not-glpi/front/computer.form.php?id=1' => [
-            'referer'  => 'http://localhost/not-glpi/front/computer.form.php?id=1',
-            'base_url' => 'http://localhost/glpi',
-            'expected' => 'http://localhost/glpi',
-        ];
-        yield 'http://notglpi/front/computer.form.php?id=1' => [
-            'referer'  => 'http://notglpi/front/computer.form.php?id=1',
-            'base_url' => 'http://localhost/glpi',
-            'expected' => 'http://localhost/glpi',
-        ];
-
         // Invalid referer
         yield '/invalid/referer' => [
             'referer'  => '/invalid/referer',

--- a/src/Html.php
+++ b/src/Html.php
@@ -622,12 +622,12 @@ class Html
     /**
      * Return an URL for getting back to previous page.
      * Remove `forcetab` parameter if exists to prevent bad tab display.
-     * If the referer does not match an URL inside GLPI, return value will be the GLPI index page.
+     * If the referer does not match a valid URL, return value will be the GLPI index page.
      *
      * @since 9.2.2
      * @since 11.0.0 The `$url_in` parameter has been removed.
      *
-     * @return string|false Referer URL or false if referer URL is outside the GLPI path.
+     * @return string|false Referer URL or false if referer URL is invalid.
      */
     public static function getBackUrl()
     {
@@ -637,19 +637,6 @@ class Html
         $referer_url  = self::getRefererUrl();
 
         if ($referer_url === null) {
-            return $CFG_GLPI['url_base'];
-        }
-
-        $referer_host = parse_url($referer_url, PHP_URL_HOST);
-        $referer_path = parse_url($referer_url, PHP_URL_PATH);
-
-        $glpi_host      = parse_url($CFG_GLPI['url_base'], PHP_URL_HOST);
-        $glpi_base_path = parse_url($CFG_GLPI['url_base'], PHP_URL_PATH) ?: '/';
-
-        if (
-            $referer_host !== $glpi_host
-            || !str_starts_with($referer_path, $glpi_base_path)
-        ) {
             return $CFG_GLPI['url_base'];
         }
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

The strict validation of the referer introduced in #17938 prevents GLPI from working correctly when it is accessed with an URL that does not match the configured base URL. This could be a problem in many legitimate cases :
 - a sysadmin is preparing a migration to a new server with a GLPI connected to the production database, but using the server IP to access it until the DNS switch;
 - GLPI is accessible at a different address whether it is accessed by the company workers from the local network (`https://support/`) or by the customers (`http://company.tld/support/`).

We could not rely on the `Host` header to handle this, as its value could be changed too.

The initial problem was the fact that the referer value could contain some JS code instead of a valid URL. I propose to keep only that check related on the referer validity (i.e. it is a valid URL) and remove the check that validates that it matches the configured GLPI base URL.