### PR TITLE
Remove -T option of docker compose exec

### DIFF
--- a/.github/actions/init_initialize-0.85.5-db.sh
+++ b/.github/actions/init_initialize-0.85.5-db.sh
@@ -3,6 +3,6 @@ set -e -u -x -o pipefail
 
 ROOT_DIR=$(readlink -f "$(dirname $0)/../..")
 
-docker compose exec -T db mysql --user=root --execute="DROP DATABASE IF EXISTS \`glpitest085\`;"
-docker compose exec -T db mysql --user=root --execute="CREATE DATABASE \`glpitest085\`;"
-cat $ROOT_DIR/tests/glpi-0.85.5-empty.sql | docker compose exec -T db mysql --user=root glpitest085
+docker compose exec db mysql --user=root --execute="DROP DATABASE IF EXISTS \`glpitest085\`;"
+docker compose exec db mysql --user=root --execute="CREATE DATABASE \`glpitest085\`;"
+cat $ROOT_DIR/tests/glpi-0.85.5-empty.sql | docker compose exec db mysql --user=root glpitest085

--- a/.github/actions/init_initialize-9.5-db.sh
+++ b/.github/actions/init_initialize-9.5-db.sh
@@ -3,7 +3,7 @@ set -e -u -x -o pipefail
 
 ROOT_DIR=$(readlink -f "$(dirname $0)/../..")
 
-docker compose exec -T db mysql --user=root --execute="DROP DATABASE IF EXISTS \`glpitest-9.5\`;"
-docker compose exec -T db mysql --user=root --execute="CREATE DATABASE \`glpitest-9.5\`;"
-cat $ROOT_DIR/install/mysql/glpi-9.5.13-empty.sql | docker compose exec -T db mysql --user=root glpitest-9.5
-cat $ROOT_DIR/tests/glpi-9.5-data.sql | docker compose exec -T db mysql --user=root glpitest-9.5
+docker compose exec db mysql --user=root --execute="DROP DATABASE IF EXISTS \`glpitest-9.5\`;"
+docker compose exec db mysql --user=root --execute="CREATE DATABASE \`glpitest-9.5\`;"
+cat $ROOT_DIR/install/mysql/glpi-9.5.13-empty.sql | docker compose exec db mysql --user=root glpitest-9.5
+cat $ROOT_DIR/tests/glpi-9.5-data.sql | docker compose exec db mysql --user=root glpitest-9.5

--- a/.github/actions/init_initialize-imap-fixtures.sh
+++ b/.github/actions/init_initialize-imap-fixtures.sh
@@ -3,8 +3,8 @@ set -e -u -x -o pipefail
 
 ROOT_DIR=$(readlink -f "$(dirname $0)/../..")
 
-docker compose exec -T --user root dovecot doveadm expunge -u glpi mailbox 'INBOX' all
-docker compose exec -T --user root dovecot doveadm purge -u glpi
+docker compose exec --user root dovecot doveadm expunge -u glpi mailbox 'INBOX' all
+docker compose exec --user root dovecot doveadm purge -u glpi
 for f in `ls $ROOT_DIR/tests/emails-tests/*.eml`; do
-  cat $f | docker compose exec -T --user glpi dovecot getmail_maildir /home/glpi/Maildir/
+  cat $f | docker compose exec --user glpi dovecot getmail_maildir /home/glpi/Maildir/
 done

--- a/.github/actions/init_initialize-ldap-fixtures.sh
+++ b/.github/actions/init_initialize-ldap-fixtures.sh
@@ -4,8 +4,8 @@ set -e -u -x -o pipefail
 ROOT_DIR=$(readlink -f "$(dirname $0)/../..")
 
 # Recursively delete all LDAP entries
-docker compose exec -T openldap ldapdelete -x -r -H ldap://127.0.0.1:3890/ -D "cn=Manager,dc=glpi,dc=org" -w insecure -c "dc=glpi,dc=org" || true
+docker compose exec openldap ldapdelete -x -r -H ldap://127.0.0.1:3890/ -D "cn=Manager,dc=glpi,dc=org" -w insecure -c "dc=glpi,dc=org" || true
 
 for f in `ls $ROOT_DIR/tests/LDAP/ldif/*.ldif`; do
-  cat $f | docker compose exec -T openldap ldapadd -x -H ldap://127.0.0.1:3890/ -D "cn=Manager,dc=glpi,dc=org" -w insecure
+  cat $f | docker compose exec openldap ldapadd -x -H ldap://127.0.0.1:3890/ -D "cn=Manager,dc=glpi,dc=org" -w insecure
 done

