### PR TITLE
Fix DataProvider attributes

### DIFF
--- a/phpunit/AbstractRightsDropdown.php
+++ b/phpunit/AbstractRightsDropdown.php
@@ -91,7 +91,7 @@ abstract class AbstractRightsDropdown extends \GLPITestCase
         ];
     }
 
-    #[dataProvider('getPostedIdsProvider')]
+    #[DataProvider('getPostedIdsProvider')]
     public function testGetPostedIds(
         array $values,
         string $class,

--- a/phpunit/CommonDropdown.php
+++ b/phpunit/CommonDropdown.php
@@ -47,7 +47,7 @@ abstract class CommonDropdown extends DbTestCase
     abstract protected function getObjectClass();
 
     abstract public static function typenameProvider();
-    #[dataProvider('typenameProvider')]
+    #[DataProvider('typenameProvider')]
     public function testGetTypeName($string, $expected)
     {
         $this->assertSame($expected, $string);

--- a/phpunit/functional/AuthTest.php
+++ b/phpunit/functional/AuthTest.php
@@ -62,7 +62,7 @@ class AuthTest extends DbTestCase
         ];
     }
 
-    #[dataProvider('loginProvider')]
+    #[DataProvider('loginProvider')]
     public function testIsValidLogin($login, $isvalid)
     {
         $this->assertSame($isvalid, \Auth::isValidLogin($login));
@@ -144,7 +144,7 @@ class AuthTest extends DbTestCase
     /**
      * Test that account is lock when authentication is done using an expired password.
      */
-    #[dataProvider('lockStrategyProvider')]
+    #[DataProvider('lockStrategyProvider')]
     public function testAccountLockStrategy(string $last_update, int $exp_delay, int $lock_delay, bool $expected_lock)
     {
         /** @var array $CFG_GLPI */
@@ -185,7 +185,7 @@ class AuthTest extends DbTestCase
         ];
     }
 
-    #[dataProvider('validateLoginProvider')]
+    #[DataProvider('validateLoginProvider')]
     public function testValidateLogin(string $login, string $password, bool $noauto, $login_auth, bool $expected)
     {
         $auth = new \Auth();

--- a/phpunit/functional/AutoloadTest.php
+++ b/phpunit/functional/AutoloadTest.php
@@ -57,7 +57,7 @@ class AutoloadTest extends DbTestCase
         ];
     }
 
-    #[dataProvider('dataItemType')]
+    #[DataProvider('dataItemType')]
     public function testIsPluginItemType($type, $plug, $class)
     {
         $res = isPluginItemType($type);

--- a/phpunit/functional/BlacklistTest.php
+++ b/phpunit/functional/BlacklistTest.php
@@ -104,7 +104,7 @@ class BlacklistTest extends DbTestCase
         ];
     }
 
-    #[dataProvider('processProvider')]
+    #[DataProvider('processProvider')]
     public function testProcess($input, $expected)
     {
         $blacklist = new \Blacklist();

--- a/phpunit/functional/ComputerTest.php
+++ b/phpunit/functional/ComputerTest.php
@@ -966,7 +966,7 @@ class ComputerTest extends DbTestCase
      *
      * @return void
      */
-    #[dataProvider('formatSessionMessageAfterActionProvider')]
+    #[DataProvider('formatSessionMessageAfterActionProvider')]
     public function testFormatSessionMessageAfterAction(
         string $item_str,
         string $raw_message,

--- a/phpunit/functional/ConfigTest.php
+++ b/phpunit/functional/ConfigTest.php
@@ -461,7 +461,7 @@ class ConfigTest extends DbTestCase
         ];
     }
 
-    #[dataProvider('dbEngineProvider')]
+    #[DataProvider('dbEngineProvider')]
     public function testCheckDbEngine($raw, $version, $compat)
     {
         global $DB;
@@ -524,7 +524,7 @@ class ConfigTest extends DbTestCase
      * @param string $key
      * @param string $itemtype
      */
-    #[dataProvider('itemtypeLinkedToConfigurationProvider')]
+    #[DataProvider('itemtypeLinkedToConfigurationProvider')]
     public function testCleanRelationDataOfLinkedItems($key, $itemtype)
     {
 
@@ -781,7 +781,7 @@ class ConfigTest extends DbTestCase
         ];
     }
 
-    #[dataProvider('logConfigChangeProvider')]
+    #[DataProvider('logConfigChangeProvider')]
     public function testLogConfigChange(string $context, string $name, bool $is_secured, string $old_value_prefix, string $itemtype)
     {
         global $PLUGIN_HOOKS;

--- a/phpunit/functional/DbUtilsTest.php
+++ b/phpunit/functional/DbUtilsTest.php
@@ -76,7 +76,7 @@ class DbUtilsTest extends DbTestCase
         ];
     }
 
-    #[dataProvider('dataTableKey')]
+    #[DataProvider('dataTableKey')]
     public function testGetForeignKeyFieldForTable($table, $key)
     {
         $instance = new \DbUtils();
@@ -86,7 +86,7 @@ class DbUtilsTest extends DbTestCase
         $this->assertSame($key, getForeignKeyFieldForTable($table));
     }
 
-    #[dataProvider('dataTableForeignKey')]
+    #[DataProvider('dataTableForeignKey')]
     public function testIsForeignKeyFieldBase($table, $key)
     {
         $instance = new \DbUtils();
@@ -115,7 +115,7 @@ class DbUtilsTest extends DbTestCase
         $this->assertFalse(isForeignKeyField(42));
     }
 
-    #[dataProvider('dataTableForeignKey')]
+    #[DataProvider('dataTableForeignKey')]
     public function testGetTableNameForForeignKeyField($table, $key)
     {
         $instance = new \DbUtils();
@@ -193,7 +193,7 @@ class DbUtilsTest extends DbTestCase
         return $table_types_mapping;
     }
 
-    #[dataProvider('getTableForItemTypeProvider')]
+    #[DataProvider('getTableForItemTypeProvider')]
     public function testGetTableForItemType($table, $type)
     {
         $instance = new \DbUtils();
@@ -203,7 +203,7 @@ class DbUtilsTest extends DbTestCase
         $this->assertSame($table, getTableForItemType($type));
     }
 
-    #[dataProvider('dataTableType')]
+    #[DataProvider('dataTableType')]
     public function testGetExpectedTableNameForClass($table, $type, $is_valid_type)
     {
         $instance = new \DbUtils();
@@ -213,7 +213,7 @@ class DbUtilsTest extends DbTestCase
         );
     }
 
