### PR TITLE
Remove some usages of `Glpi\Http\Response::send()`

### DIFF
--- a/ajax/criteria_filter.php
+++ b/ajax/criteria_filter.php
@@ -37,7 +37,6 @@ use Glpi\Exception\Http\AccessDeniedHttpException;
 use Glpi\Exception\Http\BadRequestHttpException;
 use Glpi\Exception\Http\NotFoundHttpException;
 use Glpi\Exception\Http\UnprocessableEntityHttpException;
-use Glpi\Http\Response;
 use Glpi\Search\FilterableInterface;
 
 // Read endpoint
@@ -83,9 +82,8 @@ switch ($action) {
             throw new UnprocessableEntityHttpException('Unable to process data');
         }
 
-        // OK
-        (new Response(200))->send();
-        break;
+        // Send empty response when OK
+        return;
 
     case "delete_filter":
         // Default values for this endpoint
@@ -117,7 +115,6 @@ switch ($action) {
             throw new UnprocessableEntityHttpException('Unable to process data');
         }
 
-        // OK
-        (new Response(200))->send();
-        break;
+        // Send empty response when OK
+        return;
 }

--- a/ajax/stencil.php
+++ b/ajax/stencil.php
@@ -34,7 +34,6 @@
  */
 
 use Glpi\Exception\Http\NotFoundHttpException;
-use Glpi\Http\Response;
 
 if (isset($_POST['id'])) {
     $stencil = Stencil::getStencilFromID($_POST['id']);

--- a/ajax/task.php
+++ b/ajax/task.php
@@ -38,7 +38,6 @@
  */
 
 use Glpi\Exception\Http\BadRequestHttpException;
-use Glpi\Http\Response;
 
 /** @var \Glpi\Controller\LegacyFileLoadController $this */
 $this->setAjax();

--- a/src/Glpi/Controller/ApiController.php
+++ b/src/Glpi/Controller/ApiController.php
@@ -40,7 +40,6 @@ use Glpi\Application\ErrorHandler;
 use Glpi\Http\HeaderlessStreamedResponse;
 use Glpi\Http\JSONResponse;
 use Glpi\Http\Request;
-use Glpi\Http\Response;
 use Glpi\Security\Attribute\SecurityStrategy;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
@@ -60,15 +59,6 @@ final class ApiController extends AbstractController
     {
         $_SERVER['PATH_INFO'] = $request->get('request_parameters');
 
-        return new HeaderlessStreamedResponse($this->call(...));
-    }
-
-    private function call(): void
-    {
-        /**
-         * High-level API entrypoint
-         */
-
         // Ensure errors will not break API output.
         ErrorHandler::getInstance()->disableOutput();
 
@@ -79,10 +69,10 @@ final class ApiController extends AbstractController
 
         // If the relative URI starts with /v1/ or is /v1 then we are dealing with a legacy API request
         if (preg_match('/^\/v1(\/|$)/', $relative_uri)) {
-            // Include the legacy API entrypoint and then die
-            $api = new \Glpi\Api\APIRest();
-            $api->call();
-            return;
+            return new HeaderlessStreamedResponse(function () {
+                $api = new \Glpi\Api\APIRest();
+                $api->call();
+            });
         }
 
         $supported_versions = Router::getAPIVersions();
@@ -104,7 +94,6 @@ final class ApiController extends AbstractController
 
         try {
             $response = $router->handleRequest($request);
-            $response->send();
         } catch (\InvalidArgumentException $e) {
             $response = new JSONResponse(
                 ApiAbstractController::getErrorResponseBody(
@@ -115,8 +104,13 @@ final class ApiController extends AbstractController
             );
         } catch (\Throwable $e) {
             ErrorHandler::getInstance()->handleException($e, true);
-            $response = new Response(500);
-            $response->send();
+            $response = new JSONResponse(null, 500);
         }
+
+        return new SymfonyResponse(
+            $response->getBody()->getContents(),
+            $response->getStatusCode(),
+            $response->getHeaders()
+        );
     }
 }

--- a/src/Glpi/Controller/StatusController.php
+++ b/src/Glpi/Controller/StatusController.php
@@ -37,9 +37,8 @@ namespace Glpi\Controller;
 use Session;
 use Glpi\Api\HL\Router;
 use Glpi\Application\ErrorHandler;
-use Glpi\Http\HeaderlessStreamedResponse;
+use Glpi\Http\JSONResponse;
 use Glpi\Http\Request;
-use Glpi\Http\Response;
 use Glpi\Security\Attribute\SecurityStrategy;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
@@ -54,23 +53,23 @@ final class StatusController extends AbstractController
     #[SecurityStrategy('no_check')]
     public function __invoke(SymfonyRequest $request): SymfonyResponse
     {
-        return new HeaderlessStreamedResponse($this->call(...));
-    }
-
-    private function call(): void
-    {
         // Force in normal mode
         $_SESSION['glpi_use_mode'] = Session::NORMAL_MODE;
+
         // Redirect handling to the High-Level API (we may eventually remove this script)
         $request = new Request('GET', '/Status/All', getallheaders() ?? []);
 
         try {
             $response = Router::getInstance()->handleRequest($request);
-            $response->send();
         } catch (\Throwable $e) {
             ErrorHandler::getInstance()->handleException($e, true);
-            $response = new Response(500);
-            $response->send();
+            $response = new JSONResponse(null, 500);
         }
+
+        return new SymfonyResponse(
+            $response->getBody()->getContents(),
+            $response->getStatusCode(),
+            $response->getHeaders()
+        );
     }
 }

--- a/src/QueuedWebhook.php
+++ b/src/QueuedWebhook.php
@@ -36,7 +36,6 @@
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
-use Glpi\Http\Response;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\RequestOptions;


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

`Glpi\Http\Response::send()` uses the `http_response_code()` function. We have to remore its usages, when possible, to get a better compatibility with the Symfony framework.