### PR TITLE
Do no show empty reminder/rss tabs on home page

### DIFF
--- a/phpunit/functional/Glpi/Helpdesk/HomePageTabsTest.php
+++ b/phpunit/functional/Glpi/Helpdesk/HomePageTabsTest.php
@@ -1,0 +1,142 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace test\units\Glpi\Helpdesk;
+
+use DbTestCase;
+use Glpi\Helpdesk\HomePageTabs;
+use Profile;
+use Reminder;
+use Reminder_User;
+use RSSFeed;
+use RSSFeed_User;
+use User;
+
+final class HomePageTabsTest extends DbTestCase
+{
+    public function testDefaultTabs(): void
+    {
+        // Arrange: create a new user without reminders / rssfeeds
+        $this->createItem(User::class, [
+            'name'          => 'tmp_user',
+            'password'      => 'tmp_user',
+            'password2'     => 'tmp_user',
+            '_profiles_id'  => getItemByTypeName(Profile::class, 'Self-Service', true),
+            '_entities_id'  => $this->getTestRootEntity(true),
+            '_is_recursive' => true,
+        ], ['password', 'password2']);
+
+        // Act: get tabs names
+        $this->login('tmp_user', 'tmp_user');
+        $tabs = $this->getHomeTabsNames();
+
+        // Assert: the reminder and rss tabs should not be displayed as there is no data.
+        $this->assertEquals([
+            'Ongoing tickets',
+            'Solved tickets',
+        ], $tabs);
+    }
+
+    public function testPublicReminderTabIsAddedWhenReminderExists(): void
+    {
+        // Arrange: create a new user and one public reminder
+        $user = $this->createItem(User::class, [
+            'name'          => 'tmp_user',
+            'password'      => 'tmp_user',
+            'password2'     => 'tmp_user',
+            '_profiles_id'  => getItemByTypeName(Profile::class, 'Self-Service', true),
+            '_entities_id'  => $this->getTestRootEntity(true),
+            '_is_recursive' => true,
+        ], ['password', 'password2']);
+        $reminder = $this->createItem(Reminder::class, [
+            'name' => 'My reminder',
+        ]);
+        $this->createItem(Reminder_User::class, [
+            'users_id' => $user->getID(),
+            'reminders_id' => $reminder->getID(),
+        ]);
+
+        // Act: get tabs names
+        $this->login('tmp_user', 'tmp_user');
+        $tabs = $this->getHomeTabsNames();
+
+        // Assert: the reminder and rss tabs should not be displayed as there is no data.
+        $this->assertEquals([
+            'Ongoing tickets',
+            'Solved tickets',
+            'Reminders',
+        ], $tabs);
+    }
+
+    public function testRssFeedsTabIsAddedWhenRssFeedsExists(): void
+    {
+        // Arrange: create a new user and one public reminder
+        $user = $this->createItem(User::class, [
+            'name'          => 'tmp_user',
+            'password'      => 'tmp_user',
+            'password2'     => 'tmp_user',
+            '_profiles_id'  => getItemByTypeName(Profile::class, 'Self-Service', true),
+            '_entities_id'  => $this->getTestRootEntity(true),
+            '_is_recursive' => true,
+        ], ['password', 'password2']);
+        $this->login('tmp_user', 'tmp_user'); // Need to be logged in to create the RSS feed
+        $reminder = $this->createItem(RSSFeed::class, [
+            'name' => 'My feed',
+            'url'  => 'https://fake-rss.localhost.com/feed',
+            '_do_not_compute_name' => true,
+        ]);
+        $this->createItem(RSSFeed_User::class, [
+            'users_id' => $user->getID(),
+            'rssfeeds_id' => $reminder->getID(),
+        ]);
+
+        // Act: get tabs names
+        $tabs = $this->getHomeTabsNames();
+
+        // Assert: the reminder and rss tabs should not be displayed as there is no data.
+        $this->assertEquals([
+            'Ongoing tickets',
+            'Solved tickets',
+            'RSS feed',
+        ], $tabs);
+    }
+
+    private function getHomeTabsNames(): array
+    {
+        $tabs = new HomePageTabs();
+        $tabs = $tabs->getTabNameForItem($tabs);
+        $tabs = array_map('strip_tags', $tabs);
+        return array_values($tabs);
+    }
+}

