### PR TITLE
Fix response body from API

### DIFF
--- a/src/Glpi/Controller/ApiController.php
+++ b/src/Glpi/Controller/ApiController.php
@@ -108,7 +108,7 @@ final class ApiController extends AbstractController
         }
 
         return new SymfonyResponse(
-            $response->getBody()->getContents(),
+            (string) $response->getBody(),
             $response->getStatusCode(),
             $response->getHeaders()
         );

--- a/src/Glpi/Controller/StatusController.php
+++ b/src/Glpi/Controller/StatusController.php
@@ -67,7 +67,7 @@ final class StatusController extends AbstractController
         }
 
         return new SymfonyResponse(
-            $response->getBody()->getContents(),
+            (string) $response->getBody(),
             $response->getStatusCode(),
             $response->getHeaders()
         );


### PR DESCRIPTION
Can't use `getContents` on response body stream if pointer is already at the end of the stream. Symfony was dropping the response body for all API requests.