### PR TITLE
Fix ancestors/sons cache update when moving an item in the tree

### DIFF
--- a/install/migrations/update_10.0.16_to_10.0.17/tree_dropdowns.php
+++ b/install/migrations/update_10.0.16_to_10.0.17/tree_dropdowns.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * @var \DBmysql $DB
+ * @var \Migration $migration
+ */
+
+// Drop the ancestors/sons cache that may have been corrupted by bugs that have now been resolved.
+$tree_dropdown_tables = [
+    'glpi_businesscriticities',
+    'glpi_documentcategories',
+    'glpi_entities',
+    'glpi_groups',
+    'glpi_ipnetworks',
+    'glpi_itilcategories',
+    'glpi_knowbaseitemcategories',
+    'glpi_locations',
+    'glpi_softwarecategories',
+    'glpi_softwarelicenses',
+    'glpi_softwarelicensetypes',
+    'glpi_states',
+    'glpi_taskcategories',
+];
+foreach ($tree_dropdown_tables as $table) {
+    $migration->addPostQuery(
+        $DB->buildUpdate(
+            $table,
+            [
+                'ancestors_cache' => null,
+                'sons_cache' => null,
+            ],
+            [
+                new QueryExpression(true),
+            ]
+        )
+    );
+}

--- a/phpunit/functional/EntityTest.php
+++ b/phpunit/functional/EntityTest.php
@@ -296,6 +296,89 @@ class EntityTest extends DbTestCase
         $this->runChangeEntityParent(true);
     }
 
+    public function testMoveParentEntity(): void
+    {
+        $this->doTestMoveParentEntity(false);
+    }
+
+    /**
+     * @tags cache
+     */
+    public function testMoveParentEntityCached(): void
+    {
+        $this->doTestMoveParentEntity(true);
+    }
+
+    private function doTestMoveParentEntity(bool $cache): void
+    {
+        $this->login();
+
+        $entities = [];
+
+        // Create the test entities
+        $parent_id = 0;
+        for ($i = 0; $i < 5; $i++) {
+            $entity = $this->createItem(
+                \Entity::class,
+                [
+                    'name'         => sprintf('Level %s entity', $i + 1),
+                    'entities_id'  => $parent_id
+                ]
+            );
+            $entities[$i] = $entity;
+            $parent_id = $entity->getID();
+        }
+
+        // Validate that sons/ancestors are correctly set
+        $this->checkEntitiesTree($entities, $cache);
+
+        // Move the "Level 3 entity"
+        $entities[2]->update(['id' => $entities[2]->getID(), 'entities_id' => 0]);
+
+        // Validate that sons/ancestors are correctly updated
+        $this->checkEntitiesTree(\array_slice($entities, 2), $cache);
+        $this->checkEntitiesTree(\array_slice($entities, 0, 2), $cache);
+    }
+
+    /**
+     * Check that the entities tree is correctly returned by `getAncestorsOf`/`getSonsOf` methods.
+     *
+     * @param array $entities   The entities list. Each item is supposed to be the son of the previous item, and the
+     *                          first item is supposed to be a son of the root entity.
+     * @param bool $cache
+     */
+    private function checkEntitiesTree(array $entities, bool $cache): void
+    {
+        global $GLPI_CACHE;
+
+        foreach ($entities as $key => $entity) {
+            $expected_sons_ids = \array_map(
+                static fn (\Entity $ent) => $ent->getID(),
+                \array_slice($entities, $key)
+            );
+            $expected_sons = \array_combine($expected_sons_ids, $expected_sons_ids);
+
+            $expected_ancestors_ids = array_merge(
+                [0], // root entity
+                \array_map(
+                    static fn (\Entity $ent) => $ent->getID(),
+                    \array_slice($entities, 0, $key)
+                )
+            );
+            $expected_ancestors = \array_combine($expected_ancestors_ids, $expected_ancestors_ids);
+
+            $this->assertSame($expected_ancestors, getAncestorsOf('glpi_entities', $entity->getID()));
+            if ($cache === true) {
+                $this->assertSame($expected_ancestors, $GLPI_CACHE->get('ancestors_cache_glpi_entities_' . $entity->getID()));
+            }
+
+            $this->assertSame($expected_sons, getSonsOf('glpi_entities', $entity->getID()));
+            if ($cache === true) {
+                $this->assertSame($expected_sons, $GLPI_CACHE->get('sons_cache_glpi_entities_' . $entity->getID()));
+            }
+        }
+    }
+
     public function testInheritGeolocation()
     {
         $this->login();

--- a/src/CommonTreeDropdown.php
+++ b/src/CommonTreeDropdown.php
@@ -302,9 +302,9 @@ abstract class CommonTreeDropdown extends CommonDropdown
 
 
     /**
-     * Clean sons of all parents from caches
+     * Clean from database and caches the sons of the current entity and of all its parents.
      *
-     * @param null|integer $id    Parent id to clean. Default to current id
+     * @param null|integer $id    ID of the entity that have its sons cache to be cleaned.
      * @param boolean      $cache Whether to clean cache (defaults to true)
      *
      * @return void
@@ -322,12 +322,7 @@ abstract class CommonTreeDropdown extends CommonDropdown
         }
 
         $ancestors = getAncestorsOf($this->getTable(), $id);
-        if ($id != $this->getID()) {
-            $ancestors[$id] = "$id";
-        }
-        if (!count($ancestors)) {
-            return;
-        }
+        $ancestors[$id] = "$id";
 
         $DB->update(
             $this->getTable(),
@@ -339,15 +334,10 @@ abstract class CommonTreeDropdown extends CommonDropdown
             ]
         );
 
-       //drop from sons cache when needed
+        // drop from sons cache when needed
         if ($cache) {
             foreach ($ancestors as $ancestor) {
-                $ckey = 'sons_cache_' . $this->getTable() . '_' . $ancestor;
-                $sons = $GLPI_CACHE->get($ckey);
-                if ($sons !== null && isset($sons[$this->getID()])) {
-                    unset($sons[$this->getID()]);
-                    $GLPI_CACHE->set($ckey, $sons);
-                }
+                $GLPI_CACHE->delete('sons_cache_' . $this->getTable() . '_' . $ancestor);
             }
         }
     }
@@ -434,8 +424,7 @@ abstract class CommonTreeDropdown extends CommonDropdown
             }
 
             if ($parent->getFromDB($newParentID)) {
-                $this->cleanParentsSons(null, false);
-                $this->addSonInParents();
+                $this->cleanParentsSons();
                 if ($history) {
                     $newParentNameID = $parent->getNameID(['forceid' => true]);
                     $changes = [
@@ -467,7 +456,10 @@ abstract class CommonTreeDropdown extends CommonDropdown
                     Log::HISTORY_UPDATE_SUBITEM
                 );
             }
+
+            // Force DB cache refresh
             getAncestorsOf(getTableForItemType($this->getType()), $ID);
+            getSonsOf(getTableForItemType($this->getType()), $ID);
         }
     }
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

When an entity was moved inside the entity tree, its own ID was correctly removed from its previous ancestors sons and was correctly added to its new ancestors in the corresponding `$GLPI_CACHE` entries, but its own children were not moved correctly. Also, the `$GLPI_CACHE` entries related to the moved entity were not correctly updated.

Instead of trying to implement a complex logic to properly update the existing cache entries in `CommonTreeDropdown::cleanParentsSons()`, I propose to just invalidate them. Moving an entity is not something that is expected to be done often, so it should not be an issue if it then requires some cache entries to be recomputed.


