### PR TITLE
Fix `AuthenticationFailedException` constructor

### DIFF
--- a/src/Glpi/Exception/AuthenticationFailedException.php
+++ b/src/Glpi/Exception/AuthenticationFailedException.php
@@ -37,8 +37,8 @@ namespace Glpi\Exception;
 class AuthenticationFailedException extends \Exception
 {
     public function __construct(
-        string $message = '""',
-        int $code = null,
+        string $message = '',
+        int $code = 0,
         ?\Throwable $previous = null,
         private array $authentication_errors = []
     ) {


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

The constructor signature was not correct.

It fixes the following error:
```
PHP Deprecated function (8192): Exception::__construct(): Passing null to parameter #2 ($code) of type int is deprecated in /var/www/glpi/src/Glpi/Exception/AuthenticationFailedException.php at line 45
```