### PR TITLE
[11.0] Fix minor issues in phpunit script

### DIFF
--- a/.github/actions/test_tests-phpunit.sh
+++ b/.github/actions/test_tests-phpunit.sh
@@ -2,7 +2,7 @@
 set -e -u -x -o pipefail
 
 PHPUNIT_ADDITIONNAL_OPTIONS=""
-if [[ "$CODE_COVERAGE" = true ]]; then
+if [[ "${CODE_COVERAGE:-}" = true ]]; then
   export COVERAGE_DIR="coverage-functional"
   PHPUNIT_ADDITIONNAL_OPTIONS="--coverage-filter src --coverage-clover phpunit/$COVERAGE_DIR/clover.xml"
 

--- a/.github/actions/test_tests-phpunit.sh
+++ b/.github/actions/test_tests-phpunit.sh
@@ -10,6 +10,6 @@ else
   PHPUNIT_ADDITIONNAL_OPTIONS="--no-coverage";
 fi
 
-vendor/bin/phpunit $PHPUNIT_ADDITIONNAL_OPTIONS
+vendor/bin/phpunit $PHPUNIT_ADDITIONNAL_OPTIONS $@
 
 unset COVERAGE_DIR


### PR DESCRIPTION
This PR allows executing the PHPUnit script locally with commands like this:

```bash
docker compose exec app .github/actions/test_tests-phpunit.sh # add other args...
```

Mainly to be able to easily run a single test class/file/method/dataset.