### PR TITLE
Fix SQL error when items linked to a ticket doesn't support entities

### DIFF
--- a/src/CommonDBRelation.php
+++ b/src/CommonDBRelation.php
@@ -2126,7 +2126,12 @@ abstract class CommonDBRelation extends CommonDBConnexity
                 continue;
             }
 
-            $params = static::getTypeItemsQueryParams($item->fields['id'], $data['itemtype']);
+            $linked_item = getItemForItemtype($data['itemtype']);
+            $params = static::getTypeItemsQueryParams(
+                $item->fields['id'],
+                $data['itemtype'],
+                $linked_item->isEntityAssign(),
+            );
             unset($params['SELECT']);
             $params['COUNT'] = 'cpt';
             $iterator = $DB->request($params);


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works
    -> Not relevant to add a test because this is only reproductible with the `Ticket` <-> `Answer` relation, which we plan to delete in the near future (replaced by a direct `Ticket` <-> `Form` relation, which does not trigger the same issue as `Form` has an entity field).

## Description

Quick fix for #18175.