-    #[dataProvider('dataTableType')]
+    #[DataProvider('dataTableType')]
     public function testGetItemTypeForTable($table, $type, $is_valid_type)
     {
         require_once __DIR__ . '/../../tests/fixtures/another_test.php';
@@ -259,7 +259,7 @@ class DbUtilsTest extends DbTestCase
         }
     }
 
-    #[dataProvider('getItemForItemtypeProvider')]
+    #[DataProvider('getItemForItemtypeProvider')]
     public function testGetItemForItemtype($itemtype, $is_valid, $expected_class)
     {
         // Pseudo plugin class for test
@@ -332,7 +332,7 @@ class DbUtilsTest extends DbTestCase
         ];
     }
 
-    #[dataProvider('dataPlural')]
+    #[DataProvider('dataPlural')]
     public function testGetPlural($singular, $plural)
     {
         $instance = new \DbUtils();
@@ -358,7 +358,7 @@ class DbUtilsTest extends DbTestCase
         );
     }
 
-    #[dataProvider('dataPlural')]
+    #[DataProvider('dataPlural')]
     public function testGetSingular($singular, $plural)
     {
         $instance = new \DbUtils();
@@ -455,7 +455,7 @@ class DbUtilsTest extends DbTestCase
         ];
     }
 
-    #[dataProvider('dataCountMyEntities')]
+    #[DataProvider('dataCountMyEntities')]
     public function testCountElementsInTableForMyEntities(
         $entity,
         $recursive,
@@ -487,7 +487,7 @@ class DbUtilsTest extends DbTestCase
     }
 
 
-    #[dataProvider('dataCountEntities')]
+    #[DataProvider('dataCountEntities')]
     public function testCountElementsInTableForEntity(
         $entity,
         $table,
@@ -1501,7 +1501,7 @@ class DbUtilsTest extends DbTestCase
         ];
     }
 
-    #[dataProvider('autoNameProvider')]
+    #[DataProvider('autoNameProvider')]
     public function testAutoName($name, $field, $is_template, $itemtype, $entities_id, $expected)
     {
         $instance = new \DbUtils();
@@ -1577,7 +1577,7 @@ class DbUtilsTest extends DbTestCase
         ];
     }
 
-    #[dataProvider('fixItemtypeCaseProvider')]
+    #[DataProvider('fixItemtypeCaseProvider')]
     public function testGetItemtypeWithFixedCase($itemtype, $expected)
     {
         $name = 'glpi' . mt_rand();

--- a/phpunit/functional/DocumentTest.php
+++ b/phpunit/functional/DocumentTest.php
@@ -70,7 +70,7 @@ class DocumentTest extends DbTestCase
         ];
     }
 
-    #[dataProvider('canApplyOnProvider')]
+    #[DataProvider('canApplyOnProvider')]
     public function testCanApplyOn($item, $can)
     {
         $doc = new \Document();
@@ -327,7 +327,7 @@ class DocumentTest extends DbTestCase
         ];
     }
 
-    #[dataProvider('validDocProvider')]
+    #[DataProvider('validDocProvider')]
     public function testIsValidDoc($filename, $expected)
     {
         $this->assertSame($expected, \Document::isValidDoc($filename));
@@ -367,7 +367,7 @@ class DocumentTest extends DbTestCase
         ];
     }
 
-    #[dataProvider('isImageProvider')]
+    #[DataProvider('isImageProvider')]
     public function testIsImage($file, $expected)
     {
         $this->assertSame($expected, \Document::isImage($file));
@@ -658,7 +658,7 @@ class DocumentTest extends DbTestCase
     /**
      * Check visibility of document attached to ITIL objects.
      */
-    #[dataProvider('itilTypeProvider')]
+    #[DataProvider('itilTypeProvider')]
     public function testCanViewItilFile($itemtype)
     {
 
@@ -792,7 +792,7 @@ class DocumentTest extends DbTestCase
     /**
      * Check visibility of document inlined in ITIL followup, tasks, solutions.
      */
-    #[dataProvider('ticketChildClassProvider')]
+    #[DataProvider('ticketChildClassProvider')]
     public function testCanViewTicketChildFile($itil_itemtype, $child_itemtype)
     {
 

--- a/phpunit/functional/DomainTest.php
+++ b/phpunit/functional/DomainTest.php
@@ -333,7 +333,7 @@ class DomainTest extends DbTestCase
         ];
     }
 
-    #[dataProvider('linkContentProvider')]
+    #[DataProvider('linkContentProvider')]
     public function testGenerateLinkContents(
         string $link,
         bool $safe_url,

--- a/phpunit/functional/DropdownTest.php
+++ b/phpunit/functional/DropdownTest.php
@@ -83,7 +83,7 @@ class DropdownTest extends DbTestCase
         ];
     }
 
-    #[dataProvider('dataTestImport')]
+    #[DataProvider('dataTestImport')]
     public function testImport($input, $result, $msg)
     {
         $id = \Dropdown::import('UserTitle', $input);
@@ -116,7 +116,7 @@ class DropdownTest extends DbTestCase
         ];
     }
 
-    #[dataProvider('dataTestTreeImport')]
+    #[DataProvider('dataTestTreeImport')]
     public function testTreeImport($input, $result, $complete, $msg)
     {
         $input['entities_id'] = getItemByTypeName('Entity', '_test_root_entity', true);
@@ -461,7 +461,7 @@ HTML;
         ];
     }
 
-    #[dataProvider('dataGetValueWithUnit')]
+    #[DataProvider('dataGetValueWithUnit')]
     public function testGetValueWithUnit($input, $unit, $decimals, $expected)
     {
         $value = $decimals !== null
@@ -1037,7 +1037,7 @@ HTML;
         ];
     }
 
-    #[dataProvider('getDropdownValueProvider')]
+    #[DataProvider('getDropdownValueProvider')]
     public function testGetDropdownValue($params, $expected, $session_params = [])
     {
         $this->login();
@@ -1200,7 +1200,7 @@ HTML;
         ];
     }
 
-    #[dataProvider('getDropdownConnectProvider')]
+    #[DataProvider('getDropdownConnectProvider')]
     public function testGetDropdownConnect($params, $expected, $session_params = [])
     {
         $this->login();
@@ -1384,7 +1384,7 @@ HTML;
         ];
     }
 
-    #[dataProvider('getDropdownNumberProvider')]
+    #[DataProvider('getDropdownNumberProvider')]
     public function testGetDropdownNumber($params, $expected)
     {
         global $CFG_GLPI;
@@ -1508,7 +1508,7 @@ HTML;
         ];
     }
 
