### PR TITLE
Fix nullable state of DatabaseInstance itemtype

### DIFF
--- a/install/migrations/update_10.0.16_to_10.0.17/databases.php
+++ b/install/migrations/update_10.0.16_to_10.0.17/databases.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * @var \DBmysql $DB
+ * @var \Migration $migration
+ */
+
+$migration->changeField('glpi_databaseinstances', 'itemtype', 'itemtype', 'varchar(100) DEFAULT NULL');
+
+$migration->addPostQuery(
+    $DB->buildUpdate(
+        'glpi_databaseinstances',
+        [
+            'itemtype' => null,
+        ],
+        [
+            'itemtype' => '0',
+        ]
+    )
+);

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -9191,7 +9191,7 @@ CREATE TABLE `glpi_databaseinstances` (
   `users_id_tech` int unsigned NOT NULL DEFAULT '0',
   `groups_id_tech` int unsigned NOT NULL DEFAULT '0',
   `states_id` int unsigned NOT NULL DEFAULT '0',
-  `itemtype` varchar(100) NOT NULL DEFAULT '',
+  `itemtype` varchar(100) DEFAULT NULL,
   `items_id` int unsigned NOT NULL DEFAULT '0',
   `is_onbackup` tinyint NOT NULL DEFAULT '0',
   `is_active` tinyint NOT NULL DEFAULT '0',

--- a/src/DatabaseInstance.php
+++ b/src/DatabaseInstance.php
@@ -314,12 +314,32 @@ class DatabaseInstance extends CommonDBTM
 
     public function prepareInputForAdd($input)
     {
+        $input = $this->cleanInput($input);
+
         if (isset($input['date_lastbackup']) && empty($input['date_lastbackup'])) {
             unset($input['date_lastbackup']);
         }
 
         if (isset($input['size']) && empty($input['size'])) {
             unset($input['size']);
+        }
+
+        return $input;
+    }
+
+    public function prepareInputForUpdate($input)
+    {
+        $input = $this->cleanInput($input);
+
+        return $input;
+    }
+
+    private function cleanInput(array $input): array
+    {
+        if (($input['itemtype'] ?? null) === '0') {
+            // `itemtype` value will be '0' if no itemtype is selected in the dropdown
+            // see `Dropdown::showItemTypes()` / `Dropdown::showFromArray()`
+            $input['itemtype'] = null;
         }
 
         return $input;


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

It fixes #17019.

A database instance is not necessarily linked to an item. Therefore, the `itemtype` field should be nullable.