### PR TITLE
Fix console error on missing config table

### DIFF
--- a/src/Glpi/Console/Application.php
+++ b/src/Glpi/Console/Application.php
@@ -434,7 +434,11 @@ class Application extends BaseApplication
 
         Config::detectRootDoc();
 
-        if (!($this->db instanceof DBmysql) || !$this->db->connected) {
+        if (
+            !($this->db instanceof DBmysql)
+            || !$this->db->connected
+            || !$this->db->tableExists('glpi_configs')
+        ) {
             return;
         }
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

When a user created a database manually, then uses the `bin/console db:configure` command to create the database configuration file, and then uses the `bin/console db:install` command, the following SQL error is triggerred: `` SQL Error "1146": Table 'glpi.glpi_configs' doesn't exist in query "SELECT * FROM `glpi_configs`" ``.

The proposed change fixed it.