### PR TITLE
Drop useless session checks

### DIFF
--- a/ajax/2fa.php
+++ b/ajax/2fa.php
@@ -36,8 +36,6 @@
 /** @var \Glpi\Controller\LegacyFileLoadController $this */
 $this->setAjax();
 
-Session::checkLoginUser();
-
 if (isset($_POST['regenerate_backup_codes'])) {
     $totp = new \Glpi\Security\TOTPManager();
     $codes = $totp->regenerateBackupCodes(Session::getLoginUserID());

--- a/ajax/actorinformation.php
+++ b/ajax/actorinformation.php
@@ -41,8 +41,6 @@ if (strpos($_SERVER['PHP_SELF'], "actorinformation.php")) {
     Html::header_nocache();
 }
 
-Session::checkLoginUser();
-
 // save value and force boolval for security of $_REQUEST['only_number]
 $only_number = boolval($_REQUEST['only_number'] ?? false);
 

--- a/ajax/actors.php
+++ b/ajax/actors.php
@@ -36,8 +36,6 @@
 /** @var \Glpi\Controller\LegacyFileLoadController $this */
 $this->setAjax();
 
-Session::checkLoginUser();
-
 switch ($_REQUEST['action']) {
     case "getActors":
         header("Content-Type: application/json; charset=UTF-8");

--- a/ajax/agent.php
+++ b/ajax/agent.php
@@ -42,8 +42,6 @@ $this->setAjax();
 header("Content-Type: application/json; charset=UTF-8");
 Html::header_nocache();
 
-Session::checkLoginUser();
-
 if (isset($_POST['action']) && isset($_POST['id'])) {
     $agent = new Agent();
     if (!$agent->getFromDB($_POST['id'])) {

--- a/ajax/central.php
+++ b/ajax/central.php
@@ -43,8 +43,6 @@ $this->setAjax();
 header("Content-Type: text/html; charset=UTF-8");
 Html::header_nocache();
 
-Session::checkLoginUser();
-
 if (
     (!isset($_REQUEST['params']['_idor_token']) || empty($_REQUEST['params']['_idor_token'])) || !isset($_REQUEST['itemtype'])
     || !isset($_REQUEST['widget'])

--- a/ajax/comments.php
+++ b/ajax/comments.php
@@ -45,8 +45,6 @@ $this->setAjax();
 header("Content-Type: text/html; charset=UTF-8");
 Html::header_nocache();
 
-Session::checkLoginUser();
-
 use Glpi\Application\View\TemplateRenderer;
 
 if (

--- a/ajax/common.tabs.php
+++ b/ajax/common.tabs.php
@@ -44,6 +44,8 @@ $this->setAjax();
 header("Content-Type: text/html; charset=UTF-8");
 Html::header_nocache();
 
+// Session check is disabled for this script (see `\Glpi\Http\Firewall::computeStrategyForCoreLegacyScript()`)
+// to be able to adapt the checks depending on the request.
 if (!($CFG_GLPI["use_public_faq"] && str_ends_with($_GET["_target"], '/front/helpdesk.faq.php'))) {
     Session::checkLoginUser();
 }

--- a/ajax/commonitilobject_item.php
+++ b/ajax/commonitilobject_item.php
@@ -38,8 +38,6 @@ use Glpi\Exception\Http\BadRequestHttpException;
 header("Content-Type: text/html; charset=UTF-8");
 Html::header_nocache();
 
-Session::checkLoginUser();
-
 // Should be defined by other files that include this file.
 // See: change_item.php, item_problem.php, item_ticket.php and item_ticketrecurrent.php
 $obj = $obj ?? null;

--- a/ajax/criteria_filter.php
+++ b/ajax/criteria_filter.php
@@ -40,8 +40,6 @@ use Glpi\Exception\Http\UnprocessableEntityHttpException;
 use Glpi\Http\Response;
 use Glpi\Search\FilterableInterface;
 
-Session::checkLoginUser();
-
 // Read endpoint
 $action = $_POST['action'] ?? false;
 switch ($action) {

--- a/ajax/dashboard.php
+++ b/ajax/dashboard.php
@@ -45,6 +45,8 @@ if (!isset($_REQUEST["action"])) {
 $request_data = array_merge($_REQUEST, json_decode($_REQUEST['data'] ?? '{}', true));
 unset($request_data['data']);
 
+// Session check is disabled for this script (see `\Glpi\Http\Firewall::computeStrategyForCoreLegacyScript()`)
+// to be able to adapt the checks depending on the request.
 $embed = false;
 if (
     in_array($_REQUEST['action'], ['get_dashboard_items', 'get_card', 'get_cards'])

--- a/ajax/dcroom_size.php
+++ b/ajax/dcroom_size.php
@@ -35,8 +35,6 @@
 
 Html::header_nocache();
 
-Session::checkLoginUser();
-
 if (!isset($_REQUEST['id'])) {
     throw new \RuntimeException('Required argument missing!');
 }

--- a/ajax/debug.php
+++ b/ajax/debug.php
@@ -40,8 +40,6 @@ use Glpi\Exception\Http\NotFoundHttpException;
 
 Html::header_nocache();
 
-Session::checkLoginUser();
-
 if ($_SESSION['glpi_use_mode'] !== Session::DEBUG_MODE) {
     throw new AccessDeniedHttpException();
 }

--- a/ajax/displayMessageAfterRedirect.php
+++ b/ajax/displayMessageAfterRedirect.php
@@ -37,7 +37,6 @@
 $this->setAjax();
 
 Html::header_nocache();
-Session::checkLoginUser();
 
 if (isset($_GET['get_raw']) && filter_var(($_GET['display_container'] ?? true), FILTER_VALIDATE_BOOLEAN)) {
     header("Content-Type: application/json; charset=UTF-8");

--- a/ajax/displaypreference.php
+++ b/ajax/displaypreference.php
@@ -37,8 +37,6 @@ use Glpi\Exception\Http\BadRequestHttpException;
 
 Html::header_nocache();
 
-Session::checkLoginUser();
-
 $setupdisplay = new DisplayPreference();
 
 if (isset($_POST['users_id']) && (int) $_POST['users_id'] !== (int) Session::getLoginUserID()) {

--- a/ajax/domainrecord_data_form.php
+++ b/ajax/domainrecord_data_form.php
@@ -35,8 +35,6 @@
 
 Html::header_nocache();
 
-Session::checkLoginUser();
-
 $domainrecordtype = new DomainRecordType();
 if (
     !array_key_exists('domainrecordtypes_id', $_REQUEST)

--- a/ajax/dropdownDelegationUsers.php
+++ b/ajax/dropdownDelegationUsers.php
@@ -42,8 +42,6 @@ if (strpos($_SERVER['PHP_SELF'], "dropdownDelegationUsers.php")) {
     Html::header_nocache();
 }
 
-Session::checkLoginUser();
-
 $_POST['_users_id_requester'] = 0;
 $_POST['_right'] = "delegate";
 if ($_POST["nodelegate"] == 1) {

--- a/ajax/dropdownLocation.php
+++ b/ajax/dropdownLocation.php
@@ -35,8 +35,6 @@
 
 Html::header_nocache();
 
-Session::checkLoginUser();
-
 if (
     !isset($_REQUEST['itemtype'])
     && !is_subclass_of($_REQUEST['itemtype'], 'CommonDBTM')

--- a/ajax/dropdownProjectTaskTicket.php
+++ b/ajax/dropdownProjectTaskTicket.php
@@ -40,8 +40,6 @@
 header("Content-Type: text/html; charset=UTF-8");
 Html::header_nocache();
 
-Session::checkLoginUser();
-
 if (isset($_POST["projects_id"])) {
     $condition = ['glpi_projecttasks.projectstates_id' => ['<>', 3]];
 

--- a/ajax/dropdownTrackingDeviceType.php
+++ b/ajax/dropdownTrackingDeviceType.php
@@ -41,8 +41,6 @@ global $CFG_GLPI;
 header("Content-Type: text/html; charset=UTF-8");
 Html::header_nocache();
 
-Session::checkLoginUser();
-
 // Read parameters
 $context  = $_POST['context'] ?? '';
 $itemtype = $_POST["itemtype"] ?? '';

--- a/ajax/entitytreesons.php
+++ b/ajax/entitytreesons.php
@@ -45,7 +45,5 @@ $this->setAjax();
 header("Content-Type: application/json; charset=UTF-8");
 Html::header_nocache();
 
-Session::checkLoginUser();
-
 echo json_encode(Entity::getEntitySelectorTree());
 return;

--- a/ajax/fileupload.php
+++ b/ajax/fileupload.php
@@ -39,8 +39,6 @@
 
 use Glpi\Application\ErrorHandler;
 
-Session::checkLoginUser();
-
 // Ensure warnings will not break ajax output.
 ErrorHandler::getInstance()->disableOutput();
 

--- a/ajax/fuzzysearch.php
+++ b/ajax/fuzzysearch.php
@@ -39,6 +39,4 @@ $this->setAjax();
 header("Content-Type: text/html; charset=UTF-8");
 Html::header_nocache();
 
-Session::checkLoginUser();
-
 echo json_encode(Html::getMenuFuzzySearchList(), JSON_THROW_ON_ERROR);

--- a/ajax/genericdate.php
+++ b/ajax/genericdate.php
@@ -40,8 +40,6 @@ $this->setAjax();
 header("Content-Type: text/html; charset=UTF-8");
 Html::header_nocache();
 
-Session::checkLoginUser();
-
 if (isset($_POST['value']) && (strcmp($_POST['value'], '0') == 0)) {
     if ($_POST['withtime']) {
         Html::showDateTimeField($_POST['name'], ['value' => $_POST['specificvalue']]);

--- a/ajax/getAbstractRightDropdownValue.php
+++ b/ajax/getAbstractRightDropdownValue.php
@@ -35,7 +35,6 @@
 
 header("Content-Type: application/json; charset=UTF-8");
 Html::header_nocache();
-Session::checkLoginUser();
 
 function show_rights_dropdown(string $class)
 {

--- a/ajax/getDropdownFindNum.php
+++ b/ajax/getDropdownFindNum.php
@@ -41,5 +41,4 @@
 header("Content-Type: application/json; charset=UTF-8");
 Html::header_nocache();
 
-Session::checkLoginUser();
 echo Dropdown::getDropdownFindNum($_POST);

--- a/ajax/getDropdownNumber.php
+++ b/ajax/getDropdownNumber.php
@@ -43,5 +43,4 @@ if (strpos($_SERVER['PHP_SELF'], "getDropdownNumber.php")) {
     Html::header_nocache();
 }
 
-Session::checkLoginUser();
 echo Dropdown::getDropdownNumber($_POST);

--- a/ajax/getDropdownUsers.php
+++ b/ajax/getDropdownUsers.php
@@ -46,5 +46,4 @@ if (strpos($_SERVER['PHP_SELF'], "getDropdownUsers.php")) {
     Html::header_nocache();
 }
 
-Session::checkLoginUser();
 echo Dropdown::getDropdownUsers($_POST);

--- a/ajax/getDropdownValue.php
+++ b/ajax/getDropdownValue.php
@@ -43,5 +43,4 @@ if (strpos($_SERVER['PHP_SELF'], "getDropdownValue.php")) {
     Html::header_nocache();
 }
 
-Session::checkLoginUser();
 echo Dropdown::getDropdownValue($_POST);

--- a/ajax/getFileTag.php
+++ b/ajax/getFileTag.php
@@ -43,8 +43,6 @@ $this->setAjax();
 header('Content-type: application/json');
 Html::header_nocache();
 
-Session::checkLoginUser();
-
 if (isset($_POST['data'])) {
     $response = [];
 

--- a/ajax/getFormQuestionActorsDropdownValue.php
+++ b/ajax/getFormQuestionActorsDropdownValue.php
@@ -42,8 +42,6 @@ use Glpi\Form\QuestionType\QuestionTypeRequester;
 
 include(__DIR__ . '/getAbstractRightDropdownValue.php');
 
-Session::checkLoginUser();
-
 if (Session::getCurrentInterface() !== 'central') {
     $questions = (new Question())->find([
         'type' => [

--- a/ajax/getKnowbaseItemAnswer.php
+++ b/ajax/getKnowbaseItemAnswer.php
@@ -40,8 +40,6 @@
 header('Content-type: application/json');
 Html::header_nocache();
 
-Session::checkLoginUser();
-
 if (isset($_POST['knowbaseitems_id'])) {
     $kbitem = new KnowbaseItem();
     $kbitem->getFromDB(intval($_POST['knowbaseitems_id']));

--- a/ajax/getMapPoint.php
+++ b/ajax/getMapPoint.php
@@ -36,8 +36,6 @@
 header("Content-Type: application/json; charset=UTF-8");
 Html::header_nocache();
 
-Session::checkLoginUser();
-
 $result = [];
 if (!isset($_POST['itemtype']) || !isset($_POST['items_id']) || (int)$_POST['items_id'] < 1) {
     $result = [

--- a/ajax/getUserPicture.php
+++ b/ajax/getUserPicture.php
@@ -41,8 +41,6 @@ $this->setAjax();
 header("Content-Type: application/json; charset=UTF-8");
 Html::header_nocache();
 
-Session::checkLoginUser();
-
 if (!isset($_REQUEST['users_id'])) {
     throw new BadRequestHttpException("Missing users_id parameter");
 } else if (!is_array($_REQUEST['users_id'])) {

--- a/ajax/get_item_content.php
+++ b/ajax/get_item_content.php
@@ -41,8 +41,6 @@ use Glpi\RichText\RichText;
  * Ajax tooltip endpoint for CommonITILObjects
  */
 
-Session::checkLoginUser();
-
 // Read parameters
 $itemtype = $_GET['itemtype'] ?? null;
 $items_id = $_GET['items_id'] ?? null;

--- a/ajax/helpdesk_observer.php
+++ b/ajax/helpdesk_observer.php
@@ -40,6 +40,4 @@ $this->setAjax();
 header("Content-Type: text/html; charset=UTF-8");
 Html::header_nocache();
 
-Session::checkLoginUser();
-
 Ticket::showFormHelpdeskObserver($_REQUEST);

--- a/ajax/impact.php
+++ b/ajax/impact.php
@@ -53,8 +53,6 @@ global $CFG_GLPI;
 header("Content-Type: application/json; charset=UTF-8");
 Html::header_nocache();
 
-Session::checkLoginUser();
-
 switch ($_SERVER['REQUEST_METHOD']) {
    // GET request: build the impact graph for a given asset
     case 'GET':

--- a/ajax/inputtext.php
+++ b/ajax/inputtext.php
@@ -39,8 +39,6 @@ $this->setAjax();
 header("Content-Type: text/html; charset=UTF-8");
 Html::header_nocache();
 
-Session::checkLoginUser();
-
 if (isset($_POST['name'])) {
     echo "<input type='text' " . (isset($_POST["size"]) ? " size='" . (int) $_POST["size"] . "' " : "") . " " .
          (isset($_POST["maxlength"]) ? "maxlength='" . (int) $_POST["maxlength"] . "' " : "") . " name='" .

--- a/ajax/item_rack.php
+++ b/ajax/item_rack.php
@@ -39,8 +39,6 @@ $this->setAjax();
 header("Content-Type: text/html; charset=UTF-8");
 Html::header_nocache();
 
-Session::checkLoginUser();
-
 if (isset($_POST['action'])) {
     $item_rack = new Item_Rack();
     $item_rack->getFromDB((int) $_POST['id']);

--- a/ajax/itilfollowup.php
+++ b/ajax/itilfollowup.php
@@ -45,8 +45,6 @@ $this->setAjax();
 header("Content-Type: application/json; charset=UTF-8");
 Html::header_nocache();
 
-Session::checkLoginUser();
-
 // Mandatory parameter: itilfollowuptemplates_id
 $itilfollowuptemplates_id = $_POST['itilfollowuptemplates_id'] ?? null;
 if ($itilfollowuptemplates_id === null) {

--- a/ajax/itillayout.php
+++ b/ajax/itillayout.php
@@ -36,8 +36,6 @@
 header('Content-Type: application/json; charset=UTF-8');
 Html::header_nocache();
 
-Session::checkLoginUser();
-
 $raw_itillayout  = $_POST['itil_layout'];
 
 $json_itillayout = json_encode($raw_itillayout);

--- a/ajax/itilvalidation.php
+++ b/ajax/itilvalidation.php
@@ -45,8 +45,6 @@ $this->setAjax();
 header("Content-Type: application/json; charset=UTF-8");
 Html::header_nocache();
 
-Session::checkLoginUser();
-
 // Mandatory parameter: validationtemplates_id
 $validationtemplates_id = $_POST['validationtemplates_id'] ?? null;
 if ($validationtemplates_id === null) {

--- a/ajax/kanban.php
+++ b/ajax/kanban.php
@@ -46,8 +46,6 @@ $this->setAjax();
 header("Content-Type: text/html; charset=UTF-8");
 Html::header_nocache();
 
-Session::checkLoginUser();
-
 if (!isset($_REQUEST['action'])) {
     throw new BadRequestHttpException("Missing action parameter");
 }

--- a/ajax/kblink.php
+++ b/ajax/kblink.php
@@ -45,8 +45,6 @@ global $DB;
 header("Content-Type: text/html; charset=UTF-8");
 Html::header_nocache();
 
-Session::checkLoginUser();
-
 if (isset($_POST["table"], $_POST["value"])) {
     // Security
     if (!$DB->tableExists($_POST['table'])) {

--- a/ajax/ldapdaterestriction.php
+++ b/ajax/ldapdaterestriction.php
@@ -38,5 +38,4 @@ if (strpos($_SERVER['PHP_SELF'], "ldapdaterestriction.php")) {
     Html::header_nocache();
 }
 
-Session::checkLoginUser();
 AuthLDAP::showDateRestrictionForm($_POST);

--- a/ajax/mailcollector.php
+++ b/ajax/mailcollector.php
@@ -40,8 +40,6 @@ $this->setAjax();
 header("Content-Type: text/html; charset=UTF-8");
 Html::header_nocache();
 
-Session::checkLoginUser();
-
 $mailcollector = new MailCollector();
 
 if (isset($_REQUEST['action'])) {

--- a/ajax/map.php
+++ b/ajax/map.php
@@ -38,8 +38,6 @@ use Glpi\Exception\Http\BadRequestHttpException;
 header("Content-Type: application/json; charset=UTF-8");
 Html::header_nocache();
 
-Session::checkLoginUser();
-
 $result = [];
 if (!isset($_POST['itemtype']) || !isset($_POST['params'])) {
     throw new BadRequestHttpException();

--- a/ajax/massiveaction.php
+++ b/ajax/massiveaction.php
@@ -43,8 +43,6 @@ global $CFG_GLPI;
 header("Content-Type: text/html; charset=UTF-8");
 Html::header_nocache();
 
-Session::checkLoginUser();
-
 try {
     $ma = new MassiveAction($_POST, $_GET, 'initial');
 } catch (\Throwable $e) {

--- a/ajax/networkname.php
+++ b/ajax/networkname.php
@@ -38,8 +38,6 @@ use Glpi\Event;
 header("Content-Type: text/html; charset=UTF-8");
 Html::header_nocache();
 
-Session::checkLoginUser();
-
 $nn = new NetworkName();
 if (isset($_POST["unaffect"])) {
     $nn->check($_POST['id'], UPDATE);

--- a/ajax/notifications_ajax.php
+++ b/ajax/notifications_ajax.php
@@ -33,8 +33,6 @@
  * ---------------------------------------------------------------------
  */
 
-Session::checkLoginUser();
-
 header('Content-Type: application/json; charset=utf-8');
 
 if (isset($_GET['delete'])) {

--- a/ajax/pendingreason.php
+++ b/ajax/pendingreason.php
@@ -40,8 +40,6 @@ use Glpi\Exception\Http\BadRequestHttpException;
 
 header("Content-Type: application/json; charset=UTF-8");
 
-Session::checkLoginUser();
-
 // Tech only
 if (Session::getCurrentInterface() !== "central") {
     throw new AccessDeniedHttpException();

--- a/ajax/pin_savedsearches.php
+++ b/ajax/pin_savedsearches.php
@@ -36,8 +36,6 @@
 header('Content-Type: application/json; charset=UTF-8');
 Html::header_nocache();
 
-Session::checkLoginUser();
-
 $success = false;
 
 $user = new User();

--- a/ajax/planningend.php
+++ b/ajax/planningend.php
@@ -40,8 +40,6 @@ $this->setAjax();
 header("Content-Type: text/html; charset=UTF-8");
 Html::header_nocache();
 
-Session::checkLoginUser();
-
 if (
     isset($_POST['duration']) && ($_POST['duration'] == 0)
     && isset($_POST['name'])

--- a/ajax/priority.php
+++ b/ajax/priority.php
@@ -35,8 +35,6 @@
 
 Html::header_nocache();
 
-Session::checkLoginUser();
-
 if (
     isset($_REQUEST["urgency"])
     && isset($_REQUEST["impact"])

--- a/ajax/private_public.php
+++ b/ajax/private_public.php
@@ -39,8 +39,6 @@ if (strpos($_SERVER['PHP_SELF'], "private_public.php")) {
 }
 
 if (isset($_POST['is_private'])) {
-    Session::checkLoginUser();
-
     switch ($_POST['is_private']) {
         case true:
             echo "<input type='hidden' name='is_private' value='1'>\n";

--- a/ajax/projecttask.php
+++ b/ajax/projecttask.php
@@ -43,8 +43,6 @@ $this->setAjax();
 header("Content-Type: application/json; charset=UTF-8");
 Html::header_nocache();
 
-Session::checkLoginUser();
-
 if (isset($_POST['projecttasktemplates_id']) && ($_POST['projecttasktemplates_id'] > 0)) {
     $template = new ProjectTaskTemplate();
     $template->getFromDB($_POST['projecttasktemplates_id']);

--- a/ajax/rack.php
+++ b/ajax/rack.php
@@ -43,8 +43,6 @@ $this->setAjax();
 header("Content-Type: text/html; charset=UTF-8");
 Html::header_nocache();
 
-Session::checkLoginUser();
-
 if (!Session::haveRight('datacenter', UPDATE)) {
     throw new AccessDeniedHttpException();
 }

--- a/ajax/resaperiod.php
+++ b/ajax/resaperiod.php
@@ -44,8 +44,6 @@ $this->setAjax();
 header("Content-Type: text/html; charset=UTF-8");
 Html::header_nocache();
 
-Session::checkLoginUser();
-
 if (isset($_POST['type'], $_POST['end'])) {
     echo "<table style='width: 90%'>";
     switch ($_POST['type']) {

--- a/ajax/rule.php
+++ b/ajax/rule.php
@@ -36,8 +36,6 @@
 /** @var \Glpi\Controller\LegacyFileLoadController $this */
 $this->setAjax();
 
-Session::checkLoginUser();
-
 switch ($_REQUEST['action']) {
     case "move_rule":
         $rule_collection = getItemForItemtype($_POST['collection_classname']);

--- a/ajax/ruleaction.php
+++ b/ajax/ruleaction.php
@@ -42,8 +42,6 @@ if (strpos($_SERVER['PHP_SELF'], "ruleaction.php")) {
     Html::header_nocache();
 }
 
-Session::checkLoginUser();
-
 // Non define case
 if (isset($_POST["sub_type"]) && class_exists($_POST["sub_type"])) {
     if (!isset($_POST["field"])) {

--- a/ajax/ruleactionvalue.php
+++ b/ajax/ruleactionvalue.php
@@ -39,8 +39,6 @@ if (strpos($_SERVER['PHP_SELF'], "ruleactionvalue.php")) {
     Html::header_nocache();
 }
 
-Session::checkLoginUser();
-
 $ra = new RuleAction();
 
 $ra->displayActionSelectPattern($_POST);

--- a/ajax/rulecriteria.php
+++ b/ajax/rulecriteria.php
@@ -42,8 +42,6 @@ if (strpos($_SERVER['PHP_SELF'], "rulecriteria.php")) {
     Html::header_nocache();
 }
 
-Session::checkLoginUser();
-
 /** @var Rule $rule */
 if (isset($_POST["sub_type"]) && ($rule = getItemForItemtype($_POST["sub_type"]))) {
     $criterias = $rule->getAllCriteria();

--- a/ajax/rulecriteriavalue.php
+++ b/ajax/rulecriteriavalue.php
@@ -39,8 +39,6 @@ if (strstr($_SERVER['PHP_SELF'], "rulecriteriavalue.php")) {
     Html::header_nocache();
 }
 
-Session::checkLoginUser();
-
 // Non define case
 /** @var Rule $rule */
 if (isset($_POST["sub_type"]) && ($rule = getItemForItemtype($_POST["sub_type"]))) {

--- a/ajax/savedsearch.php
+++ b/ajax/savedsearch.php
@@ -36,8 +36,6 @@
 header('Content-Type: application/json; charset=UTF-8');
 Html::header_nocache();
 
-Session::checkLoginUser();
-
 $savedsearch = new SavedSearch();
 
 if (isset($_POST["name"])) {

--- a/ajax/search.php
+++ b/ajax/search.php
@@ -45,8 +45,6 @@ $this->setAjax();
 header("Content-Type: text/html; charset=UTF-8");
 Html::header_nocache();
 
-Session::checkLoginUser();
-
 if (!isset($_REQUEST['action'])) {
     return;
 }

--- a/ajax/searchoptionvalue.php
+++ b/ajax/searchoptionvalue.php
@@ -41,8 +41,6 @@ if (strpos($_SERVER['PHP_SELF'], "searchoptionvalue.php")) {
     Html::header_nocache();
 }
 
-Session::checkLoginUser();
-
 if (isset($_POST['searchtype'])) {
     $searchopt      = $_POST['searchopt'];
     if ($ajax) {

--- a/ajax/solution.php
+++ b/ajax/solution.php
@@ -42,8 +42,6 @@ $this->setAjax();
 header("Content-Type: application/json; charset=UTF-8");
 Html::header_nocache();
 
-Session::checkLoginUser();
-
 // Mandatory parameter: solutiontemplates_id
 $solutiontemplates_id = $_POST['solutiontemplates_id'] ?? null;
 if ($solutiontemplates_id === null) {

--- a/ajax/stencil.php
+++ b/ajax/stencil.php
@@ -36,8 +36,6 @@
 use Glpi\Exception\Http\NotFoundHttpException;
 use Glpi\Http\Response;
 
-Session::checkLoginUser();
-
 if (isset($_POST['id'])) {
     $stencil = Stencil::getStencilFromID($_POST['id']);
 

--- a/ajax/subvisibility.php
+++ b/ajax/subvisibility.php
@@ -42,8 +42,6 @@ if (strpos($_SERVER['PHP_SELF'], "subvisibility.php")) {
     Html::header_nocache();
 }
 
-Session::checkLoginUser();
-
 if (!empty($_POST['type']) && isset($_POST['items_id']) && ($_POST['items_id'] > 0)) {
     $prefix = '';
     $suffix = '';

--- a/ajax/switchfoldmenu.php
+++ b/ajax/switchfoldmenu.php
@@ -36,8 +36,6 @@
 header('Content-Type: application/json; charset=UTF-8');
 Html::header_nocache();
 
-Session::checkLoginUser();
-
 $user = new User();
 $success = $user->update(
     [

--- a/ajax/task.php
+++ b/ajax/task.php
@@ -46,8 +46,6 @@ $this->setAjax();
 header("Content-Type: application/json; charset=UTF-8");
 Html::header_nocache();
 
-Session::checkLoginUser();
-
 // Mandatory parameter: tasktemplates_id
 $tasktemplates_id = $_POST['tasktemplates_id'] ?? null;
 if ($tasktemplates_id === null) {

--- a/ajax/textarea.php
+++ b/ajax/textarea.php
@@ -39,8 +39,6 @@ $this->setAjax();
 header("Content-Type: text/html; charset=UTF-8");
 Html::header_nocache();
 
-Session::checkLoginUser();
-
 if (isset($_POST['name'])) {
     echo "<textarea " . (isset($_POST['rows']) ? " rows='" . $_POST['rows'] . "' " : "") . " " .
          (isset($_POST['cols']) ? " cols='" . $_POST['cols'] . "' " : "") . "  name='" . $_POST['name'] . "'>";

--- a/ajax/timeline.php
+++ b/ajax/timeline.php
@@ -36,8 +36,6 @@
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\Exception\Http\AccessDeniedHttpException;
 
-Session::checkLoginUser();
-
 if (($_POST['action'] ?? null) === 'change_task_state') {
     header("Content-Type: application/json; charset=UTF-8");
 

--- a/ajax/uemailUpdate.php
+++ b/ajax/uemailUpdate.php
@@ -43,8 +43,6 @@ if (strpos($_SERVER['PHP_SELF'], "uemailUpdate.php")) {
     Html::header_nocache();
 }
 
-Session::checkLoginUser();
-
 if (
     (isset($_POST['field']) && ($_POST["value"] > 0))
     || (isset($_POST['allow_email']) && $_POST['allow_email'])

--- a/ajax/unlockobject.php
+++ b/ajax/unlockobject.php
@@ -47,7 +47,6 @@ $this->setAjax();
 
 header("Content-Type: text/html; charset=UTF-8");
 Html::header_nocache();
-Session::checkLoginUser();
 
 $ret = 0;
 if (isset($_POST['unlock']) && isset($_POST["id"])) {

--- a/ajax/viewsubitem.php
+++ b/ajax/viewsubitem.php
@@ -36,8 +36,6 @@
 header("Content-Type: text/html; charset=UTF-8");
 Html::header_nocache();
 
-Session::checkLoginUser();
-
 if (!isset($_POST['type'])) {
     return;
 }

--- a/front/change.form.php
+++ b/front/change.form.php
@@ -39,8 +39,6 @@ if (empty($_GET["id"])) {
     $_GET["id"] = '';
 }
 
-Session::checkLoginUser();
-
 // as _actors virtual field stores json, bypass automatic escaping
 if (isset($_POST['_actors'])) {
     $_POST['_actors'] = json_decode($_POST['_actors'], true);

--- a/front/change_group.form.php
+++ b/front/change_group.form.php
@@ -46,8 +46,6 @@ global $CFG_GLPI;
 $link = new Change_Group();
 $item = new Change();
 
-Session::checkLoginUser();
-
 if (isset($_POST['delete'])) {
     $link->check($_POST['id'], DELETE);
     $link->delete($_POST);

--- a/front/change_problem.form.php
+++ b/front/change_problem.form.php
@@ -36,8 +36,6 @@
 use Glpi\Event;
 use Glpi\Exception\Http\BadRequestHttpException;
 
-Session::checkLoginUser();
-
 $item = new Change_Problem();
 if (isset($_POST["add"])) {
     $item->check(-1, CREATE, $_POST);

--- a/front/change_supplier.form.php
+++ b/front/change_supplier.form.php
@@ -42,7 +42,6 @@ use Glpi\Exception\Http\BadRequestHttpException;
 
 $link = new Change_Supplier();
 
-Session::checkLoginUser();
 Html::popHeader(__('Email followup'), $_SERVER['PHP_SELF']);
 
 if (isset($_POST["update"])) {

--- a/front/change_ticket.form.php
+++ b/front/change_ticket.form.php
@@ -36,8 +36,6 @@
 use Glpi\Event;
 use Glpi\Exception\Http\BadRequestHttpException;
 
-Session::checkLoginUser();
-
 $item = new Change_Ticket();
 if (isset($_POST["add"])) {
     if (!empty($_POST['tickets_id']) && empty($_POST['changes_id'])) {

--- a/front/change_user.form.php
+++ b/front/change_user.form.php
@@ -46,7 +46,6 @@ global $CFG_GLPI;
 $link = new Change_User();
 $item = new Change();
 
-Session::checkLoginUser();
 Html::popHeader(__('Email followup'), $_SERVER['PHP_SELF']);
 
 if (isset($_POST["update"])) {

--- a/front/changesatisfaction.form.php
+++ b/front/changesatisfaction.form.php
@@ -36,8 +36,6 @@
 use Glpi\Event;
 use Glpi\Exception\Http\BadRequestHttpException;
 
-Session::checkLoginUser();
-
 $inquest = new ChangeSatisfaction();
 
 if (isset($_POST["update"])) {

--- a/front/commonitilobject_item.form.php
+++ b/front/commonitilobject_item.form.php
@@ -41,8 +41,6 @@ use Glpi\Exception\Http\BadRequestHttpException;
  * @var CommonItilObject_Item $item_obj
  */
 
-Session::checkLoginUser();
-
 if (!($obj instanceof CommonDBTM) || !($item_obj instanceof CommonItilObject_Item)) {
     throw new BadRequestHttpException('Bad request');
 }

--- a/front/commonitilvalidation.form.php
+++ b/front/commonitilvalidation.form.php
@@ -46,8 +46,6 @@ use Glpi\Exception\Http\BadRequestHttpException;
  * @var CommonITILValidation $validation
  */
 
-Session::checkLoginUser();
-
 if (!($validation instanceof CommonITILValidation)) {
     throw new BadRequestHttpException();
 }

--- a/front/document.form.php
+++ b/front/document.form.php
@@ -35,8 +35,6 @@
 
 use Glpi\Event;
 
-Session::checkLoginUser();
-
 if (!isset($_GET["id"])) {
     $_GET["id"] = -1;
 }

--- a/front/documenttype.list.php
+++ b/front/documenttype.list.php
@@ -33,8 +33,6 @@
  * ---------------------------------------------------------------------
  */
 
-Session::checkLoginUser();
-
 Html::popHeader(__('Setup'), $_SERVER['PHP_SELF']);
 
 $params = Search::manageParams('DocumentType', $_GET);

--- a/front/dropdown.php
+++ b/front/dropdown.php
@@ -35,8 +35,6 @@
 
 use Glpi\Exception\Http\AccessDeniedHttpException;
 
-Session::checkLoginUser();
-
 Html::header(__('Setup'), $_SERVER['PHP_SELF'], "config", "commondropdown");
 
 echo "<div class='center'>";

--- a/front/group_problem.form.php
+++ b/front/group_problem.form.php
@@ -46,8 +46,6 @@ global $CFG_GLPI;
 $link = new Group_Problem();
 $item = new Problem();
 
-Session::checkLoginUser();
-
 if (isset($_POST['delete'])) {
     $link->check($_POST['id'], DELETE);
     $link->delete($_POST);

--- a/front/group_ticket.form.php
+++ b/front/group_ticket.form.php
@@ -46,8 +46,6 @@ global $CFG_GLPI;
 $link = new Group_Ticket();
 $item = new Ticket();
 
-Session::checkLoginUser();
-
 if (isset($_POST['delete'])) {
     $link->check($_POST['id'], DELETE);
     $link->delete($_POST);

--- a/front/helpdesk.public.php
+++ b/front/helpdesk.public.php
@@ -64,8 +64,6 @@ if (
     }
 }
 
-Session::checkValidSessionId();
-
 Html::helpHeader(__('Home'));
 
 $password_alert = "";

--- a/front/item_project.form.php
+++ b/front/item_project.form.php
@@ -40,8 +40,6 @@ use Glpi\Exception\Http\BadRequestHttpException;
  * @since 0.85
  */
 
-Session::checkLoginUser();
-
 $item = new Item_Project();
 
 if (isset($_POST["add"])) {

--- a/front/itil_project.form.php
+++ b/front/itil_project.form.php
@@ -40,8 +40,6 @@ use Glpi\Exception\Http\BadRequestHttpException;
  * @since 9.4.0
  */
 
-Session::checkLoginUser();
-
 $item = new Itil_Project();
 
 if (isset($_POST['add'])) {

--- a/front/itilfollowup.form.php
+++ b/front/itilfollowup.form.php
@@ -39,8 +39,6 @@ use Glpi\Exception\Http\BadRequestHttpException;
 /** @var \DBmysql $DB */
 global $DB;
 
-Session::checkLoginUser();
-
 $fup = new ITILFollowup();
 
 $redirect = null;

--- a/front/itilsolution.form.php
+++ b/front/itilsolution.form.php
@@ -38,8 +38,6 @@ use Glpi\Event;
 /** @var \DBmysql $DB */
 global $DB;
 
-Session::checkLoginUser();
-
 $solution = new ITILSolution();
 $track = getItemForItemtype($_POST['itemtype']);
 $track->getFromDB($_POST['items_id']);

--- a/front/knowbaseitem_comment.form.php
+++ b/front/knowbaseitem_comment.form.php
@@ -37,8 +37,6 @@ use Glpi\Event;
 use Glpi\Exception\Http\AccessDeniedHttpException;
 use Glpi\Exception\Http\BadRequestHttpException;
 
-Session::checkLoginUser();
-
 $comment = new KnowbaseItem_Comment();
 if (!isset($_POST['knowbaseitems_id'])) {
     Session::addMessageAfterRedirect(__s('Mandatory fields are not filled!'), false, ERROR);

--- a/front/knowbaseitem_item.form.php
+++ b/front/knowbaseitem_item.form.php
@@ -36,8 +36,6 @@
 use Glpi\Event;
 use Glpi\Exception\Http\BadRequestHttpException;
 
-Session::checkLoginUser();
-
 $item = new KnowbaseItem_Item();
 
 if (isset($_POST["add"])) {

--- a/front/knowbaseitem_knowbaseitemcategory.form.php
+++ b/front/knowbaseitem_knowbaseitemcategory.form.php
@@ -36,8 +36,6 @@
 use Glpi\Event;
 use Glpi\Exception\Http\BadRequestHttpException;
 
-Session::checkLoginUser();
-
 $category = new KnowbaseItem_KnowbaseItemCategory();
 
 if (isset($_POST["add"])) {

--- a/front/manuallink.form.php
+++ b/front/manuallink.form.php
@@ -37,8 +37,6 @@ use Glpi\Event;
 use Glpi\Exception\Http\BadRequestHttpException;
 use Glpi\Exception\Http\NotFoundHttpException;
 
-Session::checkValidSessionId();
-
 $link = new ManualLink();
 if (array_key_exists('id', $_REQUEST) && !$link->getFromDB($_REQUEST['id'])) {
     throw new NotFoundHttpException('No item found for given id');

--- a/front/massiveaction.php
+++ b/front/massiveaction.php
@@ -36,8 +36,6 @@
 /** @var array $CFG_GLPI */
 global $CFG_GLPI;
 
-Session::checkLoginUser();
-
 header("Content-Type: text/html; charset=UTF-8");
 Html::header_nocache();
 

--- a/front/planning.form.php
+++ b/front/planning.form.php
@@ -37,8 +37,6 @@
  * @since 9.1
  */
 
-Session::checkLoginUser();
-
 if ($_REQUEST["action"] == "send_add_user_form") {
     Planning::sendAddUserForm($_REQUEST);
 }

--- a/front/planningrecall.form.php
+++ b/front/planningrecall.form.php
@@ -39,8 +39,6 @@ use Glpi\Exception\Http\BadRequestHttpException;
  * @since 0.84.3
  */
 
-Session::checkLoginUser();
-
 $pr = new PlanningRecall();
 
 if (isset($_POST["update"])) {

--- a/front/preference.php
+++ b/front/preference.php
@@ -38,8 +38,6 @@ use Glpi\Security\TOTPManager;
 
 $user = new User();
 
-Session::checkLoginUser();
-
 // Manage 2FA
 if (isset($_POST['disable_2fa'])) {
     $totp_manager = new TOTPManager();

--- a/front/problem.form.php
+++ b/front/problem.form.php
@@ -39,8 +39,6 @@ if (empty($_GET["id"])) {
     $_GET["id"] = '';
 }
 
-Session::checkLoginUser();
-
 // as _actors virtual field stores json, bypass automatic escaping
 if (isset($_POST['_actors'])) {
     $_POST['_actors'] = json_decode($_POST['_actors'], true);

--- a/front/problem_supplier.form.php
+++ b/front/problem_supplier.form.php
@@ -42,7 +42,6 @@ use Glpi\Exception\Http\BadRequestHttpException;
 
 $link = new Problem_Supplier();
 
-Session::checkLoginUser();
 Html::popHeader(__('Email followup'), $_SERVER['PHP_SELF']);
 
 if (isset($_POST["update"])) {

--- a/front/problem_ticket.form.php
+++ b/front/problem_ticket.form.php
@@ -36,8 +36,6 @@
 use Glpi\Event;
 use Glpi\Exception\Http\BadRequestHttpException;
 
-Session::checkLoginUser();
-
 $item = new Problem_Ticket();
 
 if (isset($_POST["add"])) {

--- a/front/problem_user.form.php
+++ b/front/problem_user.form.php
@@ -46,7 +46,6 @@ global $CFG_GLPI;
 $link = new Problem_User();
 $item = new Problem();
 
-Session::checkLoginUser();
 Html::popHeader(__('Email followup'), $_SERVER['PHP_SELF']);
 
 if (isset($_POST["update"])) {

--- a/front/project.form.php
+++ b/front/project.form.php
@@ -46,8 +46,6 @@ if (!isset($_GET["withtemplate"])) {
     $_GET["withtemplate"] = '';
 }
 
-Session::checkLoginUser();
-
 $project = new Project();
 if (isset($_POST["add"])) {
     $project->check(-1, CREATE, $_POST);

--- a/front/projecttask_ticket.form.php
+++ b/front/projecttask_ticket.form.php
@@ -40,8 +40,6 @@ use Glpi\Exception\Http\BadRequestHttpException;
  * @since 0.85
  */
 
-Session::checkLoginUser();
-
 $item = new ProjectTask_Ticket();
 
 if (isset($_POST["add"])) {

--- a/front/reminder.form.php
+++ b/front/reminder.form.php
@@ -39,7 +39,6 @@ if (!isset($_GET["id"])) {
     $_GET["id"] = "";
 }
 $remind = new Reminder();
-Session::checkLoginUser();
 
 if (isset($_POST["add"])) {
     $remind->check(-1, CREATE, $_POST);

--- a/front/report.dynamic.php
+++ b/front/report.dynamic.php
@@ -43,7 +43,6 @@ $itemtype = $_GET['item_type'];
 if ($itemtype === 'AllAssets') {
     Session::checkCentralAccess();
 } else {
-    Session::checkValidSessionId();
     $item = new $itemtype();
     if (!$item::canView()) {
         throw new AccessDeniedHttpException();

--- a/front/reservation.php
+++ b/front/reservation.php
@@ -33,8 +33,6 @@
  * ---------------------------------------------------------------------
  */
 
-Session::checkLoginUser();
-
 if (!isset($_GET["reservationitems_id"])) {
     $_GET["reservationitems_id"] = 0;
 }

--- a/front/rssfeed.form.php
+++ b/front/rssfeed.form.php
@@ -43,7 +43,6 @@ if (!isset($_GET["id"])) {
     $_GET["id"] = "";
 }
 $rssfeed = new RSSFeed();
-Session::checkLoginUser();
 
 if (isset($_POST["add"])) {
     $rssfeed->check(-1, CREATE, $_POST);

--- a/front/savedsearch.php
+++ b/front/savedsearch.php
@@ -33,8 +33,6 @@
  * ---------------------------------------------------------------------
  */
 
-Session::checkLoginUser();
-
 if (Session::getCurrentInterface() == "helpdesk") {
     Html::helpHeader(SavedSearch::getTypeName(Session::getPluralNumber()));
 } else {

--- a/front/stencil.form.php
+++ b/front/stencil.form.php
@@ -36,8 +36,6 @@
 use Glpi\Exception\Http\AccessDeniedHttpException;
 use Glpi\Exception\Http\NotFoundHttpException;
 
-Session::checkLoginUser();
-
 if (isset($_POST['id'])) {
     $stencil = Stencil::getStencilFromID($_POST['id']);
 

--- a/front/supplier_ticket.form.php
+++ b/front/supplier_ticket.form.php
@@ -42,7 +42,6 @@ use Glpi\Exception\Http\BadRequestHttpException;
 
 $link = new Supplier_Ticket();
 
-Session::checkLoginUser();
 Html::popHeader(__('Email followup'), $_SERVER['PHP_SELF']);
 
 if (isset($_POST["update"])) {

--- a/front/ticket.form.php
+++ b/front/ticket.form.php
@@ -42,7 +42,6 @@ use Glpi\Exception\Http\AccessDeniedHttpException;
  */
 global $CFG_GLPI, $DB;
 
-Session::checkLoginUser();
 $track = new Ticket();
 
 if (!isset($_GET['id'])) {

--- a/front/ticket.php
+++ b/front/ticket.php
@@ -33,8 +33,6 @@
  * ---------------------------------------------------------------------
  */
 
-Session::checkLoginUser();
-
 if (Session::getCurrentInterface() == "helpdesk") {
     Html::helpHeader(Ticket::getTypeName(Session::getPluralNumber()), 'tickets', 'ticket');
 } else {

--- a/front/ticket_contract.form.php
+++ b/front/ticket_contract.form.php
@@ -35,8 +35,6 @@
 
 use Glpi\Exception\Http\BadRequestHttpException;
 
-Session::checkLoginUser();
-
 $item = new Ticket_Contract();
 
 if (isset($_POST["add"])) {

--- a/front/ticket_user.form.php
+++ b/front/ticket_user.form.php
@@ -42,7 +42,6 @@ global $CFG_GLPI;
 $link = new Ticket_User();
 $item = new Ticket();
 
-Session::checkLoginUser();
 Html::popHeader(__('Email followup'), $_SERVER['PHP_SELF']);
 
 if (isset($_POST["update"])) {

--- a/front/ticketsatisfaction.form.php
+++ b/front/ticketsatisfaction.form.php
@@ -36,8 +36,6 @@
 use Glpi\Event;
 use Glpi\Exception\Http\BadRequestHttpException;
 
-Session::checkLoginUser();
-
 $inquest = new TicketSatisfaction();
 
 if (isset($_POST["update"])) {

--- a/front/user.form.php
+++ b/front/user.form.php
@@ -46,8 +46,6 @@ if (isset($_POST['language']) && !Session::getLoginUserID()) {
     Html::back();
 }
 
-Session::checkLoginUser();
-
 if (empty($_GET["id"])) {
     $_GET["id"] = "";
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Since #15614, access to any `/ajax` or `/front` script automatically triggers a session check (except for a few hardcoded endpoints). Therefore, it is no longer necessary to manually validate that session is valid.