### PR TITLE
Permit to authenticate to the HL API doc using the session cookie

### DIFF
--- a/src/Glpi/Api/HL/Middleware/CookieAuthMiddleware.php
+++ b/src/Glpi/Api/HL/Middleware/CookieAuthMiddleware.php
@@ -41,18 +41,16 @@ class CookieAuthMiddleware extends AbstractMiddleware implements AuthMiddlewareI
 {
     public function process(MiddlewareInput $input, callable $next): void
     {
-        $auth = new \Auth();
-        if ($auth->getAlternateAuthSystemsUserLogin(\Auth::COOKIE)) {
-            // User could be authenticated by a cookie
-            // Need to use cookies for session and start it manually
-            ini_set('session.use_cookies', '1');
-            Session::start();
+        ini_set('session.use_cookies', '1');
+        Session::start();
+
+        if (($user_id = Session::getLoginUserID()) !== false) {
             // unset the response to indicate a successful auth
             $input->response = null;
             $input->client = [
                 'client_id' => 'internal', // Internal just means the user was authenticated internally either by cookie or an already existing session.
-                'users_id'  => Session::getLoginUserID(),
-                'scopes' => []
+                'users_id'  => $user_id,
+                'scopes'    => [],
             ];
         } else {
             $next($input);


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Instead of using the `remember_me` cookie, I propose to use directly the session cookie for the HL API doc authentication. It fixes #18299.
