### PR TITLE
Prevent double escaping of multiline when cloning an item

### DIFF
--- a/src/Features/Clonable.php
+++ b/src/Features/Clonable.php
@@ -37,8 +37,8 @@ namespace Glpi\Features;
 
 use CommonDBConnexity;
 use CommonDBTM;
+use Glpi\Toolbox\Sanitizer;
 use Session;
-use Toolbox;
 
 /**
  * Clonable objects
@@ -230,10 +230,9 @@ trait Clonable
             return false;
         }
         $new_item = new static();
-        $input = Toolbox::addslashes_deep($this->fields);
-        foreach ($override_input as $key => $value) {
-            $input[$key] = Toolbox::addslashes_deep($value);
-        }
+
+        $input = array_merge($this->fields, $override_input);
+        $input = Sanitizer::sanitize($input);
         $input = $new_item->cleanCloneInput($input);
 
         // Do not compute a clone name if a new name is specified (Like creating from template)


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

Fixes #18123.

The `$override_input` parameter of the `clone()` method is used to inject specific input defined by the user when an item is created from a template. Most of the time, il will already be escaped automatically by the global sanitization logic.

`Sanitizer::sanitize()` is designed to prevent double escaping/encoding. I propose to use it instead of `Toolbox::addslashes_deep()` to fix the issue.