### PR TITLE
Fix HTL API response body

### DIFF
--- a/src/Glpi/Controller/ApiController.php
+++ b/src/Glpi/Controller/ApiController.php
@@ -108,7 +108,7 @@ final class ApiController extends AbstractController
         }
 
         return new SymfonyResponse(
-            $response->getBody()->getContents(),
+            (string) $response->getBody(),
             $response->getStatusCode(),
             $response->getHeaders()
         );


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

`$response->getBody()->getContents()` produces an empty string while `(string) $response->getBody()` works as expected.

