### PR TITLE
Fix(Core): prevent log overload when HTTP user-agent is missing

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -2023,8 +2023,17 @@ HTML;
         $platform = "";
         if (!defined('TU_USER')) {
             $parser = new UserAgentParser();
-            $ua = $parser->parse();
-            $platform = $ua->platform();
+            try {
+                $ua = $parser->parse();
+                $platform = $ua->platform();
+            } catch (InvalidArgumentException $e) {
+                // To avoid log overload, we suppress the InvalidArgumentException error.
+                // Some non-standard clients, such as bots or simplified HTTP services,
+                // don’t always send the User-Agent header,
+                // and privacy-focused browsers or extensions may also block it.
+                // Additionally, server configurations like proxies or firewalls
+                // may remove this header for security reasons.
+            }
         }
 
         $help_url_key = Session::getCurrentInterface() === 'central'

--- a/src/Html.php
+++ b/src/Html.php
@@ -2021,19 +2021,17 @@ HTML;
         $user = Session::getLoginUserID() !== false ? User::getById(Session::getLoginUserID()) : null;
 
         $platform = "";
-        if (!defined('TU_USER')) {
-            $parser = new UserAgentParser();
-            try {
-                $ua = $parser->parse();
-                $platform = $ua->platform();
-            } catch (InvalidArgumentException $e) {
-                // To avoid log overload, we suppress the InvalidArgumentException error.
-                // Some non-standard clients, such as bots or simplified HTTP services,
-                // don’t always send the User-Agent header,
-                // and privacy-focused browsers or extensions may also block it.
-                // Additionally, server configurations like proxies or firewalls
-                // may remove this header for security reasons.
-            }
+        $parser = new UserAgentParser();
+        try {
+            $ua = $parser->parse();
+            $platform = $ua->platform();
+        } catch (InvalidArgumentException $e) {
+            // To avoid log overload, we suppress the InvalidArgumentException error.
+            // Some non-standard clients, such as bots or simplified HTTP services,
+            // don’t always send the User-Agent header,
+            // and privacy-focused browsers or extensions may also block it.
+            // Additionally, server configurations like proxies or firewalls
+            // may remove this header for security reasons.
         }
 
         $help_url_key = Session::getCurrentInterface() === 'central'


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !34988

To avoid log overload, we suppress the InvalidArgumentException error.
Some non-standard clients, such as bots or simplified HTTP services, don’t always send the User-Agent header,
and privacy-focused browsers or extensions may also block it.
Additionally, server configurations like proxies or firewalls may remove this header for security reasons.