--- a/.github/actions/init_show-versions.sh
+++ b/.github/actions/init_show-versions.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
 set -e -u -o pipefail
 
-docker compose exec -T app php --version
-docker compose exec -T app php -r 'echo(sprintf("PHP extensions: %s\n", implode(", ", get_loaded_extensions())));'
-docker compose exec -T app composer --version
-docker compose exec -T app sh -c 'echo "node $(node --version)"'
-docker compose exec -T app sh -c 'echo "npm $(npm --version)"'
+docker compose exec app php --version
+docker compose exec app php -r 'echo(sprintf("PHP extensions: %s\n", implode(", ", get_loaded_extensions())));'
+docker compose exec app composer --version
+docker compose exec app sh -c 'echo "node $(node --version)"'
+docker compose exec app sh -c 'echo "npm $(npm --version)"'
 
 if [[ -n $(docker compose ps --all --services | grep "db") ]]; then
-  docker compose exec -T db mysql --version;
+  docker compose exec db mysql --version;
 fi
 if [[ -n $(docker compose ps --all --services | grep "redis") ]]; then
-  docker compose exec -T redis redis-server --version;
+  docker compose exec redis redis-server --version;
 fi
 if [[ -n $(docker compose ps --all --services | grep "memcached") ]]; then
-  docker compose exec -T memcached memcached --version;
+  docker compose exec memcached memcached --version;
 fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,31 +75,31 @@ jobs:
           .github/actions/init_show-versions.sh
       - name: "Force used PHP version"
         run: |
-          docker compose exec -T app composer config --unset platform.php
-          docker compose exec -T app composer require "php:>=${{ matrix.php-version }}" --ignore-platform-req=php+ --no-install --no-scripts
+          docker compose exec app composer config --unset platform.php
+          docker compose exec app composer require "php:>=${{ matrix.php-version }}" --ignore-platform-req=php+ --no-install --no-scripts
       - name: "Build dependencies / translations"
         run: |
-          docker compose exec -T app .github/actions/init_build.sh
+          docker compose exec app .github/actions/init_build.sh
       - name: "PHP lint"
         if: "${{ success() || failure() }}"
         run: |
-          docker compose exec -T app .github/actions/lint_php-lint.sh
+          docker compose exec app .github/actions/lint_php-lint.sh
       - name: "Twig lint"
         if: "${{ success() || failure() }}"
         run: |
-          docker compose exec -T app .github/actions/lint_twig-lint.sh
+          docker compose exec app .github/actions/lint_twig-lint.sh
       - name: "JS lint"
         if: "${{ success() || failure() }}"
         run: |
-          docker compose exec -T app .github/actions/lint_js-lint.sh
+          docker compose exec app .github/actions/lint_js-lint.sh
       - name: "SCSS lint"
         if: "${{ success() || failure() }}"
         run: |
-          docker compose exec -T app .github/actions/lint_scss-lint.sh
+          docker compose exec app .github/actions/lint_scss-lint.sh
       - name: "Misc lint"
         if: "${{ success() || failure() }}"
         run: |
-          docker compose exec -T app .github/actions/lint_misc-lint.sh
+          docker compose exec app .github/actions/lint_misc-lint.sh
 
   generate-tests-matrix:
     # Do not run scheduled tests on tier repositories
@@ -174,47 +174,47 @@ jobs:
           .github/actions/init_show-versions.sh
       - name: "Build dependencies / translations"
         run: |
-          docker compose exec -T app .github/actions/init_build.sh
+          docker compose exec app .github/actions/init_build.sh
       - name: "Install DB tests"
         if: "${{ success() || failure() }}"
         run: |
-          docker compose exec -T app .github/actions/test_install.sh
+          docker compose exec app .github/actions/test_install.sh
       - name: "Update DB tests (from 0.85.5, not using utf8mb4)"
         if: "${{ success() || failure() }}"
         run: |
           .github/actions/init_initialize-0.85.5-db.sh
-          docker compose exec -T app .github/actions/test_update-from-older-version.sh
+          docker compose exec app .github/actions/test_update-from-older-version.sh
       - name: "Update DB tests (from 9.5, using utf8mb4)"
         if: "${{ success() || failure() }}"
         run: |
           .github/actions/init_initialize-9.5-db.sh
-          docker compose exec -T app .github/actions/test_update-from-9.5.sh
+          docker compose exec app .github/actions/test_update-from-9.5.sh
       - name: "PHPUnit tests"
         if: "${{ success() || failure() }}"
         run: |
