### PR TITLE
Add the port ID connected to the requested port

### DIFF
--- a/src/Glpi/Api/API.php
+++ b/src/Glpi/Api/API.php
@@ -2949,6 +2949,15 @@ TWIG, ['md' => (new MarkdownRenderer())->render($documentation)]);
 
                 foreach ($netp_iterator as $data) {
                     if (isset($data['netport_id'])) {
+                        // append contact
+                        $npo = new NetworkPort();
+                        $oppositecontactID = $npo->getContact($data['netport_id']) ;
+                        if ($oppositecontactID) {
+                            $data['networkports_id_opposite'] = $oppositecontactID ;
+                        } else {
+                            $data['networkports_id_opposite'] = null;
+                        }
+
                         // append network name
                         $concat_expr = QueryFunction::groupConcat(
                             expression: QueryFunction::concat([

--- a/tests/web/APIRest.php
+++ b/tests/web/APIRest.php
@@ -48,6 +48,7 @@ use Glpi\Tests\Api\Deprecated\ComputerVirtualMachine;
 use Glpi\Tests\Api\Deprecated\TicketFollowup;
 use GuzzleHttp;
 use Item_DeviceSimcard;
+use NetworkPort_NetworkPort;
 use Notepad;
 use QueuedNotification;
 use TicketTemplate;
@@ -2240,6 +2241,126 @@ class APIRest extends atoum
             400,
             'ERROR_JSON_PAYLOAD_INVALID'
         );
+    }
+
+    public function testGetItemWithContacts()
+    {
+        $computers = $this->createComputers(['Computer 1', 'Computer 2']);
+        $this->assertComputersCreated($computers);
+
+        $networkports = [];
+        foreach ($computers as $computer_id) {
+            $this->assertComputerNetworkPorts($computer_id, true);
+            $this->createNetworkPort($computer_id);
+            $networkports[] = $this->assertComputerNetworkPorts($computer_id, false);
+        }
+
+        $this->linkNetworkPorts($networkports);
+        $this->assertNetworkPortLink($computers, $networkports);
+    }
+
+    private function createComputers(array $names)
+    {
+        $data = $this->query(
+            'createItems',
+            [
+                'verb' => 'POST',
+                'itemtype' => 'Computer',
+                'headers' => ['Session-Token' => $this->session_token],
+                'json' => ['input' => array_map(fn($name) => ['name' => $name], $names)]
+            ],
+            201
+        );
+
+        $this->variable($data)->isNotFalse();
+        return array_column($data, 'id');
+    }
+
+    private function assertComputersCreated(array $computers)
+    {
+        foreach ($computers as $computer_id) {
+            $computer = new Computer();
+            $this->boolean((bool)$computer->getFromDB($computer_id))->isTrue();
+        }
+    }
+
+    private function assertComputerNetworkPorts($computer_id, $shouldBeEmpty)
+    {
+        $data = $this->query(
+            'getItem',
+            [
+                'itemtype' => 'Computer',
+                'id' => $computer_id,
+                'headers' => ['Session-Token' => $this->session_token],
+                'query' => ['with_networkports' => true]
+            ]
+        );
+
+        $this->variable($data)->isNotFalse();
+        $this->array($data)->hasKey('id')->hasKey('name')->hasKey('_networkports');
+        $this->array($data['_networkports'])->hasKey('NetworkPortEthernet');
+
+        if ($shouldBeEmpty) {
+            $this->array($data['_networkports']['NetworkPortEthernet'])->isEmpty();
+            return null;
+        } else {
+            $this->array($data['_networkports']['NetworkPortEthernet'])->isNotEmpty();
+            $networkport = $data['_networkports']['NetworkPortEthernet'][0];
+            $this->array($networkport)->hasKey('NetworkName')->hasKey('networkports_id_opposite')->hasKey('netport_id');
+            $this->variable($networkport['networkports_id_opposite'])->isNull();
+            $this->integer($networkport['netport_id'])->isGreaterThan(0);
+            return $networkport['netport_id'];
+        }
+    }
+
+    private function linkNetworkPorts(array $networkports)
+    {
+        $data = $this->query(
+            'createItems',
+            [
+                'verb' => 'POST',
+                'itemtype' => 'NetworkPort_NetworkPort',
+                'headers' => ['Session-Token' => $this->session_token],
+                'json' => [
+                    'input' => [
+                        [
+                            'networkports_id_1' => $networkports[0],
+                            'networkports_id_2' => $networkports[1]
+                        ]
+                    ]
+                ]
+            ],
+            201
+        );
+
+        $this->variable($data)->isNotFalse();
+        $data = $data[0];
+        $this->array($data)->hasKey('id')->hasKey('message');
+        $this->integer((int)$data['id'])->isGreaterThan(0);
+
+        $networkport_networkport = new NetworkPort_NetworkPort();
+        $this->boolean((bool)$networkport_networkport->getFromDB($data['id']))->isTrue();
+    }
+
+    private function assertNetworkPortLink(array $computers, array $networkports)
+    {
+        $data = $this->query(
+            'getItem',
+            [
+                'itemtype' => 'Computer',
+                'id' => $computers[0],
+                'headers' => ['Session-Token' => $this->session_token],
+                'query' => ['with_networkports' => true]
+            ]
+        );
+
+        $this->variable($data)->isNotFalse();
+        $this->array($data)->hasKey('id')->hasKey('name')->hasKey('_networkports');
+        $this->array($data['_networkports'])->hasKey('NetworkPortEthernet');
+        $this->array($data['_networkports']['NetworkPortEthernet'])->isNotEmpty();
+        $networkport = $data['_networkports']['NetworkPortEthernet'][0];
+        $this->array($networkport)->hasKey('NetworkName')->hasKey('networkports_id_opposite')->hasKey('netport_id');
+        $this->integer($networkport['networkports_id_opposite'])->isEqualTo($networkports[1]);
     }
 
     /**


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !35017
- Here is a brief description of what this PR does

Retrieve the network ports of connected devices. Previously, the API only provided information about the main device's network ports, not its connections. The added code uses `NetworkPort::getContact` to retrieve the connected port ID `netport_oppositecontactID`, allowing users to identify connected devices directly in the API response. This addition is visible when the `with_networkports` option is enabled in the request.

