### PR TITLE
Autoload custom palettes

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -1206,20 +1206,17 @@ HTML;
             }
         }
 
-        if ($theme->isCustomTheme()) {
-            $theme_path = $theme->getKey() . '?is_custom_theme=1';
-
-            // Custom theme files might be modified by external source
-            $theme_path .= "&lastupdate=" . filemtime($theme->getPath(false));
-        } else {
-            $theme_path = $theme->getPath();
-        }
         $tpl_vars['css_files'][] = ['path' => 'public/lib/tabler.css'];
         $tpl_vars['css_files'][] = ['path' => 'css/glpi.scss'];
-        if ($theme->isCustomTheme()) {
+        $tpl_vars['css_files'][] = ['path' => 'css/core_palettes.scss'];
+        foreach (ThemeManager::getInstance()->getAllThemes() as $info) {
+            if (!$info->isCustomTheme()) {
+                continue;
+            }
+            $theme_path = $info->getKey() . '?is_custom_theme=1';
+            // Custom theme files might be modified by external source
+            $theme_path .= "&lastupdate=" . filemtime($info->getPath(false));
             $tpl_vars['css_files'][] = ['path' => $theme_path];
-        } else {
-            $tpl_vars['css_files'][] = ['path' => 'css/core_palettes.scss'];
         }
 
         // Add specific meta tags for plugins


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Automatically load custom palettes the same way core palettes are so they can be easily swapped based on root element attributes.

Example custom palette SCSS (mycustomtheme.scss):
```scss
:root[data-glpi-theme="mycustomtheme"] {
    --tblr-primary-rgb: 142, 197, 71;
    --tblr-secondary: #768363;
    --tblr-secondary-fg: #fcfcfc;
    --tblr-link-color-rgb: 69, 148, 54;
    --glpi-mainmenu-bg: #459436;
    --glpi-mainmenu-fg: #f4f6fa;
}
```
