### PR TITLE
Prevent dropdown parent reassignment during partial updates

### DIFF
--- a/phpunit/functional/EntityTest.php
+++ b/phpunit/functional/EntityTest.php
@@ -1286,9 +1286,8 @@ class EntityTest extends DbTestCase
 
     /**
      * Regression test to ensure that renaming an entity doesn't force it to become a child of the root entity (ID 0)
-     * @return void
      */
-    public function testRenameDoesntChangeParent()
+    public function testRenameDoesntChangeParent(): void
     {
         $this->login();
         $entity = $this->createItem('Entity', [

--- a/phpunit/functional/EntityTest.php
+++ b/phpunit/functional/EntityTest.php
@@ -1284,6 +1284,26 @@ class EntityTest extends DbTestCase
         $this->assertEquals('New entity', $new_entity->fields['name']);
     }
 
+    /**
+     * Regression test to ensure that renaming an entity doesn't force it to become a child of the root entity (ID 0)
+     * @return void
+     */
+    public function testRenameDoesntChangeParent()
+    {
+        $this->login();
+        $entity = $this->createItem('Entity', [
+            'name'        => __FUNCTION__,
+            'entities_id' => $this->getTestRootEntity(true),
+        ]);
+        $this->assertTrue($entity->update([
+            'id'   => $entity->getID(),
+            'name' => __FUNCTION__ . ' renamed',
+        ]));
+        $this->assertTrue($entity->getFromDB($entity->getID()));
+        $this->assertEquals($this->getTestRootEntity(true), $entity->fields['entities_id']);
+        $this->assertEquals(__FUNCTION__ . ' renamed', $entity->fields['name']);
+    }
+
     public static function entityTreeProvider(): iterable
     {
         $e2e_test_root = getItemByTypeName('Entity', 'E2ETestEntity', true);

--- a/src/CommonTreeDropdown.php
+++ b/src/CommonTreeDropdown.php
@@ -125,31 +125,32 @@ abstract class CommonTreeDropdown extends CommonDropdown
      **/
     public function adaptTreeFieldsFromUpdateOrAdd($input)
     {
-
         $parent = clone $this;
-       // Update case input['name'] not set :
-        if (!isset($input['name']) && isset($this->fields['name'])) {
-            $input['name'] = $this->fields['name'];
+
+        $fkey = static::getForeignKeyField();
+
+        // Fallback to current values if all required fields are set in input
+        foreach (['name', $fkey] as $fieldname) {
+            if (!isset($input[$fieldname]) && isset($this->fields[$fieldname])) {
+                $input[$fieldname] = $this->fields[$fieldname];
+            }
         }
-       // leading/ending space will break findID/import
+
+        // leading/ending space will break findID/import
         $input['name'] = trim($input['name']);
 
-        $fk = static::getForeignKeyField();
-        $input[$fk] ??= $this->fields[$fk] ?? '';
-        $valid_parent = $parent->getFromDB($input[$fk]);
-        if ($valid_parent) {
+        if (
+            isset($input[$fkey])
+            && !$this->isNewID($input[$fkey])
+            && $parent->getFromDB($input[$fkey])
+        ) {
             $input['level']        = $parent->fields['level'] + 1;
-           // Sometimes (internet address), the complete name may be different ...
-           /* if ($input[$this->getForeignKeyField()]==0) { // Root entity case
-            $input['completename'] =  $input['name'];
-           } else {*/
             $input['completename'] = self::getCompleteNameFromParents(
                 $parent->fields['completename'],
                 $input['name']
             );
-           // }
         } else {
-            $input[$fk] = 0;
+            $input[$fkey] = 0;
             $input['level']                     = 1;
             $input['completename']              = $input['name'];
         }

--- a/src/CommonTreeDropdown.php
+++ b/src/CommonTreeDropdown.php
@@ -134,11 +134,10 @@ abstract class CommonTreeDropdown extends CommonDropdown
        // leading/ending space will break findID/import
         $input['name'] = trim($input['name']);
 
-        if (
-            isset($input[$this->getForeignKeyField()])
-            && !$this->isNewID($input[$this->getForeignKeyField()])
-            && $parent->getFromDB($input[$this->getForeignKeyField()])
-        ) {
+        $fk = static::getForeignKeyField();
+        $input[$fk] ??= $this->fields[$fk] ?? '';
+        $valid_parent = $parent->getFromDB($input[$fk]);
+        if ($valid_parent) {
             $input['level']        = $parent->fields['level'] + 1;
            // Sometimes (internet address), the complete name may be different ...
            /* if ($input[$this->getForeignKeyField()]==0) { // Root entity case
@@ -150,7 +149,7 @@ abstract class CommonTreeDropdown extends CommonDropdown
             );
            // }
         } else {
-            $input[$this->getForeignKeyField()] = 0;
+            $input[$fk] = 0;
             $input['level']                     = 1;
             $input['completename']              = $input['name'];
         }


### PR DESCRIPTION
## Checklist before requesting a review
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

I found while trying to debug the test failure on `main` after the 10.0 merge that updating an entity name with nothing else in the update parameters would cause the entity's parent to be replaced with the root entity. This seems like it would be an issue with the API, but not the web interface. When renaming an entity (and presumably any tree dropdown), it was assumed that the parent ID field was always in the input array.

I'm not 100% confident in this fix because I don't completely understand what the original code was trying to accomplish. That is why this targets `main` currently.