-    #[dataProvider('getDropdownUsersProvider')]
+    #[DataProvider('getDropdownUsersProvider')]
     public function testGetDropdownUsers($params, $expected)
     {
         $this->login();
@@ -1927,7 +1927,7 @@ HTML;
      *
      * @return void
      */
-    #[dataProvider('testDropdownNumberProvider')]
+    #[DataProvider('testDropdownNumberProvider')]
     public function testDropdownNumber(array $params, array $expected): void
     {
         $params['display'] = false;
@@ -2010,7 +2010,7 @@ HTML;
         ];
     }
 
-    #[dataProvider('assignableAssetsProvider')]
+    #[DataProvider('assignableAssetsProvider')]
     public function testGetDropdownValueAssignableItems($itemtype)
     {
         $this->login();
@@ -2101,7 +2101,7 @@ HTML;
         $this->assertNotContains(__FUNCTION__ . '3', $children);
     }
 
-    #[dataProvider('assignableAssetsProvider')]
+    #[DataProvider('assignableAssetsProvider')]
     public function testGetDropdownFindNumAssignableItems($itemtype)
     {
         $this->login();
@@ -2246,7 +2246,7 @@ HTML;
         ];
     }
 
-    #[dataProvider('displayWithProvider')]
+    #[DataProvider('displayWithProvider')]
     public function testFilterDisplayWith(CommonDBTM $item, array $displaywith, array $filtered): void
     {
         $instance = new \Dropdown();

--- a/phpunit/functional/EntityTest.php
+++ b/phpunit/functional/EntityTest.php
@@ -639,7 +639,7 @@ class EntityTest extends DbTestCase
         ];
     }
 
-    #[dataProvider('getUsedConfigProvider')]
+    #[DataProvider('getUsedConfigProvider')]
     public function testGetUsedConfig(
         array $root_values,
         array $child_values,
@@ -762,7 +762,7 @@ class EntityTest extends DbTestCase
         ];
     }
 
-    #[dataProvider('customCssProvider')]
+    #[DataProvider('customCssProvider')]
     public function testGetCustomCssTag(
         int $entity_id,
         int $root_enable_custom_css,
@@ -868,7 +868,7 @@ class EntityTest extends DbTestCase
         ];
     }
 
-    #[dataProvider('testAnonymizeSettingProvider')]
+    #[DataProvider('testAnonymizeSettingProvider')]
     public function testAnonymizeSetting(
         string $interface,
         int $setting,
@@ -1391,7 +1391,7 @@ class EntityTest extends DbTestCase
         ];
     }
 
-    #[dataProvider('entityTreeProvider')]
+    #[DataProvider('entityTreeProvider')]
     public function testGetEntityTree(int $entity_id, array $result): void
     {
         $this->login();

--- a/phpunit/functional/GLPIMailerTest.php
+++ b/phpunit/functional/GLPIMailerTest.php
@@ -72,7 +72,7 @@ class GLPIMailerTest extends DbTestCase
         ];
     }
 
-    #[dataProvider('valideAddressProvider')]
+    #[DataProvider('valideAddressProvider')]
     public function testValidateAddress($address, $is_valid)
     {
         $mailer = new \GLPIMailer();

--- a/phpunit/functional/Glpi/Agent/Communication/Headers/CommonTest.php
+++ b/phpunit/functional/Glpi/Agent/Communication/Headers/CommonTest.php
@@ -64,7 +64,7 @@ class CommonTest extends GLPITestCase
         ];
     }
 
-    #[dataProvider('namesProvider')]
+    #[DataProvider('namesProvider')]
     public function testHeaders($propname, $headername)
     {
         $instance = new \Glpi\Agent\Communication\Headers\Common();

--- a/phpunit/functional/Glpi/Cache/CacheManagerTest.php
+++ b/phpunit/functional/Glpi/Cache/CacheManagerTest.php
@@ -74,7 +74,7 @@ class CacheManagerTest extends \GLPITestCase
         ];
     }
 
-    #[dataProvider('contextProvider')]
+    #[DataProvider('contextProvider')]
     public function testIsContextValid(string $context, bool $is_valid, bool $is_configurable): void
     {
         vfsStream::setup('glpi', null, ['config' => [], 'files' => ['_cache' => []]]);
@@ -218,7 +218,7 @@ class CacheManagerTest extends \GLPITestCase
         }
     }
 
-    #[dataProvider('configurationProvider')]
+    #[DataProvider('configurationProvider')]
     public function testSetConfiguration(
         string $context,
         $dsn,
@@ -315,7 +315,7 @@ class CacheManagerTest extends \GLPITestCase
         $this->assertEquals($expected_config, include($config_file));
     }
 
-    #[dataProvider('configurationProvider')]
+    #[DataProvider('configurationProvider')]
     public function testGetConfigurableCache(
         string $context,
         $dsn,
@@ -365,7 +365,7 @@ class CacheManagerTest extends \GLPITestCase
         }
     }
 
-    #[dataProvider('contextProvider')]
+    #[DataProvider('contextProvider')]
     public function testGetCacheInstanceDefault(string $context, bool $is_valid, bool $is_configurable): void
     {
         if (!$is_valid) {
@@ -435,7 +435,7 @@ class CacheManagerTest extends \GLPITestCase
         ];
     }
 
-    #[dataProvider('dsnProvider')]
+    #[DataProvider('dsnProvider')]
     public function testIsDsnValid($dsn, bool $is_valid, ?string $scheme = null): void
     {
 
@@ -449,7 +449,7 @@ class CacheManagerTest extends \GLPITestCase
         $this->assertSame($is_valid, $instance->isDsnValid($dsn));
     }
 
-    #[dataProvider('dsnProvider')]
+    #[DataProvider('dsnProvider')]
     public function testExtractScheme($dsn, bool $is_valid, ?string $scheme = null): void
     {
 

--- a/phpunit/functional/Glpi/DBAL/QueryParamTest.php
+++ b/phpunit/functional/Glpi/DBAL/QueryParamTest.php
@@ -52,7 +52,7 @@ class QueryParamTest extends DbTestCase
         ];
     }
 
-    #[dataProvider('dataParamsProvider')]
+    #[DataProvider('dataParamsProvider')]
     public function testQueryParam($value, $expected)
     {
         $qpa = new \Glpi\DBAL\QueryParam($value);

--- a/phpunit/functional/Glpi/Inventory/Assets/AntivirusTest.php
+++ b/phpunit/functional/Glpi/Inventory/Assets/AntivirusTest.php
@@ -104,7 +104,7 @@ class AntivirusTest extends AbstractInventoryAsset
         ];
     }
 
