### PR TITLE
Hide empty note section in ticket panel

### DIFF
--- a/templates/components/itilobject/fields_panel.html.twig
+++ b/templates/components/itilobject/fields_panel.html.twig
@@ -286,30 +286,26 @@
    {% if canreadnote %}
       {% set notes = call('Notepad::getAllForItem', [get_item('Entity', item.fields['entities_id']), 'Ticket']) %}
       {% set notes_show = headers_states['notes'] is not defined or headers_states['notes'] == "true" ? true : (notes|length > 0) %}
-      <section class="accordion-item" aria-label="{{ __('Notes') }}">
-         <h2 class="accordion-header" id="notes-heading" title="{{ __('Notes') }}" data-bs-toggle="tooltip">
-            <button class="accordion-button {{ notes_show ? "" : "collapsed" }}" type="button" data-bs-toggle="collapse" data-bs-target="#notes" aria-expanded="true" aria-controls="notes">
-               <i class="ti ti-notes me-1"></i>
-               <span class="item-title">
-                  {{ __('Entity notes') }}
-               </span>
-               <span class="badge bg-secondary text-secondary-fg ms-2">{{ notes|length }}</span>
-            </button>
-         </h2>
-         <div id="notes" class="accordion-collapse collapse {{ notes_show ? "show" : "" }}" aria-labelledby="notes-heading">
-            <div class="accordion-body row m-0 mt-n2">
-               {% if notes|length == 0 %}
-                  <div class="alert alert-info" role="alert">
-                     {{ __('There is no notes on this entity') }}
-                  </div>
-               {% else %}
+       {% if notes|length != 0 %}
+          <section class="accordion-item" aria-label="{{ __('Notes') }}">
+             <h2 class="accordion-header" id="notes-heading" title="{{ __('Notes') }}" data-bs-toggle="tooltip">
+                <button class="accordion-button {{ notes_show ? "" : "collapsed" }}" type="button" data-bs-toggle="collapse" data-bs-target="#notes" aria-expanded="true" aria-controls="notes">
+                   <i class="ti ti-notes me-1"></i>
+                   <span class="item-title">
+                      {{ __('Entity notes') }}
+                   </span>
+                   <span class="badge bg-secondary text-secondary-fg ms-2">{{ notes|length }}</span>
+                </button>
+             </h2>
+             <div id="notes" class="accordion-collapse collapse {{ notes_show ? "show" : "" }}" aria-labelledby="notes-heading">
+                <div class="accordion-body row m-0 mt-n2">
                   {% for note in notes %}
                      <div class="alert alert-info entitynote rich_text_container" role="alert">{{ note['content']|safe_html }}</div>
                   {% endfor %}
-               {% endif %}
-            </div>
-         </div>
-      </section>
+                </div>
+             </div>
+          </section>
+       {% endif %}
    {% endif %}
 
    {% if item_commonitilobject is defined and item_commonitilobject is not null %}


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Hides the entity notes section of the info panel when there are no notes to display
Fixes #17855