-          docker compose exec -T app .github/actions/test_tests-phpunit.sh
+          docker compose exec app .github/actions/test_tests-phpunit.sh
       - name: "Functional tests"
         if: "${{ success() || failure() }}"
         run: |
-          docker compose exec -T app .github/actions/test_tests-functional.sh
+          docker compose exec app .github/actions/test_tests-functional.sh
       - name: "Cache tests"
         if: "${{ success() || failure() }}"
         run: |
-          docker compose exec -T app .github/actions/test_tests-cache.sh
+          docker compose exec app .github/actions/test_tests-cache.sh
       - name: "LDAP tests"
         if: "${{ success() || failure() }}"
         run: |
           .github/actions/init_initialize-ldap-fixtures.sh
-          docker compose exec -T app .github/actions/test_tests-ldap.sh
+          docker compose exec app .github/actions/test_tests-ldap.sh
       - name: "IMAP tests"
         if: "${{ success() || failure() }}"
         run: |
           .github/actions/init_initialize-imap-fixtures.sh
-          docker compose exec -T app .github/actions/test_tests-imap.sh
+          docker compose exec app .github/actions/test_tests-imap.sh
       - name: "Javascript tests"
         if: "${{ success() || failure() }}"
         run: |
-          docker compose exec -T app .github/actions/test_javascript.sh
+          docker compose exec app .github/actions/test_javascript.sh
 
   e2e:
     # Do not run scheduled tests on tier repositories
@@ -251,20 +251,20 @@ jobs:
           .github/actions/init_show-versions.sh
       - name: "Build dependencies / translations"
         run: |
-          docker compose exec -T app .github/actions/init_build.sh
+          docker compose exec app .github/actions/init_build.sh
       - name: "Install DB tests"
         if: "${{ success() || failure() }}"
         run: |
-          docker compose exec -T app .github/actions/test_install.sh
+          docker compose exec app .github/actions/test_install.sh
       - name: "WEB tests"
         if: "${{ success() || failure() }}"
         run: |
-          docker compose exec -T app .github/actions/test_tests-web.sh
+          docker compose exec app .github/actions/test_tests-web.sh
       - name: "E2E tests"
         if: "${{ success() || failure() }}"
         id: "e2e"
         run: |
-          docker compose exec -T app .github/actions/test_tests-e2e.sh
+          docker compose exec app .github/actions/test_tests-e2e.sh
       - name: "Upload Cypress screenshots"
         if: "${{ failure() && steps.e2e.conclusion == 'failure' }}"
         uses: actions/upload-artifact@v4

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -57,24 +57,24 @@ jobs:
           .github/actions/init_show-versions.sh
       - name: "Build dependencies / translations"
         run: |
-          docker compose exec -T app .github/actions/init_build.sh
+          docker compose exec app .github/actions/init_build.sh
       - name: "Install database"
         run: |
-          docker compose exec -T app .github/actions/test_install.sh
+          docker compose exec app .github/actions/test_install.sh
       - name: "PHPUnit tests"
         run: |
-          docker compose exec -T app .github/actions/test_tests-phpunit.sh
+          docker compose exec app .github/actions/test_tests-phpunit.sh
       - name: "Functional tests"
         run: |
-          docker compose exec -T app .github/actions/test_tests-functional.sh
+          docker compose exec app .github/actions/test_tests-functional.sh
       - name: "LDAP tests"
         run: |
           .github/actions/init_initialize-ldap-fixtures.sh
-          docker compose exec -T app .github/actions/test_tests-ldap.sh
+          docker compose exec app .github/actions/test_tests-ldap.sh
       - name: "IMAP tests"
         run: |
           .github/actions/init_initialize-imap-fixtures.sh
-          docker compose exec -T app .github/actions/test_tests-imap.sh
+          docker compose exec app .github/actions/test_tests-imap.sh
       - name: "Codecov"
         uses: "codecov/codecov-action@v4"
         env:

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -206,7 +206,7 @@ $APPLICATION_ROOT/.github/actions/init_containers-start.sh
 $APPLICATION_ROOT/.github/actions/init_show-versions.sh
 
 # Install dependencies if required
-[[ "$BUILD" = false ]] || docker compose exec -T app .github/actions/init_build.sh
+[[ "$BUILD" = false ]] || docker compose exec app .github/actions/init_build.sh
 
 INSTALL_TESTS_RUN=false
 
