### PR TITLE
Remove unneeded dashboard JS imports

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -1170,13 +1170,15 @@ HTML;
                 }
             }
 
-            // include more js libs for dashboard case
-            $jslibs = array_merge($jslibs, [
-                'gridstack',
-                'charts',
-                'clipboard',
-                'sortable'
-            ]);
+            if (in_array('dashboard', $jslibs)) {
+                // include more js libs for dashboard case
+                $jslibs = array_merge($jslibs, [
+                    'gridstack',
+                    'charts',
+                    'clipboard',
+                    'sortable'
+                ]);
+            }
 
             if (in_array('planning', $jslibs)) {
                 Html::requireJs('planning');


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Since 10.0.6, all of the "extra" required libraries for dashboards were always being included even when `dashboard` wasn't in the array of requested libraries. In a non-archive release (so nothing minified) this saves approximately 800kb on non-dashboard pages. Most of the savings is from not importing `echarts`.