### PR TITLE
Fix key generation when database has no tables yet

### DIFF
--- a/install/install.php
+++ b/install/install.php
@@ -262,7 +262,7 @@ function step4($databasename, $newdatabasename)
 
    //create security key
     $glpikey = new GLPIKey();
-    if (!$glpikey->generate()) {
+    if (!$glpikey->generate(update_db: false)) {
         echo "<p><strong>" . __('Security key cannot be generated!') . "</strong></p>";
         $prev_form($host, $user, $password);
         return;

--- a/src/GLPIKey.php
+++ b/src/GLPIKey.php
@@ -181,8 +181,8 @@ class GLPIKey
 
        // Fetch old key before generating the new one (but only if DB exists and there is something to migrate)
         $previous_key = null;
-        if ($update_db) {
-            $previous_key = $this->keyExists() ? $this->get() : null;
+        if ($update_db && $this->keyExists()) {
+            $previous_key = $this->get();
             if ($previous_key === null) {
                 // Do not continue if unable to get previous key when DB update is requested.
                 // Detailed warning has already been triggered by `get()` method.

--- a/src/GLPIKey.php
+++ b/src/GLPIKey.php
@@ -165,7 +165,7 @@ class GLPIKey
      *
      * @return bool
      */
-    public function generate(): bool
+    public function generate(bool $update_db = true): bool
     {
         /** @var \DBmysql $DB */
         global $DB;
@@ -181,14 +181,12 @@ class GLPIKey
 
        // Fetch old key before generating the new one (but only if DB exists and there is something to migrate)
         $previous_key = null;
-        if ($DB instanceof DBmysql && $DB->connected) {
-            if ($this->keyExists()) {
-                $previous_key = $this->get();
-                if ($previous_key === null) {
-                    // Do not continue if unable to get previous key.
-                    // Detailed warning has already been triggered by `get()` method.
-                    return false;
-                }
+        if ($update_db) {
+            $previous_key = $this->keyExists() ? $this->get() : null;
+            if ($previous_key === null) {
+                // Do not continue if unable to get previous key when DB update is requested.
+                // Detailed warning has already been triggered by `get()` method.
+                return false;
             }
         }
 
@@ -199,11 +197,12 @@ class GLPIKey
             return false;
         }
 
-        if ($DB instanceof DBmysql && $DB->connected) {
-            if (!$this->migrateFieldsInDb($previous_key) || !$this->migrateConfigsInDb($previous_key)) {
-                trigger_error('Error during encrypted data update in database.', E_USER_WARNING);
-                return false;
-            }
+        if (
+            $update_db
+            && (!$this->migrateFieldsInDb($previous_key) || !$this->migrateConfigsInDb($previous_key))
+        ) {
+            trigger_error('Error during encrypted data update in database.', E_USER_WARNING);
+            return false;
         }
 
         return true;

--- a/src/Glpi/Console/Database/InstallCommand.php
+++ b/src/Glpi/Console/Database/InstallCommand.php
@@ -222,7 +222,7 @@ class InstallCommand extends AbstractConfigureCommand implements ConfigurationCo
 
        // Create security key
         $glpikey = new GLPIKey();
-        if (!$glpikey->generate()) {
+        if (!$glpikey->generate(update_db: false)) {
             $message = __('Security key cannot be generated!');
             $output->writeln('<error>' . $message . '</error>', OutputInterface::VERBOSITY_QUIET);
             return self::ERROR_CANNOT_CREATE_ENCRYPTION_KEY_FILE;


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

When a user created a database manually, then uses the `bin/console db:configure` command to create the database configuration file, and then uses the `bin/console db:install` command, the following SQL error are triggerred:
```
SQL Error "1146": Table 'glpi.glpi_mailcollectors' doesn't exist in query "SELECT `id`, `passwd` FROM `glpi_mailcollectors` WHERE ( NOT (`passwd` IS NULL))"
SQL Error "1146": Table 'glpi.glpi_oauthclients' doesn't exist in query "SELECT `id`, `secret` FROM `glpi_oauthclients` WHERE ( NOT (`secret` IS NULL))"
SQL Error "1146": Table 'glpi.glpi_snmpcredentials' doesn't exist in query "SELECT `id`, `auth_passphrase` FROM `glpi_snmpcredentials` WHERE ( NOT (`auth_passphrase` IS NULL))"
SQL Error "1146": Table 'glpi.glpi_snmpcredentials' doesn't exist in query "SELECT `id`, `priv_passphrase` FROM `glpi_snmpcredentials` WHERE ( NOT (`priv_passphrase` IS NULL))"
SQL Error "1146": Table 'glpi.glpi_configs' doesn't exist in query "SELECT * FROM `glpi_configs` WHERE `context` = 'core' AND `name` IN ('glpinetwork_registration_key', 'proxy_passwd', 'smtp_passwd', 'smtp_oauth_client_secret', 'smtp_oauth_refresh_token') AND ( NOT (`value` IS NULL))"
```

The proposed change fixed it.

