### PR TITLE
Fix session e2e tests

### DIFF
--- a/templates/pages/login.html.twig
+++ b/templates/pages/login.html.twig
@@ -53,11 +53,13 @@
                     <input type="text" class="form-control" id="login_name" name="{{ namfield }}" placeholder="" tabindex="1"/>
                 </div>
                 <div class="mb-4">
-                    <label class="form-label" for="login_password">
-                        {{ __('Password') }}
+                    <div class="d-flex">
+                        <label class="form-label" for="login_password">
+                            {{ __('Password') }}
+                        </label>
 
                         {% if show_lost_password %}
-                            <span class="form-label-description forgot_password {{ config('display_login_source') ? 'd-none' : '' }}">
+                            <span class="ms-auto form-label-description forgot_password {{ config('display_login_source') ? 'd-none' : '' }}">
                                 <a href="{{ path('front/lostpassword.php?lostpassword=1') }}">
                                     {{ __('Forgotten password?') }}
                                 </a>
@@ -79,7 +81,7 @@
                                 </script>
                             {% endif %}
                         {% endif %}
-                    </label>
+                    </div>
                     <input type="password" class="form-control" id="login_password" name="{{ pwdfield }}" placeholder="" autocomplete="off" tabindex="2"/>
                 </div>
 


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.

## Description

Session e2e tests have been broken since the latest 10.0 merge into main.
It seems to be because the `label` tag also contains some extra content (the "forgot password" link), thus the `getInputByLabel('Password')` call fails.

Not sure why it only happens since last merge (in fact it doesn't even happen on my local env running the same docker script...) but this change should hopefully fix it as I've moved the extra content outside the label.
