### PR TITLE
Fix itemMatchFilter() return

### DIFF
--- a/src/Glpi/Search/FilterableTrait.php
+++ b/src/Glpi/Search/FilterableTrait.php
@@ -90,11 +90,15 @@ trait FilterableTrait
             'criteria' => $criteria,
         ]);
 
+        // The result of itemMatchFilter was always equal to true even when the match was not correct.
+        // This is due to the result of the SQL query, which always returns at least one row even if the columns are empty.
         if ($data['data']['totalcount'] > 0) {
-            if (!isset($data['data']['rows'][0]['id'])) {
-                return false;
-            }
-            return true;
+            // Remove invalid rows before counting
+            $validRows = array_filter($data['data']['rows'], function ($row) use ($id_field) {
+                return isset($row[$id_field]);
+            });
+
+            return count($validRows) > 0;
         }
 
         return false;

--- a/src/Glpi/Search/FilterableTrait.php
+++ b/src/Glpi/Search/FilterableTrait.php
@@ -90,7 +90,12 @@ trait FilterableTrait
             'criteria' => $criteria,
         ]);
 
-        return $data['data']['totalcount'] > 0;
+        if ($data['data']['totalcount'] > 0) {
+            if (!isset($data['data']['rows'][0]['id'])) {
+                return false;
+            }
+            return true;
+        }
     }
 
     public function saveFilter(

--- a/src/Glpi/Search/FilterableTrait.php
+++ b/src/Glpi/Search/FilterableTrait.php
@@ -96,6 +96,8 @@ trait FilterableTrait
             }
             return true;
         }
+
+        return false;
     }
 
     public function saveFilter(


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !35030
- Here is a brief description of what this PR does

## Screenshots (if appropriate):

The result of itemMatchFilter was always equal to true even when the match was not correct. This is due to the result of the SQL query which always returns at least one row even if the columns are empty: 
![image](https://github.com/user-attachments/assets/25e15b64-691f-434c-9489-bcdb901d5a0d)

