### PR TITLE
Try to fix error page flaky test

### DIFF
--- a/tests/cypress/e2e/error_page.cy.js
+++ b/tests/cypress/e2e/error_page.cy.js
@@ -32,6 +32,9 @@
 describe('Error page', () => {
     beforeEach(() => {
         cy.login();
+
+        // prevent race conditions with ajax callbacks and speed up execution
+        cy.intercept({path: '/ajax/debug.php**'}, { statusCode: 404, body: '' });
     });
 
     it('Displays a bad request error', () => {
@@ -58,11 +61,8 @@ describe('Error page', () => {
             });
         }
 
-        // eslint-disable-next-line
-        cy.wait(100); // The debug bar throw an error if we disable it immediately after loading a page...
-        cy.disableDebugMode();
-
         // Check without debug mode (stack trace should NOT be displayed)
+        cy.disableDebugMode();
         for (const url of urls) {
             cy.visit({
                 url: url,


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

The `error_page` test seems to fail often. I do not understand why, but I suspect a race condition between debug mode disabling and debug bar ajax callbacks.

Blocking requests to the `ajax/debug.php` endpoint could fix the issue.