### PR TITLE
Fix document fields readonly

### DIFF
--- a/src/Document.php
+++ b/src/Document.php
@@ -1714,11 +1714,21 @@ class Document extends CommonDBTM
             $values[$data['id']] = $data['name'];
         }
         $rand = mt_rand();
-        $out  = Dropdown::showFromArray('_rubdoc', $values, ['width'               => '30%',
+        $readonly = $p['readonly'] ?? false;
+        $out = '';
+        $width = '30%';
+        if ($readonly) {
+            $width = '100%';
+            $out .= '<div class="row">';
+            $out .= '<div class="col-xxl-5 p-0">';
+        }
+        $out  .= Dropdown::showFromArray('_rubdoc', $values, [
+            'width'               => $width,
             'rand'                => $rand,
             'display'             => false,
             'display_emptychoice' => true,
             'value'               => $p['rubdoc'] ?? 0,
+            'readonly'            => $readonly
         ]);
         $field_id = Html::cleanId("dropdown__rubdoc$rand");
 
@@ -1729,6 +1739,10 @@ class Document extends CommonDBTM
             'used'   => $p['used']
         ];
 
+        if ($readonly) {
+            $out .= '</div>';
+            $out .= '<div class="col-xxl-7 p-0">';
+        }
         $out .= Ajax::updateItemOnSelectEvent(
             $field_id,
             "show_" . $p['name'] . $rand,
@@ -1741,12 +1755,31 @@ class Document extends CommonDBTM
 
         $params['rubdoc'] = $p['rubdoc'] ?? 0;
         $params['value'] = $p['value'] ?? 0;
-        $out .= Ajax::updateItem(
-            "show_" . $p['name'] . $rand,
-            $CFG_GLPI["root_doc"] . "/ajax/dropdownRubDocument.php",
-            $params,
-            false
-        );
+        if ($readonly) {
+            $document = new Document();
+            $doclist = $document->find([]);
+            foreach ($doclist as $doc) {
+                $docvalue[$doc['id']] = $doc['name'];
+            }
+
+            $out .= Dropdown::showFromArray('document', $docvalue ?? [], [
+                'width'               => $width,
+                'rand'                => $rand,
+                'display'             => false,
+                'display_emptychoice' => true,
+                'value'               => $p['value'] ?? 0,
+                'readonly'            => $readonly
+            ]);
+            $out .= '</div>';
+            $out .= '</div>';
+        } else {
+            $out .= Ajax::updateItem(
+                "show_" . $p['name'] . $rand,
+                $CFG_GLPI["root_doc"] . "/ajax/dropdownRubDocument.php",
+                $params,
+                false
+            );
+        }
         if ($p['display']) {
             echo $out;
             return $rand;

--- a/src/Document.php
+++ b/src/Document.php
@@ -1714,7 +1714,7 @@ class Document extends CommonDBTM
             $values[$data['id']] = $data['name'];
         }
         $rand = mt_rand();
-        $readonly = $p['readonly'] ?? false;
+        $readonly = $p['readonly'];
         $out = '';
         $width = '30%';
         if ($readonly) {

--- a/src/Document.php
+++ b/src/Document.php
@@ -1670,6 +1670,7 @@ class Document extends CommonDBTM
         $p['used']    = [];
         $p['display'] = true;
         $p['hide_if_no_elements'] = false;
+        $p['readonly'] = false;
 
         if (is_array($options) && count($options)) {
             foreach ($options as $key => $val) {


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !34821
- Here is a brief description of what this PR does

The document fields could not be passed as readonly, the problem arose when a user wanted to pass a Fields field as readonly but this failed. And the field could still be modified.

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/47f1a79d-c610-4f99-8bf7-5e9ae7427ace)



