### PR TITLE
Less restrictive input name sanitization

### DIFF
--- a/phpunit/functional/HtmlTest.php
+++ b/phpunit/functional/HtmlTest.php
@@ -1108,8 +1108,14 @@ SCSS
         ];
 
         yield [
-            'name'      => 'foo\'"$**-_23',
+            'name'      => 'foo\'"$**_23',
             'expected'  => 'foo_23',
+        ];
+
+        // Make sure the format used in form destination config is not broken
+        yield [
+            'name'     => 'config[glpi-form-destination-commonitilfield-olattrfield][slm_id]',
+            'expected' => 'config[glpi-form-destination-commonitilfield-olattrfield][slm_id]',
         ];
     }
 

--- a/src/Html.php
+++ b/src/Html.php
@@ -6675,6 +6675,6 @@ CSS;
      */
     public static function sanitizeInputName(string $name): string
     {
-        return preg_replace('/[^a-z0-9_\[\]]/i', '', $name);
+        return preg_replace('/[^a-z0-9_\[\]\-]/i', '', $name);
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

The changes from 797589190599f8eb49009b261be55342ba0f1e71 are a bit too restrictive a break some input names used by the helpdesk forms feature.

@cedric-anne says it should be ok to allow the `-` character.