### PR TITLE
Fix update password form with debug mode

### DIFF
--- a/src/Session.php
+++ b/src/Session.php
@@ -171,6 +171,11 @@ class Session
                     self::loadLanguage();
 
                     if ($auth->password_expired) {
+                        // Make sure we are not in debug mode, as it could trigger some ajax request that would
+                        // fail the session check (as we use a special partial session here without profiles) and thus
+                        // destroy the session (which would make the "password expired" form impossible to submit as the
+                        // csrf check would fail as the session data would be empty).
+                        $_SESSION["glpi_use_mode"] = self::NORMAL_MODE;
                         $_SESSION['glpi_password_expired'] = 1;
                        // Do not init profiles, as user has to update its password to be able to use GLPI
                         return;


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works
Can't really be tested without a very specific e2e test, which is not possible in this version.

## Description

Fix !35193.

The "password expired" form is impossible to submit if the debug mode is enabled.

This is because we use a special "partial session" without profiles to display this form, which would make any AJAX request expecting a full session to fail the session check and thus trigger the session deletion (and the CSRF data with it, making the form impossible to submit).
Having the debug mode enabled will trigger such requests.

Fixed by forcing the `NORMAL_MODE` mode when a user has an expired password.