-    #[dataProvider('assetProvider')]
+    #[DataProvider('assetProvider')]
     public function testPrepare($xml, $expected)
     {
         $converter = new \Glpi\Inventory\Converter();

--- a/phpunit/functional/Glpi/Inventory/Assets/BatteryTest.php
+++ b/phpunit/functional/Glpi/Inventory/Assets/BatteryTest.php
@@ -104,7 +104,7 @@ class BatteryTest extends AbstractInventoryAsset
         ];
     }
 
-    #[dataProvider('assetProvider')]
+    #[DataProvider('assetProvider')]
     public function testPrepare($xml, $expected)
     {
         $converter = new \Glpi\Inventory\Converter();

--- a/phpunit/functional/Glpi/Inventory/Assets/BiosTest.php
+++ b/phpunit/functional/Glpi/Inventory/Assets/BiosTest.php
@@ -88,7 +88,7 @@ class BiosTest extends AbstractInventoryAsset
         ];
     }
 
-    #[dataProvider('assetProvider')]
+    #[DataProvider('assetProvider')]
     public function testPrepare($xml, $expected)
     {
         $converter = new \Glpi\Inventory\Converter();

--- a/phpunit/functional/Glpi/Inventory/Assets/CameraTest.php
+++ b/phpunit/functional/Glpi/Inventory/Assets/CameraTest.php
@@ -80,7 +80,7 @@ class CameraTest extends AbstractInventoryAsset
         ];
     }
 
-    #[dataProvider('assetProvider')]
+    #[DataProvider('assetProvider')]
     public function testPrepare($xml, $expected)
     {
         $converter = new \Glpi\Inventory\Converter();

--- a/phpunit/functional/Glpi/Inventory/Assets/CartridgeTest.php
+++ b/phpunit/functional/Glpi/Inventory/Assets/CartridgeTest.php
@@ -86,7 +86,7 @@ class CartridgeTest extends AbstractInventoryAsset
         ];
     }
 
-    #[dataProvider('assetProvider')]
+    #[DataProvider('assetProvider')]
     public function testPrepare($xml, $expected)
     {
         $converter = new \Glpi\Inventory\Converter();

--- a/phpunit/functional/Glpi/Inventory/Assets/ComputerTest.php
+++ b/phpunit/functional/Glpi/Inventory/Assets/ComputerTest.php
@@ -176,7 +176,7 @@ class ComputerTest extends AbstractInventoryAsset
         ];
     }
 
-    #[dataProvider('assetProvider')]
+    #[DataProvider('assetProvider')]
     public function testPrepare($xml, $asset)
     {
         $date_now = date('Y-m-d H:i:s');

--- a/phpunit/functional/Glpi/Inventory/Assets/ControllerTest.php
+++ b/phpunit/functional/Glpi/Inventory/Assets/ControllerTest.php
@@ -94,7 +94,7 @@ class ControllerTest extends AbstractInventoryAsset
         ];
     }
 
-    #[dataProvider('assetProvider')]
+    #[DataProvider('assetProvider')]
     public function testPrepare($xml, $expected)
     {
         $converter = new \Glpi\Inventory\Converter();

--- a/phpunit/functional/Glpi/Inventory/Assets/DriveTest.php
+++ b/phpunit/functional/Glpi/Inventory/Assets/DriveTest.php
@@ -91,7 +91,7 @@ class DriveTest extends AbstractInventoryAsset
         ];
     }
 
-    #[dataProvider('assetProvider')]
+    #[DataProvider('assetProvider')]
     public function testPrepare($xml, $expected)
     {
         $converter = new \Glpi\Inventory\Converter();

--- a/phpunit/functional/Glpi/Inventory/Assets/Environment.php
+++ b/phpunit/functional/Glpi/Inventory/Assets/Environment.php
@@ -82,7 +82,7 @@ class Environment extends AbstractInventoryAsset
         ];
     }
 
-    #[dataProvider('assetProvider')]
+    #[DataProvider('assetProvider')]
     public function testPrepare($xml, $expected)
     {
         $this->login();

--- a/phpunit/functional/Glpi/Inventory/Assets/FirmwareTest.php
+++ b/phpunit/functional/Glpi/Inventory/Assets/FirmwareTest.php
@@ -84,7 +84,7 @@ class FirmwareTest extends AbstractInventoryAsset
         ];
     }
 
-    #[dataProvider('assetProvider')]
+    #[DataProvider('assetProvider')]
     public function testPrepare($xml, $expected)
     {
         $converter = new \Glpi\Inventory\Converter();

--- a/phpunit/functional/Glpi/Inventory/Assets/GraphicCardTest.php
+++ b/phpunit/functional/Glpi/Inventory/Assets/GraphicCardTest.php
@@ -81,7 +81,7 @@ class GraphicCardTest extends AbstractInventoryAsset
         ];
     }
 
-    #[dataProvider('assetProvider')]
+    #[DataProvider('assetProvider')]
     public function testPrepare($xml, $expected)
     {
         $converter = new \Glpi\Inventory\Converter();

--- a/phpunit/functional/Glpi/Inventory/Assets/MemoryTest.php
+++ b/phpunit/functional/Glpi/Inventory/Assets/MemoryTest.php
@@ -72,7 +72,7 @@ class MemoryTest extends AbstractInventoryAsset
         ];
     }
 
-    #[dataProvider('assetProvider')]
+    #[DataProvider('assetProvider')]
     public function testPrepare($xml, $expected)
     {
         $converter = new \Glpi\Inventory\Converter();

--- a/phpunit/functional/Glpi/Inventory/Assets/MonitorTest.php
+++ b/phpunit/functional/Glpi/Inventory/Assets/MonitorTest.php
@@ -131,7 +131,7 @@ class MonitorTest extends AbstractInventoryAsset
         ];
     }
 
-    #[dataProvider('assetProvider')]
+    #[DataProvider('assetProvider')]
     public function testPrepare($xml, $expected)
     {
         $converter = new \Glpi\Inventory\Converter();

--- a/phpunit/functional/Glpi/Inventory/Assets/NetworkCardTest.php
+++ b/phpunit/functional/Glpi/Inventory/Assets/NetworkCardTest.php
@@ -229,7 +229,7 @@ class NetworkCardTest extends AbstractInventoryAsset
         ];
     }
 