@@ -245,71 +245,71 @@ run_single_test () {
       # Misc lint (licence headers and locales) is not executed here as their output is not configurable yet
       # and it would be a pain to handle rolling back of their changes.
       # TODO Add ability to simulate locales extact without actually modifying locale files.
-         docker compose exec -T app .github/actions/lint_php-lint.sh \
-      && docker compose exec -T app .github/actions/lint_js-lint.sh \
-      && docker compose exec -T app .github/actions/lint_scss-lint.sh \
-      && docker compose exec -T app .github/actions/lint_twig-lint.sh \
+         docker compose exec app .github/actions/lint_php-lint.sh \
+      && docker compose exec app .github/actions/lint_js-lint.sh \
+      && docker compose exec app .github/actions/lint_scss-lint.sh \
+      && docker compose exec app .github/actions/lint_twig-lint.sh \
       || LAST_EXIT_CODE=$?
       ;;
     "lint_php")
-         docker compose exec -T app .github/actions/lint_php-lint.sh \
+         docker compose exec app .github/actions/lint_php-lint.sh \
       || LAST_EXIT_CODE=$?
       ;;
     "lint_js")
-         docker compose exec -T app .github/actions/lint_js-lint.sh \
+         docker compose exec app .github/actions/lint_js-lint.sh \
       || LAST_EXIT_CODE=$?
       ;;
     "lint_scss")
-         docker compose exec -T app .github/actions/lint_scss-lint.sh \
+         docker compose exec app .github/actions/lint_scss-lint.sh \
       || LAST_EXIT_CODE=$?
       ;;
     "lint_twig")
-         docker compose exec -T app .github/actions/lint_twig-lint.sh \
+         docker compose exec app .github/actions/lint_twig-lint.sh \
       || LAST_EXIT_CODE=$?
       ;;
     "install")
-         docker compose exec -T app .github/actions/test_install.sh \
+         docker compose exec app .github/actions/test_install.sh \
       || LAST_EXIT_CODE=$?
       ;;
     "update")
          $APPLICATION_ROOT/.github/actions/init_initialize-0.85.5-db.sh \
       && $APPLICATION_ROOT/.github/actions/init_initialize-9.5-db.sh \
-      && docker compose exec -T app .github/actions/test_update-from-older-version.sh \
-      && docker compose exec -T app .github/actions/test_update-from-9.5.sh \
+      && docker compose exec app .github/actions/test_update-from-older-version.sh \
+      && docker compose exec app .github/actions/test_update-from-9.5.sh \
       || LAST_EXIT_CODE=$?
       ;;
     "phpunit")
-         docker compose exec -T app .github/actions/test_tests-phpunit.sh $TEST_ARGS \
+         docker compose exec app .github/actions/test_tests-phpunit.sh $TEST_ARGS \
       || LAST_EXIT_CODE=$?
       ;;
     "functional")
-         docker compose exec -T app .github/actions/test_tests-functional.sh $TEST_ARGS \
+         docker compose exec app .github/actions/test_tests-functional.sh $TEST_ARGS \
       || LAST_EXIT_CODE=$?
       ;;
     "cache")
-         docker compose exec -T app .github/actions/test_tests-cache.sh \
+         docker compose exec app .github/actions/test_tests-cache.sh \
       || LAST_EXIT_CODE=$?
       ;;
     "ldap")
          $APPLICATION_ROOT/.github/actions/init_initialize-ldap-fixtures.sh \
-      && docker compose exec -T app .github/actions/test_tests-ldap.sh \
+      && docker compose exec app .github/actions/test_tests-ldap.sh \
       || LAST_EXIT_CODE=$?
       ;;
     "imap")
          $APPLICATION_ROOT/.github/actions/init_initialize-imap-fixtures.sh \
-      && docker compose exec -T app .github/actions/test_tests-imap.sh \
+      && docker compose exec app .github/actions/test_tests-imap.sh \
       || LAST_EXIT_CODE=$?
       ;;
     "web")
-         docker compose exec -T app .github/actions/test_tests-web.sh \
+         docker compose exec app .github/actions/test_tests-web.sh \
       || LAST_EXIT_CODE=$?
       ;;
     "javascript")
-         docker compose exec -T app .github/actions/test_javascript.sh \
+         docker compose exec app .github/actions/test_javascript.sh \
       || LAST_EXIT_CODE=$?
       ;;
     "e2e")
-         docker compose exec -T app .github/actions/test_tests-e2e.sh \
+         docker compose exec app .github/actions/test_tests-e2e.sh \
       || LAST_EXIT_CODE=$?
       ;;
   esac


### PR DESCRIPTION
## Description

Allow docker to get a TTY so we can have colored output (make it a lot easier to spot errors in e2e tests reports).

![image](https://github.com/user-attachments/assets/fb567b64-d22c-4012-97d8-b30df44ecc20)
