### PR TITLE
Fix(Core): prevent twice 'date_mod' updates

### DIFF
--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -1687,7 +1687,10 @@ class CommonDBTM extends CommonGLPI
                         // is a non blacklist field exists
                         if (count(array_diff($this->updates, $this->history_blacklist)) > 0) {
                             $this->fields['date_mod'] = $_SESSION["glpi_currenttime"];
-                            $this->updates[$x++]      = 'date_mod';
+                            //prevent twice 'date_mod'
+                            if (array_search('date_mod', $this->updates) === false) {
+                                $this->updates[$x++]      = 'date_mod';
+                            }
                         }
                     }
                     $this->pre_updateInDB();


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Bug found with `fields` plugin (but all plugins could be impacted when) 

The `fields` plugin (after managing additional fields) adds a `date_mod` in the mainitem's input to update **only** last modification date.

when the update occurs `glpi` checks if `date_mod` exists in `$this->fields`, and if so, adds it to `$this->updates` (which already contains `date_mode` -> because of `fields` plugin)

```php
if (array_key_exists('date_mod', $this->fields)) {
    // is a non blacklist field exists
    if (count(array_diff($this->updates, $this->history_blacklist)) > 0) {
        $this->fields['date_mod'] = $_SESSION["glpi_currenttime"];
        $this->updates[$x++]      = 'date_mod';
    }
}
```

When glpihandle locked fields, this  

```php
$idx = array_search('date_mod', $fields);
if ($idx !== false) {
    unset($fields[$idx]);
}
```

doesn't work perfectly because the `date_mod` value exists twice and `array_search` returns only the first occurrence found.

So we need to check if `date_mod` alrady exist in `$this->updates`

To sum up, it is currently impossible to update only `date_mod` without causing a lock on this field (for dynamic item).

Set `is_dynamic` to `false` is not a good solution either, as it removes the link between the `mainitem` and related `agent`.


- It fixes https://github.com/pluginsGLPI/fields/issues/849


## Screenshots (if appropriate):