-    #[dataProvider('assetProvider')]
+    #[DataProvider('assetProvider')]
     public function testPrepare($xml, $expected, $virtual)
     {
         $converter = new \Glpi\Inventory\Converter();
@@ -245,7 +245,7 @@ class NetworkCardTest extends AbstractInventoryAsset
         $this->assertEquals(json_decode($expected), $result[0]);
     }
 
-    #[dataProvider('assetProvider')]
+    #[DataProvider('assetProvider')]
     public function testNoVirtuals($xml, $expected, $virtual)
     {
         $converter = new \Glpi\Inventory\Converter();

--- a/phpunit/functional/Glpi/Inventory/Assets/NetworkEquipmentTest.php
+++ b/phpunit/functional/Glpi/Inventory/Assets/NetworkEquipmentTest.php
@@ -161,7 +161,7 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
         ];
     }
 
-    #[dataProvider('assetProvider')]
+    #[DataProvider('assetProvider')]
     public function testPrepare($xml, $asset)
     {
         $date_now = date('Y-m-d H:i:s');
@@ -2747,7 +2747,7 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
         ];
     }
 
-    #[dataProvider('prepareConnectionsProvider')]
+    #[DataProvider('prepareConnectionsProvider')]
     public function testPrepareConnections($json_source)
     {
         $networkEquipment = new \NetworkEquipment();

--- a/phpunit/functional/Glpi/Inventory/Assets/NetworkPortTest.php
+++ b/phpunit/functional/Glpi/Inventory/Assets/NetworkPortTest.php
@@ -325,7 +325,7 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
         ];
     }
 
-    #[dataProvider('assetProvider')]
+    #[DataProvider('assetProvider')]
     public function testPrepare($xml, $ports, $connections, $vlans, $aggregates)
     {
         $converter = new \Glpi\Inventory\Converter();

--- a/phpunit/functional/Glpi/Inventory/Assets/OperatingSystemTest.php
+++ b/phpunit/functional/Glpi/Inventory/Assets/OperatingSystemTest.php
@@ -85,7 +85,7 @@ class OperatingSystemTest extends AbstractInventoryAsset
         ] + self::commonProvider();
     }
 
-    #[dataProvider('assetProvider')]
+    #[DataProvider('assetProvider')]
     public function testPrepare($nodes, $expected)
     {
         $xml = $this->buildXml($nodes);
@@ -364,7 +364,7 @@ class OperatingSystemTest extends AbstractInventoryAsset
         return $data  + self::commonProvider();
     }
 
-    #[dataProvider('assetCleanOsProvider')]
+    #[DataProvider('assetCleanOsProvider')]
     public function testPrepareWithCleanOS($nodes, $expected)
     {
         global $DB;

--- a/phpunit/functional/Glpi/Inventory/Assets/PeripheralTest.php
+++ b/phpunit/functional/Glpi/Inventory/Assets/PeripheralTest.php
@@ -69,7 +69,7 @@ class PeripheralTest extends AbstractInventoryAsset
         ];
     }
 
-    #[dataProvider('assetProvider')]
+    #[DataProvider('assetProvider')]
     public function testPrepare($xml, $expected)
     {
         $converter = new \Glpi\Inventory\Converter();

--- a/phpunit/functional/Glpi/Inventory/Assets/PowerSupplyTest.php
+++ b/phpunit/functional/Glpi/Inventory/Assets/PowerSupplyTest.php
@@ -66,7 +66,7 @@ class PowerSupplyTest extends AbstractInventoryAsset
         ];
     }
 
-    #[dataProvider('assetProvider')]
+    #[DataProvider('assetProvider')]
     public function testPrepare($xml, $expected)
     {
         $converter = new \Glpi\Inventory\Converter();

--- a/phpunit/functional/Glpi/Inventory/Assets/PrinterTest.php
+++ b/phpunit/functional/Glpi/Inventory/Assets/PrinterTest.php
@@ -74,7 +74,7 @@ class PrinterTest extends AbstractInventoryAsset
         ];
     }
 
-    #[dataProvider('assetProvider')]
+    #[DataProvider('assetProvider')]
     public function testPrepare($xml, $expected)
     {
         $date_now = date('Y-m-d H:i:s');

--- a/phpunit/functional/Glpi/Inventory/Assets/Process.php
+++ b/phpunit/functional/Glpi/Inventory/Assets/Process.php
@@ -97,7 +97,7 @@ class Process extends AbstractInventoryAsset
         ];
     }
 
-    #[dataProvider('assetProvider')]
+    #[DataProvider('assetProvider')]
     public function testPrepare($xml, $expected)
     {
         $this->login();

--- a/phpunit/functional/Glpi/Inventory/Assets/ProcessorTest.php
+++ b/phpunit/functional/Glpi/Inventory/Assets/ProcessorTest.php
@@ -100,7 +100,7 @@ class ProcessorTest extends AbstractInventoryAsset
         ];
     }
 
-    #[dataProvider('assetProvider')]
+    #[DataProvider('assetProvider')]
     public function testPrepare($xml, $expected)
     {
         $converter = new \Glpi\Inventory\Converter();

--- a/phpunit/functional/Glpi/Inventory/Assets/RemoteManagementTest.php
+++ b/phpunit/functional/Glpi/Inventory/Assets/RemoteManagementTest.php
@@ -92,7 +92,7 @@ class RemoteManagementTest extends AbstractInventoryAsset
         ];
     }
 
-    #[dataProvider('assetProvider')]
+    #[DataProvider('assetProvider')]
     public function testPrepare($xml, $expected)
     {
         $converter = new \Glpi\Inventory\Converter();

--- a/phpunit/functional/Glpi/Inventory/Assets/SensorTest.php
+++ b/phpunit/functional/Glpi/Inventory/Assets/SensorTest.php
@@ -84,7 +84,7 @@ class SensorTest extends AbstractInventoryAsset
         ];
     }
 
-    #[dataProvider('assetProvider')]
+    #[DataProvider('assetProvider')]
     public function testPrepare($xml, $expected)
     {
         $converter = new \Glpi\Inventory\Converter();

--- a/phpunit/functional/Glpi/Inventory/Assets/SoftwareTest.php
+++ b/phpunit/functional/Glpi/Inventory/Assets/SoftwareTest.php
@@ -104,7 +104,7 @@ class SoftwareTest extends AbstractInventoryAsset
         ];
     }
 
-    #[dataProvider('assetProvider')]
+    #[DataProvider('assetProvider')]
     public function testPrepare($xml, $expected)
     {
         $converter = new \Glpi\Inventory\Converter();
@@ -812,7 +812,7 @@ class SoftwareTest extends AbstractInventoryAsset
         ];
     }
 
