### PR TITLE
Optimize disk I/O when checking session groups validity

### DIFF
--- a/src/Glpi/Config/LegacyConfigurators/ConfigRest.php
+++ b/src/Glpi/Config/LegacyConfigurators/ConfigRest.php
@@ -94,10 +94,12 @@ final readonly class ConfigRest implements LegacyConfigProviderInterface
         // The user's current groups are stored in his session
         // If there was any change regarding groups membership and/or configuration, we
         // need to reset the data stored in his session
-        $last_group_change = $GLPI_CACHE->get('last_group_change');
         if (
             isset($_SESSION['glpigroups'])
-            && ($_SESSION['glpigroups_cache_date'] ?? "") < $last_group_change
+            && (
+                !isset($_SESSION['glpigroups_cache_date'])
+                || $_SESSION['glpigroups_cache_date'] < $GLPI_CACHE->get('last_group_change')
+            )
         ) {
             Session::loadGroups();
         }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

On any page that can be accessed without a full session loaded (login page, FAQ, install, update, ...), the proposed change will save a useless cache entry access. Indeed, in this case, `isset($_SESSION['glpigroups'])` will be `false` so the `last_group_change` cache entry value will not be used.