### PR TITLE
feat(mail collector): add 'TO' as observer

### DIFF
--- a/install/migrations/update_10.0.x_to_11.0.0/mailcollectors.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/mailcollectors.php
@@ -38,3 +38,4 @@
  */
 
 $migration->addField('glpi_mailcollectors', 'create_user_from_email', 'bool', ['value' => 0]);
+$migration->addField('glpi_mailcollectors', 'add_to_to_observer', 'bool', ['value' => 1]);

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -4265,6 +4265,7 @@ CREATE TABLE `glpi_mailcollectors` (
   `use_mail_date` tinyint NOT NULL DEFAULT '0',
   `date_creation` timestamp NULL DEFAULT NULL,
   `requester_field` int NOT NULL DEFAULT '0',
+  `add_to_to_observer` tinyint NOT NULL DEFAULT '1',
   `add_cc_to_observer` tinyint NOT NULL DEFAULT '0',
   `collect_only_unread` tinyint NOT NULL DEFAULT '0',
   `create_user_from_email` tinyint NOT NULL DEFAULT '0',

--- a/src/MailCollector.php
+++ b/src/MailCollector.php
@@ -927,7 +927,7 @@ class MailCollector extends CommonDBTM
         }
 
         $tos = $headers['tos'];
-        if (is_array($tos) && count($tos)) {
+        if (is_array($tos) && count($tos) && $this->getField("add_to_to_observer")) {
             foreach ($tos as $to) {
                 if (
                     $to != $requester

--- a/templates/pages/setup/mailcollector/setup_form.html.twig
+++ b/templates/pages/setup/mailcollector/setup_form.html.twig
@@ -95,6 +95,7 @@
       (constant('MailCollector::REQUESTER_FIELD_FROM')): __('No'),
       (constant('MailCollector::REQUESTER_FIELD_REPLY_TO')): __('Yes'),
    }, __('Use Reply-To as requester (when available)')) }}
+   {{ fields.dropdownYesNo('add_to_to_observer', item.fields['add_to_to_observer'], __('Add TO users as observer')) }}
    {{ fields.dropdownYesNo('add_cc_to_observer', item.fields['add_cc_to_observer'], __('Add CC users as observer')) }}
    {{ fields.dropdownYesNo('collect_only_unread', item.fields['collect_only_unread'], __('Collect only unread mail')) }}
    {% set create_user_helper %}

--- a/tests/emails-tests/44-multiple-to.eml
+++ b/tests/emails-tests/44-multiple-to.eml
@@ -1,0 +1,32 @@
+Return-Path: tech@glpi-project.org
+Received: from 192.168.1.3 (LHLO mail.glpi-project.org) (192.168.1.3)
+ by mail.glpi-project.org with LMTP; Tue, 2 Apr 2019 14:43:12 +0200
+ (CEST)
+Received: from mail.glpi-project.org (localhost [127.0.0.1])
+	by mail.glpi-project.org (Postfix) with ESMTP id 6F3457E80D1E
+	for <unittests@glpi-project.org>; Tue,  2 Apr 2019 14:43:12 +0200 (CEST)
+Received: from localhost (localhost [127.0.0.1])
+	by mail.glpi-project.org (Postfix) with ESMTP id 645C77E80D1C
+	for <unittests@glpi-project.org>; Tue,  2 Apr 2019 14:43:12 +0200 (CEST)
+Received: from mail.glpi-project.org ([127.0.0.1])
+	by localhost (mail.glpi-project.org [127.0.0.1]) (amavisd-new, port 10026)
+	with ESMTP id POJTfrC8TVrL for <unittests@glpi-project.org>;
+	Tue,  2 Apr 2019 14:43:12 +0200 (CEST)
+Received: from mail.glpi-project.org (localhost [127.0.0.1])
+	by mail.glpi-project.org (Postfix) with ESMTP id 55AF37E80C20
+	for <unittests@glpi-project.org>; Tue,  2 Apr 2019 14:43:12 +0200 (CEST)
+Date: Tue, 2 Apr 2019 14:43:12 +0200 (CEST)
+From: Tech Ni Cian <tech@glpi-project.org>
+To: GLPI debug <unittests@glpi-project.org>, Normal User <normal@glpi-project.org>
+Message-ID: <2078889367.1658939.1554208992329.JavaMail.zimbra@glpi-project.org>
+Subject: Ticket with multiple to
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 7bit
+X-Mailer: Zimbra 8.0.9_GA_6191 (ZimbraWebClient - FF66 (Linux)/8.0.9_GA_6191)
+Thread-Topic: Ticket with multiple to
+Thread-Index: OOKl6v3Lu6HeDTdJe0OrUl01ERm/dw==
+
+This ticket have multiple to
+
+Best regards,

--- a/tests/imap/MailCollector.php
+++ b/tests/imap/MailCollector.php
@@ -76,6 +76,7 @@ class MailCollector extends DbTestCase
                    'use_mail_date'        => '',
                    'date_creation'        => '',
                    'requester_field'      => '',
+                   'add_to_to_observer'   => '',
                    'add_cc_to_observer'   => '',
                    'collect_only_unread'  => '',
                    'create_user_from_email' => '',
@@ -597,6 +598,7 @@ class MailCollector extends DbTestCase
             'server_port'           => 143,
             'server_ssl'            => '',
             'server_cert'           => '/novalidate-cert',
+            'add_to_to_observer'    => 1,
             'add_cc_to_observer'    => 1,
             'collect_only_unread'   => 1,
             'requester_field'       => \MailCollector::REQUESTER_FIELD_REPLY_TO,
@@ -738,6 +740,7 @@ class MailCollector extends DbTestCase
                     'Ticket with observer',
                     'Re: [GLPI #0038927] Update - Issues with new Windows 10 machine',
                     'A message without to header',
+                    'Ticket with multiple to',
                 ]
             ],
          // Mails having "normal" user as requester
@@ -781,12 +784,13 @@ class MailCollector extends DbTestCase
                     '43 - Korean encoding issue',
                 ]
             ],
-         // Mails having "normal" user as observer (add_cc_to_observer = true)
+            // Mails having "normal" user as observer
             [
                 'users_id'      => $nuid,
                 'actor_type'    => \CommonITILActor::OBSERVER,
                 'tickets_names' => [
-                    'Ticket with observer',
+                    'Ticket with observer',     // add_cc_to_observer = true
+                    'Ticket with multiple to',  // add_to_to_observer = true
                 ]
             ],
         ];
@@ -937,6 +941,8 @@ PLAINTEXT,
                 $names[] = $name;
             }
 
+            sort($names);
+            sort($actor_specs['tickets_names']);
             $this->array($names)->isIdenticalTo($actor_specs['tickets_names']);
         }
 
@@ -984,6 +990,8 @@ PLAINTEXT,
         foreach ($iterator as $data) {
             $filenames[$data['filename']] = $data['mime'];
         }
+        ksort($filenames);
+        ksort($expected_docs);
         $this->array($filenames)->isIdenticalTo($expected_docs);
 
         $this->integer(count($iterator))->isIdenticalTo(count($expected_docs));


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !34412

Currently, other addresses in the "TO" field of emails are automatically added as ticket observers. This PR introduces an option to enable or disable this behavior.

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/4c1fca99-6a98-4233-94b3-fb2ddd0bc5fa)

