### PR TITLE
Throw exceptions on SQL errors

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -80,12 +80,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/install/empty_data.php',
 ];
 $ignoreErrors[] = [
-	// identifier: if.alwaysFalse
-	'message' => '#^If condition is always false\\.$#',
-	'count' => 2,
-	'path' => __DIR__ . '/install/install.php',
-];
-$ignoreErrors[] = [
 	// identifier: foreach.emptyArray
 	'message' => '#^Empty array passed to foreach\\.$#',
 	'count' => 2,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,10 +119,10 @@ The present file will list all changes made to the project; according to the
 - All types of rules are now sortable and ordered by ranking.
 - Plugins console commands must now use the normalized prefix `plugins:XXX` where `XXX` is the plugin key.
 - GLPI web root is now the `/public` directory and all web request to PHP scripts are proxified by `public/index.php` script.
-- Usage of `DBmysql::query()`, `DBmysql::queryOrDie()` method are prohibited to ensure that legacy unsafe DB are no more executed.
+- Usage of `DBmysql::query()` and `DBmysql::queryOrDie()` method are prohibited to ensure that legacy unsafe DB are no more executed.
   Building and executing raw queries using `DBmysql::request()`, `DBmysqlIterator::buildQuery()` and `DBmysqlIterator::execute()` methods is also prohibited.
   To execute DB queries, either `DBmysql::request()` can be used to craft query using the GLPI query builder,
-  either `DBmysql::doQuery()`/`DBmysql::doQueryOrDie()` can be used for safe queries to execute DB query using a self-crafted a SQL string.
+  or `DBmysql::doQuery()` can be used for safe queries to execute DB query using a self-crafted a SQL string.
 - `js/fuzzysearch.js` replaced with `FuzzySearch/Modal` Vue component.
 - `Html::fuzzySearch()` replaced with `Html::getMenuFuzzySearchList()` function.
 - `NotificationEvent::raiseEvent()` signature cahnged. A new `$trigger` parameter has been added at 4th position, and `$label` is now the 5th parameter.
@@ -241,8 +241,12 @@ The present file will list all changes made to the project; according to the
 - `ComputerVirtualMachine` has been deprecated and replaced by `ItemVirtualMachine`
 - `Config::validatePassword()`
 - `Contract::getExpiredCriteria()` renamed to `Contract::getNotExpiredCriteria()` to match the actual behavior.
+- `DBmysql::deleteOrDie()`. Use `DBmysql::delete()` instead.
+- `DBmysql::doQueryOrDie()`. Use `DBmysql::doQuery()` instead.
+- `DBmysql::insertOrDie()`. Use `DBmysql::insert()` instead.
 - `DBmysql::truncate()`
 - `DBmysql::truncateOrDie()`
+- `DBmysql::updateOrDie()`. Use `DBmysql::update()` instead.
 - `Document::getImage()`
 - `Glpi\Application\View\Extension\DataHelpersExtension::getVerbatimValue()`
 - `Glpi\Application\View\Extension\PluginExtension::getPluginWebDir()`
@@ -370,6 +374,7 @@ The present file will list all changes made to the project; according to the
 - `GLPI::getLogLevel()`
 - `Glpi\Api\API::showDebug()`
 - `Glpi\Api\API::returnSanitizedContent()`
+- `Glpi\Application\ErrorHandler::handleSqlError()`
 - `Glpi\Dashboard\Filter::dates()`
 - `Glpi\Dashboard\Filter::dates_mod()`
 - `Glpi\Dashboard\Filter::itilcategory()`

--- a/install/migrations/update_0.90.1_to_0.90.5.php
+++ b/install/migrations/update_0.90.1_to_0.90.5.php
@@ -75,7 +75,7 @@ function update0901to0905()
 
    // fix https://github.com/glpi-project/glpi/issues/820
    // remove empty suppliers in tickets
-    $DB->deleteOrDie("glpi_suppliers_tickets", [
+    $DB->delete("glpi_suppliers_tickets", [
         'suppliers_id'       => 0,
         'alternative_email'  => ""
     ]);

--- a/install/migrations/update_0.90.x_to_9.1.0.php
+++ b/install/migrations/update_0.90.x_to_9.1.0.php
@@ -93,7 +93,7 @@ function update090xto910()
                  PRIMARY KEY (`id`),
                  UNIQUE INDEX `item` (`itemtype`, `items_id`)
                ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
-        $DB->doQueryOrDie($query, "9.1 add table glpi_objectlocks");
+        $DB->doQuery($query);
 
        // insert new profile (read only access for locks)
         $query = "INSERT INTO `glpi_profiles`
@@ -108,9 +108,9 @@ function update090xto910()
                         0, 0,
                         '{\"1\":{\"9\":0,\"10\":0,\"7\":0,\"4\":0,\"11\":0,\"12\":0,\"5\":0,\"8\":0,\"6\":0},\"9\":{\"1\":0,\"10\":0,\"7\":0,\"4\":0,\"11\":0,\"12\":0,\"5\":0,\"8\":0,\"6\":0},\"10\":{\"1\":0,\"9\":0,\"7\":0,\"4\":0,\"11\":0,\"12\":0,\"5\":0,\"8\":0,\"6\":0},\"7\":{\"1\":0,\"9\":0,\"10\":0,\"4\":0,\"11\":0,\"12\":0,\"5\":0,\"8\":0,\"6\":0},\"4\":{\"1\":0,\"9\":0,\"10\":0,\"7\":0,\"11\":0,\"12\":0,\"5\":0,\"8\":0,\"6\":0},\"11\":{\"1\":0,\"9\":0,\"10\":0,\"7\":0,\"4\":0,\"12\":0,\"5\":0,\"8\":0,\"6\":0},\"12\":{\"1\":0,\"9\":0,\"10\":0,\"7\":0,\"4\":0,\"11\":0,\"5\":0,\"8\":0,\"6\":0},\"5\":{\"1\":0,\"9\":0,\"10\":0,\"7\":0,\"4\":0,\"11\":0,\"12\":0,\"8\":0,\"6\":0},\"8\":{\"1\":0,\"9\":0,\"10\":0,\"7\":0,\"4\":0,\"11\":0,\"12\":0,\"5\":0,\"6\":0},\"6\":{\"1\":0,\"9\":0,\"10\":0,\"7\":0,\"4\":0,\"11\":0,\"12\":0,\"5\":0,\"8\":0}}')";
 
-        $DB->doQueryOrDie($query, "9.1 update profile with Unlock profile");
+        $DB->doQuery($query);
         $ro_p_id = $DB->insertId();
-        $DB->doQueryOrDie("INSERT INTO `glpi_profilerights`
+        $DB->doQuery("INSERT INTO `glpi_profilerights`
                               (`profiles_id`, `name`, `rights`)
                        VALUES ($ro_p_id, 'backup',                    '1'),
                               ($ro_p_id, 'bookmark_public',           '1'),
@@ -190,7 +190,7 @@ function update090xto910()
             $rightnames[] = $itemtype::$rightname;
         }
 
-        $DB->updateOrDie(
+        $DB->update(
             "glpi_profilerights",
             [
                 'rights' => new QueryExpression(
@@ -200,8 +200,7 @@ function update090xto910()
             [
                 'profiles_id'  => 4,
                 'name'         => $rightnames
-            ],
-            "update super-admin profile with UNLOCK right"
+            ]
         );
 
         Config::setConfigurationValues('core', ['lock_use_lock_item'             => 0,
@@ -219,7 +218,7 @@ function update090xto910()
             ['itemtype' => 'ObjectLock', 'name' => 'unlockobject']
         )
     ) {
-        $DB->insertOrDie(
+        $DB->insert(
             "glpi_crontasks",
             [
                 'itemtype'        => "ObjectLock",
@@ -235,8 +234,7 @@ function update090xto910()
                 'lastrun'         => null,
                 'lastcode'        => null,
                 'comment'         => null
-            ],
-            "9.1 Add UnlockObject cron task"
+            ]
         );
     }
    // notification template
@@ -246,14 +244,13 @@ function update090xto910()
     ]);
 
     if (count($notificationtemplatesIterator) == 0) {
-        $DB->insertOrDie(
+        $DB->insert(
             "glpi_notificationtemplates",
             [
                 'name'      => "Unlock Item request",
                 'itemtype'  => "ObjectLock",
                 'date_mod'  => new QueryExpression("NOW()")
-            ],
-            "9.1 Add unlock request notification template"
+            ]
         );
         $notid = $DB->insertId();
 
@@ -288,7 +285,7 @@ function update090xto910()
          &lt;/table&gt;
          &lt;p&gt;&lt;span style=\"font-size: small;\"&gt;Hello ##objectlock.lockedby.firstname##,&lt;br /&gt;Could go to this item and unlock it for me?&lt;br /&gt;Thank you,&lt;br /&gt;Regards,&lt;br /&gt;##objectlock.requester.firstname## ##objectlock.requester.lastname##&lt;/span&gt;&lt;/p&gt;';
 
-        $DB->insertOrDie(
+        $DB->insert(
             "glpi_notificationtemplatetranslations",
             [
                 'notificationtemplates_id' => $notid,
@@ -296,11 +293,10 @@ function update090xto910()
                 'subject'                  => "##objectlock.action##",
                 'content_text'             => $contentText,
                 'content_html'             => $contentHtml
-            ],
-            "9.1 add Unlock Request notification translation"
+            ]
         );
 
-        $DB->insertOrDie(
+        $DB->insert(
             "glpi_notifications",
             [
                 'name'                     => "Request Unlock Items",
@@ -313,20 +309,18 @@ function update090xto910()
                 'is_recursive'             => 1,
                 'is_active'                => 1,
                 'date_mod'                 => new QueryExpression("NOW()")
-            ],
-            "9.1 add Unlock Request notification"
+            ]
         );
         $notifid = $DB->insertId();
 
-        $DB->insertOrDie(
+        $DB->insert(
             "glpi_notificationtargets",
             [
                 'id'                 => null,
                 'notifications_id'   => $notifid,
                 'type'               => Notification::USER_TYPE,
                 'items_id'           => Notification::USER
-            ],
-            "9.1 add Unlock Request notification target"
+            ]
         );
     }
 
@@ -375,7 +369,7 @@ function update090xto910()
                   KEY `date_mod` (`date_mod`),
                   KEY `date_creation` (`date_creation`)
                 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;";
-        $DB->doQueryOrDie($query, "9.1 add table glpi_operatingsystemarchitectures");
+        $DB->doQuery($query);
     }
 
    /************** Task's templates *************/
@@ -395,7 +389,7 @@ function update090xto910()
                   KEY `taskcategories_id` (`taskcategories_id`),
                   KEY `entities_id` (`entities_id`)
                 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;";
-        $DB->doQueryOrDie($query, "9.1 add table glpi_tasktemplates");
+        $DB->doQuery($query);
     }
 
    /************** Installation date for softwares *************/
@@ -418,14 +412,14 @@ function update090xto910()
                   KEY `date_mod` (`date_mod`),
                   KEY `date_creation` (`date_creation`)
                 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;";
-        $DB->doQueryOrDie($query, "add table glpi_budgettypes");
+        $DB->doQuery($query);
     }
 
     $new = $migration->addField("glpi_budgets", "budgettypes_id", "integer");
     $migration->addKey("glpi_budgets", "budgettypes_id");
 
     if ($new) {
-        $DB->updateOrDie(
+        $DB->update(
             "glpi_displaypreferences",
             [
                 'num' => 6
@@ -433,8 +427,7 @@ function update090xto910()
             [
                 'itemtype'  => "Budget",
                 'num'       => 4,
-            ],
-            "change budget display preference"
+            ]
         );
     }
     $ADDTODISPLAYPREF['Budget'] = [4];
@@ -466,9 +459,9 @@ function update090xto910()
                   KEY `date_mod` (`date_mod`),
                   KEY `is_active` (`is_active`)
                 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;";
-        $DB->doQueryOrDie($query, "9.1 add table glpi_apiclients");
+        $DB->doQuery($query);
 
-        $DB->insertOrDie(
+        $DB->insert(
             "glpi_apiclients",
             [
                 'id'                 => 1,
@@ -484,8 +477,7 @@ function update090xto910()
                 'app_token_date'     => null,
                 'dolog_method'       => 0,
                 'comment'            => null
-            ],
-            "9.1 insert first line into table glpi_apiclients"
+            ]
         );
     }
 
