### PR TITLE
Save home page tiles to database

### DIFF
--- a/inc/relation.constant.php
+++ b/inc/relation.constant.php
@@ -715,6 +715,7 @@ $RELATION = [
         "_glpi_forms_answerssets"                       => "forms_forms_id",
         "_glpi_forms_destinations_formdestinations"     => "forms_forms_id",
         "_glpi_forms_sections"                          => "forms_forms_id",
+        "_glpi_helpdesks_tiles_formtiles"               => "forms_forms_id",
     ],
 
     'glpi_forms_sections' => [
@@ -1165,12 +1166,13 @@ $RELATION = [
     ],
 
     'glpi_profiles' => [
-        '_glpi_knowbaseitems_profiles' => 'profiles_id',
-        '_glpi_profilerights'          => 'profiles_id',
-        '_glpi_profiles_reminders'     => 'profiles_id',
-        '_glpi_profiles_rssfeeds'      => 'profiles_id',
-        '_glpi_profiles_users'         => 'profiles_id',
-        'glpi_users'                   => 'profiles_id',
+        '_glpi_helpdesks_tiles_profiles_tiles' => 'profiles_id',
+        '_glpi_knowbaseitems_profiles'         => 'profiles_id',
+        '_glpi_profilerights'                  => 'profiles_id',
+        '_glpi_profiles_reminders'             => 'profiles_id',
+        '_glpi_profiles_rssfeeds'              => 'profiles_id',
+        '_glpi_profiles_users'                 => 'profiles_id',
+        'glpi_users'                           => 'profiles_id',
     ],
 
     'glpi_projects' => [

--- a/install/migrations/update_10.0.x_to_11.0.0/form.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/form.php
@@ -204,6 +204,53 @@ if (!$DB->tableExists('glpi_forms_accesscontrols_formaccesscontrols')) {
         ) ENGINE=InnoDB DEFAULT CHARSET={$default_charset} COLLATE={$default_collation} ROW_FORMAT=DYNAMIC;"
     );
 }
+if (!$DB->tableExists('glpi_helpdesks_tiles_profiles_tiles')) {
+    $DB->doQueryOrDie(
+        "CREATE TABLE `glpi_helpdesks_tiles_profiles_tiles` (
+            `id` int unsigned NOT NULL AUTO_INCREMENT,
+            `profiles_id` int unsigned NOT NULL DEFAULT '0',
+            `itemtype` varchar(255) DEFAULT NULL,
+            `items_id` int unsigned NOT NULL DEFAULT '0',
+            PRIMARY KEY (`id`),
+            KEY `profiles_id` (`profiles_id`),
+            KEY `item` (`itemtype`,`items_id`)
+        ) ENGINE=InnoDB DEFAULT CHARSET={$default_charset} COLLATE={$default_collation} ROW_FORMAT=DYNAMIC;"
+    );
+}
+if (!$DB->tableExists('glpi_helpdesks_tiles_formtiles')) {
+    $DB->doQueryOrDie(
+        "CREATE TABLE `glpi_helpdesks_tiles_formtiles` (
+            `id` int unsigned NOT NULL AUTO_INCREMENT,
+            `forms_forms_id` int unsigned NOT NULL DEFAULT '0',
+            PRIMARY KEY (`id`),
+            KEY `forms_forms_id` (`forms_forms_id`)
+        ) ENGINE=InnoDB DEFAULT CHARSET={$default_charset} COLLATE={$default_collation} ROW_FORMAT=DYNAMIC;"
+    );
+}
+if (!$DB->tableExists('glpi_helpdesks_tiles_glpipagetiles')) {
+    $DB->doQueryOrDie(
+        "CREATE TABLE `glpi_helpdesks_tiles_glpipagetiles` (
+            `id` int unsigned NOT NULL AUTO_INCREMENT,
+            `title` varchar(255) DEFAULT NULL,
+            `description` varchar(255) DEFAULT NULL,
+            `illustration` varchar(255) DEFAULT NULL,
+            `page` varchar(255) DEFAULT NULL,
+            PRIMARY KEY (`id`)
+        ) ENGINE=InnoDB DEFAULT CHARSET={$default_charset} COLLATE={$default_collation} ROW_FORMAT=DYNAMIC;"
+    );
+}
+if (!$DB->tableExists('glpi_helpdesks_tiles_externalpagetiles')) {
+    $DB->doQueryOrDie(
+        "CREATE TABLE `glpi_helpdesks_tiles_externalpagetiles` (
+            `id` int unsigned NOT NULL AUTO_INCREMENT,
+            `title` varchar(255) DEFAULT NULL,
+            `description` varchar(255) DEFAULT NULL,
+            `illustration` varchar(255) DEFAULT NULL,
+            `url` text DEFAULT NULL,
+            PRIMARY KEY (`id`)
+        ) ENGINE=InnoDB DEFAULT CHARSET={$default_charset} COLLATE={$default_collation} ROW_FORMAT=DYNAMIC;"
+    );
+}
 
 // Add rights for the forms object
 $migration->addRight("form", ALLSTANDARDRIGHT, ['config' => UPDATE]);

