### PR TITLE
Fix warning on API ticket searches

### DIFF
--- a/phpunit/functional/UserTest.php
+++ b/phpunit/functional/UserTest.php
@@ -1640,4 +1640,22 @@ class UserTest extends \DbTestCase
             }
         }
     }
+
+    public function testUnsetUndisclosedFieldsWithPartialFields()
+    {
+        $fields = [
+            //'id' is missing
+            'name'                       => 'test',
+            'password'                   => \bin2hex(\random_bytes(16)),
+            'api_token'                  => \bin2hex(\random_bytes(16)),
+            'cookie_token'               => \bin2hex(\random_bytes(16)),
+            'password_forget_token'      => \bin2hex(\random_bytes(16)),
+            'personal_token'             => \bin2hex(\random_bytes(16)),
+            'password_forget_token_date' => '2024-10-25 13:15:12',
+        ];
+
+        \User::unsetUndisclosedFields($fields);
+
+        $this->assertEquals(['name' => 'test'], $fields);
+    }
 }

--- a/src/User.php
+++ b/src/User.php
@@ -730,14 +730,28 @@ class User extends CommonDBTM
     {
         parent::unsetUndisclosedFields($fields);
 
-        $user = new self();
-        $can_see_token = Session::getLoginUserID() === $fields['id']
-            || (
-                $user->can($fields['id'], UPDATE)
-                && $user->currentUserHaveMoreRightThan($fields['id'])
-            );
-        if (!$can_see_token) {
-            unset($fields['password_forget_token'], $fields['password_forget_token_date']);
+        if (
+            array_key_exists('password_forget_token', $fields)
+            || array_key_exists('password_forget_token_date', $fields)
+        ) {
+            if (array_key_exists('id', $fields)) {
+                // `id` is present mainly when the whole object is fetched.
+                // In this case, we must show the token only if the user is allowed to read it.
+                $user = new self();
+                $can_see_token = Session::getLoginUserID() === $fields['id']
+                    || (
+                        $user->can($fields['id'], UPDATE)
+                        && $user->currentUserHaveMoreRightThan($fields['id'])
+                    );
+            } else {
+                // `id` may be missing when a partial object is fetch.
+                // In this case, we cannot ensure that the user is allowed to read the token
+                // and we must NOT show it.
+                $can_see_token = false;
+            }
+            if (!$can_see_token) {
+                unset($fields['password_forget_token'], $fields['password_forget_token_date']);
+            }
         }
     }
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

It fixes #18261.

From the search endpoint, the `User::unsetUndisclosedFields()` method will receive an array that does not cotnains the `id` of the user. In this case, we cannot be sure that the current user is allowed to view the `password_forget_token` field and therefore we must remove it.