### PR TITLE
[11.0] Fix missing Kernel in Application class

### DIFF
--- a/src/Glpi/Console/Application.php
+++ b/src/Glpi/Console/Application.php
@@ -59,6 +59,7 @@ use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
 use Toolbox;
 use Update;
 
@@ -617,5 +618,19 @@ class Application extends BaseApplication
         }
 
         return implode(':', null === $limit ? $parts : \array_slice($parts, 0, $limit));
+    }
+
+    /**
+     * Gets the Kernel associated with this Console.
+     *
+     * This method is required by most of the commands provided by the `symfony/framework-bundle`.
+     * @see \Symfony\Bundle\FrameworkBundle\Console\Application::getKernel()
+     */
+    public function getKernel(): ?KernelInterface
+    {
+        /** @var KernelInterface|null $kernel */
+        global $kernel;
+
+        return $kernel;
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

The #17985 PR added the ability to run Symfony commands, however it misses this change for which the Symfony Kernel sometimes need to get the Kernel from the Application class, such as the `debug:router` command (which can be run as `symfony:debug:router` in GLPI)