--- a/phpunit/functional/Glpi/Helpdesk/HomePageTabsTest.php
+++ b/phpunit/functional/Glpi/Helpdesk/HomePageTabsTest.php
@@ -114,7 +114,7 @@ final class HomePageTabsTest extends DbTestCase
         $reminder = $this->createItem(RSSFeed::class, [
             'name' => 'My feed',
             'url'  => 'https://fake-rss.localhost.com/feed',
-            '_do_not_compute_name' => true,
+            '_do_not_fetch_values' => true,
         ]);
         $this->createItem(RSSFeed_User::class, [
             'users_id' => $user->getID(),

--- a/src/Glpi/Controller/Helpdesk/IndexController.php
+++ b/src/Glpi/Controller/Helpdesk/IndexController.php
@@ -35,10 +35,10 @@
 namespace Glpi\Controller\Helpdesk;
 
 use Glpi\Controller\AbstractController;
+use Glpi\Helpdesk\HomePageTabs;
 use Glpi\Helpdesk\Tile\TilesManager;
 use Glpi\Http\Firewall;
 use Glpi\Security\Attribute\SecurityStrategy;
-use Glpi\SelfService\HomePageTabs;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;

--- a/src/Glpi/Helpdesk/HomePageTabs.php
+++ b/src/Glpi/Helpdesk/HomePageTabs.php
@@ -32,7 +32,7 @@
  * ---------------------------------------------------------------------
  */
 
-namespace Glpi\SelfService;
+namespace Glpi\Helpdesk;
 
 use CommonGLPI;
 use Override;
@@ -80,7 +80,10 @@ final class HomePageTabs extends CommonGLPI
             ),
         ];
 