-    #[dataProvider('softwareProvider')]
+    #[DataProvider('softwareProvider')]
     public function testSoftwareWithHtmlentites($path)
     {
         $fixtures_path = FIXTURE_DIR . '/inventories/software/';

--- a/phpunit/functional/Glpi/Inventory/Assets/SoundCardTest.php
+++ b/phpunit/functional/Glpi/Inventory/Assets/SoundCardTest.php
@@ -65,7 +65,7 @@ class SoundCardTest extends AbstractInventoryAsset
         ];
     }
 
-    #[dataProvider('assetProvider')]
+    #[DataProvider('assetProvider')]
     public function testPrepare($xml, $expected)
     {
         $converter = new \Glpi\Inventory\Converter();

--- a/phpunit/functional/Glpi/Inventory/Assets/UnmanagedTest.php
+++ b/phpunit/functional/Glpi/Inventory/Assets/UnmanagedTest.php
@@ -91,7 +91,7 @@ class UnmanagedTest extends AbstractInventoryAsset
         ];
     }
 
-    #[dataProvider('assetProvider')]
+    #[DataProvider('assetProvider')]
     public function testPrepare($xml, $expected)
     {
         $converter = new \Glpi\Inventory\Converter();

--- a/phpunit/functional/Glpi/Inventory/Assets/VirtualMachineTest.php
+++ b/phpunit/functional/Glpi/Inventory/Assets/VirtualMachineTest.php
@@ -107,7 +107,7 @@ class VirtualMachineTest extends AbstractInventoryAsset
         ];
     }
 
-    #[dataProvider('assetProvider')]
+    #[DataProvider('assetProvider')]
     public function testPrepare($xml, $expected)
     {
         $converter = new \Glpi\Inventory\Converter();

--- a/phpunit/functional/Glpi/Inventory/Assets/VolumeTest.php
+++ b/phpunit/functional/Glpi/Inventory/Assets/VolumeTest.php
@@ -181,7 +181,7 @@ class VolumeTest extends AbstractInventoryAsset
         ];
     }
 
-    #[dataProvider('assetProvider')]
+    #[DataProvider('assetProvider')]
     public function testPrepare($xml, $expected)
     {
         $converter = new \Glpi\Inventory\Converter();

--- a/phpunit/functional/Glpi/Inventory/ConfTest.php
+++ b/phpunit/functional/Glpi/Inventory/ConfTest.php
@@ -74,7 +74,7 @@ class ConfTest extends \GLPITestCase
         ];
     }
 
-    #[dataProvider('inventoryfilesProvider')]
+    #[DataProvider('inventoryfilesProvider')]
     public function testIsInventoryFile(string $file, bool $expected)
     {
         $conf = new \Glpi\Inventory\Conf();
@@ -95,7 +95,7 @@ class ConfTest extends \GLPITestCase
         return $provider;
     }
 
-    #[dataProvider('confProvider')]
+    #[DataProvider('confProvider')]
     public function testGetter($key, $value)
     {
         $conf = new \Glpi\Inventory\Conf();

--- a/phpunit/functional/Glpi/Inventory/InventoryTest.php
+++ b/phpunit/functional/Glpi/Inventory/InventoryTest.php
@@ -8198,7 +8198,7 @@ Compiled Tue 28-Sep-10 13:44 by prod_rel_team",
         ];
     }
 
-    #[dataProvider('getAssignUserByFieldAndRegexRules')]
+    #[DataProvider('getAssignUserByFieldAndRegexRules')]
     public function testAssignUserByFieldAndRegex($rules_fields, $xml_fields, $result)
     {
         global $DB;

--- a/phpunit/functional/Glpi/Inventory/RequestTest.php
+++ b/phpunit/functional/Glpi/Inventory/RequestTest.php
@@ -101,7 +101,7 @@ class RequestTest extends \GLPITestCase
     /**
      * Test known queries
      */
-    #[dataProvider('queriesProvider')]
+    #[DataProvider('queriesProvider')]
     public function testSnmpQuery($query)
     {
         $data = "<?xml version=\"1.0\"?>\n<REQUEST><DEVICEID>atoumized-device</DEVICEID><CONTENT><DEVICE></DEVICE></CONTENT><QUERY>$query</QUERY></REQUEST>";
@@ -133,7 +133,7 @@ class RequestTest extends \GLPITestCase
     /**
      * Test unknown queries
      */
-    #[dataProvider('unhandledQueriesProvider')]
+    #[DataProvider('unhandledQueriesProvider')]
     public function testWrongQuery($query)
     {
         $data = "<?xml version=\"1.0\"?>\n<REQUEST><DEVICEID>atoumized-device</DEVICEID><QUERY>$query</QUERY></REQUEST>";
@@ -248,7 +248,7 @@ class RequestTest extends \GLPITestCase
      *
      * @return void
      */
-    #[dataProvider('compressionProvider')]
+    #[DataProvider('compressionProvider')]
     public function testCompression(string $function, string $mime)
     {
         $data = "<?xml version=\"1.0\"?>\n<REQUEST><DEVICEID>atoumized-device</DEVICEID><QUERY>PROLOG</QUERY></REQUEST>";

--- a/phpunit/functional/LinkTest.php
+++ b/phpunit/functional/LinkTest.php
@@ -123,7 +123,7 @@ TEXT,
         ];
     }
 
-    #[dataProvider('linkContentProvider')]
+    #[DataProvider('linkContentProvider')]
     public function testGenerateLinkContents(
         string $link,
         bool $safe_url,
@@ -278,7 +278,7 @@ TEXT,
         ];
     }
 
-    #[dataProvider('invalidLinkContentsProvider')]
+    #[DataProvider('invalidLinkContentsProvider')]
     public function testInvalidLinkContents($content)
     {
         $link = new \Link();

--- a/phpunit/functional/LocationTest.php
+++ b/phpunit/functional/LocationTest.php
@@ -235,7 +235,7 @@ class LocationTest extends DbTestCase
         }
     }
 
-    #[dataProvider('importProvider')]
+    #[DataProvider('importProvider')]
     public function testImport(array $input, array $imported): void
     {
         $instance = new \Location();

--- a/phpunit/functional/LogTest.php
+++ b/phpunit/functional/LogTest.php
@@ -423,7 +423,7 @@ class LogTest extends DbTestCase
         ];
     }
 
-    #[dataProvider('dataLogToAffectedField')]
+    #[DataProvider('dataLogToAffectedField')]
     public function testValuesComputationForGetDistinctAffectedFieldValuesInItemLog($log_data, $expected_result)
     {
         $computer = $this->createComputer();
@@ -487,13 +487,13 @@ class LogTest extends DbTestCase
         ];
     }
 