--- a/install/migrations/update_10.0.x_to_11.0.0/form.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/form.php
@@ -205,7 +205,7 @@ if (!$DB->tableExists('glpi_forms_accesscontrols_formaccesscontrols')) {
     );
 }
 if (!$DB->tableExists('glpi_helpdesks_tiles_profiles_tiles')) {
-    $DB->doQueryOrDie(
+    $DB->doQuery(
         "CREATE TABLE `glpi_helpdesks_tiles_profiles_tiles` (
             `id` int unsigned NOT NULL AUTO_INCREMENT,
             `profiles_id` int unsigned NOT NULL DEFAULT '0',
@@ -218,7 +218,7 @@ if (!$DB->tableExists('glpi_helpdesks_tiles_profiles_tiles')) {
     );
 }
 if (!$DB->tableExists('glpi_helpdesks_tiles_formtiles')) {
-    $DB->doQueryOrDie(
+    $DB->doQuery(
         "CREATE TABLE `glpi_helpdesks_tiles_formtiles` (
             `id` int unsigned NOT NULL AUTO_INCREMENT,
             `forms_forms_id` int unsigned NOT NULL DEFAULT '0',
@@ -228,7 +228,7 @@ if (!$DB->tableExists('glpi_helpdesks_tiles_formtiles')) {
     );
 }
 if (!$DB->tableExists('glpi_helpdesks_tiles_glpipagetiles')) {
-    $DB->doQueryOrDie(
+    $DB->doQuery(
         "CREATE TABLE `glpi_helpdesks_tiles_glpipagetiles` (
             `id` int unsigned NOT NULL AUTO_INCREMENT,
             `title` varchar(255) DEFAULT NULL,
@@ -240,7 +240,7 @@ if (!$DB->tableExists('glpi_helpdesks_tiles_glpipagetiles')) {
     );
 }
 if (!$DB->tableExists('glpi_helpdesks_tiles_externalpagetiles')) {
-    $DB->doQueryOrDie(
+    $DB->doQuery(
         "CREATE TABLE `glpi_helpdesks_tiles_externalpagetiles` (
             `id` int unsigned NOT NULL AUTO_INCREMENT,
             `title` varchar(255) DEFAULT NULL,

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -3159,6 +3159,52 @@ CREATE TABLE `glpi_groups_users` (
   KEY `is_manager` (`is_manager`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
+### Dump table glpi_helpdesks_tiles_profiles_tiles
+
+DROP TABLE IF EXISTS `glpi_helpdesks_tiles_profiles_tiles`;
+CREATE TABLE `glpi_helpdesks_tiles_profiles_tiles` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `profiles_id` int unsigned NOT NULL DEFAULT '0',
+  `itemtype` varchar(255) DEFAULT NULL,
+  `items_id` int unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`id`),
+  KEY `profiles_id` (`profiles_id`),
+  KEY `item` (`itemtype`,`items_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+
+### Dump table glpi_helpdesks_tiles_formtiles
+
+DROP TABLE IF EXISTS `glpi_helpdesks_tiles_formtiles`;
+CREATE TABLE `glpi_helpdesks_tiles_formtiles` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `forms_forms_id` int unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`id`),
+  KEY `forms_forms_id` (`forms_forms_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+
+### Dump table glpi_helpdesks_tiles_glpipagetiles
+
+DROP TABLE IF EXISTS `glpi_helpdesks_tiles_glpipagetiles`;
+CREATE TABLE `glpi_helpdesks_tiles_glpipagetiles` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `title` varchar(255) DEFAULT NULL,
+  `description` varchar(255) DEFAULT NULL,
+  `illustration` varchar(255) DEFAULT NULL,
+  `page` varchar(255) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+
+### Dump table glpi_helpdesks_tiles_externalpagetiles
+
+DROP TABLE IF EXISTS `glpi_helpdesks_tiles_externalpagetiles`;
+CREATE TABLE `glpi_helpdesks_tiles_externalpagetiles` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `title` varchar(255) DEFAULT NULL,
+  `description` varchar(255) DEFAULT NULL,
+  `illustration` varchar(255) DEFAULT NULL,
+  `url` text DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 ### Dump table glpi_holidays
 

--- a/phpunit/functional/Glpi/Helpdesk/DefaultDataManagerTest.php
+++ b/phpunit/functional/Glpi/Helpdesk/DefaultDataManagerTest.php
@@ -44,8 +44,11 @@ use Glpi\Form\AccessControl\FormAccessParameters;
 use Glpi\Form\AnswersSet;
 use Glpi\Helpdesk\DefaultDataManager;
 use Glpi\Form\Form;
+use Glpi\Helpdesk\Tile\Profile_Tile;
+use Glpi\Helpdesk\Tile\TileInterface;
 use Glpi\Session\SessionInfo;
 use Glpi\Tests\FormTesterTrait;
+use Glpi\UI\IllustrationManager;
 use ITILCategory;
 use Location;
 use Monitor;
@@ -72,7 +75,7 @@ final class DefaultDataManagerTest extends DbTestCase
         // Arrange: count the number of forms that already exist in the database
         $number_of_forms_before = countElementsInTable(Form::getTable());
 
-        // Act: create default forms
+        // Act: initialize default data
         $this->getManager()->initializeDataIfNeeded();
 
         // Assert: there must be not be any new forms
@@ -338,5 +341,51 @@ final class DefaultDataManagerTest extends DbTestCase
 
         // Assert: the user should be able to see the form
         $this->assertEquals(true, $can_answer);
+    }
+
+    public function testsTilesAreAddedAfterInstallation(): void
+    {
+        $this->assertEquals(5, countElementsInTable(Profile_Tile::getTable()));
+    }
+
+    public function testNoTilesAreCreatedWhenDatabaseIsNotEmpty(): void
+    {
+        // Arrange: count the number of tiles that already exist in the database
+        $number_of_tiles_before = countElementsInTable(Profile_Tile::getTable());
+
+        // Act: initialize default data
+        $this->getManager()->initializeDataIfNeeded();
+
+        // Assert: there must be not be any new tiles
+        $number_of_tiles_after = countElementsInTable(Profile_Tile::getTable());
+        $number_of_new_tiles = $number_of_tiles_after - $number_of_tiles_before;
+        $this->assertEquals(0, $number_of_new_tiles);
+    }
+
+    public function testDefaultTilesAreValid(): void
+    {
+        // Arrange: load valid illustration names
+        $illustration_manager = new IllustrationManager();
+        $valid_illustrations = $illustration_manager->getAllIllustrationsNames();
+
+        // Act: load the default tiles
+        $profile_tiles = (new Profile_Tile())->find([]);
+        $tiles = array_map(function ($row) {
+            $itemtype = $row['itemtype'];
+            $tile = new $itemtype();
+            $tile->getFromDb($row['items_id']);
+            return $tile;
+        }, $profile_tiles);
+
+        // Assert: there should be at least one tile and each tile should have a
+        // valid title, description, illustration and link
+        $this->assertNotEmpty($tiles);
+        foreach ($tiles as $tile) {
+            $this->assertInstanceOf(TileInterface::class, $tile);
+            $this->assertNotEmpty($tile->getTitle());
+            $this->assertNotEmpty($tile->getDescription());
+            $this->assertContains($tile->getIllustration(), $valid_illustrations);
+            $this->assertNotEmpty($tile->getTileLink());
+        }
     }
 }

--- a/phpunit/functional/Glpi/Helpdesk/DefaultDataManagerTest.php
+++ b/phpunit/functional/Glpi/Helpdesk/DefaultDataManagerTest.php
@@ -385,7 +385,7 @@ final class DefaultDataManagerTest extends DbTestCase
             $this->assertNotEmpty($tile->getTitle());
             $this->assertNotEmpty($tile->getDescription());
             $this->assertContains($tile->getIllustration(), $valid_illustrations);
-            $this->assertNotEmpty($tile->getTileLink());
+            $this->assertNotEmpty($tile->getTileUrl());
         }
     }
 }

--- a/phpunit/functional/Glpi/Helpdesk/Tile/TilesManagerTest.php
+++ b/phpunit/functional/Glpi/Helpdesk/Tile/TilesManagerTest.php
@@ -219,7 +219,7 @@ final class TilesManagerTest extends DbTestCase
         $builder->allowAllUsers();
         $forms[] = $this->createForm($builder);
 
-        $builder = new FormBuilder("Form inside entity");
+        $builder = new FormBuilder("Form outside current entity");
         $builder->setIsActive(true);
         $builder->setEntitiesId(0);
         $builder->allowAllUsers();

--- a/phpunit/functional/Glpi/Helpdesk/Tile/TilesManagerTest.php
+++ b/phpunit/functional/Glpi/Helpdesk/Tile/TilesManagerTest.php
@@ -80,14 +80,14 @@ final class TilesManagerTest extends DbTestCase
         $this->assertEquals("GLPI project", $first_tile->getTitle());
         $this->assertEquals("Link to GLPI project website", $first_tile->getDescription());
         $this->assertEquals("request-service.svg", $first_tile->getIllustration());
-        $this->assertEquals("https://glpi-project.org", $first_tile->getTileLink());
+        $this->assertEquals("https://glpi-project.org", $first_tile->getTileUrl());
 
         $second_tile = $tiles[1];
         $this->assertInstanceOf(GlpiPageTile::class, $second_tile);
         $this->assertEquals("FAQ", $second_tile->getTitle());
         $this->assertEquals("Link to the FAQ", $second_tile->getDescription());
         $this->assertEquals("browse-help.svg", $second_tile->getIllustration());
-        $this->assertEquals("/front/helpdesk.faq.php", $second_tile->getTileLink());
+        $this->assertEquals("/glpi/front/helpdesk.faq.php", $second_tile->getTileUrl());
     }
 
     public function testTilesCantBeAddedToCentralProfiles(): void

--- a/phpunit/functional/Glpi/Helpdesk/Tile/TilesManagerTest.php
+++ b/phpunit/functional/Glpi/Helpdesk/Tile/TilesManagerTest.php
@@ -222,6 +222,14 @@ final class TilesManagerTest extends DbTestCase
         $builder = new FormBuilder("Form outside current entity");
         $builder->setIsActive(true);
         $builder->setEntitiesId(0);
+        $builder->setIsRecursive(false);
+        $builder->allowAllUsers();
+        $forms[] = $this->createForm($builder);
+
+        $builder = new FormBuilder("Form inside recursive parent entity");
+        $builder->setIsActive(true);
+        $builder->setEntitiesId(0);
+        $builder->setIsRecursive(true);
         $builder->allowAllUsers();
         $forms[] = $this->createForm($builder);
 
@@ -240,6 +248,9 @@ final class TilesManagerTest extends DbTestCase
 
         // Assert: only the form with a valid access policy should be found
         $form_names = array_map(fn($tile) => $tile->getTitle(), $tiles);
-        $this->assertEquals(["Form inside current entity"], $form_names);
+        $this->assertEquals([
+            "Form inside current entity",
+            "Form inside recursive parent entity",
+        ], $form_names);
     }
 }

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -3141,6 +3141,29 @@ class CommonDBTM extends CommonGLPI
         }
     }
 
+    /** @param int[] $entities_ids */
+    public function isAccessibleFromEntities(array $entities_ids): bool
+    {
+        if (!$this->isEntityAssign()) {
+            // Item does not have any entity so it is always visible.
+            return true;
+        }
+
+        if ($this->maybeRecursive() && $this->fields['is_recursive']) {
+            // Item is recursive, check if it is accessible from any of the ancestors of the given entities.
+            return in_array(
+                $this->getEntityID(),
+                getAncestorsOf("glpi_entities", $entities_ids),
+            );
+        } else {
+            // Item is not recursive, check if it is accessible from any of the given entities.
+            return in_array(
+                $this->getEntityID(),
+                $entities_ids,
+            );
+        }
+    }
+
     /**
      * Check if have right on this entity
      *

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -3149,19 +3149,25 @@ class CommonDBTM extends CommonGLPI
             return true;
         }
 
-        if ($this->maybeRecursive() && $this->fields['is_recursive']) {
-            // Item is recursive, check if it is accessible from any of the ancestors of the given entities.
-            return in_array(
+        // Check if the item entity is in the list of given entities.
+        if (in_array($this->getEntityID(), $entities_ids)) {
+            return true;
+        }
+
+        // If the item is recursive, we also check if it is accessible from any
+        // of the ancestors of the given entities.
+        if (
+            $this->maybeRecursive()
+            && $this->fields['is_recursive']
+            && in_array(
                 $this->getEntityID(),
                 getAncestorsOf("glpi_entities", $entities_ids),
-            );
-        } else {
-            // Item is not recursive, check if it is accessible from any of the given entities.
-            return in_array(
-                $this->getEntityID(),
-                $entities_ids,
-            );
+            )
+        ) {
+            return true;
         }
+
+        return false;
     }
 
     /**

--- a/src/Glpi/Controller/Helpdesk/IndexController.php
+++ b/src/Glpi/Controller/Helpdesk/IndexController.php
@@ -39,11 +39,11 @@ use Glpi\Helpdesk\HomePageTabs;
 use Glpi\Helpdesk\Tile\TilesManager;
 use Glpi\Http\Firewall;
 use Glpi\Security\Attribute\SecurityStrategy;
+use Session;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 use User;
-use Session;
 
 final class IndexController extends AbstractController
 {
@@ -67,7 +67,7 @@ final class IndexController extends AbstractController
         return $this->render('pages/helpdesk/index.html.twig', [
             'title' => __("Home"),
             'menu'  => ['helpdesk-home'],
-            'tiles' => $this->tiles_manager->getTiles(),
+            'tiles' => $this->tiles_manager->getTiles(Session::getCurrentProfile()),
             'tabs'  => new HomePageTabs(),
             'password_alert' => $user->getPasswordExpirationMessage(),
         ]);

--- a/src/Glpi/Controller/Helpdesk/IndexController.php
+++ b/src/Glpi/Controller/Helpdesk/IndexController.php
@@ -67,7 +67,7 @@ final class IndexController extends AbstractController
         return $this->render('pages/helpdesk/index.html.twig', [
             'title' => __("Home"),
             'menu'  => ['helpdesk-home'],
-            'tiles' => $this->tiles_manager->getTiles(Session::getCurrentProfile()),
+            'tiles' => $this->tiles_manager->getTiles(Session::getCurrentSessionInfo()),
             'tabs'  => new HomePageTabs(),
             'password_alert' => $user->getPasswordExpirationMessage(),
         ]);

--- a/src/Glpi/Helpdesk/Tile/ExternalPageTile.php
+++ b/src/Glpi/Helpdesk/Tile/ExternalPageTile.php
@@ -34,66 +34,32 @@
 
 namespace Glpi\Helpdesk\Tile;
 
-use CommonDBChild;
-use Glpi\Form\Form;
+use CommonDBTM;
 use Override;
 
-final class FormTile extends CommonDBChild implements TileInterface
+final class ExternalPageTile extends CommonDBTM implements TileInterface
 {
-    public static $itemtype = Form::class;
-    public static $items_id = 'forms_forms_id';
-
-    private ?Form $form;
-
-    #[Override]
-    public function post_getFromDB(): void
-    {
-        $form = $this->getItem();
-        if (!($form instanceof Form)) {
-            // We don't throw an exception here because we don't want to crash
-            // the home page in case of one invalid tile.
-            // It is better to display an empty tile in this case rather
-            // than blocking access to the helpdesk.
-            trigger_error("Unable to load linked form", E_USER_WARNING);
-            $this->form = null;
-        } else {
-            $this->form = $form;
-        }
-    }
-
     #[Override]
     public function getTitle(): string
     {
-        if ($this->form === null) {
-            return "";
-        }
-        return $this->form->fields['name'];
+        return $this->fields['title'];
     }
 
     #[Override]
     public function getDescription(): string
     {
-        if ($this->form === null) {
-            return "";
-        }
-        return $this->form->fields['description'];
+        return $this->fields['description'];
     }
 
     #[Override]
     public function getIllustration(): string
     {
-        if ($this->form === null) {
-            return "";
-        }
-        return $this->form->fields['illustration'];
+        return $this->fields['illustration'];
     }
 
     #[Override]
     public function getTileLink(): string
     {
-        if ($this->form === null) {
-            return "";
-        }
-        return '/Form/Render/' .  $this->form->getID();
+        return $this->fields['url'];
     }
 }

--- a/src/Glpi/Helpdesk/Tile/ExternalPageTile.php
+++ b/src/Glpi/Helpdesk/Tile/ExternalPageTile.php
@@ -35,6 +35,7 @@
 namespace Glpi\Helpdesk\Tile;
 
 use CommonDBTM;
+use Glpi\Session\SessionInfo;
 use Override;
 
 final class ExternalPageTile extends CommonDBTM implements TileInterface
@@ -61,5 +62,11 @@ final class ExternalPageTile extends CommonDBTM implements TileInterface
     public function getTileUrl(): string
     {
         return $this->fields['url'];
+    }
+
+    #[Override]
+    public function isValid(SessionInfo $session_info): bool
+    {
+        return true;
     }
 }

--- a/src/Glpi/Helpdesk/Tile/ExternalPageTile.php
+++ b/src/Glpi/Helpdesk/Tile/ExternalPageTile.php
@@ -58,7 +58,7 @@ final class ExternalPageTile extends CommonDBTM implements TileInterface
     }
 
     #[Override]
-    public function getTileLink(): string
+    public function getTileUrl(): string
     {
         return $this->fields['url'];
     }

--- a/src/Glpi/Helpdesk/Tile/FormTile.php
+++ b/src/Glpi/Helpdesk/Tile/FormTile.php
@@ -36,6 +36,7 @@ namespace Glpi\Helpdesk\Tile;
 
 use CommonDBChild;
 use Glpi\Form\Form;
+use Html;
 use Override;
 
 final class FormTile extends CommonDBChild implements TileInterface
@@ -89,11 +90,12 @@ final class FormTile extends CommonDBChild implements TileInterface
     }
 
     #[Override]
-    public function getTileLink(): string
+    public function getTileUrl(): string
     {
         if ($this->form === null) {
             return "";
         }
-        return '/Form/Render/' .  $this->form->getID();
+
+        return Html::getPrefixedUrl('/Form/Render/' .  $this->form->getID());
     }
 }

--- a/src/Glpi/Helpdesk/Tile/FormTile.php
+++ b/src/Glpi/Helpdesk/Tile/FormTile.php
@@ -113,7 +113,7 @@ final class FormTile extends CommonDBChild implements TileInterface
         }
 
         // Check that the form entity is visible
-        if ($this->form->isAccessibleFromEntities($session_info->getActiveEntitiesIds())) {
+        if (!$this->form->isAccessibleFromEntities($session_info->getActiveEntitiesIds())) {
             return false;
         }
 

--- a/src/Glpi/Helpdesk/Tile/GlpiPageTile.php
+++ b/src/Glpi/Helpdesk/Tile/GlpiPageTile.php
@@ -35,6 +35,7 @@
 namespace Glpi\Helpdesk\Tile;
 
 use CommonDBTM;
+use Glpi\Session\SessionInfo;
 use Html;
 use Override;
 
@@ -76,5 +77,15 @@ final class GlpiPageTile extends CommonDBTM implements TileInterface
         };
 
         return Html::getPrefixedUrl($url);
+    }
+
+    #[Override]
+    public function isValid(SessionInfo $session_info): bool
+    {
+        // We could check rights here for extra safety but it is not really needed
+        // since tiles are defined per profile so a page tile defined for a
+        // profile should be accessible to the user of that profile.
+        // TODO: add extra safety check here when we have more time.
+        return true;
     }
 }

--- a/src/Glpi/Helpdesk/Tile/GlpiPageTile.php
+++ b/src/Glpi/Helpdesk/Tile/GlpiPageTile.php
@@ -34,33 +34,44 @@
 
 namespace Glpi\Helpdesk\Tile;
 
-final class Tile implements TileInterface
-{
-    public function __construct(
-        private string $title,
-        private string $description,
-        private string $illustration,
-        private string $link,
-    ) {
-    }
+use CommonDBTM;
+use Override;
 
+final class GlpiPageTile extends CommonDBTM implements TileInterface
+{
+    public const PAGE_SERVICE_CATALOG = 'service_catalog';
+    public const PAGE_FAQ = 'faq';
+    public const PAGE_RESERVATION = 'reservation';
+    public const PAGE_APPROVAL = 'approval';
+
+    #[Override]
     public function getTitle(): string
     {
-        return $this->title;
+        return $this->fields['title'];
     }
 
+    #[Override]
     public function getDescription(): string
     {
-        return $this->description;
+        return $this->fields['description'];
     }
 
+    #[Override]
     public function getIllustration(): string
     {
-        return $this->illustration;
+        return $this->fields['illustration'];
     }
 
-    public function getLink(): string
+    #[Override]
+    public function getTileLink(): string
     {
-        return $this->link;
+        return match ($this->fields['page']) {
+            self::PAGE_SERVICE_CATALOG => '/ServiceCatalog',
+            self::PAGE_FAQ             => '/front/helpdesk.faq.php',
+            self::PAGE_RESERVATION     => '/front/reservationitem.php',
+            // TODO: apply correct search filter
+            self::PAGE_APPROVAL        => '/front/ticket.php',
+            default                    => '/Helpdesk',
+        };
     }
 }

--- a/src/Glpi/Helpdesk/Tile/GlpiPageTile.php
+++ b/src/Glpi/Helpdesk/Tile/GlpiPageTile.php
@@ -35,6 +35,7 @@
 namespace Glpi\Helpdesk\Tile;
 
 use CommonDBTM;
+use Html;
 use Override;
 
 final class GlpiPageTile extends CommonDBTM implements TileInterface
@@ -63,9 +64,9 @@ final class GlpiPageTile extends CommonDBTM implements TileInterface
     }
 
     #[Override]
-    public function getTileLink(): string
+    public function getTileUrl(): string
     {
-        return match ($this->fields['page']) {
+        $url = match ($this->fields['page']) {
             self::PAGE_SERVICE_CATALOG => '/ServiceCatalog',
             self::PAGE_FAQ             => '/front/helpdesk.faq.php',
             self::PAGE_RESERVATION     => '/front/reservationitem.php',
@@ -73,5 +74,7 @@ final class GlpiPageTile extends CommonDBTM implements TileInterface
             self::PAGE_APPROVAL        => '/front/ticket.php',
             default                    => '/Helpdesk',
         };
+
+        return Html::getPrefixedUrl($url);
     }
 }

--- a/src/Glpi/Helpdesk/Tile/Profile_Tile.php
+++ b/src/Glpi/Helpdesk/Tile/Profile_Tile.php
@@ -8,6 +8,7 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -32,15 +33,16 @@
  * ---------------------------------------------------------------------
  */
 
- namespace Glpi\Helpdesk\Tile;
+namespace Glpi\Helpdesk\Tile;
 
-interface TileInterface
+use CommonDBRelation;
+use Profile;
+
+final class Profile_Tile extends CommonDBRelation
 {
-    public function getTitle(): string;
+    public static $itemtype_1 = Profile::class;
+    public static $items_id_1 = 'profiles_id';
 
-    public function getDescription(): string;
-
-    public function getIllustration(): string;
-
-    public function getTileLink(): string;
+    public static $itemtype_2 = 'itemtype';
+    public static $items_id_2 = 'items_id';
 }

--- a/src/Glpi/Helpdesk/Tile/TileInterface.php
+++ b/src/Glpi/Helpdesk/Tile/TileInterface.php
@@ -34,6 +34,8 @@
 
  namespace Glpi\Helpdesk\Tile;
 
+ use Glpi\Session\SessionInfo;
+
 interface TileInterface
 {
     public function getTitle(): string;
@@ -43,4 +45,5 @@ interface TileInterface
     public function getIllustration(): string;
 
     public function getTileUrl(): string;
+    public function isValid(SessionInfo $session_info): bool;
 }

--- a/src/Glpi/Helpdesk/Tile/TileInterface.php
+++ b/src/Glpi/Helpdesk/Tile/TileInterface.php
@@ -42,5 +42,5 @@ interface TileInterface
 
     public function getIllustration(): string;
 
-    public function getTileLink(): string;
+    public function getTileUrl(): string;
 }

