### PR TITLE
Fix update without config file

### DIFF
--- a/src/Glpi/Console/Database/UpdateCommand.php
+++ b/src/Glpi/Console/Database/UpdateCommand.php
@@ -92,10 +92,8 @@ class UpdateCommand extends AbstractCommand implements ConfigurationCommandInter
     #[Override]
     public function getSpecificMandatoryRequirements(): array
     {
-        /** @var DBmysql|null $DB */
-        global $DB;
-
-        return $this->db instanceof DBmysql && $this->db->connected ? [new DatabaseTablesEngine($this->db)] : [];
+        $valid_db = $this->db instanceof DBmysql && $this->db->connected;
+        return $valid_db ? [new DatabaseTablesEngine($this->db)] : [];
     }
 
     protected function configure()

--- a/src/Glpi/Console/Database/UpdateCommand.php
+++ b/src/Glpi/Console/Database/UpdateCommand.php
@@ -95,7 +95,7 @@ class UpdateCommand extends AbstractCommand implements ConfigurationCommandInter
         /** @var DBmysql|null $DB */
         global $DB;
 
-        return $DB instanceof DBmysql ? [new DatabaseTablesEngine($DB)] : [];
+        return $this->db instanceof DBmysql && $this->db->connected ? [new DatabaseTablesEngine($this->db)] : [];
     }
 
     protected function configure()

--- a/src/Glpi/Console/Database/UpdateCommand.php
+++ b/src/Glpi/Console/Database/UpdateCommand.php
@@ -35,6 +35,7 @@
 
 namespace Glpi\Console\Database;
 
+use DBmysql;
 use Glpi\Cache\CacheManager;
 use Glpi\Console\AbstractCommand;
 use Glpi\Console\Command\ConfigurationCommandInterface;
@@ -91,10 +92,10 @@ class UpdateCommand extends AbstractCommand implements ConfigurationCommandInter
     #[Override]
     public function getSpecificMandatoryRequirements(): array
     {
-        /** @var \DBmysql $DB */
+        /** @var DBmysql|null $DB */
         global $DB;
 
-        return [new DatabaseTablesEngine($DB)];
+        return $DB instanceof DBmysql ? [new DatabaseTablesEngine($DB)] : [];
     }
 
     protected function configure()


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
    -> not easily testable

## Description

Fix an issue reported by @cedric-anne where an user can try to update GLPI without a valid config file.

```
Uncaught Exception TypeError: Glpi\System\Requirement\DatabaseTablesEngine::__construct(): Argument #1 ($db)
must be of type DBmysql, null given, called in /var/www/glpi/src/Glpi/Console/Database/UpdateCommand.php 
on line 97 in /var/www/glpi/src/Glpi/System/Requirement/DatabaseTablesEngine.php at line 47
```
