### PR TITLE
Add new right : See private task assign to my group

### DIFF
--- a/phpunit/functional/TicketTest.php
+++ b/phpunit/functional/TicketTest.php
@@ -7104,9 +7104,9 @@ HTML
                 'public followup',
             ],
             'expected_tasks'     => [
-                'private task of normal user',
-                'private task assigned to normal user',
                 'private task assigned to see group',
+                'private task assigned to normal user',
+                'private task of normal user',
                 'private task of tech user',
                 'public task',
             ],
@@ -7123,9 +7123,9 @@ HTML
                 'public followup',
             ],
             'expected_tasks'     => [
-                'private task of normal user',
-                'private task assigned to normal user',
                 'private task assigned to see group',
+                'private task assigned to normal user',
+                'private task of normal user',
                 'public task',
             ],
         ];
@@ -7160,9 +7160,9 @@ HTML
                     'public followup',
                 ],
                 'expected_tasks'     => [
-                    'private task of normal user',
-                    'private task assigned to normal user',
                     'private task assigned to see group',
+                    'private task assigned to normal user',
+                    'private task of normal user',
                     'private task of tech user',
                     'public task',
                 ],

--- a/phpunit/functional/TicketTest.php
+++ b/phpunit/functional/TicketTest.php
@@ -7088,7 +7088,7 @@ HTML
                 'content'           => 'private task assigned to see group',
                 'is_private'        => 1,
                 'groups_id_tech'    => $seegroup_id,
-                'date_creation'     => date('Y-m-d H:i:s', strtotime('+30s', $now)), // to ensure result order is correct
+                'date_creation'     => date('Y-m-d H:i:s', strtotime('+50s', $now)), // to ensure result order is correct
             ]
         );
 

--- a/phpunit/functional/TicketTest.php
+++ b/phpunit/functional/TicketTest.php
@@ -7077,7 +7077,7 @@ HTML
                 'content'       => 'private task assigned to normal user',
                 'is_private'    => 1,
                 'users_id_tech' => $normal_user_id,
-                'date_creation' => date('Y-m-d H:i:s', strtotime('+30s', $now)), // to ensure result order is correct
+                'date_creation' => date('Y-m-d H:i:s', strtotime('+40s', $now)), // to ensure result order is correct
             ]
         );
 

--- a/phpunit/functional/TicketTest.php
+++ b/phpunit/functional/TicketTest.php
@@ -6957,15 +6957,8 @@ HTML
         $postonly_user_id = getItemByTypeName(User::class, 'post-only', true);
         $normal_user_id   = getItemByTypeName(User::class, 'normal', true);
         $tech_user_id     = getItemByTypeName(User::class, 'tech', true);
-        $test_user_id     = getItemByTypeName(User::class, '_test_user', true);
 
-        $profile = $this->createItem(
-            \Profile::class,
-            [
-                'name'                => 'SeeGrouptask',
-                'interface'           => 'central',
-            ]
-        );
+        $profile = getItemByTypeName(\Profile::class, 'Observer');
 
         $profile_right = new \ProfileRight();
         $profile_right->getFromDBByCrit([
@@ -6977,29 +6970,7 @@ HTML
             \ProfileRight::class,
             $profile_right->getID(),
             [
-                'rights' => 121879,
-            ]
-        );
-
-        $profile_right->getFromDBByCrit([
-            'profiles_id' => $profile->getID(),
-            'name'        => 'ticket',
-        ]);
-
-        $this->updateItem(
-            \ProfileRight::class,
-            $profile_right->getID(),
-            [
-                'rights' => 523295,
-            ]
-        );
-
-        $this->createItem(
-            Profile_User::class,
-            [
-                'users_id'    => $test_user_id,
-                'profiles_id' => $profile->getID(),
-                'entities_id' => 0,
+                'rights' => \CommonITILTask::SEEPRIVATEGROUPS + \CommonITILTask::SEEPUBLIC,
             ]
         );
 
@@ -7014,7 +6985,7 @@ HTML
             Group_User::class,
             [
                 'groups_id' => $group->getID(),
-                'users_id'  => $test_user_id,
+                'users_id'  => $normal_user_id,
             ]
         );
 
@@ -7154,6 +7125,7 @@ HTML
             'expected_tasks'     => [
                 'private task of normal user',
                 'private task assigned to normal user',
+                'private task assigned to see group',
                 'public task',
             ],
         ];
@@ -7167,17 +7139,6 @@ HTML
             'expected_followups' => [
                 'public followup',
             ],
