### PR TITLE
Genericdate always shows datetime fields

### DIFF
--- a/ajax/genericdate.php
+++ b/ajax/genericdate.php
@@ -43,7 +43,8 @@ Html::header_nocache();
 Session::checkLoginUser();
 
 if (isset($_POST['value']) && (strcmp($_POST['value'], '0') == 0)) {
-    if ($_POST['withtime']) {
+    $withtime = filter_var($_POST['withtime'], FILTER_VALIDATE_BOOLEAN);
+    if ($withtime) {
         Html::showDateTimeField($_POST['name'], ['value' => $_POST['specificvalue']]);
     } else {
         Html::showDateField($_POST['name'], ['value' => $_POST['specificvalue']]);


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does:
AJAX-generated date fields are always of type datetime, an example is contracts that have a Start date field with datatype date.
This is because the POST receives false as a boolean but interprets it as a text string, so the check is always correct as it is always text.
The fix validates value as a boolean option.

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/4e46c20c-7e36-47ce-ac3e-36dd263b6ac0)
![image](https://github.com/user-attachments/assets/8ce0cfde-49e1-4168-88f3-e1dcd4f2f92c)
![image](https://github.com/user-attachments/assets/a5e6412d-2b4f-4c00-88d9-0d7ed28e0bd5)




