### PR TITLE
Fix missing interface criteria when updating display preferences

### DIFF
--- a/src/DisplayPreference.php
+++ b/src/DisplayPreference.php
@@ -271,9 +271,10 @@ class DisplayPreference extends CommonDBTM
                     'interface' => $interface,
                 ],
                 [
-                    'itemtype' => $itemtype,
-                    'users_id' => $users_id,
-                    'num'      => $num,
+                    'itemtype'  => $itemtype,
+                    'users_id'  => $users_id,
+                    'num'       => $num,
+                    'interface' => $interface,
                 ]
             );
         }


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
  -> Not needed, there is already a test on this feature. It went unnoticed because we don't check if there are warning in logs after the E2E tests are executed and the test itself still worked as intented.

## Description

Fix #18177.

