### PR TITLE
Fix install requirements

### DIFF
--- a/.github/actions/test_install.sh
+++ b/.github/actions/test_install.sh
@@ -4,6 +4,9 @@ set -e -u -x -o pipefail
 LOG_FILE="./tests/files/_log/install.log"
 mkdir -p $(dirname "$LOG_FILE")
 
+# Run the check requirements command to make sure it is working
+bin/console system:check_requirements
+
 # Execute install
 bin/console database:install \
   --ansi --no-interaction \

--- a/src/Glpi/Console/System/CheckRequirementsCommand.php
+++ b/src/Glpi/Console/System/CheckRequirementsCommand.php
@@ -60,7 +60,10 @@ class CheckRequirementsCommand extends AbstractCommand
         $requirements_manager = new RequirementsManager();
         $optional_db = $this->db instanceof \DBmysql && $this->db->connected ? $this->db : null;
         $core_requirements = $requirements_manager->getCoreRequirementList($optional_db);
-        $core_requirements->add(new DatabaseTablesEngine($optional_db));
+
+        if ($optional_db) {
+            $core_requirements->add(new DatabaseTablesEngine($optional_db));
+        }
 
         $informations = new Table($output);
         $informations->setHeaders(


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Fix #18150, introduced by #18017.

The code would trigger a fatal error when `$optional_db` is null because `DatabaseTablesEngine`'s constructor only accept a `DBmysql` object.

It is weird that PHPStan did not report it.