-    #[dataProvider('dataLinkedActionLabel')]
+    #[DataProvider('dataLinkedActionLabel')]
     public function testGetLinkedActionLabel($linked_action, $expected_label)
     {
         $this->assertSame($expected_label, \Log::getLinkedActionLabel($linked_action));
     }
 
-    #[dataProvider('dataLinkedActionLabel')]
+    #[DataProvider('dataLinkedActionLabel')]
     public function testValuesComputationForGetDistinctLinkedActionValuesInItemLog($linked_action, $expected_value)
     {
         $computer = $this->createComputer();
@@ -730,7 +730,7 @@ class LogTest extends DbTestCase
     }
 
 
-    #[dataProvider('dataFiltersValuesToSqlCriteria')]
+    #[DataProvider('dataFiltersValuesToSqlCriteria')]
     public function testConvertFiltersValuesToSqlCriteria($filters_values, $expected_result)
     {
         $this->assertSame($expected_result, \Log::convertFiltersValuesToSqlCriteria($filters_values));
@@ -744,7 +744,7 @@ class LogTest extends DbTestCase
         ];
     }
 
-    #[dataProvider('userNameFormattingProvider')]
+    #[DataProvider('userNameFormattingProvider')]
     public function testUserNameFormatting(string $username, string $password, string $expected_name)
     {
         global $DB, $CFG_GLPI;

--- a/phpunit/functional/TicketTest.php
+++ b/phpunit/functional/TicketTest.php
@@ -8050,9 +8050,7 @@ HTML
         ];
     }
 
-    /**
-     * @dataProvider isCategoryValidProvider
-     */
+    #[DataProvider('isCategoryValidProvider')]
     public function testIsCategoryValid(array $category_fields, array $input, bool $expected): void
     {
         $category = $this->createItem('ITILCategory', $category_fields);

--- a/phpunit/functional/ToolboxTest.php
+++ b/phpunit/functional/ToolboxTest.php
@@ -79,7 +79,7 @@ class ToolboxTest extends DbTestCase
         ];
     }
 
-    #[dataProvider('slugifyProvider')]
+    #[DataProvider('slugifyProvider')]
     public function testSlugify($string, $expected)
     {
         $this->assertSame($expected, \Toolbox::slugify($string));
@@ -128,7 +128,7 @@ class ToolboxTest extends DbTestCase
         ];
     }
 
-    #[dataProvider('filenameProvider')]
+    #[DataProvider('filenameProvider')]
     public function testFilename($name, $expected)
     {
         $this->assertSame($expected, \Toolbox::filename($name));
@@ -149,7 +149,7 @@ class ToolboxTest extends DbTestCase
         ];
     }
 
-    #[dataProvider('dataGetSize')]
+    #[DataProvider('dataGetSize')]
     public function testGetSize($input, $expected)
     {
         $this->assertSame($expected, \Toolbox::getSize($input));
@@ -213,7 +213,7 @@ class ToolboxTest extends DbTestCase
         ];
     }
 
-    #[dataProvider('cleanIntegerProvider')]
+    #[DataProvider('cleanIntegerProvider')]
     public function testCleanInteger($value, $expected)
     {
         $this->assertSame($expected, \Toolbox::cleanInteger($value));
@@ -229,7 +229,7 @@ class ToolboxTest extends DbTestCase
         ];
     }
 
-    #[dataProvider('jsonDecodeProvider')]
+    #[DataProvider('jsonDecodeProvider')]
     public function testJsonDecode($json, $expected)
     {
         $this->assertSame($expected, \Toolbox::jsonDecode($json, true));
@@ -270,7 +270,7 @@ class ToolboxTest extends DbTestCase
         ];
     }
 
-    #[dataProvider('isJSONProvider')]
+    #[DataProvider('isJSONProvider')]
     public function testIsJSON($json, bool $expected)
     {
         $this->assertSame(
@@ -298,7 +298,7 @@ class ToolboxTest extends DbTestCase
         ];
     }
 
-    #[dataProvider('ucProvider')]
+    #[DataProvider('ucProvider')]
     public function testUcfirst($in, $out)
     {
         $this->assertSame($out, \Toolbox::ucfirst($in));
@@ -314,7 +314,7 @@ class ToolboxTest extends DbTestCase
         ];
     }
 
-    #[dataProvider('shortcutProvider')]
+    #[DataProvider('shortcutProvider')]
     public function testShortcut($string, $letter, $expected)
     {
         $this->assertSame($expected, \Toolbox::shortcut($string, $letter));
@@ -335,7 +335,7 @@ class ToolboxTest extends DbTestCase
         ];
     }
 
-    #[dataProvider('strposProvider')]
+    #[DataProvider('strposProvider')]
     public function testStrpos($string, $search, $offset, $expected)
     {
         $this->assertSame(
@@ -357,7 +357,7 @@ class ToolboxTest extends DbTestCase
         ];
     }
 
-    #[dataProvider('padProvider')]
+    #[DataProvider('padProvider')]
     public function testStr_pad($string, $length, $char, $pad, $expected)
     {
         $this->assertSame(
@@ -374,7 +374,7 @@ class ToolboxTest extends DbTestCase
         ];
     }
 
-    #[dataProvider('strlenProvider')]
+    #[DataProvider('strlenProvider')]
     public function testStrlen($string, $length)
     {
         $this->assertSame($length, \Toolbox::strlen($string));
@@ -392,7 +392,7 @@ class ToolboxTest extends DbTestCase
         ];
     }
 
-    #[dataProvider('substrProvider')]
+    #[DataProvider('substrProvider')]
     public function testSubstr($string, $start, $length, $expected)
     {
         $this->assertSame(
@@ -410,7 +410,7 @@ class ToolboxTest extends DbTestCase
         ];
     }
 
-    #[dataProvider('lowercaseProvider')]
+    #[DataProvider('lowercaseProvider')]
     public function testStrtolower($upper, $lower)
     {
         $this->assertSame($lower, \Toolbox::strtolower($upper));
@@ -425,7 +425,7 @@ class ToolboxTest extends DbTestCase
         ];
     }
 
-    #[dataProvider('uppercaseProvider')]
+    #[DataProvider('uppercaseProvider')]
     public function testStrtoupper($lower, $upper)
     {
         $this->assertSame($upper, \Toolbox::strtoupper($lower));
@@ -441,7 +441,7 @@ class ToolboxTest extends DbTestCase
         ];
     }
 
