### PR TITLE
Fix (dashboard): entities restrict criteria on bigNumber card

### DIFF
--- a/src/Dashboard/Provider.php
+++ b/src/Dashboard/Provider.php
@@ -118,7 +118,7 @@ class Provider
             ];
         } else {
             if ($item->isEntityAssign()) {
-                $where += getEntitiesRestrictCriteria($item::getTable());
+                $where += getEntitiesRestrictCriteria($item::getTable(), '', '', $item->maybeRecursive());
             }
             $request = [
                 'SELECT' => ['COUNT DISTINCT' => $item::getTableField($item::getIndexName()) . ' as cpt'],

--- a/src/Dashboard/Provider.php
+++ b/src/Dashboard/Provider.php
@@ -102,7 +102,7 @@ class Provider
         }
 
         if ($item instanceof User) {
-            $where += getEntitiesRestrictCriteria(Profile_User::getTable());
+            $where += getEntitiesRestrictCriteria(Profile_User::getTable(), '', '', true);
             $request = [
                 'SELECT' => ['COUNT DISTINCT' => $item::getTableField($item::getIndexName()) . ' as cpt'],
                 'FROM'   => $i_table,


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !34859
- Here is a brief description of what this PR does

There was a discrepancy between the number displayed on a 'bigNumber' card and the number of results shown when clicking on the card, because the recursion of parent entities was not considered.

## Screenshots (if appropriate):


