### PR TITLE
Revert "Fix sub queries negation for `notcontains` searches"

### DIFF
--- a/phpunit/functional/SearchTest.php
+++ b/phpunit/functional/SearchTest.php
@@ -2355,26 +2355,6 @@ class SearchTest extends DbTestCase
                 'meta' => false,
                 'expected' => "AND (INET_ATON(`glpi_ipaddresses`.`name`) > INET_ATON('192.168.1.10'))",
             ],
-            [
-                'link' => ' AND ',
-                'nott' => 0,
-                'itemtype' => \Computer::class,
-                'ID' => 2, // Search ID 2 (ID field)
-                'searchtype' => 'notequals',
-                'val' => 42,
-                'meta' => false,
-                'expected' => "AND (`glpi_computers`.`id` <> 42)",
-            ],
-            [
-                'link' => ' AND ',
-                'nott' => 0,
-                'itemtype' => \Printer::class,
-                'ID' => 12, // Search ID 12 (last pages counter field)
-                'searchtype' => 'notcontains',
-                'val' => 42,
-                'meta' => false,
-                'expected' => "AND (`glpi_printers`.`last_pages_counter` <> 42)",
-            ],
         ];
     }
 

--- a/src/Search.php
+++ b/src/Search.php
@@ -4747,6 +4747,8 @@ JAVASCRIPT;
 
         switch ($searchtype) {
             case "notcontains":
+                $nott = !$nott;
+               //negated, use contains case
             case "contains":
                 // FIXME
                 // `field LIKE '%test%'` condition is not supposed to be relevant, and can sometimes result in SQL performances issues/warnings/errors,
@@ -4788,13 +4790,9 @@ JAVASCRIPT;
 
                     // Potential negation will be handled by the subquery operator
                     $SEARCH = self::makeTextSearch($val, false);
-                    if ($searchtype === 'contains') {
-                        $subquery_operator = $nott ? "NOT IN" : "IN";
-                    } else {
-                        $subquery_operator = $nott ? "IN" : "NOT IN";
-                    }
+                    $subquery_operator = $nott ? "NOT IN" : "IN";
                 } else {
-                    $SEARCH = self::makeTextSearch($val, $searchtype === 'contains' ? $nott : !$nott);
+                    $SEARCH = self::makeTextSearch($val, $nott);
                 }
                 break;
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

A quick fix for #18251.
This reverts commit d80db3a6534bfeabe3e7406e8ceadd549e7366fb. The initial bug was less problematic by the regression introduced by this commit.