-     #[dataProvider('utfProvider')]
+     #[DataProvider('utfProvider')]
     public function testSeems_utf8($string, $utf)
     {
         $this->assertSame($utf, @\Toolbox::seems_utf8($string));
@@ -494,7 +494,7 @@ class ToolboxTest extends DbTestCase
         ];
     }
 
-    #[dataProvider('getPictureUrlProvider')]
+    #[DataProvider('getPictureUrlProvider')]
     public function testGetPictureUrl($path, $url)
     {
         $this->assertSame($url, \Toolbox::getPictureUrl($path));
@@ -553,7 +553,7 @@ class ToolboxTest extends DbTestCase
     /**
      * Check conversion of tags to images.
      */
-    #[dataProvider('convertTagToImageProvider')]
+    #[DataProvider('convertTagToImageProvider')]
     public function testConvertTagToImage($item, $expected_url)
     {
 
@@ -609,7 +609,7 @@ class ToolboxTest extends DbTestCase
     /**
      * Check base url handling in conversion of tags to images.
      */
-    #[dataProvider('convertTagToImageBaseUrlProvider')]
+    #[DataProvider('convertTagToImageBaseUrlProvider')]
     public function testBaseUrlInConvertTagToImage($url_base, $item, $expected_url)
     {
 
@@ -894,7 +894,7 @@ HTML;
         ];
     }
 
-    #[dataProvider('shortenNumbers')]
+    #[DataProvider('shortenNumbers')]
     public function testShortenNumber($number, int $precision, string $expected)
     {
         $this->assertEquals(
@@ -950,7 +950,7 @@ HTML;
         ];
     }
 
-    #[dataProvider('colors')]
+    #[DataProvider('colors')]
     public function testGetFgColor(string $bg_color, int $offset, string $fg_color)
     {
         $this->assertEquals(
@@ -981,7 +981,7 @@ HTML;
         ];
     }
 
-    #[dataProvider('testIsCommonDBTMProvider')]
+    #[DataProvider('testIsCommonDBTMProvider')]
     public function testIsCommonDBTM(string $class, bool $is_commondbtm)
     {
         $this->assertSame(
@@ -1012,7 +1012,7 @@ HTML;
         ];
     }
 
-    #[dataProvider('testIsAPIDeprecatedProvider')]
+    #[DataProvider('testIsAPIDeprecatedProvider')]
     public function testIsAPIDeprecated(string $class, bool $is_deprecated)
     {
         $this->assertSame(
@@ -1067,7 +1067,7 @@ HTML;
         ];
     }
 
-    #[dataProvider('urlProvider')]
+    #[DataProvider('urlProvider')]
     public function testIsValidWebUrl(string $url, bool $result)
     {
         $this->assertSame(
@@ -1131,7 +1131,7 @@ HTML;
         ];
     }
 
-    #[dataProvider('hasTraitProvider')]
+    #[DataProvider('hasTraitProvider')]
     public function testHasTrait(string $class, string $trait, bool $result)
     {
         $this->assertSame($result, \Toolbox::hasTrait($class, $trait));
@@ -1216,7 +1216,7 @@ HTML;
         ];
     }
 
-    #[dataProvider('appendParametersProvider')]
+    #[DataProvider('appendParametersProvider')]
     public function testAppendParameters(array $params, string $separator, string $expected)
     {
         $this->assertEquals($expected, \Toolbox::append_params($params, $separator));
@@ -1297,7 +1297,7 @@ HTML;
      *
      * @return void
      */
-    #[dataProvider('isFloatProvider')]
+    #[DataProvider('isFloatProvider')]
     public function testIsFloat($value, bool $expected, ?string $warning = null): void
     {
         $result = \Toolbox::isFloat($value);
@@ -1380,7 +1380,7 @@ HTML;
      *
      * @return void
      */
-    #[dataProvider('getDecimalNumbersProvider')]
+    #[DataProvider('getDecimalNumbersProvider')]
     public function testGetDecimalNumbers($value, int $decimals, ?string $warning = null): void
     {
         $result = \Toolbox::getDecimalNumbers($value);
@@ -1464,7 +1464,7 @@ HTML;
      *
      * @return void
      */
-    #[dataProvider('getMioSizeFromStringProvider')]
+    #[DataProvider('getMioSizeFromStringProvider')]
     public function testGetMioSizeFromString(string $size, $expected): void
     {
         $result = \Toolbox::getMioSizeFromString($size);
@@ -1544,7 +1544,7 @@ HTML;
     }
 
 
-    #[dataProvider('safeUrlProvider')]
+    #[DataProvider('safeUrlProvider')]
     public function testIsUrlSafe(string $url, bool $expected, ?array $allowlist = null): void
     {
         $params = [$url];

--- a/phpunit/functional/UserTest.php
+++ b/phpunit/functional/UserTest.php
@@ -450,7 +450,7 @@ class UserTest extends \DbTestCase
         ];
     }
 
-    #[dataProvider('prepareInputForTimezoneUpdateProvider')]
+    #[DataProvider('prepareInputForTimezoneUpdateProvider')]
     public function testPrepareInputForUpdateTimezone(array $input, array $expected)
     {
         $this->login();
@@ -917,7 +917,7 @@ class UserTest extends \DbTestCase
         ];
     }
 
-    #[dataProvider('rawNameProvider')]
+    #[DataProvider('rawNameProvider')]
     public function testGetFriendlyName($input, $rawname)
     {
         $user = new \User();
@@ -1222,7 +1222,7 @@ class UserTest extends \DbTestCase
         ];
     }
 
-    #[dataProvider('cronPasswordExpirationNotificationsProvider')]
+    #[DataProvider('cronPasswordExpirationNotificationsProvider')]
     public function testCronPasswordExpirationNotifications(
         int $expiration_delay,
         int $notice_delay,
@@ -1932,7 +1932,7 @@ class UserTest extends \DbTestCase
         ];
     }
 
-    #[dataProvider('toggleSavedSearchPinProvider')]
+    #[DataProvider('toggleSavedSearchPinProvider')]
     public function testToggleSavedSearchPin(string $initial_db_value, string $itemtype, bool $success, string $result_db_value): void
     {
         $user = $this->createItem(


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

1. Fixes the following deprecation:
```
There was 1 PHPUnit test runner deprecation:

1) Metadata found in doc-comment for method tests\units\TicketTest::testIsCategoryValid(). Metadata in doc-comments is deprecated and will no longer be supported in PHPUnit 12. Update your test code to use attributes instead.
```

2. Use the correct case.