### PR TITLE
Add planning filter to filter done events

### DIFF
--- a/js/planning.js
+++ b/js/planning.js
@@ -455,13 +455,8 @@ var GLPIPlanning  = {
                     var view_name = GLPIPlanning.calendar
                         ? GLPIPlanning.calendar.state.viewType
                         : options.default_view;
-                    var display_done_events = 1;
-                    if (view_name.indexOf('list') >= 0) {
-                        display_done_events = 0;
-                    }
                     return {
                         'action': 'get_events',
-                        'display_done_events': display_done_events,
                         'view_name': view_name
                     };
                 },

--- a/src/Glpi/Features/PlanningEvent.php
+++ b/src/Glpi/Features/PlanningEvent.php
@@ -383,7 +383,6 @@ trait PlanningEvent
      *    - color
      *    - event_type_color
      *    - check_planned (boolean)
-     *    - display_done_events (boolean)
      *
      * @return array of planning item
      **/
@@ -400,7 +399,7 @@ trait PlanningEvent
             'color'               => '',
             'event_type_color'    => '',
             'check_planned'       => false,
-            'display_done_events' => true,
+            'state_done'          => true,
         ];
         $options = array_merge($default_options, $options);
 
@@ -509,13 +508,13 @@ trait PlanningEvent
             $WHERE['state'] = ['!=', Planning::INFO];
         }
 
-        if (!$options['display_done_events']) {
+        if (!$options['state_done']) {
             $WHERE[] = [
                 'OR' => [
-                    'state'  => Planning::TODO,
-                    'AND'    => [
-                        'state'  => Planning::INFO,
-                        'end'    => ['>', QueryFunction::now()]
+                    'state' => Planning::TODO,
+                    [
+                        'state' => Planning::INFO,
+                        'end' => ['>', QueryFunction::now()]
                     ]
                 ]
             ];

--- a/src/Planning.php
+++ b/src/Planning.php
@@ -640,7 +640,7 @@ TWIG, ['options' => $options]);
 
         return array_merge(
             $CFG_GLPI['planning_types'],
-            ['NotPlanned', 'OnlyBgEvents']
+            ['NotPlanned', 'OnlyBgEvents', 'StateDone']
         );
     }
 
@@ -672,7 +672,7 @@ TWIG, ['options' => $options]);
         $filters = &$_SESSION['glpi_plannings']['filters'];
         $index_color = 0;
         foreach (self::getPlanningTypes() as $planning_type) {
-            if (in_array($planning_type, ['NotPlanned', 'OnlyBgEvents']) || $planning_type::canView()) {
+            if (in_array($planning_type, ['NotPlanned', 'OnlyBgEvents', 'StateDone']) || $planning_type::canView()) {
                 if (!isset($filters[$planning_type])) {
                     $filters[$planning_type] = [
                         'color'   => self::getPaletteColor('ev', $index_color),
@@ -787,6 +787,8 @@ TWIG, ['options' => $options]);
                 $title = __('Not planned tasks');
             } else if ($filter_key === 'OnlyBgEvents') {
                 $title = __('Only background events');
+            } else if ($filter_key === 'StateDone') {
+                $title = __('Done elements');
             } else {
                 if (!getItemForItemtype($filter_key)) {
                     return;
@@ -1545,7 +1547,6 @@ TWIG, $twig_params);
      *       (should be an ISO_8601 date, but could be anything wo can be parsed by strtotime)
      *  - end: mandatory, planning end.
      *       (should be an ISO_8601 date, but could be anything wo can be parsed by strtotime)
-     *  - display_done_events: default true, show also events tagged as done
      *  - force_all_events: even if the range is big, don't reduce the returned set
      * @return array $events : array with events in fullcalendar.io format
      */
@@ -1557,8 +1558,8 @@ TWIG, $twig_params);
         $param['start']               = '';
         $param['end']                 = '';
         $param['view_name']           = '';
-        $param['display_done_events'] = true;
         $param['force_all_events']    = false;
+        $param['state_done']          = true;
 
         if (is_array($options) && count($options)) {
             foreach ($options as $key => $val) {
@@ -1584,6 +1585,10 @@ TWIG, $twig_params);
 
         $param['begin'] = date("Y-m-d H:i:s", $time_begin);
         $param['end']   = date("Y-m-d H:i:s", $time_end);
+
+        if (!$_SESSION['glpi_plannings']['filters']['StateDone']['display']) {
+            $param['state_done'] = false;
+        }
 
         $raw_events = [];
         $not_planned = [];

--- a/src/ProjectTask.php
+++ b/src/ProjectTask.php
@@ -1889,6 +1889,7 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
             'genical'             => false,
             'color'               => '',
             'event_type_color'    => '',
+            'state_done'          => true,
         ];
         $options = array_merge($default_options, $options);
 
@@ -1940,12 +1941,13 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
             ];
         }
 
-        if (!isset($options['display_done_events']) || !$options['display_done_events']) {
+        if ($options['state_done']) {
             $ADDWHERE['glpi_projecttasks.percent_done'] = ['<', 100];
-            $ADDWHERE[] = ['OR' => [
-                ['glpi_projectstates.is_finished'  => 0],
-                ['glpi_projectstates.is_finished'  => null]
-            ]
+            $ADDWHERE[] = [
+                'OR' => [
+                    ['glpi_projectstates.is_finished' => 0],
+                    ['glpi_projectstates.is_finished' => null]
+                ]
             ];
         }
 

--- a/templates/pages/assistance/planning/single_filter.html.twig
+++ b/templates/pages/assistance/planning/single_filter.html.twig
@@ -47,7 +47,7 @@
 
     <span class="ms-auto d-flex align-items-center">
         {# Colors not for groups #}
-        {% if filter_data.type != 'group_users' and filter_key != 'OnlyBgEvents' %}
+        {% if filter_data.type != 'group_users' and filter_key != 'OnlyBgEvents' and filter_key != 'StateDone' %}
             <span class="color_input">
                 <input type="color" name="{{ filter_key }}_color" aria-label="{{ __('%s color')|format(title) }}" value="{{ color }}">
             </span>


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Add a planning filter to display events/tasks that are done.
Basically replace the 'display_done_event' option, which currently is applied when using the month view, by a new filter that can be toggled.

## Screenshots :

![image](https://github.com/user-attachments/assets/a1fc55b6-433b-4125-bf9e-98b0700b5b2a)

![image](https://github.com/user-attachments/assets/ae177397-26d7-4746-afa6-aa930b81447a)




