### PR TITLE
Fix HTML escaping in `CommonGLPI::createTabEntry()`

### DIFF
--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -4418,7 +4418,7 @@ TWIG, $twig_params);
             && $item->can($item->getField('id'), READ)
         ) {
             $ong     = [];
-            $ong[1]  = self::createTabEntry(_sx('button', 'Test'), 0, $item::class, "ti ti-stethoscope"); // test connexion
+            $ong[1]  = self::createTabEntry(_x('button', 'Test'), 0, $item::class, "ti ti-stethoscope"); // test connexion
             $ong[2]  = self::createTabEntry(User::getTypeName(Session::getPluralNumber()), 0, $item::class, User::getIcon());
             $ong[3]  = self::createTabEntry(Group::getTypeName(Session::getPluralNumber()), 0, $item::class, User::getIcon());
             $ong[5]  = self::createTabEntry(__('Advanced information'));   // params for entity advanced config

--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -728,7 +728,7 @@ class CommonGLPI implements CommonGLPIInterface
         $counter_html = $nb !== 0 ? sprintf('<span class="badge glpi-badge">%d</span>', $nb) : '';
 
         return sprintf(
-            '<span class="d-flex align-items-center">%s %s %s</span>',
+            '<span class="d-flex align-items-center">%s%s%s</span>',
             $icon_html,
             htmlspecialchars($text),
             $counter_html

--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -717,21 +717,22 @@ class CommonGLPI implements CommonGLPIInterface
      **/
     public static function createTabEntry($text, $nb = 0, ?string $form_itemtype = null, string $icon = '')
     {
-        if (empty($icon)) {
+        if ($icon === '') {
             $icon = static::getTabIconClass($form_itemtype);
         }
         if (str_contains($icon, 'fa-empty-icon')) {
             $icon = '';
         }
-        $icon = !empty($icon) ? "<i class='$icon me-2'></i>" : '';
-        if (!empty($icon)) {
-            $text = '<span class="d-flex align-items-center">' . $icon . $text . '</span>';
-        }
-        if ($nb) {
-           //TRANS: %1$s is the name of the tab, $2$d is number of items in the tab between ()
-            $text = sprintf(__('%1$s %2$s'), $text, "<span class='badge glpi-badge'>$nb</span>");
-        }
-        return $text;
+
+        $icon_html = $icon !== '' ? sprintf('<i class="%s me-2"></i>', htmlspecialchars($icon)) : '';
+        $counter_html = $nb !== 0 ? sprintf('<span class="badge glpi-badge">%d</span>', $nb) : '';
+
+        return sprintf(
+            '<span class="d-flex align-items-center">%s %s %s</span>',
+            $icon_html,
+            htmlspecialchars($text),
+            $counter_html
+        );
     }
 
     /**

--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -725,7 +725,7 @@ class CommonGLPI implements CommonGLPIInterface
         }
 
         $icon_html = $icon !== '' ? sprintf('<i class="%s me-2"></i>', htmlspecialchars($icon)) : '';
-        $counter_html = $nb !== 0 ? sprintf('<span class="badge glpi-badge">%d</span>', $nb) : '';
+        $counter_html = $nb !== 0 ? sprintf(' <span class="badge glpi-badge">%d</span>', $nb) : '';
 
         return sprintf(
             '<span class="d-flex align-items-center">%s%s%s</span>',

--- a/src/Glpi/Inventory/Conf.php
+++ b/src/Glpi/Inventory/Conf.php
@@ -647,11 +647,11 @@ class Conf extends CommonGLPI
                 $collection = new $col_class();
                 $rules = $collection->getRuleClass();
                 echo "<td colspan='2'>";
-                echo \Rule::createTabEntry(sprintf(
-                    "<a href='%s'>%s</a>",
+                echo sprintf(
+                    '<a href="%s">%s</a>',
                     $rules::getSearchURL(),
-                    \htmlspecialchars($collection->getTitle())
-                ), 0, \Rule::getType());
+                    \Rule::createTabEntry($collection->getTitle(), 0, \Rule::getType())
+                );
                 echo "</td>";
             }
             echo "</tr>";
@@ -659,11 +659,11 @@ class Conf extends CommonGLPI
             echo "<tr class='tab_bg_1'>";
             echo "<td>";
 
-            echo \NetworkPort::createTabEntry(sprintf(
-                "<a href='%s'>%s</a>",
+            echo sprintf(
+                '<a href="%s">%s</a>',
                 NetworkPortType::getSearchURL(),
-                \htmlspecialchars(NetworkPortType::getTypeName())
-            ), 0, \NetworkPort::getType());
+                \NetworkPort::createTabEntry(NetworkPortType::getTypeName(), 0, \NetworkPort::getType())
+            );
             echo "</td>";
             echo "</tr>";
 

--- a/tests/functional/ValidatorSubstitute.php
+++ b/tests/functional/ValidatorSubstitute.php
@@ -75,7 +75,7 @@ class ValidatorSubstitute extends DbTestCase
 
         yield [
             'item' => new Preference(),
-            'expected' => "Authorized substitute <span class='badge glpi-badge'>1</span>",
+            'expected' => "Authorized substitute 1",
         ];
 
         $_SESSION['glpishow_count_on_tabs'] = 0;
@@ -94,7 +94,7 @@ class ValidatorSubstitute extends DbTestCase
 
         yield [
             'item' => new Preference(),
-            'expected' => "Authorized substitutes <span class='badge glpi-badge'>2</span>",
+            'expected' => "Authorized substitutes 2",
         ];
 
         $_SESSION['glpishow_count_on_tabs'] = 0;
@@ -117,7 +117,7 @@ class ValidatorSubstitute extends DbTestCase
         $instance = $this->newTestedInstance;
 
         $output = $instance->getTabNameForItem($item);
-        $this->string($output)->isEqualTo($expected);
+        $this->string(strip_tags($output))->isEqualTo($expected);
     }
 
     public function providerCanCreateItem()


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Ensures that  `CommonGLPI::createTabEntry()` produces a safe HTML code.