### PR TITLE
Only reinit rules when inventory capacity enabled

### DIFF
--- a/src/Glpi/Asset/Capacity/AbstractCapacity.php
+++ b/src/Glpi/Asset/Capacity/AbstractCapacity.php
@@ -186,6 +186,10 @@ abstract class AbstractCapacity implements CapacityInterface
     {
     }
 
+    public function onCapacityEnabled(string $classname): void
+    {
+    }
+
     public function onCapacityDisabled(string $classname): void
     {
     }

--- a/src/Glpi/Asset/Capacity/CapacityInterface.php
+++ b/src/Glpi/Asset/Capacity/CapacityInterface.php
@@ -110,6 +110,14 @@ interface CapacityInterface
     public function onClassBootstrap(string $classname): void;
 
     /**
+     * Method executed when capacity is enabled on given asset class.
+     *
+     * @param class-string<\Glpi\Asset\Asset> $classname
+     * @return void
+     */
+    public function onCapacityEnabled(string $classname): void;
+
+    /**
      * Method executed when capacity is disabled on given asset class.
      *
      * @param class-string<\Glpi\Asset\Asset> $classname

--- a/src/Glpi/Asset/Capacity/IsInventoriableCapacity.php
+++ b/src/Glpi/Asset/Capacity/IsInventoriableCapacity.php
@@ -100,7 +100,10 @@ class IsInventoriableCapacity extends AbstractCapacity
 
         CommonGLPI::registerStandardTab($classname, Item_Environment::class, 85);
         CommonGLPI::registerStandardTab($classname, Item_Process::class, 85);
+    }
 
+    public function onCapacityEnabled(string $classname): void
+    {
         //create rules
         $rules = new \RuleImportAsset();
         $rules->initRules(true, $classname);

--- a/src/Glpi/CustomObject/AbstractDefinitionManager.php
+++ b/src/Glpi/CustomObject/AbstractDefinitionManager.php
@@ -126,6 +126,15 @@ abstract class AbstractDefinitionManager
     }
 
     /**
+     * Clear the definitions cache.
+     * @return void
+     */
+    final public function clearDefinitionsCache(): void
+    {
+        $this->definitions_data = [];
+    }
+
+    /**
      * Get all the dropdown definitions.
      *
      * @param bool $only_active


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Fixes #18304
Rules should only be re-initialized when the inventory capacity of an asset definition is enabled, not every time the capacity is bootstrapped. Rules take a long time to initialize even for a single class, and the bootstrap process happens for every request.