-            'expected_tasks'     => [
-                'public task',
-            ],
-        ];
-
-        yield [
-            'login'              => '_test_user',
-            'pass'               => TU_PASS,
-            'ticket_id'          => $ticket->getID(),
-            'options'            => [],
-            'expected_followups' => [],
             'expected_tasks'     => [
                 'public task',
             ],
@@ -7241,10 +7202,6 @@ HTML
                 $this->login($login, $pass);
             } else {
                 $this->resetSession();
-            }
-
-            if ($login === '_test_user') {
-                Session::changeProfile(getItemByTypeName('Profile', 'Test_Group_Task', true));
             }
 
             $ticket = new \Ticket();

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -7583,13 +7583,24 @@ abstract class CommonITILObject extends CommonDBTM
                     'is_private' => 0,
                 ];
             } else {
-                $restrict_task = [
-                    'OR' => [
-                        'is_private' => 0,
-                        'users_id'   => Session::getCurrentInterface() === "central" ? (int)Session::getLoginUserID() : 0,
-                        'users_id_tech' => Session::getCurrentInterface() === "central" ? (int)Session::getLoginUserID() : 0,
-                    ]
-                ];
+                if (Session::haveRight($task_obj::$rightname, CommonITILTask::SEEPRIVATEGROUPS)) {
+                    $restrict_task = [
+                        'OR' => [
+                            'is_private' => 0,
+                            'users_id'   => Session::getCurrentInterface() === "central" ? (int)Session::getLoginUserID() : 0,
+                            'users_id_tech' => Session::getCurrentInterface() === "central" ? (int)Session::getLoginUserID() : 0,
+                            'groups_id_tech' => $_SESSION["glpigroups"],
+                        ]
+                    ];
+                } else {
+                    $restrict_task = [
+                        'OR' => [
+                            'is_private' => 0,
+                            'users_id'   => Session::getCurrentInterface() === "central" ? (int)Session::getLoginUserID() : 0,
+                            'users_id_tech' => Session::getCurrentInterface() === "central" ? (int)Session::getLoginUserID() : 0,
+                        ]
+                    ];
+                }
             }
         }
 

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -7583,23 +7583,18 @@ abstract class CommonITILObject extends CommonDBTM
                     'is_private' => 0,
                 ];
             } else {
+                $current_user_id = (Session::getCurrentInterface() === "central") ? (int)Session::getLoginUserID() : 0;
+
+                $restrict_task = [
+                    'OR' => [
+                        'is_private' => 0,
+                        'users_id'   => $current_user_id,
+                        'users_id_tech' => $current_user_id,
+                    ]
+                ];
+
                 if (Session::haveRight($task_obj::$rightname, CommonITILTask::SEEPRIVATEGROUPS)) {
-                    $restrict_task = [
-                        'OR' => [
-                            'is_private' => 0,
-                            'users_id'   => Session::getCurrentInterface() === "central" ? (int)Session::getLoginUserID() : 0,
-                            'users_id_tech' => Session::getCurrentInterface() === "central" ? (int)Session::getLoginUserID() : 0,
-                            'groups_id_tech' => $_SESSION["glpigroups"],
-                        ]
-                    ];
-                } else {
-                    $restrict_task = [
-                        'OR' => [
-                            'is_private' => 0,
-                            'users_id'   => Session::getCurrentInterface() === "central" ? (int)Session::getLoginUserID() : 0,
-                            'users_id_tech' => Session::getCurrentInterface() === "central" ? (int)Session::getLoginUserID() : 0,
-                        ]
-                    ];
+                    $restrict_task['OR']['groups_id_tech'] = $_SESSION["glpigroups"];
                 }
             }
         }

--- a/src/ITILSubItemRights.php
+++ b/src/ITILSubItemRights.php
@@ -45,6 +45,8 @@ trait ITILSubItemRights
     public const ADD_AS_OBSERVER    = 16384;
     public const ADD_AS_TECHNICIAN  = 32768;
 
+    public const SEEPRIVATEGROUPS         = 65536;
+
     public function getRights($interface = 'central')
     {
 
@@ -55,6 +57,7 @@ trait ITILSubItemRights
             $values[self::UPDATEALL] = __('Update all');
             $values[self::ADDALLITEM] = __('Add to all items');
             $values[self::SEEPRIVATE] = __('See private ones');
+            $values[self::SEEPRIVATEGROUPS] = __('See private of my groups');
         }
 
         $values[self::ADD_AS_GROUP] = [


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !34489
- Here is a brief description of what this PR does

Added a new right so that I can see the private tasks assigned to my group even if I can't see the basic private tasks.

## Screenshots (if appropriate):