--- a/src/Glpi/Helpdesk/Tile/TilesManager.php
+++ b/src/Glpi/Helpdesk/Tile/TilesManager.php
@@ -54,11 +54,8 @@ final class TilesManager
         foreach ($profile_tiles as $row) {
             $itemtype = $row['itemtype'];
 
-            if (
-                !is_a($itemtype, TileInterface::class, true)
-                || !is_a($itemtype, CommonDBTM::class, true)
-                || (new ReflectionClass($itemtype))->isAbstract()
-            ) {
+            $tile = getItemForItemtype($itemtype);
+            if (!($tile instanceof TileInterface)) {
                 continue;
             }
 

--- a/src/Glpi/Helpdesk/Tile/TilesManager.php
+++ b/src/Glpi/Helpdesk/Tile/TilesManager.php
@@ -65,7 +65,7 @@ final class TilesManager
             }
 
             // Make sure the tile is valid for the given session and entity details
-            if (!$tile->isAccessibleForSession($session_info)) {
+            if (!$tile->isValid($session_info)) {
                 continue;
             }
 

--- a/src/Glpi/Session/SessionInfo.php
+++ b/src/Glpi/Session/SessionInfo.php
@@ -125,7 +125,7 @@ final class SessionInfo
 
     private function getRights(): array
     {
-        if ($this->rights !== null) {
+        if ($this->rights === null) {
             $profile = $this->getProfile();
             $profile->cleanProfile();
             $this->rights = $profile->fields;

--- a/src/Glpi/Session/SessionInfo.php
+++ b/src/Glpi/Session/SessionInfo.php
@@ -37,9 +37,9 @@ namespace Glpi\Session;
 
 use Profile;
 
-final readonly class SessionInfo
+final class SessionInfo
 {
-    private Profile $profile;
+    private ?Profile $profile = null;
     private ?array $rights = null;
 
     public function __construct(

--- a/src/Glpi/Session/SessionInfo.php
+++ b/src/Glpi/Session/SessionInfo.php
@@ -35,12 +35,16 @@
 
 namespace Glpi\Session;
 
+use Profile;
+
 final readonly class SessionInfo
 {
     public function __construct(
         private int $user_id = 0,
         private array $group_ids = [],
         private int $profile_id = 0,
+        /** @var int[] $entities_ids */
+        private array $active_entities_ids = [],
     ) {
     }
 
@@ -57,5 +61,11 @@ final readonly class SessionInfo
     public function getProfileId(): int
     {
         return $this->profile_id;
+    }
+
+    /** @return int[] */
+    public function getActiveEntitiesIds(): array
+    {
+        return $this->active_entities_ids;
     }
 }

--- a/src/Session.php
+++ b/src/Session.php
@@ -2376,6 +2376,7 @@ class Session
             user_id   : self::getLoginUserID(),
             group_ids : $_SESSION['glpigroups'] ?? [],
             profile_id: $_SESSION['glpiactiveprofile']['id'],
+            active_entities_ids: $_SESSION['glpiactiveentities'],
         );
     }
 

--- a/src/Session.php
+++ b/src/Session.php
@@ -2394,4 +2394,19 @@ class Session
     {
         self::$is_ajax_request = false;
     }
+
+    public static function getCurrentProfile(): Profile
+    {
+        $profile_id = $_SESSION['glpiactiveprofile']['id'] ?? null;
+        if ($profile_id === null) {
+            throw new RuntimeException("No active session");
+        }
+
+        $profile = Profile::getById($profile_id);
+        if (!$profile) {
+            throw new RuntimeException("Failed to load profile: $profile_id");
+        }
+
+        return $profile;
+    }
 }

--- a/templates/pages/helpdesk/index.html.twig
+++ b/templates/pages/helpdesk/index.html.twig
@@ -94,7 +94,7 @@
                         <div class="col-12 col-sm-6 col-md-4 d-flex">
                             <a
                                 class="card mx-1 my-2 flex-grow-1"
-                                href="{{ path(tile.getLink()) }}"
+                                href="{{ path(tile.getTileLink()) }}"
                             >
                                 <section class="card-body">
                                     <div class="d-flex">

--- a/templates/pages/helpdesk/index.html.twig
+++ b/templates/pages/helpdesk/index.html.twig
@@ -94,7 +94,7 @@
                         <div class="col-12 col-sm-6 col-md-4 d-flex">
                             <a
                                 class="card mx-1 my-2 flex-grow-1"
-                                href="{{ path(tile.getTileLink()) }}"
+                                href="{{ tile.getTileUrl() }}"
                             >
                                 <section class="card-body">
                                     <div class="d-flex">


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

Move the hardcoded tiles of the home page into the database.
Next step is allowing tiles to be added and removed from GLPI's UI.

While a tile is technically just a title + a description + an illustration + a link, there are 3 distinct types to ease configuration:
* `GlpiPageTile`: harcoded link to a GLPI page.
* `ExternalPageTile`: link to any page.
* `FormTile`: link to a form.

Having these dedicated types will make it easier for user to configure their own tiles later as it abstract the 'link' away from the user in most cases (e.g. no need to know the URL of the service catalog page to add a "ServiceCatalog" tile).