@@ -717,7 +709,7 @@ function update090xto910()
                 foreach ($items_to_update as $templates_id => $type) {
                     if (isset($type['itemtype'])) {
                         if (isset($type['items_id'])) {
-                            $DB->updateOrDie(
+                            $DB->update(
                                 $table,
                                 [
                                     'value' => $type['itemtype'] . "_" . $type['items_id']
@@ -725,17 +717,15 @@ function update090xto910()
                                 [
                                     'num'                => $item_num,
                                     'tickettemplates_id' => $templates_id,
-                                ],
-                                "Associated items migration : update predefined items"
+                                ]
                             );
 
-                            $DB->deleteOrDie(
+                            $DB->delete(
                                 $table,
                                 [
                                     'num'                => $itemtype_num,
                                     'tickettemplates_id' => $templates_id,
-                                ],
-                                "Associated items migration : delete $table itemtypes"
+                                ]
                             );
                         }
                     }
@@ -746,16 +736,15 @@ function update090xto910()
                 foreach ($items_to_update as $templates_id => $type) {
                     if (isset($type['itemtype'])) {
                         if (isset($type['items_id'])) {
-                            $DB->deleteOrDie(
+                            $DB->delete(
                                 $table,
                                 [
                                     'num'                => $item_num,
                                     'tickettemplates_id' => $templates_id,
-                                ],
-                                "Associated items migration : delete $table itemtypes"
+                                ]
                             );
                         }
-                        $DB->updateOrDie(
+                        $DB->update(
                             $table,
                             [
                                 'num' => $item_num
@@ -763,8 +752,7 @@ function update090xto910()
                             [
                                 'num'                => $itemtype_num,
                                 'tickettemplates_id' => $templates_id,
-                            ],
-                            "Associated items migration : update $table itemtypes"
+                            ]
                         );
                     }
                 }
@@ -842,7 +830,7 @@ function update090xto910()
                   KEY `date_mod` (`date_mod`),
                   KEY `date_creation` (`date_creation`)
                 ) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=1;";
-        $DB->doQueryOrDie($query, "Add antivirus table");
+        $DB->doQuery($query);
     }
 
     if (countElementsInTable("glpi_profilerights", ['name' => 'license']) == 0) {
@@ -850,15 +838,14 @@ function update090xto910()
         //copy the software right value to the new license right
         $prights = $DB->request(['FROM' => 'glpi_profilerights', 'WHERE' => ['name' => 'software']]);
         foreach ($prights as $profrights) {
-            $DB->insertOrDie(
+            $DB->insert(
                 "glpi_profilerights",
                 [
                     'id'           => null,
                     'profiles_id'  => $profrights['profiles_id'],
                     'name'         => "license",
                     'rights'       => $profrights['rights'],
-                ],
-                "9.1 add right for softwarelicense"
+                ]
             );
         }
     }
@@ -866,7 +853,7 @@ function update090xto910()
     //new right for survey
     $prights = $DB->request(['FROM' => 'glpi_profilerights', 'WHERE' => ['name' => 'ticket']]);
     foreach ($prights as $profrights) {
-        $DB->updateOrDie(
+        $DB->update(
             "glpi_profilerights",
             [
                 'rights' => new QueryExpression(
@@ -876,8 +863,7 @@ function update090xto910()
             [
                 'profiles_id'  => $profrights['profiles_id'],
                 'name'         => "ticket"
-            ],
-            "9.1 update ticket with survey right"
+            ]
         );
     }
 
@@ -919,7 +905,7 @@ function update090xto910()
                           ],
                       ]);
                     if (count($iterator) == 0) {
-                         $DB->insertOrDie("glpi_displaypreferences", [
+                         $DB->insert("glpi_displaypreferences", [
                              'itemtype'  => $type,
                              'num'       => $newval,
                              'rank'      => $rank++,
@@ -931,7 +917,7 @@ function update090xto910()
         } else { // Add for default user
             $rank = 1;
             foreach ($tab as $newval) {
-                $DB->insertOrDie("glpi_displaypreferences", [
+                $DB->insert("glpi_displaypreferences", [
                     'itemtype'  => $type,
                     'num'       => $newval,
                     'rank'      => $rank++,
@@ -964,13 +950,13 @@ function update090xto910()
                   KEY `date_creation` (`date_creation`),
                   KEY `slas_id` (`slas_id`)
                 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;";
-        $DB->doQueryOrDie($query, "9.1 add table glpi_slts");
+        $DB->doQuery($query);
 
        // Sla migration
         $slasIterator = $DB->request(['FROM' => "glpi_slas"]);
         if (count($slasIterator)) {
             foreach ($slasIterator as $data) {
-                $DB->insertOrDie(
+                $DB->insert(
                     "glpi_slts",
                     [
                         'id'                 => $data['id'],
@@ -985,8 +971,7 @@ function update090xto910()
                         'end_of_working_day' => $data['end_of_working_day'],
                         'date_creation'      => date('Y-m-d H:i:s'),
                         'slas_id'            => $data['id']
-                    ],
-                    "SLA migration to SLT"
+                    ]
                 );
             }
         }
@@ -1046,19 +1031,17 @@ function update090xto910()
     );
 
    // Sla rules criterias migration
-    $DB->updateOrDie(
+    $DB->update(
         "glpi_rulecriterias",
         ['criteria' => "slts_ttr_id" ],
-        ['criteria' => "slas_id"],
-        "SLA rulecriterias migration"
+        ['criteria' => "slas_id"]
     );
 
    // Sla rules actions migration
-    $DB->updateOrDie(
+    $DB->update(
         "glpi_ruleactions",
         ['field' => "slts_ttr_id" ],
-        ['field' => "slas_id"],
-        "SLA ruleactions migration"
+        ['field' => "slas_id"]
     );
 
    // to delete in next version - fix change in update
@@ -1118,7 +1101,7 @@ function update090xto910()
     $migration->addKey("glpi_requesttypes", "is_mailfollowup_default");
 
    /************** Fix autoclose_delay for root_entity in glpi_entities (from -1 to 0) **************/
-    $DB->updateOrDie(
+    $DB->update(
         "glpi_entities",
         [
             'autoclose_delay' => 0
@@ -1126,8 +1109,7 @@ function update090xto910()
         [
             'autoclose_delay' => -1,
             'id'              => 0
-        ],
-        "glpi_entities root_entity change autoclose_delay value from -1 to 0"
+        ]
     );
 
    // ************ Keep it at the end **************

--- a/install/migrations/update_10.0.0_to_10.0.1.php
+++ b/install/migrations/update_10.0.0_to_10.0.1.php
@@ -81,7 +81,7 @@ function update1000to1001()
         }
     }
     foreach ($DELFROMDISPLAYPREF as $type => $tab) {
-        $DB->deleteOrDie(
+        $DB->delete(
             'glpi_displaypreferences',
             [
                 'itemtype'  => $type,

--- a/install/migrations/update_10.0.1_to_10.0.2.php
+++ b/install/migrations/update_10.0.1_to_10.0.2.php
@@ -81,7 +81,7 @@ function update1001to1002()
         }
     }
     foreach ($DELFROMDISPLAYPREF as $type => $tab) {
-        $DB->deleteOrDie(
+        $DB->delete(
             'glpi_displaypreferences',
             [
                 'itemtype'  => $type,

--- a/install/migrations/update_10.0.2_to_10.0.3.php
+++ b/install/migrations/update_10.0.2_to_10.0.3.php
@@ -81,7 +81,7 @@ function update1002to1003()
         }
     }
     foreach ($DELFROMDISPLAYPREF as $type => $tab) {
-        $DB->deleteOrDie(
+        $DB->delete(
             'glpi_displaypreferences',
             [
                 'itemtype'  => $type,

--- a/install/migrations/update_10.0.2_to_10.0.3/notifications.php
+++ b/install/migrations/update_10.0.2_to_10.0.3/notifications.php
@@ -68,7 +68,7 @@ foreach ($iterator as $notification) {
             || $items_id === Notification::ITEM_TECH_IN_CHARGE
             || $items_id === Notification::ITEM_USER
         ) {
-            $DB->deleteOrDie('glpi_notificationtargets', [
+            $DB->delete('glpi_notificationtargets', [
                 'id' => $target_id,
             ]);
             if ($items_id === Notification::ITEM_TECH_GROUP_IN_CHARGE) {
@@ -80,7 +80,7 @@ foreach ($iterator as $notification) {
         }
     }
     if ($notification['event'] === 'assign_group' && $removed_item_group && !$found_assigned_group) {
-        $DB->insertOrDie('glpi_notificationtargets', [
+        $DB->insert('glpi_notificationtargets', [
             'notifications_id'  => $notification['id'],
             'type'              => Notification::USER_TYPE,
             'items_id'          => Notification::ASSIGN_GROUP,

--- a/install/migrations/update_10.0.3_to_10.0.4.php
+++ b/install/migrations/update_10.0.3_to_10.0.4.php
@@ -81,7 +81,7 @@ function update1003to1004()
         }
     }
     foreach ($DELFROMDISPLAYPREF as $type => $tab) {
-        $DB->deleteOrDie(
+        $DB->delete(
             'glpi_displaypreferences',
             [
                 'itemtype'  => $type,

--- a/install/migrations/update_10.0.4_to_10.0.5.php
+++ b/install/migrations/update_10.0.4_to_10.0.5.php
@@ -81,7 +81,7 @@ function update1004to1005()
         }
     }
     foreach ($DELFROMDISPLAYPREF as $type => $tab) {
-        $DB->deleteOrDie(
+        $DB->delete(
             'glpi_displaypreferences',
             [
                 'itemtype'  => $type,

--- a/install/migrations/update_10.0.5_to_10.0.6/inventory.php
+++ b/install/migrations/update_10.0.5_to_10.0.6/inventory.php
@@ -43,7 +43,7 @@ $migration->addConfig(["entities_id_default" => 0], 'inventory');
 $config = \Config::getConfigurationValues('inventory');
 if (isset($config['stale_agents_action']) && is_numeric($config['stale_agents_action'])) {
     //convert stale_agents_action to an array
-    $DB->updateOrDie(
+    $DB->update(
         'glpi_configs',
         [
             'value' => exportArrayToDB([$config['stale_agents_action']])

--- a/install/migrations/update_10.0.6_to_10.0.7/ruleticket.php
+++ b/install/migrations/update_10.0.6_to_10.0.7/ruleticket.php
@@ -38,13 +38,12 @@
  */
 
 // Replace old rule criteria itilcategories_id_cn
-$DB->updateOrDie(
+$DB->update(
     'glpi_rulecriterias',
     [
         'criteria' => 'itilcategories_id'
     ],
     [
         'criteria' => 'itilcategories_id_cn'
-    ],
-    '10.0.7 replace old rule criteria itilcategories_id_cn'
+    ]
 );

--- a/install/migrations/update_10.0.6_to_10.0.7/unmanageds.php
+++ b/install/migrations/update_10.0.6_to_10.0.7/unmanageds.php
@@ -48,7 +48,7 @@ if ($DB->fieldExists(\Unmanaged::getTable(), 'domains_id')) {
     ]);
     if (count($iterator)) {
         foreach ($iterator as $row) {
-            $DB->insertOrDie("glpi_domains_items", [
+            $DB->insert("glpi_domains_items", [
                 'domains_id'   => $row['domains_id'],
                 'itemtype'     => 'Unmanaged',
                 'items_id'     => $row['id']

--- a/install/migrations/update_10.0.7_to_10.0.8/ram_field.php
+++ b/install/migrations/update_10.0.7_to_10.0.8/ram_field.php
@@ -57,13 +57,13 @@ foreach (['glpi_computervirtualmachines', 'glpi_networkequipments'] as $table) {
         ],
     ]);
     foreach ($iterator as $row) {
-        $DB->updateOrDie(
+        $DB->update(
             $table,
             ['ram' => preg_replace('/[^0-9]+/', '', $row['ram'])],
             ['id'  => $row['id']]
         );
     }
-    $DB->updateOrDie(
+    $DB->update(
         $table,
         ['ram' => null],
         [

--- a/install/migrations/update_10.0.7_to_10.0.8/rule_tickets.php
+++ b/install/migrations/update_10.0.7_to_10.0.8/rule_tickets.php
@@ -37,13 +37,12 @@
  * @var \DBmysql $DB
  */
 
-$DB->updateOrDie(
+$DB->update(
     'glpi_rulecriterias',
     [
         'criteria' => '_locations_id_of_item'
     ],
     [
         'criteria' => 'items_locations'
-    ],
-    '10.0.8 replace old rule criteria items_locations'
+    ]
 );

--- a/install/migrations/update_10.0.x_to_11.0.0/assets.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/assets.php
@@ -63,7 +63,7 @@ if (!$DB->tableExists('glpi_assets_assetdefinitions')) {
             KEY `date_mod` (`date_mod`)
         ) ENGINE=InnoDB DEFAULT CHARSET={$default_charset} COLLATE={$default_collation} ROW_FORMAT=DYNAMIC;
 SQL;
-    $DB->doQueryOrDie($query);
+    $DB->doQuery($query);
 } else {
     foreach (['profiles', 'translations'] as $field) {
         $migration->addField('glpi_assets_assetdefinitions', $field, 'JSON NOT NULL', ['update' => "'[]'"]);
@@ -123,7 +123,7 @@ if (!$DB->tableExists('glpi_assets_assets')) {
             KEY `date_mod` (`date_mod`)
         ) ENGINE=InnoDB DEFAULT CHARSET={$default_charset} COLLATE={$default_collation} ROW_FORMAT=DYNAMIC;
 SQL;
-    $DB->doQueryOrDie($query);
+    $DB->doQuery($query);
 } else {
     $migration->addField('glpi_assets_assets', 'assets_assetmodels_id', 'fkey');
     $migration->addKey('glpi_assets_assets', 'assets_assetmodels_id');
@@ -173,7 +173,7 @@ if (!$DB->tableExists('glpi_assets_assetmodels')) {
           KEY `product_number` (`product_number`)
         ) ENGINE=InnoDB DEFAULT CHARSET={$default_charset} COLLATE={$default_collation} ROW_FORMAT=DYNAMIC;
 SQL;
-    $DB->doQueryOrDie($query);
+    $DB->doQuery($query);
 }
 
 if (!$DB->tableExists('glpi_assets_assettypes')) {
@@ -192,7 +192,7 @@ if (!$DB->tableExists('glpi_assets_assettypes')) {
           KEY `date_creation` (`date_creation`)
         ) ENGINE=InnoDB DEFAULT CHARSET={$default_charset} COLLATE={$default_collation} ROW_FORMAT=DYNAMIC;
 SQL;
-    $DB->doQueryOrDie($query);
+    $DB->doQuery($query);
 }
 
 if (!$DB->tableExists('glpi_assets_customfielddefinitions')) {
@@ -211,7 +211,7 @@ if (!$DB->tableExists('glpi_assets_customfielddefinitions')) {
           KEY `name` (`name`)
         ) ENGINE=InnoDB DEFAULT CHARSET={$default_charset} COLLATE={$default_collation} ROW_FORMAT=DYNAMIC;
 SQL;
-    $DB->doQueryOrDie($query);
+    $DB->doQuery($query);
 }
 
 // Dev migration

--- a/install/migrations/update_10.0.x_to_11.0.0/assignable_items.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/assignable_items.php
@@ -174,7 +174,7 @@ if (!$DB->tableExists('glpi_groups_items')) {
           KEY `type` (`type`)
         ) ENGINE=InnoDB DEFAULT CHARSET={$default_charset} COLLATE={$default_collation} ROW_FORMAT=DYNAMIC;
 SQL;
-    $DB->doQueryOrDie($query);
+    $DB->doQuery($query);
 }
 
 foreach ($assignable_itemtypes as $itemtype => $specs) {

--- a/install/migrations/update_10.0.x_to_11.0.0/changesatisfactions.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/changesatisfactions.php
@@ -56,7 +56,7 @@ if (!$DB->tableExists('glpi_changesatisfactions')) {
         PRIMARY KEY (`id`),
         UNIQUE KEY `changes_id` (`changes_id`)
         ) ENGINE=InnoDB DEFAULT CHARSET={$default_charset} COLLATE={$default_collation} ROW_FORMAT=DYNAMIC;";
-    $DB->doQueryOrDie($query, "11.0.0 add table glpi_changesatisfactions");
+    $DB->doQuery($query);
 }
 
 // Register crontask
@@ -134,7 +134,7 @@ $migration->addRight('change', CommonITILObject::SURVEY, [
 ]);
 
 // Replace old TICKETCATEGORY tags in Entity inquest_URL field with ITILCATEGORY
-$DB->updateOrDie(
+$DB->update(
     'glpi_entities',
     [
         'inquest_URL' => new QueryExpression(
@@ -143,8 +143,7 @@ $DB->updateOrDie(
     ],
     [
         'inquest_URL' => ['LIKE', '%[TICKETCATEGORY_%'],
-    ],
-    'Replace old TICKETCATEGORY tags in Entity inquest_URL field with ITILCATEGORY'
+    ]
 );
 
 // Keep track of satisfaction on a fixed scale (for stats)

--- a/install/migrations/update_10.0.x_to_11.0.0/commonitilobject_commonitilobject.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/commonitilobject_commonitilobject.php
@@ -64,7 +64,7 @@ if (!$DB->tableExists('glpi_changes_changes')) {
         UNIQUE KEY `unicity` (`changes_id_1`,`changes_id_2`),
         KEY `changes_id_2` (`changes_id_2`)
         ) ENGINE=InnoDB DEFAULT CHARSET={$default_charset} COLLATE={$default_collation} ROW_FORMAT=DYNAMIC;";
-    $DB->doQueryOrDie($query, "11.0.0 add table glpi_changes_changes");
+    $DB->doQuery($query);
 }
 
 if (!$DB->tableExists('glpi_problems_problems')) {
@@ -77,5 +77,5 @@ if (!$DB->tableExists('glpi_problems_problems')) {
         UNIQUE KEY `unicity` (`problems_id_1`,`problems_id_2`),
         KEY `problems_id_2` (`problems_id_2`)
         ) ENGINE=InnoDB DEFAULT CHARSET={$default_charset} COLLATE={$default_collation} ROW_FORMAT=DYNAMIC;";
-    $DB->doQueryOrDie($query, "11.0.0 add table glpi_problems_problems");
+    $DB->doQuery($query);
 }

--- a/install/migrations/update_10.0.x_to_11.0.0/criteriafilter.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/criteriafilter.php
@@ -55,7 +55,7 @@ if (!$DB->tableExists($table)) {
         KEY `search_itemtype` (`search_itemtype`)
     ) ENGINE=InnoDB DEFAULT CHARSET={$default_charset} COLLATE={$default_collation} ROW_FORMAT=DYNAMIC;";
 
-    $DB->doQueryOrDie($query, "Add table $table");
+    $DB->doQuery($query);
 }
 
 $table = "glpi_defaultfilters";
@@ -72,7 +72,7 @@ if (!$DB->tableExists($table)) {
         KEY `is_active` (`is_active`)
     ) ENGINE=InnoDB DEFAULT CHARSET={$default_charset} COLLATE={$default_collation} ROW_FORMAT=DYNAMIC;";
 
-    $DB->doQueryOrDie($query, "Add table $table");
+    $DB->doQuery($query);
 }
 
 $migration->addRight(DefaultFilter::$rightname, ALLSTANDARDRIGHT, ['config' => UPDATE]);

--- a/install/migrations/update_10.0.x_to_11.0.0/deviceharddrivetypes.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/deviceharddrivetypes.php
@@ -53,5 +53,5 @@ if (!$DB->tableExists('glpi_deviceharddrivetypes')) {
         PRIMARY KEY (`id`),
         KEY `name` (`name`)
       ) ENGINE=InnoDB DEFAULT CHARSET={$default_charset} COLLATE={$default_collation} ROW_FORMAT=DYNAMIC";
-    $DB->doQueryOrDie($query, "11.0.0 add table glpi_deviceharddrivetypes");
+    $DB->doQuery($query);
 }

--- a/install/migrations/update_10.0.x_to_11.0.0/dropdowns.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/dropdowns.php
@@ -61,7 +61,7 @@ if (!$DB->tableExists('glpi_dropdowns_dropdowndefinitions')) {
             KEY `date_mod` (`date_mod`)
     ) ENGINE=InnoDB DEFAULT CHARSET={$default_charset} COLLATE={$default_collation} ROW_FORMAT=DYNAMIC;
 SQL;
-    $DB->doQueryOrDie($query);
+    $DB->doQuery($query);
 }
 
 if (!$DB->tableExists('glpi_dropdowns_dropdowns')) {
@@ -91,7 +91,7 @@ if (!$DB->tableExists('glpi_dropdowns_dropdowns')) {
             KEY `date_mod` (`date_mod`)
         ) ENGINE=InnoDB DEFAULT CHARSET={$default_charset} COLLATE={$default_collation} ROW_FORMAT=DYNAMIC;
 SQL;
-    $DB->doQueryOrDie($query);
+    $DB->doQuery($query);
 } else {
     // TODO Remove it before the GLPI 11.0 final release.
     $migration->dropField('glpi_dropdowns_dropdowns', 'is_deleted');

--- a/install/migrations/update_10.0.x_to_11.0.0/environments.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/environments.php
@@ -55,5 +55,5 @@ if (!$DB->tableExists('glpi_items_environments')) {
       KEY `is_deleted` (`is_deleted`),
       KEY `is_dynamic` (`is_dynamic`)
     ) ENGINE=InnoDB DEFAULT CHARSET={$default_charset} COLLATE={$default_collation} ROW_FORMAT=DYNAMIC;";
-    $DB->doQueryOrDie($query, "10.0 add table glpi_items_environments");
+    $DB->doQuery($query);
 }

--- a/install/migrations/update_10.0.x_to_11.0.0/form.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/form.php
@@ -45,7 +45,7 @@ $default_key_sign  = DBConnection::getDefaultPrimaryKeySignOption();
 
 // Create tables
 if (!$DB->tableExists('glpi_forms_forms')) {
-    $DB->doQueryOrDie(
+    $DB->doQuery(
         "CREATE TABLE `glpi_forms_forms` (
             `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
             `entities_id` int {$default_key_sign} NOT NULL DEFAULT '0',
@@ -72,7 +72,7 @@ if (!$DB->tableExists('glpi_forms_forms')) {
     );
 }
 if (!$DB->tableExists('glpi_forms_sections')) {
-    $DB->doQueryOrDie(
+    $DB->doQuery(
         "CREATE TABLE `glpi_forms_sections` (
             `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
             `forms_forms_id` int {$default_key_sign} NOT NULL DEFAULT '0',
@@ -86,7 +86,7 @@ if (!$DB->tableExists('glpi_forms_sections')) {
     );
 }
 if (!$DB->tableExists('glpi_forms_questions')) {
-    $DB->doQueryOrDie(
+    $DB->doQuery(
         "CREATE TABLE `glpi_forms_questions` (
             `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
             `forms_sections_id` int {$default_key_sign} NOT NULL DEFAULT '0',
@@ -104,7 +104,7 @@ if (!$DB->tableExists('glpi_forms_questions')) {
     );
 }
 if (!$DB->tableExists('glpi_forms_comments')) {
-    $DB->doQueryOrDie(
+    $DB->doQuery(
         "CREATE TABLE `glpi_forms_comments` (
             `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
             `forms_sections_id` int {$default_key_sign} NOT NULL DEFAULT '0',
@@ -118,7 +118,7 @@ if (!$DB->tableExists('glpi_forms_comments')) {
     );
 }
 if (!$DB->tableExists('glpi_forms_answerssets')) {
-    $DB->doQueryOrDie(
+    $DB->doQuery(
         "CREATE TABLE `glpi_forms_answerssets` (
             `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
             `forms_forms_id` int {$default_key_sign} NOT NULL DEFAULT '0',
@@ -140,7 +140,7 @@ if (!$DB->tableExists('glpi_forms_answerssets')) {
     );
 }
 if (!$DB->tableExists('glpi_forms_destinations_answerssets_formdestinationitems')) {
-    $DB->doQueryOrDie(
+    $DB->doQuery(
         "CREATE TABLE `glpi_forms_destinations_answerssets_formdestinationitems` (
             `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
             `forms_answerssets_id` int {$default_key_sign} NOT NULL DEFAULT '0',
@@ -153,7 +153,7 @@ if (!$DB->tableExists('glpi_forms_destinations_answerssets_formdestinationitems'
     );
 }
 if (!$DB->tableExists('glpi_forms_destinations_formdestinations')) {
-    $DB->doQueryOrDie(
+    $DB->doQuery(
         "CREATE TABLE `glpi_forms_destinations_formdestinations` (
             `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
             `forms_forms_id` int {$default_key_sign} NOT NULL DEFAULT '0',
@@ -168,7 +168,7 @@ if (!$DB->tableExists('glpi_forms_destinations_formdestinations')) {
     );
 }
 if (!$DB->tableExists('glpi_forms_accesscontrols_formaccesscontrols')) {
-    $DB->doQueryOrDie(
+    $DB->doQuery(
         "CREATE TABLE `glpi_forms_accesscontrols_formaccesscontrols` (
             `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
             `forms_forms_id` int {$default_key_sign} NOT NULL DEFAULT '0',

--- a/install/migrations/update_10.0.x_to_11.0.0/items_lines.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/items_lines.php
@@ -51,5 +51,5 @@ if (!$DB->tableExists('glpi_items_lines')) {
       UNIQUE KEY `unicity` (`lines_id`,`itemtype`,`items_id`),
       KEY `item` (`itemtype`,`items_id`)
     ) ENGINE=InnoDB DEFAULT CHARSET={$default_charset} COLLATE={$default_collation} ROW_FORMAT=DYNAMIC;";
-    $DB->doQueryOrDie($query, "10.0 add table glpi_items_lines");
+    $DB->doQuery($query);
 }

--- a/install/migrations/update_10.0.x_to_11.0.0/items_ticketrecurrents.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/items_ticketrecurrents.php
@@ -55,7 +55,7 @@ if (!$DB->tableExists('glpi_items_ticketrecurrents')) {
         KEY `items_id` (`items_id`),
         KEY `ticketrecurrents_id` (`ticketrecurrents_id`)
         ) ENGINE=InnoDB DEFAULT CHARSET={$default_charset} COLLATE={$default_collation} ROW_FORMAT=DYNAMIC;";
-    $DB->doQueryOrDie($query, "11.0.0 add table glpi_items_ticket");
+    $DB->doQuery($query);
 }
 
 // Add glpi_items_ticketrecurrents table for associated elements

--- a/install/migrations/update_10.0.x_to_11.0.0/itilobject_templates.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/itilobject_templates.php
@@ -81,7 +81,7 @@ if (!$DB->tableExists('glpi_tickettemplatereadonlyfields')) {
         PRIMARY KEY (`id`),
         UNIQUE KEY `unicity` (`tickettemplates_id`,`num`)
    ) ENGINE = InnoDB ROW_FORMAT = DYNAMIC DEFAULT CHARSET = {$default_charset} COLLATE = {$default_collation};";
-    $DB->doQueryOrDie($query, "add table glpi_tickettemplatereadonlyfields");
+    $DB->doQuery($query);
 }
 
 if (!$DB->tableExists('glpi_changetemplatereadonlyfields')) {
@@ -92,7 +92,7 @@ if (!$DB->tableExists('glpi_changetemplatereadonlyfields')) {
         PRIMARY KEY (`id`),
         UNIQUE KEY `unicity` (`changetemplates_id`,`num`)
    ) ENGINE = InnoDB ROW_FORMAT = DYNAMIC DEFAULT CHARSET = {$default_charset} COLLATE = {$default_collation};";
-    $DB->doQueryOrDie($query, "add table glpi_changetemplatereadonlyfields");
+    $DB->doQuery($query);
 }
 
 if (!$DB->tableExists('glpi_problemtemplatereadonlyfields')) {
@@ -103,5 +103,5 @@ if (!$DB->tableExists('glpi_problemtemplatereadonlyfields')) {
         PRIMARY KEY (`id`),
         UNIQUE KEY `unicity` (`problemtemplates_id`,`num`)
    ) ENGINE = InnoDB ROW_FORMAT = DYNAMIC DEFAULT CHARSET = {$default_charset} COLLATE = {$default_collation};";
-    $DB->doQueryOrDie($query, "add table glpi_problemtemplatereadonlyfields");
+    $DB->doQuery($query);
 }

--- a/install/migrations/update_10.0.x_to_11.0.0/itilreminders.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/itilreminders.php
@@ -60,7 +60,7 @@ if (!$DB->tableExists('glpi_itilreminders')) {
         KEY `date_creation` (`date_creation`),
         KEY `pendingreasons_id` (`pendingreasons_id`)
     ) ENGINE=InnoDB DEFAULT CHARSET=$default_charset COLLATE=$default_collation ROW_FORMAT=DYNAMIC;";
-    $DB->doQueryOrDie($query, '11.0 add table glpi_itilreminders');
+    $DB->doQuery($query);
 } else {
     $migration->addField('glpi_itilreminders', 'name', 'varchar(255) DEFAULT NULL');
     $migration->addField('glpi_itilreminders', 'content', 'text');

--- a/install/migrations/update_10.0.x_to_11.0.0/itilvalidationtemplates.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/itilvalidationtemplates.php
@@ -60,7 +60,7 @@ if (!$DB->tableExists('glpi_itilvalidationtemplates')) {
         KEY `date_mod` (`date_mod`),
         KEY `date_creation` (`date_creation`)
     ) ENGINE=InnoDB DEFAULT CHARSET=$default_charset COLLATE=$default_collation ROW_FORMAT=DYNAMIC;";
-    $DB->doQueryOrDie($query, '11.0 add table glpi_itilvalidationtemplates');
+    $DB->doQuery($query);
 }
 
 // Add ITILValidationTemplatesTargets table
@@ -76,7 +76,7 @@ if (!$DB->tableExists('glpi_itilvalidationtemplates_targets')) {
         KEY `item` (`itemtype`,`items_id`),
         KEY `groups_id` (`groups_id`)
     ) ENGINE=InnoDB DEFAULT CHARSET=$default_charset COLLATE=$default_collation ROW_FORMAT=DYNAMIC;";
-    $DB->doQueryOrDie($query, '11.0 add table glpi_itilvalidationtemplates_targets');
+    $DB->doQuery($query);
 }
 
 $table = 'glpi_changevalidations';

--- a/install/migrations/update_10.0.x_to_11.0.0/knowbase.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/knowbase.php
@@ -40,17 +40,16 @@
 
 /** KnowbaseItem notifications */
 if (countElementsInTable('glpi_notifications', ['itemtype' => 'KnowbaseItem']) === 0) {
-    $DB->insertOrDie(
+    $DB->insert(
         'glpi_notificationtemplates',
         [
             'name'            => 'Knowledge base item',
             'itemtype'        => 'KnowbaseItem',
-        ],
-        'Add new knowbase notification template'
+        ]
     );
     $notificationtemplate_id = $DB->insertId();
 
-    $DB->insertOrDie(
+    $DB->insert(
         'glpi_notificationtemplatetranslations',
         [
             'notificationtemplates_id' => $notificationtemplate_id,
@@ -104,8 +103,7 @@ if (countElementsInTable('glpi_notifications', ['itemtype' => 'KnowbaseItem']) =
             &lt;br&gt;##lang.target.name## : ##target.name##
             &lt;br&gt;##lang.target.url## : ##target.url## &lt;/p&gt;##ENDFOREACHtargets##
             HTML
-        ],
-        'Add new knowbase notification template translation'
+        ]
     );
 
     $notifications_data = [
@@ -124,7 +122,7 @@ if (countElementsInTable('glpi_notifications', ['itemtype' => 'KnowbaseItem']) =
     ];
 
     foreach ($notifications_data as $notification_data) {
-        $DB->insertOrDie(
+        $DB->insert(
             'glpi_notifications',
             [
                 'name'            => $notification_data['name'],
@@ -136,19 +134,17 @@ if (countElementsInTable('glpi_notifications', ['itemtype' => 'KnowbaseItem']) =
                 'is_active'       => 0,
                 'date_creation'   => null,
                 'date_mod'        => null,
-            ],
-            'Add 3 knowbase notification'
+            ]
         );
         $notification_id = $DB->insertId();
 
-        $DB->insertOrDie(
+        $DB->insert(
             'glpi_notifications_notificationtemplates',
             [
                 'notifications_id'         => $notification_id,
                 'mode'                     => Notification_NotificationTemplate::MODE_MAIL,
                 'notificationtemplates_id' => $notificationtemplate_id,
-            ],
-            'Add knowbase notification templates'
+            ]
         );
     }
 }

--- a/install/migrations/update_10.0.x_to_11.0.0/notifications.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/notifications.php
@@ -43,7 +43,7 @@ use Glpi\DBAL\QueryExpression;
 /** Password initialization notification */
 $notification_exists = countElementsInTable('glpi_notifications', ['itemtype' => 'User', 'event' => 'passwordinit']) > 0;
 if (!$notification_exists) {
-    $DB->insertOrDie(
+    $DB->insert(
         'glpi_notifications',
         [
             'id'              => null,
@@ -56,23 +56,21 @@ if (!$notification_exists) {
             'is_active'       => 1,
             'date_creation'   => new QueryExpression('NOW()'),
             'date_mod'        => new QueryExpression('NOW()')
-        ],
-        '11.0 Add password initialization notification'
+        ]
     );
     $notification_id = $DB->insertId();
 
-    $DB->insertOrDie(
+    $DB->insert(
         'glpi_notificationtemplates',
         [
             'name' => 'Password Initialization',
             'itemtype' => 'User'
-        ],
-        '11.0 Add password initialization template'
+        ]
     );
 
     $notificationtemplate_id = $DB->insertId();
 
-    $DB->insertOrDie(
+    $DB->insert(
         'glpi_notificationtemplatetranslations',
         [
             'notificationtemplates_id' => $notificationtemplate_id,
@@ -90,28 +88,25 @@ if (!$notification_exists) {
     &lt;p&gt;##lang.passwordinit.information##&lt;/p&gt;
     &lt;p&gt;##lang.passwordinit.link## &lt;a title="##user.passwordiniturl##" href="##user.passwordiniturl##"&gt;##user.passwordiniturl##&lt;/a&gt;&lt;/p&gt;
     HTML,
-        ],
-        '11.0 Add password initialization notification template translations'
+        ]
     );
 
-    $DB->insertOrDie(
+    $DB->insert(
         'glpi_notifications_notificationtemplates',
         [
             'notifications_id'         => $notification_id,
             'mode'                     => Notification_NotificationTemplate::MODE_MAIL,
             'notificationtemplates_id' => $notificationtemplate_id,
-        ],
-        '11.0 Add password initialization notification template'
+        ]
     );
 
-    $DB->insertOrDie(
+    $DB->insert(
         'glpi_notificationtargets',
         [
             'items_id'         => '19',
             'type'             => '1',
             'notifications_id' => $notification_id,
-        ],
-        '11.0 Add password initialization target'
+        ]
     );
 }
 /** /Password initialization notification */
@@ -119,18 +114,17 @@ if (!$notification_exists) {
 
 /** Change Satisfaction notification */
 if (countElementsInTable('glpi_notifications', ['itemtype' => 'Change', 'event' => 'satisfaction']) === 0) {
-    $DB->insertOrDie(
+    $DB->insert(
         'glpi_notificationtemplates',
         [
             'name'            => 'Change Satisfaction',
             'itemtype'        => 'Change',
             'date_mod'        => new QueryExpression('NOW()'),
-        ],
-        'Add change satisfaction survey notification template'
+        ]
     );
     $notificationtemplate_id = $DB->insertId();
 
-    $DB->insertOrDie(
+    $DB->insert(
         'glpi_notificationtemplatetranslations',
         [
             'notificationtemplates_id' => $notificationtemplate_id,
@@ -148,8 +142,7 @@ PLAINTEXT,
 &lt;p&gt;##lang.change.closedate## : ##change.closedate##&lt;/p&gt;
 &lt;p&gt;##lang.satisfaction.text## &lt;a href="##change.urlsatisfaction##"&gt;##change.urlsatisfaction##&lt;/a&gt;&lt;/p&gt;
 HTML,
-        ],
-        'Add change satisfaction survey notification template translations'
+        ]
     );
 
     $notifications_data = [
@@ -163,7 +156,7 @@ HTML,
         ]
     ];
     foreach ($notifications_data as $notification_data) {
-        $DB->insertOrDie(
+        $DB->insert(
             'glpi_notifications',
             [
                 'name'            => $notification_data['name'],
@@ -175,40 +168,36 @@ HTML,
                 'is_active'       => 1,
                 'date_creation'   => new QueryExpression('NOW()'),
                 'date_mod'        => new QueryExpression('NOW()'),
-            ],
-            'Add change satisfaction survey notification'
+            ]
         );
         $notification_id = $DB->insertId();
 
-        $DB->insertOrDie(
+        $DB->insert(
             'glpi_notifications_notificationtemplates',
             [
                 'notifications_id'         => $notification_id,
                 'mode'                     => Notification_NotificationTemplate::MODE_MAIL,
                 'notificationtemplates_id' => $notificationtemplate_id,
-            ],
-            'Add change satisfaction survey notification template instance'
+            ]
         );
 
-        $DB->insertOrDie(
+        $DB->insert(
             'glpi_notificationtargets',
             [
                 'items_id'         => 3,
                 'type'             => 1,
                 'notifications_id' => $notification_id,
-            ],
-            'Add change satisfaction survey notification targets'
+            ]
         );
 
         if ($notification_data['event'] === 'replysatisfaction') {
-            $DB->insertOrDie(
+            $DB->insert(
                 'glpi_notificationtargets',
                 [
                     'items_id'         => 2,
                     'type'             => 1,
                     'notifications_id' => $notification_id,
-                ],
-                'Add change satisfaction survey notification targets'
+                ]
             );
         }
     }
@@ -217,14 +206,14 @@ HTML,
 
 /** Add new notification for AutoBump */
 if (countElementsInTable('glpi_notifications', ['itemtype' => 'Ticket', 'event' => 'auto_reminder']) === 0) {
-    $DB->insertOrDie('glpi_notificationtemplates', [
+    $DB->insert('glpi_notificationtemplates', [
         'name' => 'Automatic reminder',
         'itemtype' => 'Ticket'
     ]);
 
     $notificationtemplate_id = $DB->insertId();
 
-    $DB->insertOrDie('glpi_notificationtemplatetranslations', [
+    $DB->insert('glpi_notificationtemplatetranslations', [
         'notificationtemplates_id' => $notificationtemplate_id,
         'language' => '',
         'subject' => '##ticket.action## ##ticket.name##',
@@ -244,7 +233,7 @@ if (countElementsInTable('glpi_notifications', ['itemtype' => 'Ticket', 'event' 
             &lt;p&gt;##lang.ticket.reminder.text##: ##ticket.reminder.text##&lt;/p&gt;',
     ]);
 
-    $DB->insertOrDie(
+    $DB->insert(
         'glpi_notifications',
         [
             'name'            => 'Automatic reminder',
@@ -253,8 +242,7 @@ if (countElementsInTable('glpi_notifications', ['itemtype' => 'Ticket', 'event' 
             'comment'         => null,
             'is_recursive'    => 1,
             'is_active'       => 0,
-        ],
-        'Add automatic reminder notification'
+        ]
     );
     $notification_id = $DB->insertId();
 
@@ -274,14 +262,14 @@ if (countElementsInTable('glpi_notifications', ['itemtype' => 'Ticket', 'event' 
     ];
 
     foreach ($targets as $target) {
-        $DB->insertOrDie('glpi_notificationtargets', [
+        $DB->insert('glpi_notificationtargets', [
             'items_id'         => $target['items_id'],
             'type'             => $target['type'],
             'notifications_id' => $notification_id,
         ]);
     }
 
-    $DB->insertOrDie('glpi_notifications_notificationtemplates', [
+    $DB->insert('glpi_notifications_notificationtemplates', [
         'notifications_id'         => $notification_id,
         'mode'                     => Notification_NotificationTemplate::MODE_MAIL,
         'notificationtemplates_id' => $notificationtemplate_id,

--- a/install/migrations/update_10.0.x_to_11.0.0/oauth.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/oauth.php
@@ -52,7 +52,7 @@ if (!$DB->tableExists('glpi_oauth_access_tokens')) {
         PRIMARY KEY (`identifier`),
         KEY `client` (`client`)
         ) ENGINE=InnoDB DEFAULT CHARSET={$default_charset} COLLATE={$default_collation} ROW_FORMAT=DYNAMIC";
-    $DB->doQueryOrDie($query, "11.0.0 add table glpi_oauth_access_tokens");
+    $DB->doQuery($query);
 }
 
 if (!$DB->tableExists('glpi_oauth_auth_codes')) {
@@ -65,7 +65,7 @@ if (!$DB->tableExists('glpi_oauth_auth_codes')) {
         PRIMARY KEY (`identifier`),
         KEY `client` (`client`)
         ) ENGINE=InnoDB DEFAULT CHARSET={$default_charset} COLLATE={$default_collation} ROW_FORMAT=DYNAMIC";
-    $DB->doQueryOrDie($query, "11.0.0 add table glpi_oauth_auth_codes");
+    $DB->doQuery($query);
 }
 
 if (!$DB->tableExists('glpi_oauth_refresh_tokens')) {
@@ -76,7 +76,7 @@ if (!$DB->tableExists('glpi_oauth_refresh_tokens')) {
         PRIMARY KEY (`identifier`),
         KEY `access_token` (`access_token`)
         ) ENGINE=InnoDB DEFAULT CHARSET={$default_charset} COLLATE={$default_collation} ROW_FORMAT=DYNAMIC";
-    $DB->doQueryOrDie($query, "11.0.0 add table glpi_oauth_refresh_tokens");
+    $DB->doQuery($query);
 }
 
 if (!$DB->tableExists('glpi_oauthclients')) {
@@ -97,7 +97,7 @@ if (!$DB->tableExists('glpi_oauthclients')) {
         KEY `name` (`name`),
         KEY `is_active` (`is_active`)
         ) ENGINE=InnoDB DEFAULT CHARSET={$default_charset} COLLATE={$default_collation} ROW_FORMAT=DYNAMIC";
-    $DB->doQueryOrDie($query, "11.0.0 add table glpi_oauthclients");
+    $DB->doQuery($query);
 } else {
     // Dev migration for `redirect_uri` column from varchar(255) to TEXT
     $migration->changeField('glpi_oauthclients', 'redirect_uri', 'redirect_uri', 'TEXT NOT NULL');

--- a/install/migrations/update_10.0.x_to_11.0.0/processes.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/processes.php
@@ -62,5 +62,5 @@ if (!$DB->tableExists('glpi_items_processes')) {
       KEY `is_deleted` (`is_deleted`),
       KEY `is_dynamic` (`is_dynamic`)
     ) ENGINE=InnoDB DEFAULT CHARSET={$default_charset} COLLATE={$default_collation} ROW_FORMAT=DYNAMIC;";
-    $DB->doQueryOrDie($query, "10.0 add table glpi_items_processes");
+    $DB->doQuery($query);
 }

--- a/install/migrations/update_10.0.x_to_11.0.0/states.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/states.php
@@ -76,7 +76,7 @@ if (!$DB->tableExists('glpi_dropdownvisibilities')) {
         KEY `visible_itemtype` (`visible_itemtype`),
         KEY `item` (`itemtype`,`items_id`)
     ) ENGINE=InnoDB DEFAULT CHARSET={$default_charset} COLLATE={$default_collation} ROW_FORMAT=DYNAMIC;";
-    $DB->doQueryOrDie($query, "10.1.0 add table glpi_dropdownvisibilities");
+    $DB->doQuery($query);
 
     $states = $DB->request(['FROM' => 'glpi_states']);
     foreach ($states as $state) {
@@ -89,7 +89,7 @@ if (!$DB->tableExists('glpi_dropdownvisibilities')) {
             if (isset($state['is_visible_' . $known_visibility])) {
                 $insert_data['visible_itemtype'] = $known_visibility;
                 $insert_data['is_visible'] = $state['is_visible_' . $known_visibility];
-                $DB->doQueryOrDie($DB->buildInsert('glpi_dropdownvisibilities', $insert_data));
+                $DB->doQuery($DB->buildInsert('glpi_dropdownvisibilities', $insert_data));
             }
         }
     }

--- a/install/migrations/update_10.0.x_to_11.0.0/stencil.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/stencil.php
@@ -58,5 +58,5 @@ if (!$DB->tableExists($table)) {
         KEY `date_mod` (`date_mod`),
         KEY `date_creation` (`date_creation`)
     ) ENGINE=InnoDB DEFAULT CHARSET=$default_charset COLLATE=$default_collation ROW_FORMAT=DYNAMIC;";
-    $DB->doQueryOrDie($query, '11.0 add table $table');
+    $DB->doQuery($query);
 }

--- a/install/migrations/update_10.0.x_to_11.0.0/validations.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/validations.php
@@ -66,7 +66,7 @@ foreach ($validation_tables as $validation_table) {
 
 // Use the fact fields had changed as an indication this one-time migration hasn't been run yet
 if ($needed_migration) {
-    $DB->updateOrDie('glpi_notificationtargets', [
+    $DB->update('glpi_notificationtargets', [
         'items_id'  => Notification::VALIDATION_TARGET,
     ], [
         'items_id'  => Notification::VALIDATION_APPROVER,

--- a/install/migrations/update_10.0.x_to_11.0.0/validatorsubstitute.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/validatorsubstitute.php
@@ -51,7 +51,7 @@ if (!$DB->tableExists('glpi_validatorsubstitutes')) {
         UNIQUE KEY `users_id_users_id_substitute` (`users_id`, `users_id_substitute`),
         KEY `users_id_substitute` (`users_id_substitute`)
     ) ENGINE = InnoDB ROW_FORMAT = DYNAMIC DEFAULT CHARSET = {$default_charset} COLLATE = {$default_collation};";
-    $DB->doQueryOrDie($query, "add table glpi_validatorsubstitutes");
+    $DB->doQuery($query);
 }
 
 $table = 'glpi_users';

--- a/install/migrations/update_10.0.x_to_11.0.0/webhook.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/webhook.php
@@ -81,7 +81,7 @@ if (!$DB->tableExists('glpi_webhooks')) {
       KEY `date_mod` (`date_mod`),
       KEY `webhookcategories_id` (`webhookcategories_id`)
     ) ENGINE = InnoDB ROW_FORMAT = DYNAMIC DEFAULT CHARSET = {$default_charset} COLLATE = {$default_collation};";
-    $DB->doQueryOrDie($query, "add table glpi_webhooks");
+    $DB->doQuery($query);
 }
 
 if (!$DB->fieldExists('glpi_webhooks', 'webhookcategories_id')) {
@@ -111,7 +111,7 @@ if (!$DB->tableExists('glpi_webhookcategories')) {
       KEY `date_creation` (`date_creation`),
       KEY `level` (`level`)
     ) ENGINE = InnoDB ROW_FORMAT = DYNAMIC DEFAULT CHARSET = {$default_charset} COLLATE = {$default_collation};";
-    $DB->doQueryOrDie($query, "add table glpi_webhookcategories");
+    $DB->doQuery($query);
 }
 
 $ADDTODISPLAYPREF[Webhook::class] = [3, 4, 5];
@@ -146,7 +146,7 @@ if (!$DB->tableExists('glpi_queuedwebhooks')) {
       KEY `send_time` (`send_time`),
       KEY `sent_time` (`sent_time`)
     ) ENGINE = InnoDB ROW_FORMAT = DYNAMIC DEFAULT CHARSET = {$default_charset} COLLATE = {$default_collation};";
-    $DB->doQueryOrDie($query, "add table glpi_webhooks");
+    $DB->doQuery($query);
 }
 
 // Entity, ID, Webhook, Itemtype, Items ID, URL, Creation date

--- a/install/migrations/update_9.1.0_to_9.1.1.php
+++ b/install/migrations/update_9.1.0_to_9.1.1.php
@@ -81,15 +81,14 @@ function update910to911()
     if (countElementsInTable("glpi_profilerights", ['name' => 'license']) == 0) {
         $prights = $DB->request(['FROM' => 'glpi_profilerights', 'WHERE' => ['name' => 'software']]);
         foreach ($prights as $profrights) {
-            $DB->insertOrDie(
+            $DB->insert(
                 "glpi_profilerights",
                 [
                     'id'           => null,
                     'profiles_id'  => $profrights['profiles_id'],
                     'name'         => "license",
                     'rights'       => $profrights['rights']
-                ],
-                "9.1 add right for softwarelicense"
+                ]
             );
         }
     }

--- a/install/migrations/update_9.1.1_to_9.1.3.php
+++ b/install/migrations/update_9.1.1_to_9.1.3.php
@@ -78,7 +78,7 @@ function update911to913()
 
    //Fix duplicated search options
     if (countElementsInTable("glpi_displaypreferences", ['itemtype' => 'IPNetwork', 'num' => '17']) == 0) {
-        $DB->updateOrDie(
+        $DB->update(
             "glpi_displaypreferences",
             [
                 "num" => 17
@@ -86,12 +86,11 @@ function update911to913()
             [
                 'itemtype'  => "IPNetwork",
                 'num'       => 13
-            ],
-            "9.1.3 Fix duplicate IPNetwork Gateway search option"
+            ]
         );
     }
     if (countElementsInTable("glpi_displaypreferences", ['itemtype' => 'IPNetwork', 'num' => '18']) == 0) {
-        $DB->updateOrDie(
+        $DB->update(
             "glpi_displaypreferences",
             [
                 "num" => 18
@@ -99,8 +98,7 @@ function update911to913()
             [
                 'itemtype'  => "IPNetwork",
                 'num'       => 14
-            ],
-            "9.1.3 Fix duplicate IPNetwork addressable network search option"
+            ]
         );
     }
 

--- a/install/migrations/update_9.1.x_to_9.2.0.php
+++ b/install/migrations/update_9.1.x_to_9.2.0.php
@@ -81,7 +81,7 @@ function update91xto920()
         KEY `date_mod` (`date_mod`),
         KEY `date_creation` (`date_creation`)
                 ) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
-        $DB->doQueryOrDie($query, "Add business criticity table");
+        $DB->doQuery($query);
     }
 
    // Issue #1250 - Add decimal to monitor size
@@ -100,19 +100,18 @@ function update91xto920()
 
    //First time the dropdown is changed from CommonDropdown to CommonTreeDropdown
     if ($tree) {
-        $DB->updateOrDie(
+        $DB->update(
             "glpi_softwarelicensetypes",
             [
                 'completename' =>  new QueryExpression(DBmysql::quoteName("name")),
                 'is_recursive' => "1"
             ],
-            [true],
-            "9.2 make glpi_softwarelicensetypes a tree dropdown"
+            [true]
         );
     }
 
    // give READ right on components to profiles having UPDATE right
-    $DB->updateOrDie(
+    $DB->update(
         "glpi_profilerights",
         [
             'rights' => new QueryExpression($DB->quoteName("rights") . " | " . READ)
@@ -120,8 +119,7 @@ function update91xto920()
         [
             new QueryExpression(DBmysql::quoteName("rights") . " & " . DBmysql::quoteValue(UPDATE)),
             'name' => "device"
-        ],
-        "grant READ right on components to profiles having UPDATE right"
+        ]
     );
 
     $migration->displayMessage(sprintf(__('Add of - %s to database'), 'Knowbase item link to tickets'));
@@ -139,7 +137,7 @@ function update91xto920()
                  KEY `item_id` (`items_id`),
                  KEY `item` (`itemtype`,`items_id`)
                ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
-        $DB->doQueryOrDie($query, "9.2 add table glpi_knowbaseitems_items");
+        $DB->doQuery($query);
     }
 
     $migration->displayMessage(sprintf(__('Add of - %s to database'), 'Knowbase item revisions'));
@@ -157,7 +155,7 @@ function update91xto920()
                  UNIQUE KEY `unicity` (`knowbaseitems_id`, `revision`, `language`),
                  KEY `revision` (`revision`)
                ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
-        $DB->doQueryOrDie($query, "9.2 add table glpi_knowbaseitems_revisions");
+        $DB->doQuery($query);
     }
 
     $migration->addField("glpi_knowbaseitemtranslations", "users_id", "integer");
@@ -178,11 +176,10 @@ function update91xto920()
         ]
     ]);
     foreach ($knowitems_iterator as $knowitems) {
-        $DB->updateOrDie(
+        $DB->update(
             "glpi_knowbaseitemtranslations",
             ['users_id' => $knowitems['users_id']],
-            ['knowbaseitems_id' => $knowitems['id']],
-            "Set knowledge base translations users"
+            ['knowbaseitems_id' => $knowitems['id']]
         );
     }
 
@@ -202,18 +199,17 @@ function update91xto920()
                  `date_mod` datetime DEFAULT NULL,
                  PRIMARY KEY (`id`)
                 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
-        $DB->doQueryOrDie($query, "9.2 add table glpi_knowbaseitems_comments");
+        $DB->doQuery($query);
     }
 
-    $DB->updateOrDie(
+    $DB->update(
         "glpi_profilerights",
         [
             'rights' => new QueryExpression(
                 DBmysql::quoteName("rights") . " | " . DBmysql::quoteValue(KnowbaseItem::COMMENTS)
             )
         ],
-        ['name' => "knowbase"],
-        "9.2 update knowledge base with comment right"
+        ['name' => "knowbase"]
     );
 
    // add kb category to task categories
@@ -324,7 +320,7 @@ function update91xto920()
                       INDEX `name` (`name`),
                       INDEX `product_number` (`product_number`)
                    ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
-            $DB->doQueryOrDie($query, "9.2 add model tables for devices");
+            $DB->doQuery($query);
         }
     }
 
@@ -375,7 +371,7 @@ function update91xto920()
                   KEY `date_creation` (`date_creation`),
                   KEY `devicegenericmodels_id` (`devicegenericmodels_id`)
                ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
-         $DB->doQueryOrDie($query, "9.2 add table glpi_devicegenerics");
+         $DB->doQuery($query);
     }
 
     if (!$DB->tableExists('glpi_items_devicegenerics')) {
@@ -403,7 +399,7 @@ function update91xto920()
                    INDEX `item` (`itemtype`, `items_id`),
                    INDEX `otherserial` (`otherserial`)
                 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
-        $DB->doQueryOrDie($query, "9.2 add table glpi_items_devicegenerics");
+        $DB->doQuery($query);
     }
 
     if (!$DB->tableExists('glpi_devicegenerictypes')) {
@@ -414,7 +410,7 @@ function update91xto920()
                    PRIMARY KEY (`id`),
                    INDEX `name` (`name`)
                 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
-        $DB->doQueryOrDie($query, "9.2 add table glpi_devicegenerictypes");
+        $DB->doQuery($query);
     }
 
     if (!$DB->tableExists('glpi_devicebatteries')) {
@@ -441,7 +437,7 @@ function update91xto920()
                   KEY `devicebatterymodels_id` (`devicebatterymodels_id`),
                   KEY `devicebatterytypes_id` (`devicebatterytypes_id`)
                 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
-        $DB->doQueryOrDie($query, "9.2 add table glpi_devicebatteries");
+        $DB->doQuery($query);
     }
 
     if (!$DB->tableExists('glpi_items_devicebatteries')) {
@@ -470,7 +466,7 @@ function update91xto920()
                   KEY `item` (`itemtype`,`items_id`),
                   KEY `otherserial` (`otherserial`)
                ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
-        $DB->doQueryOrDie($query, "9.2 add table glpi_items_devicebatteries");
+        $DB->doQuery($query);
     }
 
     if (!$DB->tableExists('glpi_devicebatterytypes')) {
@@ -485,7 +481,7 @@ function update91xto920()
                   KEY `date_mod` (`date_mod`),
                   KEY `date_creation` (`date_creation`)
                ) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
-        $DB->doQueryOrDie($query, "9.2 add table glpi_devicebatterytypes");
+        $DB->doQuery($query);
     }
 
     if (!$DB->tableExists('glpi_devicefirmwares')) {
@@ -512,7 +508,7 @@ function update91xto920()
                   KEY `devicefirmwaremodels_id` (`devicefirmwaremodels_id`),
                   KEY `devicefirmwaretypes_id` (`devicefirmwaretypes_id`)
                ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
-        $DB->doQueryOrDie($query, "9.2 add table glpi_devicefirmwares");
+        $DB->doQuery($query);
     }
     if (!$DB->tableExists('glpi_items_devicefirmwares')) {
         $query = "CREATE TABLE `glpi_items_devicefirmwares` (
@@ -539,7 +535,7 @@ function update91xto920()
                   KEY `item` (`itemtype`,`items_id`),
                   KEY `otherserial` (`otherserial`)
                ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
-        $DB->doQueryOrDie($query, "9.2 add table glpi_items_devicefirmwares");
+        $DB->doQuery($query);
     }
     if (!$DB->tableExists('glpi_devicefirmwaretypes')) {
         $query = "CREATE TABLE `glpi_devicefirmwaretypes` (
@@ -553,9 +549,9 @@ function update91xto920()
                   KEY `date_mod` (`date_mod`),
                   KEY `date_creation` (`date_creation`)
                ) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
-        $DB->doQueryOrDie($query, "9.2 add table glpi_devicefirmwaretypes");
+        $DB->doQuery($query);
 
-        $DB->insertOrDie("glpi_devicefirmwaretypes", [
+        $DB->insert("glpi_devicefirmwaretypes", [
             'id'              => "1",
             'name'            => "BIOS",
             'comment'         => null,
@@ -563,7 +559,7 @@ function update91xto920()
             'date_creation'   => null
         ]);
 
-        $DB->insertOrDie("glpi_devicefirmwaretypes", [
+        $DB->insert("glpi_devicefirmwaretypes", [
             'id'              => "2",
             'name'            => "UEFI",
             'comment'         => null,
@@ -571,7 +567,7 @@ function update91xto920()
             'date_creation'   => null
         ]);
 
-        $DB->insertOrDie("glpi_devicefirmwaretypes", [
+        $DB->insert("glpi_devicefirmwaretypes", [
             'id'              => "3",
             'name'            => "Firmware",
             'comment'         => null,
@@ -606,7 +602,7 @@ function update91xto920()
                   KEY `date_mod` (`date_mod`),
                   KEY `date_creation` (`date_creation`)
                ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
-         $DB->doQueryOrDie($query, "9.2 add table glpi_devicesensors");
+         $DB->doQuery($query);
     }
 
     if (!$DB->tableExists('glpi_items_devicesensors')) {
@@ -636,7 +632,7 @@ function update91xto920()
                 )
                 COLLATE='utf8_unicode_ci'
                 ENGINE=InnoDB;";
-        $DB->doQueryOrDie($query, "9.2 add table glpi_items_devicesensors");
+        $DB->doQuery($query);
     }
 
     if (!$DB->tableExists('glpi_devicesensortypes')) {
@@ -648,7 +644,7 @@ function update91xto920()
                    INDEX `name` (`name`)
                 )
                 COLLATE='utf8_unicode_ci' ENGINE=InnoDB;";
-        $DB->doQueryOrDie($query, "9.2 add table glpi_devicesensortypes");
+        $DB->doQuery($query);
     }
 
    //Father/son for Software licenses
@@ -657,13 +653,12 @@ function update91xto920()
     $migration->addField("glpi_softwarelicenses", "level", "integer", ['after' => 'completename']);
     $migration->migrationOneTable("glpi_softwarelicenses");
     if ($new) {
-        $DB->updateOrDie(
+        $DB->update(
             "glpi_softwarelicenses",
             [
                 'completename' => new QueryExpression(DBmysql::quoteName("name"))
             ],
-            [true],
-            "9.2 copy name to completename for software licenses"
+            [true]
         );
     }
 
@@ -769,7 +764,7 @@ function update91xto920()
                   KEY `date_creation` (`date_creation`),
                   KEY `slms_id` (`slms_id`)
                 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;";
-        $DB->doQueryOrDie($query, "9.2 add table glpi_olas");
+        $DB->doQuery($query);
     }
 
     if (!$DB->tableExists('glpi_olalevelactions')) {
@@ -782,7 +777,7 @@ function update91xto920()
                PRIMARY KEY (`id`),
                KEY `olalevels_id` (`olalevels_id`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;";
-        $DB->doQueryOrDie($query, "9.2 add table glpi_olalevelactions");
+        $DB->doQuery($query);
     }
 
     if (!$DB->tableExists('glpi_olalevelcriterias')) {
@@ -796,7 +791,7 @@ function update91xto920()
                KEY `olalevels_id` (`olalevels_id`),
                KEY `condition` (`condition`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;";
-        $DB->doQueryOrDie($query, "9.2 add table glpi_olalevelcriterias");
+        $DB->doQuery($query);
     }
 
     if (!$DB->tableExists('glpi_olalevels')) {
@@ -815,7 +810,7 @@ function update91xto920()
                KEY `is_active` (`is_active`),
                KEY `olas_id` (`olas_id`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;";
-        $DB->doQueryOrDie($query, "9.2 add table glpi_olalevels");
+        $DB->doQuery($query);
     }
 
     if (!$DB->tableExists('glpi_olalevels_tickets')) {
@@ -829,7 +824,7 @@ function update91xto920()
                   KEY `olalevels_id` (`olalevels_id`),
                   KEY `unicity` (`tickets_id`,`olalevels_id`)
                ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;";
-        $DB->doQueryOrDie($query, "9.2 add table glpi_olalevels_tickets");
+        $DB->doQuery($query);
 
         $DB->updateOrInsert("glpi_crontasks", [
             'frequency'       => "604800",
@@ -959,41 +954,36 @@ function update91xto920()
     }
 
    // ProfileRights changes
-    $DB->updateOrDie(
+    $DB->update(
         "glpi_profilerights",
         ['name' => "slm"],
-        ['name' => "sla"],
-        "SLM profilerights migration"
+        ['name' => "sla"]
     );
 
    //Sla rules criterias migration
-    $DB->updateOrDie(
+    $DB->update(
         "glpi_rulecriterias",
         ['criteria' => "slas_ttr_id"],
-        ['criteria' => "slts_ttr_id"],
-        "SLA rulecriterias migration"
+        ['criteria' => "slts_ttr_id"]
     );
 
-    $DB->updateOrDie(
+    $DB->update(
         "glpi_rulecriterias",
         ['criteria' => "slas_tto_id"],
-        ['criteria' => "slts_tto_id"],
-        "SLA rulecriterias migration"
+        ['criteria' => "slts_tto_id"]
     );
 
    // Sla rules actions migration
-    $DB->updateOrDie(
+    $DB->update(
         "glpi_ruleactions",
         ['field' => "slas_ttr_id"],
-        ['field' => "slts_ttr_id"],
-        "SLA ruleactions migration"
+        ['field' => "slts_ttr_id"]
     );
 
-    $DB->updateOrDie(
+    $DB->update(
         "glpi_ruleactions",
         ['field' => "slas_tto_id"],
-        ['field' => "slts_tto_id"],
-        "SLA ruleactions migration"
+        ['field' => "slts_tto_id"]
     );
 
    /************** Auto login **************/
@@ -1134,7 +1124,7 @@ function update91xto920()
                   KEY `notificationtemplates_id` (`notificationtemplates_id`),
                   KEY `mode` (`mode`)
                 ) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
-        $DB->doQueryOrDie($query, "9.2 add table glpi_notifications_notificationtemplates");
+        $DB->doQuery($query);
     }
 
     if ($DB->fieldExists("glpi_notifications", "mode", false)) {
@@ -1143,7 +1133,7 @@ function update91xto920()
                        (`notifications_id`, `mode`, `notificationtemplates_id`)
                        SELECT `id`, `mode`, `notificationtemplates_id`
                        FROM `glpi_notifications`";
-        $DB->doQueryOrDie($query, "9.2 migrate notifications templates");
+        $DB->doQuery($query);
 
        //migrate any existing mode before removing the field
         $migration->dropField('glpi_notifications', 'mode');
@@ -1206,7 +1196,7 @@ function update91xto920()
                   KEY `date_creation` (`date_creation`),
                   UNIQUE KEY `unicity` (`savedsearches_id`,`operator`, `value`)
                  ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
-        $DB->doQueryOrDie($query, "9.2 add table glpi_savedsearches_alerts");
+        $DB->doQuery($query);
     }
 
     $migration->displayMessage(sprintf(__('Data migration - %s'), 'glpi_displaypreferences'));
@@ -1244,7 +1234,7 @@ function update91xto920()
             ['itemtype' => 'SavedSearch', 'name' => 'countAll']
         )
     ) {
-        $DB->insertOrDie(
+        $DB->insert(
             "glpi_crontasks",
             [
                 'itemtype'        => "SavedSearch",
@@ -1260,8 +1250,7 @@ function update91xto920()
                 'lastrun'         => null,
                 'lastcode'        => null,
                 'comment'         => null
-            ],
-            "9.2 Add countAll SavedSearch cron task"
+            ]
         );
     };
 
@@ -1272,7 +1261,7 @@ function update91xto920()
             ['itemtype' => 'SavedSearch_Alert', 'name' => 'savedsearchesalerts']
         )
     ) {
-        $DB->insertOrDie(
+        $DB->insert(
             "glpi_crontasks",
             [
                 'itemtype'        => "SavedSearch_Alert",
@@ -1288,8 +1277,7 @@ function update91xto920()
                 'lastrun'         => null,
                 'lastcode'        => null,
                 'comment'         => null
-            ],
-            "9.2 Add saved searches alerts cron task"
+            ]
         );
     }
 
@@ -1299,7 +1287,7 @@ function update91xto920()
             ['itemtype' => 'SavedSearch_Alert']
         )
     ) {
-        $DB->insertOrDie(
+        $DB->insert(
             "glpi_notifications",
             [
                 'id'              => null,
@@ -1312,19 +1300,17 @@ function update91xto920()
                 'is_active'       => "1",
                 'date_creation'   => new QueryExpression("NOW()"),
                 'date_mod'        => new QueryExpression("NOW()")
-            ],
-            "9.2 Add saved search alerts notification"
+            ]
         );
         $notid = $DB->insertId();
 
-        $DB->insertOrDie(
+        $DB->insert(
             "glpi_notificationtemplates",
             [
                 'name'            => "Saved searches alerts",
                 'itemtype'        => "SavedSearch_Alert",
                 'date_mod'        => new QueryExpression("NOW()")
-            ],
-            "9.2 Add saved search alerts notification template"
+            ]
         );
         $nottid = $DB->insertId();
 
@@ -1343,15 +1329,14 @@ function update91xto920()
             ]);
         }
 
-        $DB->insertOrDie(
+        $DB->insert(
             "glpi_notificationtargets",
             [
                 'id'               => null,
                 'items_id'         => "19",
                 'type'             => "1",
                 'notifications_id' => $notid
-            ],
-            "9.2 Add saved search alerts notification targets"
+            ]
         );
 
         $query = "INSERT INTO `glpi_notificationtemplatetranslations`
@@ -1379,7 +1364,7 @@ Regards,',
                      &lt;/table&gt;
                      &lt;p&gt;&lt;span style=\"font-size: small;\"&gt;Hello &lt;br /&gt;Regards,&lt;/span&gt;&lt;/p&gt;')";
 
-        $DB->doQueryOrDie($query, "9.2 add saved searches alerts notification translation");
+        $DB->doQuery($query);
     }
 
    // Create a dedicated token for api
@@ -1419,7 +1404,7 @@ Regards,',
                   UNIQUE KEY `unicity`(`items_id`,`itemtype`, `operatingsystems_id`,
                                        `operatingsystemarchitectures_id`)
                 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
-        $DB->doQueryOrDie($query, "9.2 add table glpi_items_operatingsystems");
+        $DB->doQuery($query);
     }
 
     if (!$DB->tableExists('glpi_operatingsystemkernels')) {
@@ -1432,7 +1417,7 @@ Regards,',
                   PRIMARY KEY (`id`),
                   KEY `name` (`name`)
                 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
-        $DB->doQueryOrDie($query, "9.2 add table glpi_operatingsystemkernels");
+        $DB->doQuery($query);
     }
 
     if (!$DB->tableExists('glpi_operatingsystemkernelversions')) {
@@ -1447,7 +1432,7 @@ Regards,',
                   KEY `name` (`name`),
                   KEY `operatingsystemkernels_id` (`operatingsystemkernels_id`)
                 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
-        $DB->doQueryOrDie($query, "9.2 add table glpi_operatingsystemversions");
+        $DB->doQuery($query);
     }
 
     if (!$DB->tableExists('glpi_operatingsystemeditions')) {
@@ -1460,7 +1445,7 @@ Regards,',
                   PRIMARY KEY (`id`),
                   KEY `name` (`name`)
                 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
-        $DB->doQueryOrDie($query, "9.2 add table glpi_operatingsystemeditions");
+        $DB->doQuery($query);
     }
 
     if ($DB->fieldExists('glpi_computers', 'operatingsystems_id')) {
@@ -1480,7 +1465,7 @@ Regards,',
                       OR `os_license_number` IS NOT NULL
                       OR `os_kernel_version` IS NOT NULL
                       OR `os_licenseid` IS NOT NULL";
-        $DB->doQueryOrDie($query, "9.2 migrate main operating system information");
+        $DB->doQuery($query);
 
        //migrate kernel versions.
         $kver = new OperatingSystemKernelVersion();
@@ -1501,7 +1486,7 @@ Regards,',
 
         foreach ($mapping as $map) {
             foreach ($map as $computers_id => $kver_id) {
-                $DB->updateOrDie(
+                $DB->update(
                     "glpi_items_operatingsystems",
                     ['operatingsystemkernelversions_id' => $kver_id],
                     [
@@ -1601,7 +1586,7 @@ Regards,',
         KEY `date_creation` (`date_creation`),
         KEY `date_mod` (`date_mod`)
       ) ENGINE = InnoDB DEFAULT CHARSET = utf8 COLLATE = utf8_unicode_ci";
-        $DB->doQueryOrDie($query, "9.2 copy add certificate table");
+        $DB->doQuery($query);
     }
 
     if (!$DB->tableExists('glpi_certificates_items')) {
@@ -1619,7 +1604,7 @@ Regards,',
            KEY `date_creation` (`date_creation`),
            KEY `date_mod` (`date_mod`)
         ) ENGINE = InnoDB DEFAULT CHARSET = utf8 COLLATE = utf8_unicode_ci";
-        $DB->doQueryOrDie($query, "9.2 copy add certificate items table");
+        $DB->doQuery($query);
     }
 
     if (!$DB->tableExists('glpi_certificatetypes')) {
@@ -1638,7 +1623,7 @@ Regards,',
            KEY `date_creation` (`date_creation`),
            KEY `date_mod` (`date_mod`)
         ) ENGINE = InnoDB DEFAULT CHARSET = utf8 COLLATE = utf8_unicode_ci";
-        $DB->doQueryOrDie($query, "9.2 copy add certificate type table");
+        $DB->doQuery($query);
     }
 
     if (countElementsInTable("glpi_profilerights", ['name' => 'certificate']) == 0) {
@@ -1652,15 +1637,14 @@ Regards,',
                 $rightValue = 0;
             }
 
-            $DB->insertOrDie(
+            $DB->insert(
                 "glpi_profilerights",
                 [
                     'id'           => null,
                     'profiles_id'  => $profrights['profiles_id'],
                     'name'         => "certificate",
                     'rights'       => $rightValue,
-                ],
-                "9.2 add right for certificates"
+                ]
             );
         }
     }
@@ -1694,7 +1678,7 @@ Regards,',
         ]
     );
     if (!countElementsInTable('glpi_notifications', ['itemtype' => 'Certificate'])) {
-        $DB->insertOrDie(
+        $DB->insert(
             "glpi_notifications",
             [
                 'id'              => null,
@@ -1707,19 +1691,17 @@ Regards,',
                 'is_active'       => "1",
                 'date_creation'   => new QueryExpression("NOW()"),
                 'date_mod'        => new QueryExpression("NOW()")
-            ],
-            "9.2 Add certificate alerts notification"
+            ]
         );
         $notid = $DB->insertId();
 
-        $DB->insertOrDie(
+        $DB->insert(
             "glpi_notificationtemplates",
             [
                 'name'      => "Certificates",
                 'itemtype'  => "Certificate",
                 'date_mod'  => new QueryExpression("NOW()")
-            ],
-            "9.2 Add certifcate alerts notification template"
+            ]
         );
         $nottid = $DB->insertId();
 
@@ -1759,27 +1741,25 @@ Regards,',
 &lt;br /&gt; &lt;a href=\"##certificate.url##\"&gt; ##certificate.url##
 &lt;/a&gt;&lt;br /&gt; ##ENDFOREACHcertificates##&lt;/p&gt;')";
 
-        $DB->doQueryOrDie($query, "9.2 add certificates alerts notification translation");
+        $DB->doQuery($query);
 
-        $DB->insertOrDie(
+        $DB->insert(
             "glpi_notificationtargets",
             [
                 'id'                 => null,
                 'notifications_id'   => $notid,
                 'type'               => Notification::USER_TYPE,
                 'items_id'           => Notification::ITEM_TECH_IN_CHARGE
-            ],
-            "9.2 add certificates alerts notification target"
+            ]
         );
-        $DB->insertOrDie(
+        $DB->insert(
             "glpi_notificationtargets",
             [
                 'id'                 => null,
                 'notifications_id'   => $notid,
                 'type'               => Notification::USER_TYPE,
                 'items_id'           => Notification::ITEM_TECH_GROUP_IN_CHARGE
-            ],
-            "9.2 add certificates alerts notification target"
+            ]
         );
     }
 
@@ -1805,7 +1785,7 @@ Regards,',
                    KEY `date_creation` (`date_creation`),
                    UNIQUE KEY `unicity` (`mcc`,`mnc`)
                 ) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;";
-        $DB->doQueryOrDie($query, "9.2 add table glpi_lineoperators");
+        $DB->doQuery($query);
     }
 
     if (!$DB->tableExists('glpi_linetypes')) {
@@ -1820,7 +1800,7 @@ Regards,',
          KEY `date_mod` (`date_mod`),
          KEY `date_creation` (`date_creation`)
          ) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;";
-        $DB->doQueryOrDie($query, "9.2 add table glpi_linetypes");
+        $DB->doQuery($query);
     }
 
     if (!$DB->tableExists('glpi_lines')) {
@@ -1847,7 +1827,7 @@ Regards,',
             KEY `users_id`         (`users_id`),
             KEY `lineoperators_id` (`lineoperators_id`)
             ) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
-        $DB->doQueryOrDie($query, "9.2 add table glpi_lines");
+        $DB->doQuery($query);
     }
 
     if (!$DB->tableExists('glpi_devicesimcardtypes')) {
@@ -1862,11 +1842,11 @@ Regards,',
                   KEY `date_mod` (`date_mod`),
                   KEY `date_creation` (`date_creation`)
                 ) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;";
-        $DB->doQueryOrDie($query, "9.2 add table glpi_devicesimcardtypes");
+        $DB->doQuery($query);
     }
 
     if (!countElementsInTable('glpi_devicesimcardtypes', ['name' => 'Full SIM'])) {
-        $DB->insertOrDie("glpi_devicesimcardtypes", [
+        $DB->insert("glpi_devicesimcardtypes", [
             'id'              => null,
             'name'            => "Full SIM",
             'comment'         => null,
@@ -1875,7 +1855,7 @@ Regards,',
         ]);
     }
     if (!countElementsInTable('glpi_devicesimcardtypes', ['name' => 'Mini SIM'])) {
-        $DB->insertOrDie("glpi_devicesimcardtypes", [
+        $DB->insert("glpi_devicesimcardtypes", [
             'id'              => null,
             'name'            => "Mini SIM",
             'comment'         => null,
@@ -1884,7 +1864,7 @@ Regards,',
         ]);
     }
     if (!countElementsInTable('glpi_devicesimcardtypes', ['name' => 'Micro SIM'])) {
-        $DB->insertOrDie("glpi_devicesimcardtypes", [
+        $DB->insert("glpi_devicesimcardtypes", [
             'id'              => null,
             'name'            => "Micro SIM",
             'comment'         => null,
@@ -1893,7 +1873,7 @@ Regards,',
         ]);
     }
     if (!countElementsInTable('glpi_devicesimcardtypes', ['name' => 'Nano SIM'])) {
-        $DB->insertOrDie("glpi_devicesimcardtypes", [
+        $DB->insert("glpi_devicesimcardtypes", [
             'id'              => null,
             'name'            => "Nano SIM",
             'comment'         => null,
@@ -1924,7 +1904,7 @@ Regards,',
                KEY `date_creation` (`date_creation`),
                KEY `manufacturers_id` (`manufacturers_id`)
             ) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
-        $DB->doQueryOrDie($query, "9.2 add table glpi_devicesimcards");
+        $DB->doQuery($query);
     }
 
     if (!$DB->tableExists('glpi_items_devicesimcards')) {
@@ -1957,7 +1937,7 @@ Regards,',
                   KEY `locations_id` (`locations_id`),
                   KEY `lines_id` (`lines_id`)
                 ) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
-        $DB->doQueryOrDie($query, "9.2 add table glpi_items_devicesimcards");
+        $DB->doQuery($query);
     }
 
     if (countElementsInTable("glpi_profilerights", ['name' => 'line']) == 0) {
@@ -1970,15 +1950,14 @@ Regards,',
             } else {
                 $rightValue = 0;
             }
-            $DB->insertOrDie(
+            $DB->insert(
                 "glpi_profilerights",
                 [
                     'id'           => null,
                     'profiles_id'  => $profrights['profiles_id'],
                     'name'         => "line",
                     'rights'       => $rightValue
-                ],
-                "9.2 add right for line"
+                ]
             );
         }
     }
@@ -1993,15 +1972,14 @@ Regards,',
             } else {
                 $rightValue = 0;
             }
-            $DB->insertOrDie(
+            $DB->insert(
                 "glpi_profilerights",
                 [
                     'id'           => null,
                     'profiles_id'  => $profrights['profiles_id'],
                     'name'         => "lineoperator",
                     'rights'       => $rightValue
-                ],
-                "9.2 add right for lineoperator"
+                ]
             );
         }
     }
@@ -2016,15 +1994,14 @@ Regards,',
             } else {
                 $rightValue = 0;
             }
-            $DB->insertOrDie(
+            $DB->insert(
                 "glpi_profilerights",
                 [
                     'id'           => null,
                     'profiles_id'  => $profrights['profiles_id'],
                     'name'         => "devicesimcard_pinpuk",
                     'rights'       => $rightValue
-                ],
-                "9.2 add right for simcards pin and puk codes"
+                ]
             );
         }
     }
@@ -2154,7 +2131,7 @@ Regards,',
                        KEY `projecttasktypes_id` (`projecttasktypes_id`),
                        KEY `is_milestone` (`is_milestone`)
                      ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;";
-        $DB->doQueryOrDie($query, "9.2 add table glpi_projecttasktemplates");
+        $DB->doQuery($query);
     }
 
    //add editor in followupps
@@ -2213,32 +2190,32 @@ Regards,',
 
     if (isIndex('glpi_authldaps', 'use_tls')) {
         $query = "ALTER TABLE `glpi_authldaps` DROP INDEX `use_tls`";
-        $DB->doQueryOrDie($query, "9.2 drop index use_tls for glpi_authldaps");
+        $DB->doQuery($query);
     }
 
    //Fix some field order from old migrations
     $migration->migrationOneTable('glpi_states');
-    $DB->doQueryOrDie("ALTER TABLE `glpi_budgets` CHANGE `date_creation` `date_creation` DATETIME NULL DEFAULT NULL AFTER `date_mod`");
-    $DB->doQueryOrDie("ALTER TABLE `glpi_changetasks` CHANGE `groups_id_tech` `groups_id_tech` INT NOT NULL DEFAULT '0' AFTER `users_id_tech`");
-    $DB->doQueryOrDie("ALTER TABLE `glpi_problemtasks` CHANGE `groups_id_tech` `groups_id_tech` INT NOT NULL DEFAULT '0' AFTER `users_id_tech`");
-    $DB->doQueryOrDie("ALTER TABLE `glpi_tickettasks` CHANGE `groups_id_tech` `groups_id_tech` INT NOT NULL DEFAULT '0' AFTER `users_id_tech`");
-    $DB->doQueryOrDie("ALTER TABLE `glpi_knowbaseitemcategories` CHANGE `sons_cache` `sons_cache` LONGTEXT CHARACTER SET utf8 COLLATE utf8_unicode_ci NULL DEFAULT NULL AFTER `level`");
-    $DB->doQueryOrDie("ALTER TABLE `glpi_requesttypes` CHANGE `is_followup_default` `is_followup_default` TINYINT NOT NULL DEFAULT '0' AFTER `is_helpdesk_default`");
-    $DB->doQueryOrDie("ALTER TABLE `glpi_requesttypes` CHANGE `is_mailfollowup_default` `is_mailfollowup_default` TINYINT NOT NULL DEFAULT '0' AFTER `is_mail_default`");
-    $DB->doQueryOrDie("ALTER TABLE `glpi_requesttypes` CHANGE `comment` `comment` TEXT CHARACTER SET utf8 COLLATE utf8_unicode_ci NULL DEFAULT NULL AFTER `is_ticketfollowup`");
-    $DB->doQueryOrDie("ALTER TABLE `glpi_requesttypes` CHANGE `date_mod` `date_mod` DATETIME NULL DEFAULT NULL AFTER `comment`");
-    $DB->doQueryOrDie("ALTER TABLE `glpi_requesttypes` CHANGE `date_creation` `date_creation` DATETIME NULL DEFAULT NULL AFTER `date_mod`");
-    $DB->doQueryOrDie("ALTER TABLE `glpi_groups` CHANGE `is_task` `is_task` TINYINT NOT NULL DEFAULT '1' AFTER `is_assign`");
-    $DB->doQueryOrDie("ALTER TABLE `glpi_states` CHANGE `date_mod` `date_mod` DATETIME NULL DEFAULT NULL AFTER `is_visible_certificate`");
-    $DB->doQueryOrDie("ALTER TABLE `glpi_states` CHANGE `date_creation` `date_creation` DATETIME NULL DEFAULT NULL AFTER `date_mod`");
-    $DB->doQueryOrDie("ALTER TABLE `glpi_taskcategories` CHANGE `is_active` `is_active` TINYINT NOT NULL DEFAULT '1' AFTER `sons_cache`");
-    $DB->doQueryOrDie("ALTER TABLE `glpi_users` CHANGE `palette` `palette` CHAR(20) CHARACTER SET utf8 COLLATE utf8_unicode_ci NULL DEFAULT NULL AFTER `layout`");
-    $DB->doQueryOrDie("ALTER TABLE `glpi_users` CHANGE `set_default_requester` `set_default_requester` TINYINT NULL DEFAULT NULL AFTER `ticket_timeline_keep_replaced_tabs`");
-    $DB->doQueryOrDie("ALTER TABLE `glpi_users` CHANGE `plannings` `plannings` TEXT CHARACTER SET utf8 COLLATE utf8_unicode_ci NULL DEFAULT NULL AFTER `highcontrast_css`");
+    $DB->doQuery("ALTER TABLE `glpi_budgets` CHANGE `date_creation` `date_creation` DATETIME NULL DEFAULT NULL AFTER `date_mod`");
+    $DB->doQuery("ALTER TABLE `glpi_changetasks` CHANGE `groups_id_tech` `groups_id_tech` INT NOT NULL DEFAULT '0' AFTER `users_id_tech`");
+    $DB->doQuery("ALTER TABLE `glpi_problemtasks` CHANGE `groups_id_tech` `groups_id_tech` INT NOT NULL DEFAULT '0' AFTER `users_id_tech`");
+    $DB->doQuery("ALTER TABLE `glpi_tickettasks` CHANGE `groups_id_tech` `groups_id_tech` INT NOT NULL DEFAULT '0' AFTER `users_id_tech`");
+    $DB->doQuery("ALTER TABLE `glpi_knowbaseitemcategories` CHANGE `sons_cache` `sons_cache` LONGTEXT CHARACTER SET utf8 COLLATE utf8_unicode_ci NULL DEFAULT NULL AFTER `level`");
+    $DB->doQuery("ALTER TABLE `glpi_requesttypes` CHANGE `is_followup_default` `is_followup_default` TINYINT NOT NULL DEFAULT '0' AFTER `is_helpdesk_default`");
+    $DB->doQuery("ALTER TABLE `glpi_requesttypes` CHANGE `is_mailfollowup_default` `is_mailfollowup_default` TINYINT NOT NULL DEFAULT '0' AFTER `is_mail_default`");
+    $DB->doQuery("ALTER TABLE `glpi_requesttypes` CHANGE `comment` `comment` TEXT CHARACTER SET utf8 COLLATE utf8_unicode_ci NULL DEFAULT NULL AFTER `is_ticketfollowup`");
+    $DB->doQuery("ALTER TABLE `glpi_requesttypes` CHANGE `date_mod` `date_mod` DATETIME NULL DEFAULT NULL AFTER `comment`");
+    $DB->doQuery("ALTER TABLE `glpi_requesttypes` CHANGE `date_creation` `date_creation` DATETIME NULL DEFAULT NULL AFTER `date_mod`");
+    $DB->doQuery("ALTER TABLE `glpi_groups` CHANGE `is_task` `is_task` TINYINT NOT NULL DEFAULT '1' AFTER `is_assign`");
+    $DB->doQuery("ALTER TABLE `glpi_states` CHANGE `date_mod` `date_mod` DATETIME NULL DEFAULT NULL AFTER `is_visible_certificate`");
+    $DB->doQuery("ALTER TABLE `glpi_states` CHANGE `date_creation` `date_creation` DATETIME NULL DEFAULT NULL AFTER `date_mod`");
+    $DB->doQuery("ALTER TABLE `glpi_taskcategories` CHANGE `is_active` `is_active` TINYINT NOT NULL DEFAULT '1' AFTER `sons_cache`");
+    $DB->doQuery("ALTER TABLE `glpi_users` CHANGE `palette` `palette` CHAR(20) CHARACTER SET utf8 COLLATE utf8_unicode_ci NULL DEFAULT NULL AFTER `layout`");
+    $DB->doQuery("ALTER TABLE `glpi_users` CHANGE `set_default_requester` `set_default_requester` TINYINT NULL DEFAULT NULL AFTER `ticket_timeline_keep_replaced_tabs`");
+    $DB->doQuery("ALTER TABLE `glpi_users` CHANGE `plannings` `plannings` TEXT CHARACTER SET utf8 COLLATE utf8_unicode_ci NULL DEFAULT NULL AFTER `highcontrast_css`");
 
    //Fix bad default values
-    $DB->doQueryOrDie("ALTER TABLE `glpi_states` CHANGE `is_visible_softwarelicense` `is_visible_softwarelicense` TINYINT NOT NULL DEFAULT '1'");
-    $DB->doQueryOrDie("ALTER TABLE `glpi_states` CHANGE `is_visible_line` `is_visible_line` TINYINT NOT NULL DEFAULT '1'");
+    $DB->doQuery("ALTER TABLE `glpi_states` CHANGE `is_visible_softwarelicense` `is_visible_softwarelicense` TINYINT NOT NULL DEFAULT '1'");
+    $DB->doQuery("ALTER TABLE `glpi_states` CHANGE `is_visible_line` `is_visible_line` TINYINT NOT NULL DEFAULT '1'");
 
    //Fields added in 0905_91 script but not in empty sql...
     if (!$DB->fieldExists('glpi_changetasks', 'date_creation', false)) {
@@ -2279,7 +2256,7 @@ Regards,',
     }
 
    //Fix comments...
-    $DB->doQueryOrDie("ALTER TABLE `glpi_savedsearches` CHANGE `type` `type` INT NOT NULL DEFAULT '0' COMMENT 'see SavedSearch:: constants'");
+    $DB->doQuery("ALTER TABLE `glpi_savedsearches` CHANGE `type` `type` INT NOT NULL DEFAULT '0' COMMENT 'see SavedSearch:: constants'");
 
    //Fix unicity...
     $tables = [
@@ -2330,7 +2307,7 @@ Regards,',
     }
 
    //wrong type
-    $DB->doQueryOrDie("ALTER TABLE `glpi_users` CHANGE `keep_devices_when_purging_item` `keep_devices_when_purging_item` TINYINT NULL DEFAULT NULL");
+    $DB->doQuery("ALTER TABLE `glpi_users` CHANGE `keep_devices_when_purging_item` `keep_devices_when_purging_item` TINYINT NULL DEFAULT NULL");
 
    //missing index
     $migration->addKey('glpi_networknames', 'is_deleted');

--- a/install/migrations/update_9.2.0_to_9.2.1.php
+++ b/install/migrations/update_9.2.0_to_9.2.1.php
@@ -89,19 +89,17 @@ function update920to921()
     }
 
    // Sla rules criterias migration
-    $DB->updateOrDie(
+    $DB->update(
         "glpi_rulecriterias",
         ['criteria' => "slts_ttr_id"],
-        ['criteria' => "slas_id"],
-        "SLA rulecriterias migration"
+        ['criteria' => "slas_id"]
     );
 
    // Sla rules actions migration
-    $DB->updateOrDie(
+    $DB->update(
         "glpi_ruleactions",
         ['field' => "slts_ttr_id"],
-        ['field' => "slas_id"],
-        "SLA ruleactions migration"
+        ['field' => "slas_id"]
     );
    // end fix 9.1.x migration
 
@@ -117,7 +115,7 @@ function update920to921()
                PRIMARY KEY (`id`),
                KEY `olalevels_id` (`olalevels_id`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;";
-        $DB->doQueryOrDie($query, "9.2 add table glpi_olalevelactions");
+        $DB->doQuery($query);
     }
 
     if (!$DB->tableExists('glpi_olalevelcriterias')) {
@@ -131,7 +129,7 @@ function update920to921()
                KEY `olalevels_id` (`olalevels_id`),
                KEY `condition` (`condition`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;";
-        $DB->doQueryOrDie($query, "9.2 add table glpi_olalevelcriterias");
+        $DB->doQuery($query);
     }
 
     if (!$DB->tableExists('glpi_olalevels')) {
@@ -150,7 +148,7 @@ function update920to921()
                KEY `is_active` (`is_active`),
                KEY `olas_id` (`olas_id`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;";
-        $DB->doQueryOrDie($query, "9.2 add table glpi_olalevels");
+        $DB->doQuery($query);
     }
 
     if (!$DB->tableExists('glpi_olalevels_tickets')) {
@@ -164,9 +162,9 @@ function update920to921()
                   KEY `olalevels_id` (`olalevels_id`),
                   KEY `unicity` (`tickets_id`,`olalevels_id`)
                ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;";
-        $DB->doQueryOrDie($query, "9.2 add table glpi_olalevels_tickets");
+        $DB->doQuery($query);
 
-        $DB->insertOrDie("glpi_crontasks", [
+        $DB->insert("glpi_crontasks", [
             'itemtype'        => "OlaLevel_Ticket",
             'name'            => "olaticket",
             'frequency'       => "604800",
@@ -180,7 +178,7 @@ function update920to921()
             'lastrun'         => null,
             'lastcode'        => null,
             'comment'         => null,
-        ], "9.2 populate glpi_crontasks for olaticket");
+        ]);
     }
 
     if (!$DB->tableExists('glpi_slms')) {
@@ -295,41 +293,36 @@ function update920to921()
     }
 
    // ProfileRights changes
-    $DB->updateOrDie(
+    $DB->update(
         "glpi_profilerights",
         ['name' => "slm"],
-        ['name' => "sla"],
-        "SLM profilerights migration"
+        ['name' => "sla"]
     );
 
    //Sla rules criterias migration
-    $DB->updateOrDie(
+    $DB->update(
         "glpi_rulecriterias",
         ['criteria' => "slas_ttr_id"],
-        ['criteria' => "slts_ttr_id"],
-        "SLA rulecriterias migration"
+        ['criteria' => "slts_ttr_id"]
     );
 
-    $DB->updateOrDie(
+    $DB->update(
         "glpi_rulecriterias",
         ['criteria' => "slas_tto_id"],
-        ['criteria' => "slts_tto_id"],
-        "SLA rulecriterias migration"
+        ['criteria' => "slts_tto_id"]
     );
 
    // Sla rules actions migration
-    $DB->updateOrDie(
+    $DB->update(
         "glpi_ruleactions",
         ['field' => "slas_ttr_id"],
-        ['field' => "slts_ttr_id"],
-        "SLA ruleactions migration"
+        ['field' => "slts_ttr_id"]
     );
 
-    $DB->updateOrDie(
+    $DB->update(
         "glpi_ruleactions",
         ['field' => "slas_tto_id"],
-        ['field' => "slts_tto_id"],
-        "SLA ruleactions migration"
+        ['field' => "slts_tto_id"]
     );
 
    //see https://github.com/glpi-project/glpi/issues/3037
@@ -387,7 +380,7 @@ function update920to921()
                        (`notifications_id`, `mode`, `notificationtemplates_id`)
                        SELECT `id`, `mode`, `notificationtemplates_id`
                        FROM `glpi_notifications`";
-        $DB->doQueryOrDie($query, "9.2 migrate notifications templates");
+        $DB->doQuery($query);
 
        //migrate any existing mode before removing the field
         $migration->dropField('glpi_notifications', 'mode');

--- a/install/migrations/update_9.2.2_to_9.2.3.php
+++ b/install/migrations/update_9.2.2_to_9.2.3.php
@@ -82,7 +82,7 @@ function update922to923()
             $notification->getFromDBByCrit(['itemtype' => $notif, 'event' => 'alert'])
             && $template->getFromDBByCrit(['itemtype' => $notif])
         ) {
-            $DB->updateOrDie(
+            $DB->update(
                 "glpi_notificationtemplatetranslations",
                 ["notificationtemplates_id" => $template->fields['id']],
                 ["notificationtemplates_id" => $notification->fields['id']]
@@ -100,7 +100,7 @@ function update922to923()
                 ) == 0
             ) {
                 //Add missing notification template link for saved searches
-                $DB->insertOrDie("glpi_notifications_notificationtemplates", [
+                $DB->insert("glpi_notifications_notificationtemplates", [
                     'notifications_id'         => $notification->fields['id'],
                     'mode'                     => Notification_NotificationTemplate::MODE_MAIL,
                     'notificationtemplates_id' => $template->fields['id']

--- a/install/migrations/update_9.2.x_to_9.3.0.php
+++ b/install/migrations/update_9.2.x_to_9.3.0.php
@@ -85,7 +85,7 @@ function update92xto930()
          KEY `status` (`status`),
          KEY `ticketfollowups_id` (`ticketfollowups_id`)
          ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
-        $DB->doQueryOrDie($query, "9.3 add table glpi_itilsolutions");
+        $DB->doQuery($query);
     }
 
    //add unicity key required for migration only
@@ -126,7 +126,7 @@ function update92xto930()
                   OR solutiontypes_id > 0
                GROUP BY ticket.`id`
                ORDER BY ticket.`id` ASC, log.id DESC";
-        $DB->doQueryOrDie($query, "9.3 migrate Ticket solution history");
+        $DB->doQuery($query);
         $migration->dropField('glpi_tickets', 'solution');
         $migration->dropKey('glpi_tickets', 'solutiontypes_id');
         $migration->dropField('glpi_tickets', 'solutiontypes_id');
@@ -162,7 +162,7 @@ function update92xto930()
                   OR solutiontypes_id > 0
                GROUP BY problem.`id`
                ORDER BY problem.`id` ASC, log.id DESC";
-        $DB->doQueryOrDie($query, "9.3 migrate Problem solution history");
+        $DB->doQuery($query);
         $migration->dropField('glpi_problems', 'solution');
         $migration->dropKey('glpi_problems', 'solutiontypes_id');
         $migration->dropField('glpi_problems', 'solutiontypes_id');
@@ -198,7 +198,7 @@ function update92xto930()
                   OR solutiontypes_id > 0
                GROUP BY changes.`id`
                ORDER BY changes.`id` ASC, log.id DESC";
-        $DB->doQueryOrDie($query, "9.3 migrate Change solution history");
+        $DB->doQuery($query);
         $migration->dropField('glpi_changes', 'solution');
         $migration->dropKey('glpi_changes', 'solutiontypes_id');
         $migration->dropField('glpi_changes', 'solutiontypes_id');
@@ -225,7 +225,7 @@ function update92xto930()
                   KEY `locations_id` (`locations_id`),
                   KEY `is_deleted` (`is_deleted`)
                   ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
-        $DB->doQueryOrDie($query, "9.3 add table glpi_datacenters");
+        $DB->doQuery($query);
     }
 
     if (!$DB->tableExists('glpi_dcrooms')) {
@@ -249,7 +249,7 @@ function update92xto930()
                   KEY `datacenters_id` (`datacenters_id`),
                   KEY `is_deleted` (`is_deleted`)
                   ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
-        $DB->doQueryOrDie($query, "9.3 add table glpi_dcrooms");
+        $DB->doQuery($query);
     }
     if (!$DB->fieldExists('glpi_dcrooms', 'blueprint')) {
         $migration->addField('glpi_dcrooms', 'blueprint', 'text', ['after' => 'vis_rows']);
@@ -267,7 +267,7 @@ function update92xto930()
                   KEY `name` (`name`),
                   KEY `product_number` (`product_number`)
                   ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
-        $DB->doQueryOrDie($query, "9.3 add table glpi_rackmodels");
+        $DB->doQuery($query);
     }
 
     if (!$DB->tableExists('glpi_racktypes')) {
@@ -286,7 +286,7 @@ function update92xto930()
                   KEY `date_creation` (`date_creation`),
                   KEY `date_mod` (`date_mod`)
                   ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;";
-        $DB->doQueryOrDie($query, "9.3 add table glpi_racktypes");
+        $DB->doQuery($query);
     }
 
     if (!$DB->tableExists('glpi_racks')) {
@@ -335,7 +335,7 @@ function update92xto930()
                   KEY `is_deleted` (`is_deleted`),
                   KEY `dcrooms_id` (`dcrooms_id`)
                   ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
-        $DB->doQueryOrDie($query, "9.3 add table glpi_racks");
+        $DB->doQuery($query);
     }
 
     if (!$DB->tableExists('glpi_items_racks')) {
@@ -353,7 +353,7 @@ function update92xto930()
                   UNIQUE KEY `item` (`itemtype`,`items_id`, `is_reserved`),
                   KEY `relation` (`racks_id`,`itemtype`,`items_id`)
                   ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
-        $DB->doQueryOrDie($query, "9.3 add table glpi_items_racks");
+        $DB->doQuery($query);
     }
 
     $migration->addRight(
@@ -435,7 +435,7 @@ function update92xto930()
                   KEY `date_creation` (`date_creation`),
                   KEY `product_number` (`product_number`)
                   ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;";
-        $DB->doQueryOrDie($query, "9.3 add table glpi_enclosuremodels");
+        $DB->doQuery($query);
     }
 
     if (!$DB->tableExists('glpi_enclosures')) {
@@ -472,7 +472,7 @@ function update92xto930()
                   KEY `states_id` (`states_id`),
                   KEY `manufacturers_id` (`manufacturers_id`)
                   ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;";
-        $DB->doQueryOrDie($query, "9.3 add table glpi_enclosures");
+        $DB->doQuery($query);
     }
 
     if (!$DB->tableExists('glpi_items_enclosures')) {
@@ -486,7 +486,7 @@ function update92xto930()
                   UNIQUE KEY `item` (`itemtype`,`items_id`),
                   KEY `relation` (`enclosures_id`,`itemtype`,`items_id`)
                   ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;";
-        $DB->doQueryOrDie($query, "9.3 add table glpi_items_enclosures");
+        $DB->doQuery($query);
     }
 
     if (!$DB->tableExists('glpi_pdumodels')) {
@@ -511,7 +511,7 @@ function update92xto930()
                   KEY `is_rackable` (`is_rackable`),
                   KEY `product_number` (`product_number`)
                   ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;";
-        $DB->doQueryOrDie($query, "9.3 ad table glpi_pdumodels");
+        $DB->doQuery($query);
     }
     if ($DB->fieldExists('glpi_pdumodels', 'power_consumption')) {
         $migration->changeField(
@@ -539,7 +539,7 @@ function update92xto930()
                   KEY `date_creation` (`date_creation`),
                   KEY `date_mod` (`date_mod`)
                   ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;";
-        $DB->doQueryOrDie($query, "9.3 add table glpi_pdutypes");
+        $DB->doQuery($query);
     }
 
     if (!$DB->tableExists('glpi_pdus')) {
@@ -576,7 +576,7 @@ function update92xto930()
                   KEY `manufacturers_id` (`manufacturers_id`),
                   KEY `pdutypes_id` (`pdutypes_id`)
                   ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;";
-        $DB->doQueryOrDie($query, "9.3 add table glpi_pdus");
+        $DB->doQuery($query);
     }
 
     if (!$DB->tableExists('glpi_plugs')) {
@@ -591,7 +591,7 @@ function update92xto930()
                   KEY `date_mod` (`date_mod`),
                   KEY `date_creation` (`date_creation`)
                   ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;";
-        $DB->doQueryOrDie($query, '9.3 add table glpi_plugs');
+        $DB->doQuery($query);
     }
 
     if (!$DB->tableExists('glpi_pdus_plugs')) {
@@ -606,7 +606,7 @@ function update92xto930()
                   KEY `plugs_id` (`plugs_id`),
                   KEY `pdus_id` (`pdus_id`)
                   ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;";
-        $DB->doQueryOrDie($query, '9.3 add table glpi_pdus_plugs');
+        $DB->doQuery($query);
     }
 
     if (!countElementsInTable('glpi_plugs')) {
@@ -632,7 +632,7 @@ function update92xto930()
                   KEY `racks_id` (`racks_id`),
                   KEY `pdus_id` (`pdus_id`)
                   ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;";
-        $DB->doQueryOrDie($query, '9.3 add table glpi_pdus_racks');
+        $DB->doQuery($query);
     }
 
     $migration->addField('glpi_states', 'is_visible_rack', 'bool', ['value' => 1,
@@ -864,7 +864,7 @@ function update92xto930()
             'WHERE'  => ['id' => $row['items_id']]
         ]);
         if (!count($exists)) {
-            $DB->deleteOrDie(
+            $DB->delete(
                 Item_Rack::getTable(),
                 [
                     'id' => $row['id']

--- a/install/migrations/update_9.3.1_to_9.3.2.php
+++ b/install/migrations/update_9.3.1_to_9.3.2.php
@@ -65,8 +65,8 @@ function update931to932()
             'items_id' => 0,
         ],
     ];
-    $DB->deleteOrDie(Item_Rack::getTable(), $corrupted_criteria);
-    $DB->deleteOrDie(Item_Enclosure::getTable(), $corrupted_criteria);
+    $DB->delete(Item_Rack::getTable(), $corrupted_criteria);
+    $DB->delete(Item_Enclosure::getTable(), $corrupted_criteria);
     /** /Clean rack/enclosure items corrupted relations */
 
    // limit state visibility for enclosures and pdus

--- a/install/migrations/update_9.3.x_to_9.4.0.php
+++ b/install/migrations/update_9.3.x_to_9.4.0.php
@@ -130,7 +130,7 @@ function update93xto940()
     $migration->createRule($rule, $criteria, $action);
 
     if (!countElementsInTable('glpi_profilerights', ['profiles_id' => 4, 'name' => 'rule_asset'])) {
-        $DB->insertOrDie("glpi_profilerights", [
+        $DB->insert("glpi_profilerights", [
             'id'           => null,
             'profiles_id'  => "4",
             'name'         => "rule_asset",
@@ -209,7 +209,7 @@ function update93xto940()
     $migration->addConfig(['cas_version' => 'CAS_VERSION_2_0']);
 
     /** Drop old embed ocs search options */
-    $DB->deleteOrDie(
+    $DB->delete(
         'glpi_displaypreferences',
         [
             'itemtype'  => 'Computer',
@@ -240,7 +240,7 @@ function update93xto940()
         '95'  => '117'
     ];
     foreach ($so_maping as $old => $new) {
-        $DB->updateOrDie(
+        $DB->update(
             'glpi_displaypreferences',
             [
                 'num' => $new

--- a/install/migrations/update_9.4.0_to_9.4.1.php
+++ b/install/migrations/update_9.4.0_to_9.4.1.php
@@ -151,7 +151,7 @@ function update940to941()
             );
             foreach ($elements_to_fix as $data) {
                  $data['content'] = $fix_content_fct($data['content'], $data['items_id'], $itil_fkey);
-                 $DB->updateOrDie($itil_element_table, $data, ['id' => $data['id']]);
+                 $DB->update($itil_element_table, $data, ['id' => $data['id']]);
             }
         }
 
@@ -167,7 +167,7 @@ function update940to941()
         );
         foreach ($tasks_to_fix as $data) {
             $data['content'] = $fix_content_fct($data['content'], $data[$itil_fkey], $itil_fkey);
-            $DB->updateOrDie($task_table, $data, ['id' => $data['id']]);
+            $DB->update($task_table, $data, ['id' => $data['id']]);
         }
     }
     /** /Fix URL of images inside ITIL objects contents */

--- a/install/migrations/update_9.4.1_to_9.4.2.php
+++ b/install/migrations/update_9.4.1_to_9.4.2.php
@@ -130,7 +130,7 @@ function update941to942()
             );
             foreach ($elements_to_fix as $data) {
                  $data['content'] = $DB->escape($fix_content_fct($data['content'], $data['items_id'], $itil_fkey));
-                 $DB->updateOrDie($itil_element_table, $data, ['id' => $data['id']]);
+                 $DB->update($itil_element_table, $data, ['id' => $data['id']]);
             }
         }
 
@@ -146,7 +146,7 @@ function update941to942()
         );
         foreach ($tasks_to_fix as $data) {
             $data['content'] = $DB->escape($fix_content_fct($data['content'], $data[$itil_fkey], $itil_fkey));
-            $DB->updateOrDie($task_table, $data, ['id' => $data['id']]);
+            $DB->update($task_table, $data, ['id' => $data['id']]);
         }
     }
     /** /Fix URL of images inside ITIL objects contents */

--- a/install/migrations/update_9.4.2_to_9.4.3.php
+++ b/install/migrations/update_9.4.2_to_9.4.3.php
@@ -111,7 +111,7 @@ function update942to943()
             );
             foreach ($elements_to_fix as $data) {
                  $data['content'] = $fix_content_fct($data['content'], $data['items_id'], $itil_fkey);
-                 $DB->updateOrDie($itil_element_table, $data, ['id' => $data['id']]);
+                 $DB->update($itil_element_table, $data, ['id' => $data['id']]);
             }
         }
 
@@ -127,7 +127,7 @@ function update942to943()
         );
         foreach ($tasks_to_fix as $data) {
             $data['content'] = $fix_content_fct($data['content'], $data[$itil_fkey], $itil_fkey);
-            $DB->updateOrDie($task_table, $data, ['id' => $data['id']]);
+            $DB->update($task_table, $data, ['id' => $data['id']]);
         }
     }
     /** /Fix URL of images inside ITIL objects contents */

--- a/install/migrations/update_9.4.5_to_9.4.6.php
+++ b/install/migrations/update_9.4.5_to_9.4.6.php
@@ -49,7 +49,7 @@ function update945to946()
    //TRANS: %s is the number of new version
     $migration->displayTitle(sprintf(__('Update to %s'), '9.4.6'));
     $migration->setVersion('9.4.6');
-    $DB->deleteOrDie(
+    $DB->delete(
         'glpi_profilerights',
         [
             'name'  => 'backup'

--- a/install/migrations/update_9.4.6_to_9.4.7.php
+++ b/install/migrations/update_9.4.6_to_9.4.7.php
@@ -52,7 +52,7 @@ function update946to947()
     $migration->displayTitle(sprintf(__('Update to %s'), '9.4.7'));
     $migration->setVersion('9.4.7');
 
-    $DB->updateOrDie('glpi_events', ['type'   => 'dcrooms'], ['type' => 'serverroms']);
+    $DB->update('glpi_events', ['type'   => 'dcrooms'], ['type' => 'serverroms']);
 
    // ************ Keep it at the end **************
     $migration->executeMigration();

--- a/install/migrations/update_9.4.x_to_9.5.0.php
+++ b/install/migrations/update_9.4.x_to_9.5.0.php
@@ -173,7 +173,7 @@ function update94xto950()
          KEY `date_creation` (`date_creation`),
          KEY `date_mod` (`date_mod`)
          ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;";
-        $DB->doQueryOrDie($query, "9.5 add table glpi_clustertypes");
+        $DB->doQuery($query);
     }
 
     if (!$DB->tableExists('glpi_clusters')) {
@@ -203,7 +203,7 @@ function update94xto950()
          KEY `entities_id` (`entities_id`),
          KEY `is_recursive` (`is_recursive`)
          ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;";
-        $DB->doQueryOrDie($query, "9.5 add table glpi_clusters");
+        $DB->doQuery($query);
     }
 
     if (!$DB->tableExists('glpi_items_clusters')) {
@@ -216,7 +216,7 @@ function update94xto950()
          UNIQUE KEY `unicity` (`clusters_id`,`itemtype`,`items_id`),
          KEY `item` (`itemtype`,`items_id`)
          ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;";
-        $DB->doQueryOrDie($query, "9.5 add table glpi_items_clusters");
+        $DB->doQuery($query);
     }
 
     $migration->addField('glpi_states', 'is_visible_cluster', 'bool', [
@@ -285,7 +285,7 @@ function update94xto950()
             KEY `entities_id` (`entities_id`),
             KEY `is_recursive` (`is_recursive`)
             ) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;";
-            $DB->doQueryOrDie($query, "add table glpi_{$itiltype}templates");
+            $DB->doQuery($query);
             $migration->addPostQuery(
                 $DB->buildInsert(
                     "glpi_{$itiltype}templates",
@@ -307,7 +307,7 @@ function update94xto950()
             UNIQUE KEY `unicity` (`{$itiltype}templates_id`,`num`),
             KEY `{$itiltype}templates_id` (`{$itiltype}templates_id`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;";
-            $DB->doQueryOrDie($query, "add table glpi_{$itiltype}templatehiddenfields");
+            $DB->doQuery($query);
         }
 
         if (!$DB->tableExists("glpi_{$itiltype}templatemandatoryfields")) {
@@ -319,7 +319,7 @@ function update94xto950()
             UNIQUE KEY `unicity` (`{$itiltype}templates_id`,`num`),
             KEY `{$itiltype}templates_id` (`{$itiltype}templates_id`)
             ) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;";
-            $DB->doQueryOrDie($query, "add table glpi_{$itiltype}templatemandatoryfields");
+            $DB->doQuery($query);
             $migration->addPostQuery(
                 $DB->buildInsert(
                     "glpi_{$itiltype}templatemandatoryfields",
@@ -341,7 +341,7 @@ function update94xto950()
             PRIMARY KEY (`id`),
             KEY `{$itiltype}templates_id` (`{$itiltype}templates_id`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;";
-            $DB->doQueryOrDie($query, "add table glpi_{$itiltype}templatepredefinedfields");
+            $DB->doQuery($query);
         } else {
            //drop key -- usefull only for 9.5 rolling release
             $migration->dropKey("glpi_{$itiltype}templatepredefinedfields", 'unicity');
@@ -371,7 +371,7 @@ function update94xto950()
          INDEX `date_creation` (`date_creation`),
          INDEX `is_private` (`is_private`)
       ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
-        $DB->doQueryOrDie($query, "add table glpi_itilfollowuptemplates");
+        $DB->doQuery($query);
     }
     /** /add templates for followups */
 
@@ -425,7 +425,7 @@ function update94xto950()
         foreach ($elements_to_fix as $data) {
             $data['picture_front'] = $fix_picture_fct($data['picture_front']);
             $data['picture_rear']  = $fix_picture_fct($data['picture_rear']);
-            $DB->updateOrDie($table, $data, ['id' => $data['id']]);
+            $DB->update($table, $data, ['id' => $data['id']]);
         }
     }
 
@@ -440,7 +440,7 @@ function update94xto950()
     );
     foreach ($elements_to_fix as $data) {
         $data['blueprint'] = $fix_picture_fct($data['blueprint']);
-        $DB->updateOrDie('glpi_dcrooms', $data, ['id' => $data['id']]);
+        $DB->update('glpi_dcrooms', $data, ['id' => $data['id']]);
     }
     /** /Make datacenter pictures path relative */
 
@@ -500,7 +500,7 @@ function update94xto950()
          KEY `date_mod` (`date_mod`),
          KEY `date_creation` (`date_creation`)
        ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
-        $DB->doQueryOrDie($query, "add table glpi_planningexternalevents");
+        $DB->doQuery($query);
 
         $new_rights = ALLSTANDARDRIGHT + PlanningExternalEvent::MANAGE_BG_EVENTS;
         $migration->addRight('externalevent', $new_rights, [
@@ -541,7 +541,7 @@ function update94xto950()
          KEY `date_mod` (`date_mod`),
          KEY `date_creation` (`date_creation`)
        ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;";
-        $DB->doQueryOrDie($query, "add table glpi_planningeventcategories");
+        $DB->doQuery($query);
     }
 
    // partial update (for developers)
@@ -573,7 +573,7 @@ function update94xto950()
          KEY `date_mod` (`date_mod`),
          KEY `date_creation` (`date_creation`)
        ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
-        $DB->doQueryOrDie($query, "add table glpi_planningexternaleventtemplates");
+        $DB->doQuery($query);
     }
     /** /Add Externals events for planning */
 
@@ -745,7 +745,7 @@ function update94xto950()
          KEY `source_asset` (`itemtype_source`, `items_id_source`),
          KEY `impacted_asset` (`itemtype_impacted`, `items_id_impacted`)
          ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
-        $DB->doQueryOrDie($query, "add table glpi_impacts");
+        $DB->doQuery($query);
     }
 
    // Impact compounds
@@ -756,7 +756,7 @@ function update94xto950()
             `color` VARCHAR(255) NOT NULL DEFAULT '' COLLATE 'utf8_unicode_ci',
             PRIMARY KEY (`id`)
          ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
-        $DB->doQueryOrDie($query, "add table glpi_impacts_compounds");
+        $DB->doQuery($query);
     }
 
    // Impact parents
@@ -785,7 +785,7 @@ function update94xto950()
             KEY `source` (`itemtype`, `items_id`),
             KEY `parent_id` (`parent_id`)
          ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
-        $DB->doQueryOrDie($query, "add table glpi_impacts_parent");
+        $DB->doQuery($query);
     }
     /** /Impact analysis */
 
@@ -845,7 +845,7 @@ function update94xto950()
 
     /** Add Apple File System (All Apple devices since 2017) */
     if (countElementsInTable('glpi_filesystems', ['name' => 'APFS']) === 0) {
-        $DB->insertOrDie('glpi_filesystems', [
+        $DB->insert('glpi_filesystems', [
             'name'   => 'APFS'
         ]);
     }
@@ -868,7 +868,7 @@ function update94xto950()
          PRIMARY KEY (`id`),
          UNIQUE KEY `unicity` (`itemtype`,`items_id`,`users_id`)
       ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
-        $DB->doQueryOrDie($query, "add table glpi_kanbans");
+        $DB->doQuery($query);
     }
     if (!$DB->fieldExists('glpi_users', 'refresh_views')) {
         $migration->changeField('glpi_users', 'refresh_ticket_list', 'refresh_views', 'int DEFAULT NULL');
@@ -932,7 +932,7 @@ function update94xto950()
             KEY `date_mod` (`date_mod`),
             KEY `date_creation` (`date_creation`)
          ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
-        $DB->doQueryOrDie($query, "add table glpi_vobjects");
+        $DB->doQuery($query);
     }
     /** /Add glpi_vobjects table for CalDAV server */
 
@@ -966,7 +966,7 @@ function update94xto950()
          PRIMARY KEY (`id`),
          UNIQUE KEY `key` (`key`)
       ) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;";
-        $DB->doQueryOrDie($query, "add table glpi_dashboards_dashboards");
+        $DB->doQuery($query);
     }
     if (!$DB->tableExists('glpi_dashboards_items')) {
         $query = "CREATE TABLE `glpi_dashboards_items` (
@@ -982,7 +982,7 @@ function update94xto950()
         PRIMARY KEY (`id`),
         KEY `dashboards_dashboards_id` (`dashboards_dashboards_id`)
       ) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
-        $DB->doQueryOrDie($query, "add table glpi_dashboards_items");
+        $DB->doQuery($query);
     }
     if (!$DB->tableExists('glpi_dashboards_rights')) {
         $query = "CREATE TABLE `glpi_dashboards_rights` (
@@ -994,7 +994,7 @@ function update94xto950()
          KEY `dashboards_dashboards_id` (`dashboards_dashboards_id`),
          UNIQUE KEY `unicity` (`dashboards_dashboards_id`, `itemtype`,`items_id`)
        ) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
-        $DB->doQueryOrDie($query, "add table glpi_dashboards_rights");
+        $DB->doQuery($query);
     }
 
    // migration from previous development versions
@@ -1089,7 +1089,7 @@ function update94xto950()
             PRIMARY KEY (`id`),
             KEY `name` (`name`)
          ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
-        $DB->doQueryOrDie($query, "add table glpi_domaintypes");
+        $DB->doQuery($query);
     }
 
     $dfields = [
@@ -1131,7 +1131,7 @@ function update94xto950()
             KEY `FK_device` (`items_id`, `itemtype`),
             KEY `item` (`itemtype`, `items_id`)
          ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
-        $DB->doQueryOrDie($query, "add table glpi_domains_items");
+        $DB->doQuery($query);
     }
 
     foreach (['Computer', 'NetworkEquipment', 'Printer'] as $itemtype) {
@@ -1145,7 +1145,7 @@ function update94xto950()
                  //migrate existing data
                  $migration->migrationOneTable('glpi_domains_items');
                 foreach ($iterator as $row) {
-                    $DB->insertOrDie("glpi_domains_items", [
+                    $DB->insert("glpi_domains_items", [
                         'domains_id'   => $row['domains_id'],
                         'itemtype'     => $itemtype,
                         'items_id'     => $row['id']
@@ -1210,7 +1210,7 @@ function update94xto950()
             PRIMARY KEY (`id`),
             KEY `name` (`name`)
          ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
-        $DB->doQueryOrDie($query, "add table glpi_domainrelations");
+        $DB->doQuery($query);
         $relations = DomainRelation::getDefaults();
         foreach ($relations as $relation) {
             $migration->addPostQuery(
@@ -1239,7 +1239,7 @@ function update94xto950()
             PRIMARY KEY (`id`),
             KEY `name` (`name`)
          ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
-        $DB->doQueryOrDie($query, "add table glpi_domainrecordtypes");
+        $DB->doQuery($query);
         $types = DomainRecordType::getDefaults();
         foreach ($types as $type) {
             unset($type['fields']); // This field was not present before GLPI 10.0
@@ -1279,7 +1279,7 @@ function update94xto950()
             KEY `is_deleted` (`is_deleted`),
             KEY `date_creation` (`date_creation`)
          ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
-        $DB->doQueryOrDie($query, "add table glpi_domainrecords");
+        $DB->doQuery($query);
     }
 
     if ($DB->fieldExists('glpi_domainrecords', 'status')) {
@@ -1290,18 +1290,17 @@ function update94xto950()
 
     /** Domains expiration notifications */
     if (countElementsInTable('glpi_notifications', ['itemtype' => 'Domain']) === 0) {
-        $DB->insertOrDie(
+        $DB->insert(
             'glpi_notificationtemplates',
             [
                 'name'            => 'Alert domains',
                 'itemtype'        => 'Domain',
                 'date_mod'        => new QueryExpression('NOW()'),
-            ],
-            'Add domains expiration notification template'
+            ]
         );
         $notificationtemplate_id = $DB->insertId();
 
-        $DB->insertOrDie(
+        $DB->insert(
             'glpi_notificationtemplatetranslations',
             [
                 'notificationtemplates_id' => $notificationtemplate_id,
@@ -1321,8 +1320,7 @@ PLAINTEXT
 ##ENDFOREACHdomains##&lt;/p&gt;
 HTML
             ,
-            ],
-            'Add domains expiration notification template translations'
+            ]
         );
 
         $notifications_data = [
@@ -1336,7 +1334,7 @@ HTML
             ]
         ];
         foreach ($notifications_data as $notification_data) {
-            $DB->insertOrDie(
+            $DB->insert(
                 'glpi_notifications',
                 [
                     'name'            => $notification_data['name'],
@@ -1348,39 +1346,35 @@ HTML
                     'is_active'       => 1,
                     'date_creation'   => new QueryExpression('NOW()'),
                     'date_mod'        => new QueryExpression('NOW()'),
-                ],
-                'Add domains expiration notification'
+                ]
             );
             $notification_id = $DB->insertId();
 
-            $DB->insertOrDie(
+            $DB->insert(
                 'glpi_notifications_notificationtemplates',
                 [
                     'notifications_id'         => $notification_id,
                     'mode'                     => Notification_NotificationTemplate::MODE_MAIL,
                     'notificationtemplates_id' => $notificationtemplate_id,
-                ],
-                'Add domains expiration notification template instance'
+                ]
             );
 
-            $DB->insertOrDie(
+            $DB->insert(
                 'glpi_notificationtargets',
                 [
                     'items_id'         => Notification::ITEM_TECH_IN_CHARGE,
                     'type'             => 1,
                     'notifications_id' => $notification_id,
-                ],
-                'Add domains expiration notification targets'
+                ]
             );
 
-            $DB->insertOrDie(
+            $DB->insert(
                 'glpi_notificationtargets',
                 [
                     'items_id'         => Notification::ITEM_TECH_GROUP_IN_CHARGE,
                     'type'             => 1,
                     'notifications_id' => $notification_id,
-                ],
-                'Add domains expiration notification targets'
+                ]
             );
         }
     }
@@ -1404,7 +1398,7 @@ HTML
             `max_depth` INT NOT NULL DEFAULT '5',
             PRIMARY KEY (`id`)
          ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
-        $DB->doQueryOrDie($query, "add table glpi_impactcontexts");
+        $DB->doQuery($query);
 
        // Update glpi_impactitems
         $migration->dropField("glpi_impactitems", "zoom");
@@ -1506,7 +1500,7 @@ HTML
         ]
     );
     if ($passwordexpires_notif_count === 0) {
-        $DB->insertOrDie(
+        $DB->insert(
             'glpi_notifications',
             [
                 'name'            => 'Password expires alert',
@@ -1518,43 +1512,39 @@ HTML
                 'is_active'       => 1,
                 'date_creation'   => new QueryExpression('NOW()'),
                 'date_mod'        => new QueryExpression('NOW()'),
-            ],
-            'Add password expires notification'
+            ]
         );
         $notification_id = $DB->insertId();
 
-        $DB->insertOrDie(
+        $DB->insert(
             'glpi_notificationtemplates',
             [
                 'name'            => 'Password expires alert',
                 'itemtype'        => 'User',
                 'date_mod'        => new QueryExpression('NOW()'),
-            ],
-            'Add password expires notification template'
+            ]
         );
         $notificationtemplate_id = $DB->insertId();
 
-        $DB->insertOrDie(
+        $DB->insert(
             'glpi_notifications_notificationtemplates',
             [
                 'notifications_id'         => $notification_id,
                 'mode'                     => Notification_NotificationTemplate::MODE_MAIL,
                 'notificationtemplates_id' => $notificationtemplate_id,
-            ],
-            'Add password expires notification template instance'
+            ]
         );
 
-        $DB->insertOrDie(
+        $DB->insert(
             'glpi_notificationtargets',
             [
                 'items_id'         => 19,
                 'type'             => 1,
                 'notifications_id' => $notification_id,
-            ],
-            'Add password expires notification targets'
+            ]
         );
 
-        $DB->insertOrDie(
+        $DB->insert(
             'glpi_notificationtemplatetranslations',
             [
                 'notificationtemplates_id' => $notificationtemplate_id,
@@ -1594,8 +1584,7 @@ PLAINTEXT
 &lt;p&gt;##lang.password.update.link## &lt;a href="##user.password.update.url##"&gt;##user.password.update.url##&lt;/a&gt;&lt;/p&gt;
 HTML
             ,
-            ],
-            'Add password expires notification template translations'
+            ]
         );
     }
     CronTask::Register(
@@ -1628,18 +1617,17 @@ HTML
             'itemtype' => 'Glpi\Marketplace\Controller'
         ]) === 0
     ) {
-        $DB->insertOrDie(
+        $DB->insert(
             'glpi_notificationtemplates',
             [
                 'name'            => 'Plugin updates',
                 'itemtype'        => 'Glpi\Marketplace\Controller',
                 'date_mod'        => new QueryExpression('NOW()'),
-            ],
-            'Add plugins updates notification template'
+            ]
         );
         $notificationtemplate_id = $DB->insertId();
 
-        $DB->insertOrDie(
+        $DB->insert(
             'glpi_notificationtemplatetranslations',
             [
                 'notificationtemplates_id' => $notificationtemplate_id,
@@ -1660,11 +1648,10 @@ PLAINTEXT
 ##ENDFOREACHplugins##&lt;/ul&gt;
 HTML
             ,
-            ],
-            'Add plugins updates notification template translations'
+            ]
         );
 
-        $DB->insertOrDie(
+        $DB->insert(
             'glpi_notifications',
             [
                 'name'            => 'Check plugin updates',
@@ -1676,29 +1663,26 @@ HTML
                 'is_active'       => 1,
                 'date_creation'   => new QueryExpression('NOW()'),
                 'date_mod'        => new QueryExpression('NOW()'),
-            ],
-            'Add plugins updates notification'
+            ]
         );
         $notification_id = $DB->insertId();
 
-        $DB->insertOrDie(
+        $DB->insert(
             'glpi_notifications_notificationtemplates',
             [
                 'notifications_id'         => $notification_id,
                 'mode'                     => Notification_NotificationTemplate::MODE_MAIL,
                 'notificationtemplates_id' => $notificationtemplate_id,
-            ],
-            'Add plugins updates notification template instance'
+            ]
         );
 
-        $DB->insertOrDie(
+        $DB->insert(
             'glpi_notificationtargets',
             [
                 'items_id'         => Notification::GLOBAL_ADMINISTRATOR,
                 'type'             => 1,
                 'notifications_id' => $notification_id,
-            ],
-            'Add domains expiration notification targets'
+            ]
         );
     }
     /** /Marketplace */
@@ -1775,26 +1759,24 @@ HTML
         ) {
            // rule matches previous default rule (same criteria and actions)
            // so we can replace criteria
-            $DB->deleteOrDie('glpi_rulecriterias', ['rules_id' => $rule->fields['id']]);
-            $DB->insertOrDie(
+            $DB->delete('glpi_rulecriterias', ['rules_id' => $rule->fields['id']]);
+            $DB->insert(
                 'glpi_rulecriterias',
                 [
                     'rules_id'  => $rule->fields['id'],
                     'criteria'  => 'TYPE',
                     'condition' => 0,
                     'pattern'   => Auth::LDAP,
-                ],
-                'Update default right assignement rule'
+                ]
             );
-            $DB->insertOrDie(
+            $DB->insert(
                 'glpi_rulecriterias',
                 [
                     'rules_id'  => $rule->fields['id'],
                     'criteria'  => 'TYPE',
                     'condition' => 0,
                     'pattern'   => Auth::MAIL,
-                ],
-                'Update default right assignement rule'
+                ]
             );
         }
     }
@@ -1835,7 +1817,7 @@ HTML
          KEY `states_id` (`states_id`),
          KEY `manufacturers_id` (`manufacturers_id`)
        ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;";
-        $DB->doQueryOrDie($query, "add table glpi_passivedcequipments");
+        $DB->doQuery($query);
     }
     if (!$DB->tableExists('glpi_passivedcequipmentmodels')) {
         $query = "CREATE TABLE `glpi_passivedcequipmentmodels` (
@@ -1859,7 +1841,7 @@ HTML
          KEY `date_creation` (`date_creation`),
          KEY `product_number` (`product_number`)
        ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;";
-        $DB->doQueryOrDie($query, "add table glpi_passivedcequipmentmodels");
+        $DB->doQuery($query);
     }
     if (!$DB->tableExists('glpi_passivedcequipmenttypes')) {
         $query = "CREATE TABLE `glpi_passivedcequipmenttypes` (
@@ -1873,7 +1855,7 @@ HTML
          KEY `date_mod` (`date_mod`),
          KEY `date_creation` (`date_creation`)
        ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;";
-        $DB->doQueryOrDie($query, "add table glpi_passivedcequipmenttypes");
+        $DB->doQuery($query);
     }
     if (!$DB->fieldExists('glpi_states', 'is_visible_passivedcequipment')) {
         $migration->addField('glpi_states', 'is_visible_passivedcequipment', 'bool', [
@@ -1939,7 +1921,7 @@ HTML
                  KEY `item` (`reminders_id`,`language`),
                  KEY `users_id` (`users_id`)
                ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;";
-        $DB->doQueryOrDie($query, "add table glpi_remindertranslations");
+        $DB->doQuery($query);
     }
     /**  Reminders translations */
 

--- a/install/migrations/update_9.4.x_to_9.5.0/appliances.php
+++ b/install/migrations/update_9.4.x_to_9.5.0/appliances.php
@@ -78,7 +78,7 @@ if (!$DB->tableExists('glpi_appliances')) {
          KEY `serial` (`serial`),
          KEY `otherserial` (`otherserial`)
       ) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;";
-    $DB->doQueryOrDie($query, "9.5 add table glpi_appliances");
+    $DB->doQuery($query);
 }
 
 if (!$DB->tableExists('glpi_appliances_items')) {
@@ -92,7 +92,7 @@ if (!$DB->tableExists('glpi_appliances_items')) {
          KEY `appliances_id` (`appliances_id`),
          KEY `item` (`itemtype`,`items_id`)
       ) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;";
-    $DB->doQueryOrDie($query, "9.5 add table glpi_appliances_items");
+    $DB->doQuery($query);
 }
 
 if (!$DB->tableExists('glpi_appliancetypes')) {
@@ -108,7 +108,7 @@ if (!$DB->tableExists('glpi_appliancetypes')) {
          KEY `entities_id` (`entities_id`),
          UNIQUE (`externalidentifier`)
       ) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;";
-    $DB->doQueryOrDie($query, "9.5 add table glpi_appliancetypes");
+    $DB->doQuery($query);
 }
 
 if (!$DB->tableExists('glpi_applianceenvironments')) {
@@ -119,7 +119,7 @@ if (!$DB->tableExists('glpi_applianceenvironments')) {
          PRIMARY KEY (`id`),
          KEY `name` (`name`)
       ) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;";
-    $DB->doQueryOrDie($query, "9.5 add table glpi_applianceenvironments");
+    $DB->doQuery($query);
 }
 
 if (!$DB->tableExists('glpi_appliancerelations')) {
@@ -131,7 +131,7 @@ if (!$DB->tableExists('glpi_appliancerelations')) {
          KEY `appliances_items_id` (`appliances_items_id`),
          KEY `relations_id` (`relations_id`)
       ) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;";
-    $DB->doQueryOrDie($query, "9.5 add table glpi_appliancerelations");
+    $DB->doQuery($query);
 }
 
 $migration->addRight('appliance', ALLSTANDARDRIGHT);

--- a/install/migrations/update_9.5.1_to_9.5.2.php
+++ b/install/migrations/update_9.5.1_to_9.5.2.php
@@ -132,7 +132,7 @@ function update951to952()
         if (countElementsInTable('glpi_documents_items', $unicity_fields) > 0) {
             continue; // Already declared in DB
         }
-        $DB->insertOrDie('glpi_documents_items', $doc_input);
+        $DB->insert('glpi_documents_items', $doc_input);
     }
     /* /Fix document_item migration */
 

--- a/install/migrations/update_9.5.3_to_9.5.4.php
+++ b/install/migrations/update_9.5.3_to_9.5.4.php
@@ -53,7 +53,7 @@ function update953to954()
     $migration->setVersion('9.5.4');
 
    /* Remove invalid Profile SO */
-    $DB->deleteOrDie('glpi_displaypreferences', ['itemtype' => 'Profile', 'num' => 62]);
+    $DB->delete('glpi_displaypreferences', ['itemtype' => 'Profile', 'num' => 62]);
    /* /Remove invalid Profile SO */
 
    /* Add is_default_profile */

--- a/install/migrations/update_9.5.x_to_10.0.0.php
+++ b/install/migrations/update_9.5.x_to_10.0.0.php
@@ -81,7 +81,7 @@ function update95xto1000()
         }
     }
     foreach ($DELFROMDISPLAYPREF as $type => $tab) {
-        $DB->deleteOrDie(
+        $DB->delete(
             'glpi_displaypreferences',
             [
                 'itemtype'  => $type,

--- a/install/migrations/update_9.5.x_to_10.0.0/cable.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/cable.php
@@ -56,7 +56,7 @@ if (!$DB->tableExists('glpi_cabletypes')) {
       KEY `date_mod` (`date_mod`),
       KEY `date_creation` (`date_creation`)
     ) ENGINE=InnoDB DEFAULT CHARSET = {$default_charset} COLLATE = {$default_collation} ROW_FORMAT=DYNAMIC;";
-    $DB->doQueryOrDie($query, "10.0 add table glpi_cabletypes");
+    $DB->doQuery($query);
 }
 
 if (!$DB->tableExists('glpi_cablestrands')) {
@@ -71,7 +71,7 @@ if (!$DB->tableExists('glpi_cablestrands')) {
       KEY `date_mod` (`date_mod`),
       KEY `date_creation` (`date_creation`)
     ) ENGINE=InnoDB DEFAULT CHARSET = {$default_charset} COLLATE = {$default_collation} ROW_FORMAT=DYNAMIC;";
-    $DB->doQueryOrDie($query, "10.0 add table glpi_cablestrands");
+    $DB->doQuery($query);
 }
 
 if (!$DB->tableExists('glpi_socketmodels')) {
@@ -86,7 +86,7 @@ if (!$DB->tableExists('glpi_socketmodels')) {
       KEY `date_mod` (`date_mod`),
       KEY `date_creation` (`date_creation`)
     ) ENGINE=InnoDB DEFAULT CHARSET= {$default_charset} COLLATE = {$default_collation} ROW_FORMAT=DYNAMIC;";
-    $DB->doQueryOrDie($query, "10.0 add table glpi_socketmodels");
+    $DB->doQuery($query);
 }
 
 if (!$DB->tableExists('glpi_cables')) {
@@ -131,7 +131,7 @@ if (!$DB->tableExists('glpi_cables')) {
       KEY `date_mod` (`date_mod`),
       KEY `date_creation` (`date_creation`)
     ) ENGINE=InnoDB DEFAULT CHARSET = {$default_charset} COLLATE = {$default_collation} ROW_FORMAT=DYNAMIC;";
-    $DB->doQueryOrDie($query, "10.0 add table glpi_cables");
+    $DB->doQuery($query);
 }
 $migration->addField('glpi_states', 'is_visible_cable', 'bool', [
     'value' => 1,
@@ -164,7 +164,7 @@ if (!$DB->tableExists('glpi_sockets')) {
       KEY `date_mod` (`date_mod`),
       KEY `date_creation` (`date_creation`)
     ) ENGINE=InnoDB DEFAULT CHARSET = {$default_charset} COLLATE = {$default_collation} ROW_FORMAT=DYNAMIC;";
-    $DB->doQueryOrDie($query, "10.0 add table glpi_sockets");
+    $DB->doQuery($query);
 }
 
 if ($DB->tableExists('glpi_netpoints')) {
@@ -243,7 +243,7 @@ if (!$DB->tableExists('glpi_networkportfiberchanneltypes')) {
       KEY `date_mod` (`date_mod`),
       KEY `date_creation` (`date_creation`)
       ) ENGINE = InnoDB DEFAULT CHARSET = {$default_charset} COLLATE = {$default_collation} ROW_FORMAT=DYNAMIC;";
-    $DB->doQueryOrDie($query, "10.0 add table glpi_networkportfiberchanneltypes");
+    $DB->doQuery($query);
 }
 
 $migration->addField('glpi_networkportfiberchannels', 'networkportfiberchanneltypes_id', "int {$default_key_sign} NOT NULL DEFAULT '0'", ['after' => 'items_devicenetworkcards_id']);

--- a/install/migrations/update_9.5.x_to_10.0.0/cache.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/cache.php
@@ -40,11 +40,11 @@
 
 $had_custom_config = false;
 if (countElementsInTable('glpi_configs', ['name' => 'cache_db', 'context' => 'core'])) {
-    $DB->deleteOrDie('glpi_configs', ['name' => 'cache_db', 'context' => 'core']);
+    $DB->delete('glpi_configs', ['name' => 'cache_db', 'context' => 'core']);
     $had_custom_config = true;
 }
 if (countElementsInTable('glpi_configs', ['name' => 'cache_trans', 'context' => 'core'])) {
-    $DB->deleteOrDie('glpi_configs', ['name' => 'cache_trans', 'context' => 'core']);
+    $DB->delete('glpi_configs', ['name' => 'cache_trans', 'context' => 'core']);
     $had_custom_config = true;
 }
 

--- a/install/migrations/update_9.5.x_to_10.0.0/cameras.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/cameras.php
@@ -68,7 +68,7 @@ if (!$DB->tableExists('glpi_devicecameras')) {
       KEY `date_mod` (`date_mod`),
       KEY `date_creation` (`date_creation`)
       ) ENGINE = InnoDB ROW_FORMAT = DYNAMIC DEFAULT CHARSET = {$default_charset} COLLATE = {$default_collation};";
-    $DB->doQueryOrDie($query, "10.0 add table glpi_devicecameras");
+    $DB->doQuery($query);
 } else {
     $migration->dropKey('glpi_devicecameras', 'unicity');
     $migration->addKey('glpi_devicecameras', 'manufacturers_id', 'manufacturers_id');
@@ -84,7 +84,7 @@ if (!$DB->tableExists('glpi_devicecameramodels')) {
       KEY `name` (`name`),
       KEY `product_number` (`product_number`)
       ) ENGINE = InnoDB ROW_FORMAT = DYNAMIC DEFAULT CHARSET = {$default_charset} COLLATE = {$default_collation};";
-    $DB->doQueryOrDie($query, "10.0 add table glpi_devicecameramodels");
+    $DB->doQuery($query);
 }
 
 if (!$DB->tableExists('glpi_imageformats')) {
@@ -103,7 +103,7 @@ if (!$DB->tableExists('glpi_imageformats')) {
       KEY `is_recursive` (`is_recursive`),
       KEY `date_creation` (`date_creation`)
       ) ENGINE = InnoDB ROW_FORMAT = DYNAMIC DEFAULT CHARSET = {$default_charset} COLLATE = {$default_collation};";
-    $DB->doQueryOrDie($query, "10.0 add table glpi_imageformats");
+    $DB->doQuery($query);
 }
 
 if (!$DB->tableExists('glpi_imageresolutions')) {
@@ -124,7 +124,7 @@ if (!$DB->tableExists('glpi_imageresolutions')) {
       KEY `is_recursive` (`is_recursive`),
       KEY `date_creation` (`date_creation`)
       ) ENGINE = InnoDB ROW_FORMAT = DYNAMIC DEFAULT CHARSET = {$default_charset} COLLATE = {$default_collation};";
-    $DB->doQueryOrDie($query, "10.0 add table glpi_imageresolutions");
+    $DB->doQuery($query);
 }
 
 if (!$DB->tableExists('glpi_items_devicecameras')) {
@@ -146,7 +146,7 @@ if (!$DB->tableExists('glpi_items_devicecameras')) {
       KEY `is_recursive` (`is_recursive`),
       KEY `item` (`itemtype`,`items_id`)
       ) ENGINE = InnoDB ROW_FORMAT = DYNAMIC DEFAULT CHARSET = {$default_charset} COLLATE = {$default_collation};";
-    $DB->doQueryOrDie($query, "10.0 add table glpi_items_devicecameras");
+    $DB->doQuery($query);
 }
 
 if (!$DB->tableExists('glpi_items_devicecameras_imageformats')) {
@@ -160,7 +160,7 @@ if (!$DB->tableExists('glpi_items_devicecameras_imageformats')) {
       KEY `imageformats_id` (`imageformats_id`),
       KEY `is_dynamic` (`is_dynamic`)
    ) ENGINE = InnoDB ROW_FORMAT = DYNAMIC DEFAULT CHARSET = {$default_charset} COLLATE = {$default_collation};";
-    $DB->doQueryOrDie($query, "10.0 add table glpi_items_devicecameras_imageformats");
+    $DB->doQuery($query);
 }
 
 if (!$DB->tableExists('glpi_items_devicecameras_imageresolutions')) {
@@ -174,5 +174,5 @@ if (!$DB->tableExists('glpi_items_devicecameras_imageresolutions')) {
       KEY `imageresolutions_id` (`imageresolutions_id`),
       KEY `is_dynamic` (`is_dynamic`)
    ) ENGINE = InnoDB ROW_FORMAT = DYNAMIC DEFAULT CHARSET = {$default_charset} COLLATE = {$default_collation};";
-    $DB->doQueryOrDie($query, "10.0 add table glpi_items_devicecameras_imageresolutions");
+    $DB->doQuery($query);
 }

--- a/install/migrations/update_9.5.x_to_10.0.0/dashboard_filters.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/dashboard_filters.php
@@ -55,5 +55,5 @@ if (!$DB->tableExists('glpi_dashboards_filters')) {
          KEY `dashboards_dashboards_id` (`dashboards_dashboards_id`),
          KEY `users_id` (`users_id`)
       ) ENGINE = InnoDB ROW_FORMAT = DYNAMIC DEFAULT CHARSET = {$default_charset} COLLATE = {$default_collation};";
-    $DB->doQueryOrDie($query, "10.0 add table glpi_dashboards_filters");
+    $DB->doQuery($query);
 }

--- a/install/migrations/update_9.5.x_to_10.0.0/databases.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/databases.php
@@ -55,7 +55,7 @@ if (!$DB->tableExists('glpi_databaseinstancetypes')) {
          KEY `date_mod` (`date_mod`),
          KEY `date_creation` (`date_creation`)
       ) ENGINE = InnoDB ROW_FORMAT = DYNAMIC DEFAULT CHARSET = {$default_charset} COLLATE = {$default_collation};";
-    $DB->doQueryOrDie($query, "10.0 add table glpi_databaseinstancetypes");
+    $DB->doQuery($query);
 }
 
 if (!$DB->tableExists('glpi_databaseinstancecategories')) {
@@ -70,7 +70,7 @@ if (!$DB->tableExists('glpi_databaseinstancecategories')) {
          KEY `date_mod` (`date_mod`),
          KEY `date_creation` (`date_creation`)
       ) ENGINE = InnoDB ROW_FORMAT = DYNAMIC DEFAULT CHARSET = {$default_charset} COLLATE = {$default_collation};";
-    $DB->doQueryOrDie($query, "10.0 add table glpi_databaseinstancecategoriess");
+    $DB->doQuery($query);
 }
 
 if (!$DB->tableExists('glpi_databaseinstances')) {
@@ -121,7 +121,7 @@ if (!$DB->tableExists('glpi_databaseinstances')) {
          KEY `is_helpdesk_visible` (`is_helpdesk_visible`),
          KEY `is_dynamic` (`is_dynamic`)
       ) ENGINE = InnoDB ROW_FORMAT = DYNAMIC DEFAULT CHARSET = {$default_charset} COLLATE = {$default_collation};";
-    $DB->doQueryOrDie($query, "10.0 add table glpi_databaseinstances");
+    $DB->doQuery($query);
 }
 
 // Create glpi_databaseinstances itemtype/items_id if they are not existing (datamodel changed during v10.0 development)
@@ -168,7 +168,7 @@ if (!$DB->tableExists('glpi_databases')) {
          KEY `date_mod` (`date_mod`),
          KEY `databaseinstances_id` (`databaseinstances_id`)
       ) ENGINE = InnoDB ROW_FORMAT = DYNAMIC DEFAULT CHARSET = {$default_charset} COLLATE = {$default_collation};";
-    $DB->doQueryOrDie($query, "10.0 add table glpi_databases");
+    $DB->doQuery($query);
 }
 
 if ($DB->fieldExists('glpi_states', 'is_visible_database')) {

--- a/install/migrations/update_9.5.x_to_10.0.0/entity.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/entity.php
@@ -58,11 +58,11 @@ if (!$DB->fieldExists("glpi_entities", "registration_number")) {
 /** Replace -1 value for entities_id field */
 // Replace -1 value for root entity to be able to change type to unsigned.
 // Use max int signed value of mysql to be fairly certain not to be blocked because of the uniqueness key.
-$DB->updateOrDie('glpi_entities', ['entities_id' => pow(2, 31) - 1], ['id' => '0']);
+$DB->update('glpi_entities', ['entities_id' => pow(2, 31) - 1], ['id' => '0']);
 
 $migration->changeField('glpi_entities', 'entities_id', 'entities_id', "int {$default_key_sign} DEFAULT '0'");
 $migration->migrationOneTable('glpi_entities'); // Ensure 'entities_id' is nullable.
-$DB->updateOrDie('glpi_entities', ['entities_id' => 'NULL'], ['id' => '0']);
+$DB->update('glpi_entities', ['entities_id' => 'NULL'], ['id' => '0']);
 /** /Replace -1 value for entities_id field */
 
 /** Replace negative values for config foreign keys */
@@ -93,7 +93,7 @@ foreach ($fkey_config_fields as $fkey_config_field) {
 
         if ($DB->fieldExists('glpi_entities', $fkey_config_field)) {
             // 'contracts_id_default' and 'transfers_id' fields will only exist if a previous dev install exists
-            $DB->updateOrDie(
+            $DB->update(
                 'glpi_entities',
                 [
                     // Put negative values (-10[never]/ -2[inherit]/ -1[auto]) in strategy field

--- a/install/migrations/update_9.5.x_to_10.0.0/gantt.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/gantt.php
@@ -56,5 +56,5 @@ if (!$DB->tableExists('glpi_projecttasklinks')) {
        KEY `projecttasks_id_source` (`projecttasks_id_source`),
        KEY `projecttasks_id_target` (`projecttasks_id_target`)
       ) ENGINE = InnoDB ROW_FORMAT = DYNAMIC DEFAULT CHARSET = {$default_charset} COLLATE = {$default_collation};";
-    $DB->doQueryOrDie($query, "Adding table glpi_projecttasklinks");
+    $DB->doQuery($query);
 }

--- a/install/migrations/update_9.5.x_to_10.0.0/inventory_management.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/inventory_management.php
@@ -53,5 +53,5 @@ if (!$DB->tableExists('glpi_items_remotemanagements')) {
          KEY `is_dynamic` (`is_dynamic`),
          KEY `item` (`itemtype`,`items_id`)
       ) ENGINE = InnoDB ROW_FORMAT = DYNAMIC DEFAULT CHARSET = {$default_charset} COLLATE = {$default_collation};";
-    $DB->doQueryOrDie($query, "10.0 add table glpi_items_remotemanagements");
+    $DB->doQuery($query);
 }

--- a/install/migrations/update_9.5.x_to_10.0.0/knowbaseitem_knowbaseitemcategory.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/knowbaseitem_knowbaseitemcategory.php
@@ -52,7 +52,7 @@ if (!$DB->tableExists('glpi_knowbaseitems_knowbaseitemcategories')) {
       KEY `knowbaseitems_id` (`knowbaseitems_id`),
       KEY `knowbaseitemcategories_id` (`knowbaseitemcategories_id`)
       ) ENGINE = InnoDB ROW_FORMAT = DYNAMIC DEFAULT CHARSET = {$default_charset} COLLATE = {$default_collation};";
-    $DB->doQueryOrDie($query, "add table glpi_knowbaseitems_knowbaseitemcategories");
+    $DB->doQuery($query);
 }
 
 if ($DB->fieldExists('glpi_knowbaseitems', 'knowbaseitemcategories_id')) {
@@ -64,7 +64,7 @@ if ($DB->fieldExists('glpi_knowbaseitems', 'knowbaseitemcategories_id')) {
     if (count($iterator)) {
        //migrate existing data
         foreach ($iterator as $row) {
-            $DB->insertOrDie("glpi_knowbaseitems_knowbaseitemcategories", [
+            $DB->insert("glpi_knowbaseitems_knowbaseitemcategories", [
                 'knowbaseitemcategories_id'   => $row['knowbaseitemcategories_id'],
                 'knowbaseitems_id'            => $row['id']
             ]);

--- a/install/migrations/update_9.5.x_to_10.0.0/manuallinks.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/manuallinks.php
@@ -59,5 +59,5 @@ if (!$DB->tableExists('glpi_manuallinks')) {
       KEY `date_creation` (`date_creation`),
       KEY `date_mod` (`date_mod`)
       ) ENGINE = InnoDB ROW_FORMAT = DYNAMIC DEFAULT CHARSET = {$default_charset} COLLATE = {$default_collation};";
-    $DB->doQueryOrDie($query, "10.0 add table glpi_manuallinks");
+    $DB->doQuery($query);
 }

--- a/install/migrations/update_9.5.x_to_10.0.0/native_inventory.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/native_inventory.php
@@ -55,7 +55,7 @@ if (!$DB->tableExists('glpi_agenttypes')) {
          PRIMARY KEY (`id`),
          KEY `name` (`name`)
       ) ENGINE = InnoDB ROW_FORMAT = DYNAMIC DEFAULT CHARSET = {$default_charset} COLLATE = {$default_collation};";
-    $DB->doQueryOrDie($query, "10.0 add table glpi_agenttypes");
+    $DB->doQuery($query);
     $migration->addPostQuery(
         $DB->buildInsert(
             "glpi_agenttypes",
@@ -94,7 +94,7 @@ if (!$DB->tableExists('glpi_agents')) {
          UNIQUE KEY `deviceid` (`deviceid`),
          KEY `agenttypes_id` (`agenttypes_id`)
    ) ENGINE = InnoDB ROW_FORMAT = DYNAMIC DEFAULT CHARSET = {$default_charset} COLLATE = {$default_collation};";
-    $DB->doQueryOrDie($query, "10.0 add table glpi_agents");
+    $DB->doQuery($query);
 } else {
     $migration->dropKey('glpi_agents', 'items_id');
     $migration->dropKey('glpi_agents', 'itemtype');
@@ -153,7 +153,7 @@ if (!$DB->tableExists('glpi_rulematchedlogs')) {
          KEY `agents_id` (`agents_id`),
          KEY `rules_id` (`rules_id`)
       ) ENGINE = InnoDB ROW_FORMAT = DYNAMIC DEFAULT CHARSET = {$default_charset} COLLATE = {$default_collation};";
-    $DB->doQueryOrDie($query, "10.0 add table glpi_rulematchedlogs");
+    $DB->doQuery($query);
 } else {
     $migration->addKey('glpi_rulematchedlogs', 'agents_id');
     $migration->addKey('glpi_rulematchedlogs', 'rules_id');
@@ -172,7 +172,7 @@ if (!$DB->tableExists('glpi_lockedfields')) {
          UNIQUE KEY `unicity` (`itemtype`, `items_id`, `field`),
          KEY `date_creation` (`date_creation`)
       ) ENGINE = InnoDB ROW_FORMAT = DYNAMIC DEFAULT CHARSET = {$default_charset} COLLATE = {$default_collation};";
-    $DB->doQueryOrDie($query, "10.0 add table glpi_lockedfields");
+    $DB->doQuery($query);
 } else {
     $migration->dropKey('glpi_lockedfields', 'item');
     $migration->migrationOneTable('glpi_lockedfields');
@@ -385,7 +385,7 @@ if (!$DB->tableExists('glpi_unmanageds')) {
          KEY `agents_id` (`agents_id`),
          KEY `snmpcredentials_id` (`snmpcredentials_id`)
       ) ENGINE = InnoDB ROW_FORMAT = DYNAMIC DEFAULT CHARSET = {$default_charset} COLLATE = {$default_collation};";
-    $DB->doQueryOrDie($query, "10.0 add table glpi_unmanageds");
+    $DB->doQuery($query);
 } else {
     $migration->addKey('glpi_unmanageds', 'is_recursive');
 }
@@ -412,7 +412,7 @@ if (!$DB->tableExists('glpi_networkporttypes')) {
          KEY `date_mod` (`date_mod`),
          KEY `date_creation` (`date_creation`)
       ) ENGINE = InnoDB ROW_FORMAT = DYNAMIC DEFAULT CHARSET = {$default_charset} COLLATE = {$default_collation};";
-    $DB->doQueryOrDie($query, "10.0 add table glpi_networkporttypes");
+    $DB->doQuery($query);
 } else {
     $migration->addKey('glpi_networkporttypes', 'is_recursive');
 }
@@ -432,10 +432,6 @@ if (!$DB->tableExists('glpi_networkporttypes') || countElementsInTable(NetworkPo
         )
     );
     $stmt = $DB->prepare($DB->buildInsert(NetworkPortType::getTable(), $reference));
-    if (false === $stmt) {
-        $msg = "Error preparing statement in table " . NetworkPortType::getTable();
-        throw new \RuntimeException($msg);
-    }
 
     $types = str_repeat('s', count($default_types[0]));
     foreach ($default_types as $row) {
@@ -470,7 +466,7 @@ if (!$DB->tableExists('glpi_printers_cartridgeinfos')) {
          KEY `date_mod` (`date_mod`),
          KEY `date_creation` (`date_creation`)
       ) ENGINE = InnoDB ROW_FORMAT = DYNAMIC DEFAULT CHARSET = {$default_charset} COLLATE = {$default_collation};";
-    $DB->doQueryOrDie($query, "10.0 add table glpi_printers_cartridgeinfos");
+    $DB->doQuery($query);
 }
 
 if (!$DB->tableExists('glpi_printerlogs')) {
@@ -498,7 +494,7 @@ if (!$DB->tableExists('glpi_printerlogs')) {
          KEY `date_mod` (`date_mod`),
          KEY `date_creation` (`date_creation`)
       ) ENGINE = InnoDB ROW_FORMAT = DYNAMIC DEFAULT CHARSET = {$default_charset} COLLATE = {$default_collation};";
-    $DB->doQueryOrDie($query, "10.0 add table glpi_printerlogs");
+    $DB->doQuery($query);
 } else {
     foreach (['date_creation', 'date_mod'] as $date_field) {
         if (!$DB->fieldExists('glpi_printerlogs', $date_field)) {
@@ -532,7 +528,7 @@ if (!$DB->tableExists('glpi_printerlogs')) {
         );
         $to_preserve_result = $DB->doQuery($to_preserve_sql->getValue())->fetch_all(MYSQLI_ASSOC);
         if (!empty($to_preserve_result)) { // If there is no entries to preserve, it means that table is empty, and nothing has to be deleted
-            $DB->deleteOrDie(
+            $DB->delete(
                 'glpi_printerlogs',
                 [
                     'NOT' => ['id' => array_column($to_preserve_result, 'id')]
@@ -555,7 +551,7 @@ if (!$DB->tableExists('glpi_networkportconnectionlogs')) {
          KEY `networkports_id_destination` (`networkports_id_destination`),
          KEY `networkports_id_source` (`networkports_id_source`)
       ) ENGINE = InnoDB ROW_FORMAT = DYNAMIC DEFAULT CHARSET = {$default_charset} COLLATE = {$default_collation};";
-    $DB->doQueryOrDie($query, "10.0 add table glpi_networkportconnectionlogs");
+    $DB->doQuery($query);
 } else {
     $migration->addKey('glpi_networkportconnectionlogs', 'networkports_id_destination');
     $migration->addKey('glpi_networkportconnectionlogs', 'networkports_id_source');
@@ -578,7 +574,7 @@ if (!$DB->tableExists('glpi_networkportmetrics')) {
          KEY `date_mod` (`date_mod`),
          KEY `date_creation` (`date_creation`)
       ) ENGINE = InnoDB ROW_FORMAT = DYNAMIC DEFAULT CHARSET = {$default_charset} COLLATE = {$default_collation};";
-    $DB->doQueryOrDie($query, "10.0 add table glpi_networkportmetrics");
+    $DB->doQuery($query);
 } else {
     foreach (['date_creation', 'date_mod'] as $date_field) {
         if (!$DB->fieldExists('glpi_networkportmetrics', $date_field)) {
@@ -612,7 +608,7 @@ if (!$DB->tableExists('glpi_networkportmetrics')) {
         );
         $to_preserve_result = $DB->doQuery($to_preserve_sql->getValue())->fetch_all(MYSQLI_ASSOC);
         if (!empty($to_preserve_result)) { // If there is no entries to preserve, it means that table is empty, and nothing has to be deleted
-            $DB->deleteOrDie(
+            $DB->delete(
                 'glpi_networkportmetrics',
                 [
                     'NOT' => ['id' => array_column($to_preserve_result, 'id')]
@@ -647,7 +643,7 @@ if (!$DB->tableExists('glpi_refusedequipments')) {
          KEY `date_creation` (`date_creation`),
          KEY `date_mod` (`date_mod`)
       ) ENGINE = InnoDB ROW_FORMAT = DYNAMIC DEFAULT CHARSET = {$default_charset} COLLATE = {$default_collation};";
-    $DB->doQueryOrDie($query, "10.0 add table glpi_refusedequipments");
+    $DB->doQuery($query);
 } else {
     $migration->addKey('glpi_refusedequipments', 'entities_id');
     $migration->addKey('glpi_refusedequipments', 'agents_id');
@@ -709,7 +705,7 @@ if (!$DB->tableExists('glpi_usbvendors')) {
          KEY `date_mod` (`date_mod`),
          KEY `date_creation` (`date_creation`)
       ) ENGINE = InnoDB ROW_FORMAT = DYNAMIC DEFAULT CHARSET = {$default_charset} COLLATE = {$default_collation};";
-    $DB->doQueryOrDie($query, "10.0 add table glpi_usbvendors");
+    $DB->doQuery($query);
 } else {
     $migration->dropKey('glpi_usbvendors', 'vendorid');
     $migration->migrationOneTable('glpi_usbvendors');
@@ -737,7 +733,7 @@ if (!$DB->tableExists('glpi_pcivendors')) {
          KEY `date_mod` (`date_mod`),
          KEY `date_creation` (`date_creation`)
       ) ENGINE = InnoDB ROW_FORMAT = DYNAMIC DEFAULT CHARSET = {$default_charset} COLLATE = {$default_collation};";
-    $DB->doQueryOrDie($query, "10.0 add table glpi_pcivendors");
+    $DB->doQuery($query);
 } else {
     $migration->dropKey('glpi_pcivendors', 'vendorid');
     $migration->migrationOneTable('glpi_pcivendors');
@@ -762,7 +758,7 @@ if (!$DB->tableExists('glpi_snmpcredentials')) {
          KEY `snmpversion` (`snmpversion`),
          KEY `is_deleted` (`is_deleted`)
       ) ENGINE = InnoDB ROW_FORMAT = DYNAMIC DEFAULT CHARSET = {$default_charset} COLLATE = {$default_collation};";
-    $DB->doQueryOrDie($query, "10.0 add table glpi_snmpcredentials");
+    $DB->doQuery($query);
 }
 if (countElementsInTable('glpi_snmpcredentials') === 0) {
     $migration->addPostQuery(
@@ -838,10 +834,6 @@ if (countElementsInTable(Blacklist::getTable()) === 4) {
             ]
         )
     );
-    if (false === $stmt) {
-        $msg = "Error preparing statement in table " . Blacklist::getTable();
-        throw new \RuntimeException($msg);
-    }
 
     $types = 'sss';
     foreach (Blacklist::getDefaults() as $type => $values) {

--- a/install/migrations/update_9.5.x_to_10.0.0/notifications.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/notifications.php
@@ -43,7 +43,7 @@ use Glpi\DBAL\QueryExpression;
 /** User mention notification */
 $notification_exists = countElementsInTable('glpi_notifications', ['itemtype' => 'Ticket', 'event' => 'user_mention']) > 0;
 if (!$notification_exists) {
-    $DB->insertOrDie(
+    $DB->insert(
         'glpi_notifications',
         [
             'id'              => null,
@@ -56,32 +56,29 @@ if (!$notification_exists) {
             'is_active'       => 1,
             'date_creation'   => new QueryExpression('NOW()'),
             'date_mod'        => new QueryExpression('NOW()')
-        ],
-        '10.0 Add user mention notification'
+        ]
     );
     $notification_id = $DB->insertId();
 
     $notificationtemplate = new NotificationTemplate();
     if ($notificationtemplate->getFromDBByCrit(['name' => 'Tickets', 'itemtype' => 'Ticket'])) {
-        $DB->insertOrDie(
+        $DB->insert(
             'glpi_notifications_notificationtemplates',
             [
                 'notifications_id'         => $notification_id,
                 'mode'                     => Notification_NotificationTemplate::MODE_MAIL,
                 'notificationtemplates_id' => $notificationtemplate->fields['id'],
-            ],
-            '10.0 Add user mention notification template'
+            ]
         );
     }
 
-    $DB->insertOrDie(
+    $DB->insert(
         'glpi_notificationtargets',
         [
             'items_id'         => '39',
             'type'             => '1',
             'notifications_id' => $notification_id,
-        ],
-        '10.0 Add user mention notification target'
+        ]
     );
 }
 /** /User mention notification */

--- a/install/migrations/update_9.5.x_to_10.0.0/pendingreason.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/pendingreason.php
@@ -61,7 +61,7 @@ if (!$DB->tableExists('glpi_pendingreasons')) {
          KEY `is_recursive` (`is_recursive`),
          KEY `solutiontemplates_id` (`solutiontemplates_id`)
       ) ENGINE = InnoDB ROW_FORMAT = DYNAMIC DEFAULT CHARSET = $default_charset COLLATE = $default_collation;";
-    $DB->doQueryOrDie($query, "10.0 add table glpi_pendingreasons");
+    $DB->doQuery($query);
 }
 
 // Add pending reason items table
@@ -80,7 +80,7 @@ if (!$DB->tableExists('glpi_pendingreasons_items')) {
          KEY `pendingreasons_id` (`pendingreasons_id`),
          KEY `item` (`itemtype`,`items_id`)
       ) ENGINE = InnoDB ROW_FORMAT = DYNAMIC DEFAULT CHARSET = $default_charset COLLATE = $default_collation;";
-    $DB->doQueryOrDie($query, "10.0 add table glpi_pendingreasons_items");
+    $DB->doQuery($query);
 }
 
 // Add pendingreason right
@@ -101,7 +101,7 @@ if (empty($config['system_user'])) {
         'password'      => '',
         'authtype'      => 1,
     ];
-    $DB->insertOrDie('glpi_users', $system_user_params, "Can't add 'glpi-system' user");
+    $DB->insert('glpi_users', $system_user_params);
 
     $migration->addConfig(['system_user' => $DB->insertId()], 'core');
 }

--- a/install/migrations/update_9.5.x_to_10.0.0/recurrentchange.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/recurrentchange.php
@@ -44,7 +44,7 @@ $default_charset = DBConnection::getDefaultCharset();
 $default_collation = DBConnection::getDefaultCollation();
 $default_key_sign = DBConnection::getDefaultPrimaryKeySignOption();
 
-$DB->updateOrDie(
+$DB->update(
     'glpi_crontasks',
     [
         'itemtype' => 'CommonITILRecurrentCron',
@@ -53,13 +53,12 @@ $DB->updateOrDie(
     [
         'itemtype' => 'TicketRecurrent',
         'name'     => 'ticketrecurrent',
-    ],
-    "CommonITILReccurent crontask"
+    ]
 );
 
 $recurrent_change_table = 'glpi_recurrentchanges';
 if (!$DB->tableExists($recurrent_change_table)) {
-    $DB->doQueryOrDie("CREATE TABLE `$recurrent_change_table` (
+    $DB->doQuery("CREATE TABLE `$recurrent_change_table` (
          `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
          `name` varchar(255) DEFAULT NULL,
          `comment` text,

--- a/install/migrations/update_9.5.x_to_10.0.0/reservationitem.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/reservationitem.php
@@ -64,7 +64,7 @@ $select = $DB->request([
 ])->getSql();
 
 // "IGNORE" keyword used to avoid duplicates
-$DB->doQueryOrDie("INSERT IGNORE INTO $quote_tmp_table $select");
+$DB->doQuery("INSERT IGNORE INTO $quote_tmp_table $select");
 
 // Replace table with the new version
 $migration->dropTable($table);

--- a/install/migrations/update_9.5.x_to_10.0.0/schema_fixes.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/schema_fixes.php
@@ -750,14 +750,14 @@ $tables = [
 foreach ($tables as $table) {
     $migration->addField($table, 'no_entity_restriction', 'boolean', ['update' => 0]);
     $migration->migrationOneTable($table); // Ensure 'no_entity_restriction' is created
-    $DB->updateOrDie(
+    $DB->update(
         $table,
         ['entities_id' => 0, 'no_entity_restriction' => 1],
         ['entities_id' => -1]
     );
     $migration->changeField($table, 'entities_id', 'entities_id', "int {$default_key_sign} DEFAULT NULL");
     $migration->migrationOneTable($table); // Ensure 'entities_id' is nullable
-    $DB->updateOrDie(
+    $DB->update(
         $table,
         ['entities_id' => 'NULL'],
         ['no_entity_restriction' => 1]
@@ -765,7 +765,7 @@ foreach ($tables as $table) {
 }
 
 // Replace -1 default values on glpi_rules.entities_id
-$DB->updateOrDie(
+$DB->update(
     'glpi_rules',
     ['entities_id' => 0],
     ['entities_id' => -1]
@@ -781,7 +781,7 @@ foreach ($tables as $table) {
 }
 
 // Replace -1 default values on glpi_queuednotifications.items_id
-$DB->updateOrDie(
+$DB->update(
     'glpi_queuednotifications',
     ['items_id' => 0],
     ['items_id' => -1]

--- a/install/migrations/update_9.5.x_to_10.0.0/ticket_contract.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/ticket_contract.php
@@ -51,7 +51,7 @@ if (!$DB->tableExists('glpi_tickets_contracts')) {
       UNIQUE KEY `unicity` (`tickets_id`,`contracts_id`),
       KEY `contracts_id` (`contracts_id`)
    ) ENGINE = InnoDB ROW_FORMAT = DYNAMIC DEFAULT CHARSET = {$default_charset} COLLATE = {$default_collation};";
-    $DB->doQueryOrDie($query, "add table glpi_tickets_contracts");
+    $DB->doQuery($query);
 }
 
 if (!$DB->fieldExists("glpi_entities", "contracts_id_default")) {

--- a/phpunit/functional/CommonDBTMTest.php
+++ b/phpunit/functional/CommonDBTMTest.php
@@ -333,7 +333,8 @@ class CommonDBTMTest extends DbTestCase
         $this->assertTrue($res);
 
         //multiple update case
-        $res = $DB->updateOrInsert(
+        $this->expectExceptionObject(new \RuntimeException('Update would change too many rows!'));
+        $DB->updateOrInsert(
             \Computer::getTable(),
             [
                 'name'   => 'serial-to-change',
@@ -342,11 +343,6 @@ class CommonDBTMTest extends DbTestCase
             [
                 'name'   => 'serial-to-change'
             ]
-        );
-        $this->assertFalse($res);
-        $this->hasPhpLogRecordThatContains(
-            'Update would change too many rows!',
-            LogLevel::WARNING
         );
     }
 
@@ -412,7 +408,8 @@ class CommonDBTMTest extends DbTestCase
         $this->assertTrue($res);
 
         //multiple update case
-        $res = $DB->updateOrInsert(
+        $this->expectExceptionObject(new \RuntimeException('Update would change too many rows!'));
+        $DB->updateOrInsert(
             \Computer::getTable(),
             [
                 'serial' => 'serial-changed'
@@ -420,11 +417,6 @@ class CommonDBTMTest extends DbTestCase
             [
                 'name'   => 'serial-to-change'
             ]
-        );
-        $this->assertFalse($res);
-        $this->hasPhpLogRecordThatContains(
-            'Update would change too many rows!',
-            LogLevel::WARNING
         );
     }
 

--- a/phpunit/functional/Glpi/System/Requirement/DatabaseTablesEngineTest.php
+++ b/phpunit/functional/Glpi/System/Requirement/DatabaseTablesEngineTest.php
@@ -37,21 +37,9 @@ namespace tests\units\Glpi\System\Requirement;
 
 use Glpi\System\Requirement\DatabaseTablesEngine;
 use GLPITestCase;
-use Override;
 
 final class DatabaseTablesEngineTest extends GLPITestCase
 {
-    #[Override]
-    public function tearDown(): void
-    {
-        /** @var \DBmysql $db */
-        global $DB;
-
-        parent::tearDown();
-        $DB->doQuery("DROP TABLE glpi_tmp_testTablesWithIncorrectEngineAreFound1");
-        $DB->doQuery("DROP TABLE glpi_tmp_testTablesWithIncorrectEngineAreFound2");
-    }
-
     public function testTablesWithIncorrectEngineAreFound(): void
     {
         /** @var \DBmysql $db */
@@ -75,6 +63,10 @@ final class DatabaseTablesEngineTest extends GLPITestCase
         $table_engine_requirement = new DatabaseTablesEngine($DB);
         $is_validated = $table_engine_requirement->isValidated();
         $messages = $table_engine_requirement->getValidationMessages();
+
+        // Clean created tables
+        $DB->doQuery("DROP TABLE glpi_tmp_testTablesWithIncorrectEngineAreFound1");
+        $DB->doQuery("DROP TABLE glpi_tmp_testTablesWithIncorrectEngineAreFound2");
 
         // Assert: validation should fail with 2 invalid tables
         $this->assertFalse($is_validated);

--- a/phpunit/functional/Item_OperatingSystemTest.php
+++ b/phpunit/functional/Item_OperatingSystemTest.php
@@ -36,7 +36,6 @@
 namespace tests\units;
 
 use DbTestCase;
-use Psr\Log\LogLevel;
 
 /* Test for inc/item_operatingsystem.class.php */
 
@@ -105,8 +104,8 @@ class Item_OperatingSystemTest extends DbTestCase
         );
 
         $expected_error = "/Duplicate entry '{$computer->getID()}-Computer-{$objects['']->getID()}-{$objects['Architecture']->getID()}' for key '(glpi_items_operatingsystems\.)?unicity'/";
+        $this->expectExceptionMessageMatches($expected_error);
         $this->assertFalse($ios->add($input));
-        $this->hasSqlLogRecordThatMatches($expected_error, LogLevel::ERROR);
 
         $this->assertSame(
             1,

--- a/phpunit/functional/LocationTest.php
+++ b/phpunit/functional/LocationTest.php
@@ -37,7 +37,6 @@ namespace tests\units;
 
 use DbTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
-use Psr\Log\LogLevel;
 
 /* Test for inc/location.class.php */
 
@@ -201,11 +200,12 @@ class LocationTest extends DbTestCase
         $this->assertTrue($location2->getFromDB($location2_id));
         $this->assertEquals('Non unique location', $location2->fields['completename']);
 
+
+        $this->expectExceptionMessageMatches('/Unique location\' for key \'/');
         $updated = $location2->update([
             'id'           => $location2_id,
             'name'         => 'Unique location',
         ]);
-        $this->hasSqlLogRecordThatContains('Unique location\' for key \'', LogLevel::ERROR);
 
         $this->assertFalse($updated);
         $this->assertTrue($location2->getFromDB($location2_id));

--- a/src/DBmysql.php
+++ b/src/DBmysql.php
@@ -1030,9 +1030,7 @@ class DBmysql
             $query = trim($query);
             if ($query != '') {
                 $query = htmlentities($query, ENT_COMPAT, 'UTF-8');
-                if (!$this->doQuery($query)) {
-                    return false;
-                }
+                $this->doQuery($query);
                 if (!isCommandLine()) {
                   // Flush will prevent proxy to timeout as it will receive data.
                   // Flush requires a content to be sent, so we sent spaces as multiple spaces

--- a/src/DBmysql.php
+++ b/src/DBmysql.php
@@ -357,7 +357,7 @@ class DBmysql
      */
     public function query($query)
     {
-        trigger_error('Executing direct queries is not allowed!', E_USER_ERROR);
+        throw new \Exception('Executing direct queries is not allowed!');
     }
 
     /**
@@ -383,16 +383,14 @@ class DBmysql
 
         $res = $this->dbh->query($query);
         if (!$res) {
-            // no translation for error logs
-            $error = "  *** MySQL query error:\n  SQL: " . $query . "\n  Error: " .
-                   $this->dbh->error . "\n";
-            $error .= Toolbox::backtrace(false, 'DBmysql->doQuery()', ['Toolbox::backtrace()']);
-
-            Toolbox::logSqlError($error);
-
-            ErrorHandler::getInstance()->handleSqlError($this->dbh->errno, $this->dbh->error, $query);
-
-            $debug_data['errors'] = $this->error();
+            throw new \RuntimeException(
+                sprintf(
+                    'MySQL query error: %s (%d) in SQL query "%s".',
+                    $this->dbh->error,
+                    $this->dbh->errno,
+                    $query
+                )
+            );
         }
 
         $duration = (microtime(true) - $start_time) * 1000;
@@ -458,37 +456,24 @@ class DBmysql
      */
     public function queryOrDie($query, $message = '')
     {
-        trigger_error('Executing direct queries is not allowed!', E_USER_ERROR);
+        throw new \Exception('Executing direct queries is not allowed!');
     }
 
     /**
-     * Execute a MySQL query and die
-     * (optionnaly with a message) if it fails
+     * Execute a MySQL query and throw an exception if it fails.
      *
      * @param string $query   Query to execute
      * @param string $message Explanation of query (default '')
      *
      * @return mysqli_result Query result handler
+     *
+     * @deprecated 11.0.0
      */
     public function doQueryOrDie($query, $message = '')
     {
-        $res = $this->doQuery($query);
-        if (!$res) {
-            //TRANS: %1$s is the description, %2$s is the query, %3$s is the error message
-            $message = sprintf(
-                __('%1$s - Error during the database query: %2$s - Error is %3$s'),
-                $message,
-                $query,
-                $this->error()
-            );
-            if (isCommandLine()) {
-                 throw new \RuntimeException($message);
-            } else {
-                echo $message . "\n";
-                die(1);
-            }
-        }
-        return $res;
+        Toolbox::deprecated('Use `DBmysql::doQuery()`.');
+
+        return $this->doQuery($query);
     }
 
     /**
@@ -496,28 +481,20 @@ class DBmysql
      *
      * @param string $query Query to prepare
      *
-     * @return mysqli_stmt|boolean statement object or FALSE if an error occurred.
+     * @return mysqli_stmt
      */
     public function prepare($query)
     {
         $res = $this->dbh->prepare($query);
         if (!$res) {
-            // no translation for error logs
-            $error = "  *** MySQL prepare error:\n  SQL: " . $query . "\n  Error: " .
-                   $this->dbh->error . "\n";
-            $error .= Toolbox::backtrace(false, 'DBmysql->prepare()', ['Toolbox::backtrace()']);
-
-            Toolbox::logSqlError($error);
-
-            ErrorHandler::getInstance()->handleSqlError($this->dbh->errno, $this->dbh->error, $query);
-
-            if (isset($_SESSION['glpi_use_mode']) && $_SESSION['glpi_use_mode'] == Session::DEBUG_MODE) {
-                \Glpi\Debug\Profile::getCurrent()->addSQLQueryData(
-                    query: $query,
-                    time: 0,
-                    errors: $this->error()
-                );
-            }
+            throw new \RuntimeException(
+                sprintf(
+                    'MySQL prepare error: %s (%d) in SQL query "%s".',
+                    $this->dbh->error,
+                    $this->dbh->errno,
+                    $query
+                )
+            );
         }
         $this->current_query = $query;
         return $res;
@@ -1358,8 +1335,7 @@ class DBmysql
     }
 
     /**
-     * Insert a row in the database and die
-     * (optionnaly with a message) if it fails
+     * Insert a row in the database and throw an exception if it fails.
      *
      * @since 9.3
      *
@@ -1368,26 +1344,14 @@ class DBmysql
      * @param string $message Explanation of query (default '')
      *
      * @return mysqli_result|boolean Query result handler
+     *
+     * @deprecated 11.0.0
      */
     public function insertOrDie($table, $params, $message = '')
     {
-        $res = $this->insert($table, $params);
-        if (!$res) {
-            //TRANS: %1$s is the description, %2$s is the query, %3$s is the error message
-            $message = sprintf(
-                __('%1$s - Error during the database query: %2$s - Error is %3$s'),
-                $message,
-                $this->current_query,
-                $this->error()
-            );
-            if (isCommandLine()) {
-                 throw new \RuntimeException($message);
-            } else {
-                echo $message . "\n";
-                die(1);
-            }
-        }
-        return $res;
+        Toolbox::deprecated('Use `DBmysql::insert()`.');
+
+        return $this->insert($table, $params);
     }
 
     /**
@@ -1488,8 +1452,7 @@ class DBmysql
     }
 
     /**
-     * Update a row in the database or die
-     * (optionnaly with a message) if it fails
+     * Update a row in the database and throw an exception if it fails.
      *
      * @since 9.3
      *
@@ -1501,26 +1464,14 @@ class DBmysql
      *
      * @since 9.4.0 $joins parameter added
      * @return mysqli_result|boolean Query result handler
+     *
+     * @deprecated 11.0.0
      */
     public function updateOrDie($table, $params, $where, $message = '', array $joins = [])
     {
-        $res = $this->update($table, $params, $where, $joins);
-        if (!$res) {
-           //TRANS: %1$s is the description, %2$s is the query, %3$s is the error message
-            $message = sprintf(
-                __('%1$s - Error during the database query: %2$s - Error is %3$s'),
-                $message,
-                $this->current_query,
-                $this->error()
-            );
-            if (isCommandLine()) {
-                 throw new \RuntimeException($message);
-            } else {
-                echo $message . "\n";
-                die(1);
-            }
-        }
-        return $res;
+        Toolbox::deprecated('Use `DBmysql::update()`.');
+
+        return $this->update($table, $params, $where, $joins);
     }
 
     /**
@@ -1537,13 +1488,8 @@ class DBmysql
      */
     public function updateOrInsert($table, $params, $where, $onlyone = true)
     {
-        try {
-            $query = $this->buildUpdateOrInsert($table, $params, $where, $onlyone);
-            return $this->doQueryOrDie($query, 'Unable to create new element or update existing one');
-        } catch (\RuntimeException $e) {
-            trigger_error($e->getMessage(), E_USER_WARNING);
-            return false;
-        }
+        $query = $this->buildUpdateOrInsert($table, $params, $where, $onlyone);
+        return $this->doQuery($query);
     }
 
     public function buildUpdateOrInsert($table, $params, $where, $onlyone = true): string
@@ -1607,8 +1553,7 @@ class DBmysql
     }
 
     /**
-     * Delete a row in the database and die
-     * (optionnaly with a message) if it fails
+     * Delete a row in the database and throw an exception if it fails.
      *
      * @since 9.3
      *
@@ -1619,26 +1564,14 @@ class DBmysql
      *
      * @since 9.4.0 $joins parameter added
      * @return mysqli_result|boolean Query result handler
+     *
+     * @deprecated 11.0.0
      */
     public function deleteOrDie($table, $where, $message = '', array $joins = [])
     {
-        $res = $this->delete($table, $where, $joins);
-        if (!$res) {
-           //TRANS: %1$s is the description, %2$s is the query, %3$s is the error message
-            $message = sprintf(
-                __('%1$s - Error during the database query: %2$s - Error is %3$s'),
-                $message,
-                $this->current_query,
-                $this->error()
-            );
-            if (isCommandLine()) {
-                 throw new \RuntimeException($message);
-            } else {
-                echo $message . "\n";
-                die(1);
-            }
-        }
-        return $res;
+        Toolbox::deprecated('Use `DBmysql::delete()`.');
+
+        return $this->delete($table, $where, $joins);
     }
 
 
@@ -2087,9 +2020,10 @@ class DBmysql
         if (!$stmt->execute()) {
             throw new \RuntimeException(
                 sprintf(
-                    'Error executing statement "%s": %s',
-                    $this->current_query,
-                    $stmt->error
+                    'MySQL statement error: %s (%d) in SQL query "%s".',
+                    $stmt->error,
+                    $stmt->errno,
+                    $this->current_query
                 )
             );
         }

--- a/src/Glpi/Application/ErrorHandler.php
+++ b/src/Glpi/Application/ErrorHandler.php
@@ -314,26 +314,6 @@ class ErrorHandler
     }
 
     /**
-     * SQL error handler.
-     *
-     * This handler is manually called by application when a SQL error occurred.
-     *
-     * @param integer $error_code
-     * @param string  $error_message
-     * @param string  $query
-     *
-     * @return void
-     */
-    public function handleSqlError(int $error_code, string $error_message, string $query)
-    {
-        $this->outputDebugMessage(
-            sprintf('SQL Error "%s"', $error_code),
-            sprintf('%s in query "%s"', $error_message, preg_replace('/\\n/', ' ', $query)),
-            self::ERROR_LEVEL_MAP[E_USER_ERROR]
-        );
-    }
-
-    /**
      * SQL warnings handler.
      *
      * This handler is manually called by application when warnings are triggered by a SQL query.

--- a/src/Glpi/Console/Database/InstallCommand.php
+++ b/src/Glpi/Console/Database/InstallCommand.php
@@ -306,12 +306,15 @@ class InstallCommand extends AbstractConfigureCommand implements ConfigurationCo
             '<comment>' . __('Loading default schema...') . '</comment>',
             OutputInterface::VERBOSITY_VERBOSE
         );
-       // TODO Get rid of output buffering
-        ob_start();
-        $this->db->connect(); // Reconnect DB to ensure it uses update configuration (see `self::configureDatabase()`)
-        Toolbox::createSchema($default_language, $this->db);
-        $message = ob_get_clean();
-        if (!empty($message)) {
+
+        try {
+            $this->db->connect(); // Reconnect DB to ensure it uses update configuration (see `self::configureDatabase()`)
+            Toolbox::createSchema($default_language, $this->db);
+        } catch (\Throwable $e) {
+            $message = sprintf(
+                __('An error occurred during the database initialization. The error was: %s'),
+                $e->getMessage()
+            );
             $output->writeln('<error>' . $message . '</error>', OutputInterface::VERBOSITY_QUIET);
             return self::ERROR_SCHEMA_CREATION_FAILED;
         }

--- a/src/Glpi/Inventory/Asset/NetworkPort.php
+++ b/src/Glpi/Inventory/Asset/NetworkPort.php
@@ -508,9 +508,7 @@ class NetworkPort extends InventoryAsset
                         $vlan->getTable(),
                         $reference
                     );
-                    if (!$this->vlan_stmt = $DB->prepare($insert_query)) {
-                        throw new \RuntimeException(sprintf('Error preparing query `%s`.', $insert_query));
-                    }
+                    $this->vlan_stmt = $DB->prepare($insert_query);
                 }
 
                 $stmt_values = array_values($stmt_columns);
@@ -538,9 +536,7 @@ class NetworkPort extends InventoryAsset
                     $pvlan->getTable(),
                     $reference
                 );
-                if (!$this->pvlan_stmt = $DB->prepare($insert_query)) {
-                    throw new \RuntimeException(sprintf('Error preparing query `%s`.', $insert_query));
-                }
+                $this->pvlan_stmt = $DB->prepare($insert_query);
             }
 
             $pvlan_stmt_values = array_values($pvlan_stmt_columns);

--- a/src/Migration.php
+++ b/src/Migration.php
@@ -436,7 +436,7 @@ class Migration
                     $query = "UPDATE `$table`
                         SET `$field` = " . $params['update'] . " " .
                         $params['condition'] . "";
-                    $DB->doQueryOrDie($query, $this->version . " set $field in $table");
+                    $DB->doQuery($query);
                 }
                 return true;
             }
@@ -644,7 +644,7 @@ class Migration
 
         if (!$DB->tableExists("$newtable") && $DB->tableExists("$oldtable")) {
             $query = "RENAME TABLE `$oldtable` TO `$newtable`";
-            $DB->doQueryOrDie($query, $this->version . " rename $oldtable");
+            $DB->doQuery($query);
 
            // Clear possibly forced value of table name.
            // Actually the only forced value in core is for config table.
@@ -714,12 +714,12 @@ class Migration
            // $DB->doQuery($query);
 
             $query = "CREATE TABLE `$newtable` LIKE `$oldtable`";
-            $DB->doQueryOrDie($query, $this->version . " create $newtable");
+            $DB->doQuery($query);
 
             if ($insert) {
                //needs DB::insert to support subqueries to get migrated
                 $query = "INSERT INTO `$newtable` (SELECT * FROM `$oldtable`)";
-                $DB->doQueryOrDie($query, $this->version . " copy from $oldtable to $newtable");
+                $DB->doQuery($query);
             }
         }
     }
@@ -750,7 +750,7 @@ class Migration
                 }
             }
 
-            $DB->insertOrDie($table, $values, $this->version . " insert in $table");
+            $DB->insert($table, $values);
 
             return $DB->insertId();
         }
@@ -773,7 +773,7 @@ class Migration
         if (isset($this->change[$table])) {
             $query = "ALTER TABLE `$table` " . implode(" ,\n", $this->change[$table]) . " ";
             $this->displayMessage(sprintf(__('Change of the database layout - %s'), $table));
-            $DB->doQueryOrDie($query, $this->version . " multiple alter in $table");
+            $DB->doQuery($query);
             unset($this->change[$table]);
         }
 
@@ -781,7 +781,7 @@ class Migration
             $this->displayMessage(sprintf(__('Adding fulltext indices - %s'), $table));
             foreach ($this->fulltexts[$table] as $idx) {
                 $query = "ALTER TABLE `$table` " . $idx;
-                $DB->doQueryOrDie($query, $this->version . " $idx");
+                $DB->doQuery($query);
             }
             unset($this->fulltexts[$table]);
         }
@@ -790,7 +790,7 @@ class Migration
             $this->displayMessage(sprintf(__('Adding unicity indices - %s'), $table));
             foreach ($this->uniques[$table] as $idx) {
                 $query = "ALTER TABLE `$table` " . $idx;
-                $DB->doQueryOrDie($query, $this->version . " $idx");
+                $DB->doQuery($query);
             }
             unset($this->uniques[$table]);
         }
@@ -807,7 +807,7 @@ class Migration
         global $DB;
 
         foreach ($this->queries[self::PRE_QUERY] as $query) {
-            $DB->doQueryOrDie($query['query'], $query['message']);
+            $DB->doQuery($query['query']);
         }
         $this->queries[self::PRE_QUERY] = [];
 
@@ -821,7 +821,7 @@ class Migration
         }
 
         foreach ($this->queries[self::POST_QUERY] as $query) {
-            $DB->doQueryOrDie($query['query'], $query['message']);
+            $DB->doQuery($query['query']);
         }
         $this->queries[self::POST_QUERY] = [];
 
@@ -867,7 +867,7 @@ class Migration
         foreach ($rule as $field => $value) {
             $values[$field] = $value;
         }
-        $DB->insertOrDie('glpi_rules', $values);
+        $DB->insert('glpi_rules', $values);
         $rid = $DB->insertId();
 
         // The rule criteria
@@ -876,7 +876,7 @@ class Migration
             foreach ($criterion as $field => $value) {
                 $values[$field] = $value;
             }
-            $DB->insertOrDie('glpi_rulecriterias', $values);
+            $DB->insert('glpi_rulecriterias', $values);
         }
 
         // The rule criteria actions
@@ -885,7 +885,7 @@ class Migration
             foreach ($action as $field => $value) {
                 $values[$field] = $value;
             }
-            $DB->insertOrDie('glpi_ruleactions', $values);
+            $DB->insert('glpi_ruleactions', $values);
         }
 
         return $rid;
@@ -1225,15 +1225,14 @@ class Migration
                 $reqmet = (count($iterator) === count($requiredrights));
             }
 
-            $DB->insertOrDie(
+            $DB->insert(
                 'glpi_profilerights',
                 [
                     'id'           => null,
                     'profiles_id'  => $profile['id'],
                     'name'         => $name,
                     'rights'       => $reqmet ? $rights : 0
-                ],
-                sprintf('%1$s add right for %2$s', $this->version, $name)
+                ]
             );
 
             $this->updateProfileLastRightsUpdate($profile['id']);
@@ -1523,7 +1522,7 @@ class Migration
             return;
         }
 
-        $DB->updateOrDie(
+        $DB->update(
             'glpi_profiles',
             [
                 'last_rights_update' => Session::getCurrentTime()
@@ -1839,11 +1838,11 @@ class Migration
                 ]);
                 if ($duplicates_iterator->count() > 0) {
                     $ids = array_column(iterator_to_array($duplicates_iterator), 'id');
-                    $DB->deleteOrDie(DisplayPreference::getTable(), ['id' => $ids]);
+                    $DB->delete(DisplayPreference::getTable(), ['id' => $ids]);
                 }
 
                 // Update display preferences
-                $DB->updateOrDie(DisplayPreference::getTable(), [
+                $DB->update(DisplayPreference::getTable(), [
                     'num' => $new_search_opt
                 ], [
                     'itemtype' => $itemtype,
@@ -1861,7 +1860,7 @@ class Migration
                         if (!$DB->tableExists($table)) {
                             continue;
                         }
-                        $DB->updateOrDie($table, [
+                        $DB->update($table, [
                             'num' => $new_search_opt
                         ], [
                             'num' => $old_search_opt
@@ -1919,7 +1918,7 @@ class Migration
 
             // Write changes if any were made
             if ($is_changed) {
-                $DB->updateOrDie(SavedSearch::getTable(), [
+                $DB->update(SavedSearch::getTable(), [
                     'query'  => http_build_query($query)
                 ], [
                     'id'     => $data['id']
@@ -1957,7 +1956,7 @@ class Migration
         $default_collation = DBConnection::getDefaultCollation();
         $default_key_sign = DBConnection::getDefaultPrimaryKeySignOption();
 
-        $DB->doQueryOrDie("
+        $DB->doQuery("
             CREATE TABLE `$table` (
                 `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
                 `$fk_1` int {$default_key_sign} NOT NULL DEFAULT '0',
@@ -1966,6 +1965,6 @@ class Migration
                 KEY `$fk_1` (`$fk_1`),
                 KEY `$fk_2` (`$fk_2`)
             ) ENGINE=InnoDB DEFAULT CHARSET = {$default_charset} COLLATE = {$default_collation} ROW_FORMAT=DYNAMIC;
-        ", "Create link table between $class_1 and $class_2");
+        ");
     }
 }

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -2126,10 +2126,6 @@ class Toolbox
                 );
 
                 $stmt = $DB->prepare($DB->buildInsert($table, $reference));
-                if (false === $stmt) {
-                     $msg = "Error preparing statement in table $table";
-                     throw new \RuntimeException($msg);
-                }
 
                 $types = str_repeat('s', count($data[0]));
                 foreach ($data as $row) {
@@ -2178,7 +2174,7 @@ class Toolbox
 
             if (defined('GLPI_SYSTEM_CRON')) {
                // Downstream packages may provide a good system cron
-                $DB->updateOrDie(
+                $DB->update(
                     'glpi_crontasks',
                     [
                         'mode'   => 2
@@ -2186,8 +2182,7 @@ class Toolbox
                     [
                         'name'      => ['!=', 'watcher'],
                         'allowmode' => ['&', 2]
-                    ],
-                    '4203'
+                    ]
                 );
             }
         }

--- a/src/Update.php
+++ b/src/Update.php
@@ -319,7 +319,7 @@ class Update
 
         if (defined('GLPI_SYSTEM_CRON')) {
            // Downstream packages may provide a good system cron
-            $DB->updateOrDie(
+            $DB->update(
                 'glpi_crontasks',
                 [
                     'mode'   => 2

--- a/src/Update.php
+++ b/src/Update.php
@@ -259,7 +259,16 @@ class Update
         $migrations = $this->getMigrationsToDo($current_version, $force_latest);
         foreach ($migrations as $key => $migration_specs) {
             include_once($migration_specs['file']);
-            $migration_specs['function']();
+
+            try {
+                $migration_specs['function']();
+            } catch (\Throwable $e) {
+                $this->migration->displayError(sprintf(
+                    __('An error occurred during the update. The error was: %s'),
+                    $e->getMessage()
+                ));
+                die(1);
+            }
 
             if ($key !== array_key_last($migrations)) {
                 // Set current version to target version to ensure complete migrations to not be replayed if one

--- a/tests/LDAP/AuthLdap.php
+++ b/tests/LDAP/AuthLdap.php
@@ -1233,7 +1233,7 @@ class AuthLDAP extends DbTestCase
         )->isTrue();
 
         global $DB;
-        $DB->updateOrDie(
+        $DB->update(
             'glpi_authldaps',
             ['sync_field' => null],
             ['id' => $ldap->getID()]
@@ -1356,7 +1356,7 @@ class AuthLDAP extends DbTestCase
          ->string['user_dn']->isIdenticalTo('uid=brazil6,ou=people,ou=R&D,dc=glpi,dc=org');
 
         global $DB;
-        $DB->updateOrDie(
+        $DB->update(
             'glpi_authldaps',
             ['sync_field' => null],
             ['id' => $ldap->getID()]

--- a/tests/functional/DBmysqlIterator.php
+++ b/tests/functional/DBmysqlIterator.php
@@ -57,9 +57,12 @@ class DBmysqlIterator extends DbTestCase
     {
         global $DB;
 
-        $expected_error = "Table '{$DB->dbdefault}.fakeTable' doesn't exist";
-        $DB->request(['FROM' => 'fakeTable']);
-        $this->hasSqlLogRecordThatContains($expected_error, LogLevel::ERROR);
+        $this->exception(
+            function () use ($DB) {
+                $DB->request(['FROM' => 'fakeTable']);
+            }
+        )->isInstanceOf(\RuntimeException::class)
+         ->hasMessage("MySQL query error: Table '{$DB->dbdefault}.fakeTable' doesn't exist (1146) in SQL query \"SELECT * FROM `fakeTable`\".");
     }
 
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] This change requires a documentation update.

## Description

Since we did not have a centralized error catching in the past, we were not able to throw exceptions when a SQL error occurred. They were just logged and were not stopping the code execution, and this could have the effect of triggering hard-to-debug errors in subsequently executed code.

Now we have a centralized error catching system, we can throw exceptions when a SQL error is triggered. It would result in displaying the error page. For instance, if I force a SQL querry error in the impact analysis tab:
![image](https://github.com/user-attachments/assets/fa2878a6-17ef-459a-b80d-83eb3778b154)