-        if (Session::haveRight("reminder_public", READ)) {
+        if (
+            Session::haveRight("reminder_public", READ)
+            && Reminder::countPublicReminders() > 0
+        ) {
             // TODO: only show if at least one reminder is visible
             $tabs[self::PUBLIC_REMINDER_TAB] = self::createTabEntry(
                 text: Reminder::getTypeName(),
@@ -88,7 +91,10 @@ final class HomePageTabs extends CommonGLPI
             );
         }
 
-        if (Session::haveRight("rssfeed_public", READ)) {
+        if (
+            Session::haveRight("rssfeed_public", READ)
+            && RSSFeed::countPublicRssFedds() > 0
+        ) {
             // TODO: only show if at least one RSS feed is visible
             $tabs[self::RSS_FEED_PUBLIC] = self::createTabEntry(
                 text: RSSFeed::getTypeName(),

--- a/src/Glpi/Helpdesk/HomePageTabs.php
+++ b/src/Glpi/Helpdesk/HomePageTabs.php
@@ -84,7 +84,6 @@ final class HomePageTabs extends CommonGLPI
             Session::haveRight("reminder_public", READ)
             && Reminder::countPublicReminders() > 0
         ) {
-            // TODO: only show if at least one reminder is visible
             $tabs[self::PUBLIC_REMINDER_TAB] = self::createTabEntry(
                 text: Reminder::getTypeName(),
                 icon: Reminder::getIcon()
@@ -95,7 +94,6 @@ final class HomePageTabs extends CommonGLPI
             Session::haveRight("rssfeed_public", READ)
             && RSSFeed::countPublicRssFedds() > 0
         ) {
-            // TODO: only show if at least one RSS feed is visible
             $tabs[self::RSS_FEED_PUBLIC] = self::createTabEntry(
                 text: RSSFeed::getTypeName(),
                 icon: RSSFeed::getIcon()

--- a/src/RSSFeed.php
+++ b/src/RSSFeed.php
@@ -486,10 +486,10 @@ class RSSFeed extends CommonDBVisible implements ExtraVisibilityCriteria
         }
         $input['users_id'] = $current_user_id;
 
-        // We may want to disable the name computation when working with fake
+        // We may want to disable the title/description values fetching when working with fake
         // feeds in our unit tests
-        $compute_name = $input['_do_not_compute_name'] ?? false;
-        if (!$compute_name) {
+        $fetch_values = ($input['_do_not_fetch_values'] ?? false) === false;
+        if ($fetch_values) {
             if ($feed = self::getRSSFeed($input['url'])) {
                 $input['have_error'] = 0;
                 $input['name']       = $feed->get_title();
@@ -506,10 +506,6 @@ class RSSFeed extends CommonDBVisible implements ExtraVisibilityCriteria
         if (empty($input["name"])) {
             $input["name"] = __('Without title');
         }
-
-        // Owner cannot be changed
-        unset($input['users_id']);
-
         return $input;
     }
 

--- a/src/Reminder.php
+++ b/src/Reminder.php
@@ -584,23 +584,8 @@ class Reminder extends CommonDBVisible implements
         ]);
     }
 
-    /**
-     * Show list for central view
-     *
-     * @param boolean $personal display reminders created by me?
-     * @param boolean $display if false return html
-     *
-     * @return string|void
-     * @phpstan-return $display ? void : string
-     **/
-    public static function showListForCentral(bool $personal = true, bool $display = true)
+    final public static function getListCriteria(): array
     {
-        /**
-         * @var array $CFG_GLPI
-         * @var \DBmysql $DB
-         */
-        global $CFG_GLPI, $DB;
-
         $users_id = Session::getLoginUserID();
         $today    = date('Y-m-d');
         $now      = date('Y-m-d H:i:s');
@@ -666,6 +651,54 @@ class Reminder extends CommonDBVisible implements
             $personal_criteria = array_merge_recursive($personal_criteria, $additional_criteria);
             $public_criteria   = array_merge_recursive($public_criteria, $additional_criteria);
         }
+
+        // TOOD: would be cleaner to have two separate method like getPersonalCriteria
+        // and getPublicCriteria
+        return [
+            'personal' => $personal_criteria,
+            'public' => $public_criteria,
+        ];
+    }
+
+    final public static function countPublicReminders(): int
+    {
+        /** @var DBmysql $DB */
+        global $DB;
+
+        $criteria = self::getListCriteria();
+        $public_criteria = $criteria['public'];
+
+        // Replace select * by count
+        $public_criteria['COUNT'] = 'total_rows';
+        unset($public_criteria['ORDER BY']);
+        unset($public_criteria['DISTINCT']);
+        unset($public_criteria['SELECT']);
+
+        $data = $DB->request($public_criteria);
+        $row = $data->current();
+        return $row['total_rows'];
+    }
+
+    /**
+     * Show list for central view
+     *
+     * @param boolean $personal display reminders created by me?
+     * @param boolean $display if false return html
+     *
+     * @return string|void
+     * @phpstan-return $display ? void : string
+     **/
+    public static function showListForCentral(bool $personal = true, bool $display = true)
+    {
+        /**
+         * @var array $CFG_GLPI
+         * @var \DBmysql $DB
+         */
+        global $CFG_GLPI, $DB;
+
+        $criteria = self::getListCriteria();
+        $personal_criteria = $criteria['personal'];
+        $public_criteria = $criteria['public'];
 
         // Only standard interface users have personal reminders
         $can_see_personal = Session::getCurrentInterface() === 'central';


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

On the helpdesk home page, do not display the `Reminder` and `Rss feeds` tabs if they have no content.
