### PR TITLE
replace mt_rand by random_int

### DIFF
--- a/ajax/dcroom_size.php
+++ b/ajax/dcroom_size.php
@@ -41,7 +41,7 @@ if (!isset($_REQUEST['id'])) {
 
 $id = $_REQUEST['id'];
 $current = $_REQUEST['current'] ?? null;
-$rand = $_REQUEST['rand'] ?? random_int();
+$rand = $_REQUEST['rand'] ?? random_int(0, 2**32);
 
 $room = new DCRoom();
 if ($room->getFromDB($id)) {

--- a/ajax/dcroom_size.php
+++ b/ajax/dcroom_size.php
@@ -41,7 +41,7 @@ if (!isset($_REQUEST['id'])) {
 
 $id = $_REQUEST['id'];
 $current = $_REQUEST['current'] ?? null;
-$rand = $_REQUEST['rand'] ?? random_int(0, 2**32);
+$rand = $_REQUEST['rand'] ?? random_int(0, 2 ** 32);
 
 $room = new DCRoom();
 if ($room->getFromDB($id)) {

--- a/ajax/dcroom_size.php
+++ b/ajax/dcroom_size.php
@@ -41,7 +41,7 @@ if (!isset($_REQUEST['id'])) {
 
 $id = $_REQUEST['id'];
 $current = $_REQUEST['current'] ?? null;
-$rand = $_REQUEST['rand'] ?? mt_rand();
+$rand = $_REQUEST['rand'] ?? random_int();
 
 $room = new DCRoom();
 if ($room->getFromDB($id)) {

--- a/ajax/dropdownAllItems.php
+++ b/ajax/dropdownAllItems.php
@@ -54,7 +54,7 @@ if ($_POST["idtable"] && class_exists($_POST["idtable"])) {
         $link = "getDropdownUsers.php";
     }
 
-    $rand = $_POST['rand'] ?? mt_rand();
+    $rand = $_POST['rand'] ?? random_int();
 
     $field_id = Html::cleanId("dropdown_" . $_POST["name"] . $rand);
 

--- a/ajax/dropdownAllItems.php
+++ b/ajax/dropdownAllItems.php
@@ -54,7 +54,7 @@ if ($_POST["idtable"] && class_exists($_POST["idtable"])) {
         $link = "getDropdownUsers.php";
     }
 
-    $rand = $_POST['rand'] ?? random_int(0, 2**32);
+    $rand = $_POST['rand'] ?? random_int(0, 2 ** 32);
 
     $field_id = Html::cleanId("dropdown_" . $_POST["name"] . $rand);
 

--- a/ajax/dropdownAllItems.php
+++ b/ajax/dropdownAllItems.php
@@ -54,7 +54,7 @@ if ($_POST["idtable"] && class_exists($_POST["idtable"])) {
         $link = "getDropdownUsers.php";
     }
 
-    $rand = $_POST['rand'] ?? random_int();
+    $rand = $_POST['rand'] ?? random_int(0, 2**32);
 
     $field_id = Html::cleanId("dropdown_" . $_POST["name"] . $rand);
 

--- a/ajax/dropdownConnectNetworkPortDeviceType.php
+++ b/ajax/dropdownConnectNetworkPortDeviceType.php
@@ -49,7 +49,7 @@ Session::checkRight("networking", UPDATE);
 
 // Make a select box
 if (class_exists($_POST["itemtype"])) {
-    $rand     = mt_rand();
+    $rand     = random_int();
 
     $toupdate = [
         'value_fieldname' => 'item',

--- a/ajax/dropdownConnectNetworkPortDeviceType.php
+++ b/ajax/dropdownConnectNetworkPortDeviceType.php
@@ -49,7 +49,7 @@ Session::checkRight("networking", UPDATE);
 
 // Make a select box
 if (class_exists($_POST["itemtype"])) {
-    $rand     = random_int(0, 2**32);
+    $rand     = random_int(0, 2 ** 32);
 
     $toupdate = [
         'value_fieldname' => 'item',

--- a/ajax/dropdownConnectNetworkPortDeviceType.php
+++ b/ajax/dropdownConnectNetworkPortDeviceType.php
@@ -49,7 +49,7 @@ Session::checkRight("networking", UPDATE);
 
 // Make a select box
 if (class_exists($_POST["itemtype"])) {
-    $rand     = random_int();
+    $rand     = random_int(0, 2**32);
 
     $toupdate = [
         'value_fieldname' => 'item',

--- a/ajax/dropdownItilActors.php
+++ b/ajax/dropdownItilActors.php
@@ -47,7 +47,7 @@ if (
     && isset($_POST["actortype"])
     && isset($_POST["itemtype"])
 ) {
-    $rand = mt_rand();
+    $rand = random_int();
     $withemail = isset($_POST['allow_email']) && filter_var($_POST['allow_email'], FILTER_VALIDATE_BOOLEAN);
 
     /** @var CommonITILObject $item */

--- a/ajax/dropdownItilActors.php
+++ b/ajax/dropdownItilActors.php
@@ -47,7 +47,7 @@ if (
     && isset($_POST["actortype"])
     && isset($_POST["itemtype"])
 ) {
-    $rand = random_int();
+    $rand = random_int(0, 2**32);
     $withemail = isset($_POST['allow_email']) && filter_var($_POST['allow_email'], FILTER_VALIDATE_BOOLEAN);
 
     /** @var CommonITILObject $item */

--- a/ajax/dropdownItilActors.php
+++ b/ajax/dropdownItilActors.php
@@ -47,7 +47,7 @@ if (
     && isset($_POST["actortype"])
     && isset($_POST["itemtype"])
 ) {
-    $rand = random_int(0, 2**32);
+    $rand = random_int(0, 2 ** 32);
     $withemail = isset($_POST['allow_email']) && filter_var($_POST['allow_email'], FILTER_VALIDATE_BOOLEAN);
 
     /** @var CommonITILObject $item */

--- a/ajax/dropdownMassiveActionAddActor.php
+++ b/ajax/dropdownMassiveActionAddActor.php
@@ -43,7 +43,7 @@ Session::checkRight('ticket', UPDATE);
 
 if ($_POST["actortype"] > 0) {
     $ticket = new Ticket();
-    $rand   = random_int(0, 2**32);
+    $rand   = random_int(0, 2 ** 32);
     $ticket->showActorAddForm(
         $_POST["actortype"],
         $rand,

--- a/ajax/dropdownMassiveActionAddActor.php
+++ b/ajax/dropdownMassiveActionAddActor.php
@@ -43,7 +43,7 @@ Session::checkRight('ticket', UPDATE);
 
 if ($_POST["actortype"] > 0) {
     $ticket = new Ticket();
-    $rand   = random_int();
+    $rand   = random_int(0, 2**32);
     $ticket->showActorAddForm(
         $_POST["actortype"],
         $rand,

--- a/ajax/dropdownMassiveActionAddActor.php
+++ b/ajax/dropdownMassiveActionAddActor.php
@@ -43,7 +43,7 @@ Session::checkRight('ticket', UPDATE);
 
 if ($_POST["actortype"] > 0) {
     $ticket = new Ticket();
-    $rand   = mt_rand();
+    $rand   = random_int();
     $ticket->showActorAddForm(
         $_POST["actortype"],
         $rand,

--- a/ajax/dropdownTrackingDeviceType.php
+++ b/ajax/dropdownTrackingDeviceType.php
@@ -61,7 +61,7 @@ if ($context == "impact") {
 if ($isValidItemtype) {
     $table = getTableForItemType($itemtype);
 
-    $rand = $_POST["rand"] ?? random_int();
+    $rand = $_POST["rand"] ?? random_int(0, 2**32);
 
     // Message for post-only
     if (!isset($_POST["admin"]) || ($_POST["admin"] == 0)) {

--- a/ajax/dropdownTrackingDeviceType.php
+++ b/ajax/dropdownTrackingDeviceType.php
@@ -61,7 +61,7 @@ if ($context == "impact") {
 if ($isValidItemtype) {
     $table = getTableForItemType($itemtype);
 
-    $rand = $_POST["rand"] ?? random_int(0, 2**32);
+    $rand = $_POST["rand"] ?? random_int(0, 2 ** 32);
 
     // Message for post-only
     if (!isset($_POST["admin"]) || ($_POST["admin"] == 0)) {

--- a/ajax/dropdownTrackingDeviceType.php
+++ b/ajax/dropdownTrackingDeviceType.php
@@ -61,7 +61,7 @@ if ($context == "impact") {
 if ($isValidItemtype) {
     $table = getTableForItemType($itemtype);
 
-    $rand = $_POST["rand"] ?? mt_rand();
+    $rand = $_POST["rand"] ?? random_int();
 
     // Message for post-only
     if (!isset($_POST["admin"]) || ($_POST["admin"] == 0)) {

--- a/ajax/massiveaction.php
+++ b/ajax/massiveaction.php
@@ -69,7 +69,7 @@ if (count($actions)) {
             echo Html::hidden($key, ['value' => $val]);
         }
     }
-    $rand = random_int(0, 2**32);
+    $rand = random_int(0, 2 ** 32);
 
     echo "<label for=\"dropdown_massiveaction$rand\">" . _sn('Action', 'Actions', 1) . "</label>";
     echo "&nbsp;";

--- a/ajax/massiveaction.php
+++ b/ajax/massiveaction.php
@@ -69,7 +69,7 @@ if (count($actions)) {
             echo Html::hidden($key, ['value' => $val]);
         }
     }
-    $rand = random_int();
+    $rand = random_int(0, 2**32);
 
     echo "<label for=\"dropdown_massiveaction$rand\">" . _sn('Action', 'Actions', 1) . "</label>";
     echo "&nbsp;";

--- a/ajax/massiveaction.php
+++ b/ajax/massiveaction.php
@@ -69,7 +69,7 @@ if (count($actions)) {
             echo Html::hidden($key, ['value' => $val]);
         }
     }
-    $rand = mt_rand();
+    $rand = random_int();
 
     echo "<label for=\"dropdown_massiveaction$rand\">" . _sn('Action', 'Actions', 1) . "</label>";
     echo "&nbsp;";

--- a/ajax/visibility.php
+++ b/ajax/visibility.php
@@ -54,7 +54,7 @@ if (
     && isset($_POST['right'])
 ) {
     $display = false;
-    $rand    = random_int(0, 2**32);
+    $rand    = random_int(0, 2 ** 32);
     $prefix = '';
     $suffix = '';
     if (isset($_POST['prefix']) && !empty($_POST['prefix'])) {

--- a/ajax/visibility.php
+++ b/ajax/visibility.php
@@ -54,7 +54,7 @@ if (
     && isset($_POST['right'])
 ) {
     $display = false;
-    $rand    = random_int();
+    $rand    = random_int(0, 2**32);
     $prefix = '';
     $suffix = '';
     if (isset($_POST['prefix']) && !empty($_POST['prefix'])) {

--- a/ajax/visibility.php
+++ b/ajax/visibility.php
@@ -54,7 +54,7 @@ if (
     && isset($_POST['right'])
 ) {
     $display = false;
-    $rand    = mt_rand();
+    $rand    = random_int();
     $prefix = '';
     $suffix = '';
     if (isset($_POST['prefix']) && !empty($_POST['prefix'])) {

--- a/phpunit/GLPITestCase.php
+++ b/phpunit/GLPITestCase.php
@@ -397,7 +397,7 @@ class GLPITestCase extends TestCase
     protected function getUniqueInteger()
     {
         if (is_null($this->int)) {
-            return $this->int = mt_rand(1000, 10000);
+            return $this->int = random_int(1000, 10000);
         }
         return $this->int++;
     }

--- a/phpunit/functional/AuthTest.php
+++ b/phpunit/functional/AuthTest.php
@@ -154,7 +154,7 @@ class AuthTest extends DbTestCase
         $this->login();
 
         $user = new \User();
-        $username = 'test_lock_' . random_int(0, 2**32);
+        $username = 'test_lock_' . random_int(0, 2 ** 32);
         $user_id = (int) $user->add([
             'name'         => $username,
             'password'     => 'test',

--- a/phpunit/functional/AuthTest.php
+++ b/phpunit/functional/AuthTest.php
@@ -154,7 +154,7 @@ class AuthTest extends DbTestCase
         $this->login();
 
         $user = new \User();
-        $username = 'test_lock_' . random_int();
+        $username = 'test_lock_' . random_int(0, 2**32);
         $user_id = (int) $user->add([
             'name'         => $username,
             'password'     => 'test',

--- a/phpunit/functional/AuthTest.php
+++ b/phpunit/functional/AuthTest.php
@@ -154,7 +154,7 @@ class AuthTest extends DbTestCase
         $this->login();
 
         $user = new \User();
-        $username = 'test_lock_' . mt_rand();
+        $username = 'test_lock_' . random_int();
         $user_id = (int) $user->add([
             'name'         => $username,
             'password'     => 'test',

--- a/phpunit/functional/ConfigTest.php
+++ b/phpunit/functional/ConfigTest.php
@@ -630,7 +630,7 @@ class ConfigTest extends DbTestCase
             $user = new \User();
             $user_id = $user->add(
                 [
-                    'name'     => 'test_user_' . random_int(),
+                    'name'     => 'test_user_' . random_int(0, 2**32),
                     'authtype' => $authtype,
                 ]
             );

--- a/phpunit/functional/ConfigTest.php
+++ b/phpunit/functional/ConfigTest.php
@@ -548,7 +548,7 @@ class ConfigTest extends DbTestCase
         $item = new $itemtype();
         $item->fields = ['id' => 15];
 
-        $random_id = mt_rand(20, 100);
+        $random_id = random_int(20, 100);
 
         \Config::setConfigurationValues('core', [$key => $random_id]);
 
@@ -630,7 +630,7 @@ class ConfigTest extends DbTestCase
             $user = new \User();
             $user_id = $user->add(
                 [
-                    'name'     => 'test_user_' . mt_rand(),
+                    'name'     => 'test_user_' . random_int(),
                     'authtype' => $authtype,
                 ]
             );

--- a/phpunit/functional/ConfigTest.php
+++ b/phpunit/functional/ConfigTest.php
@@ -630,7 +630,7 @@ class ConfigTest extends DbTestCase
             $user = new \User();
             $user_id = $user->add(
                 [
-                    'name'     => 'test_user_' . random_int(0, 2**32),
+                    'name'     => 'test_user_' . random_int(0, 2 ** 32),
                     'authtype' => $authtype,
                 ]
             );

--- a/phpunit/functional/DbUtilsTest.php
+++ b/phpunit/functional/DbUtilsTest.php
@@ -1580,7 +1580,7 @@ class DbUtilsTest extends DbTestCase
     #[DataProvider('fixItemtypeCaseProvider')]
     public function testGetItemtypeWithFixedCase($itemtype, $expected)
     {
-        $name = 'glpi' . mt_rand();
+        $name = 'glpi' . random_int();
         vfsStream::setup(
             $name,
             null,

--- a/phpunit/functional/DbUtilsTest.php
+++ b/phpunit/functional/DbUtilsTest.php
@@ -1580,7 +1580,7 @@ class DbUtilsTest extends DbTestCase
     #[DataProvider('fixItemtypeCaseProvider')]
     public function testGetItemtypeWithFixedCase($itemtype, $expected)
     {
-        $name = 'glpi' . random_int();
+        $name = 'glpi' . random_int(0, 2**32);
         vfsStream::setup(
             $name,
             null,

--- a/phpunit/functional/DbUtilsTest.php
+++ b/phpunit/functional/DbUtilsTest.php
@@ -1580,7 +1580,7 @@ class DbUtilsTest extends DbTestCase
     #[DataProvider('fixItemtypeCaseProvider')]
     public function testGetItemtypeWithFixedCase($itemtype, $expected)
     {
-        $name = 'glpi' . random_int(0, 2**32);
+        $name = 'glpi' . random_int(0, 2 ** 32);
         vfsStream::setup(
             $name,
             null,

--- a/phpunit/functional/Glpi/Cache/SimpleCacheTest.php
+++ b/phpunit/functional/Glpi/Cache/SimpleCacheTest.php
@@ -80,7 +80,7 @@ class SimpleCacheTest extends \GLPITestCase
             $this->assertEquals($value, $instance->get($key));
 
             // Overwriting an existing value works
-            $rand = mt_rand();
+            $rand = random_int();
             $this->assertTrue($instance->set($key, $rand));
             $this->assertEquals($rand, $instance->get($key));
 

--- a/phpunit/functional/Glpi/Cache/SimpleCacheTest.php
+++ b/phpunit/functional/Glpi/Cache/SimpleCacheTest.php
@@ -80,7 +80,7 @@ class SimpleCacheTest extends \GLPITestCase
             $this->assertEquals($value, $instance->get($key));
 
             // Overwriting an existing value works
-            $rand = random_int();
+            $rand = random_int(0, 2**32);
             $this->assertTrue($instance->set($key, $rand));
             $this->assertEquals($rand, $instance->get($key));
 

--- a/phpunit/functional/Glpi/Cache/SimpleCacheTest.php
+++ b/phpunit/functional/Glpi/Cache/SimpleCacheTest.php
@@ -80,7 +80,7 @@ class SimpleCacheTest extends \GLPITestCase
             $this->assertEquals($value, $instance->get($key));
 
             // Overwriting an existing value works
-            $rand = random_int(0, 2**32);
+            $rand = random_int(0, 2 ** 32);
             $this->assertTrue($instance->set($key, $rand));
             $this->assertEquals($rand, $instance->get($key));
 

--- a/phpunit/functional/Glpi/Form/Export/FormSerializerTest.php
+++ b/phpunit/functional/Glpi/Form/Export/FormSerializerTest.php
@@ -690,7 +690,7 @@ final class FormSerializerTest extends \DbTestCase
 
     private function createAndGetFormWithBasicPropertiesFilled(): Form
     {
-        $form_name = "Form with basic properties fully filled " . random_int(0, 2**32);
+        $form_name = "Form with basic properties fully filled " . random_int(0, 2 ** 32);
         $builder = new FormBuilder($form_name);
         $builder->setHeader("My custom header")
             ->setEntitiesId($this->getTestRootEntity(only_id: true))

--- a/phpunit/functional/Glpi/Form/Export/FormSerializerTest.php
+++ b/phpunit/functional/Glpi/Form/Export/FormSerializerTest.php
@@ -690,7 +690,7 @@ final class FormSerializerTest extends \DbTestCase
 
     private function createAndGetFormWithBasicPropertiesFilled(): Form
     {
-        $form_name = "Form with basic properties fully filled " . mt_rand();
+        $form_name = "Form with basic properties fully filled " . random_int();
         $builder = new FormBuilder($form_name);
         $builder->setHeader("My custom header")
             ->setEntitiesId($this->getTestRootEntity(only_id: true))

--- a/phpunit/functional/Glpi/Form/Export/FormSerializerTest.php
+++ b/phpunit/functional/Glpi/Form/Export/FormSerializerTest.php
@@ -690,7 +690,7 @@ final class FormSerializerTest extends \DbTestCase
 
     private function createAndGetFormWithBasicPropertiesFilled(): Form
     {
-        $form_name = "Form with basic properties fully filled " . random_int();
+        $form_name = "Form with basic properties fully filled " . random_int(0, 2**32);
         $builder = new FormBuilder($form_name);
         $builder->setHeader("My custom header")
             ->setEntitiesId($this->getTestRootEntity(only_id: true))

--- a/phpunit/functional/Glpi/Inventory/Assets/FirmwareTest.php
+++ b/phpunit/functional/Glpi/Inventory/Assets/FirmwareTest.php
@@ -169,7 +169,7 @@ class FirmwareTest extends AbstractInventoryAsset
         //add lockedfield to check for DB warning on manage DeviceFirmware lockedField
         $this->assertGreaterThan(
             0,
-            (int)$DB->insert("glpi_lockedfields", ["field" => random_int(), "itemtype" => "Item_DeviceFirmware", "is_global" => 0])
+            (int)$DB->insert("glpi_lockedfields", ["field" => random_int(0, 2**32), "itemtype" => "Item_DeviceFirmware", "is_global" => 0])
         );
 
         //computer inventory knows only "UCS 6248UP 48-Port" and "HP-HttpMg-Version" firmwares

--- a/phpunit/functional/Glpi/Inventory/Assets/FirmwareTest.php
+++ b/phpunit/functional/Glpi/Inventory/Assets/FirmwareTest.php
@@ -169,7 +169,7 @@ class FirmwareTest extends AbstractInventoryAsset
         //add lockedfield to check for DB warning on manage DeviceFirmware lockedField
         $this->assertGreaterThan(
             0,
-            (int)$DB->insert("glpi_lockedfields", ["field" => random_int(0, 2**32), "itemtype" => "Item_DeviceFirmware", "is_global" => 0])
+            (int)$DB->insert("glpi_lockedfields", ["field" => random_int(0, 2 ** 32), "itemtype" => "Item_DeviceFirmware", "is_global" => 0])
         );
 
         //computer inventory knows only "UCS 6248UP 48-Port" and "HP-HttpMg-Version" firmwares

--- a/phpunit/functional/Glpi/Inventory/Assets/FirmwareTest.php
+++ b/phpunit/functional/Glpi/Inventory/Assets/FirmwareTest.php
@@ -169,7 +169,7 @@ class FirmwareTest extends AbstractInventoryAsset
         //add lockedfield to check for DB warning on manage DeviceFirmware lockedField
         $this->assertGreaterThan(
             0,
-            (int)$DB->insert("glpi_lockedfields", ["field" => mt_rand(), "itemtype" => "Item_DeviceFirmware", "is_global" => 0])
+            (int)$DB->insert("glpi_lockedfields", ["field" => random_int(), "itemtype" => "Item_DeviceFirmware", "is_global" => 0])
         );
 
         //computer inventory knows only "UCS 6248UP 48-Port" and "HP-HttpMg-Version" firmwares

--- a/phpunit/functional/Glpi/UI/IllustrationManagerTest.php
+++ b/phpunit/functional/Glpi/UI/IllustrationManagerTest.php
@@ -129,7 +129,7 @@ final class IllustrationManagerTest extends GLPITestCase
 
     public function testGetAllIllustrationNames(): void
     {
-        $virtual_dir = 'glpi' . mt_rand();
+        $virtual_dir = 'glpi' . random_int();
 
         // Arrange: create a virtual file system and use it as our base directory
         vfsStream::setup($virtual_dir, null, [

--- a/phpunit/functional/Glpi/UI/IllustrationManagerTest.php
+++ b/phpunit/functional/Glpi/UI/IllustrationManagerTest.php
@@ -129,7 +129,7 @@ final class IllustrationManagerTest extends GLPITestCase
 
     public function testGetAllIllustrationNames(): void
     {
-        $virtual_dir = 'glpi' . random_int();
+        $virtual_dir = 'glpi' . random_int(0, 2**32);
 
         // Arrange: create a virtual file system and use it as our base directory
         vfsStream::setup($virtual_dir, null, [

--- a/phpunit/functional/Glpi/UI/IllustrationManagerTest.php
+++ b/phpunit/functional/Glpi/UI/IllustrationManagerTest.php
@@ -129,7 +129,7 @@ final class IllustrationManagerTest extends GLPITestCase
 
     public function testGetAllIllustrationNames(): void
     {
-        $virtual_dir = 'glpi' . random_int(0, 2**32);
+        $virtual_dir = 'glpi' . random_int(0, 2 ** 32);
 
         // Arrange: create a virtual file system and use it as our base directory
         vfsStream::setup($virtual_dir, null, [

--- a/phpunit/functional/ITILFollowupTest.php
+++ b/phpunit/functional/ITILFollowupTest.php
@@ -356,7 +356,7 @@ class ITILFollowupTest extends DbTestCase
         $this->assertGreaterThan(0, $ticket_id);
 
         // Create test user
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
         $user = new User();
         $users_id = $user->add([
             'name' => "testIsFromSupportAgent$rand",

--- a/phpunit/functional/ITILFollowupTest.php
+++ b/phpunit/functional/ITILFollowupTest.php
@@ -356,7 +356,7 @@ class ITILFollowupTest extends DbTestCase
         $this->assertGreaterThan(0, $ticket_id);
 
         // Create test user
-        $rand = mt_rand();
+        $rand = random_int();
         $user = new User();
         $users_id = $user->add([
             'name' => "testIsFromSupportAgent$rand",

--- a/phpunit/functional/ITILFollowupTest.php
+++ b/phpunit/functional/ITILFollowupTest.php
@@ -356,7 +356,7 @@ class ITILFollowupTest extends DbTestCase
         $this->assertGreaterThan(0, $ticket_id);
 
         // Create test user
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
         $user = new User();
         $users_id = $user->add([
             'name' => "testIsFromSupportAgent$rand",

--- a/phpunit/functional/KnowbaseItemTest.php
+++ b/phpunit/functional/KnowbaseItemTest.php
@@ -745,7 +745,7 @@ HTML,
     public function testGetAnswerAnchors(): void
     {
         // Create test KB with multiple headers
-        $kb_name = 'Test testGetAnswerAnchors' . random_int();
+        $kb_name = 'Test testGetAnswerAnchors' . random_int(0, 2**32);
         $input = [
             'name' => $kb_name,
             'answer' => '<h1>title 1a</h1><h2>title2</h2><h1>title 1b</h1><h1>title 1c</h1>'

--- a/phpunit/functional/KnowbaseItemTest.php
+++ b/phpunit/functional/KnowbaseItemTest.php
@@ -745,7 +745,7 @@ HTML,
     public function testGetAnswerAnchors(): void
     {
         // Create test KB with multiple headers
-        $kb_name = 'Test testGetAnswerAnchors' . mt_rand();
+        $kb_name = 'Test testGetAnswerAnchors' . random_int();
         $input = [
             'name' => $kb_name,
             'answer' => '<h1>title 1a</h1><h2>title2</h2><h1>title 1b</h1><h1>title 1c</h1>'

--- a/phpunit/functional/KnowbaseItemTest.php
+++ b/phpunit/functional/KnowbaseItemTest.php
@@ -745,7 +745,7 @@ HTML,
     public function testGetAnswerAnchors(): void
     {
         // Create test KB with multiple headers
-        $kb_name = 'Test testGetAnswerAnchors' . random_int(0, 2**32);
+        $kb_name = 'Test testGetAnswerAnchors' . random_int(0, 2 ** 32);
         $input = [
             'name' => $kb_name,
             'answer' => '<h1>title 1a</h1><h2>title2</h2><h1>title 1b</h1><h1>title 1c</h1>'

--- a/phpunit/functional/LogTest.php
+++ b/phpunit/functional/LogTest.php
@@ -750,7 +750,7 @@ class LogTest extends DbTestCase
         global $DB, $CFG_GLPI;
 
         $this->login($username, $password);
-        $rand = mt_rand(90000, 99999);
+        $rand = random_int(90000, 99999);
         $log_event = function () use ($rand, $DB) {
             \Log::history($rand, 'Computer', [4, '', '']);
             // Get last log entry for itemtype=Computer and items_id=$rand

--- a/phpunit/functional/ProjectTest.php
+++ b/phpunit/functional/ProjectTest.php
@@ -331,7 +331,7 @@ class ProjectTest extends DbTestCase
     public function testClone()
     {
        // Create a basic project
-        $project_name = 'Project testClone' . random_int();
+        $project_name = 'Project testClone' . random_int(0, 2**32);
         $project_input = [
             'name'     => $project_name,
             'priority' => 5,
@@ -340,12 +340,12 @@ class ProjectTest extends DbTestCase
         $projects_id = getItemByTypeName("Project", $project_name, true);
 
         // Create a user
-        $user_name = 'Project testClone - User' . random_int();
+        $user_name = 'Project testClone - User' . random_int(0, 2**32);
         $this->createItems('User', [['name' => $user_name]]);
         $users_id = getItemByTypeName("User", $user_name, true);
 
         // Create a group
-        $group_name = 'Project testClone - Group' . random_int();
+        $group_name = 'Project testClone - Group' . random_int(0, 2**32);
         $this->createItems('Group', [['name' => $group_name]]);
         $groups_id = getItemByTypeName("Group", $group_name, true);
 
@@ -407,7 +407,7 @@ class ProjectTest extends DbTestCase
         $this->assertEquals($team, $team_clone);
 
         // Add a task to project
-        $task1_name = 'Project testClone - Task' . random_int();
+        $task1_name = 'Project testClone - Task' . random_int(0, 2**32);
         $task1 = $this->createItem('ProjectTask', [
             'projects_id' => $projects_id,
             'name'        => $task1_name,
@@ -415,7 +415,7 @@ class ProjectTest extends DbTestCase
         $task1_id = $task1->fields['id'];
 
         // Add a task, child of the previous task
-        $task2_name = 'Project testClone - Task' . random_int();
+        $task2_name = 'Project testClone - Task' . random_int(0, 2**32);
         $task2 = $this->createItem('ProjectTask', [
             'projects_id'     => $projects_id,
             'name'            => $task2_name,

--- a/phpunit/functional/ProjectTest.php
+++ b/phpunit/functional/ProjectTest.php
@@ -331,7 +331,7 @@ class ProjectTest extends DbTestCase
     public function testClone()
     {
        // Create a basic project
-        $project_name = 'Project testClone' . random_int(0, 2**32);
+        $project_name = 'Project testClone' . random_int(0, 2 ** 32);
         $project_input = [
             'name'     => $project_name,
             'priority' => 5,
@@ -340,12 +340,12 @@ class ProjectTest extends DbTestCase
         $projects_id = getItemByTypeName("Project", $project_name, true);
 
         // Create a user
-        $user_name = 'Project testClone - User' . random_int(0, 2**32);
+        $user_name = 'Project testClone - User' . random_int(0, 2 ** 32);
         $this->createItems('User', [['name' => $user_name]]);
         $users_id = getItemByTypeName("User", $user_name, true);
 
         // Create a group
-        $group_name = 'Project testClone - Group' . random_int(0, 2**32);
+        $group_name = 'Project testClone - Group' . random_int(0, 2 ** 32);
         $this->createItems('Group', [['name' => $group_name]]);
         $groups_id = getItemByTypeName("Group", $group_name, true);
 
@@ -407,7 +407,7 @@ class ProjectTest extends DbTestCase
         $this->assertEquals($team, $team_clone);
 
         // Add a task to project
-        $task1_name = 'Project testClone - Task' . random_int(0, 2**32);
+        $task1_name = 'Project testClone - Task' . random_int(0, 2 ** 32);
         $task1 = $this->createItem('ProjectTask', [
             'projects_id' => $projects_id,
             'name'        => $task1_name,
@@ -415,7 +415,7 @@ class ProjectTest extends DbTestCase
         $task1_id = $task1->fields['id'];
 
         // Add a task, child of the previous task
-        $task2_name = 'Project testClone - Task' . random_int(0, 2**32);
+        $task2_name = 'Project testClone - Task' . random_int(0, 2 ** 32);
         $task2 = $this->createItem('ProjectTask', [
             'projects_id'     => $projects_id,
             'name'            => $task2_name,

--- a/phpunit/functional/ProjectTest.php
+++ b/phpunit/functional/ProjectTest.php
@@ -331,7 +331,7 @@ class ProjectTest extends DbTestCase
     public function testClone()
     {
        // Create a basic project
-        $project_name = 'Project testClone' . mt_rand();
+        $project_name = 'Project testClone' . random_int();
         $project_input = [
             'name'     => $project_name,
             'priority' => 5,
@@ -340,12 +340,12 @@ class ProjectTest extends DbTestCase
         $projects_id = getItemByTypeName("Project", $project_name, true);
 
         // Create a user
-        $user_name = 'Project testClone - User' . mt_rand();
+        $user_name = 'Project testClone - User' . random_int();
         $this->createItems('User', [['name' => $user_name]]);
         $users_id = getItemByTypeName("User", $user_name, true);
 
         // Create a group
-        $group_name = 'Project testClone - Group' . mt_rand();
+        $group_name = 'Project testClone - Group' . random_int();
         $this->createItems('Group', [['name' => $group_name]]);
         $groups_id = getItemByTypeName("Group", $group_name, true);
 
@@ -407,7 +407,7 @@ class ProjectTest extends DbTestCase
         $this->assertEquals($team, $team_clone);
 
         // Add a task to project
-        $task1_name = 'Project testClone - Task' . mt_rand();
+        $task1_name = 'Project testClone - Task' . random_int();
         $task1 = $this->createItem('ProjectTask', [
             'projects_id' => $projects_id,
             'name'        => $task1_name,
@@ -415,7 +415,7 @@ class ProjectTest extends DbTestCase
         $task1_id = $task1->fields['id'];
 
         // Add a task, child of the previous task
-        $task2_name = 'Project testClone - Task' . mt_rand();
+        $task2_name = 'Project testClone - Task' . random_int();
         $task2 = $this->createItem('ProjectTask', [
             'projects_id'     => $projects_id,
             'name'            => $task2_name,

--- a/phpunit/functional/SLMTest.php
+++ b/phpunit/functional/SLMTest.php
@@ -1379,7 +1379,7 @@ class SLMTest extends DbTestCase
     {
         $this->login();
         $entity = getItemByTypeName('Entity', '_test_root_entity', true);
-        $test_ticket_name = "Test ticket with multiple LA assignation " . random_int();
+        $test_ticket_name = "Test ticket with multiple LA assignation " . random_int(0, 2**32);
 
         // OLA change are recomputed from the current date so we need to set
         // glpi_currenttime to get predictable results
@@ -1602,7 +1602,7 @@ class SLMTest extends DbTestCase
     {
         $this->login();
         $entity = getItemByTypeName('Entity', '_test_root_entity', true);
-        $test_ticket_name = "Test ticket with multiple LA assignation " . random_int();
+        $test_ticket_name = "Test ticket with multiple LA assignation " . random_int(0, 2**32);
 
         // OLA change are recomputed from the current date so we need to set
         // glpi_currenttime to get predictable results

--- a/phpunit/functional/SLMTest.php
+++ b/phpunit/functional/SLMTest.php
@@ -1379,7 +1379,7 @@ class SLMTest extends DbTestCase
     {
         $this->login();
         $entity = getItemByTypeName('Entity', '_test_root_entity', true);
-        $test_ticket_name = "Test ticket with multiple LA assignation " . mt_rand();
+        $test_ticket_name = "Test ticket with multiple LA assignation " . random_int();
 
         // OLA change are recomputed from the current date so we need to set
         // glpi_currenttime to get predictable results
@@ -1602,7 +1602,7 @@ class SLMTest extends DbTestCase
     {
         $this->login();
         $entity = getItemByTypeName('Entity', '_test_root_entity', true);
-        $test_ticket_name = "Test ticket with multiple LA assignation " . mt_rand();
+        $test_ticket_name = "Test ticket with multiple LA assignation " . random_int();
 
         // OLA change are recomputed from the current date so we need to set
         // glpi_currenttime to get predictable results

--- a/phpunit/functional/SLMTest.php
+++ b/phpunit/functional/SLMTest.php
@@ -1379,7 +1379,7 @@ class SLMTest extends DbTestCase
     {
         $this->login();
         $entity = getItemByTypeName('Entity', '_test_root_entity', true);
-        $test_ticket_name = "Test ticket with multiple LA assignation " . random_int(0, 2**32);
+        $test_ticket_name = "Test ticket with multiple LA assignation " . random_int(0, 2 ** 32);
 
         // OLA change are recomputed from the current date so we need to set
         // glpi_currenttime to get predictable results
@@ -1602,7 +1602,7 @@ class SLMTest extends DbTestCase
     {
         $this->login();
         $entity = getItemByTypeName('Entity', '_test_root_entity', true);
-        $test_ticket_name = "Test ticket with multiple LA assignation " . random_int(0, 2**32);
+        $test_ticket_name = "Test ticket with multiple LA assignation " . random_int(0, 2 ** 32);
 
         // OLA change are recomputed from the current date so we need to set
         // glpi_currenttime to get predictable results

--- a/phpunit/functional/ToolboxTest.php
+++ b/phpunit/functional/ToolboxTest.php
@@ -509,7 +509,7 @@ class ToolboxTest extends DbTestCase
 
         foreach ([\Computer::class, \Change::class, \Problem::class, \Ticket::class] as $itemtype) {
             $item = new $itemtype();
-            $item->fields['id'] = mt_rand(1, 50);
+            $item->fields['id'] = random_int(1, 50);
 
             $img_url = '/front/document.send.php?docid={docid}'; //{docid} to replace by generated doc id
             if ($item instanceof \CommonDBTM) {
@@ -586,7 +586,7 @@ class ToolboxTest extends DbTestCase
     public static function convertTagToImageBaseUrlProvider()
     {
         $item = new \Ticket();
-        $item->fields['id'] = mt_rand(1, 50);
+        $item->fields['id'] = random_int(1, 50);
 
         $img_url = '/front/document.send.php?docid={docid}'; //{docid} to replace by generated doc id
         $img_url .= '&itemtype=' . $item->getType();
@@ -655,7 +655,7 @@ class ToolboxTest extends DbTestCase
         $img_tag_3 = uniqid('', true);
 
         $item = new \Ticket();
-        $item->fields['id'] = mt_rand(1, 50);
+        $item->fields['id'] = random_int(1, 50);
 
        // Create multiple documents in DB
         $document = new \Document();
@@ -716,7 +716,7 @@ class ToolboxTest extends DbTestCase
         $img_tag = uniqid('', true);
 
         $item = new \Ticket();
-        $item->fields['id'] = mt_rand(1, 50);
+        $item->fields['id'] = random_int(1, 50);
 
        // Create multiple documents in DB
         $document = new \Document();
@@ -766,7 +766,7 @@ class ToolboxTest extends DbTestCase
         $img_tag = uniqid('', true);
 
         $item = new \Ticket();
-        $item->fields['id'] = mt_rand(1, 50);
+        $item->fields['id'] = random_int(1, 50);
 
        // Create multiple documents in DB
         $document = new \Document();
@@ -798,7 +798,7 @@ class ToolboxTest extends DbTestCase
         $img_2_tag = uniqid('', true);
 
         $item = new \Ticket();
-        $item->fields['id'] = mt_rand(1, 50);
+        $item->fields['id'] = random_int(1, 50);
 
         $document_1 = $this->createItem(
             \Document::class,

--- a/phpunit/functional/UserTest.php
+++ b/phpunit/functional/UserTest.php
@@ -455,7 +455,7 @@ class UserTest extends \DbTestCase
     {
         $this->login();
         $user = new \User();
-        $username = 'prepare_for_update_' . random_int();
+        $username = 'prepare_for_update_' . random_int(0, 2**32);
         $user_id = $user->add(
             [
                 'name'         => $username,
@@ -518,7 +518,7 @@ class UserTest extends \DbTestCase
             $messages = $row['messages'] ?? null;
 
             $user = new \User();
-            $username = 'prepare_for_update_' . random_int();
+            $username = 'prepare_for_update_' . random_int(0, 2**32);
             $user_id = $user->add(
                 [
                     'name' => $username,
@@ -1116,7 +1116,7 @@ class UserTest extends \DbTestCase
             $expected_has_password_expire = $row['expected_has_password_expire'];
 
             $user = new \User();
-            $username = 'prepare_for_update_' . random_int();
+            $username = 'prepare_for_update_' . random_int(0, 2**32);
             $user_id = $user->add(
                 [
                     'date_creation' => $creation_date,
@@ -1245,7 +1245,7 @@ class UserTest extends \DbTestCase
         for ($i = 1; $i < 100; $i += 10) {
             $user_id = $user->add(
                 [
-                    'name'     => 'cron_user_' . random_int(),
+                    'name'     => 'cron_user_' . random_int(0, 2**32),
                     'authtype' => \Auth::DB_GLPI,
                 ]
             );
@@ -1938,7 +1938,7 @@ class UserTest extends \DbTestCase
         $user = $this->createItem(
             \User::class,
             [
-                'name'                  => __FUNCTION__ . (string) random_int(),
+                'name'                  => __FUNCTION__ . (string) random_int(0, 2**32),
                 'savedsearches_pinned'  => $initial_db_value,
             ]
         );

--- a/phpunit/functional/UserTest.php
+++ b/phpunit/functional/UserTest.php
@@ -455,7 +455,7 @@ class UserTest extends \DbTestCase
     {
         $this->login();
         $user = new \User();
-        $username = 'prepare_for_update_' . random_int(0, 2**32);
+        $username = 'prepare_for_update_' . random_int(0, 2 ** 32);
         $user_id = $user->add(
             [
                 'name'         => $username,
@@ -518,7 +518,7 @@ class UserTest extends \DbTestCase
             $messages = $row['messages'] ?? null;
 
             $user = new \User();
-            $username = 'prepare_for_update_' . random_int(0, 2**32);
+            $username = 'prepare_for_update_' . random_int(0, 2 ** 32);
             $user_id = $user->add(
                 [
                     'name' => $username,
@@ -1116,7 +1116,7 @@ class UserTest extends \DbTestCase
             $expected_has_password_expire = $row['expected_has_password_expire'];
 
             $user = new \User();
-            $username = 'prepare_for_update_' . random_int(0, 2**32);
+            $username = 'prepare_for_update_' . random_int(0, 2 ** 32);
             $user_id = $user->add(
                 [
                     'date_creation' => $creation_date,
@@ -1245,7 +1245,7 @@ class UserTest extends \DbTestCase
         for ($i = 1; $i < 100; $i += 10) {
             $user_id = $user->add(
                 [
-                    'name'     => 'cron_user_' . random_int(0, 2**32),
+                    'name'     => 'cron_user_' . random_int(0, 2 ** 32),
                     'authtype' => \Auth::DB_GLPI,
                 ]
             );
@@ -1938,7 +1938,7 @@ class UserTest extends \DbTestCase
         $user = $this->createItem(
             \User::class,
             [
-                'name'                  => __FUNCTION__ . (string) random_int(0, 2**32),
+                'name'                  => __FUNCTION__ . (string) random_int(0, 2 ** 32),
                 'savedsearches_pinned'  => $initial_db_value,
             ]
         );

--- a/phpunit/functional/UserTest.php
+++ b/phpunit/functional/UserTest.php
@@ -455,7 +455,7 @@ class UserTest extends \DbTestCase
     {
         $this->login();
         $user = new \User();
-        $username = 'prepare_for_update_' . mt_rand();
+        $username = 'prepare_for_update_' . random_int();
         $user_id = $user->add(
             [
                 'name'         => $username,
@@ -518,7 +518,7 @@ class UserTest extends \DbTestCase
             $messages = $row['messages'] ?? null;
 
             $user = new \User();
-            $username = 'prepare_for_update_' . mt_rand();
+            $username = 'prepare_for_update_' . random_int();
             $user_id = $user->add(
                 [
                     'name' => $username,
@@ -1116,7 +1116,7 @@ class UserTest extends \DbTestCase
             $expected_has_password_expire = $row['expected_has_password_expire'];
 
             $user = new \User();
-            $username = 'prepare_for_update_' . mt_rand();
+            $username = 'prepare_for_update_' . random_int();
             $user_id = $user->add(
                 [
                     'date_creation' => $creation_date,
@@ -1245,7 +1245,7 @@ class UserTest extends \DbTestCase
         for ($i = 1; $i < 100; $i += 10) {
             $user_id = $user->add(
                 [
-                    'name'     => 'cron_user_' . mt_rand(),
+                    'name'     => 'cron_user_' . random_int(),
                     'authtype' => \Auth::DB_GLPI,
                 ]
             );
@@ -1938,7 +1938,7 @@ class UserTest extends \DbTestCase
         $user = $this->createItem(
             \User::class,
             [
-                'name'                  => __FUNCTION__ . (string) mt_rand(),
+                'name'                  => __FUNCTION__ . (string) random_int(),
                 'savedsearches_pinned'  => $initial_db_value,
             ]
         );

--- a/src/AbstractRightsDropdown.php
+++ b/src/AbstractRightsDropdown.php
@@ -93,7 +93,7 @@ abstract class AbstractRightsDropdown
         }
 
         // Build DOM id
-        $field_id = $name . "_" . random_int(0, 2**32);
+        $field_id = $name . "_" . random_int(0, 2 ** 32);
 
         // Build url
         $url = static::getAjaxUrl();

--- a/src/AbstractRightsDropdown.php
+++ b/src/AbstractRightsDropdown.php
@@ -93,7 +93,7 @@ abstract class AbstractRightsDropdown
         }
 
         // Build DOM id
-        $field_id = $name . "_" . random_int();
+        $field_id = $name . "_" . random_int(0, 2**32);
 
         // Build url
         $url = static::getAjaxUrl();

--- a/src/AbstractRightsDropdown.php
+++ b/src/AbstractRightsDropdown.php
@@ -93,7 +93,7 @@ abstract class AbstractRightsDropdown
         }
 
         // Build DOM id
-        $field_id = $name . "_" . mt_rand();
+        $field_id = $name . "_" . random_int();
 
         // Build url
         $url = static::getAjaxUrl();

--- a/src/Ajax.php
+++ b/src/Ajax.php
@@ -173,7 +173,7 @@ class Ajax
             $url .= (strstr($url, '?') ? '&' :  '?') . Toolbox::append_params($options['extradata'], '&');
         }
 
-        $rand = mt_rand();
+        $rand = random_int();
 
         $domid  = htmlescape($domid);
         $url    = htmlescape($url);
@@ -291,7 +291,7 @@ JAVASCRIPT;
        // Compute tabs ids.
         $active_id = null;
         foreach ($tabs as $key => $val) {
-            $id = sprintf('tab-%s-%s', str_replace('$', '_', $key), mt_rand());
+            $id = sprintf('tab-%s-%s', str_replace('$', '_', $key), random_int());
 
             $tabs[$key]['id'] = $id;
 

--- a/src/Ajax.php
+++ b/src/Ajax.php
@@ -173,7 +173,7 @@ class Ajax
             $url .= (strstr($url, '?') ? '&' :  '?') . Toolbox::append_params($options['extradata'], '&');
         }
 
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
 
         $domid  = htmlescape($domid);
         $url    = htmlescape($url);
@@ -291,7 +291,7 @@ JAVASCRIPT;
        // Compute tabs ids.
         $active_id = null;
         foreach ($tabs as $key => $val) {
-            $id = sprintf('tab-%s-%s', str_replace('$', '_', $key), random_int());
+            $id = sprintf('tab-%s-%s', str_replace('$', '_', $key), random_int(0, 2**32));
 
             $tabs[$key]['id'] = $id;
 

--- a/src/Ajax.php
+++ b/src/Ajax.php
@@ -173,7 +173,7 @@ class Ajax
             $url .= (strstr($url, '?') ? '&' :  '?') . Toolbox::append_params($options['extradata'], '&');
         }
 
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
 
         $domid  = htmlescape($domid);
         $url    = htmlescape($url);
@@ -291,7 +291,7 @@ JAVASCRIPT;
        // Compute tabs ids.
         $active_id = null;
         foreach ($tabs as $key => $val) {
-            $id = sprintf('tab-%s-%s', str_replace('$', '_', $key), random_int(0, 2**32));
+            $id = sprintf('tab-%s-%s', str_replace('$', '_', $key), random_int(0, 2 ** 32));
 
             $tabs[$key]['id'] = $id;
 

--- a/src/Appliance_Item.php
+++ b/src/Appliance_Item.php
@@ -113,7 +113,7 @@ class Appliance_Item extends CommonDBRelation
         global $DB;
 
         $ID = $appliance->fields['id'];
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
 
         if (
             !$appliance->getFromDB($ID)
@@ -239,7 +239,7 @@ class Appliance_Item extends CommonDBRelation
         }
 
         $canedit = $item->can($ID, UPDATE);
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
 
         $iterator = self::getListForItem($item);
 

--- a/src/Appliance_Item.php
+++ b/src/Appliance_Item.php
@@ -113,7 +113,7 @@ class Appliance_Item extends CommonDBRelation
         global $DB;
 
         $ID = $appliance->fields['id'];
-        $rand = mt_rand();
+        $rand = random_int();
 
         if (
             !$appliance->getFromDB($ID)
@@ -239,7 +239,7 @@ class Appliance_Item extends CommonDBRelation
         }
 
         $canedit = $item->can($ID, UPDATE);
-        $rand = mt_rand();
+        $rand = random_int();
 
         $iterator = self::getListForItem($item);
 

--- a/src/Appliance_Item.php
+++ b/src/Appliance_Item.php
@@ -113,7 +113,7 @@ class Appliance_Item extends CommonDBRelation
         global $DB;
 
         $ID = $appliance->fields['id'];
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
 
         if (
             !$appliance->getFromDB($ID)
@@ -239,7 +239,7 @@ class Appliance_Item extends CommonDBRelation
         }
 
         $canedit = $item->can($ID, UPDATE);
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
 
         $iterator = self::getListForItem($item);
 

--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -631,7 +631,7 @@ TWIG, ['authldaps_id' => $ID]);
                 'showmassiveactions' => true,
                 'massiveactionparams' => [
                     'num_displayed' => count($entries),
-                    'container'     => 'massAuthLdapReplicate' . mt_rand(),
+                    'container'     => 'massAuthLdapReplicate' . random_int(),
                     'item'          => $this
                 ]
             ]);
@@ -1687,7 +1687,7 @@ TWIG, $twig_params);
             'showmassiveactions' => true,
             'massiveactionparams' => [
                 'num_displayed' => count($entries),
-                'container'     => 'mass' . self::class . mt_rand(),
+                'container'     => 'mass' . self::class . random_int(),
                 'specific_actions' => [$form_action => $textbutton],
                 'extraparams' => [
                     'authldaps_id' => $config_ldap->getID(),
@@ -2203,7 +2203,7 @@ TWIG, $twig_params);
             'showmassiveactions' => true,
             'massiveactionparams' => [
                 'num_displayed' => count($entries),
-                'container'     => 'mass' . self::class . mt_rand(),
+                'container'     => 'mass' . self::class . random_int(),
                 'specific_actions' => [
                     __CLASS__ . MassiveAction::CLASS_ACTION_SEPARATOR . 'import_group' => _sx('button', 'Import')
                 ],

--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -631,7 +631,7 @@ TWIG, ['authldaps_id' => $ID]);
                 'showmassiveactions' => true,
                 'massiveactionparams' => [
                     'num_displayed' => count($entries),
-                    'container'     => 'massAuthLdapReplicate' . random_int(0, 2**32),
+                    'container'     => 'massAuthLdapReplicate' . random_int(0, 2 ** 32),
                     'item'          => $this
                 ]
             ]);
@@ -1687,7 +1687,7 @@ TWIG, $twig_params);
             'showmassiveactions' => true,
             'massiveactionparams' => [
                 'num_displayed' => count($entries),
-                'container'     => 'mass' . self::class . random_int(0, 2**32),
+                'container'     => 'mass' . self::class . random_int(0, 2 ** 32),
                 'specific_actions' => [$form_action => $textbutton],
                 'extraparams' => [
                     'authldaps_id' => $config_ldap->getID(),
@@ -2203,7 +2203,7 @@ TWIG, $twig_params);
             'showmassiveactions' => true,
             'massiveactionparams' => [
                 'num_displayed' => count($entries),
-                'container'     => 'mass' . self::class . random_int(0, 2**32),
+                'container'     => 'mass' . self::class . random_int(0, 2 ** 32),
                 'specific_actions' => [
                     __CLASS__ . MassiveAction::CLASS_ACTION_SEPARATOR . 'import_group' => _sx('button', 'Import')
                 ],

--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -631,7 +631,7 @@ TWIG, ['authldaps_id' => $ID]);
                 'showmassiveactions' => true,
                 'massiveactionparams' => [
                     'num_displayed' => count($entries),
-                    'container'     => 'massAuthLdapReplicate' . random_int(),
+                    'container'     => 'massAuthLdapReplicate' . random_int(0, 2**32),
                     'item'          => $this
                 ]
             ]);
@@ -1687,7 +1687,7 @@ TWIG, $twig_params);
             'showmassiveactions' => true,
             'massiveactionparams' => [
                 'num_displayed' => count($entries),
-                'container'     => 'mass' . self::class . random_int(),
+                'container'     => 'mass' . self::class . random_int(0, 2**32),
                 'specific_actions' => [$form_action => $textbutton],
                 'extraparams' => [
                     'authldaps_id' => $config_ldap->getID(),
@@ -2203,7 +2203,7 @@ TWIG, $twig_params);
             'showmassiveactions' => true,
             'massiveactionparams' => [
                 'num_displayed' => count($entries),
-                'container'     => 'mass' . self::class . random_int(),
+                'container'     => 'mass' . self::class . random_int(0, 2**32),
                 'specific_actions' => [
                     __CLASS__ . MassiveAction::CLASS_ACTION_SEPARATOR . 'import_group' => _sx('button', 'Import')
                 ],

--- a/src/CalendarSegment.php
+++ b/src/CalendarSegment.php
@@ -364,7 +364,7 @@ class CalendarSegment extends CommonDBChild
         }
 
         $canedit = $calendar->can($ID, UPDATE);
-        $rand    = random_int();
+        $rand    = random_int(0, 2**32);
 
         $iterator = $DB->request([
             'SELECT' => ['id', 'day', 'begin', 'end'],

--- a/src/CalendarSegment.php
+++ b/src/CalendarSegment.php
@@ -364,7 +364,7 @@ class CalendarSegment extends CommonDBChild
         }
 
         $canedit = $calendar->can($ID, UPDATE);
-        $rand    = random_int(0, 2**32);
+        $rand    = random_int(0, 2 ** 32);
 
         $iterator = $DB->request([
             'SELECT' => ['id', 'day', 'begin', 'end'],

--- a/src/CalendarSegment.php
+++ b/src/CalendarSegment.php
@@ -364,7 +364,7 @@ class CalendarSegment extends CommonDBChild
         }
 
         $canedit = $calendar->can($ID, UPDATE);
-        $rand    = mt_rand();
+        $rand    = random_int();
 
         $iterator = $DB->request([
             'SELECT' => ['id', 'day', 'begin', 'end'],

--- a/src/Calendar_Holiday.php
+++ b/src/Calendar_Holiday.php
@@ -76,7 +76,7 @@ class Calendar_Holiday extends CommonDBRelation
 
         $canedit = $calendar->can($ID, UPDATE);
 
-        $rand    = random_int();
+        $rand    = random_int(0, 2**32);
 
         $iterator = $DB->request([
             'SELECT' => [

--- a/src/Calendar_Holiday.php
+++ b/src/Calendar_Holiday.php
@@ -76,7 +76,7 @@ class Calendar_Holiday extends CommonDBRelation
 
         $canedit = $calendar->can($ID, UPDATE);
 
-        $rand    = mt_rand();
+        $rand    = random_int();
 
         $iterator = $DB->request([
             'SELECT' => [

--- a/src/Calendar_Holiday.php
+++ b/src/Calendar_Holiday.php
@@ -76,7 +76,7 @@ class Calendar_Holiday extends CommonDBRelation
 
         $canedit = $calendar->can($ID, UPDATE);
 
-        $rand    = random_int(0, 2**32);
+        $rand    = random_int(0, 2 ** 32);
 
         $iterator = $DB->request([
             'SELECT' => [

--- a/src/Cartridge.php
+++ b/src/Cartridge.php
@@ -806,7 +806,7 @@ TWIG, ['counts' => $counts, 'highlight' => $highlight]);
 
         $number = count($iterator);
 
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
 
         // Display the pager
         $actions = [];
@@ -1000,7 +1000,7 @@ TWIG, ['add_label' => __('Add cartridges')]);
             return false;
         }
         $canedit = Session::haveRight("cartridge", UPDATE);
-        $rand    = random_int();
+        $rand    = random_int(0, 2**32);
 
         $where = ['glpi_cartridges.printers_id' => $instID];
         if ($old) {

--- a/src/Cartridge.php
+++ b/src/Cartridge.php
@@ -806,7 +806,7 @@ TWIG, ['counts' => $counts, 'highlight' => $highlight]);
 
         $number = count($iterator);
 
-        $rand = mt_rand();
+        $rand = random_int();
 
         // Display the pager
         $actions = [];
@@ -1000,7 +1000,7 @@ TWIG, ['add_label' => __('Add cartridges')]);
             return false;
         }
         $canedit = Session::haveRight("cartridge", UPDATE);
-        $rand    = mt_rand();
+        $rand    = random_int();
 
         $where = ['glpi_cartridges.printers_id' => $instID];
         if ($old) {

--- a/src/Cartridge.php
+++ b/src/Cartridge.php
@@ -806,7 +806,7 @@ TWIG, ['counts' => $counts, 'highlight' => $highlight]);
 
         $number = count($iterator);
 
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
 
         // Display the pager
         $actions = [];
@@ -1000,7 +1000,7 @@ TWIG, ['add_label' => __('Add cartridges')]);
             return false;
         }
         $canedit = Session::haveRight("cartridge", UPDATE);
-        $rand    = random_int(0, 2**32);
+        $rand    = random_int(0, 2 ** 32);
 
         $where = ['glpi_cartridges.printers_id' => $instID];
         if ($old) {

--- a/src/CartridgeItem_PrinterModel.php
+++ b/src/CartridgeItem_PrinterModel.php
@@ -100,7 +100,7 @@ class CartridgeItem_PrinterModel extends CommonDBRelation
             return false;
         }
         $canedit = $item->canEdit($instID);
-        $rand    = mt_rand();
+        $rand    = random_int();
 
         $iterator = self::getListForItem($item);
         $number = count($iterator);
@@ -135,7 +135,7 @@ class CartridgeItem_PrinterModel extends CommonDBRelation
         if ($number) {
             echo "<div class='spaced'>";
             if ($canedit) {
-                $rand     = mt_rand();
+                $rand     = random_int();
                 Html::openMassiveActionsForm('mass' . __CLASS__ . $rand);
                 $massiveactionparams = ['num_displayed' => min($_SESSION['glpilist_limit'], count($used)),
                     'container'     => 'mass' . __CLASS__ . $rand

--- a/src/CartridgeItem_PrinterModel.php
+++ b/src/CartridgeItem_PrinterModel.php
@@ -100,7 +100,7 @@ class CartridgeItem_PrinterModel extends CommonDBRelation
             return false;
         }
         $canedit = $item->canEdit($instID);
-        $rand    = random_int();
+        $rand    = random_int(0, 2**32);
 
         $iterator = self::getListForItem($item);
         $number = count($iterator);
@@ -135,7 +135,7 @@ class CartridgeItem_PrinterModel extends CommonDBRelation
         if ($number) {
             echo "<div class='spaced'>";
             if ($canedit) {
-                $rand     = random_int();
+                $rand     = random_int(0, 2**32);
                 Html::openMassiveActionsForm('mass' . __CLASS__ . $rand);
                 $massiveactionparams = ['num_displayed' => min($_SESSION['glpilist_limit'], count($used)),
                     'container'     => 'mass' . __CLASS__ . $rand

--- a/src/CartridgeItem_PrinterModel.php
+++ b/src/CartridgeItem_PrinterModel.php
@@ -100,7 +100,7 @@ class CartridgeItem_PrinterModel extends CommonDBRelation
             return false;
         }
         $canedit = $item->canEdit($instID);
-        $rand    = random_int(0, 2**32);
+        $rand    = random_int(0, 2 ** 32);
 
         $iterator = self::getListForItem($item);
         $number = count($iterator);
@@ -135,7 +135,7 @@ class CartridgeItem_PrinterModel extends CommonDBRelation
         if ($number) {
             echo "<div class='spaced'>";
             if ($canedit) {
-                $rand     = random_int(0, 2**32);
+                $rand     = random_int(0, 2 ** 32);
                 Html::openMassiveActionsForm('mass' . __CLASS__ . $rand);
                 $massiveactionparams = ['num_displayed' => min($_SESSION['glpilist_limit'], count($used)),
                     'container'     => 'mass' . __CLASS__ . $rand

--- a/src/Certificate_Item.php
+++ b/src/Certificate_Item.php
@@ -206,7 +206,7 @@ class Certificate_Item extends CommonDBRelation
             return false;
         }
         $canedit = $certificate->can($instID, UPDATE);
-        $rand    = mt_rand();
+        $rand    = random_int();
 
         $types_iterator = self::getDistinctTypes($instID, ['itemtype' => Certificate::getTypes(true)]);
         $number = count($types_iterator);
@@ -361,7 +361,7 @@ class Certificate_Item extends CommonDBRelation
         }
 
         $canedit      = $item->canAddItem('Certificate');
-        $rand         = mt_rand();
+        $rand         = random_int();
         $is_recursive = $item->isRecursive();
 
         $iterator = self::getListForItem($item);

--- a/src/Certificate_Item.php
+++ b/src/Certificate_Item.php
@@ -206,7 +206,7 @@ class Certificate_Item extends CommonDBRelation
             return false;
         }
         $canedit = $certificate->can($instID, UPDATE);
-        $rand    = random_int(0, 2**32);
+        $rand    = random_int(0, 2 ** 32);
 
         $types_iterator = self::getDistinctTypes($instID, ['itemtype' => Certificate::getTypes(true)]);
         $number = count($types_iterator);
@@ -361,7 +361,7 @@ class Certificate_Item extends CommonDBRelation
         }
 
         $canedit      = $item->canAddItem('Certificate');
-        $rand         = random_int(0, 2**32);
+        $rand         = random_int(0, 2 ** 32);
         $is_recursive = $item->isRecursive();
 
         $iterator = self::getListForItem($item);

--- a/src/Certificate_Item.php
+++ b/src/Certificate_Item.php
@@ -206,7 +206,7 @@ class Certificate_Item extends CommonDBRelation
             return false;
         }
         $canedit = $certificate->can($instID, UPDATE);
-        $rand    = random_int();
+        $rand    = random_int(0, 2**32);
 
         $types_iterator = self::getDistinctTypes($instID, ['itemtype' => Certificate::getTypes(true)]);
         $number = count($types_iterator);
@@ -361,7 +361,7 @@ class Certificate_Item extends CommonDBRelation
         }
 
         $canedit      = $item->canAddItem('Certificate');
-        $rand         = random_int();
+        $rand         = random_int(0, 2**32);
         $is_recursive = $item->isRecursive();
 
         $iterator = self::getListForItem($item);

--- a/src/Change.php
+++ b/src/Change.php
@@ -1321,7 +1321,7 @@ class Change extends CommonITILObject
                 ];
                 foreach ($iterator as $data) {
                     $change = new self();
-                    $rand = random_int(0, 2**32);
+                    $rand = random_int(0, 2 ** 32);
                     $row = [
                         'values' => []
                     ];
@@ -1550,7 +1550,7 @@ class Change extends CommonITILObject
         $viewusers = User::canView();
 
         $change   = new self();
-        $rand      = random_int(0, 2**32);
+        $rand      = random_int(0, 2 ** 32);
         if ($change->getFromDBwithData($ID)) {
             $bgcolor = $_SESSION["glpipriority_" . $change->fields["priority"]];
             $name    = htmlescape(sprintf(__('%1$s: %2$s'), __('ID'), $change->fields["id"]));

--- a/src/Change.php
+++ b/src/Change.php
@@ -1321,7 +1321,7 @@ class Change extends CommonITILObject
                 ];
                 foreach ($iterator as $data) {
                     $change = new self();
-                    $rand = random_int();
+                    $rand = random_int(0, 2**32);
                     $row = [
                         'values' => []
                     ];
@@ -1550,7 +1550,7 @@ class Change extends CommonITILObject
         $viewusers = User::canView();
 
         $change   = new self();
-        $rand      = random_int();
+        $rand      = random_int(0, 2**32);
         if ($change->getFromDBwithData($ID)) {
             $bgcolor = $_SESSION["glpipriority_" . $change->fields["priority"]];
             $name    = htmlescape(sprintf(__('%1$s: %2$s'), __('ID'), $change->fields["id"]));

--- a/src/Change.php
+++ b/src/Change.php
@@ -1321,7 +1321,7 @@ class Change extends CommonITILObject
                 ];
                 foreach ($iterator as $data) {
                     $change = new self();
-                    $rand = mt_rand();
+                    $rand = random_int();
                     $row = [
                         'values' => []
                     ];
@@ -1550,7 +1550,7 @@ class Change extends CommonITILObject
         $viewusers = User::canView();
 
         $change   = new self();
-        $rand      = mt_rand();
+        $rand      = random_int();
         if ($change->getFromDBwithData($ID)) {
             $bgcolor = $_SESSION["glpipriority_" . $change->fields["priority"]];
             $name    = htmlescape(sprintf(__('%1$s: %2$s'), __('ID'), $change->fields["id"]));

--- a/src/Change_Problem.php
+++ b/src/Change_Problem.php
@@ -114,7 +114,7 @@ class Change_Problem extends CommonITILObject_CommonITILObject
         }
 
         $canedit = $problem->canEdit($ID);
-        $rand    = mt_rand();
+        $rand    = random_int();
 
         $iterator = $DB->request([
             'SELECT' => [
@@ -206,7 +206,7 @@ class Change_Problem extends CommonITILObject_CommonITILObject
         }
 
         $canedit = $change->canEdit($ID);
-        $rand    = mt_rand();
+        $rand    = random_int();
 
         $iterator = $DB->request([
             'SELECT' => [

--- a/src/Change_Problem.php
+++ b/src/Change_Problem.php
@@ -114,7 +114,7 @@ class Change_Problem extends CommonITILObject_CommonITILObject
         }
 
         $canedit = $problem->canEdit($ID);
-        $rand    = random_int();
+        $rand    = random_int(0, 2**32);
 
         $iterator = $DB->request([
             'SELECT' => [
@@ -206,7 +206,7 @@ class Change_Problem extends CommonITILObject_CommonITILObject
         }
 
         $canedit = $change->canEdit($ID);
-        $rand    = random_int();
+        $rand    = random_int(0, 2**32);
 
         $iterator = $DB->request([
             'SELECT' => [

--- a/src/Change_Problem.php
+++ b/src/Change_Problem.php
@@ -114,7 +114,7 @@ class Change_Problem extends CommonITILObject_CommonITILObject
         }
 
         $canedit = $problem->canEdit($ID);
-        $rand    = random_int(0, 2**32);
+        $rand    = random_int(0, 2 ** 32);
 
         $iterator = $DB->request([
             'SELECT' => [
@@ -206,7 +206,7 @@ class Change_Problem extends CommonITILObject_CommonITILObject
         }
 
         $canedit = $change->canEdit($ID);
-        $rand    = random_int(0, 2**32);
+        $rand    = random_int(0, 2 ** 32);
 
         $iterator = $DB->request([
             'SELECT' => [

--- a/src/Change_Ticket.php
+++ b/src/Change_Ticket.php
@@ -218,7 +218,7 @@ class Change_Ticket extends CommonITILObject_CommonITILObject
         }
 
         $canedit = $change->canEdit($ID);
-        $rand    = mt_rand();
+        $rand    = random_int();
 
         $iterator = $DB->request([
             'SELECT' => [
@@ -319,7 +319,7 @@ class Change_Ticket extends CommonITILObject_CommonITILObject
         }
 
         $canedit = $ticket->canEdit($ID);
-        $rand    = mt_rand();
+        $rand    = random_int();
 
         $iterator = $DB->request([
             'SELECT'          => [

--- a/src/Change_Ticket.php
+++ b/src/Change_Ticket.php
@@ -218,7 +218,7 @@ class Change_Ticket extends CommonITILObject_CommonITILObject
         }
 
         $canedit = $change->canEdit($ID);
-        $rand    = random_int();
+        $rand    = random_int(0, 2**32);
 
         $iterator = $DB->request([
             'SELECT' => [
@@ -319,7 +319,7 @@ class Change_Ticket extends CommonITILObject_CommonITILObject
         }
 
         $canedit = $ticket->canEdit($ID);
-        $rand    = random_int();
+        $rand    = random_int(0, 2**32);
 
         $iterator = $DB->request([
             'SELECT'          => [

--- a/src/Change_Ticket.php
+++ b/src/Change_Ticket.php
@@ -218,7 +218,7 @@ class Change_Ticket extends CommonITILObject_CommonITILObject
         }
 
         $canedit = $change->canEdit($ID);
-        $rand    = random_int(0, 2**32);
+        $rand    = random_int(0, 2 ** 32);
 
         $iterator = $DB->request([
             'SELECT' => [
@@ -319,7 +319,7 @@ class Change_Ticket extends CommonITILObject_CommonITILObject
         }
 
         $canedit = $ticket->canEdit($ID);
-        $rand    = random_int(0, 2**32);
+        $rand    = random_int(0, 2 ** 32);
 
         $iterator = $DB->request([
             'SELECT'          => [

--- a/src/CommonDBVisible.php
+++ b/src/CommonDBVisible.php
@@ -216,7 +216,7 @@ abstract class CommonDBVisible extends CommonDBTM
 
         $ID      = (int)$this->fields['id'];
         $canedit = $this->canEdit($ID);
-        $rand    = random_int();
+        $rand    = random_int(0, 2**32);
         $nb      = $this->countVisibilities();
         $str_type = htmlescape(strtolower($this::getType()));
         $fk = static::getForeignKeyField();

--- a/src/CommonDBVisible.php
+++ b/src/CommonDBVisible.php
@@ -216,7 +216,7 @@ abstract class CommonDBVisible extends CommonDBTM
 
         $ID      = (int)$this->fields['id'];
         $canedit = $this->canEdit($ID);
-        $rand    = random_int(0, 2**32);
+        $rand    = random_int(0, 2 ** 32);
         $nb      = $this->countVisibilities();
         $str_type = htmlescape(strtolower($this::getType()));
         $fk = static::getForeignKeyField();

--- a/src/CommonDBVisible.php
+++ b/src/CommonDBVisible.php
@@ -216,7 +216,7 @@ abstract class CommonDBVisible extends CommonDBTM
 
         $ID      = (int)$this->fields['id'];
         $canedit = $this->canEdit($ID);
-        $rand    = mt_rand();
+        $rand    = random_int();
         $nb      = $this->countVisibilities();
         $str_type = htmlescape(strtolower($this::getType()));
         $fk = static::getForeignKeyField();

--- a/src/CommonDropdown.php
+++ b/src/CommonDropdown.php
@@ -946,7 +946,7 @@ abstract class CommonDropdown extends CommonDBTM
                 $condition[KnowbaseItem::getTable() . '.is_faq'] = 1;
             }
 
-            $rand = random_int(0, 2**32);
+            $rand = random_int(0, 2 ** 32);
             $kbitem = new KnowbaseItem();
             $found_kbitem = $kbitem->find($condition);
 

--- a/src/CommonDropdown.php
+++ b/src/CommonDropdown.php
@@ -946,7 +946,7 @@ abstract class CommonDropdown extends CommonDBTM
                 $condition[KnowbaseItem::getTable() . '.is_faq'] = 1;
             }
 
-            $rand = mt_rand();
+            $rand = random_int();
             $kbitem = new KnowbaseItem();
             $found_kbitem = $kbitem->find($condition);
 

--- a/src/CommonDropdown.php
+++ b/src/CommonDropdown.php
@@ -946,7 +946,7 @@ abstract class CommonDropdown extends CommonDBTM
                 $condition[KnowbaseItem::getTable() . '.is_faq'] = 1;
             }
 
-            $rand = random_int();
+            $rand = random_int(0, 2**32);
             $kbitem = new KnowbaseItem();
             $found_kbitem = $kbitem->find($condition);
 

--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -1317,7 +1317,7 @@ class CommonGLPI implements CommonGLPIInterface
         }
 
         if (count($found_kbitem)) {
-            $rand = random_int();
+            $rand = random_int(0, 2**32);
             $kbitem = new KnowbaseItem();
             $kbitem->getFromDB(reset($found_kbitem)['id']);
             $ret .= "<div class='faqadd_block'>";

--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -1317,7 +1317,7 @@ class CommonGLPI implements CommonGLPIInterface
         }
 
         if (count($found_kbitem)) {
-            $rand = mt_rand();
+            $rand = random_int();
             $kbitem = new KnowbaseItem();
             $kbitem->getFromDB(reset($found_kbitem)['id']);
             $ret .= "<div class='faqadd_block'>";

--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -1317,7 +1317,7 @@ class CommonGLPI implements CommonGLPIInterface
         }
 
         if (count($found_kbitem)) {
-            $rand = random_int(0, 2**32);
+            $rand = random_int(0, 2 ** 32);
             $kbitem = new KnowbaseItem();
             $kbitem->getFromDB(reset($found_kbitem)['id']);
             $ret .= "<div class='faqadd_block'>";

--- a/src/CommonITILCost.php
+++ b/src/CommonITILCost.php
@@ -497,7 +497,7 @@ abstract class CommonITILCost extends CommonDBChild
             'ORDER'  => 'begin_date'
         ]);
 
-        $rand   = mt_rand();
+        $rand   = random_int();
 
         if (
             $canedit

--- a/src/CommonITILCost.php
+++ b/src/CommonITILCost.php
@@ -497,7 +497,7 @@ abstract class CommonITILCost extends CommonDBChild
             'ORDER'  => 'begin_date'
         ]);
 
-        $rand   = random_int();
+        $rand   = random_int(0, 2**32);
 
         if (
             $canedit

--- a/src/CommonITILCost.php
+++ b/src/CommonITILCost.php
@@ -497,7 +497,7 @@ abstract class CommonITILCost extends CommonDBChild
             'ORDER'  => 'begin_date'
         ]);
 
-        $rand   = random_int(0, 2**32);
+        $rand   = random_int(0, 2 ** 32);
 
         if (
             $canedit

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -6540,7 +6540,7 @@ abstract class CommonITILObject extends CommonDBTM
             }
         }
 
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
 
        /// TODO to be cleaned. Get datas and clean display links
 
@@ -7011,7 +7011,7 @@ abstract class CommonITILObject extends CommonDBTM
 
         $showprivate_fup = Session::haveRight('followup', ITILFollowup::SEEPRIVATE);
         $showprivate_task = [];
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
         // Cache of entity names
         $entity_cache = [];
         // Cache of user names
@@ -7475,7 +7475,7 @@ abstract class CommonITILObject extends CommonDBTM
 
         ob_start();
         Plugin::doHook(Hooks::TIMELINE_ACTIONS, [
-            'rand'   => random_int(0, 2**32),
+            'rand'   => random_int(0, 2 ** 32),
             'item'   => $this
         ]);
         $legacy_actions .= ob_get_clean() ?? '';
@@ -11191,7 +11191,7 @@ abstract class CommonITILObject extends CommonDBTM
             'canassigntome' => false,
             'field_options' => $field_options,
             'allow_auto_submit' => false,
-            'main_rand' => random_int(0, 2**32),
+            'main_rand' => random_int(0, 2 ** 32),
         ]);
     }
 }

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -6540,7 +6540,7 @@ abstract class CommonITILObject extends CommonDBTM
             }
         }
 
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
 
        /// TODO to be cleaned. Get datas and clean display links
 
@@ -7011,7 +7011,7 @@ abstract class CommonITILObject extends CommonDBTM
 
         $showprivate_fup = Session::haveRight('followup', ITILFollowup::SEEPRIVATE);
         $showprivate_task = [];
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
         // Cache of entity names
         $entity_cache = [];
         // Cache of user names
@@ -7475,7 +7475,7 @@ abstract class CommonITILObject extends CommonDBTM
 
         ob_start();
         Plugin::doHook(Hooks::TIMELINE_ACTIONS, [
-            'rand'   => random_int(),
+            'rand'   => random_int(0, 2**32),
             'item'   => $this
         ]);
         $legacy_actions .= ob_get_clean() ?? '';
@@ -11191,7 +11191,7 @@ abstract class CommonITILObject extends CommonDBTM
             'canassigntome' => false,
             'field_options' => $field_options,
             'allow_auto_submit' => false,
-            'main_rand' => random_int(),
+            'main_rand' => random_int(0, 2**32),
         ]);
     }
 }

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -6540,7 +6540,7 @@ abstract class CommonITILObject extends CommonDBTM
             }
         }
 
-        $rand = mt_rand();
+        $rand = random_int();
 
        /// TODO to be cleaned. Get datas and clean display links
 
@@ -7011,7 +7011,7 @@ abstract class CommonITILObject extends CommonDBTM
 
         $showprivate_fup = Session::haveRight('followup', ITILFollowup::SEEPRIVATE);
         $showprivate_task = [];
-        $rand = mt_rand();
+        $rand = random_int();
         // Cache of entity names
         $entity_cache = [];
         // Cache of user names
@@ -7475,7 +7475,7 @@ abstract class CommonITILObject extends CommonDBTM
 
         ob_start();
         Plugin::doHook(Hooks::TIMELINE_ACTIONS, [
-            'rand'   => mt_rand(),
+            'rand'   => random_int(),
             'item'   => $this
         ]);
         $legacy_actions .= ob_get_clean() ?? '';
@@ -10644,7 +10644,7 @@ abstract class CommonITILObject extends CommonDBTM
             $max_closedate = '';
             foreach ($iterator as $itil_item) {
                 $max_closedate = $itil_item['closedate'];
-                if (mt_rand(1, 100) <= $rate) {
+                if (random_int(1, 100) <= $rate) {
                     if (
                         $inquest->add([
                             $fk             => $itil_item['id'],
@@ -10773,7 +10773,7 @@ abstract class CommonITILObject extends CommonDBTM
             && in_array($this->input["status"], $this->getClosedStatusArray())
             && ($delay == 0)
             && ($rate > 0)
-            && (mt_rand(1, 100) <= $rate)
+            && (random_int(1, 100) <= $rate)
         ) {
             $fkey = $this->getForeignKeyField();
 
@@ -11191,7 +11191,7 @@ abstract class CommonITILObject extends CommonDBTM
             'canassigntome' => false,
             'field_options' => $field_options,
             'allow_auto_submit' => false,
-            'main_rand' => mt_rand(),
+            'main_rand' => random_int(),
         ]);
     }
 }

--- a/src/CommonITILSatisfaction.php
+++ b/src/CommonITILSatisfaction.php
@@ -270,7 +270,7 @@ abstract class CommonITILSatisfaction extends CommonDBTM
             $value = $max_rate;
         }
 
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
         $out = "<div id='rateit_$rand' class='rateit'></div>";
         $out .= Html::scriptBlock("
             $(function () {

--- a/src/CommonITILSatisfaction.php
+++ b/src/CommonITILSatisfaction.php
@@ -270,7 +270,7 @@ abstract class CommonITILSatisfaction extends CommonDBTM
             $value = $max_rate;
         }
 
-        $rand = mt_rand();
+        $rand = random_int();
         $out = "<div id='rateit_$rand' class='rateit'></div>";
         $out .= Html::scriptBlock("
             $(function () {

--- a/src/CommonITILSatisfaction.php
+++ b/src/CommonITILSatisfaction.php
@@ -270,7 +270,7 @@ abstract class CommonITILSatisfaction extends CommonDBTM
             $value = $max_rate;
         }
 
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
         $out = "<div id='rateit_$rand' class='rateit'></div>";
         $out .= Html::scriptBlock("
             $(function () {

--- a/src/CommonITILTask.php
+++ b/src/CommonITILTask.php
@@ -1574,7 +1574,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
         global $CFG_GLPI;
 
         $html = "";
-        $rand      = mt_rand();
+        $rand      = random_int();
         $styleText = "";
         if (isset($val["state"])) {
             switch ($val["state"]) {
@@ -1917,7 +1917,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
         global $DB;
 
         $job  = new $itemtype();
-        $rand = mt_rand();
+        $rand = random_int();
         if ($job->getFromDB($ID)) {
             if ($DB->fieldExists($job->getTable(), 'tickets_id')) {
                 $item_link = new Ticket();

--- a/src/CommonITILTask.php
+++ b/src/CommonITILTask.php
@@ -1574,7 +1574,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
         global $CFG_GLPI;
 
         $html = "";
-        $rand      = random_int();
+        $rand      = random_int(0, 2**32);
         $styleText = "";
         if (isset($val["state"])) {
             switch ($val["state"]) {
@@ -1917,7 +1917,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
         global $DB;
 
         $job  = new $itemtype();
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
         if ($job->getFromDB($ID)) {
             if ($DB->fieldExists($job->getTable(), 'tickets_id')) {
                 $item_link = new Ticket();

--- a/src/CommonITILTask.php
+++ b/src/CommonITILTask.php
@@ -1574,7 +1574,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
         global $CFG_GLPI;
 
         $html = "";
-        $rand      = random_int(0, 2**32);
+        $rand      = random_int(0, 2 ** 32);
         $styleText = "";
         if (isset($val["state"])) {
             switch ($val["state"]) {
@@ -1917,7 +1917,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
         global $DB;
 
         $job  = new $itemtype();
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
         if ($job->getFromDB($ID)) {
             if ($DB->fieldExists($job->getTable(), 'tickets_id')) {
                 $item_link = new Ticket();

--- a/src/CommonITILValidation.php
+++ b/src/CommonITILValidation.php
@@ -966,7 +966,7 @@ abstract class CommonITILValidation extends CommonDBChild
         $tID    = $item->fields['id'];
 
         $tmp    = [static::$items_id => $tID];
-        $rand   = mt_rand();
+        $rand   = random_int();
 
         $iterator = $DB->Request([
             'FROM'   => $this->getTable(),
@@ -1637,7 +1637,7 @@ HTML;
             'readonly'           => false,
             'width'              => '100%',
             'required'           => false,
-            'rand'               => mt_rand(),
+            'rand'               => random_int(),
         ];
         $params['applyto'] = 'show_validator_field' . $params['rand'];
 

--- a/src/CommonITILValidation.php
+++ b/src/CommonITILValidation.php
@@ -966,7 +966,7 @@ abstract class CommonITILValidation extends CommonDBChild
         $tID    = $item->fields['id'];
 
         $tmp    = [static::$items_id => $tID];
-        $rand   = random_int(0, 2**32);
+        $rand   = random_int(0, 2 ** 32);
 
         $iterator = $DB->Request([
             'FROM'   => $this->getTable(),
@@ -1637,7 +1637,7 @@ HTML;
             'readonly'           => false,
             'width'              => '100%',
             'required'           => false,
-            'rand'               => random_int(0, 2**32),
+            'rand'               => random_int(0, 2 ** 32),
         ];
         $params['applyto'] = 'show_validator_field' . $params['rand'];
 

--- a/src/CommonITILValidation.php
+++ b/src/CommonITILValidation.php
@@ -966,7 +966,7 @@ abstract class CommonITILValidation extends CommonDBChild
         $tID    = $item->fields['id'];
 
         $tmp    = [static::$items_id => $tID];
-        $rand   = random_int();
+        $rand   = random_int(0, 2**32);
 
         $iterator = $DB->Request([
             'FROM'   => $this->getTable(),
@@ -1637,7 +1637,7 @@ HTML;
             'readonly'           => false,
             'width'              => '100%',
             'required'           => false,
-            'rand'               => random_int(),
+            'rand'               => random_int(0, 2**32),
         ];
         $params['applyto'] = 'show_validator_field' . $params['rand'];
 

--- a/src/CommonItilObject_Item.php
+++ b/src/CommonItilObject_Item.php
@@ -201,7 +201,7 @@ abstract class CommonItilObject_Item extends CommonDBRelation
             }
         }
 
-        $rand  = random_int(0, 2**32);
+        $rand  = random_int(0, 2 ** 32);
         $count = 0;
         $twig_params = [
             'rand'               => $rand,
@@ -305,7 +305,7 @@ abstract class CommonItilObject_Item extends CommonDBRelation
     public static function showItemToAdd($object_id, $itemtype, $items_id, $options)
     {
         $params = [
-            'rand'      => random_int(0, 2**32),
+            'rand'      => random_int(0, 2 ** 32),
             'delete'    => true,
             'visible'   => true,
             'kblink'    => true
@@ -358,7 +358,7 @@ abstract class CommonItilObject_Item extends CommonDBRelation
         }
         //can Add Item takes type as param but there is none here
         $canedit = $obj->canAddItem('');
-        $rand    = random_int(0, 2**32);
+        $rand    = random_int(0, 2 ** 32);
 
         $types_iterator = static::getDistinctTypes($instID);
         $number = count($types_iterator);
@@ -741,7 +741,7 @@ abstract class CommonItilObject_Item extends CommonDBRelation
             static::$items_id_1 => 0,
             'used'       => [],
             'multiple'   => false,
-            'rand'       => random_int(0, 2**32)
+            'rand'       => random_int(0, 2 ** 32)
         ];
 
         foreach ($options as $key => $val) {
@@ -1227,7 +1227,7 @@ abstract class CommonItilObject_Item extends CommonDBRelation
         $p['entity_sons']    = false;
         $p['used']           = [];
         $p['toupdate']       = '';
-        $p['rand']           = random_int(0, 2**32);
+        $p['rand']           = random_int(0, 2 ** 32);
         $p['display']        = true;
         $p['hide_if_no_elements'] = false;
 
@@ -1614,7 +1614,7 @@ abstract class CommonItilObject_Item extends CommonDBRelation
         $params = [static::$items_id_1 => 0,
             'used'       => [],
             'multiple'   => 0,
-            'rand'       => random_int(0, 2**32)
+            'rand'       => random_int(0, 2 ** 32)
         ];
 
         foreach ($options as $key => $val) {

--- a/src/CommonItilObject_Item.php
+++ b/src/CommonItilObject_Item.php
@@ -201,7 +201,7 @@ abstract class CommonItilObject_Item extends CommonDBRelation
             }
         }
 
-        $rand  = mt_rand();
+        $rand  = random_int();
         $count = 0;
         $twig_params = [
             'rand'               => $rand,
@@ -305,7 +305,7 @@ abstract class CommonItilObject_Item extends CommonDBRelation
     public static function showItemToAdd($object_id, $itemtype, $items_id, $options)
     {
         $params = [
-            'rand'      => mt_rand(),
+            'rand'      => random_int(),
             'delete'    => true,
             'visible'   => true,
             'kblink'    => true
@@ -358,7 +358,7 @@ abstract class CommonItilObject_Item extends CommonDBRelation
         }
         //can Add Item takes type as param but there is none here
         $canedit = $obj->canAddItem('');
-        $rand    = mt_rand();
+        $rand    = random_int();
 
         $types_iterator = static::getDistinctTypes($instID);
         $number = count($types_iterator);
@@ -741,7 +741,7 @@ abstract class CommonItilObject_Item extends CommonDBRelation
             static::$items_id_1 => 0,
             'used'       => [],
             'multiple'   => false,
-            'rand'       => mt_rand()
+            'rand'       => random_int()
         ];
 
         foreach ($options as $key => $val) {
@@ -1227,7 +1227,7 @@ abstract class CommonItilObject_Item extends CommonDBRelation
         $p['entity_sons']    = false;
         $p['used']           = [];
         $p['toupdate']       = '';
-        $p['rand']           = mt_rand();
+        $p['rand']           = random_int();
         $p['display']        = true;
         $p['hide_if_no_elements'] = false;
 
@@ -1614,7 +1614,7 @@ abstract class CommonItilObject_Item extends CommonDBRelation
         $params = [static::$items_id_1 => 0,
             'used'       => [],
             'multiple'   => 0,
-            'rand'       => mt_rand()
+            'rand'       => random_int()
         ];
 
         foreach ($options as $key => $val) {

--- a/src/CommonItilObject_Item.php
+++ b/src/CommonItilObject_Item.php
@@ -201,7 +201,7 @@ abstract class CommonItilObject_Item extends CommonDBRelation
             }
         }
 
-        $rand  = random_int();
+        $rand  = random_int(0, 2**32);
         $count = 0;
         $twig_params = [
             'rand'               => $rand,
@@ -305,7 +305,7 @@ abstract class CommonItilObject_Item extends CommonDBRelation
     public static function showItemToAdd($object_id, $itemtype, $items_id, $options)
     {
         $params = [
-            'rand'      => random_int(),
+            'rand'      => random_int(0, 2**32),
             'delete'    => true,
             'visible'   => true,
             'kblink'    => true
@@ -358,7 +358,7 @@ abstract class CommonItilObject_Item extends CommonDBRelation
         }
         //can Add Item takes type as param but there is none here
         $canedit = $obj->canAddItem('');
-        $rand    = random_int();
+        $rand    = random_int(0, 2**32);
 
         $types_iterator = static::getDistinctTypes($instID);
         $number = count($types_iterator);
@@ -741,7 +741,7 @@ abstract class CommonItilObject_Item extends CommonDBRelation
             static::$items_id_1 => 0,
             'used'       => [],
             'multiple'   => false,
-            'rand'       => random_int()
+            'rand'       => random_int(0, 2**32)
         ];
 
         foreach ($options as $key => $val) {
@@ -1227,7 +1227,7 @@ abstract class CommonItilObject_Item extends CommonDBRelation
         $p['entity_sons']    = false;
         $p['used']           = [];
         $p['toupdate']       = '';
-        $p['rand']           = random_int();
+        $p['rand']           = random_int(0, 2**32);
         $p['display']        = true;
         $p['hide_if_no_elements'] = false;
 
@@ -1614,7 +1614,7 @@ abstract class CommonItilObject_Item extends CommonDBRelation
         $params = [static::$items_id_1 => 0,
             'used'       => [],
             'multiple'   => 0,
-            'rand'       => random_int()
+            'rand'       => random_int(0, 2**32)
         ];
 
         foreach ($options as $key => $val) {

--- a/src/CommonTreeDropdown.php
+++ b/src/CommonTreeDropdown.php
@@ -664,7 +664,7 @@ TWIG, $twig_params);
             'showmassiveactions' => static::canUpdate(),
             'massiveactionparams' => [
                 'num_displayed' => count($entries),
-                'container'     => 'mass' . Toolbox::slugify(static::class) . random_int()
+                'container'     => 'mass' . Toolbox::slugify(static::class) . random_int(0, 2**32)
             ]
         ]);
     }

--- a/src/CommonTreeDropdown.php
+++ b/src/CommonTreeDropdown.php
@@ -664,7 +664,7 @@ TWIG, $twig_params);
             'showmassiveactions' => static::canUpdate(),
             'massiveactionparams' => [
                 'num_displayed' => count($entries),
-                'container'     => 'mass' . Toolbox::slugify(static::class) . mt_rand()
+                'container'     => 'mass' . Toolbox::slugify(static::class) . random_int()
             ]
         ]);
     }

--- a/src/CommonTreeDropdown.php
+++ b/src/CommonTreeDropdown.php
@@ -664,7 +664,7 @@ TWIG, $twig_params);
             'showmassiveactions' => static::canUpdate(),
             'massiveactionparams' => [
                 'num_displayed' => count($entries),
-                'container'     => 'mass' . Toolbox::slugify(static::class) . random_int(0, 2**32)
+                'container'     => 'mass' . Toolbox::slugify(static::class) . random_int(0, 2 ** 32)
             ]
         ]);
     }

--- a/src/Consumable.php
+++ b/src/Consumable.php
@@ -668,7 +668,7 @@ class Consumable extends CommonDBChild
             'showmassiveactions' => true,
             'massiveactionparams' => [
                 'num_displayed'    => min($_SESSION['glpilist_limit'], $filtered_number),
-                'container'        => 'mass' . __CLASS__ . mt_rand(),
+                'container'        => 'mass' . __CLASS__ . random_int(),
                 'specific_actions' => [
                     'delete' => __('Delete permanently'),
                     'Consumable' . MassiveAction::CLASS_ACTION_SEPARATOR . 'backtostock' => __('Back to stock'),

--- a/src/Consumable.php
+++ b/src/Consumable.php
@@ -668,7 +668,7 @@ class Consumable extends CommonDBChild
             'showmassiveactions' => true,
             'massiveactionparams' => [
                 'num_displayed'    => min($_SESSION['glpilist_limit'], $filtered_number),
-                'container'        => 'mass' . __CLASS__ . random_int(),
+                'container'        => 'mass' . __CLASS__ . random_int(0, 2**32),
                 'specific_actions' => [
                     'delete' => __('Delete permanently'),
                     'Consumable' . MassiveAction::CLASS_ACTION_SEPARATOR . 'backtostock' => __('Back to stock'),

--- a/src/Consumable.php
+++ b/src/Consumable.php
@@ -668,7 +668,7 @@ class Consumable extends CommonDBChild
             'showmassiveactions' => true,
             'massiveactionparams' => [
                 'num_displayed'    => min($_SESSION['glpilist_limit'], $filtered_number),
-                'container'        => 'mass' . __CLASS__ . random_int(0, 2**32),
+                'container'        => 'mass' . __CLASS__ . random_int(0, 2 ** 32),
                 'specific_actions' => [
                     'delete' => __('Delete permanently'),
                     'Consumable' . MassiveAction::CLASS_ACTION_SEPARATOR . 'backtostock' => __('Back to stock'),

--- a/src/Contact_Supplier.php
+++ b/src/Contact_Supplier.php
@@ -112,7 +112,7 @@ class Contact_Supplier extends CommonDBRelation
         }
 
         $canedit = $contact->can($instID, UPDATE);
-        $rand = mt_rand();
+        $rand = random_int();
 
         $iterator = self::getListForItem($contact);
         $number = count($iterator);
@@ -244,7 +244,7 @@ class Contact_Supplier extends CommonDBRelation
             return;
         }
         $canedit = $supplier->can($instID, UPDATE);
-        $rand = mt_rand();
+        $rand = random_int();
 
         $iterator = self::getListForItem($supplier);
         $number = count($iterator);

--- a/src/Contact_Supplier.php
+++ b/src/Contact_Supplier.php
@@ -112,7 +112,7 @@ class Contact_Supplier extends CommonDBRelation
         }
 
         $canedit = $contact->can($instID, UPDATE);
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
 
         $iterator = self::getListForItem($contact);
         $number = count($iterator);
@@ -244,7 +244,7 @@ class Contact_Supplier extends CommonDBRelation
             return;
         }
         $canedit = $supplier->can($instID, UPDATE);
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
 
         $iterator = self::getListForItem($supplier);
         $number = count($iterator);

--- a/src/Contact_Supplier.php
+++ b/src/Contact_Supplier.php
@@ -112,7 +112,7 @@ class Contact_Supplier extends CommonDBRelation
         }
 
         $canedit = $contact->can($instID, UPDATE);
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
 
         $iterator = self::getListForItem($contact);
         $number = count($iterator);
@@ -244,7 +244,7 @@ class Contact_Supplier extends CommonDBRelation
             return;
         }
         $canedit = $supplier->can($instID, UPDATE);
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
 
         $iterator = self::getListForItem($supplier);
         $number = count($iterator);

--- a/src/Contract.php
+++ b/src/Contract.php
@@ -1418,7 +1418,7 @@ class Contract extends CommonDBTM
             'name'           => 'contracts_id',
             'value'          => '',
             'entity'         => '',
-            'rand'           => random_int(),
+            'rand'           => random_int(0, 2**32),
             'entity_sons'    => false,
             'used'           => [],
             'nochecklimit'   => false,

--- a/src/Contract.php
+++ b/src/Contract.php
@@ -1395,7 +1395,7 @@ class Contract extends CommonDBTM
      *    - value         : integer / preselected value (default 0)
      *    - entity        : integer or array / restrict to a defined entity or array of entities
      *                      (default -1 : no restriction)
-     *    - rand          : (defauolt mt_rand)
+     *    - rand          : (defauolt random_int)
      *    - entity_sons   : boolean / if entity restrict specified auto select its sons
      *                      only available if entity is a single value not an array (default false)
      *    - used          : array / Already used items ID: not to display in dropdown (default empty)
@@ -1418,7 +1418,7 @@ class Contract extends CommonDBTM
             'name'           => 'contracts_id',
             'value'          => '',
             'entity'         => '',
-            'rand'           => mt_rand(),
+            'rand'           => random_int(),
             'entity_sons'    => false,
             'used'           => [],
             'nochecklimit'   => false,

--- a/src/Contract.php
+++ b/src/Contract.php
@@ -1418,7 +1418,7 @@ class Contract extends CommonDBTM
             'name'           => 'contracts_id',
             'value'          => '',
             'entity'         => '',
-            'rand'           => random_int(0, 2**32),
+            'rand'           => random_int(0, 2 ** 32),
             'entity_sons'    => false,
             'used'           => [],
             'nochecklimit'   => false,

--- a/src/ContractCost.php
+++ b/src/ContractCost.php
@@ -311,7 +311,7 @@ class ContractCost extends CommonDBChild
             'ORDER'  => ["$sort $order"],
         ];
         $iterator = $DB->request($criteria);
-        $rand   = random_int(0, 2**32);
+        $rand   = random_int(0, 2 ** 32);
 
         if (
             $canedit

--- a/src/ContractCost.php
+++ b/src/ContractCost.php
@@ -311,7 +311,7 @@ class ContractCost extends CommonDBChild
             'ORDER'  => ["$sort $order"],
         ];
         $iterator = $DB->request($criteria);
-        $rand   = mt_rand();
+        $rand   = random_int();
 
         if (
             $canedit

--- a/src/ContractCost.php
+++ b/src/ContractCost.php
@@ -311,7 +311,7 @@ class ContractCost extends CommonDBChild
             'ORDER'  => ["$sort $order"],
         ];
         $iterator = $DB->request($criteria);
-        $rand   = random_int();
+        $rand   = random_int(0, 2**32);
 
         if (
             $canedit

--- a/src/Contract_Item.php
+++ b/src/Contract_Item.php
@@ -264,7 +264,7 @@ class Contract_Item extends CommonDBRelation
         }
 
         $canedit = $item->can($ID, UPDATE);
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
 
         $iterator = self::getListForItem($item);
 
@@ -403,7 +403,7 @@ TWIG, $twig_params);
             return false;
         }
         $canedit = $contract->can($instID, UPDATE);
-        $rand    = random_int(0, 2**32);
+        $rand    = random_int(0, 2 ** 32);
 
         $types_iterator = self::getDistinctTypes($instID);
 

--- a/src/Contract_Item.php
+++ b/src/Contract_Item.php
@@ -264,7 +264,7 @@ class Contract_Item extends CommonDBRelation
         }
 
         $canedit = $item->can($ID, UPDATE);
-        $rand = mt_rand();
+        $rand = random_int();
 
         $iterator = self::getListForItem($item);
 
@@ -403,7 +403,7 @@ TWIG, $twig_params);
             return false;
         }
         $canedit = $contract->can($instID, UPDATE);
-        $rand    = mt_rand();
+        $rand    = random_int();
 
         $types_iterator = self::getDistinctTypes($instID);
 

--- a/src/Contract_Item.php
+++ b/src/Contract_Item.php
@@ -264,7 +264,7 @@ class Contract_Item extends CommonDBRelation
         }
 
         $canedit = $item->can($ID, UPDATE);
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
 
         $iterator = self::getListForItem($item);
 
@@ -403,7 +403,7 @@ TWIG, $twig_params);
             return false;
         }
         $canedit = $contract->can($instID, UPDATE);
-        $rand    = random_int();
+        $rand    = random_int(0, 2**32);
 
         $types_iterator = self::getDistinctTypes($instID);
 

--- a/src/Contract_Supplier.php
+++ b/src/Contract_Supplier.php
@@ -116,7 +116,7 @@ class Contract_Supplier extends CommonDBRelation
             return;
         }
         $canedit = $supplier->can($ID, UPDATE);
-        $rand    = random_int(0, 2**32);
+        $rand    = random_int(0, 2 ** 32);
 
         $iterator = self::getListForItem($supplier);
 
@@ -239,7 +239,7 @@ TWIG, $twig_params);
             return;
         }
         $canedit = $contract->can($instID, UPDATE);
-        $rand    = random_int(0, 2**32);
+        $rand    = random_int(0, 2 ** 32);
 
         $iterator = self::getListForItem($contract);
         $number = count($iterator);

--- a/src/Contract_Supplier.php
+++ b/src/Contract_Supplier.php
@@ -116,7 +116,7 @@ class Contract_Supplier extends CommonDBRelation
             return;
         }
         $canedit = $supplier->can($ID, UPDATE);
-        $rand    = mt_rand();
+        $rand    = random_int();
 
         $iterator = self::getListForItem($supplier);
 
@@ -239,7 +239,7 @@ TWIG, $twig_params);
             return;
         }
         $canedit = $contract->can($instID, UPDATE);
-        $rand    = mt_rand();
+        $rand    = random_int();
 
         $iterator = self::getListForItem($contract);
         $number = count($iterator);

--- a/src/Contract_Supplier.php
+++ b/src/Contract_Supplier.php
@@ -116,7 +116,7 @@ class Contract_Supplier extends CommonDBRelation
             return;
         }
         $canedit = $supplier->can($ID, UPDATE);
-        $rand    = random_int();
+        $rand    = random_int(0, 2**32);
 
         $iterator = self::getListForItem($supplier);
 
@@ -239,7 +239,7 @@ TWIG, $twig_params);
             return;
         }
         $canedit = $contract->can($instID, UPDATE);
-        $rand    = random_int();
+        $rand    = random_int(0, 2**32);
 
         $iterator = self::getListForItem($contract);
         $number = count($iterator);

--- a/src/DBmysql.php
+++ b/src/DBmysql.php
@@ -248,7 +248,7 @@ class DBmysql
 
         if (is_array($this->dbhost)) {
             // Round robin choice
-            $i    = (isset($choice) ? $choice : mt_rand(0, count($this->dbhost) - 1));
+            $i    = (isset($choice) ? $choice : random_int(0, count($this->dbhost) - 1));
             $host = $this->dbhost[$i];
         } else {
             $host = $this->dbhost;

--- a/src/DCRoom.php
+++ b/src/DCRoom.php
@@ -301,7 +301,7 @@ class DCRoom extends CommonDBTM
         global $DB;
 
         $ID = $datacenter->getID();
-        $rand = mt_rand();
+        $rand = random_int();
 
         if (
             !$datacenter->getFromDB($ID)

--- a/src/DCRoom.php
+++ b/src/DCRoom.php
@@ -301,7 +301,7 @@ class DCRoom extends CommonDBTM
         global $DB;
 
         $ID = $datacenter->getID();
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
 
         if (
             !$datacenter->getFromDB($ID)

--- a/src/DCRoom.php
+++ b/src/DCRoom.php
@@ -301,7 +301,7 @@ class DCRoom extends CommonDBTM
         global $DB;
 
         $ID = $datacenter->getID();
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
 
         if (
             !$datacenter->getFromDB($ID)

--- a/src/DisplayPreference.php
+++ b/src/DisplayPreference.php
@@ -576,7 +576,7 @@ class DisplayPreference extends CommonDBTM
         } else {
             $specific_actions[ __CLASS__ . MassiveAction::CLASS_ACTION_SEPARATOR . 'reset_to_default'] = _x('button', 'Reset to default');
         }
-        $rand = mt_rand();
+        $rand = random_int();
         $massiveactionparams = [
             'width'            => 400,
             'height'           => 200,

--- a/src/DisplayPreference.php
+++ b/src/DisplayPreference.php
@@ -576,7 +576,7 @@ class DisplayPreference extends CommonDBTM
         } else {
             $specific_actions[ __CLASS__ . MassiveAction::CLASS_ACTION_SEPARATOR . 'reset_to_default'] = _x('button', 'Reset to default');
         }
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
         $massiveactionparams = [
             'width'            => 400,
             'height'           => 200,

--- a/src/DisplayPreference.php
+++ b/src/DisplayPreference.php
@@ -576,7 +576,7 @@ class DisplayPreference extends CommonDBTM
         } else {
             $specific_actions[ __CLASS__ . MassiveAction::CLASS_ACTION_SEPARATOR . 'reset_to_default'] = _x('button', 'Reset to default');
         }
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
         $massiveactionparams = [
             'width'            => 400,
             'height'           => 200,

--- a/src/Document.php
+++ b/src/Document.php
@@ -1442,7 +1442,7 @@ class Document extends CommonDBTM
         foreach ($iterator as $data) {
             $values[$data['id']] = $data['name'];
         }
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
         $readonly = $p['readonly'];
         $out = '';
         $width = '30%';

--- a/src/Document.php
+++ b/src/Document.php
@@ -1442,7 +1442,7 @@ class Document extends CommonDBTM
         foreach ($iterator as $data) {
             $values[$data['id']] = $data['name'];
         }
-        $rand = mt_rand();
+        $rand = random_int();
         $readonly = $p['readonly'];
         $out = '';
         $width = '30%';

--- a/src/Document.php
+++ b/src/Document.php
@@ -1442,7 +1442,7 @@ class Document extends CommonDBTM
         foreach ($iterator as $data) {
             $values[$data['id']] = $data['name'];
         }
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
         $readonly = $p['readonly'];
         $out = '';
         $width = '30%';

--- a/src/DocumentType.php
+++ b/src/DocumentType.php
@@ -178,7 +178,7 @@ class DocumentType extends CommonDropdown
 
         $p = [
             'display' => true,
-            'rand'    => mt_rand(),
+            'rand'    => random_int(),
         ];
 
        //merge default options with options parameter

--- a/src/DocumentType.php
+++ b/src/DocumentType.php
@@ -178,7 +178,7 @@ class DocumentType extends CommonDropdown
 
         $p = [
             'display' => true,
-            'rand'    => random_int(),
+            'rand'    => random_int(0, 2**32),
         ];
 
        //merge default options with options parameter

--- a/src/DocumentType.php
+++ b/src/DocumentType.php
@@ -178,7 +178,7 @@ class DocumentType extends CommonDropdown
 
         $p = [
             'display' => true,
-            'rand'    => random_int(0, 2**32),
+            'rand'    => random_int(0, 2 ** 32),
         ];
 
        //merge default options with options parameter

--- a/src/Document_Item.php
+++ b/src/Document_Item.php
@@ -347,7 +347,7 @@ class Document_Item extends CommonDBRelation
         // it's done for both directions in self::showAssociated
         $types_iterator = self::getDistinctTypes($instID, ['NOT' => ['itemtype' => 'Document']]);
 
-        $rand   = mt_rand();
+        $rand   = random_int();
         if ($canedit) {
             $twig_params = [
                 'doc' => $doc,
@@ -520,7 +520,7 @@ TWIG, $twig_params);
         }
 
         $params         = [];
-        $params['rand'] = mt_rand();
+        $params['rand'] = random_int();
 
         self::showAddFormForItem($item, $withtemplate, $params);
         self::showListForItem($item, $withtemplate, $params);
@@ -544,7 +544,7 @@ TWIG, $twig_params);
         global $CFG_GLPI, $DB;
 
         //default options
-        $params['rand'] = mt_rand();
+        $params['rand'] = random_int();
         if (is_array($options) && count($options)) {
             foreach ($options as $key => $val) {
                 $params[$key] = $val;
@@ -609,7 +609,7 @@ TWIG, $twig_params);
                 'entity' => $entity,
                 'entities' => $entities,
                 'nb' => $nb,
-                'rand' => mt_rand()
+                'rand' => random_int()
             ]);
         }
 
@@ -739,7 +739,7 @@ TWIG, $twig_params);
             'showmassiveactions' => $canedit && $withtemplate < 2,
             'massiveactionparams' => [
                 'num_displayed' => count($entries),
-                'container'     => 'mass' . static::class . mt_rand()
+                'container'     => 'mass' . static::class . random_int()
             ],
         ]);
     }

--- a/src/Document_Item.php
+++ b/src/Document_Item.php
@@ -347,7 +347,7 @@ class Document_Item extends CommonDBRelation
         // it's done for both directions in self::showAssociated
         $types_iterator = self::getDistinctTypes($instID, ['NOT' => ['itemtype' => 'Document']]);
 
-        $rand   = random_int();
+        $rand   = random_int(0, 2**32);
         if ($canedit) {
             $twig_params = [
                 'doc' => $doc,
@@ -520,7 +520,7 @@ TWIG, $twig_params);
         }
 
         $params         = [];
-        $params['rand'] = random_int();
+        $params['rand'] = random_int(0, 2**32);
 
         self::showAddFormForItem($item, $withtemplate, $params);
         self::showListForItem($item, $withtemplate, $params);
@@ -544,7 +544,7 @@ TWIG, $twig_params);
         global $CFG_GLPI, $DB;
 
         //default options
-        $params['rand'] = random_int();
+        $params['rand'] = random_int(0, 2**32);
         if (is_array($options) && count($options)) {
             foreach ($options as $key => $val) {
                 $params[$key] = $val;
@@ -609,7 +609,7 @@ TWIG, $twig_params);
                 'entity' => $entity,
                 'entities' => $entities,
                 'nb' => $nb,
-                'rand' => random_int()
+                'rand' => random_int(0, 2**32)
             ]);
         }
 
@@ -739,7 +739,7 @@ TWIG, $twig_params);
             'showmassiveactions' => $canedit && $withtemplate < 2,
             'massiveactionparams' => [
                 'num_displayed' => count($entries),
-                'container'     => 'mass' . static::class . random_int()
+                'container'     => 'mass' . static::class . random_int(0, 2**32)
             ],
         ]);
     }

--- a/src/Document_Item.php
+++ b/src/Document_Item.php
@@ -347,7 +347,7 @@ class Document_Item extends CommonDBRelation
         // it's done for both directions in self::showAssociated
         $types_iterator = self::getDistinctTypes($instID, ['NOT' => ['itemtype' => 'Document']]);
 
-        $rand   = random_int(0, 2**32);
+        $rand   = random_int(0, 2 ** 32);
         if ($canedit) {
             $twig_params = [
                 'doc' => $doc,
@@ -520,7 +520,7 @@ TWIG, $twig_params);
         }
 
         $params         = [];
-        $params['rand'] = random_int(0, 2**32);
+        $params['rand'] = random_int(0, 2 ** 32);
 
         self::showAddFormForItem($item, $withtemplate, $params);
         self::showListForItem($item, $withtemplate, $params);
@@ -544,7 +544,7 @@ TWIG, $twig_params);
         global $CFG_GLPI, $DB;
 
         //default options
-        $params['rand'] = random_int(0, 2**32);
+        $params['rand'] = random_int(0, 2 ** 32);
         if (is_array($options) && count($options)) {
             foreach ($options as $key => $val) {
                 $params[$key] = $val;
@@ -609,7 +609,7 @@ TWIG, $twig_params);
                 'entity' => $entity,
                 'entities' => $entities,
                 'nb' => $nb,
-                'rand' => random_int(0, 2**32)
+                'rand' => random_int(0, 2 ** 32)
             ]);
         }
 
@@ -739,7 +739,7 @@ TWIG, $twig_params);
             'showmassiveactions' => $canedit && $withtemplate < 2,
             'massiveactionparams' => [
                 'num_displayed' => count($entries),
-                'container'     => 'mass' . static::class . random_int(0, 2**32)
+                'container'     => 'mass' . static::class . random_int(0, 2 ** 32)
             ],
         ]);
     }

--- a/src/Domain.php
+++ b/src/Domain.php
@@ -395,7 +395,7 @@ class Domain extends CommonDBTM
             }
         }
 
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
 
         $where = [
             'glpi_domains.is_deleted'  => 0

--- a/src/Domain.php
+++ b/src/Domain.php
@@ -395,7 +395,7 @@ class Domain extends CommonDBTM
             }
         }
 
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
 
         $where = [
             'glpi_domains.is_deleted'  => 0

--- a/src/Domain.php
+++ b/src/Domain.php
@@ -395,7 +395,7 @@ class Domain extends CommonDBTM
             }
         }
 
-        $rand = mt_rand();
+        $rand = random_int();
 
         $where = [
             'glpi_domains.is_deleted'  => 0

--- a/src/DomainRecord.php
+++ b/src/DomainRecord.php
@@ -395,7 +395,7 @@ class DomainRecord extends CommonDBChild
         }
         $canedit = $domain->can($instID, UPDATE)
                  || count($_SESSION['glpiactiveprofile']['managed_domainrecordtypes']);
-        $rand    = random_int();
+        $rand    = random_int(0, 2**32);
 
         $iterator = $DB->request([
             'SELECT'    => 'record.*',

--- a/src/DomainRecord.php
+++ b/src/DomainRecord.php
@@ -395,7 +395,7 @@ class DomainRecord extends CommonDBChild
         }
         $canedit = $domain->can($instID, UPDATE)
                  || count($_SESSION['glpiactiveprofile']['managed_domainrecordtypes']);
-        $rand    = mt_rand();
+        $rand    = random_int();
 
         $iterator = $DB->request([
             'SELECT'    => 'record.*',

--- a/src/DomainRecord.php
+++ b/src/DomainRecord.php
@@ -395,7 +395,7 @@ class DomainRecord extends CommonDBChild
         }
         $canedit = $domain->can($instID, UPDATE)
                  || count($_SESSION['glpiactiveprofile']['managed_domainrecordtypes']);
-        $rand    = random_int(0, 2**32);
+        $rand    = random_int(0, 2 ** 32);
 
         $iterator = $DB->request([
             'SELECT'    => 'record.*',

--- a/src/Domain_Item.php
+++ b/src/Domain_Item.php
@@ -179,7 +179,7 @@ class Domain_Item extends CommonDBRelation
             return false;
         }
         $canedit = $domain->can($instID, UPDATE);
-        $rand    = random_int();
+        $rand    = random_int(0, 2**32);
 
         $iterator = $DB->request([
             'SELECT'    => 'itemtype',
@@ -373,7 +373,7 @@ TWIG, $twig_params);
         }
 
         $canedit      = $item->canAddItem('Domain');
-        $rand         = random_int();
+        $rand         = random_int(0, 2**32);
         $is_recursive = $item->isRecursive();
 
         $criteria = [

--- a/src/Domain_Item.php
+++ b/src/Domain_Item.php
@@ -179,7 +179,7 @@ class Domain_Item extends CommonDBRelation
             return false;
         }
         $canedit = $domain->can($instID, UPDATE);
-        $rand    = random_int(0, 2**32);
+        $rand    = random_int(0, 2 ** 32);
 
         $iterator = $DB->request([
             'SELECT'    => 'itemtype',
@@ -373,7 +373,7 @@ TWIG, $twig_params);
         }
 
         $canedit      = $item->canAddItem('Domain');
-        $rand         = random_int(0, 2**32);
+        $rand         = random_int(0, 2 ** 32);
         $is_recursive = $item->isRecursive();
 
         $criteria = [

--- a/src/Domain_Item.php
+++ b/src/Domain_Item.php
@@ -179,7 +179,7 @@ class Domain_Item extends CommonDBRelation
             return false;
         }
         $canedit = $domain->can($instID, UPDATE);
-        $rand    = mt_rand();
+        $rand    = random_int();
 
         $iterator = $DB->request([
             'SELECT'    => 'itemtype',
@@ -373,7 +373,7 @@ TWIG, $twig_params);
         }
 
         $canedit      = $item->canAddItem('Domain');
-        $rand         = mt_rand();
+        $rand         = random_int();
         $is_recursive = $item->isRecursive();
 
         $criteria = [

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -126,7 +126,7 @@ class Dropdown
         $params['toadd']                = [];
         $params['on_change']            = '';
         $params['condition']            = [];
-        $params['rand']                 = mt_rand();
+        $params['rand']                 = random_int();
         $params['displaywith']          = [];
        //Parameters about choice 0
        //Empty choice's label
@@ -882,7 +882,7 @@ class Dropdown
         $params['display']             = true;
         $params['width']               = '';
         $params['display_emptychoice'] = true;
-        $params['rand']         = mt_rand();
+        $params['rand']         = random_int();
 
         if (is_array($options) && count($options)) {
             foreach ($options as $key => $val) {
@@ -980,7 +980,7 @@ class Dropdown
                         $values[$file] = $file;
                     }
                 }
-                $rand = mt_rand();
+                $rand = random_int();
                 self::showFromArray(
                     $myname,
                     $values,
@@ -1097,7 +1097,7 @@ JAVASCRIPT;
             if (!empty($params['rand'])) {
                 $rand = $params['rand'];
             } else {
-                $rand = mt_rand();
+                $rand = random_int();
             }
 
             $options = ['name' => $name,
@@ -1663,7 +1663,7 @@ JAVASCRIPT;
 
         $params['name']                = 'itemtype';
         $params['value']               = '';
-        $params['rand']                = mt_rand();
+        $params['rand']                = random_int();
         $params['on_change']           = '';
         $params['plural']              = false;
        //Parameters about choice 0
@@ -1797,7 +1797,7 @@ JAVASCRIPT;
             'used'                                  => [],
             'ajax_page'                             => $CFG_GLPI["root_doc"] . "/ajax/dropdownAllItems.php",
             'display'                               => true,
-            'rand'                                  => mt_rand(),
+            'rand'                                  => random_int(),
             'itemtype_track_changes'                => false,
             'init'                                  => true,
             'width'                                 => '80%',
@@ -1937,7 +1937,7 @@ JAVASCRIPT;
 
         $p = [
             'value'           => 0,
-            'rand'            => mt_rand(),
+            'rand'            => random_int(),
             'min'             => 0,
             'max'             => 100,
             'step'            => 1,
@@ -2091,7 +2091,7 @@ JAVASCRIPT;
         global $CFG_GLPI;
 
         $params['value']               = 0;
-        $params['rand']                = mt_rand();
+        $params['rand']                = random_int();
         $params['min']                 = 0;
         $params['max']                 = DAY_TIMESTAMP;
         $params['step']                = $CFG_GLPI["time_step"] * MINUTE_TIMESTAMP;
@@ -2274,7 +2274,7 @@ JAVASCRIPT;
         $param['size']                = 1;
         $param['display']             = true;
         $param['other']               = false;
-        $param['rand']                = mt_rand();
+        $param['rand']                = random_int();
         $param['emptylabel']          = self::EMPTY_VALUE;
         $param['display_emptychoice'] = false;
         $param['disabled']            = false;
@@ -2621,7 +2621,7 @@ JAVASCRIPT;
             }
         } else {
             if ($params['management_restrict'] == 2) {
-                $rand = mt_rand();
+                $rand = random_int();
                 $values = [MANAGEMENT_UNITARY => __('Unit management'),
                     MANAGEMENT_GLOBAL  => __('Global management')
                 ];
@@ -2754,7 +2754,7 @@ JAVASCRIPT;
             $values['-' . Search::NAMES_OUTPUT] = __('Copy names to clipboard');
         }
 
-        $rand = mt_rand();
+        $rand = random_int();
         Dropdown::showFromArray('display_type', $values, ['rand' => $rand]);
         echo "<button type='submit' name='export' class='btn' " .
              " title=\"" . _sx('button', 'Export') . "\">" .

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -126,7 +126,7 @@ class Dropdown
         $params['toadd']                = [];
         $params['on_change']            = '';
         $params['condition']            = [];
-        $params['rand']                 = random_int();
+        $params['rand']                 = random_int(0, 2**32);
         $params['displaywith']          = [];
        //Parameters about choice 0
        //Empty choice's label
@@ -882,7 +882,7 @@ class Dropdown
         $params['display']             = true;
         $params['width']               = '';
         $params['display_emptychoice'] = true;
-        $params['rand']         = random_int();
+        $params['rand']         = random_int(0, 2**32);
 
         if (is_array($options) && count($options)) {
             foreach ($options as $key => $val) {
@@ -980,7 +980,7 @@ class Dropdown
                         $values[$file] = $file;
                     }
                 }
-                $rand = random_int();
+                $rand = random_int(0, 2**32);
                 self::showFromArray(
                     $myname,
                     $values,
@@ -1097,7 +1097,7 @@ JAVASCRIPT;
             if (!empty($params['rand'])) {
                 $rand = $params['rand'];
             } else {
-                $rand = random_int();
+                $rand = random_int(0, 2**32);
             }
 
             $options = ['name' => $name,
@@ -1663,7 +1663,7 @@ JAVASCRIPT;
 
         $params['name']                = 'itemtype';
         $params['value']               = '';
-        $params['rand']                = random_int();
+        $params['rand']                = random_int(0, 2**32);
         $params['on_change']           = '';
         $params['plural']              = false;
        //Parameters about choice 0
@@ -1797,7 +1797,7 @@ JAVASCRIPT;
             'used'                                  => [],
             'ajax_page'                             => $CFG_GLPI["root_doc"] . "/ajax/dropdownAllItems.php",
             'display'                               => true,
-            'rand'                                  => random_int(),
+            'rand'                                  => random_int(0, 2**32),
             'itemtype_track_changes'                => false,
             'init'                                  => true,
             'width'                                 => '80%',
@@ -1937,7 +1937,7 @@ JAVASCRIPT;
 
         $p = [
             'value'           => 0,
-            'rand'            => random_int(),
+            'rand'            => random_int(0, 2**32),
             'min'             => 0,
             'max'             => 100,
             'step'            => 1,
@@ -2091,7 +2091,7 @@ JAVASCRIPT;
         global $CFG_GLPI;
 
         $params['value']               = 0;
-        $params['rand']                = random_int();
+        $params['rand']                = random_int(0, 2**32);
         $params['min']                 = 0;
         $params['max']                 = DAY_TIMESTAMP;
         $params['step']                = $CFG_GLPI["time_step"] * MINUTE_TIMESTAMP;
@@ -2274,7 +2274,7 @@ JAVASCRIPT;
         $param['size']                = 1;
         $param['display']             = true;
         $param['other']               = false;
-        $param['rand']                = random_int();
+        $param['rand']                = random_int(0, 2**32);
         $param['emptylabel']          = self::EMPTY_VALUE;
         $param['display_emptychoice'] = false;
         $param['disabled']            = false;
@@ -2621,7 +2621,7 @@ JAVASCRIPT;
             }
         } else {
             if ($params['management_restrict'] == 2) {
-                $rand = random_int();
+                $rand = random_int(0, 2**32);
                 $values = [MANAGEMENT_UNITARY => __('Unit management'),
                     MANAGEMENT_GLOBAL  => __('Global management')
                 ];
@@ -2754,7 +2754,7 @@ JAVASCRIPT;
             $values['-' . Search::NAMES_OUTPUT] = __('Copy names to clipboard');
         }
 
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
         Dropdown::showFromArray('display_type', $values, ['rand' => $rand]);
         echo "<button type='submit' name='export' class='btn' " .
              " title=\"" . _sx('button', 'Export') . "\">" .

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -126,7 +126,7 @@ class Dropdown
         $params['toadd']                = [];
         $params['on_change']            = '';
         $params['condition']            = [];
-        $params['rand']                 = random_int(0, 2**32);
+        $params['rand']                 = random_int(0, 2 ** 32);
         $params['displaywith']          = [];
        //Parameters about choice 0
        //Empty choice's label
@@ -882,7 +882,7 @@ class Dropdown
         $params['display']             = true;
         $params['width']               = '';
         $params['display_emptychoice'] = true;
-        $params['rand']         = random_int(0, 2**32);
+        $params['rand']         = random_int(0, 2 ** 32);
 
         if (is_array($options) && count($options)) {
             foreach ($options as $key => $val) {
@@ -980,7 +980,7 @@ class Dropdown
                         $values[$file] = $file;
                     }
                 }
-                $rand = random_int(0, 2**32);
+                $rand = random_int(0, 2 ** 32);
                 self::showFromArray(
                     $myname,
                     $values,
@@ -1097,7 +1097,7 @@ JAVASCRIPT;
             if (!empty($params['rand'])) {
                 $rand = $params['rand'];
             } else {
-                $rand = random_int(0, 2**32);
+                $rand = random_int(0, 2 ** 32);
             }
 
             $options = ['name' => $name,
@@ -1663,7 +1663,7 @@ JAVASCRIPT;
 
         $params['name']                = 'itemtype';
         $params['value']               = '';
-        $params['rand']                = random_int(0, 2**32);
+        $params['rand']                = random_int(0, 2 ** 32);
         $params['on_change']           = '';
         $params['plural']              = false;
        //Parameters about choice 0
@@ -1797,7 +1797,7 @@ JAVASCRIPT;
             'used'                                  => [],
             'ajax_page'                             => $CFG_GLPI["root_doc"] . "/ajax/dropdownAllItems.php",
             'display'                               => true,
-            'rand'                                  => random_int(0, 2**32),
+            'rand'                                  => random_int(0, 2 ** 32),
             'itemtype_track_changes'                => false,
             'init'                                  => true,
             'width'                                 => '80%',
@@ -1937,7 +1937,7 @@ JAVASCRIPT;
 
         $p = [
             'value'           => 0,
-            'rand'            => random_int(0, 2**32),
+            'rand'            => random_int(0, 2 ** 32),
             'min'             => 0,
             'max'             => 100,
             'step'            => 1,
@@ -2091,7 +2091,7 @@ JAVASCRIPT;
         global $CFG_GLPI;
 
         $params['value']               = 0;
-        $params['rand']                = random_int(0, 2**32);
+        $params['rand']                = random_int(0, 2 ** 32);
         $params['min']                 = 0;
         $params['max']                 = DAY_TIMESTAMP;
         $params['step']                = $CFG_GLPI["time_step"] * MINUTE_TIMESTAMP;
@@ -2274,7 +2274,7 @@ JAVASCRIPT;
         $param['size']                = 1;
         $param['display']             = true;
         $param['other']               = false;
-        $param['rand']                = random_int(0, 2**32);
+        $param['rand']                = random_int(0, 2 ** 32);
         $param['emptylabel']          = self::EMPTY_VALUE;
         $param['display_emptychoice'] = false;
         $param['disabled']            = false;
@@ -2621,7 +2621,7 @@ JAVASCRIPT;
             }
         } else {
             if ($params['management_restrict'] == 2) {
-                $rand = random_int(0, 2**32);
+                $rand = random_int(0, 2 ** 32);
                 $values = [MANAGEMENT_UNITARY => __('Unit management'),
                     MANAGEMENT_GLOBAL  => __('Global management')
                 ];
@@ -2754,7 +2754,7 @@ JAVASCRIPT;
             $values['-' . Search::NAMES_OUTPUT] = __('Copy names to clipboard');
         }
 
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
         Dropdown::showFromArray('display_type', $values, ['rand' => $rand]);
         echo "<button type='submit' name='export' class='btn' " .
              " title=\"" . _sx('button', 'Export') . "\">" .

--- a/src/DropdownTranslation.php
+++ b/src/DropdownTranslation.php
@@ -350,7 +350,7 @@ class DropdownTranslation extends CommonDBChild
          */
         global $DB;
 
-        $rand    = random_int();
+        $rand    = random_int(0, 2**32);
         $canedit = $item->can($item->getID(), UPDATE);
 
         if ($canedit) {

--- a/src/DropdownTranslation.php
+++ b/src/DropdownTranslation.php
@@ -350,7 +350,7 @@ class DropdownTranslation extends CommonDBChild
          */
         global $DB;
 
-        $rand    = mt_rand();
+        $rand    = random_int();
         $canedit = $item->can($item->getID(), UPDATE);
 
         if ($canedit) {

--- a/src/DropdownTranslation.php
+++ b/src/DropdownTranslation.php
@@ -350,7 +350,7 @@ class DropdownTranslation extends CommonDBChild
          */
         global $DB;
 
-        $rand    = random_int(0, 2**32);
+        $rand    = random_int(0, 2 ** 32);
         $canedit = $item->can($item->getID(), UPDATE);
 
         if ($canedit) {

--- a/src/GLPIUploadHandler.php
+++ b/src/GLPIUploadHandler.php
@@ -71,7 +71,7 @@ class GLPIUploadHandler extends UploadHandler
                         }
                     }
                 }
-                $val->id = 'doc' . $params['name'] . mt_rand();
+                $val->id = 'doc' . $params['name'] . random_int();
             }
         }
 

--- a/src/GLPIUploadHandler.php
+++ b/src/GLPIUploadHandler.php
@@ -71,7 +71,7 @@ class GLPIUploadHandler extends UploadHandler
                         }
                     }
                 }
-                $val->id = 'doc' . $params['name'] . random_int(0, 2**32);
+                $val->id = 'doc' . $params['name'] . random_int(0, 2 ** 32);
             }
         }
 

--- a/src/GLPIUploadHandler.php
+++ b/src/GLPIUploadHandler.php
@@ -71,7 +71,7 @@ class GLPIUploadHandler extends UploadHandler
                         }
                     }
                 }
-                $val->id = 'doc' . $params['name'] . random_int();
+                $val->id = 'doc' . $params['name'] . random_int(0, 2**32);
             }
         }
 

--- a/src/Glpi/Api/HL/Controller/CoreController.php
+++ b/src/Glpi/Api/HL/Controller/CoreController.php
@@ -622,7 +622,7 @@ HTML;
             try {
                 $options_hash = md5(json_encode($options, JSON_THROW_ON_ERROR));
             } catch (\JsonException) {
-                $options_hash = random_int(0, 2**32);
+                $options_hash = random_int(0, 2 ** 32);
             }
 
             // Group transfers by entity and options hash

--- a/src/Glpi/Api/HL/Controller/CoreController.php
+++ b/src/Glpi/Api/HL/Controller/CoreController.php
@@ -622,7 +622,7 @@ HTML;
             try {
                 $options_hash = md5(json_encode($options, JSON_THROW_ON_ERROR));
             } catch (\JsonException) {
-                $options_hash = mt_rand();
+                $options_hash = random_int();
             }
 
             // Group transfers by entity and options hash

--- a/src/Glpi/Api/HL/Controller/CoreController.php
+++ b/src/Glpi/Api/HL/Controller/CoreController.php
@@ -622,7 +622,7 @@ HTML;
             try {
                 $options_hash = md5(json_encode($options, JSON_THROW_ON_ERROR));
             } catch (\JsonException) {
-                $options_hash = random_int();
+                $options_hash = random_int(0, 2**32);
             }
 
             // Group transfers by entity and options hash

--- a/src/Glpi/Asset/AssetDefinition.php
+++ b/src/Glpi/Asset/AssetDefinition.php
@@ -197,7 +197,7 @@ final class AssetDefinition extends AbstractDefinition
         }
 
         $canedit = $this->canUpdateItem();
-        $rand = mt_rand();
+        $rand = random_int();
         if ($canedit) {
             TemplateRenderer::getInstance()->display('components/form/viewsubitem.html.twig', [
                 'cancreate' => CustomFieldDefinition::canCreate(),

--- a/src/Glpi/Asset/AssetDefinition.php
+++ b/src/Glpi/Asset/AssetDefinition.php
@@ -197,7 +197,7 @@ final class AssetDefinition extends AbstractDefinition
         }
 
         $canedit = $this->canUpdateItem();
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
         if ($canedit) {
             TemplateRenderer::getInstance()->display('components/form/viewsubitem.html.twig', [
                 'cancreate' => CustomFieldDefinition::canCreate(),

--- a/src/Glpi/Asset/AssetDefinition.php
+++ b/src/Glpi/Asset/AssetDefinition.php
@@ -197,7 +197,7 @@ final class AssetDefinition extends AbstractDefinition
         }
 
         $canedit = $this->canUpdateItem();
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
         if ($canedit) {
             TemplateRenderer::getInstance()->display('components/form/viewsubitem.html.twig', [
                 'cancreate' => CustomFieldDefinition::canCreate(),

--- a/src/Glpi/Asset/Asset_PeripheralAsset.php
+++ b/src/Glpi/Asset/Asset_PeripheralAsset.php
@@ -305,7 +305,7 @@ final class Asset_PeripheralAsset extends CommonDBRelation
 
         $ID      = $asset->fields['id'];
         $canedit = $asset->canEdit($ID);
-        $rand    = mt_rand();
+        $rand    = random_int();
 
         $datas = [];
         $used  = [];
@@ -341,7 +341,7 @@ final class Asset_PeripheralAsset extends CommonDBRelation
             ];
 
             $twig_params = [
-                'rand' => mt_rand(),
+                'rand' => random_int(),
                 'dropdown_params' => $dropdown_params,
                 'asset' => $asset,
                 'label' => __('Connect an item'),
@@ -478,7 +478,7 @@ TWIG, $twig_params);
         }
 
         $canedit = $peripheral->canEdit($ID);
-        $rand    = mt_rand();
+        $rand    = random_int();
 
         // Is global connection ?
         $global  = $peripheral->fields['is_global'];
@@ -684,7 +684,7 @@ TWIG, $twig_params);
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $rand     = mt_rand();
+        $rand     = random_int();
 
         $field_id = Html::cleanId("dropdown_" . $myname . $rand);
         $param    = [

--- a/src/Glpi/Asset/Asset_PeripheralAsset.php
+++ b/src/Glpi/Asset/Asset_PeripheralAsset.php
@@ -305,7 +305,7 @@ final class Asset_PeripheralAsset extends CommonDBRelation
 
         $ID      = $asset->fields['id'];
         $canedit = $asset->canEdit($ID);
-        $rand    = random_int(0, 2**32);
+        $rand    = random_int(0, 2 ** 32);
 
         $datas = [];
         $used  = [];
@@ -341,7 +341,7 @@ final class Asset_PeripheralAsset extends CommonDBRelation
             ];
 
             $twig_params = [
-                'rand' => random_int(0, 2**32),
+                'rand' => random_int(0, 2 ** 32),
                 'dropdown_params' => $dropdown_params,
                 'asset' => $asset,
                 'label' => __('Connect an item'),
@@ -478,7 +478,7 @@ TWIG, $twig_params);
         }
 
         $canedit = $peripheral->canEdit($ID);
-        $rand    = random_int(0, 2**32);
+        $rand    = random_int(0, 2 ** 32);
 
         // Is global connection ?
         $global  = $peripheral->fields['is_global'];
@@ -684,7 +684,7 @@ TWIG, $twig_params);
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $rand     = random_int(0, 2**32);
+        $rand     = random_int(0, 2 ** 32);
 
         $field_id = Html::cleanId("dropdown_" . $myname . $rand);
         $param    = [

--- a/src/Glpi/Asset/Asset_PeripheralAsset.php
+++ b/src/Glpi/Asset/Asset_PeripheralAsset.php
@@ -305,7 +305,7 @@ final class Asset_PeripheralAsset extends CommonDBRelation
 
         $ID      = $asset->fields['id'];
         $canedit = $asset->canEdit($ID);
-        $rand    = random_int();
+        $rand    = random_int(0, 2**32);
 
         $datas = [];
         $used  = [];
@@ -341,7 +341,7 @@ final class Asset_PeripheralAsset extends CommonDBRelation
             ];
 
             $twig_params = [
-                'rand' => random_int(),
+                'rand' => random_int(0, 2**32),
                 'dropdown_params' => $dropdown_params,
                 'asset' => $asset,
                 'label' => __('Connect an item'),
@@ -478,7 +478,7 @@ TWIG, $twig_params);
         }
 
         $canedit = $peripheral->canEdit($ID);
-        $rand    = random_int();
+        $rand    = random_int(0, 2**32);
 
         // Is global connection ?
         $global  = $peripheral->fields['is_global'];
@@ -684,7 +684,7 @@ TWIG, $twig_params);
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $rand     = random_int();
+        $rand     = random_int(0, 2**32);
 
         $field_id = Html::cleanId("dropdown_" . $myname . $rand);
         $param    = [

--- a/src/Glpi/Controller/IndexController.php
+++ b/src/Glpi/Controller/IndexController.php
@@ -185,7 +185,7 @@ final class IndexController extends AbstractController
                 }
             } else {
                 // Random number for html id/label
-                $rand = mt_rand();
+                $rand = random_int();
 
                 // Regular login
                 TemplateRenderer::getInstance()->display('pages/login.html.twig', [

--- a/src/Glpi/Controller/IndexController.php
+++ b/src/Glpi/Controller/IndexController.php
@@ -185,7 +185,7 @@ final class IndexController extends AbstractController
                 }
             } else {
                 // Random number for html id/label
-                $rand = random_int(0, 2**32);
+                $rand = random_int(0, 2 ** 32);
 
                 // Regular login
                 TemplateRenderer::getInstance()->display('pages/login.html.twig', [

--- a/src/Glpi/Controller/IndexController.php
+++ b/src/Glpi/Controller/IndexController.php
@@ -185,7 +185,7 @@ final class IndexController extends AbstractController
                 }
             } else {
                 // Random number for html id/label
-                $rand = random_int();
+                $rand = random_int(0, 2**32);
 
                 // Regular login
                 TemplateRenderer::getInstance()->display('pages/login.html.twig', [

--- a/src/Glpi/CustomObject/AbstractDefinition.php
+++ b/src/Glpi/CustomObject/AbstractDefinition.php
@@ -288,7 +288,7 @@ abstract class AbstractDefinition extends CommonDBTM
             static fn (string $lang_a, string $lang_b) => strnatcasecmp($CFG_GLPI['languages'][$lang_a][0], $CFG_GLPI['languages'][$lang_b][0])
         );
 
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
 
         TemplateRenderer::getInstance()->display(
             'pages/admin/customobjects/translations.html.twig',

--- a/src/Glpi/CustomObject/AbstractDefinition.php
+++ b/src/Glpi/CustomObject/AbstractDefinition.php
@@ -288,7 +288,7 @@ abstract class AbstractDefinition extends CommonDBTM
             static fn (string $lang_a, string $lang_b) => strnatcasecmp($CFG_GLPI['languages'][$lang_a][0], $CFG_GLPI['languages'][$lang_b][0])
         );
 
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
 
         TemplateRenderer::getInstance()->display(
             'pages/admin/customobjects/translations.html.twig',

--- a/src/Glpi/CustomObject/AbstractDefinition.php
+++ b/src/Glpi/CustomObject/AbstractDefinition.php
@@ -288,7 +288,7 @@ abstract class AbstractDefinition extends CommonDBTM
             static fn (string $lang_a, string $lang_b) => strnatcasecmp($CFG_GLPI['languages'][$lang_a][0], $CFG_GLPI['languages'][$lang_b][0])
         );
 
-        $rand = mt_rand();
+        $rand = random_int();
 
         TemplateRenderer::getInstance()->display(
             'pages/admin/customobjects/translations.html.twig',

--- a/src/Glpi/Dashboard/Filters/AbstractFilter.php
+++ b/src/Glpi/Dashboard/Filters/AbstractFilter.php
@@ -129,7 +129,7 @@ abstract class AbstractFilter
         bool $filled = false
     ): string {
 
-        $rand  = random_int(0, 2**32);
+        $rand  = random_int(0, 2 ** 32);
         $class = $filled ? "filled" : "";
 
         $js = <<<JAVASCRIPT
@@ -178,7 +178,7 @@ HTML;
         array $add_params = []
     ): string {
         $value     = !empty($value) ? $value : null;
-        $rand      = random_int(0, 2**32);
+        $rand      = random_int(0, 2 ** 32);
         $field     = $itemtype::dropdown([
             'name'                => $fieldname,
             'value'               => $value,

--- a/src/Glpi/Dashboard/Filters/AbstractFilter.php
+++ b/src/Glpi/Dashboard/Filters/AbstractFilter.php
@@ -129,7 +129,7 @@ abstract class AbstractFilter
         bool $filled = false
     ): string {
 
-        $rand  = random_int();
+        $rand  = random_int(0, 2**32);
         $class = $filled ? "filled" : "";
 
         $js = <<<JAVASCRIPT
@@ -178,7 +178,7 @@ HTML;
         array $add_params = []
     ): string {
         $value     = !empty($value) ? $value : null;
-        $rand      = random_int();
+        $rand      = random_int(0, 2**32);
         $field     = $itemtype::dropdown([
             'name'                => $fieldname,
             'value'               => $value,

--- a/src/Glpi/Dashboard/Filters/AbstractFilter.php
+++ b/src/Glpi/Dashboard/Filters/AbstractFilter.php
@@ -129,7 +129,7 @@ abstract class AbstractFilter
         bool $filled = false
     ): string {
 
-        $rand  = mt_rand();
+        $rand  = random_int();
         $class = $filled ? "filled" : "";
 
         $js = <<<JAVASCRIPT
@@ -178,7 +178,7 @@ HTML;
         array $add_params = []
     ): string {
         $value     = !empty($value) ? $value : null;
-        $rand      = mt_rand();
+        $rand      = random_int();
         $field     = $itemtype::dropdown([
             'name'                => $fieldname,
             'value'               => $value,

--- a/src/Glpi/Dashboard/Filters/DatesFilter.php
+++ b/src/Glpi/Dashboard/Filters/DatesFilter.php
@@ -132,7 +132,7 @@ class DatesFilter extends AbstractFilter
             : [] // can be a string if values are not initialized yet
         ;
 
-        $rand  = random_int();
+        $rand  = random_int(0, 2**32);
         $label = self::getName();
         $field = Html::showDateField('filter-dates', [
             'value'        => $values,

--- a/src/Glpi/Dashboard/Filters/DatesFilter.php
+++ b/src/Glpi/Dashboard/Filters/DatesFilter.php
@@ -132,7 +132,7 @@ class DatesFilter extends AbstractFilter
             : [] // can be a string if values are not initialized yet
         ;
 
-        $rand  = mt_rand();
+        $rand  = random_int();
         $label = self::getName();
         $field = Html::showDateField('filter-dates', [
             'value'        => $values,

--- a/src/Glpi/Dashboard/Filters/DatesFilter.php
+++ b/src/Glpi/Dashboard/Filters/DatesFilter.php
@@ -132,7 +132,7 @@ class DatesFilter extends AbstractFilter
             : [] // can be a string if values are not initialized yet
         ;
 
-        $rand  = random_int(0, 2**32);
+        $rand  = random_int(0, 2 ** 32);
         $label = self::getName();
         $field = Html::showDateField('filter-dates', [
             'value'        => $values,

--- a/src/Glpi/Dashboard/Filters/DatesModFilter.php
+++ b/src/Glpi/Dashboard/Filters/DatesModFilter.php
@@ -91,7 +91,7 @@ class DatesModFilter extends AbstractFilter
             : [] // can be a string if values are not initialized yet
         ;
 
-        $rand  = random_int();
+        $rand  = random_int(0, 2**32);
         $label = self::getName();
         $field = Html::showDateField('filter-dates', [
             'value'        => $values,

--- a/src/Glpi/Dashboard/Filters/DatesModFilter.php
+++ b/src/Glpi/Dashboard/Filters/DatesModFilter.php
@@ -91,7 +91,7 @@ class DatesModFilter extends AbstractFilter
             : [] // can be a string if values are not initialized yet
         ;
 
-        $rand  = mt_rand();
+        $rand  = random_int();
         $label = self::getName();
         $field = Html::showDateField('filter-dates', [
             'value'        => $values,

--- a/src/Glpi/Dashboard/Filters/DatesModFilter.php
+++ b/src/Glpi/Dashboard/Filters/DatesModFilter.php
@@ -91,7 +91,7 @@ class DatesModFilter extends AbstractFilter
             : [] // can be a string if values are not initialized yet
         ;
 
-        $rand  = random_int(0, 2**32);
+        $rand  = random_int(0, 2 ** 32);
         $label = self::getName();
         $field = Html::showDateField('filter-dates', [
             'value'        => $values,

--- a/src/Glpi/Dashboard/Grid.php
+++ b/src/Glpi/Dashboard/Grid.php
@@ -242,7 +242,7 @@ HTML;
         /** @var \Psr\SimpleCache\CacheInterface $GLPI_CACHE */
         global $GLPI_CACHE;
 
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
 
         if (!self::$embed && !$this->dashboard->canViewCurrent()) {
             return;
@@ -687,7 +687,7 @@ HTML;
      */
     public function displayAddDashboardForm()
     {
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
 
         echo "<form class='no-shadow display-add-dashboard-form'>";
 
@@ -803,7 +803,7 @@ HTML;
         $filters      = Filter::getFilterChoices();
         $list_filters = array_diff_key($filters, $used);
 
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
         echo "<form class='display-filter-form'>";
 
         echo "<div class='field'>";
@@ -875,7 +875,7 @@ HTML;
     public function displayEditRightsForm()
     {
         self::loadAllDashboards();
-        $rand   = random_int();
+        $rand   = random_int(0, 2**32);
         $values = [];
 
         echo "<form class='no-shadow display-rights-form'>";

--- a/src/Glpi/Dashboard/Grid.php
+++ b/src/Glpi/Dashboard/Grid.php
@@ -242,7 +242,7 @@ HTML;
         /** @var \Psr\SimpleCache\CacheInterface $GLPI_CACHE */
         global $GLPI_CACHE;
 
-        $rand = mt_rand();
+        $rand = random_int();
 
         if (!self::$embed && !$this->dashboard->canViewCurrent()) {
             return;
@@ -687,7 +687,7 @@ HTML;
      */
     public function displayAddDashboardForm()
     {
-        $rand = mt_rand();
+        $rand = random_int();
 
         echo "<form class='no-shadow display-add-dashboard-form'>";
 
@@ -803,7 +803,7 @@ HTML;
         $filters      = Filter::getFilterChoices();
         $list_filters = array_diff_key($filters, $used);
 
-        $rand = mt_rand();
+        $rand = random_int();
         echo "<form class='display-filter-form'>";
 
         echo "<div class='field'>";
@@ -875,7 +875,7 @@ HTML;
     public function displayEditRightsForm()
     {
         self::loadAllDashboards();
-        $rand   = mt_rand();
+        $rand   = random_int();
         $values = [];
 
         echo "<form class='no-shadow display-rights-form'>";

--- a/src/Glpi/Dashboard/Grid.php
+++ b/src/Glpi/Dashboard/Grid.php
@@ -242,7 +242,7 @@ HTML;
         /** @var \Psr\SimpleCache\CacheInterface $GLPI_CACHE */
         global $GLPI_CACHE;
 
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
 
         if (!self::$embed && !$this->dashboard->canViewCurrent()) {
             return;
@@ -687,7 +687,7 @@ HTML;
      */
     public function displayAddDashboardForm()
     {
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
 
         echo "<form class='no-shadow display-add-dashboard-form'>";
 
@@ -803,7 +803,7 @@ HTML;
         $filters      = Filter::getFilterChoices();
         $list_filters = array_diff_key($filters, $used);
 
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
         echo "<form class='display-filter-form'>";
 
         echo "<div class='field'>";
@@ -875,7 +875,7 @@ HTML;
     public function displayEditRightsForm()
     {
         self::loadAllDashboards();
-        $rand   = random_int(0, 2**32);
+        $rand   = random_int(0, 2 ** 32);
         $values = [];
 
         echo "<form class='no-shadow display-rights-form'>";

--- a/src/Glpi/Dashboard/Widget.php
+++ b/src/Glpi/Dashboard/Widget.php
@@ -324,7 +324,7 @@ class Widget
             'alt'     => '',
             'color'   => '',
             'icon'    => '',
-            'id'      => 'bn_' . random_int(0, 2**32),
+            'id'      => 'bn_' . random_int(0, 2 ** 32),
             'filters' => [],
         ];
         $p = array_merge($default, $params);
@@ -417,7 +417,7 @@ HTML;
             'use_gradient' => false,
             'class'        => "multiple-numbers",
             'filters'      => [],
-            'rand'         => random_int(0, 2**32),
+            'rand'         => random_int(0, 2 ** 32),
         ];
         $p = array_merge($default, $params);
         $default_entry = [
@@ -568,7 +568,7 @@ HTML;
             'palette'      => '',
             'limit'        => 99999,
             'filters'      => [],
-            'rand'         => random_int(0, 2**32),
+            'rand'         => random_int(0, 2 ** 32),
         ];
         $p = array_merge($default, $params);
         $p['cache_key'] = $p['cache_key'] ?? $p['rand'];
@@ -839,7 +839,7 @@ JAVASCRIPT;
             'icon'        => '',
             'horizontal'  => false,
             'distributed' => true,
-            'rand'        => random_int(0, 2**32),
+            'rand'        => random_int(0, 2 ** 32),
         ];
         $params = array_merge($default, $params);
         $default_entry = [
@@ -1006,7 +1006,7 @@ JAVASCRIPT;
             'point_labels' => false,
             'limit'        => 99999,
             'filters'      => [],
-            'rand'         => random_int(0, 2**32),
+            'rand'         => random_int(0, 2 ** 32),
         ];
         $p = array_merge($defaults, $params);
 
@@ -1395,7 +1395,7 @@ JAVASCRIPT;
             'line_width'   => 4,
             'limit'        => 99999,
             'filters'      => [],
-            'rand'         => random_int(0, 2**32),
+            'rand'         => random_int(0, 2 ** 32),
         ];
         $p = array_merge($defaults, $params);
         $p['cache_key'] = $p['cache_key'] ?? $p['rand'];
@@ -1652,7 +1652,7 @@ HTML;
             's_criteria' => '',
             'itemtype'   => '',
             'limit'      => $_SESSION['glpilist_limit'],
-            'rand'       => random_int(0, 2**32),
+            'rand'       => random_int(0, 2 ** 32),
             'filters'    => [],
         ];
         $p = array_merge($default, $params);
@@ -1731,7 +1731,7 @@ HTML;
             'icon'         => '',
             'limit'        => 99999,
             'class'        => "articles-list",
-            'rand'         => random_int(0, 2**32),
+            'rand'         => random_int(0, 2 ** 32),
             'filters'      => [],
         ];
         $p = array_merge($default, $params);

--- a/src/Glpi/Dashboard/Widget.php
+++ b/src/Glpi/Dashboard/Widget.php
@@ -324,7 +324,7 @@ class Widget
             'alt'     => '',
             'color'   => '',
             'icon'    => '',
-            'id'      => 'bn_' . mt_rand(),
+            'id'      => 'bn_' . random_int(),
             'filters' => [],
         ];
         $p = array_merge($default, $params);
@@ -417,7 +417,7 @@ HTML;
             'use_gradient' => false,
             'class'        => "multiple-numbers",
             'filters'      => [],
-            'rand'         => mt_rand(),
+            'rand'         => random_int(),
         ];
         $p = array_merge($default, $params);
         $default_entry = [
@@ -568,7 +568,7 @@ HTML;
             'palette'      => '',
             'limit'        => 99999,
             'filters'      => [],
-            'rand'         => mt_rand(),
+            'rand'         => random_int(),
         ];
         $p = array_merge($default, $params);
         $p['cache_key'] = $p['cache_key'] ?? $p['rand'];
@@ -839,7 +839,7 @@ JAVASCRIPT;
             'icon'        => '',
             'horizontal'  => false,
             'distributed' => true,
-            'rand'        => mt_rand(),
+            'rand'        => random_int(),
         ];
         $params = array_merge($default, $params);
         $default_entry = [
@@ -1006,7 +1006,7 @@ JAVASCRIPT;
             'point_labels' => false,
             'limit'        => 99999,
             'filters'      => [],
-            'rand'         => mt_rand(),
+            'rand'         => random_int(),
         ];
         $p = array_merge($defaults, $params);
 
@@ -1395,7 +1395,7 @@ JAVASCRIPT;
             'line_width'   => 4,
             'limit'        => 99999,
             'filters'      => [],
-            'rand'         => mt_rand(),
+            'rand'         => random_int(),
         ];
         $p = array_merge($defaults, $params);
         $p['cache_key'] = $p['cache_key'] ?? $p['rand'];
@@ -1652,7 +1652,7 @@ HTML;
             's_criteria' => '',
             'itemtype'   => '',
             'limit'      => $_SESSION['glpilist_limit'],
-            'rand'       => mt_rand(),
+            'rand'       => random_int(),
             'filters'    => [],
         ];
         $p = array_merge($default, $params);
@@ -1731,7 +1731,7 @@ HTML;
             'icon'         => '',
             'limit'        => 99999,
             'class'        => "articles-list",
-            'rand'         => mt_rand(),
+            'rand'         => random_int(),
             'filters'      => [],
         ];
         $p = array_merge($default, $params);

--- a/src/Glpi/Dashboard/Widget.php
+++ b/src/Glpi/Dashboard/Widget.php
@@ -324,7 +324,7 @@ class Widget
             'alt'     => '',
             'color'   => '',
             'icon'    => '',
-            'id'      => 'bn_' . random_int(),
+            'id'      => 'bn_' . random_int(0, 2**32),
             'filters' => [],
         ];
         $p = array_merge($default, $params);
@@ -417,7 +417,7 @@ HTML;
             'use_gradient' => false,
             'class'        => "multiple-numbers",
             'filters'      => [],
-            'rand'         => random_int(),
+            'rand'         => random_int(0, 2**32),
         ];
         $p = array_merge($default, $params);
         $default_entry = [
@@ -568,7 +568,7 @@ HTML;
             'palette'      => '',
             'limit'        => 99999,
             'filters'      => [],
-            'rand'         => random_int(),
+            'rand'         => random_int(0, 2**32),
         ];
         $p = array_merge($default, $params);
         $p['cache_key'] = $p['cache_key'] ?? $p['rand'];
@@ -839,7 +839,7 @@ JAVASCRIPT;
             'icon'        => '',
             'horizontal'  => false,
             'distributed' => true,
-            'rand'        => random_int(),
+            'rand'        => random_int(0, 2**32),
         ];
         $params = array_merge($default, $params);
         $default_entry = [
@@ -1006,7 +1006,7 @@ JAVASCRIPT;
             'point_labels' => false,
             'limit'        => 99999,
             'filters'      => [],
-            'rand'         => random_int(),
+            'rand'         => random_int(0, 2**32),
         ];
         $p = array_merge($defaults, $params);
 
@@ -1395,7 +1395,7 @@ JAVASCRIPT;
             'line_width'   => 4,
             'limit'        => 99999,
             'filters'      => [],
-            'rand'         => random_int(),
+            'rand'         => random_int(0, 2**32),
         ];
         $p = array_merge($defaults, $params);
         $p['cache_key'] = $p['cache_key'] ?? $p['rand'];
@@ -1652,7 +1652,7 @@ HTML;
             's_criteria' => '',
             'itemtype'   => '',
             'limit'      => $_SESSION['glpilist_limit'],
-            'rand'       => random_int(),
+            'rand'       => random_int(0, 2**32),
             'filters'    => [],
         ];
         $p = array_merge($default, $params);
@@ -1731,7 +1731,7 @@ HTML;
             'icon'         => '',
             'limit'        => 99999,
             'class'        => "articles-list",
-            'rand'         => random_int(),
+            'rand'         => random_int(0, 2**32),
             'filters'      => [],
         ];
         $p = array_merge($default, $params);

--- a/src/Glpi/Event.php
+++ b/src/Glpi/Event.php
@@ -208,7 +208,7 @@ class Event extends CommonDBTM
                     break;
 
                 case "infocom":
-                    $rand = random_int(0, 2**32);
+                    $rand = random_int(0, 2 ** 32);
                     echo " <a href='#' data-bs-toggle='modal' data-bs-target='#infocom$rand'>$items_id</a>";
                     Ajax::createIframeModalWindow(
                         'infocom' . $rand,

--- a/src/Glpi/Event.php
+++ b/src/Glpi/Event.php
@@ -208,7 +208,7 @@ class Event extends CommonDBTM
                     break;
 
                 case "infocom":
-                    $rand = random_int();
+                    $rand = random_int(0, 2**32);
                     echo " <a href='#' data-bs-toggle='modal' data-bs-target='#infocom$rand'>$items_id</a>";
                     Ajax::createIframeModalWindow(
                         'infocom' . $rand,

--- a/src/Glpi/Event.php
+++ b/src/Glpi/Event.php
@@ -208,7 +208,7 @@ class Event extends CommonDBTM
                     break;
 
                 case "infocom":
-                    $rand = mt_rand();
+                    $rand = random_int();
                     echo " <a href='#' data-bs-toggle='modal' data-bs-target='#infocom$rand'>$items_id</a>";
                     Ajax::createIframeModalWindow(
                         'infocom' . $rand,

--- a/src/Glpi/Features/PlanningEvent.php
+++ b/src/Glpi/Features/PlanningEvent.php
@@ -672,7 +672,7 @@ trait PlanningEvent
         global $CFG_GLPI;
 
         $html = "";
-        $rand     = random_int(0, 2**32);
+        $rand     = random_int(0, 2 ** 32);
         $users_id = "";  // show users_id reminder
         $img      = "rdv_private.png"; // default icon for reminder
         $item_fk  = getForeignKeyFieldForItemType(static::getType());
@@ -753,7 +753,7 @@ trait PlanningEvent
         $rrule = array_merge($defaults, $rrule);
 
         $default_options = [
-            'rand' => random_int(0, 2**32),
+            'rand' => random_int(0, 2 ** 32),
         ];
         $options = array_merge($default_options, $options);
         $rand    = $options['rand'];
@@ -852,7 +852,7 @@ trait PlanningEvent
         ]) . "</div>";
         $out .= "</div>";
 
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
         $out .= "<div class='field'>";
         $out .= "<label for='showdate$rand'>" . __("Exceptions") . "</label>";
         $out .= "<div>" . Html::showDateField('rrule[exceptions]', [

--- a/src/Glpi/Features/PlanningEvent.php
+++ b/src/Glpi/Features/PlanningEvent.php
@@ -672,7 +672,7 @@ trait PlanningEvent
         global $CFG_GLPI;
 
         $html = "";
-        $rand     = random_int();
+        $rand     = random_int(0, 2**32);
         $users_id = "";  // show users_id reminder
         $img      = "rdv_private.png"; // default icon for reminder
         $item_fk  = getForeignKeyFieldForItemType(static::getType());
@@ -753,7 +753,7 @@ trait PlanningEvent
         $rrule = array_merge($defaults, $rrule);
 
         $default_options = [
-            'rand' => random_int(),
+            'rand' => random_int(0, 2**32),
         ];
         $options = array_merge($default_options, $options);
         $rand    = $options['rand'];
@@ -852,7 +852,7 @@ trait PlanningEvent
         ]) . "</div>";
         $out .= "</div>";
 
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
         $out .= "<div class='field'>";
         $out .= "<label for='showdate$rand'>" . __("Exceptions") . "</label>";
         $out .= "<div>" . Html::showDateField('rrule[exceptions]', [

--- a/src/Glpi/Features/PlanningEvent.php
+++ b/src/Glpi/Features/PlanningEvent.php
@@ -672,7 +672,7 @@ trait PlanningEvent
         global $CFG_GLPI;
 
         $html = "";
-        $rand     = mt_rand();
+        $rand     = random_int();
         $users_id = "";  // show users_id reminder
         $img      = "rdv_private.png"; // default icon for reminder
         $item_fk  = getForeignKeyFieldForItemType(static::getType());
@@ -753,7 +753,7 @@ trait PlanningEvent
         $rrule = array_merge($defaults, $rrule);
 
         $default_options = [
-            'rand' => mt_rand(),
+            'rand' => random_int(),
         ];
         $options = array_merge($default_options, $options);
         $rand    = $options['rand'];
@@ -852,7 +852,7 @@ trait PlanningEvent
         ]) . "</div>";
         $out .= "</div>";
 
-        $rand = mt_rand();
+        $rand = random_int();
         $out .= "<div class='field'>";
         $out .= "<label for='showdate$rand'>" . __("Exceptions") . "</label>";
         $out .= "<div>" . Html::showDateField('rrule[exceptions]', [

--- a/src/Glpi/Inventory/Conf.php
+++ b/src/Glpi/Inventory/Conf.php
@@ -352,7 +352,7 @@ class Conf extends CommonGLPI
 
         $config = \Config::getConfigurationValues('inventory');
         $canedit = \Config::canUpdate();
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
 
         if ($canedit) {
             echo "<form name='form' action='" . $CFG_GLPI['root_doc'] . "/front/inventory.conf.php' method='post'>";

--- a/src/Glpi/Inventory/Conf.php
+++ b/src/Glpi/Inventory/Conf.php
@@ -352,7 +352,7 @@ class Conf extends CommonGLPI
 
         $config = \Config::getConfigurationValues('inventory');
         $canedit = \Config::canUpdate();
-        $rand = mt_rand();
+        $rand = random_int();
 
         if ($canedit) {
             echo "<form name='form' action='" . $CFG_GLPI['root_doc'] . "/front/inventory.conf.php' method='post'>";

--- a/src/Glpi/Inventory/Conf.php
+++ b/src/Glpi/Inventory/Conf.php
@@ -352,7 +352,7 @@ class Conf extends CommonGLPI
 
         $config = \Config::getConfigurationValues('inventory');
         $canedit = \Config::canUpdate();
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
 
         if ($canedit) {
             echo "<form name='form' action='" . $CFG_GLPI['root_doc'] . "/front/inventory.conf.php' method='post'>";

--- a/src/Glpi/Marketplace/Controller.php
+++ b/src/Glpi/Marketplace/Controller.php
@@ -286,7 +286,7 @@ class Controller extends CommonGLPI
 
         $url      = $plugin['installation_url'];
         $filename = basename(parse_url($url, PHP_URL_PATH));
-        $dest     = GLPI_TMP_DIR . '/' . random_int() . '.' . $filename;
+        $dest     = GLPI_TMP_DIR . '/' . random_int(0, 2**32) . '.' . $filename;
 
         if (!$api->downloadArchive($url, $dest, $this->plugin_key, false)) {
             $exception = new HttpException(500);

--- a/src/Glpi/Marketplace/Controller.php
+++ b/src/Glpi/Marketplace/Controller.php
@@ -286,7 +286,7 @@ class Controller extends CommonGLPI
 
         $url      = $plugin['installation_url'];
         $filename = basename(parse_url($url, PHP_URL_PATH));
-        $dest     = GLPI_TMP_DIR . '/' . mt_rand() . '.' . $filename;
+        $dest     = GLPI_TMP_DIR . '/' . random_int() . '.' . $filename;
 
         if (!$api->downloadArchive($url, $dest, $this->plugin_key, false)) {
             $exception = new HttpException(500);

--- a/src/Glpi/Marketplace/Controller.php
+++ b/src/Glpi/Marketplace/Controller.php
@@ -286,7 +286,7 @@ class Controller extends CommonGLPI
 
         $url      = $plugin['installation_url'];
         $filename = basename(parse_url($url, PHP_URL_PATH));
-        $dest     = GLPI_TMP_DIR . '/' . random_int(0, 2**32) . '.' . $filename;
+        $dest     = GLPI_TMP_DIR . '/' . random_int(0, 2 ** 32) . '.' . $filename;
 
         if (!$api->downloadArchive($url, $dest, $this->plugin_key, false)) {
             $exception = new HttpException(500);

--- a/src/Glpi/Marketplace/View.php
+++ b/src/Glpi/Marketplace/View.php
@@ -730,7 +730,7 @@ HTML;
         $buttons = "";
 
         if (strlen($error)) {
-            $rand = mt_rand();
+            $rand = random_int();
             $buttons .= "<i class='ti ti-alert-triangle plugin-error' id='plugin-error-$rand'></i>";
             Html::showToolTip($error, [
                 'applyto' => "plugin-error-$rand",
@@ -754,7 +754,7 @@ HTML;
             }
         } else if (!$is_available) {
             if (!$can_run_local_install) {
-                $rand = mt_rand();
+                $rand = random_int();
                 $buttons .= "<i class='ti ti-alert-triangle plugin-unavailable' id='plugin-tooltip-$rand'></i>";
                 Html::showToolTip(
                     __('This plugin is not available for your GLPI version.'),

--- a/src/Glpi/Marketplace/View.php
+++ b/src/Glpi/Marketplace/View.php
@@ -730,7 +730,7 @@ HTML;
         $buttons = "";
 
         if (strlen($error)) {
-            $rand = random_int(0, 2**32);
+            $rand = random_int(0, 2 ** 32);
             $buttons .= "<i class='ti ti-alert-triangle plugin-error' id='plugin-error-$rand'></i>";
             Html::showToolTip($error, [
                 'applyto' => "plugin-error-$rand",
@@ -754,7 +754,7 @@ HTML;
             }
         } else if (!$is_available) {
             if (!$can_run_local_install) {
-                $rand = random_int(0, 2**32);
+                $rand = random_int(0, 2 ** 32);
                 $buttons .= "<i class='ti ti-alert-triangle plugin-unavailable' id='plugin-tooltip-$rand'></i>";
                 Html::showToolTip(
                     __('This plugin is not available for your GLPI version.'),

--- a/src/Glpi/Marketplace/View.php
+++ b/src/Glpi/Marketplace/View.php
@@ -730,7 +730,7 @@ HTML;
         $buttons = "";
 
         if (strlen($error)) {
-            $rand = random_int();
+            $rand = random_int(0, 2**32);
             $buttons .= "<i class='ti ti-alert-triangle plugin-error' id='plugin-error-$rand'></i>";
             Html::showToolTip($error, [
                 'applyto' => "plugin-error-$rand",
@@ -754,7 +754,7 @@ HTML;
             }
         } else if (!$is_available) {
             if (!$can_run_local_install) {
-                $rand = random_int();
+                $rand = random_int(0, 2**32);
                 $buttons .= "<i class='ti ti-alert-triangle plugin-unavailable' id='plugin-tooltip-$rand'></i>";
                 Html::showToolTip(
                     __('This plugin is not available for your GLPI version.'),

--- a/src/Glpi/RichText/RichText.php
+++ b/src/Glpi/RichText/RichText.php
@@ -433,7 +433,7 @@ HTML;
                 'close'        => true,
                 'zoom'         => true,
             ],
-            'rand'               => mt_rand(),
+            'rand'               => random_int(),
             'gallery_item_class' => ''
         ];
 

--- a/src/Glpi/RichText/RichText.php
+++ b/src/Glpi/RichText/RichText.php
@@ -433,7 +433,7 @@ HTML;
                 'close'        => true,
                 'zoom'         => true,
             ],
-            'rand'               => random_int(),
+            'rand'               => random_int(0, 2**32),
             'gallery_item_class' => ''
         ];
 

--- a/src/Glpi/RichText/RichText.php
+++ b/src/Glpi/RichText/RichText.php
@@ -433,7 +433,7 @@ HTML;
                 'close'        => true,
                 'zoom'         => true,
             ],
-            'rand'               => random_int(0, 2**32),
+            'rand'               => random_int(0, 2 ** 32),
             'gallery_item_class' => ''
         ];
 

--- a/src/Glpi/Search/Input/QueryBuilder.php
+++ b/src/Glpi/Search/Input/QueryBuilder.php
@@ -399,7 +399,7 @@ final class QueryBuilder implements SearchInputInterface
         }
 
         $options     = \Search::getCleanedOptions($request["itemtype"]);
-        $randrow     = random_int(0, 2**32);
+        $randrow     = random_int(0, 2 ** 32);
         $normalized_itemtype = Toolbox::getNormalizedItemtype($request["itemtype"]);
         $rowid       = 'searchrow' . $normalized_itemtype . $randrow;
         $prefix      = isset($p['prefix_crit']) ? htmlescape($p['prefix_crit']) : '';
@@ -516,7 +516,7 @@ final class QueryBuilder implements SearchInputInterface
         }
 
         $linked =  SearchEngine::getMetaItemtypeAvailable($itemtype);
-        $rand   = random_int(0, 2**32);
+        $rand   = random_int(0, 2 ** 32);
 
         $rowid  = 'metasearchrow' . Toolbox::getNormalizedItemtype($request['itemtype']) . $rand;
         TemplateRenderer::getInstance()->display('components/search/query_builder/metacriteria.html.twig', [
@@ -565,7 +565,7 @@ final class QueryBuilder implements SearchInputInterface
             'order'      => $orders[$num] ?? 'ASC',
         ];
 
-        $randrow     = random_int(0, 2**32);
+        $randrow     = random_int(0, 2 ** 32);
         $normalized_itemtype = Toolbox::getNormalizedItemtype($request["itemtype"]);
         $rowid       = 'orderrow' . $normalized_itemtype . $randrow;
 
@@ -612,7 +612,7 @@ final class QueryBuilder implements SearchInputInterface
 
         $num         = (int) $request['num'];
         $p           = $request['p'];
-        $randrow     = random_int(0, 2**32);
+        $randrow     = random_int(0, 2 ** 32);
         $rowid       = 'searchrow' . Toolbox::getNormalizedItemtype($request['itemtype']) . $randrow;
         $prefix      = isset($p['prefix_crit']) ? htmlescape($p['prefix_crit']) : '';
         $parents_num = isset($p['parents_num']) ? $p['parents_num'] : [];

--- a/src/Glpi/Search/Input/QueryBuilder.php
+++ b/src/Glpi/Search/Input/QueryBuilder.php
@@ -399,7 +399,7 @@ final class QueryBuilder implements SearchInputInterface
         }
 
         $options     = \Search::getCleanedOptions($request["itemtype"]);
-        $randrow     = random_int();
+        $randrow     = random_int(0, 2**32);
         $normalized_itemtype = Toolbox::getNormalizedItemtype($request["itemtype"]);
         $rowid       = 'searchrow' . $normalized_itemtype . $randrow;
         $prefix      = isset($p['prefix_crit']) ? htmlescape($p['prefix_crit']) : '';
@@ -516,7 +516,7 @@ final class QueryBuilder implements SearchInputInterface
         }
 
         $linked =  SearchEngine::getMetaItemtypeAvailable($itemtype);
-        $rand   = random_int();
+        $rand   = random_int(0, 2**32);
 
         $rowid  = 'metasearchrow' . Toolbox::getNormalizedItemtype($request['itemtype']) . $rand;
         TemplateRenderer::getInstance()->display('components/search/query_builder/metacriteria.html.twig', [
@@ -565,7 +565,7 @@ final class QueryBuilder implements SearchInputInterface
             'order'      => $orders[$num] ?? 'ASC',
         ];
 
-        $randrow     = random_int();
+        $randrow     = random_int(0, 2**32);
         $normalized_itemtype = Toolbox::getNormalizedItemtype($request["itemtype"]);
         $rowid       = 'orderrow' . $normalized_itemtype . $randrow;
 
@@ -612,7 +612,7 @@ final class QueryBuilder implements SearchInputInterface
 
         $num         = (int) $request['num'];
         $p           = $request['p'];
-        $randrow     = random_int();
+        $randrow     = random_int(0, 2**32);
         $rowid       = 'searchrow' . Toolbox::getNormalizedItemtype($request['itemtype']) . $randrow;
         $prefix      = isset($p['prefix_crit']) ? htmlescape($p['prefix_crit']) : '';
         $parents_num = isset($p['parents_num']) ? $p['parents_num'] : [];

--- a/src/Glpi/Search/Input/QueryBuilder.php
+++ b/src/Glpi/Search/Input/QueryBuilder.php
@@ -399,7 +399,7 @@ final class QueryBuilder implements SearchInputInterface
         }
 
         $options     = \Search::getCleanedOptions($request["itemtype"]);
-        $randrow     = mt_rand();
+        $randrow     = random_int();
         $normalized_itemtype = Toolbox::getNormalizedItemtype($request["itemtype"]);
         $rowid       = 'searchrow' . $normalized_itemtype . $randrow;
         $prefix      = isset($p['prefix_crit']) ? htmlescape($p['prefix_crit']) : '';
@@ -516,7 +516,7 @@ final class QueryBuilder implements SearchInputInterface
         }
 
         $linked =  SearchEngine::getMetaItemtypeAvailable($itemtype);
-        $rand   = mt_rand();
+        $rand   = random_int();
 
         $rowid  = 'metasearchrow' . Toolbox::getNormalizedItemtype($request['itemtype']) . $rand;
         TemplateRenderer::getInstance()->display('components/search/query_builder/metacriteria.html.twig', [
@@ -565,7 +565,7 @@ final class QueryBuilder implements SearchInputInterface
             'order'      => $orders[$num] ?? 'ASC',
         ];
 
-        $randrow     = mt_rand();
+        $randrow     = random_int();
         $normalized_itemtype = Toolbox::getNormalizedItemtype($request["itemtype"]);
         $rowid       = 'orderrow' . $normalized_itemtype . $randrow;
 
@@ -612,7 +612,7 @@ final class QueryBuilder implements SearchInputInterface
 
         $num         = (int) $request['num'];
         $p           = $request['p'];
-        $randrow     = mt_rand();
+        $randrow     = random_int();
         $rowid       = 'searchrow' . Toolbox::getNormalizedItemtype($request['itemtype']) . $randrow;
         $prefix      = isset($p['prefix_crit']) ? htmlescape($p['prefix_crit']) : '';
         $parents_num = isset($p['parents_num']) ? $p['parents_num'] : [];

--- a/src/Glpi/Search/Output/HTMLSearchOutput.php
+++ b/src/Glpi/Search/Output/HTMLSearchOutput.php
@@ -189,7 +189,7 @@ abstract class HTMLSearchOutput extends AbstractSearchOutput
             $active_sort = true;
         }
 
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
         TemplateRenderer::getInstance()->display('components/search/display_data.html.twig', [
             'search_error'        => $search_error,
             'search_was_executed' => $search_was_executed,

--- a/src/Glpi/Search/Output/HTMLSearchOutput.php
+++ b/src/Glpi/Search/Output/HTMLSearchOutput.php
@@ -189,7 +189,7 @@ abstract class HTMLSearchOutput extends AbstractSearchOutput
             $active_sort = true;
         }
 
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
         TemplateRenderer::getInstance()->display('components/search/display_data.html.twig', [
             'search_error'        => $search_error,
             'search_was_executed' => $search_was_executed,

--- a/src/Glpi/Search/Output/HTMLSearchOutput.php
+++ b/src/Glpi/Search/Output/HTMLSearchOutput.php
@@ -189,7 +189,7 @@ abstract class HTMLSearchOutput extends AbstractSearchOutput
             $active_sort = true;
         }
 
-        $rand = mt_rand();
+        $rand = random_int();
         TemplateRenderer::getInstance()->display('components/search/display_data.html.twig', [
             'search_error'        => $search_error,
             'search_was_executed' => $search_was_executed,

--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -6084,7 +6084,7 @@ final class SQLProvider implements SearchProviderInterface
                             }
 
                             if ($html_output && (\Toolbox::strlen($plaintext) > $CFG_GLPI['cut'])) {
-                                $rand = mt_rand();
+                                $rand = random_int();
                                 $popup_params = [
                                     'display'       => false,
                                     'awesome-class' => 'fa-comments',

--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -6084,7 +6084,7 @@ final class SQLProvider implements SearchProviderInterface
                             }
 
                             if ($html_output && (\Toolbox::strlen($plaintext) > $CFG_GLPI['cut'])) {
-                                $rand = random_int();
+                                $rand = random_int(0, 2**32);
                                 $popup_params = [
                                     'display'       => false,
                                     'awesome-class' => 'fa-comments',

--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -6084,7 +6084,7 @@ final class SQLProvider implements SearchProviderInterface
                             }
 
                             if ($html_output && (\Toolbox::strlen($plaintext) > $CFG_GLPI['cut'])) {
-                                $rand = random_int(0, 2**32);
+                                $rand = random_int(0, 2 ** 32);
                                 $popup_params = [
                                     'display'       => false,
                                     'awesome-class' => 'fa-comments',

--- a/src/Glpi/Socket.php
+++ b/src/Glpi/Socket.php
@@ -652,7 +652,7 @@ class Socket extends CommonDBChild
         if ($item->isNewID($item->getID())) {
             return false;
         }
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
 
        // Link to open a new socket
         if ($item->getID() && self::canCreate()) {
@@ -810,7 +810,7 @@ class Socket extends CommonDBChild
         if ($order === '') {
             $order = 'ASC';
         }
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
         $number = countElementsInTable('glpi_sockets', ['locations_id' => $ID]);
         $socket_form_url = self::getFormURL();
 

--- a/src/Glpi/Socket.php
+++ b/src/Glpi/Socket.php
@@ -652,7 +652,7 @@ class Socket extends CommonDBChild
         if ($item->isNewID($item->getID())) {
             return false;
         }
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
 
        // Link to open a new socket
         if ($item->getID() && self::canCreate()) {
@@ -810,7 +810,7 @@ class Socket extends CommonDBChild
         if ($order === '') {
             $order = 'ASC';
         }
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
         $number = countElementsInTable('glpi_sockets', ['locations_id' => $ID]);
         $socket_form_url = self::getFormURL();
 

--- a/src/Glpi/Socket.php
+++ b/src/Glpi/Socket.php
@@ -652,7 +652,7 @@ class Socket extends CommonDBChild
         if ($item->isNewID($item->getID())) {
             return false;
         }
-        $rand = mt_rand();
+        $rand = random_int();
 
        // Link to open a new socket
         if ($item->getID() && self::canCreate()) {
@@ -810,7 +810,7 @@ class Socket extends CommonDBChild
         if ($order === '') {
             $order = 'ASC';
         }
-        $rand = mt_rand();
+        $rand = random_int();
         $number = countElementsInTable('glpi_sockets', ['locations_id' => $ID]);
         $socket_form_url = self::getFormURL();
 

--- a/src/Group.php
+++ b/src/Group.php
@@ -681,7 +681,7 @@ class Group extends CommonTreeDropdown
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
 
         $ID = $this->fields['id'];
 

--- a/src/Group.php
+++ b/src/Group.php
@@ -681,7 +681,7 @@ class Group extends CommonTreeDropdown
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
 
         $ID = $this->fields['id'];
 

--- a/src/Group.php
+++ b/src/Group.php
@@ -681,7 +681,7 @@ class Group extends CommonTreeDropdown
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $rand = mt_rand();
+        $rand = random_int();
 
         $ID = $this->fields['id'];
 

--- a/src/Group_User.php
+++ b/src/Group_User.php
@@ -169,7 +169,7 @@ class Group_User extends CommonDBRelation
 
         $canedit = $user->can($ID, UPDATE);
 
-        $rand    = random_int();
+        $rand    = random_int(0, 2**32);
 
         $iterator = self::getListForItem($user);
         $groups = [];
@@ -399,7 +399,7 @@ class Group_User extends CommonDBRelation
 
        // Have right to manage members
         $canedit = self::canUpdate();
-        $rand    = random_int();
+        $rand    = random_int(0, 2**32);
         $user    = new User();
         $used    = [];
         $ids     = [];

--- a/src/Group_User.php
+++ b/src/Group_User.php
@@ -169,7 +169,7 @@ class Group_User extends CommonDBRelation
 
         $canedit = $user->can($ID, UPDATE);
 
-        $rand    = random_int(0, 2**32);
+        $rand    = random_int(0, 2 ** 32);
 
         $iterator = self::getListForItem($user);
         $groups = [];
@@ -399,7 +399,7 @@ class Group_User extends CommonDBRelation
 
        // Have right to manage members
         $canedit = self::canUpdate();
-        $rand    = random_int(0, 2**32);
+        $rand    = random_int(0, 2 ** 32);
         $user    = new User();
         $used    = [];
         $ids     = [];

--- a/src/Group_User.php
+++ b/src/Group_User.php
@@ -169,7 +169,7 @@ class Group_User extends CommonDBRelation
 
         $canedit = $user->can($ID, UPDATE);
 
-        $rand    = mt_rand();
+        $rand    = random_int();
 
         $iterator = self::getListForItem($user);
         $groups = [];
@@ -399,7 +399,7 @@ class Group_User extends CommonDBRelation
 
        // Have right to manage members
         $canedit = self::canUpdate();
-        $rand    = mt_rand();
+        $rand    = random_int();
         $user    = new User();
         $used    = [];
         $ids     = [];

--- a/src/HTMLTableEntity.php
+++ b/src/HTMLTableEntity.php
@@ -156,7 +156,7 @@ abstract class HTMLTableEntity
             foreach ($this->content as $content) {
                 if (is_string($content)) {
                    // Manage __RAND__ to be computed on display
-                    $content = str_replace('__RAND__', mt_rand(), $content);
+                    $content = str_replace('__RAND__', random_int(), $content);
                     echo $content;
                 } else if (isset($content['function'])) {
                     $parameters = $content['parameters'] ?? [];
@@ -166,7 +166,7 @@ abstract class HTMLTableEntity
         } else {
             // Manage __RAND__ to be computed on display
             $content = $this->content ?? '';
-            $content = str_replace('__RAND__', mt_rand(), $content);
+            $content = str_replace('__RAND__', random_int(), $content);
             echo $content;
         }
     }

--- a/src/HTMLTableEntity.php
+++ b/src/HTMLTableEntity.php
@@ -156,7 +156,7 @@ abstract class HTMLTableEntity
             foreach ($this->content as $content) {
                 if (is_string($content)) {
                    // Manage __RAND__ to be computed on display
-                    $content = str_replace('__RAND__', random_int(0, 2**32), $content);
+                    $content = str_replace('__RAND__', random_int(0, 2 ** 32), $content);
                     echo $content;
                 } else if (isset($content['function'])) {
                     $parameters = $content['parameters'] ?? [];
@@ -166,7 +166,7 @@ abstract class HTMLTableEntity
         } else {
             // Manage __RAND__ to be computed on display
             $content = $this->content ?? '';
-            $content = str_replace('__RAND__', random_int(0, 2**32), $content);
+            $content = str_replace('__RAND__', random_int(0, 2 ** 32), $content);
             echo $content;
         }
     }

--- a/src/HTMLTableEntity.php
+++ b/src/HTMLTableEntity.php
@@ -156,7 +156,7 @@ abstract class HTMLTableEntity
             foreach ($this->content as $content) {
                 if (is_string($content)) {
                    // Manage __RAND__ to be computed on display
-                    $content = str_replace('__RAND__', random_int(), $content);
+                    $content = str_replace('__RAND__', random_int(0, 2**32), $content);
                     echo $content;
                 } else if (isset($content['function'])) {
                     $parameters = $content['parameters'] ?? [];
@@ -166,7 +166,7 @@ abstract class HTMLTableEntity
         } else {
             // Manage __RAND__ to be computed on display
             $content = $this->content ?? '';
-            $content = str_replace('__RAND__', random_int(), $content);
+            $content = str_replace('__RAND__', random_int(0, 2**32), $content);
             echo $content;
         }
     }

--- a/src/Html.php
+++ b/src/Html.php
@@ -2141,7 +2141,7 @@ HTML;
     {
 
         if (empty($rand)) {
-            $rand = random_int();
+            $rand = random_int(0, 2**32);
         }
 
         $out  = "<input title='" . __s('Check all as') . "' type='checkbox' class='form-check-input massive_action_checkbox'
@@ -2238,7 +2238,7 @@ HTML;
         $params                    = [];
         $params['title']           = '';
         $params['name']            = '';
-        $params['rand']            = random_int();
+        $params['rand']            = random_int(0, 2**32);
         $params['id']              = "check_" . $params['rand'];
         $params['value']           = 1;
         $params['readonly']        = false;
@@ -2405,7 +2405,7 @@ HTML;
         global $CFG_GLPI;
 
         if (empty($name)) {
-            $name = 'massaction_' . random_int();
+            $name = 'massaction_' . random_int(0, 2**32);
         }
         return  "<form name='$name' id='$name' method='post'
                action='" . $CFG_GLPI["root_doc"] . "/front/massiveaction.php'
@@ -2638,7 +2638,7 @@ HTML;
             'showyear'     => false,
             'display'      => true,
             'range'        => false,
-            'rand'         => random_int(),
+            'rand'         => random_int(0, 2**32),
             'calendar_btn' => true,
             'clear_btn'    => true,
             'yearrange'    => '',
@@ -2759,7 +2759,7 @@ JS;
     public static function showColorField($name, $options = [])
     {
         $p['value']      = '';
-        $p['rand']       = random_int();
+        $p['rand']       = random_int(0, 2**32);
         $p['display']    = true;
         foreach ($options as $key => $val) {
             if (isset($p[$key])) {
@@ -2816,7 +2816,7 @@ JS;
             'timestep'   => -1,
             'showyear'   => true,
             'display'    => true,
-            'rand'       => random_int(),
+            'rand'       => random_int(0, 2**32),
             'required'   => false,
             'on_change'  => '',
         ];
@@ -2956,7 +2956,7 @@ JS;
                 $p[$key] = $val;
             }
         }
-        $rand   = random_int();
+        $rand   = random_int(0, 2**32);
         $output = '';
        // Validate value
         if (
@@ -3394,7 +3394,7 @@ JS;
         if (empty($content)) {
             $content = "&nbsp;";
         }
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
         $out  = '';
 
        // Force link for popup
@@ -3863,7 +3863,7 @@ JAVASCRIPT
         string $selector,
         string $preset_target
     ) {
-        $link_id = "template_documentation_" . random_int();
+        $link_id = "template_documentation_" . random_int(0, 2**32);
         self::addTemplateDocumentationLink($preset_target, $link_id);
 
        // Move link before the given textarea
@@ -3996,7 +3996,7 @@ JAVASCRIPT
                 echo $key;
                 echo "</td><td>";
                 $is_array = is_array($val);
-                $rand     = random_int();
+                $rand     = random_int(0, 2**32);
                 if ($jsexpand && $is_array) {
                     echo "<a href=\"javascript:showHideDiv('content$key$rand','','','')\">";
                     echo "=></a>";
@@ -4935,7 +4935,7 @@ JS;
     public static function progress($max, $value, $params = [])
     {
         $p = [
-            'rand'            => random_int(),
+            'rand'            => random_int(0, 2**32),
             'tooltip'         => '',
             'append_percent'  => true
         ];
@@ -5189,7 +5189,7 @@ HTML;
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $randupload             = random_int();
+        $randupload             = random_int(0, 2**32);
 
         $p['name']                = 'filename';
         $p['onlyimages']          = false;
@@ -5388,7 +5388,7 @@ HTML;
        //default options
         $p['name']              = 'text';
         $p['filecontainer']     = 'fileupload_info';
-        $p['rand']              = random_int();
+        $p['rand']              = random_int(0, 2**32);
         $p['editor_id']         = 'text' . $p['rand'];
         $p['value']             = '';
         $p['enable_richtext']   = false;
@@ -5481,7 +5481,7 @@ HTML;
                 // Rebuild the minimal data to show the already uploaded files
                 $upload = [
                     'name'    => $upload,
-                    'id'      => 'doc' . $p['name'] . random_int(),
+                    'id'      => 'doc' . $p['name'] . random_int(0, 2**32),
                     'display' => $displayName,
                     'size'    => filesize(GLPI_TMP_DIR . '/' . $upload),
                     'prefix'  => $prefix,
@@ -5560,7 +5560,7 @@ HTML;
         $param['first_cell']           = '&nbsp;';
         $param['row_check_all']        = false;
         $param['col_check_all']        = false;
-        $param['rand']                 = random_int();
+        $param['rand']                 = random_int(0, 2**32);
 
         if (is_array($options) && count($options)) {
             foreach ($options as $key => $val) {

--- a/src/Html.php
+++ b/src/Html.php
@@ -2141,7 +2141,7 @@ HTML;
     {
 
         if (empty($rand)) {
-            $rand = random_int(0, 2**32);
+            $rand = random_int(0, 2 ** 32);
         }
 
         $out  = "<input title='" . __s('Check all as') . "' type='checkbox' class='form-check-input massive_action_checkbox'
@@ -2238,7 +2238,7 @@ HTML;
         $params                    = [];
         $params['title']           = '';
         $params['name']            = '';
-        $params['rand']            = random_int(0, 2**32);
+        $params['rand']            = random_int(0, 2 ** 32);
         $params['id']              = "check_" . $params['rand'];
         $params['value']           = 1;
         $params['readonly']        = false;
@@ -2405,7 +2405,7 @@ HTML;
         global $CFG_GLPI;
 
         if (empty($name)) {
-            $name = 'massaction_' . random_int(0, 2**32);
+            $name = 'massaction_' . random_int(0, 2 ** 32);
         }
         return  "<form name='$name' id='$name' method='post'
                action='" . $CFG_GLPI["root_doc"] . "/front/massiveaction.php'
@@ -2638,7 +2638,7 @@ HTML;
             'showyear'     => false,
             'display'      => true,
             'range'        => false,
-            'rand'         => random_int(0, 2**32),
+            'rand'         => random_int(0, 2 ** 32),
             'calendar_btn' => true,
             'clear_btn'    => true,
             'yearrange'    => '',
@@ -2759,7 +2759,7 @@ JS;
     public static function showColorField($name, $options = [])
     {
         $p['value']      = '';
-        $p['rand']       = random_int(0, 2**32);
+        $p['rand']       = random_int(0, 2 ** 32);
         $p['display']    = true;
         foreach ($options as $key => $val) {
             if (isset($p[$key])) {
@@ -2816,7 +2816,7 @@ JS;
             'timestep'   => -1,
             'showyear'   => true,
             'display'    => true,
-            'rand'       => random_int(0, 2**32),
+            'rand'       => random_int(0, 2 ** 32),
             'required'   => false,
             'on_change'  => '',
         ];
@@ -2956,7 +2956,7 @@ JS;
                 $p[$key] = $val;
             }
         }
-        $rand   = random_int(0, 2**32);
+        $rand   = random_int(0, 2 ** 32);
         $output = '';
        // Validate value
         if (
@@ -3394,7 +3394,7 @@ JS;
         if (empty($content)) {
             $content = "&nbsp;";
         }
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
         $out  = '';
 
        // Force link for popup
@@ -3863,7 +3863,7 @@ JAVASCRIPT
         string $selector,
         string $preset_target
     ) {
-        $link_id = "template_documentation_" . random_int(0, 2**32);
+        $link_id = "template_documentation_" . random_int(0, 2 ** 32);
         self::addTemplateDocumentationLink($preset_target, $link_id);
 
        // Move link before the given textarea
@@ -3996,7 +3996,7 @@ JAVASCRIPT
                 echo $key;
                 echo "</td><td>";
                 $is_array = is_array($val);
-                $rand     = random_int(0, 2**32);
+                $rand     = random_int(0, 2 ** 32);
                 if ($jsexpand && $is_array) {
                     echo "<a href=\"javascript:showHideDiv('content$key$rand','','','')\">";
                     echo "=></a>";
@@ -4935,7 +4935,7 @@ JS;
     public static function progress($max, $value, $params = [])
     {
         $p = [
-            'rand'            => random_int(0, 2**32),
+            'rand'            => random_int(0, 2 ** 32),
             'tooltip'         => '',
             'append_percent'  => true
         ];
@@ -5189,7 +5189,7 @@ HTML;
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $randupload             = random_int(0, 2**32);
+        $randupload             = random_int(0, 2 ** 32);
 
         $p['name']                = 'filename';
         $p['onlyimages']          = false;
@@ -5388,7 +5388,7 @@ HTML;
        //default options
         $p['name']              = 'text';
         $p['filecontainer']     = 'fileupload_info';
-        $p['rand']              = random_int(0, 2**32);
+        $p['rand']              = random_int(0, 2 ** 32);
         $p['editor_id']         = 'text' . $p['rand'];
         $p['value']             = '';
         $p['enable_richtext']   = false;
@@ -5481,7 +5481,7 @@ HTML;
                 // Rebuild the minimal data to show the already uploaded files
                 $upload = [
                     'name'    => $upload,
-                    'id'      => 'doc' . $p['name'] . random_int(0, 2**32),
+                    'id'      => 'doc' . $p['name'] . random_int(0, 2 ** 32),
                     'display' => $displayName,
                     'size'    => filesize(GLPI_TMP_DIR . '/' . $upload),
                     'prefix'  => $prefix,
@@ -5560,7 +5560,7 @@ HTML;
         $param['first_cell']           = '&nbsp;';
         $param['row_check_all']        = false;
         $param['col_check_all']        = false;
-        $param['rand']                 = random_int(0, 2**32);
+        $param['rand']                 = random_int(0, 2 ** 32);
 
         if (is_array($options) && count($options)) {
             foreach ($options as $key => $val) {

--- a/src/Html.php
+++ b/src/Html.php
@@ -2141,7 +2141,7 @@ HTML;
     {
 
         if (empty($rand)) {
-            $rand = mt_rand();
+            $rand = random_int();
         }
 
         $out  = "<input title='" . __s('Check all as') . "' type='checkbox' class='form-check-input massive_action_checkbox'
@@ -2238,7 +2238,7 @@ HTML;
         $params                    = [];
         $params['title']           = '';
         $params['name']            = '';
-        $params['rand']            = mt_rand();
+        $params['rand']            = random_int();
         $params['id']              = "check_" . $params['rand'];
         $params['value']           = 1;
         $params['readonly']        = false;
@@ -2405,7 +2405,7 @@ HTML;
         global $CFG_GLPI;
 
         if (empty($name)) {
-            $name = 'massaction_' . mt_rand();
+            $name = 'massaction_' . random_int();
         }
         return  "<form name='$name' id='$name' method='post'
                action='" . $CFG_GLPI["root_doc"] . "/front/massiveaction.php'
@@ -2638,7 +2638,7 @@ HTML;
             'showyear'     => false,
             'display'      => true,
             'range'        => false,
-            'rand'         => mt_rand(),
+            'rand'         => random_int(),
             'calendar_btn' => true,
             'clear_btn'    => true,
             'yearrange'    => '',
@@ -2759,7 +2759,7 @@ JS;
     public static function showColorField($name, $options = [])
     {
         $p['value']      = '';
-        $p['rand']       = mt_rand();
+        $p['rand']       = random_int();
         $p['display']    = true;
         foreach ($options as $key => $val) {
             if (isset($p[$key])) {
@@ -2816,7 +2816,7 @@ JS;
             'timestep'   => -1,
             'showyear'   => true,
             'display'    => true,
-            'rand'       => mt_rand(),
+            'rand'       => random_int(),
             'required'   => false,
             'on_change'  => '',
         ];
@@ -2956,7 +2956,7 @@ JS;
                 $p[$key] = $val;
             }
         }
-        $rand   = mt_rand();
+        $rand   = random_int();
         $output = '';
        // Validate value
         if (
@@ -3394,7 +3394,7 @@ JS;
         if (empty($content)) {
             $content = "&nbsp;";
         }
-        $rand = mt_rand();
+        $rand = random_int();
         $out  = '';
 
        // Force link for popup
@@ -3863,7 +3863,7 @@ JAVASCRIPT
         string $selector,
         string $preset_target
     ) {
-        $link_id = "template_documentation_" . mt_rand();
+        $link_id = "template_documentation_" . random_int();
         self::addTemplateDocumentationLink($preset_target, $link_id);
 
        // Move link before the given textarea
@@ -3996,7 +3996,7 @@ JAVASCRIPT
                 echo $key;
                 echo "</td><td>";
                 $is_array = is_array($val);
-                $rand     = mt_rand();
+                $rand     = random_int();
                 if ($jsexpand && $is_array) {
                     echo "<a href=\"javascript:showHideDiv('content$key$rand','','','')\">";
                     echo "=></a>";
@@ -4935,7 +4935,7 @@ JS;
     public static function progress($max, $value, $params = [])
     {
         $p = [
-            'rand'            => mt_rand(),
+            'rand'            => random_int(),
             'tooltip'         => '',
             'append_percent'  => true
         ];
@@ -5189,7 +5189,7 @@ HTML;
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $randupload             = mt_rand();
+        $randupload             = random_int();
 
         $p['name']                = 'filename';
         $p['onlyimages']          = false;
@@ -5388,7 +5388,7 @@ HTML;
        //default options
         $p['name']              = 'text';
         $p['filecontainer']     = 'fileupload_info';
-        $p['rand']              = mt_rand();
+        $p['rand']              = random_int();
         $p['editor_id']         = 'text' . $p['rand'];
         $p['value']             = '';
         $p['enable_richtext']   = false;
@@ -5481,7 +5481,7 @@ HTML;
                 // Rebuild the minimal data to show the already uploaded files
                 $upload = [
                     'name'    => $upload,
-                    'id'      => 'doc' . $p['name'] . mt_rand(),
+                    'id'      => 'doc' . $p['name'] . random_int(),
                     'display' => $displayName,
                     'size'    => filesize(GLPI_TMP_DIR . '/' . $upload),
                     'prefix'  => $prefix,
@@ -5560,7 +5560,7 @@ HTML;
         $param['first_cell']           = '&nbsp;';
         $param['row_check_all']        = false;
         $param['col_check_all']        = false;
-        $param['rand']                 = mt_rand();
+        $param['rand']                 = random_int();
 
         if (is_array($options) && count($options)) {
             foreach ($options as $key => $val) {

--- a/src/IPAddress.php
+++ b/src/IPAddress.php
@@ -239,7 +239,7 @@ class IPAddress extends CommonDBChild
             return;
         }
 
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
         $start       = (int) ($_GET["start"] ?? 0);
         $sort        = $_GET["sort"] ?? "";
         $order       = strtoupper($_GET["order"] ?? "");

--- a/src/IPAddress.php
+++ b/src/IPAddress.php
@@ -239,7 +239,7 @@ class IPAddress extends CommonDBChild
             return;
         }
 
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
         $start       = (int) ($_GET["start"] ?? 0);
         $sort        = $_GET["sort"] ?? "";
         $order       = strtoupper($_GET["order"] ?? "");

--- a/src/IPAddress.php
+++ b/src/IPAddress.php
@@ -239,7 +239,7 @@ class IPAddress extends CommonDBChild
             return;
         }
 
-        $rand = mt_rand();
+        $rand = random_int();
         $start       = (int) ($_GET["start"] ?? 0);
         $sort        = $_GET["sort"] ?? "";
         $order       = strtoupper($_GET["order"] ?? "");

--- a/src/IPNetwork.php
+++ b/src/IPNetwork.php
@@ -1149,7 +1149,7 @@ class IPNetwork extends CommonImplicitTreeDropdown
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $rand = mt_rand();
+        $rand = random_int();
         self::dropdown(['entity' => $entities_id,
             'rand'   => $rand,
             'value' => $value

--- a/src/IPNetwork.php
+++ b/src/IPNetwork.php
@@ -1149,7 +1149,7 @@ class IPNetwork extends CommonImplicitTreeDropdown
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
         self::dropdown(['entity' => $entities_id,
             'rand'   => $rand,
             'value' => $value

--- a/src/IPNetwork.php
+++ b/src/IPNetwork.php
@@ -1149,7 +1149,7 @@ class IPNetwork extends CommonImplicitTreeDropdown
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
         self::dropdown(['entity' => $entities_id,
             'rand'   => $rand,
             'value' => $value

--- a/src/IPNetwork_Vlan.php
+++ b/src/IPNetwork_Vlan.php
@@ -104,7 +104,7 @@ class IPNetwork_Vlan extends CommonDBRelation
         }
 
         $canedit = $port->canEdit($ID);
-        $rand    = random_int();
+        $rand    = random_int(0, 2**32);
 
         $iterator = $DB->request([
             'SELECT'    => [

--- a/src/IPNetwork_Vlan.php
+++ b/src/IPNetwork_Vlan.php
@@ -104,7 +104,7 @@ class IPNetwork_Vlan extends CommonDBRelation
         }
 
         $canedit = $port->canEdit($ID);
-        $rand    = random_int(0, 2**32);
+        $rand    = random_int(0, 2 ** 32);
 
         $iterator = $DB->request([
             'SELECT'    => [

--- a/src/IPNetwork_Vlan.php
+++ b/src/IPNetwork_Vlan.php
@@ -104,7 +104,7 @@ class IPNetwork_Vlan extends CommonDBRelation
         }
 
         $canedit = $port->canEdit($ID);
-        $rand    = mt_rand();
+        $rand    = random_int();
 
         $iterator = $DB->request([
             'SELECT'    => [

--- a/src/ITILTemplateField.php
+++ b/src/ITILTemplateField.php
@@ -144,7 +144,7 @@ abstract class ITILTemplateField extends CommonDBChild
         $itil_class    = static::$itiltype;
         $searchOption  = SearchOption::getOptionsForItemtype($itil_class);
         $itil_object   = new $itil_class();
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
 
         $crtiteria = [
             'SELECT' => ['id', 'num'],

--- a/src/ITILTemplateField.php
+++ b/src/ITILTemplateField.php
@@ -144,7 +144,7 @@ abstract class ITILTemplateField extends CommonDBChild
         $itil_class    = static::$itiltype;
         $searchOption  = SearchOption::getOptionsForItemtype($itil_class);
         $itil_object   = new $itil_class();
-        $rand = mt_rand();
+        $rand = random_int();
 
         $crtiteria = [
             'SELECT' => ['id', 'num'],

--- a/src/ITILTemplateField.php
+++ b/src/ITILTemplateField.php
@@ -144,7 +144,7 @@ abstract class ITILTemplateField extends CommonDBChild
         $itil_class    = static::$itiltype;
         $searchOption  = SearchOption::getOptionsForItemtype($itil_class);
         $itil_object   = new $itil_class();
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
 
         $crtiteria = [
             'SELECT' => ['id', 'num'],

--- a/src/Impact.php
+++ b/src/Impact.php
@@ -388,7 +388,7 @@ JS);
        // Settings dialog
         $setting_dialog = "";
         if ($can_update && $impact_context) {
-            $rand = mt_rand();
+            $rand = random_int();
 
             $setting_dialog .= '<form id="list_depth_form" action="' . htmlescape($CFG_GLPI['root_doc']) . '/front/impactitem.form.php" method="POST">';
             $setting_dialog .= '<table class="tab_cadre_fixe">';
@@ -524,7 +524,7 @@ JS);
 
         if ($count) {
             $priority = 1;
-            $id = "impact_list_itilcount_" . mt_rand();
+            $id = "impact_list_itilcount_" . random_int();
             $link = "";
 
             switch ($type) {

--- a/src/Impact.php
+++ b/src/Impact.php
@@ -388,7 +388,7 @@ JS);
        // Settings dialog
         $setting_dialog = "";
         if ($can_update && $impact_context) {
-            $rand = random_int(0, 2**32);
+            $rand = random_int(0, 2 ** 32);
 
             $setting_dialog .= '<form id="list_depth_form" action="' . htmlescape($CFG_GLPI['root_doc']) . '/front/impactitem.form.php" method="POST">';
             $setting_dialog .= '<table class="tab_cadre_fixe">';
@@ -524,7 +524,7 @@ JS);
 
         if ($count) {
             $priority = 1;
-            $id = "impact_list_itilcount_" . random_int(0, 2**32);
+            $id = "impact_list_itilcount_" . random_int(0, 2 ** 32);
             $link = "";
 
             switch ($type) {

--- a/src/Impact.php
+++ b/src/Impact.php
@@ -388,7 +388,7 @@ JS);
        // Settings dialog
         $setting_dialog = "";
         if ($can_update && $impact_context) {
-            $rand = random_int();
+            $rand = random_int(0, 2**32);
 
             $setting_dialog .= '<form id="list_depth_form" action="' . htmlescape($CFG_GLPI['root_doc']) . '/front/impactitem.form.php" method="POST">';
             $setting_dialog .= '<table class="tab_cadre_fixe">';
@@ -524,7 +524,7 @@ JS);
 
         if ($count) {
             $priority = 1;
-            $id = "impact_list_itilcount_" . random_int();
+            $id = "impact_list_itilcount_" . random_int(0, 2**32);
             $link = "";
 
             switch ($type) {

--- a/src/Item_Cluster.php
+++ b/src/Item_Cluster.php
@@ -87,7 +87,7 @@ class Item_Cluster extends CommonDBRelation
         global $DB;
 
         $ID = $cluster->fields['id'];
-        $rand = mt_rand();
+        $rand = random_int();
 
         if (
             !$cluster->getFromDB($ID)

--- a/src/Item_Cluster.php
+++ b/src/Item_Cluster.php
@@ -87,7 +87,7 @@ class Item_Cluster extends CommonDBRelation
         global $DB;
 
         $ID = $cluster->fields['id'];
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
 
         if (
             !$cluster->getFromDB($ID)

--- a/src/Item_Cluster.php
+++ b/src/Item_Cluster.php
@@ -87,7 +87,7 @@ class Item_Cluster extends CommonDBRelation
         global $DB;
 
         $ID = $cluster->fields['id'];
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
 
         if (
             !$cluster->getFromDB($ID)

--- a/src/Item_DeviceCamera_ImageFormat.php
+++ b/src/Item_DeviceCamera_ImageFormat.php
@@ -91,7 +91,7 @@ class Item_DeviceCamera_ImageFormat extends CommonDBRelation
         global $DB;
 
         $ID = $camera->getID();
-        $rand = mt_rand();
+        $rand = random_int();
 
         if (
             !$camera->getFromDB($ID)

--- a/src/Item_DeviceCamera_ImageFormat.php
+++ b/src/Item_DeviceCamera_ImageFormat.php
@@ -91,7 +91,7 @@ class Item_DeviceCamera_ImageFormat extends CommonDBRelation
         global $DB;
 
         $ID = $camera->getID();
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
 
         if (
             !$camera->getFromDB($ID)

--- a/src/Item_DeviceCamera_ImageFormat.php
+++ b/src/Item_DeviceCamera_ImageFormat.php
@@ -91,7 +91,7 @@ class Item_DeviceCamera_ImageFormat extends CommonDBRelation
         global $DB;
 
         $ID = $camera->getID();
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
 
         if (
             !$camera->getFromDB($ID)

--- a/src/Item_DeviceCamera_ImageResolution.php
+++ b/src/Item_DeviceCamera_ImageResolution.php
@@ -91,7 +91,7 @@ class Item_DeviceCamera_ImageResolution extends CommonDBRelation
         global $DB;
 
         $ID = $camera->getID();
-        $rand = mt_rand();
+        $rand = random_int();
 
         if (
             !$camera->getFromDB($ID)

--- a/src/Item_DeviceCamera_ImageResolution.php
+++ b/src/Item_DeviceCamera_ImageResolution.php
@@ -91,7 +91,7 @@ class Item_DeviceCamera_ImageResolution extends CommonDBRelation
         global $DB;
 
         $ID = $camera->getID();
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
 
         if (
             !$camera->getFromDB($ID)

--- a/src/Item_DeviceCamera_ImageResolution.php
+++ b/src/Item_DeviceCamera_ImageResolution.php
@@ -91,7 +91,7 @@ class Item_DeviceCamera_ImageResolution extends CommonDBRelation
         global $DB;
 
         $ID = $camera->getID();
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
 
         if (
             !$camera->getFromDB($ID)

--- a/src/Item_Devices.php
+++ b/src/Item_Devices.php
@@ -627,7 +627,7 @@ class Item_Devices extends CommonDBRelation
                   && $item->canEdit($ID)
                   && Session::haveRightsOr('device', [UPDATE, PURGE]));
         echo "<div class='spaced table-responsive'>";
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
         if ($canedit) {
             echo "\n<form id='form_device_add$rand' name='form_device_add$rand'
                   action='" . Toolbox::getItemTypeFormURL(__CLASS__) . "' method='post'>\n";
@@ -1001,7 +1001,7 @@ class Item_Devices extends CommonDBRelation
                     $peer->getFromDB($link[$fk]);
                 }
 
-                $peer_group   = $peer_type . '_' . $link[$fk] . '_' . random_int();
+                $peer_group   = $peer_type . '_' . $link[$fk] . '_' . random_int(0, 2**32);
                 $current_row->setHTMLID($peer_group);
 
                 if ($options['canedit']) {
@@ -1071,7 +1071,7 @@ class Item_Devices extends CommonDBRelation
                                     $percent = round(100 * $this->fields[$field] / $device->fields[$attributs['max']]);
                                     $message = sprintf(__('%1$s (%2$d%%) '), Html::formatNumber($this->fields[$field], false, 0), $percent);
                                 }
-                                $content = Html::progressBar("percent" . random_int(), [
+                                $content = Html::progressBar("percent" . random_int(0, 2**32), [
                                     'create'  => true,
                                     'percent' => $percent,
                                     'message' => htmlescape($message),

--- a/src/Item_Devices.php
+++ b/src/Item_Devices.php
@@ -627,7 +627,7 @@ class Item_Devices extends CommonDBRelation
                   && $item->canEdit($ID)
                   && Session::haveRightsOr('device', [UPDATE, PURGE]));
         echo "<div class='spaced table-responsive'>";
-        $rand = mt_rand();
+        $rand = random_int();
         if ($canedit) {
             echo "\n<form id='form_device_add$rand' name='form_device_add$rand'
                   action='" . Toolbox::getItemTypeFormURL(__CLASS__) . "' method='post'>\n";
@@ -1001,7 +1001,7 @@ class Item_Devices extends CommonDBRelation
                     $peer->getFromDB($link[$fk]);
                 }
 
-                $peer_group   = $peer_type . '_' . $link[$fk] . '_' . mt_rand();
+                $peer_group   = $peer_type . '_' . $link[$fk] . '_' . random_int();
                 $current_row->setHTMLID($peer_group);
 
                 if ($options['canedit']) {
@@ -1071,7 +1071,7 @@ class Item_Devices extends CommonDBRelation
                                     $percent = round(100 * $this->fields[$field] / $device->fields[$attributs['max']]);
                                     $message = sprintf(__('%1$s (%2$d%%) '), Html::formatNumber($this->fields[$field], false, 0), $percent);
                                 }
-                                $content = Html::progressBar("percent" . mt_rand(), [
+                                $content = Html::progressBar("percent" . random_int(), [
                                     'create'  => true,
                                     'percent' => $percent,
                                     'message' => htmlescape($message),

--- a/src/Item_Devices.php
+++ b/src/Item_Devices.php
@@ -627,7 +627,7 @@ class Item_Devices extends CommonDBRelation
                   && $item->canEdit($ID)
                   && Session::haveRightsOr('device', [UPDATE, PURGE]));
         echo "<div class='spaced table-responsive'>";
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
         if ($canedit) {
             echo "\n<form id='form_device_add$rand' name='form_device_add$rand'
                   action='" . Toolbox::getItemTypeFormURL(__CLASS__) . "' method='post'>\n";
@@ -1001,7 +1001,7 @@ class Item_Devices extends CommonDBRelation
                     $peer->getFromDB($link[$fk]);
                 }
 
-                $peer_group   = $peer_type . '_' . $link[$fk] . '_' . random_int(0, 2**32);
+                $peer_group   = $peer_type . '_' . $link[$fk] . '_' . random_int(0, 2 ** 32);
                 $current_row->setHTMLID($peer_group);
 
                 if ($options['canedit']) {
@@ -1071,7 +1071,7 @@ class Item_Devices extends CommonDBRelation
                                     $percent = round(100 * $this->fields[$field] / $device->fields[$attributs['max']]);
                                     $message = sprintf(__('%1$s (%2$d%%) '), Html::formatNumber($this->fields[$field], false, 0), $percent);
                                 }
-                                $content = Html::progressBar("percent" . random_int(0, 2**32), [
+                                $content = Html::progressBar("percent" . random_int(0, 2 ** 32), [
                                     'create'  => true,
                                     'percent' => $percent,
                                     'message' => htmlescape($message),

--- a/src/Item_Disk.php
+++ b/src/Item_Disk.php
@@ -214,7 +214,7 @@ class Item_Disk extends CommonDBChild
     {
         $ID = $item->fields['id'];
         $itemtype = $item->getType();
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
 
         if (
             !$item->getFromDB($ID)

--- a/src/Item_Disk.php
+++ b/src/Item_Disk.php
@@ -214,7 +214,7 @@ class Item_Disk extends CommonDBChild
     {
         $ID = $item->fields['id'];
         $itemtype = $item->getType();
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
 
         if (
             !$item->getFromDB($ID)

--- a/src/Item_Disk.php
+++ b/src/Item_Disk.php
@@ -214,7 +214,7 @@ class Item_Disk extends CommonDBChild
     {
         $ID = $item->fields['id'];
         $itemtype = $item->getType();
-        $rand = mt_rand();
+        $rand = random_int();
 
         if (
             !$item->getFromDB($ID)

--- a/src/Item_Enclosure.php
+++ b/src/Item_Enclosure.php
@@ -77,7 +77,7 @@ class Item_Enclosure extends CommonDBRelation
         global $DB;
 
         $ID = $enclosure->getID();
-        $rand = mt_rand();
+        $rand = random_int();
 
         if (
             !$enclosure->getFromDB($ID)
@@ -158,7 +158,7 @@ class Item_Enclosure extends CommonDBRelation
         $enclosure = new Enclosure();
         $enclosure->getFromDB($this->fields['enclosures_id']);
 
-        $rand = mt_rand();
+        $rand = random_int();
 
         echo "<tr class='tab_bg_1'>";
         echo "<td><label for='dropdown_itemtype$rand'>" . __s('Item type') . "</label></td>";

--- a/src/Item_Enclosure.php
+++ b/src/Item_Enclosure.php
@@ -77,7 +77,7 @@ class Item_Enclosure extends CommonDBRelation
         global $DB;
 
         $ID = $enclosure->getID();
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
 
         if (
             !$enclosure->getFromDB($ID)
@@ -158,7 +158,7 @@ class Item_Enclosure extends CommonDBRelation
         $enclosure = new Enclosure();
         $enclosure->getFromDB($this->fields['enclosures_id']);
 
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
 
         echo "<tr class='tab_bg_1'>";
         echo "<td><label for='dropdown_itemtype$rand'>" . __s('Item type') . "</label></td>";

--- a/src/Item_Enclosure.php
+++ b/src/Item_Enclosure.php
@@ -77,7 +77,7 @@ class Item_Enclosure extends CommonDBRelation
         global $DB;
 
         $ID = $enclosure->getID();
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
 
         if (
             !$enclosure->getFromDB($ID)
@@ -158,7 +158,7 @@ class Item_Enclosure extends CommonDBRelation
         $enclosure = new Enclosure();
         $enclosure->getFromDB($this->fields['enclosures_id']);
 
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
 
         echo "<tr class='tab_bg_1'>";
         echo "<td><label for='dropdown_itemtype$rand'>" . __s('Item type') . "</label></td>";

--- a/src/Item_Line.php
+++ b/src/Item_Line.php
@@ -163,7 +163,7 @@ class Item_Line extends CommonDBRelation
         global $CFG_GLPI, $DB;
 
         $ID = $line->fields['id'];
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
 
         if (
             !$line->getFromDB($ID)
@@ -325,7 +325,7 @@ class Item_Line extends CommonDBRelation
 
         $itemtype = $item::getType();
         $ID = $item->fields['id'];
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
 
         if (
             !$item->getFromDB($ID)

--- a/src/Item_Line.php
+++ b/src/Item_Line.php
@@ -163,7 +163,7 @@ class Item_Line extends CommonDBRelation
         global $CFG_GLPI, $DB;
 
         $ID = $line->fields['id'];
-        $rand = mt_rand();
+        $rand = random_int();
 
         if (
             !$line->getFromDB($ID)
@@ -325,7 +325,7 @@ class Item_Line extends CommonDBRelation
 
         $itemtype = $item::getType();
         $ID = $item->fields['id'];
-        $rand = mt_rand();
+        $rand = random_int();
 
         if (
             !$item->getFromDB($ID)

--- a/src/Item_Line.php
+++ b/src/Item_Line.php
@@ -163,7 +163,7 @@ class Item_Line extends CommonDBRelation
         global $CFG_GLPI, $DB;
 
         $ID = $line->fields['id'];
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
 
         if (
             !$line->getFromDB($ID)
@@ -325,7 +325,7 @@ class Item_Line extends CommonDBRelation
 
         $itemtype = $item::getType();
         $ID = $item->fields['id'];
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
 
         if (
             !$item->getFromDB($ID)

--- a/src/Item_OperatingSystem.php
+++ b/src/Item_OperatingSystem.php
@@ -151,7 +151,7 @@ class Item_OperatingSystem extends CommonDBRelation
         global $DB;
 
        //default options
-        $params = ['rand' => random_int(0, 2**32)];
+        $params = ['rand' => random_int(0, 2 ** 32)];
 
         $columns = [
             __('Name'),
@@ -581,7 +581,7 @@ class Item_OperatingSystem extends CommonDBRelation
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
         Dropdown::showFromArray(
             'os_field',
             [

--- a/src/Item_OperatingSystem.php
+++ b/src/Item_OperatingSystem.php
@@ -151,7 +151,7 @@ class Item_OperatingSystem extends CommonDBRelation
         global $DB;
 
        //default options
-        $params = ['rand' => random_int()];
+        $params = ['rand' => random_int(0, 2**32)];
 
         $columns = [
             __('Name'),
@@ -581,7 +581,7 @@ class Item_OperatingSystem extends CommonDBRelation
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
         Dropdown::showFromArray(
             'os_field',
             [

--- a/src/Item_OperatingSystem.php
+++ b/src/Item_OperatingSystem.php
@@ -151,7 +151,7 @@ class Item_OperatingSystem extends CommonDBRelation
         global $DB;
 
        //default options
-        $params = ['rand' => mt_rand()];
+        $params = ['rand' => random_int()];
 
         $columns = [
             __('Name'),
@@ -581,7 +581,7 @@ class Item_OperatingSystem extends CommonDBRelation
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $rand = mt_rand();
+        $rand = random_int();
         Dropdown::showFromArray(
             'os_field',
             [

--- a/src/Item_Plug.php
+++ b/src/Item_Plug.php
@@ -80,7 +80,7 @@ class Item_Plug extends CommonDBRelation
         global $DB;
 
         $ID = $item->getID();
-        $rand = mt_rand();
+        $rand = random_int();
 
         if (
             !$item->getFromDB($ID)
@@ -100,7 +100,7 @@ class Item_Plug extends CommonDBRelation
         ]);
 
         if ($canedit) {
-            $rand = mt_rand();
+            $rand = random_int();
             echo "\n<form id='form_device_add$rand' name='form_device_add$rand'
                action='" . htmlescape(Toolbox::getItemTypeFormURL(__CLASS__)) . "' method='post'>\n";
             echo "\t<input type='hidden' name='" . static::$items_id_1 . "' value='$ID'>\n";

--- a/src/Item_Plug.php
+++ b/src/Item_Plug.php
@@ -80,7 +80,7 @@ class Item_Plug extends CommonDBRelation
         global $DB;
 
         $ID = $item->getID();
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
 
         if (
             !$item->getFromDB($ID)
@@ -100,7 +100,7 @@ class Item_Plug extends CommonDBRelation
         ]);
 
         if ($canedit) {
-            $rand = random_int(0, 2**32);
+            $rand = random_int(0, 2 ** 32);
             echo "\n<form id='form_device_add$rand' name='form_device_add$rand'
                action='" . htmlescape(Toolbox::getItemTypeFormURL(__CLASS__)) . "' method='post'>\n";
             echo "\t<input type='hidden' name='" . static::$items_id_1 . "' value='$ID'>\n";

--- a/src/Item_Plug.php
+++ b/src/Item_Plug.php
@@ -80,7 +80,7 @@ class Item_Plug extends CommonDBRelation
         global $DB;
 
         $ID = $item->getID();
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
 
         if (
             !$item->getFromDB($ID)
@@ -100,7 +100,7 @@ class Item_Plug extends CommonDBRelation
         ]);
 
         if ($canedit) {
-            $rand = random_int();
+            $rand = random_int(0, 2**32);
             echo "\n<form id='form_device_add$rand' name='form_device_add$rand'
                action='" . htmlescape(Toolbox::getItemTypeFormURL(__CLASS__)) . "' method='post'>\n";
             echo "\t<input type='hidden' name='" . static::$items_id_1 . "' value='$ID'>\n";

--- a/src/Item_Project.php
+++ b/src/Item_Project.php
@@ -98,7 +98,7 @@ class Item_Project extends CommonDBRelation
             return false;
         }
         $canedit = $project->canEdit($instID);
-        $rand    = random_int();
+        $rand    = random_int(0, 2**32);
 
         $types_iterator = self::getDistinctTypes($instID);
         $number = count($types_iterator);

--- a/src/Item_Project.php
+++ b/src/Item_Project.php
@@ -98,7 +98,7 @@ class Item_Project extends CommonDBRelation
             return false;
         }
         $canedit = $project->canEdit($instID);
-        $rand    = random_int(0, 2**32);
+        $rand    = random_int(0, 2 ** 32);
 
         $types_iterator = self::getDistinctTypes($instID);
         $number = count($types_iterator);

--- a/src/Item_Project.php
+++ b/src/Item_Project.php
@@ -98,7 +98,7 @@ class Item_Project extends CommonDBRelation
             return false;
         }
         $canedit = $project->canEdit($instID);
-        $rand    = mt_rand();
+        $rand    = random_int();
 
         $types_iterator = self::getDistinctTypes($instID);
         $number = count($types_iterator);

--- a/src/Item_Rack.php
+++ b/src/Item_Rack.php
@@ -121,7 +121,7 @@ class Item_Rack extends CommonDBRelation
 
     private static function showItemsList(Rack $rack, iterable $items): void
     {
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
         $canedit = $rack->canEdit($rack->getID());
 
         echo "<h2>" . __("Racked items") . "</h2>";
@@ -550,7 +550,7 @@ JAVASCRIPT;
         $rack = new Rack();
         $rack->getFromDB($this->fields['racks_id']);
 
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
 
         echo "<tr class='tab_bg_1'>";
         echo "<td><label for='dropdown_itemtype$rand'>" . __s('Item type') . "</label></td>";

--- a/src/Item_Rack.php
+++ b/src/Item_Rack.php
@@ -121,7 +121,7 @@ class Item_Rack extends CommonDBRelation
 
     private static function showItemsList(Rack $rack, iterable $items): void
     {
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
         $canedit = $rack->canEdit($rack->getID());
 
         echo "<h2>" . __("Racked items") . "</h2>";
@@ -550,7 +550,7 @@ JAVASCRIPT;
         $rack = new Rack();
         $rack->getFromDB($this->fields['racks_id']);
 
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
 
         echo "<tr class='tab_bg_1'>";
         echo "<td><label for='dropdown_itemtype$rand'>" . __s('Item type') . "</label></td>";

--- a/src/Item_Rack.php
+++ b/src/Item_Rack.php
@@ -121,7 +121,7 @@ class Item_Rack extends CommonDBRelation
 
     private static function showItemsList(Rack $rack, iterable $items): void
     {
-        $rand = mt_rand();
+        $rand = random_int();
         $canedit = $rack->canEdit($rack->getID());
 
         echo "<h2>" . __("Racked items") . "</h2>";
@@ -550,7 +550,7 @@ JAVASCRIPT;
         $rack = new Rack();
         $rack->getFromDB($this->fields['racks_id']);
 
-        $rand = mt_rand();
+        $rand = random_int();
 
         echo "<tr class='tab_bg_1'>";
         echo "<td><label for='dropdown_itemtype$rand'>" . __s('Item type') . "</label></td>";

--- a/src/Item_SoftwareLicense.php
+++ b/src/Item_SoftwareLicense.php
@@ -557,7 +557,7 @@ class Item_SoftwareLicense extends CommonDBRelation
             echo "<tr class='tab_bg_2 center'>";
             echo "<td>";
 
-            $rand = random_int();
+            $rand = random_int(0, 2**32);
             Dropdown::showItemTypes('itemtype', $CFG_GLPI['software_types'], [
                 'value'                 => 'Computer',
                 'rand'                  => $rand,
@@ -762,7 +762,7 @@ JAVASCRIPT;
         ];
         $iterator = $DB->request($criteria);
 
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
 
         if ($data = $iterator->current()) {
             if ($canedit) {

--- a/src/Item_SoftwareLicense.php
+++ b/src/Item_SoftwareLicense.php
@@ -557,7 +557,7 @@ class Item_SoftwareLicense extends CommonDBRelation
             echo "<tr class='tab_bg_2 center'>";
             echo "<td>";
 
-            $rand = mt_rand();
+            $rand = random_int();
             Dropdown::showItemTypes('itemtype', $CFG_GLPI['software_types'], [
                 'value'                 => 'Computer',
                 'rand'                  => $rand,
@@ -762,7 +762,7 @@ JAVASCRIPT;
         ];
         $iterator = $DB->request($criteria);
 
-        $rand = mt_rand();
+        $rand = random_int();
 
         if ($data = $iterator->current()) {
             if ($canedit) {

--- a/src/Item_SoftwareLicense.php
+++ b/src/Item_SoftwareLicense.php
@@ -557,7 +557,7 @@ class Item_SoftwareLicense extends CommonDBRelation
             echo "<tr class='tab_bg_2 center'>";
             echo "<td>";
 
-            $rand = random_int(0, 2**32);
+            $rand = random_int(0, 2 ** 32);
             Dropdown::showItemTypes('itemtype', $CFG_GLPI['software_types'], [
                 'value'                 => 'Computer',
                 'rand'                  => $rand,
@@ -762,7 +762,7 @@ JAVASCRIPT;
         ];
         $iterator = $DB->request($criteria);
 
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
 
         if ($data = $iterator->current()) {
             if ($canedit) {

--- a/src/Item_SoftwareVersion.php
+++ b/src/Item_SoftwareVersion.php
@@ -644,7 +644,7 @@ class Item_SoftwareVersion extends CommonDBRelation
         ];
         $iterator = $DB->request($criteria);
 
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
 
         if ($data = $iterator->current()) {
             $softwares_id  = $data['sID'];
@@ -668,7 +668,7 @@ class Item_SoftwareVersion extends CommonDBRelation
             );
 
             if ($canedit) {
-                $rand = random_int(0, 2**32);
+                $rand = random_int(0, 2 ** 32);
                 Html::openMassiveActionsForm('mass' . __CLASS__ . $rand);
                 $massiveactionparams
                  = ['num_displayed'
@@ -989,7 +989,7 @@ class Item_SoftwareVersion extends CommonDBRelation
 
         $items_id      = $item->getField('id');
         $itemtype      = $item->getType();
-        $rand          = random_int(0, 2**32);
+        $rand          = random_int(0, 2 ** 32);
         $filters       = $_GET['filters'] ?? [];
         $is_filtered   = count($filters) > 0;
         $canedit       = Session::haveRightsOr("software", [CREATE, UPDATE, DELETE, PURGE]);
@@ -1066,7 +1066,7 @@ class Item_SoftwareVersion extends CommonDBRelation
 
             echo "<div class='table-responsive'>";
             if ($canedit) {
-                $rand = random_int(0, 2**32);
+                $rand = random_int(0, 2 ** 32);
                 Html::openMassiveActionsForm('mass' . __CLASS__ . $rand);
                 $massiveactionparams
                 = ['num_displayed'
@@ -1282,7 +1282,7 @@ class Item_SoftwareVersion extends CommonDBRelation
 
         if ($number = $lic_iterator->count()) {
             if ($canedit) {
-                $rand = random_int(0, 2**32);
+                $rand = random_int(0, 2 ** 32);
                 Html::openMassiveActionsForm('massSoftwareLicense' . $rand);
 
                 $actions = ['Item_SoftwareLicense' . MassiveAction::CLASS_ACTION_SEPARATOR .

--- a/src/Item_SoftwareVersion.php
+++ b/src/Item_SoftwareVersion.php
@@ -644,7 +644,7 @@ class Item_SoftwareVersion extends CommonDBRelation
         ];
         $iterator = $DB->request($criteria);
 
-        $rand = mt_rand();
+        $rand = random_int();
 
         if ($data = $iterator->current()) {
             $softwares_id  = $data['sID'];
@@ -668,7 +668,7 @@ class Item_SoftwareVersion extends CommonDBRelation
             );
 
             if ($canedit) {
-                $rand = mt_rand();
+                $rand = random_int();
                 Html::openMassiveActionsForm('mass' . __CLASS__ . $rand);
                 $massiveactionparams
                  = ['num_displayed'
@@ -989,7 +989,7 @@ class Item_SoftwareVersion extends CommonDBRelation
 
         $items_id      = $item->getField('id');
         $itemtype      = $item->getType();
-        $rand          = mt_rand();
+        $rand          = random_int();
         $filters       = $_GET['filters'] ?? [];
         $is_filtered   = count($filters) > 0;
         $canedit       = Session::haveRightsOr("software", [CREATE, UPDATE, DELETE, PURGE]);
@@ -1066,7 +1066,7 @@ class Item_SoftwareVersion extends CommonDBRelation
 
             echo "<div class='table-responsive'>";
             if ($canedit) {
-                $rand = mt_rand();
+                $rand = random_int();
                 Html::openMassiveActionsForm('mass' . __CLASS__ . $rand);
                 $massiveactionparams
                 = ['num_displayed'
@@ -1282,7 +1282,7 @@ class Item_SoftwareVersion extends CommonDBRelation
 
         if ($number = $lic_iterator->count()) {
             if ($canedit) {
-                $rand = mt_rand();
+                $rand = random_int();
                 Html::openMassiveActionsForm('massSoftwareLicense' . $rand);
 
                 $actions = ['Item_SoftwareLicense' . MassiveAction::CLASS_ACTION_SEPARATOR .

--- a/src/Item_SoftwareVersion.php
+++ b/src/Item_SoftwareVersion.php
@@ -644,7 +644,7 @@ class Item_SoftwareVersion extends CommonDBRelation
         ];
         $iterator = $DB->request($criteria);
 
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
 
         if ($data = $iterator->current()) {
             $softwares_id  = $data['sID'];
@@ -668,7 +668,7 @@ class Item_SoftwareVersion extends CommonDBRelation
             );
 
             if ($canedit) {
-                $rand = random_int();
+                $rand = random_int(0, 2**32);
                 Html::openMassiveActionsForm('mass' . __CLASS__ . $rand);
                 $massiveactionparams
                  = ['num_displayed'
@@ -989,7 +989,7 @@ class Item_SoftwareVersion extends CommonDBRelation
 
         $items_id      = $item->getField('id');
         $itemtype      = $item->getType();
-        $rand          = random_int();
+        $rand          = random_int(0, 2**32);
         $filters       = $_GET['filters'] ?? [];
         $is_filtered   = count($filters) > 0;
         $canedit       = Session::haveRightsOr("software", [CREATE, UPDATE, DELETE, PURGE]);
@@ -1066,7 +1066,7 @@ class Item_SoftwareVersion extends CommonDBRelation
 
             echo "<div class='table-responsive'>";
             if ($canedit) {
-                $rand = random_int();
+                $rand = random_int(0, 2**32);
                 Html::openMassiveActionsForm('mass' . __CLASS__ . $rand);
                 $massiveactionparams
                 = ['num_displayed'
@@ -1282,7 +1282,7 @@ class Item_SoftwareVersion extends CommonDBRelation
 
         if ($number = $lic_iterator->count()) {
             if ($canedit) {
-                $rand = random_int();
+                $rand = random_int(0, 2**32);
                 Html::openMassiveActionsForm('massSoftwareLicense' . $rand);
 
                 $actions = ['Item_SoftwareLicense' . MassiveAction::CLASS_ACTION_SEPARATOR .

--- a/src/Itil_Project.php
+++ b/src/Itil_Project.php
@@ -240,7 +240,7 @@ TWIG, $twig_params);
             'showmassiveactions' => $canedit,
             'massiveactionparams' => [
                 'num_displayed' => count($entries),
-                'container'     => 'mass' . self::class . random_int(),
+                'container'     => 'mass' . self::class . random_int(0, 2**32),
                 'specific_actions' => ['purge' => _x('button', 'Delete permanently')]
             ]
         ]);
@@ -263,7 +263,7 @@ TWIG, $twig_params);
         }
 
         $canedit = $itil->canEdit($ID);
-        $rand    = random_int();
+        $rand    = random_int(0, 2**32);
 
         $selfTable = self::getTable();
         $projectTable = Project::getTable();

--- a/src/Itil_Project.php
+++ b/src/Itil_Project.php
@@ -240,7 +240,7 @@ TWIG, $twig_params);
             'showmassiveactions' => $canedit,
             'massiveactionparams' => [
                 'num_displayed' => count($entries),
-                'container'     => 'mass' . self::class . mt_rand(),
+                'container'     => 'mass' . self::class . random_int(),
                 'specific_actions' => ['purge' => _x('button', 'Delete permanently')]
             ]
         ]);
@@ -263,7 +263,7 @@ TWIG, $twig_params);
         }
 
         $canedit = $itil->canEdit($ID);
-        $rand    = mt_rand();
+        $rand    = random_int();
 
         $selfTable = self::getTable();
         $projectTable = Project::getTable();

--- a/src/Itil_Project.php
+++ b/src/Itil_Project.php
@@ -240,7 +240,7 @@ TWIG, $twig_params);
             'showmassiveactions' => $canedit,
             'massiveactionparams' => [
                 'num_displayed' => count($entries),
-                'container'     => 'mass' . self::class . random_int(0, 2**32),
+                'container'     => 'mass' . self::class . random_int(0, 2 ** 32),
                 'specific_actions' => ['purge' => _x('button', 'Delete permanently')]
             ]
         ]);
@@ -263,7 +263,7 @@ TWIG, $twig_params);
         }
 
         $canedit = $itil->canEdit($ID);
-        $rand    = random_int(0, 2**32);
+        $rand    = random_int(0, 2 ** 32);
 
         $selfTable = self::getTable();
         $projectTable = Project::getTable();

--- a/src/KnowbaseItemTranslation.php
+++ b/src/KnowbaseItemTranslation.php
@@ -167,7 +167,7 @@ TWIG, $twig_params);
     public static function showTranslations(KnowbaseItem $item)
     {
         $canedit = $item->can($item->getID(), UPDATE);
-        $rand    = mt_rand();
+        $rand    = random_int();
         if ($canedit) {
             $twig_params = [
                 'item' => $item,

--- a/src/KnowbaseItemTranslation.php
+++ b/src/KnowbaseItemTranslation.php
@@ -167,7 +167,7 @@ TWIG, $twig_params);
     public static function showTranslations(KnowbaseItem $item)
     {
         $canedit = $item->can($item->getID(), UPDATE);
-        $rand    = random_int();
+        $rand    = random_int(0, 2**32);
         if ($canedit) {
             $twig_params = [
                 'item' => $item,

--- a/src/KnowbaseItemTranslation.php
+++ b/src/KnowbaseItemTranslation.php
@@ -167,7 +167,7 @@ TWIG, $twig_params);
     public static function showTranslations(KnowbaseItem $item)
     {
         $canedit = $item->can($item->getID(), UPDATE);
-        $rand    = random_int(0, 2**32);
+        $rand    = random_int(0, 2 ** 32);
         if ($canedit) {
             $twig_params = [
                 'item' => $item,

--- a/src/KnowbaseItem_Item.php
+++ b/src/KnowbaseItem_Item.php
@@ -114,7 +114,7 @@ class KnowbaseItem_Item extends CommonDBRelation
             ), true);
         }
 
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
         if ($canedit && $ok_state) {
             if ($item::class !== KnowbaseItem::class) {
                 $visibility = KnowbaseItem::getVisibilityCriteria();

--- a/src/KnowbaseItem_Item.php
+++ b/src/KnowbaseItem_Item.php
@@ -114,7 +114,7 @@ class KnowbaseItem_Item extends CommonDBRelation
             ), true);
         }
 
-        $rand = mt_rand();
+        $rand = random_int();
         if ($canedit && $ok_state) {
             if ($item::class !== KnowbaseItem::class) {
                 $visibility = KnowbaseItem::getVisibilityCriteria();

--- a/src/KnowbaseItem_Item.php
+++ b/src/KnowbaseItem_Item.php
@@ -114,7 +114,7 @@ class KnowbaseItem_Item extends CommonDBRelation
             ), true);
         }
 
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
         if ($canedit && $ok_state) {
             if ($item::class !== KnowbaseItem::class) {
                 $visibility = KnowbaseItem::getVisibilityCriteria();

--- a/src/LevelAgreement.php
+++ b/src/LevelAgreement.php
@@ -328,7 +328,7 @@ abstract class LevelAgreement extends CommonDBChild
         $instID   = $slm->fields['id'];
         $la       = new static();
         $calendar = new Calendar();
-        $rand     = random_int();
+        $rand     = random_int(0, 2**32);
         $canedit  = $slm->canEdit($instID) && Session::getCurrentInterface() === 'central';
 
         if ($canedit) {
@@ -413,7 +413,7 @@ TWIG, $twig_params);
             'showmassiveactions' => $canedit,
             'massiveactionparams' => [
                 'num_displayed' => count($entries),
-                'container'     => 'mass' . static::class . random_int(),
+                'container'     => 'mass' . static::class . random_int(0, 2**32),
             ]
         ]);
     }
@@ -473,7 +473,7 @@ TWIG, $twig_params);
             'showmassiveactions' => $canedit,
             'massiveactionparams' => [
                 'num_displayed' => count($entries),
-                'container'     => 'mass' . RuleTicket::class . random_int(),
+                'container'     => 'mass' . RuleTicket::class . random_int(0, 2**32),
                 'specific_actions' => [
                     'update' => _x('button', 'Update'),
                     'purge'  => _x('button', 'Delete permanently')

--- a/src/LevelAgreement.php
+++ b/src/LevelAgreement.php
@@ -328,7 +328,7 @@ abstract class LevelAgreement extends CommonDBChild
         $instID   = $slm->fields['id'];
         $la       = new static();
         $calendar = new Calendar();
-        $rand     = random_int(0, 2**32);
+        $rand     = random_int(0, 2 ** 32);
         $canedit  = $slm->canEdit($instID) && Session::getCurrentInterface() === 'central';
 
         if ($canedit) {
@@ -413,7 +413,7 @@ TWIG, $twig_params);
             'showmassiveactions' => $canedit,
             'massiveactionparams' => [
                 'num_displayed' => count($entries),
-                'container'     => 'mass' . static::class . random_int(0, 2**32),
+                'container'     => 'mass' . static::class . random_int(0, 2 ** 32),
             ]
         ]);
     }
@@ -473,7 +473,7 @@ TWIG, $twig_params);
             'showmassiveactions' => $canedit,
             'massiveactionparams' => [
                 'num_displayed' => count($entries),
-                'container'     => 'mass' . RuleTicket::class . random_int(0, 2**32),
+                'container'     => 'mass' . RuleTicket::class . random_int(0, 2 ** 32),
                 'specific_actions' => [
                     'update' => _x('button', 'Update'),
                     'purge'  => _x('button', 'Delete permanently')

--- a/src/LevelAgreement.php
+++ b/src/LevelAgreement.php
@@ -328,7 +328,7 @@ abstract class LevelAgreement extends CommonDBChild
         $instID   = $slm->fields['id'];
         $la       = new static();
         $calendar = new Calendar();
-        $rand     = mt_rand();
+        $rand     = random_int();
         $canedit  = $slm->canEdit($instID) && Session::getCurrentInterface() === 'central';
 
         if ($canedit) {
@@ -413,7 +413,7 @@ TWIG, $twig_params);
             'showmassiveactions' => $canedit,
             'massiveactionparams' => [
                 'num_displayed' => count($entries),
-                'container'     => 'mass' . static::class . mt_rand(),
+                'container'     => 'mass' . static::class . random_int(),
             ]
         ]);
     }
@@ -473,7 +473,7 @@ TWIG, $twig_params);
             'showmassiveactions' => $canedit,
             'massiveactionparams' => [
                 'num_displayed' => count($entries),
-                'container'     => 'mass' . RuleTicket::class . mt_rand(),
+                'container'     => 'mass' . RuleTicket::class . random_int(),
                 'specific_actions' => [
                     'update' => _x('button', 'Update'),
                     'purge'  => _x('button', 'Delete permanently')

--- a/src/LevelAgreementLevel.php
+++ b/src/LevelAgreementLevel.php
@@ -538,7 +538,7 @@ TWIG, ['la_level' => $la_level]);
             'showmassiveactions' => $canedit,
             'massiveactionparams' => [
                 'num_displayed' => count($entries),
-                'container'     => 'mass' . static::class . random_int(),
+                'container'     => 'mass' . static::class . random_int(0, 2**32),
             ]
         ]);
     }

--- a/src/LevelAgreementLevel.php
+++ b/src/LevelAgreementLevel.php
@@ -538,7 +538,7 @@ TWIG, ['la_level' => $la_level]);
             'showmassiveactions' => $canedit,
             'massiveactionparams' => [
                 'num_displayed' => count($entries),
-                'container'     => 'mass' . static::class . mt_rand(),
+                'container'     => 'mass' . static::class . random_int(),
             ]
         ]);
     }

--- a/src/LevelAgreementLevel.php
+++ b/src/LevelAgreementLevel.php
@@ -538,7 +538,7 @@ TWIG, ['la_level' => $la_level]);
             'showmassiveactions' => $canedit,
             'massiveactionparams' => [
                 'num_displayed' => count($entries),
-                'container'     => 'mass' . static::class . random_int(0, 2**32),
+                'container'     => 'mass' . static::class . random_int(0, 2 ** 32),
             ]
         ]);
     }

--- a/src/Lock.php
+++ b/src/Lock.php
@@ -317,7 +317,7 @@ TWIG;
             })) > 0,
             'massiveactionparams' => [
                 'num_displayed' => count($entries),
-                'container'     => 'mass' . static::class . random_int(0, 2**32)
+                'container'     => 'mass' . static::class . random_int(0, 2 ** 32)
             ]
         ]);
 

--- a/src/Lock.php
+++ b/src/Lock.php
@@ -317,7 +317,7 @@ TWIG;
             })) > 0,
             'massiveactionparams' => [
                 'num_displayed' => count($entries),
-                'container'     => 'mass' . static::class . mt_rand()
+                'container'     => 'mass' . static::class . random_int()
             ]
         ]);
 

--- a/src/Lock.php
+++ b/src/Lock.php
@@ -317,7 +317,7 @@ TWIG;
             })) > 0,
             'massiveactionparams' => [
                 'num_displayed' => count($entries),
-                'container'     => 'mass' . static::class . random_int()
+                'container'     => 'mass' . static::class . random_int(0, 2**32)
             ]
         ]);
 

--- a/src/MailCollector.php
+++ b/src/MailCollector.php
@@ -1140,7 +1140,7 @@ class MailCollector extends CommonDBTM
 
         $original = $string;
 
-        $br_marker = '==' . random_int() . '==';
+        $br_marker = '==' . random_int(0, 2**32) . '==';
 
        // Wrap content for blacklisted items
         $cleaned_count = 0;
@@ -2149,7 +2149,7 @@ TWIG, ['receivers_error_msg' => sprintf(__s('Receivers in error: %s'), $server_l
         }
 
         if ($rand === null) {
-            $rand = random_int();
+            $rand = random_int(0, 2**32);
         }
 
         Dropdown::showFromArray($name, $sizes, ['value' => $value, 'rand' => $rand]);

--- a/src/MailCollector.php
+++ b/src/MailCollector.php
@@ -1140,7 +1140,7 @@ class MailCollector extends CommonDBTM
 
         $original = $string;
 
-        $br_marker = '==' . mt_rand() . '==';
+        $br_marker = '==' . random_int() . '==';
 
        // Wrap content for blacklisted items
         $cleaned_count = 0;
@@ -2149,7 +2149,7 @@ TWIG, ['receivers_error_msg' => sprintf(__s('Receivers in error: %s'), $server_l
         }
 
         if ($rand === null) {
-            $rand = mt_rand();
+            $rand = random_int();
         }
 
         Dropdown::showFromArray($name, $sizes, ['value' => $value, 'rand' => $rand]);

--- a/src/MailCollector.php
+++ b/src/MailCollector.php
@@ -1140,7 +1140,7 @@ class MailCollector extends CommonDBTM
 
         $original = $string;
 
-        $br_marker = '==' . random_int(0, 2**32) . '==';
+        $br_marker = '==' . random_int(0, 2 ** 32) . '==';
 
        // Wrap content for blacklisted items
         $cleaned_count = 0;
@@ -2149,7 +2149,7 @@ TWIG, ['receivers_error_msg' => sprintf(__s('Receivers in error: %s'), $server_l
         }
 
         if ($rand === null) {
-            $rand = random_int(0, 2**32);
+            $rand = random_int(0, 2 ** 32);
         }
 
         Dropdown::showFromArray($name, $sizes, ['value' => $value, 'rand' => $rand]);

--- a/src/MassiveAction.php
+++ b/src/MassiveAction.php
@@ -339,7 +339,7 @@ class MassiveAction
                             'massiveaction', 'is_deleted', 'initial_items'
                         ];
 
-                        $this->identifier  = random_int();
+                        $this->identifier  = random_int(0, 2**32);
                         $this->done        = [];
                         $this->nb_done     = 0;
                         $this->action_name = $POST['action_name'];
@@ -1095,7 +1095,7 @@ class MassiveAction
                         echo "</td>";
                     }
 
-                    $next_step_rand = random_int();
+                    $next_step_rand = random_int(0, 2**32);
 
                     echo "</tr></table>";
                     echo "<span id='update_next_step$next_step_rand'>&nbsp;</span>";
@@ -1257,7 +1257,7 @@ class MassiveAction
                 return true;
 
             case 'clone':
-                $rand = random_int();
+                $rand = random_int(0, 2**32);
 
                 echo "<table width='100%'><tr>";
                 echo "<td>";
@@ -1288,7 +1288,7 @@ class MassiveAction
 
                 return true;
             case 'create_template':
-                $rand = random_int();
+                $rand = random_int(0, 2**32);
 
                 echo "<table class='w-100'><tr>";
                 echo "<td>";

--- a/src/MassiveAction.php
+++ b/src/MassiveAction.php
@@ -339,7 +339,7 @@ class MassiveAction
                             'massiveaction', 'is_deleted', 'initial_items'
                         ];
 
-                        $this->identifier  = random_int(0, 2**32);
+                        $this->identifier  = random_int(0, 2 ** 32);
                         $this->done        = [];
                         $this->nb_done     = 0;
                         $this->action_name = $POST['action_name'];
@@ -1095,7 +1095,7 @@ class MassiveAction
                         echo "</td>";
                     }
 
-                    $next_step_rand = random_int(0, 2**32);
+                    $next_step_rand = random_int(0, 2 ** 32);
 
                     echo "</tr></table>";
                     echo "<span id='update_next_step$next_step_rand'>&nbsp;</span>";
@@ -1257,7 +1257,7 @@ class MassiveAction
                 return true;
 
             case 'clone':
-                $rand = random_int(0, 2**32);
+                $rand = random_int(0, 2 ** 32);
 
                 echo "<table width='100%'><tr>";
                 echo "<td>";
@@ -1288,7 +1288,7 @@ class MassiveAction
 
                 return true;
             case 'create_template':
-                $rand = random_int(0, 2**32);
+                $rand = random_int(0, 2 ** 32);
 
                 echo "<table class='w-100'><tr>";
                 echo "<td>";

--- a/src/MassiveAction.php
+++ b/src/MassiveAction.php
@@ -339,7 +339,7 @@ class MassiveAction
                             'massiveaction', 'is_deleted', 'initial_items'
                         ];
 
-                        $this->identifier  = mt_rand();
+                        $this->identifier  = random_int();
                         $this->done        = [];
                         $this->nb_done     = 0;
                         $this->action_name = $POST['action_name'];
@@ -1095,7 +1095,7 @@ class MassiveAction
                         echo "</td>";
                     }
 
-                    $next_step_rand = mt_rand();
+                    $next_step_rand = random_int();
 
                     echo "</tr></table>";
                     echo "<span id='update_next_step$next_step_rand'>&nbsp;</span>";
@@ -1257,7 +1257,7 @@ class MassiveAction
                 return true;
 
             case 'clone':
-                $rand = mt_rand();
+                $rand = random_int();
 
                 echo "<table width='100%'><tr>";
                 echo "<td>";
@@ -1288,7 +1288,7 @@ class MassiveAction
 
                 return true;
             case 'create_template':
-                $rand = mt_rand();
+                $rand = random_int();
 
                 echo "<table class='w-100'><tr>";
                 echo "<td>";

--- a/src/NetworkAlias.php
+++ b/src/NetworkAlias.php
@@ -245,7 +245,7 @@ class NetworkAlias extends FQDNLabel
         }
 
         $canedit = $item->canEdit($ID);
-        $rand    = random_int(0, 2**32);
+        $rand    = random_int(0, 2 ** 32);
 
         $iterator = $DB->request([
             'FROM'   => 'glpi_networkaliases',

--- a/src/NetworkAlias.php
+++ b/src/NetworkAlias.php
@@ -245,7 +245,7 @@ class NetworkAlias extends FQDNLabel
         }
 
         $canedit = $item->canEdit($ID);
-        $rand    = random_int();
+        $rand    = random_int(0, 2**32);
 
         $iterator = $DB->request([
             'FROM'   => 'glpi_networkaliases',

--- a/src/NetworkAlias.php
+++ b/src/NetworkAlias.php
@@ -245,7 +245,7 @@ class NetworkAlias extends FQDNLabel
         }
 
         $canedit = $item->canEdit($ID);
-        $rand    = mt_rand();
+        $rand    = random_int();
 
         $iterator = $DB->request([
             'FROM'   => 'glpi_networkaliases',

--- a/src/NetworkName.php
+++ b/src/NetworkName.php
@@ -673,7 +673,7 @@ TWIG, ['alert' => __("Several network names available! Go to the tab 'Network Na
             return false;
         }
 
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
 
         if (
             ($item::class === NetworkPort::class)

--- a/src/NetworkName.php
+++ b/src/NetworkName.php
@@ -673,7 +673,7 @@ TWIG, ['alert' => __("Several network names available! Go to the tab 'Network Na
             return false;
         }
 
-        $rand = mt_rand();
+        $rand = random_int();
 
         if (
             ($item::class === NetworkPort::class)

--- a/src/NetworkName.php
+++ b/src/NetworkName.php
@@ -673,7 +673,7 @@ TWIG, ['alert' => __("Several network names available! Go to the tab 'Network Na
             return false;
         }
 
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
 
         if (
             ($item::class === NetworkPort::class)

--- a/src/NetworkPort.php
+++ b/src/NetworkPort.php
@@ -726,7 +726,7 @@ class NetworkPort extends CommonDBChild
             );
         }
 
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
         if ($showmassiveactions) {
             Html::openMassiveActionsForm('mass' . __CLASS__ . $rand);
         }

--- a/src/NetworkPort.php
+++ b/src/NetworkPort.php
@@ -726,7 +726,7 @@ class NetworkPort extends CommonDBChild
             );
         }
 
-        $rand = mt_rand();
+        $rand = random_int();
         if ($showmassiveactions) {
             Html::openMassiveActionsForm('mass' . __CLASS__ . $rand);
         }

--- a/src/NetworkPort.php
+++ b/src/NetworkPort.php
@@ -726,7 +726,7 @@ class NetworkPort extends CommonDBChild
             );
         }
 
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
         if ($showmassiveactions) {
             Html::openMassiveActionsForm('mass' . __CLASS__ . $rand);
         }

--- a/src/NetworkPort_Vlan.php
+++ b/src/NetworkPort_Vlan.php
@@ -100,7 +100,7 @@ class NetworkPort_Vlan extends CommonDBRelation
         }
 
         $canedit = $port->canEdit($ID);
-        $rand    = random_int(0, 2**32);
+        $rand    = random_int(0, 2 ** 32);
 
         $iterator = $DB->request([
             'SELECT'    => [
@@ -195,7 +195,7 @@ TWIG, $twig_params);
             'showmassiveactions' => $canedit,
             'massiveactionparams' => [
                 'num_displayed' => count($entries),
-                'container'     => 'mass' . static::class . random_int(0, 2**32),
+                'container'     => 'mass' . static::class . random_int(0, 2 ** 32),
             ]
         ]);
     }
@@ -266,7 +266,7 @@ TWIG, $twig_params);
             'showmassiveactions' => $canedit,
             'massiveactionparams' => [
                 'num_displayed' => count($entries),
-                'container'     => 'mass' . static::class . random_int(0, 2**32),
+                'container'     => 'mass' . static::class . random_int(0, 2 ** 32),
             ]
         ]);
     }

--- a/src/NetworkPort_Vlan.php
+++ b/src/NetworkPort_Vlan.php
@@ -100,7 +100,7 @@ class NetworkPort_Vlan extends CommonDBRelation
         }
 
         $canedit = $port->canEdit($ID);
-        $rand    = mt_rand();
+        $rand    = random_int();
 
         $iterator = $DB->request([
             'SELECT'    => [
@@ -195,7 +195,7 @@ TWIG, $twig_params);
             'showmassiveactions' => $canedit,
             'massiveactionparams' => [
                 'num_displayed' => count($entries),
-                'container'     => 'mass' . static::class . mt_rand(),
+                'container'     => 'mass' . static::class . random_int(),
             ]
         ]);
     }
@@ -266,7 +266,7 @@ TWIG, $twig_params);
             'showmassiveactions' => $canedit,
             'massiveactionparams' => [
                 'num_displayed' => count($entries),
-                'container'     => 'mass' . static::class . mt_rand(),
+                'container'     => 'mass' . static::class . random_int(),
             ]
         ]);
     }

--- a/src/NetworkPort_Vlan.php
+++ b/src/NetworkPort_Vlan.php
@@ -100,7 +100,7 @@ class NetworkPort_Vlan extends CommonDBRelation
         }
 
         $canedit = $port->canEdit($ID);
-        $rand    = random_int();
+        $rand    = random_int(0, 2**32);
 
         $iterator = $DB->request([
             'SELECT'    => [
@@ -195,7 +195,7 @@ TWIG, $twig_params);
             'showmassiveactions' => $canedit,
             'massiveactionparams' => [
                 'num_displayed' => count($entries),
-                'container'     => 'mass' . static::class . random_int(),
+                'container'     => 'mass' . static::class . random_int(0, 2**32),
             ]
         ]);
     }
@@ -266,7 +266,7 @@ TWIG, $twig_params);
             'showmassiveactions' => $canedit,
             'massiveactionparams' => [
                 'num_displayed' => count($entries),
-                'container'     => 'mass' . static::class . random_int(),
+                'container'     => 'mass' . static::class . random_int(0, 2**32),
             ]
         ]);
     }

--- a/src/Notepad.php
+++ b/src/Notepad.php
@@ -321,7 +321,7 @@ class Notepad extends CommonDBChild
             return false;
         }
         $notes     = static::getAllForItem($item);
-        $rand      = random_int();
+        $rand      = random_int(0, 2**32);
         $canedit   = Session::haveRight($item::$rightname, UPDATENOTE);
 
         if (

--- a/src/Notepad.php
+++ b/src/Notepad.php
@@ -321,7 +321,7 @@ class Notepad extends CommonDBChild
             return false;
         }
         $notes     = static::getAllForItem($item);
-        $rand      = mt_rand();
+        $rand      = random_int();
         $canedit   = Session::haveRight($item::$rightname, UPDATENOTE);
 
         if (

--- a/src/Notepad.php
+++ b/src/Notepad.php
@@ -321,7 +321,7 @@ class Notepad extends CommonDBChild
             return false;
         }
         $notes     = static::getAllForItem($item);
-        $rand      = random_int(0, 2**32);
+        $rand      = random_int(0, 2 ** 32);
         $canedit   = Session::haveRight($item::$rightname, UPDATENOTE);
 
         if (

--- a/src/NotificationTemplateTranslation.php
+++ b/src/NotificationTemplateTranslation.php
@@ -176,7 +176,7 @@ TWIG, $twig_params);
             'showmassiveactions' => $canedit,
             'massiveactionparams' => [
                 'num_displayed' => count($entries),
-                'container'     => 'mass' . static::class . random_int(0, 2**32),
+                'container'     => 'mass' . static::class . random_int(0, 2 ** 32),
             ]
         ]);
     }

--- a/src/NotificationTemplateTranslation.php
+++ b/src/NotificationTemplateTranslation.php
@@ -176,7 +176,7 @@ TWIG, $twig_params);
             'showmassiveactions' => $canedit,
             'massiveactionparams' => [
                 'num_displayed' => count($entries),
-                'container'     => 'mass' . static::class . random_int(),
+                'container'     => 'mass' . static::class . random_int(0, 2**32),
             ]
         ]);
     }

--- a/src/NotificationTemplateTranslation.php
+++ b/src/NotificationTemplateTranslation.php
@@ -176,7 +176,7 @@ TWIG, $twig_params);
             'showmassiveactions' => $canedit,
             'massiveactionparams' => [
                 'num_displayed' => count($entries),
-                'container'     => 'mass' . static::class . mt_rand(),
+                'container'     => 'mass' . static::class . random_int(),
             ]
         ]);
     }

--- a/src/Notification_NotificationTemplate.php
+++ b/src/Notification_NotificationTemplate.php
@@ -202,7 +202,7 @@ TWIG, $twig_params);
             'showmassiveactions' => $canedit,
             'massiveactionparams' => [
                 'num_displayed' => count($entries),
-                'container'     => 'mass' . static::class . mt_rand(),
+                'container'     => 'mass' . static::class . random_int(),
                 'specific_actions' => ['purge' => _x('button', 'Delete permanently')]
             ]
         ]);
@@ -279,7 +279,7 @@ TWIG, $twig_params);
             'showmassiveactions' => $canedit,
             'massiveactionparams' => [
                 'num_displayed' => count($entries),
-                'container'     => 'mass' . static::class . mt_rand(),
+                'container'     => 'mass' . static::class . random_int(),
                 'specific_actions' => ['purge' => _x('button', 'Delete permanently')]
             ]
         ]);

--- a/src/Notification_NotificationTemplate.php
+++ b/src/Notification_NotificationTemplate.php
@@ -202,7 +202,7 @@ TWIG, $twig_params);
             'showmassiveactions' => $canedit,
             'massiveactionparams' => [
                 'num_displayed' => count($entries),
-                'container'     => 'mass' . static::class . random_int(),
+                'container'     => 'mass' . static::class . random_int(0, 2**32),
                 'specific_actions' => ['purge' => _x('button', 'Delete permanently')]
             ]
         ]);
@@ -279,7 +279,7 @@ TWIG, $twig_params);
             'showmassiveactions' => $canedit,
             'massiveactionparams' => [
                 'num_displayed' => count($entries),
-                'container'     => 'mass' . static::class . random_int(),
+                'container'     => 'mass' . static::class . random_int(0, 2**32),
                 'specific_actions' => ['purge' => _x('button', 'Delete permanently')]
             ]
         ]);

--- a/src/Notification_NotificationTemplate.php
+++ b/src/Notification_NotificationTemplate.php
@@ -202,7 +202,7 @@ TWIG, $twig_params);
             'showmassiveactions' => $canedit,
             'massiveactionparams' => [
                 'num_displayed' => count($entries),
-                'container'     => 'mass' . static::class . random_int(0, 2**32),
+                'container'     => 'mass' . static::class . random_int(0, 2 ** 32),
                 'specific_actions' => ['purge' => _x('button', 'Delete permanently')]
             ]
         ]);
@@ -279,7 +279,7 @@ TWIG, $twig_params);
             'showmassiveactions' => $canedit,
             'massiveactionparams' => [
                 'num_displayed' => count($entries),
-                'container'     => 'mass' . static::class . random_int(0, 2**32),
+                'container'     => 'mass' . static::class . random_int(0, 2 ** 32),
                 'specific_actions' => ['purge' => _x('button', 'Delete permanently')]
             ]
         ]);

--- a/src/PDU_Rack.php
+++ b/src/PDU_Rack.php
@@ -236,7 +236,7 @@ class PDU_Rack extends CommonDBRelation
         $rack = new Rack();
         $rack->getFromDB($this->fields['racks_id']);
 
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
 
         echo "<tr class='tab_bg_1'>";
         echo "<td><label for='dropdown_pdus_id$rand'>" . htmlescape(PDU::getTypeName(1)) . "</label></td>";
@@ -311,7 +311,7 @@ class PDU_Rack extends CommonDBRelation
 
         $pdu     = new PDU();
         $canedit = $rack->canEdit($rack->getID());
-        $rand    = random_int();
+        $rand    = random_int(0, 2**32);
         $items   = $DB->request([
             'SELECT' => ['id', 'pdus_id', 'side', 'position'],
             'FROM'   => self::getTable(),
@@ -470,7 +470,7 @@ class PDU_Rack extends CommonDBRelation
     public static function showFirstForm($racks_id = 0)
     {
 
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
         echo "<label for='dropdown_sub_form$rand'>" . __s("The pdu will be") . "</label>&nbsp;";
         Dropdown::showFromArray('sub_form', [
             'racked'    => __('racked'),
@@ -511,7 +511,7 @@ JAVASCRIPT;
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $rand  = random_int();
+        $rand  = random_int(0, 2**32);
         $num_u = $rack->fields['number_units'];
         $pdu   = new PDU();
         $pdu_m = new PDUModel();
@@ -591,7 +591,7 @@ JAVASCRIPT;
                     $tip .= "</span>";
 
                     $picture_c = "";
-                    $item_rand = random_int();
+                    $item_rand = random_int(0, 2**32);
 
                     if ($picture) {
                         $picture_url = Toolbox::getPictureUrl($picture);

--- a/src/PDU_Rack.php
+++ b/src/PDU_Rack.php
@@ -236,7 +236,7 @@ class PDU_Rack extends CommonDBRelation
         $rack = new Rack();
         $rack->getFromDB($this->fields['racks_id']);
 
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
 
         echo "<tr class='tab_bg_1'>";
         echo "<td><label for='dropdown_pdus_id$rand'>" . htmlescape(PDU::getTypeName(1)) . "</label></td>";
@@ -311,7 +311,7 @@ class PDU_Rack extends CommonDBRelation
 
         $pdu     = new PDU();
         $canedit = $rack->canEdit($rack->getID());
-        $rand    = random_int(0, 2**32);
+        $rand    = random_int(0, 2 ** 32);
         $items   = $DB->request([
             'SELECT' => ['id', 'pdus_id', 'side', 'position'],
             'FROM'   => self::getTable(),
@@ -470,7 +470,7 @@ class PDU_Rack extends CommonDBRelation
     public static function showFirstForm($racks_id = 0)
     {
 
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
         echo "<label for='dropdown_sub_form$rand'>" . __s("The pdu will be") . "</label>&nbsp;";
         Dropdown::showFromArray('sub_form', [
             'racked'    => __('racked'),
@@ -511,7 +511,7 @@ JAVASCRIPT;
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $rand  = random_int(0, 2**32);
+        $rand  = random_int(0, 2 ** 32);
         $num_u = $rack->fields['number_units'];
         $pdu   = new PDU();
         $pdu_m = new PDUModel();
@@ -591,7 +591,7 @@ JAVASCRIPT;
                     $tip .= "</span>";
 
                     $picture_c = "";
-                    $item_rand = random_int(0, 2**32);
+                    $item_rand = random_int(0, 2 ** 32);
 
                     if ($picture) {
                         $picture_url = Toolbox::getPictureUrl($picture);

--- a/src/PDU_Rack.php
+++ b/src/PDU_Rack.php
@@ -236,7 +236,7 @@ class PDU_Rack extends CommonDBRelation
         $rack = new Rack();
         $rack->getFromDB($this->fields['racks_id']);
 
-        $rand = mt_rand();
+        $rand = random_int();
 
         echo "<tr class='tab_bg_1'>";
         echo "<td><label for='dropdown_pdus_id$rand'>" . htmlescape(PDU::getTypeName(1)) . "</label></td>";
@@ -311,7 +311,7 @@ class PDU_Rack extends CommonDBRelation
 
         $pdu     = new PDU();
         $canedit = $rack->canEdit($rack->getID());
-        $rand    = mt_rand();
+        $rand    = random_int();
         $items   = $DB->request([
             'SELECT' => ['id', 'pdus_id', 'side', 'position'],
             'FROM'   => self::getTable(),
@@ -470,7 +470,7 @@ class PDU_Rack extends CommonDBRelation
     public static function showFirstForm($racks_id = 0)
     {
 
-        $rand = mt_rand();
+        $rand = random_int();
         echo "<label for='dropdown_sub_form$rand'>" . __s("The pdu will be") . "</label>&nbsp;";
         Dropdown::showFromArray('sub_form', [
             'racked'    => __('racked'),
@@ -511,7 +511,7 @@ JAVASCRIPT;
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $rand  = mt_rand();
+        $rand  = random_int();
         $num_u = $rack->fields['number_units'];
         $pdu   = new PDU();
         $pdu_m = new PDUModel();
@@ -591,7 +591,7 @@ JAVASCRIPT;
                     $tip .= "</span>";
 
                     $picture_c = "";
-                    $item_rand = mt_rand();
+                    $item_rand = random_int();
 
                     if ($picture) {
                         $picture_url = Toolbox::getPictureUrl($picture);

--- a/src/Planning.php
+++ b/src/Planning.php
@@ -502,7 +502,7 @@ JAVASCRIPT;
                 'now'          => date("Y-m-d H:i:s"),
                 'can_create'   => PlanningExternalEvent::canCreate(),
                 'can_delete'   => PlanningExternalEvent::canPurge(),
-                'rand'         => random_int(),
+                'rand'         => random_int(0, 2**32),
             ];
         } else {
             // short view (on Central page)
@@ -511,7 +511,7 @@ JAVASCRIPT;
                 'default_view' => 'listFull',
                 'header'       => false,
                 'height'       => 'auto',
-                'rand'         => random_int(),
+                'rand'         => random_int(0, 2**32),
                 'now'          => date("Y-m-d H:i:s"),
             ];
         }
@@ -855,7 +855,7 @@ TWIG, ['options' => $options]);
 
         $twig_params = [
             'planning_types' => $planning_types,
-            'rand'           => random_int(),
+            'rand'           => random_int(0, 2**32),
             'label'          => __('Actor'),
         ];
         // language=Twig
@@ -1043,7 +1043,7 @@ TWIG, $twig_params);
             "</a>";
             echo "</div>";
             echo "<hr>";
-            $rand = random_int();
+            $rand = random_int(0, 2**32);
             $options = [
                 'from_planning_edit_ajax' => true,
                 'formoptions'             => "id='edit_event_form$rand'",
@@ -1245,7 +1245,7 @@ TWIG, $twig_params);
      */
     public static function showAddEventSubForm($params = [])
     {
-        $rand   = random_int();
+        $rand   = random_int(0, 2**32);
         $params = self::cleanDates($params);
 
         $params['res_itemtype'] = $params['res_itemtype'] ?? '';
@@ -1290,7 +1290,7 @@ TWIG, $twig_params);
             echo "<input type='hidden' name='plan[id]' value='" . $params["id"] . "'>";
         }
 
-        $rand = $params['rand'] ?? random_int();
+        $rand = $params['rand'] ?? random_int(0, 2**32);
         $display_dates = $params['_display_dates'] ?? true;
         $mintime = $CFG_GLPI["planning_begin"];
         if (!empty($params["begin"])) {
@@ -1352,7 +1352,7 @@ TWIG, $twig_params);
         }
 
         if (count($append_params) > 1) {
-            $rand = random_int();
+            $rand = random_int(0, 2**32);
             echo "<a href='#' title=\"" . __s('Availability') . "\" data-bs-toggle='modal' data-bs-target='#planningcheck$rand'>";
             echo "<i class='far fa-calendar-alt'></i>";
             echo "<span class='sr-only'>" . __s('Availability') . "</span>";

--- a/src/Planning.php
+++ b/src/Planning.php
@@ -502,7 +502,7 @@ JAVASCRIPT;
                 'now'          => date("Y-m-d H:i:s"),
                 'can_create'   => PlanningExternalEvent::canCreate(),
                 'can_delete'   => PlanningExternalEvent::canPurge(),
-                'rand'         => mt_rand(),
+                'rand'         => random_int(),
             ];
         } else {
             // short view (on Central page)
@@ -511,7 +511,7 @@ JAVASCRIPT;
                 'default_view' => 'listFull',
                 'header'       => false,
                 'height'       => 'auto',
-                'rand'         => mt_rand(),
+                'rand'         => random_int(),
                 'now'          => date("Y-m-d H:i:s"),
             ];
         }
@@ -855,7 +855,7 @@ TWIG, ['options' => $options]);
 
         $twig_params = [
             'planning_types' => $planning_types,
-            'rand'           => mt_rand(),
+            'rand'           => random_int(),
             'label'          => __('Actor'),
         ];
         // language=Twig
@@ -1043,7 +1043,7 @@ TWIG, $twig_params);
             "</a>";
             echo "</div>";
             echo "<hr>";
-            $rand = mt_rand();
+            $rand = random_int();
             $options = [
                 'from_planning_edit_ajax' => true,
                 'formoptions'             => "id='edit_event_form$rand'",
@@ -1245,7 +1245,7 @@ TWIG, $twig_params);
      */
     public static function showAddEventSubForm($params = [])
     {
-        $rand   = mt_rand();
+        $rand   = random_int();
         $params = self::cleanDates($params);
 
         $params['res_itemtype'] = $params['res_itemtype'] ?? '';
@@ -1290,7 +1290,7 @@ TWIG, $twig_params);
             echo "<input type='hidden' name='plan[id]' value='" . $params["id"] . "'>";
         }
 
-        $rand = $params['rand'] ?? mt_rand();
+        $rand = $params['rand'] ?? random_int();
         $display_dates = $params['_display_dates'] ?? true;
         $mintime = $CFG_GLPI["planning_begin"];
         if (!empty($params["begin"])) {
@@ -1352,7 +1352,7 @@ TWIG, $twig_params);
         }
 
         if (count($append_params) > 1) {
-            $rand = mt_rand();
+            $rand = random_int();
             echo "<a href='#' title=\"" . __s('Availability') . "\" data-bs-toggle='modal' data-bs-target='#planningcheck$rand'>";
             echo "<i class='far fa-calendar-alt'></i>";
             echo "<span class='sr-only'>" . __s('Availability') . "</span>";

--- a/src/Planning.php
+++ b/src/Planning.php
@@ -502,7 +502,7 @@ JAVASCRIPT;
                 'now'          => date("Y-m-d H:i:s"),
                 'can_create'   => PlanningExternalEvent::canCreate(),
                 'can_delete'   => PlanningExternalEvent::canPurge(),
-                'rand'         => random_int(0, 2**32),
+                'rand'         => random_int(0, 2 ** 32),
             ];
         } else {
             // short view (on Central page)
@@ -511,7 +511,7 @@ JAVASCRIPT;
                 'default_view' => 'listFull',
                 'header'       => false,
                 'height'       => 'auto',
-                'rand'         => random_int(0, 2**32),
+                'rand'         => random_int(0, 2 ** 32),
                 'now'          => date("Y-m-d H:i:s"),
             ];
         }
@@ -855,7 +855,7 @@ TWIG, ['options' => $options]);
 
         $twig_params = [
             'planning_types' => $planning_types,
-            'rand'           => random_int(0, 2**32),
+            'rand'           => random_int(0, 2 ** 32),
             'label'          => __('Actor'),
         ];
         // language=Twig
@@ -1043,7 +1043,7 @@ TWIG, $twig_params);
             "</a>";
             echo "</div>";
             echo "<hr>";
-            $rand = random_int(0, 2**32);
+            $rand = random_int(0, 2 ** 32);
             $options = [
                 'from_planning_edit_ajax' => true,
                 'formoptions'             => "id='edit_event_form$rand'",
@@ -1245,7 +1245,7 @@ TWIG, $twig_params);
      */
     public static function showAddEventSubForm($params = [])
     {
-        $rand   = random_int(0, 2**32);
+        $rand   = random_int(0, 2 ** 32);
         $params = self::cleanDates($params);
 
         $params['res_itemtype'] = $params['res_itemtype'] ?? '';
@@ -1290,7 +1290,7 @@ TWIG, $twig_params);
             echo "<input type='hidden' name='plan[id]' value='" . $params["id"] . "'>";
         }
 
-        $rand = $params['rand'] ?? random_int(0, 2**32);
+        $rand = $params['rand'] ?? random_int(0, 2 ** 32);
         $display_dates = $params['_display_dates'] ?? true;
         $mintime = $CFG_GLPI["planning_begin"];
         if (!empty($params["begin"])) {
@@ -1352,7 +1352,7 @@ TWIG, $twig_params);
         }
 
         if (count($append_params) > 1) {
-            $rand = random_int(0, 2**32);
+            $rand = random_int(0, 2 ** 32);
             echo "<a href='#' title=\"" . __s('Availability') . "\" data-bs-toggle='modal' data-bs-target='#planningcheck$rand'>";
             echo "<i class='far fa-calendar-alt'></i>";
             echo "<span class='sr-only'>" . __s('Availability') . "</span>";

--- a/src/PlanningExternalEvent.php
+++ b/src/PlanningExternalEvent.php
@@ -139,9 +139,9 @@ class PlanningExternalEvent extends CommonDBTM implements CalDAVCompatibleItemIn
     {
         $this->initForm($ID, $options);
         $options['canedit'] = $this->can($ID, UPDATE);
-        $rand       = random_int(0, 2**32);
-        $rand_plan  = random_int(0, 2**32);
-        $rand_rrule = random_int(0, 2**32);
+        $rand       = random_int(0, 2 ** 32);
+        $rand_plan  = random_int(0, 2 ** 32);
+        $rand_rrule = random_int(0, 2 ** 32);
 
         if (
             ($options['from_planning_ajax'] ?? false)

--- a/src/PlanningExternalEvent.php
+++ b/src/PlanningExternalEvent.php
@@ -139,9 +139,9 @@ class PlanningExternalEvent extends CommonDBTM implements CalDAVCompatibleItemIn
     {
         $this->initForm($ID, $options);
         $options['canedit'] = $this->can($ID, UPDATE);
-        $rand       = random_int();
-        $rand_plan  = random_int();
-        $rand_rrule = random_int();
+        $rand       = random_int(0, 2**32);
+        $rand_plan  = random_int(0, 2**32);
+        $rand_rrule = random_int(0, 2**32);
 
         if (
             ($options['from_planning_ajax'] ?? false)

--- a/src/PlanningExternalEvent.php
+++ b/src/PlanningExternalEvent.php
@@ -139,9 +139,9 @@ class PlanningExternalEvent extends CommonDBTM implements CalDAVCompatibleItemIn
     {
         $this->initForm($ID, $options);
         $options['canedit'] = $this->can($ID, UPDATE);
-        $rand       = mt_rand();
-        $rand_plan  = mt_rand();
-        $rand_rrule = mt_rand();
+        $rand       = random_int();
+        $rand_plan  = random_int();
+        $rand_rrule = random_int();
 
         if (
             ($options['from_planning_ajax'] ?? false)

--- a/src/PlanningRecall.php
+++ b/src/PlanningRecall.php
@@ -275,7 +275,7 @@ class PlanningRecall extends CommonDBChild
         $p['users_id'] = Session::getLoginUserID();
         $p['value']    = Entity::CONFIG_NEVER;
         $p['field']    = 'begin';
-        $p['rand']     = mt_rand();
+        $p['rand']     = random_int();
 
         if (is_array($options) && count($options)) {
             foreach ($options as $key => $val) {

--- a/src/PlanningRecall.php
+++ b/src/PlanningRecall.php
@@ -275,7 +275,7 @@ class PlanningRecall extends CommonDBChild
         $p['users_id'] = Session::getLoginUserID();
         $p['value']    = Entity::CONFIG_NEVER;
         $p['field']    = 'begin';
-        $p['rand']     = random_int(0, 2**32);
+        $p['rand']     = random_int(0, 2 ** 32);
 
         if (is_array($options) && count($options)) {
             foreach ($options as $key => $val) {

--- a/src/PlanningRecall.php
+++ b/src/PlanningRecall.php
@@ -275,7 +275,7 @@ class PlanningRecall extends CommonDBChild
         $p['users_id'] = Session::getLoginUserID();
         $p['value']    = Entity::CONFIG_NEVER;
         $p['field']    = 'begin';
-        $p['rand']     = random_int();
+        $p['rand']     = random_int(0, 2**32);
 
         if (is_array($options) && count($options)) {
             foreach ($options as $key => $val) {

--- a/src/Problem.php
+++ b/src/Problem.php
@@ -1018,7 +1018,7 @@ class Problem extends CommonITILObject
                 ];
                 foreach ($iterator as $data) {
                     $problem = new self();
-                    $rand = random_int(0, 2**32);
+                    $rand = random_int(0, 2 ** 32);
                     $row = [
                         'values' => []
                     ];
@@ -1248,7 +1248,7 @@ class Problem extends CommonITILObject
         $viewusers = User::canView();
 
         $problem   = new self();
-        $rand      = random_int(0, 2**32);
+        $rand      = random_int(0, 2 ** 32);
         if ($problem->getFromDBwithData($ID)) {
             $bgcolor = $_SESSION["glpipriority_" . $problem->fields["priority"]];
             $name    = htmlescape(sprintf(__('%1$s: %2$s'), __('ID'), $problem->fields["id"]));

--- a/src/Problem.php
+++ b/src/Problem.php
@@ -1018,7 +1018,7 @@ class Problem extends CommonITILObject
                 ];
                 foreach ($iterator as $data) {
                     $problem = new self();
-                    $rand = mt_rand();
+                    $rand = random_int();
                     $row = [
                         'values' => []
                     ];
@@ -1248,7 +1248,7 @@ class Problem extends CommonITILObject
         $viewusers = User::canView();
 
         $problem   = new self();
-        $rand      = mt_rand();
+        $rand      = random_int();
         if ($problem->getFromDBwithData($ID)) {
             $bgcolor = $_SESSION["glpipriority_" . $problem->fields["priority"]];
             $name    = htmlescape(sprintf(__('%1$s: %2$s'), __('ID'), $problem->fields["id"]));

--- a/src/Problem.php
+++ b/src/Problem.php
@@ -1018,7 +1018,7 @@ class Problem extends CommonITILObject
                 ];
                 foreach ($iterator as $data) {
                     $problem = new self();
-                    $rand = random_int();
+                    $rand = random_int(0, 2**32);
                     $row = [
                         'values' => []
                     ];
@@ -1248,7 +1248,7 @@ class Problem extends CommonITILObject
         $viewusers = User::canView();
 
         $problem   = new self();
-        $rand      = random_int();
+        $rand      = random_int(0, 2**32);
         if ($problem->getFromDBwithData($ID)) {
             $bgcolor = $_SESSION["glpipriority_" . $problem->fields["priority"]];
             $name    = htmlescape(sprintf(__('%1$s: %2$s'), __('ID'), $problem->fields["id"]));

--- a/src/Problem_Ticket.php
+++ b/src/Problem_Ticket.php
@@ -202,7 +202,7 @@ class Problem_Ticket extends CommonITILObject_CommonITILObject
 
         $canedit = $problem->canEdit($ID);
 
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
 
         $tickets = self::getProblemTicketsData($ID);
         $used    = [];
@@ -277,7 +277,7 @@ class Problem_Ticket extends CommonITILObject_CommonITILObject
 
         $canedit = $ticket->can($ID, UPDATE);
 
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
 
         $problems = self::getTicketProblemsData($ID);
         $used     = [];

--- a/src/Problem_Ticket.php
+++ b/src/Problem_Ticket.php
@@ -202,7 +202,7 @@ class Problem_Ticket extends CommonITILObject_CommonITILObject
 
         $canedit = $problem->canEdit($ID);
 
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
 
         $tickets = self::getProblemTicketsData($ID);
         $used    = [];
@@ -277,7 +277,7 @@ class Problem_Ticket extends CommonITILObject_CommonITILObject
 
         $canedit = $ticket->can($ID, UPDATE);
 
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
 
         $problems = self::getTicketProblemsData($ID);
         $used     = [];

--- a/src/Problem_Ticket.php
+++ b/src/Problem_Ticket.php
@@ -202,7 +202,7 @@ class Problem_Ticket extends CommonITILObject_CommonITILObject
 
         $canedit = $problem->canEdit($ID);
 
-        $rand = mt_rand();
+        $rand = random_int();
 
         $tickets = self::getProblemTicketsData($ID);
         $used    = [];
@@ -277,7 +277,7 @@ class Problem_Ticket extends CommonITILObject_CommonITILObject
 
         $canedit = $ticket->can($ID, UPDATE);
 
-        $rand = mt_rand();
+        $rand = random_int();
 
         $problems = self::getTicketProblemsData($ID);
         $used     = [];

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -799,7 +799,7 @@ class Profile extends CommonDBTM
             $new     = true;
         }
 
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
 
         $this->showFormHeader($options);
 
@@ -3802,7 +3802,7 @@ class Profile extends CommonDBTM
         $param['nonone']  = false;
         $param['noread']  = false;
         $param['nowrite'] = false;
-        $param['rand']    = random_int();
+        $param['rand']    = random_int(0, 2**32);
 
         if (is_array($options) && count($options)) {
             foreach ($options as $key => $val) {
@@ -3845,7 +3845,7 @@ class Profile extends CommonDBTM
 
         $p['name']  = 'profiles_id';
         $p['value'] = '';
-        $p['rand']  = random_int();
+        $p['rand']  = random_int(0, 2**32);
 
         if (is_array($options) && count($options)) {
             foreach ($options as $key => $val) {
@@ -4256,7 +4256,7 @@ class Profile extends CommonDBTM
         $param['value']         = '';
         $param['max_per_line']  = 10;
         $param['check_all']     = false;
-        $param['rand']          = random_int();
+        $param['rand']          = random_int(0, 2**32);
         $param['zero_on_empty'] = true;
         $param['display']       = true;
         $param['check_method']  = static fn ($element, $field) => (($field & $element) === $element);

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -799,7 +799,7 @@ class Profile extends CommonDBTM
             $new     = true;
         }
 
-        $rand = mt_rand();
+        $rand = random_int();
 
         $this->showFormHeader($options);
 
@@ -3802,7 +3802,7 @@ class Profile extends CommonDBTM
         $param['nonone']  = false;
         $param['noread']  = false;
         $param['nowrite'] = false;
-        $param['rand']    = mt_rand();
+        $param['rand']    = random_int();
 
         if (is_array($options) && count($options)) {
             foreach ($options as $key => $val) {
@@ -3845,7 +3845,7 @@ class Profile extends CommonDBTM
 
         $p['name']  = 'profiles_id';
         $p['value'] = '';
-        $p['rand']  = mt_rand();
+        $p['rand']  = random_int();
 
         if (is_array($options) && count($options)) {
             foreach ($options as $key => $val) {
@@ -4256,7 +4256,7 @@ class Profile extends CommonDBTM
         $param['value']         = '';
         $param['max_per_line']  = 10;
         $param['check_all']     = false;
-        $param['rand']          = mt_rand();
+        $param['rand']          = random_int();
         $param['zero_on_empty'] = true;
         $param['display']       = true;
         $param['check_method']  = static fn ($element, $field) => (($field & $element) === $element);

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -799,7 +799,7 @@ class Profile extends CommonDBTM
             $new     = true;
         }
 
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
 
         $this->showFormHeader($options);
 
@@ -3802,7 +3802,7 @@ class Profile extends CommonDBTM
         $param['nonone']  = false;
         $param['noread']  = false;
         $param['nowrite'] = false;
-        $param['rand']    = random_int(0, 2**32);
+        $param['rand']    = random_int(0, 2 ** 32);
 
         if (is_array($options) && count($options)) {
             foreach ($options as $key => $val) {
@@ -3845,7 +3845,7 @@ class Profile extends CommonDBTM
 
         $p['name']  = 'profiles_id';
         $p['value'] = '';
-        $p['rand']  = random_int(0, 2**32);
+        $p['rand']  = random_int(0, 2 ** 32);
 
         if (is_array($options) && count($options)) {
             foreach ($options as $key => $val) {
@@ -4256,7 +4256,7 @@ class Profile extends CommonDBTM
         $param['value']         = '';
         $param['max_per_line']  = 10;
         $param['check_all']     = false;
-        $param['rand']          = random_int(0, 2**32);
+        $param['rand']          = random_int(0, 2 ** 32);
         $param['zero_on_empty'] = true;
         $param['display']       = true;
         $param['check_method']  = static fn ($element, $field) => (($field & $element) === $element);

--- a/src/Profile_User.php
+++ b/src/Profile_User.php
@@ -226,7 +226,7 @@ class Profile_User extends CommonDBRelation
             'showmassiveactions' => $canedit,
             'massiveactionparams' => [
                 'num_displayed'    => min($_SESSION['glpilist_limit'], count($entries)),
-                'container'        => 'mass' . __CLASS__ . random_int(),
+                'container'        => 'mass' . __CLASS__ . random_int(0, 2**32),
                 'specific_actions' => ['purge' => _x('button', 'Delete permanently')]
             ],
         ]);
@@ -249,7 +249,7 @@ class Profile_User extends CommonDBRelation
         }
 
         $canedit     = $entity->canEdit($ID);
-        $rand        = random_int();
+        $rand        = random_int(0, 2**32);
 
         if ($canedit) {
             TemplateRenderer::getInstance()->display('pages/admin/add_profile_authorization.html.twig', [
@@ -437,7 +437,7 @@ TWIG, $avatar_params) . $username;
 
         $ID      = $prof->fields['id'];
         $canedit = Session::haveRightsOr("user", [CREATE, UPDATE, DELETE, PURGE]);
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
         if (!$prof->can($ID, READ)) {
             return false;
         }

--- a/src/Profile_User.php
+++ b/src/Profile_User.php
@@ -226,7 +226,7 @@ class Profile_User extends CommonDBRelation
             'showmassiveactions' => $canedit,
             'massiveactionparams' => [
                 'num_displayed'    => min($_SESSION['glpilist_limit'], count($entries)),
-                'container'        => 'mass' . __CLASS__ . mt_rand(),
+                'container'        => 'mass' . __CLASS__ . random_int(),
                 'specific_actions' => ['purge' => _x('button', 'Delete permanently')]
             ],
         ]);
@@ -249,7 +249,7 @@ class Profile_User extends CommonDBRelation
         }
 
         $canedit     = $entity->canEdit($ID);
-        $rand        = mt_rand();
+        $rand        = random_int();
 
         if ($canedit) {
             TemplateRenderer::getInstance()->display('pages/admin/add_profile_authorization.html.twig', [
@@ -437,7 +437,7 @@ TWIG, $avatar_params) . $username;
 
         $ID      = $prof->fields['id'];
         $canedit = Session::haveRightsOr("user", [CREATE, UPDATE, DELETE, PURGE]);
-        $rand = mt_rand();
+        $rand = random_int();
         if (!$prof->can($ID, READ)) {
             return false;
         }

--- a/src/Profile_User.php
+++ b/src/Profile_User.php
@@ -226,7 +226,7 @@ class Profile_User extends CommonDBRelation
             'showmassiveactions' => $canedit,
             'massiveactionparams' => [
                 'num_displayed'    => min($_SESSION['glpilist_limit'], count($entries)),
-                'container'        => 'mass' . __CLASS__ . random_int(0, 2**32),
+                'container'        => 'mass' . __CLASS__ . random_int(0, 2 ** 32),
                 'specific_actions' => ['purge' => _x('button', 'Delete permanently')]
             ],
         ]);
@@ -249,7 +249,7 @@ class Profile_User extends CommonDBRelation
         }
 
         $canedit     = $entity->canEdit($ID);
-        $rand        = random_int(0, 2**32);
+        $rand        = random_int(0, 2 ** 32);
 
         if ($canedit) {
             TemplateRenderer::getInstance()->display('pages/admin/add_profile_authorization.html.twig', [
@@ -437,7 +437,7 @@ TWIG, $avatar_params) . $username;
 
         $ID      = $prof->fields['id'];
         $canedit = Session::haveRightsOr("user", [CREATE, UPDATE, DELETE, PURGE]);
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
         if (!$prof->can($ID, READ)) {
             return false;
         }

--- a/src/Project.php
+++ b/src/Project.php
@@ -1183,7 +1183,7 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria
             }
         }
 
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
 
        // Prints a job in short form
        // Should be called in a <table>-segment
@@ -1437,7 +1437,7 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria
 
         $ID   = $this->getID();
         $this->check($ID, READ);
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
 
         $iterator = $DB->request([
             'FROM'   => static::getTable(),
@@ -1690,7 +1690,7 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria
         );
         echo "</td></tr>";
 
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
 
         echo "<tr class='tab_bg_1'>";
         echo "<td>" . __s('Description') . "</td>";
@@ -1758,7 +1758,7 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria
 
         echo "<div class='center'>";
 
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
         $nb   = $project->getTeamCount();
 
         if ($canedit) {

--- a/src/Project.php
+++ b/src/Project.php
@@ -1183,7 +1183,7 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria
             }
         }
 
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
 
        // Prints a job in short form
        // Should be called in a <table>-segment
@@ -1437,7 +1437,7 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria
 
         $ID   = $this->getID();
         $this->check($ID, READ);
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
 
         $iterator = $DB->request([
             'FROM'   => static::getTable(),
@@ -1690,7 +1690,7 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria
         );
         echo "</td></tr>";
 
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
 
         echo "<tr class='tab_bg_1'>";
         echo "<td>" . __s('Description') . "</td>";
@@ -1758,7 +1758,7 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria
 
         echo "<div class='center'>";
 
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
         $nb   = $project->getTeamCount();
 
         if ($canedit) {

--- a/src/Project.php
+++ b/src/Project.php
@@ -1183,7 +1183,7 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria
             }
         }
 
-        $rand = mt_rand();
+        $rand = random_int();
 
        // Prints a job in short form
        // Should be called in a <table>-segment
@@ -1437,7 +1437,7 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria
 
         $ID   = $this->getID();
         $this->check($ID, READ);
-        $rand = mt_rand();
+        $rand = random_int();
 
         $iterator = $DB->request([
             'FROM'   => static::getTable(),
@@ -1690,7 +1690,7 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria
         );
         echo "</td></tr>";
 
-        $rand = mt_rand();
+        $rand = random_int();
 
         echo "<tr class='tab_bg_1'>";
         echo "<td>" . __s('Description') . "</td>";
@@ -1758,7 +1758,7 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria
 
         echo "<div class='center'>";
 
-        $rand = mt_rand();
+        $rand = random_int();
         $nb   = $project->getTeamCount();
 
         if ($canedit) {

--- a/src/ProjectCost.php
+++ b/src/ProjectCost.php
@@ -320,7 +320,7 @@ class ProjectCost extends CommonDBChild
             'ORDER'  => ['begin_date']
         ]);
 
-        $rand   = random_int();
+        $rand   = random_int(0, 2**32);
 
         if ($canedit) {
             echo "<div id='viewcost" . $ID . "_$rand'></div>\n";

--- a/src/ProjectCost.php
+++ b/src/ProjectCost.php
@@ -320,7 +320,7 @@ class ProjectCost extends CommonDBChild
             'ORDER'  => ['begin_date']
         ]);
 
-        $rand   = random_int(0, 2**32);
+        $rand   = random_int(0, 2 ** 32);
 
         if ($canedit) {
             echo "<div id='viewcost" . $ID . "_$rand'></div>\n";

--- a/src/ProjectCost.php
+++ b/src/ProjectCost.php
@@ -320,7 +320,7 @@ class ProjectCost extends CommonDBChild
             'ORDER'  => ['begin_date']
         ]);
 
-        $rand   = mt_rand();
+        $rand   = random_int();
 
         if ($canedit) {
             echo "<div id='viewcost" . $ID . "_$rand'></div>\n";

--- a/src/ProjectTask.php
+++ b/src/ProjectTask.php
@@ -769,7 +769,7 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
             'recursive'                => $recursive,
             'duration_dropdown_to_add' => $duration_dropdown_to_add,
             'duration'                 => $duration,
-            'rand'                     => mt_rand(),
+            'rand'                     => random_int(),
         ]);
         return true;
     }
@@ -1274,7 +1274,7 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
             echo "</div>";
         }
 
-        $rand = mt_rand();
+        $rand = random_int();
         if (
             ($item->getType() == 'ProjectTask')
             && $item->can($ID, UPDATE)
@@ -1376,7 +1376,7 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
 
             foreach ($iterator as $data) {
                 Session::addToNavigateListItems('ProjectTask', $data['id']);
-                $rand = mt_rand();
+                $rand = random_int();
                 echo "<tr class='" . ($data['is_deleted'] ? "tab_bg_1_2" : "tab_bg_2") . "'>";
 
                 if ($canedit) {
@@ -1502,7 +1502,7 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
         $ID      = $task->fields['id'];
         $canedit = $task->canEdit($ID);
 
-        $rand = mt_rand();
+        $rand = random_int();
         $nb   = $task->getTeamCount();
 
         if ($canedit) {
@@ -2079,7 +2079,7 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
         global $CFG_GLPI;
 
         $html = "";
-        $rand     = mt_rand();
+        $rand     = random_int();
         $users_id = "";  // show users_id project task
         $img      = "rdv_private.png"; // default icon for project task
 

--- a/src/ProjectTask.php
+++ b/src/ProjectTask.php
@@ -769,7 +769,7 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
             'recursive'                => $recursive,
             'duration_dropdown_to_add' => $duration_dropdown_to_add,
             'duration'                 => $duration,
-            'rand'                     => random_int(),
+            'rand'                     => random_int(0, 2**32),
         ]);
         return true;
     }
@@ -1274,7 +1274,7 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
             echo "</div>";
         }
 
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
         if (
             ($item->getType() == 'ProjectTask')
             && $item->can($ID, UPDATE)
@@ -1376,7 +1376,7 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
 
             foreach ($iterator as $data) {
                 Session::addToNavigateListItems('ProjectTask', $data['id']);
-                $rand = random_int();
+                $rand = random_int(0, 2**32);
                 echo "<tr class='" . ($data['is_deleted'] ? "tab_bg_1_2" : "tab_bg_2") . "'>";
 
                 if ($canedit) {
@@ -1502,7 +1502,7 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
         $ID      = $task->fields['id'];
         $canedit = $task->canEdit($ID);
 
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
         $nb   = $task->getTeamCount();
 
         if ($canedit) {
@@ -2079,7 +2079,7 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
         global $CFG_GLPI;
 
         $html = "";
-        $rand     = random_int();
+        $rand     = random_int(0, 2**32);
         $users_id = "";  // show users_id project task
         $img      = "rdv_private.png"; // default icon for project task
 

--- a/src/ProjectTask.php
+++ b/src/ProjectTask.php
@@ -769,7 +769,7 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
             'recursive'                => $recursive,
             'duration_dropdown_to_add' => $duration_dropdown_to_add,
             'duration'                 => $duration,
-            'rand'                     => random_int(0, 2**32),
+            'rand'                     => random_int(0, 2 ** 32),
         ]);
         return true;
     }
@@ -1274,7 +1274,7 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
             echo "</div>";
         }
 
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
         if (
             ($item->getType() == 'ProjectTask')
             && $item->can($ID, UPDATE)
@@ -1376,7 +1376,7 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
 
             foreach ($iterator as $data) {
                 Session::addToNavigateListItems('ProjectTask', $data['id']);
-                $rand = random_int(0, 2**32);
+                $rand = random_int(0, 2 ** 32);
                 echo "<tr class='" . ($data['is_deleted'] ? "tab_bg_1_2" : "tab_bg_2") . "'>";
 
                 if ($canedit) {
@@ -1502,7 +1502,7 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
         $ID      = $task->fields['id'];
         $canedit = $task->canEdit($ID);
 
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
         $nb   = $task->getTeamCount();
 
         if ($canedit) {
@@ -2079,7 +2079,7 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
         global $CFG_GLPI;
 
         $html = "";
-        $rand     = random_int(0, 2**32);
+        $rand     = random_int(0, 2 ** 32);
         $users_id = "";  // show users_id project task
         $img      = "rdv_private.png"; // default icon for project task
 

--- a/src/ProjectTask_Ticket.php
+++ b/src/ProjectTask_Ticket.php
@@ -145,7 +145,7 @@ class ProjectTask_Ticket extends CommonDBRelation
         }
 
         $canedit = $projecttask->canEdit($ID);
-        $rand    = random_int(0, 2**32);
+        $rand    = random_int(0, 2 ** 32);
 
         $iterator = self::getListForItem($projecttask);
 
@@ -226,7 +226,7 @@ class ProjectTask_Ticket extends CommonDBRelation
         }
 
         $canedit = $ticket->canEdit($ID);
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
 
         $iterator = self::getListForItem($ticket);
 

--- a/src/ProjectTask_Ticket.php
+++ b/src/ProjectTask_Ticket.php
@@ -145,7 +145,7 @@ class ProjectTask_Ticket extends CommonDBRelation
         }
 
         $canedit = $projecttask->canEdit($ID);
-        $rand    = random_int();
+        $rand    = random_int(0, 2**32);
 
         $iterator = self::getListForItem($projecttask);
 
@@ -226,7 +226,7 @@ class ProjectTask_Ticket extends CommonDBRelation
         }
 
         $canedit = $ticket->canEdit($ID);
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
 
         $iterator = self::getListForItem($ticket);
 

--- a/src/ProjectTask_Ticket.php
+++ b/src/ProjectTask_Ticket.php
@@ -145,7 +145,7 @@ class ProjectTask_Ticket extends CommonDBRelation
         }
 
         $canedit = $projecttask->canEdit($ID);
-        $rand    = mt_rand();
+        $rand    = random_int();
 
         $iterator = self::getListForItem($projecttask);
 
@@ -226,7 +226,7 @@ class ProjectTask_Ticket extends CommonDBRelation
         }
 
         $canedit = $ticket->canEdit($ID);
-        $rand = mt_rand();
+        $rand = random_int();
 
         $iterator = self::getListForItem($ticket);
 

--- a/src/QueuedNotification.php
+++ b/src/QueuedNotification.php
@@ -434,7 +434,7 @@ class QueuedNotification extends CommonDBTM
                 }
 
                 if (Toolbox::strlen($plaintext) > $CFG_GLPI['cut']) {
-                    $rand = random_int(0, 2**32);
+                    $rand = random_int(0, 2 ** 32);
                     $popup_params = [
                         'display'       => false,
                         'awesome-class' => 'fa-comments',

--- a/src/QueuedNotification.php
+++ b/src/QueuedNotification.php
@@ -434,7 +434,7 @@ class QueuedNotification extends CommonDBTM
                 }
 
                 if (Toolbox::strlen($plaintext) > $CFG_GLPI['cut']) {
-                    $rand = random_int();
+                    $rand = random_int(0, 2**32);
                     $popup_params = [
                         'display'       => false,
                         'awesome-class' => 'fa-comments',

--- a/src/QueuedNotification.php
+++ b/src/QueuedNotification.php
@@ -434,7 +434,7 @@ class QueuedNotification extends CommonDBTM
                 }
 
                 if (Toolbox::strlen($plaintext) > $CFG_GLPI['cut']) {
-                    $rand = mt_rand();
+                    $rand = random_int();
                     $popup_params = [
                         'display'       => false,
                         'awesome-class' => 'fa-comments',

--- a/src/RSSFeed.php
+++ b/src/RSSFeed.php
@@ -839,7 +839,7 @@ TWIG, ['msg' => __('Check permissions to the directory: %s', GLPI_RSS_DIR)]);
                 }
 
                 $item_link = URL::sanitizeURL($item->get_permalink());
-                $rand = mt_rand();
+                $rand = random_int();
                 $output .= "<div id='rssitem$rand'>";
                 if (!empty($item_link)) {
                     $output .= '<a target="_blank" href="' . htmlescape($item_link) . '">';

--- a/src/RSSFeed.php
+++ b/src/RSSFeed.php
@@ -839,7 +839,7 @@ TWIG, ['msg' => __('Check permissions to the directory: %s', GLPI_RSS_DIR)]);
                 }
 
                 $item_link = URL::sanitizeURL($item->get_permalink());
-                $rand = random_int(0, 2**32);
+                $rand = random_int(0, 2 ** 32);
                 $output .= "<div id='rssitem$rand'>";
                 if (!empty($item_link)) {
                     $output .= '<a target="_blank" href="' . htmlescape($item_link) . '">';

--- a/src/RSSFeed.php
+++ b/src/RSSFeed.php
@@ -839,7 +839,7 @@ TWIG, ['msg' => __('Check permissions to the directory: %s', GLPI_RSS_DIR)]);
                 }
 
                 $item_link = URL::sanitizeURL($item->get_permalink());
-                $rand = random_int();
+                $rand = random_int(0, 2**32);
                 $output .= "<div id='rssitem$rand'>";
                 if (!empty($item_link)) {
                     $output .= '<a target="_blank" href="' . htmlescape($item_link) . '">';

--- a/src/Rack.php
+++ b/src/Rack.php
@@ -410,7 +410,7 @@ class Rack extends CommonDBTM
         global $CFG_GLPI, $DB;
 
         $room_id = $room->getID();
-        $rand = mt_rand();
+        $rand = random_int();
 
         if (
             !$room->getFromDB($room_id)

--- a/src/Rack.php
+++ b/src/Rack.php
@@ -410,7 +410,7 @@ class Rack extends CommonDBTM
         global $CFG_GLPI, $DB;
 
         $room_id = $room->getID();
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
 
         if (
             !$room->getFromDB($room_id)

--- a/src/Rack.php
+++ b/src/Rack.php
@@ -410,7 +410,7 @@ class Rack extends CommonDBTM
         global $CFG_GLPI, $DB;
 
         $room_id = $room->getID();
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
 
         if (
             !$room->getFromDB($room_id)

--- a/src/RefusedEquipment.php
+++ b/src/RefusedEquipment.php
@@ -209,7 +209,7 @@ class RefusedEquipment extends CommonDBTM
         echo "<td>";
         echo $rule->getLink();
 
-        $rand = mt_rand();
+        $rand = random_int();
         echo sprintf(
             "<a class='btn btn-primary' style='float:right;' href='#'  data-bs-toggle='modal' data-bs-target='#allruletest%s'>%s</a>",
             $rand,

--- a/src/RefusedEquipment.php
+++ b/src/RefusedEquipment.php
@@ -209,7 +209,7 @@ class RefusedEquipment extends CommonDBTM
         echo "<td>";
         echo $rule->getLink();
 
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
         echo sprintf(
             "<a class='btn btn-primary' style='float:right;' href='#'  data-bs-toggle='modal' data-bs-target='#allruletest%s'>%s</a>",
             $rand,

--- a/src/RefusedEquipment.php
+++ b/src/RefusedEquipment.php
@@ -209,7 +209,7 @@ class RefusedEquipment extends CommonDBTM
         echo "<td>";
         echo $rule->getLink();
 
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
         echo sprintf(
             "<a class='btn btn-primary' style='float:right;' href='#'  data-bs-toggle='modal' data-bs-target='#allruletest%s'>%s</a>",
             $rand,

--- a/src/Reminder.php
+++ b/src/Reminder.php
@@ -523,7 +523,7 @@ class Reminder extends CommonDBVisible implements
     public function showForm($ID, array $options = [])
     {
         $this->initForm($ID, $options);
-        $rand = mt_rand();
+        $rand = random_int();
 
         $canedit = $this->can($ID, UPDATE);
         $options['canedit'] = $canedit;
@@ -574,7 +574,7 @@ class Reminder extends CommonDBVisible implements
 
         return TemplateRenderer::getInstance()->render('pages/tools/reminder_planning.html.twig', [
             'val' => $val,
-            'rand' => mt_rand(),
+            'rand' => random_int(),
             'user_name' => getUserName($val["users_id"]),
             'planning_img' => $CFG_GLPI["root_doc"] . "/pics/" . $img,
             'planning_recall' => $planning_recall,
@@ -756,7 +756,7 @@ class Reminder extends CommonDBVisible implements
         $rows = [];
 
         if ($nb) {
-            $rand = mt_rand();
+            $rand = random_int();
 
             foreach ($reminders as $data) {
                 $row = [

--- a/src/Reminder.php
+++ b/src/Reminder.php
@@ -523,7 +523,7 @@ class Reminder extends CommonDBVisible implements
     public function showForm($ID, array $options = [])
     {
         $this->initForm($ID, $options);
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
 
         $canedit = $this->can($ID, UPDATE);
         $options['canedit'] = $canedit;
@@ -574,7 +574,7 @@ class Reminder extends CommonDBVisible implements
 
         return TemplateRenderer::getInstance()->render('pages/tools/reminder_planning.html.twig', [
             'val' => $val,
-            'rand' => random_int(0, 2**32),
+            'rand' => random_int(0, 2 ** 32),
             'user_name' => getUserName($val["users_id"]),
             'planning_img' => $CFG_GLPI["root_doc"] . "/pics/" . $img,
             'planning_recall' => $planning_recall,
@@ -756,7 +756,7 @@ class Reminder extends CommonDBVisible implements
         $rows = [];
 
         if ($nb) {
-            $rand = random_int(0, 2**32);
+            $rand = random_int(0, 2 ** 32);
 
             foreach ($reminders as $data) {
                 $row = [

--- a/src/Reminder.php
+++ b/src/Reminder.php
@@ -523,7 +523,7 @@ class Reminder extends CommonDBVisible implements
     public function showForm($ID, array $options = [])
     {
         $this->initForm($ID, $options);
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
 
         $canedit = $this->can($ID, UPDATE);
         $options['canedit'] = $canedit;
@@ -574,7 +574,7 @@ class Reminder extends CommonDBVisible implements
 
         return TemplateRenderer::getInstance()->render('pages/tools/reminder_planning.html.twig', [
             'val' => $val,
-            'rand' => random_int(),
+            'rand' => random_int(0, 2**32),
             'user_name' => getUserName($val["users_id"]),
             'planning_img' => $CFG_GLPI["root_doc"] . "/pics/" . $img,
             'planning_recall' => $planning_recall,
@@ -756,7 +756,7 @@ class Reminder extends CommonDBVisible implements
         $rows = [];
 
         if ($nb) {
-            $rand = random_int();
+            $rand = random_int(0, 2**32);
 
             foreach ($reminders as $data) {
                 $row = [

--- a/src/ReminderTranslation.php
+++ b/src/ReminderTranslation.php
@@ -117,7 +117,7 @@ class ReminderTranslation extends CommonDBChild
     public static function showTranslations(Reminder $item)
     {
         $canedit = $item->can($item->getID(), UPDATE);
-        $rand    = random_int();
+        $rand    = random_int(0, 2**32);
         if ($canedit) {
             $twig_params = [
                 'item' => $item,

--- a/src/ReminderTranslation.php
+++ b/src/ReminderTranslation.php
@@ -117,7 +117,7 @@ class ReminderTranslation extends CommonDBChild
     public static function showTranslations(Reminder $item)
     {
         $canedit = $item->can($item->getID(), UPDATE);
-        $rand    = mt_rand();
+        $rand    = random_int();
         if ($canedit) {
             $twig_params = [
                 'item' => $item,

--- a/src/ReminderTranslation.php
+++ b/src/ReminderTranslation.php
@@ -117,7 +117,7 @@ class ReminderTranslation extends CommonDBChild
     public static function showTranslations(Reminder $item)
     {
         $canedit = $item->can($item->getID(), UPDATE);
-        $rand    = random_int(0, 2**32);
+        $rand    = random_int(0, 2 ** 32);
         if ($canedit) {
             $twig_params = [
                 'item' => $item,

--- a/src/Reservation.php
+++ b/src/Reservation.php
@@ -431,7 +431,7 @@ class Reservation extends CommonDBChild
             return false;
         }
 
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
 
         $is_all = $ID === 0 ? "true" : "false";
         if ($ID > 0) {
@@ -911,7 +911,7 @@ JAVASCRIPT;
         }
 
         // js vars
-        $rand   = random_int(0, 2**32);
+        $rand   = random_int(0, 2 ** 32);
         $ID     = (int)$ri->fields['id'];
 
         echo "<br>";

--- a/src/Reservation.php
+++ b/src/Reservation.php
@@ -431,7 +431,7 @@ class Reservation extends CommonDBChild
             return false;
         }
 
-        $rand = mt_rand();
+        $rand = random_int();
 
         $is_all = $ID === 0 ? "true" : "false";
         if ($ID > 0) {
@@ -911,7 +911,7 @@ JAVASCRIPT;
         }
 
         // js vars
-        $rand   = mt_rand();
+        $rand   = random_int();
         $ID     = (int)$ri->fields['id'];
 
         echo "<br>";

--- a/src/Reservation.php
+++ b/src/Reservation.php
@@ -431,7 +431,7 @@ class Reservation extends CommonDBChild
             return false;
         }
 
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
 
         $is_all = $ID === 0 ? "true" : "false";
         if ($ID > 0) {
@@ -911,7 +911,7 @@ JAVASCRIPT;
         }
 
         // js vars
-        $rand   = random_int();
+        $rand   = random_int(0, 2**32);
         $ID     = (int)$ri->fields['id'];
 
         echo "<br>";

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -899,7 +899,7 @@ class Rule extends CommonDBTM
         }
 
         $canedit = $this->canEdit(static::$rightname);
-        $rand = mt_rand();
+        $rand = random_int();
 
         $plugin = isPluginItemType(static::class);
         $base_url = $CFG_GLPI["root_doc"] . ($plugin !== false ? "/plugins/{$plugin['plugin']}" : '');
@@ -1047,7 +1047,7 @@ class Rule extends CommonDBTM
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $rand = mt_rand();
+        $rand = random_int();
         $p['readonly'] = false;
 
         if (is_array($options) && count($options)) {
@@ -1176,7 +1176,7 @@ JS
      **/
     public function showCriteriasList($rules_id, $options = [])
     {
-        $rand = mt_rand();
+        $rand = random_int();
         $p['readonly'] = false;
 
         if (is_array($options) && count($options)) {
@@ -2993,7 +2993,7 @@ JS
             'showmassiveactions' => $canedit,
             'massiveactionparams' => [
                 'num_displayed' => count($entries),
-                'container'     => 'mass' . self::class . mt_rand(),
+                'container'     => 'mass' . self::class . random_int(),
                 'item'          => $this,
                 'specific_actions' => [
                     'update' => _x('button', 'Update'),

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -899,7 +899,7 @@ class Rule extends CommonDBTM
         }
 
         $canedit = $this->canEdit(static::$rightname);
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
 
         $plugin = isPluginItemType(static::class);
         $base_url = $CFG_GLPI["root_doc"] . ($plugin !== false ? "/plugins/{$plugin['plugin']}" : '');
@@ -1047,7 +1047,7 @@ class Rule extends CommonDBTM
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
         $p['readonly'] = false;
 
         if (is_array($options) && count($options)) {
@@ -1176,7 +1176,7 @@ JS
      **/
     public function showCriteriasList($rules_id, $options = [])
     {
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
         $p['readonly'] = false;
 
         if (is_array($options) && count($options)) {
@@ -2993,7 +2993,7 @@ JS
             'showmassiveactions' => $canedit,
             'massiveactionparams' => [
                 'num_displayed' => count($entries),
-                'container'     => 'mass' . self::class . random_int(0, 2**32),
+                'container'     => 'mass' . self::class . random_int(0, 2 ** 32),
                 'item'          => $this,
                 'specific_actions' => [
                     'update' => _x('button', 'Update'),

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -899,7 +899,7 @@ class Rule extends CommonDBTM
         }
 
         $canedit = $this->canEdit(static::$rightname);
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
 
         $plugin = isPluginItemType(static::class);
         $base_url = $CFG_GLPI["root_doc"] . ($plugin !== false ? "/plugins/{$plugin['plugin']}" : '');
@@ -1047,7 +1047,7 @@ class Rule extends CommonDBTM
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
         $p['readonly'] = false;
 
         if (is_array($options) && count($options)) {
@@ -1176,7 +1176,7 @@ JS
      **/
     public function showCriteriasList($rules_id, $options = [])
     {
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
         $p['readonly'] = false;
 
         if (is_array($options) && count($options)) {
@@ -2993,7 +2993,7 @@ JS
             'showmassiveactions' => $canedit,
             'massiveactionparams' => [
                 'num_displayed' => count($entries),
-                'container'     => 'mass' . self::class . random_int(),
+                'container'     => 'mass' . self::class . random_int(0, 2**32),
                 'item'          => $this,
                 'specific_actions' => [
                     'update' => _x('button', 'Update'),

--- a/src/RuleAction.php
+++ b/src/RuleAction.php
@@ -703,7 +703,7 @@ class RuleAction extends CommonDBChild
             'rules_id_field' => static::$items_id,
             'item' => $this,
             'used_actions' => $used,
-            'rand' => random_int()
+            'rand' => random_int(0, 2**32)
         ]);
 
         return true;

--- a/src/RuleAction.php
+++ b/src/RuleAction.php
@@ -703,7 +703,7 @@ class RuleAction extends CommonDBChild
             'rules_id_field' => static::$items_id,
             'item' => $this,
             'used_actions' => $used,
-            'rand' => mt_rand()
+            'rand' => random_int()
         ]);
 
         return true;

--- a/src/RuleAction.php
+++ b/src/RuleAction.php
@@ -703,7 +703,7 @@ class RuleAction extends CommonDBChild
             'rules_id_field' => static::$items_id,
             'item' => $this,
             'used_actions' => $used,
-            'rand' => random_int(0, 2**32)
+            'rand' => random_int(0, 2 ** 32)
         ]);
 
         return true;

--- a/src/RuleCollection.php
+++ b/src/RuleCollection.php
@@ -555,7 +555,7 @@ TWIG, $twig_params);
             'showmassiveactions' => true,
             'massiveactionparams' => [
                 'num_displayed' => count($entries),
-                'container'     => 'mass' . static::class . random_int(),
+                'container'     => 'mass' . static::class . random_int(0, 2**32),
                 'extraparams'   => [
                     'entity' => $this->entity,
                     'condition' => $p['condition'],

--- a/src/RuleCollection.php
+++ b/src/RuleCollection.php
@@ -555,7 +555,7 @@ TWIG, $twig_params);
             'showmassiveactions' => true,
             'massiveactionparams' => [
                 'num_displayed' => count($entries),
-                'container'     => 'mass' . static::class . mt_rand(),
+                'container'     => 'mass' . static::class . random_int(),
                 'extraparams'   => [
                     'entity' => $this->entity,
                     'condition' => $p['condition'],

--- a/src/RuleCollection.php
+++ b/src/RuleCollection.php
@@ -555,7 +555,7 @@ TWIG, $twig_params);
             'showmassiveactions' => true,
             'massiveactionparams' => [
                 'num_displayed' => count($entries),
-                'container'     => 'mass' . static::class . random_int(0, 2**32),
+                'container'     => 'mass' . static::class . random_int(0, 2 ** 32),
                 'extraparams'   => [
                     'entity' => $this->entity,
                     'condition' => $p['condition'],

--- a/src/RuleCriteria.php
+++ b/src/RuleCriteria.php
@@ -681,7 +681,7 @@ class RuleCriteria extends CommonDBChild
             'rule' => $rule,
             'rules_id_field' => static::$items_id,
             'item' => $this,
-            'rand' => random_int(0, 2**32)
+            'rand' => random_int(0, 2 ** 32)
         ]);
 
         return true;

--- a/src/RuleCriteria.php
+++ b/src/RuleCriteria.php
@@ -681,7 +681,7 @@ class RuleCriteria extends CommonDBChild
             'rule' => $rule,
             'rules_id_field' => static::$items_id,
             'item' => $this,
-            'rand' => mt_rand()
+            'rand' => random_int()
         ]);
 
         return true;

--- a/src/RuleCriteria.php
+++ b/src/RuleCriteria.php
@@ -681,7 +681,7 @@ class RuleCriteria extends CommonDBChild
             'rule' => $rule,
             'rules_id_field' => static::$items_id,
             'item' => $this,
-            'rand' => random_int()
+            'rand' => random_int(0, 2**32)
         ]);
 
         return true;

--- a/src/RuleRight.php
+++ b/src/RuleRight.php
@@ -400,7 +400,7 @@ class RuleRight extends Rule
             'item' => $this,
             'match_operators' => $this->getRulesMatch(),
             'conditions' => static::getConditionsArray(),
-            'rand' => random_int(0, 2**32),
+            'rand' => random_int(0, 2 ** 32),
             'test_url' => $CFG_GLPI["root_doc"] . "/front/rule.test.php",
             'params' => [
                 'canedit' => $canedit,

--- a/src/RuleRight.php
+++ b/src/RuleRight.php
@@ -400,7 +400,7 @@ class RuleRight extends Rule
             'item' => $this,
             'match_operators' => $this->getRulesMatch(),
             'conditions' => static::getConditionsArray(),
-            'rand' => random_int(),
+            'rand' => random_int(0, 2**32),
             'test_url' => $CFG_GLPI["root_doc"] . "/front/rule.test.php",
             'params' => [
                 'canedit' => $canedit,

--- a/src/RuleRight.php
+++ b/src/RuleRight.php
@@ -400,7 +400,7 @@ class RuleRight extends Rule
             'item' => $this,
             'match_operators' => $this->getRulesMatch(),
             'conditions' => static::getConditionsArray(),
-            'rand' => mt_rand(),
+            'rand' => random_int(),
             'test_url' => $CFG_GLPI["root_doc"] . "/front/rule.test.php",
             'params' => [
                 'canedit' => $canedit,

--- a/src/Software.php
+++ b/src/Software.php
@@ -989,7 +989,7 @@ class Software extends CommonDBTM
             'showmassiveactions' => true,
             'massiveactionparams' => [
                 'num_displayed' => count($entries),
-                'container'     => 'mass' . static::class . random_int(0, 2**32),
+                'container'     => 'mass' . static::class . random_int(0, 2 ** 32),
                 'specific_actions' => [
                     __CLASS__ . MassiveAction::CLASS_ACTION_SEPARATOR . 'merge' => __('Merge')
                 ],

--- a/src/Software.php
+++ b/src/Software.php
@@ -989,7 +989,7 @@ class Software extends CommonDBTM
             'showmassiveactions' => true,
             'massiveactionparams' => [
                 'num_displayed' => count($entries),
-                'container'     => 'mass' . static::class . mt_rand(),
+                'container'     => 'mass' . static::class . random_int(),
                 'specific_actions' => [
                     __CLASS__ . MassiveAction::CLASS_ACTION_SEPARATOR . 'merge' => __('Merge')
                 ],

--- a/src/Software.php
+++ b/src/Software.php
@@ -989,7 +989,7 @@ class Software extends CommonDBTM
             'showmassiveactions' => true,
             'massiveactionparams' => [
                 'num_displayed' => count($entries),
-                'container'     => 'mass' . static::class . random_int(),
+                'container'     => 'mass' . static::class . random_int(0, 2**32),
                 'specific_actions' => [
                     __CLASS__ . MassiveAction::CLASS_ACTION_SEPARATOR . 'merge' => __('Merge')
                 ],

--- a/src/SoftwareLicense.php
+++ b/src/SoftwareLicense.php
@@ -1126,7 +1126,7 @@ TWIG, $twig_params);
             'showmassiveactions' => $canedit,
             'massiveactionparams' => [
                 'num_displayed' => count($entries),
-                'container'     => 'mass' . static::class . mt_rand(),
+                'container'     => 'mass' . static::class . random_int(),
                 'extraparams' => [
                     'options' => [
                         'glpi_softwareversions.name' => [

--- a/src/SoftwareLicense.php
+++ b/src/SoftwareLicense.php
@@ -1126,7 +1126,7 @@ TWIG, $twig_params);
             'showmassiveactions' => $canedit,
             'massiveactionparams' => [
                 'num_displayed' => count($entries),
-                'container'     => 'mass' . static::class . random_int(0, 2**32),
+                'container'     => 'mass' . static::class . random_int(0, 2 ** 32),
                 'extraparams' => [
                     'options' => [
                         'glpi_softwareversions.name' => [

--- a/src/SoftwareLicense.php
+++ b/src/SoftwareLicense.php
@@ -1126,7 +1126,7 @@ TWIG, $twig_params);
             'showmassiveactions' => $canedit,
             'massiveactionparams' => [
                 'num_displayed' => count($entries),
-                'container'     => 'mass' . static::class . random_int(),
+                'container'     => 'mass' . static::class . random_int(0, 2**32),
                 'extraparams' => [
                     'options' => [
                         'glpi_softwareversions.name' => [

--- a/src/SoftwareVersion.php
+++ b/src/SoftwareVersion.php
@@ -370,7 +370,7 @@ TWIG, $twig_params);
             'showmassiveactions' => $canedit,
             'massiveactionparams' => [
                 'num_displayed' => count($entries),
-                'container'     => 'mass' . static::class . random_int(0, 2**32),
+                'container'     => 'mass' . static::class . random_int(0, 2 ** 32),
             ]
         ]);
     }

--- a/src/SoftwareVersion.php
+++ b/src/SoftwareVersion.php
@@ -370,7 +370,7 @@ TWIG, $twig_params);
             'showmassiveactions' => $canedit,
             'massiveactionparams' => [
                 'num_displayed' => count($entries),
-                'container'     => 'mass' . static::class . random_int(),
+                'container'     => 'mass' . static::class . random_int(0, 2**32),
             ]
         ]);
     }

--- a/src/SoftwareVersion.php
+++ b/src/SoftwareVersion.php
@@ -370,7 +370,7 @@ TWIG, $twig_params);
             'showmassiveactions' => $canedit,
             'massiveactionparams' => [
                 'num_displayed' => count($entries),
-                'container'     => 'mass' . static::class . mt_rand(),
+                'container'     => 'mass' . static::class . random_int(),
             ]
         ]);
     }

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -2178,7 +2178,7 @@ class Ticket extends CommonITILObject
 
         switch ($ma->getAction()) {
             case 'merge_as_followup':
-                $rand = random_int();
+                $rand = random_int(0, 2**32);
                 $mergeparam = [
                     'name'         => "_mergeticket",
                     'used'         => $ma->getItems()['Ticket'],
@@ -2241,7 +2241,7 @@ class Ticket extends CommonITILObject
                 return true;
 
             case 'resolve_tickets':
-                $rand = random_int();
+                $rand = random_int(0, 2**32);
                 $content_id = "content$rand";
 
                 echo '<div class="horizontal-form">';
@@ -4411,7 +4411,7 @@ JAVASCRIPT;
                     }
 
                     $job = new self();
-                    $rand = random_int();
+                    $rand = random_int(0, 2**32);
                     $row = [
                         'values' => []
                     ];
@@ -4815,11 +4815,11 @@ JAVASCRIPT;
         }
 
         $job  = new self();
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
         if ($job->getFromDBwithData($ID)) {
             $bgcolor = $_SESSION["glpipriority_" . $job->fields["priority"]];
             $name    = htmlescape(sprintf(__('%1$s: %2$s'), __('ID'), $job->fields["id"]));
-           // $rand    = random_int();
+           // $rand    = random_int(0, 2**32);
             echo "<tr class='tab_bg_2'>";
             echo "<td>
             <div class='badge_block' style='border-color: $bgcolor'>

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -2178,7 +2178,7 @@ class Ticket extends CommonITILObject
 
         switch ($ma->getAction()) {
             case 'merge_as_followup':
-                $rand = random_int(0, 2**32);
+                $rand = random_int(0, 2 ** 32);
                 $mergeparam = [
                     'name'         => "_mergeticket",
                     'used'         => $ma->getItems()['Ticket'],
@@ -2241,7 +2241,7 @@ class Ticket extends CommonITILObject
                 return true;
 
             case 'resolve_tickets':
-                $rand = random_int(0, 2**32);
+                $rand = random_int(0, 2 ** 32);
                 $content_id = "content$rand";
 
                 echo '<div class="horizontal-form">';
@@ -4411,7 +4411,7 @@ JAVASCRIPT;
                     }
 
                     $job = new self();
-                    $rand = random_int(0, 2**32);
+                    $rand = random_int(0, 2 ** 32);
                     $row = [
                         'values' => []
                     ];
@@ -4815,11 +4815,11 @@ JAVASCRIPT;
         }
 
         $job  = new self();
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
         if ($job->getFromDBwithData($ID)) {
             $bgcolor = $_SESSION["glpipriority_" . $job->fields["priority"]];
             $name    = htmlescape(sprintf(__('%1$s: %2$s'), __('ID'), $job->fields["id"]));
-           // $rand    = random_int(0, 2**32);
+           // $rand    = random_int(0, 2 ** 32);
             echo "<tr class='tab_bg_2'>";
             echo "<td>
             <div class='badge_block' style='border-color: $bgcolor'>

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -2178,7 +2178,7 @@ class Ticket extends CommonITILObject
 
         switch ($ma->getAction()) {
             case 'merge_as_followup':
-                $rand = mt_rand();
+                $rand = random_int();
                 $mergeparam = [
                     'name'         => "_mergeticket",
                     'used'         => $ma->getItems()['Ticket'],
@@ -2241,7 +2241,7 @@ class Ticket extends CommonITILObject
                 return true;
 
             case 'resolve_tickets':
-                $rand = mt_rand();
+                $rand = random_int();
                 $content_id = "content$rand";
 
                 echo '<div class="horizontal-form">';
@@ -4411,7 +4411,7 @@ JAVASCRIPT;
                     }
 
                     $job = new self();
-                    $rand = mt_rand();
+                    $rand = random_int();
                     $row = [
                         'values' => []
                     ];
@@ -4815,11 +4815,11 @@ JAVASCRIPT;
         }
 
         $job  = new self();
-        $rand = mt_rand();
+        $rand = random_int();
         if ($job->getFromDBwithData($ID)) {
             $bgcolor = $_SESSION["glpipriority_" . $job->fields["priority"]];
             $name    = htmlescape(sprintf(__('%1$s: %2$s'), __('ID'), $job->fields["id"]));
-           // $rand    = mt_rand();
+           // $rand    = random_int();
             echo "<tr class='tab_bg_2'>";
             echo "<td>
             <div class='badge_block' style='border-color: $bgcolor'>

--- a/src/Ticket_Contract.php
+++ b/src/Ticket_Contract.php
@@ -76,7 +76,7 @@ class Ticket_Contract extends CommonDBRelation
         $tabnum = 1,
         $withtemplate = 0
     ) {
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
 
         $twig_params = [
             'item' => $item,

--- a/src/Ticket_Contract.php
+++ b/src/Ticket_Contract.php
@@ -76,7 +76,7 @@ class Ticket_Contract extends CommonDBRelation
         $tabnum = 1,
         $withtemplate = 0
     ) {
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
 
         $twig_params = [
             'item' => $item,

--- a/src/Ticket_Contract.php
+++ b/src/Ticket_Contract.php
@@ -76,7 +76,7 @@ class Ticket_Contract extends CommonDBRelation
         $tabnum = 1,
         $withtemplate = 0
     ) {
-        $rand = mt_rand();
+        $rand = random_int();
 
         $twig_params = [
             'item' => $item,

--- a/src/User.php
+++ b/src/User.php
@@ -2715,7 +2715,7 @@ HTML;
             $options['no_header'] = true;
         }
         $this->showFormHeader($options);
-        $rand = mt_rand();
+        $rand = random_int();
 
         echo "<tr class='tab_bg_1'>";
         echo "<td><label for='name'>" . __('Login') . "</label></td>";
@@ -2751,7 +2751,7 @@ HTML;
             && $this->fields['auths_id']
             && AuthLDAP::isSyncFieldConfigured($this->fields['auths_id'])
         ) {
-            $syncrand = mt_rand();
+            $syncrand = random_int();
             echo "<tr class='tab_bg_1'><td><label for='textfield_sync_field$syncrand'>" . __s('Synchronization field') . "</label></td><td>";
             if (
                 self::canUpdate()
@@ -2776,7 +2776,7 @@ HTML;
             echo "<tr class='tab_bg_1'><td colspan='2'></td></tr>";
         }
 
-        $surnamerand = mt_rand();
+        $surnamerand = random_int();
         echo "<tr class='tab_bg_1'><td><label for='textfield_realname$surnamerand'>" . __s('Surname') . "</label></td><td>";
         echo Html::input(
             'realname',
@@ -2787,7 +2787,7 @@ HTML;
         );
         echo "</td></tr>";
 
-        $firstnamerand = mt_rand();
+        $firstnamerand = random_int();
         echo "<tr class='tab_bg_1'><td><label for='textfield_firstname$firstnamerand'>" . __s('First name') . "</label></td><td>";
         echo Html::input(
             'firstname',
@@ -2876,7 +2876,7 @@ JAVASCRIPT;
         }
 
         echo "<tr class='tab_bg_1'>";
-        $activerand = mt_rand();
+        $activerand = random_int();
         echo "<td><label for='dropdown_is_active$activerand'>" . __s('Active') . "</label></td><td>";
         Dropdown::showYesNo('is_active', $this->fields['is_active'], -1, ['rand' => $activerand]);
         echo "</td>";
@@ -2888,7 +2888,7 @@ JAVASCRIPT;
         echo "</tr>";
 
         if (!$simplified_form) {
-            $sincerand = mt_rand();
+            $sincerand = random_int();
             echo "<tr class='tab_bg_1'>";
             echo "<td><label for='showdate$sincerand'>" . __s('Valid since') . "</label></td><td>";
             Html::showDateTimeField("begin_date", ['value'       => $this->fields["begin_date"],
@@ -2897,7 +2897,7 @@ JAVASCRIPT;
             ]);
             echo "</td>";
 
-            $untilrand = mt_rand();
+            $untilrand = random_int();
             echo "<td><label for='showdate$untilrand'>" . __s('Valid until') . "</label></td><td>";
             Html::showDateTimeField("end_date", ['value'       => $this->fields["end_date"],
                 'rand'        => $untilrand,
@@ -2906,7 +2906,7 @@ JAVASCRIPT;
             echo "</td></tr>";
         }
 
-        $phonerand = mt_rand();
+        $phonerand = random_int();
         echo "<tr class='tab_bg_1'>";
         echo "<td><label for='textfield_phone$phonerand'>" .  htmlescape(Phone::getTypeName(1)) . "</label></td><td>";
         echo Html::input(
@@ -2957,7 +2957,7 @@ JAVASCRIPT;
 
         echo "</tr>";
 
-        $mobilerand = mt_rand();
+        $mobilerand = random_int();
         echo "<tr class='tab_bg_1'>";
         echo "<td><label for='textfield_mobile$mobilerand'>" . __s('Mobile phone') . "</label></td><td>";
         echo Html::input(
@@ -2970,14 +2970,14 @@ JAVASCRIPT;
         echo "</td>";
         echo "<td>";
         if (!$simplified_form) {
-            $catrand = mt_rand();
+            $catrand = random_int();
             echo "<label for='dropdown_usercategories_id$catrand'>" . _sn('Category', 'Categories', 1) . "</label></td><td>";
             UserCategory::dropdown(['value' => $this->fields["usercategories_id"], 'rand' => $catrand]);
         }
         echo "</td></tr>";
 
         if (!$simplified_form) {
-            $phone2rand = mt_rand();
+            $phone2rand = random_int();
             echo "<tr class='tab_bg_1'>";
             echo "<td><label for='textfield_phone2$phone2rand'>" .  __s('Phone 2') . "</label></td><td>";
             echo Html::input(
@@ -2993,7 +2993,7 @@ JAVASCRIPT;
             echo "<textarea class='form-control' id='comment' name='comment' >" . htmlescape($this->fields["comment"]) . "</textarea>";
             echo "</td></tr>";
 
-            $admnumrand = mt_rand();
+            $admnumrand = random_int();
             echo "<tr class='tab_bg_1'><td><label for='textfield_registration_number$admnumrand'>" . _sx('user', 'Administrative number') . "</label></td><td>";
             echo Html::input(
                 'registration_number',
@@ -3004,7 +3004,7 @@ JAVASCRIPT;
             );
             echo "</td></tr>";
 
-            $titlerand = mt_rand();
+            $titlerand = random_int();
             echo "<tr class='tab_bg_1'><td><label for='dropdown_usertitles_id$titlerand'>" . _sx('person', 'Title') . "</label></td><td>";
             UserTitle::dropdown(['value' => $this->fields["usertitles_id"], 'rand' => $titlerand]);
             echo "</td></tr>";
@@ -3012,7 +3012,7 @@ JAVASCRIPT;
 
         echo "<tr class='tab_bg_1'>";
         if (!empty($ID)) {
-            $locrand = mt_rand();
+            $locrand = random_int();
             echo "<td><label for='dropdown_locations_id$locrand'>" . htmlescape(Location::getTypeName(1)) . "</label></td><td>";
             $entities = $this->getEntities();
             if (count($entities) <= 0) {
@@ -3029,11 +3029,11 @@ JAVASCRIPT;
         if (empty($ID)) {
             echo "<tr class='tab_bg_1'>";
             echo "<th colspan='2'>" . _sn('Authorization', 'Authorizations', 1) . "</th>";
-            $recurrand = mt_rand();
+            $recurrand = random_int();
             echo "<td><label for='dropdown__is_recursive$recurrand'>" .  __s('Recursive') . "</label></td><td>";
             Dropdown::showYesNo("_is_recursive", 0, -1, ['rand' => $recurrand]);
             echo "</td></tr>";
-            $profilerand = mt_rand();
+            $profilerand = random_int();
             echo "<tr class='tab_bg_1'>";
             echo "<td><label for='dropdown__profiles_id$profilerand'>" .  htmlescape(Profile::getTypeName(1)) . "</label></td><td>";
             Profile::dropdownUnder(['name'  => '_profiles_id',
@@ -3041,7 +3041,7 @@ JAVASCRIPT;
                 'value' => Profile::getDefault()
             ]);
 
-            $entrand = mt_rand();
+            $entrand = random_int();
             echo "</td><td><label for='dropdown__entities_id$entrand'>" .  htmlescape(Entity::getTypeName(1)) . "</label></td><td>";
             Entity::dropdown(['name'                => '_entities_id',
                 'display_emptychoice' => false,
@@ -3052,7 +3052,7 @@ JAVASCRIPT;
             echo "</td></tr>";
         } else {
             if ($higherrights || $ismyself) {
-                $profilerand = mt_rand();
+                $profilerand = random_int();
                 echo "<tr class='tab_bg_1'>";
                 echo "<td><label for='dropdown_profiles_id$profilerand'>" .  __s('Default profile') . "</label></td><td>";
 
@@ -3071,7 +3071,7 @@ JAVASCRIPT;
                 );
             }
             if ($higherrights) {
-                $entrand = mt_rand();
+                $entrand = random_int();
                 echo "</td><td><label for='dropdown_entities_id$entrand'>" .  __s('Default entity') . "</label></td><td>";
                 $entities = $this->getEntities();
                 $toadd = [-1 => __('Full structure')];
@@ -3083,7 +3083,7 @@ JAVASCRIPT;
                 ]);
                 echo "</td></tr>";
 
-                $grouprand = mt_rand();
+                $grouprand = random_int();
                 echo "<tr class='tab_bg_1'>";
                 echo "<td><label for='dropdown_profiles_id$grouprand'>" .  __s('Default group') . "</label></td><td>";
 
@@ -3102,7 +3102,7 @@ JAVASCRIPT;
                 );
 
                 echo "</td>";
-                $userrand = mt_rand();
+                $userrand = random_int();
                 echo "<td><label for='dropdown_users_id_supervisor_$userrand'>" .  __s('Supervisor') . "</label></td><td>";
 
                 User::dropdown(['name'   => 'users_id_supervisor',
@@ -3203,7 +3203,7 @@ JAVASCRIPT;
             return false;
         }
         if ($this->getFromDB($ID)) {
-            $rand     = mt_rand();
+            $rand     = random_int();
             $authtype = $this->getAuthMethodsByID();
 
             $extauth  = !(($this->fields["authtype"] == Auth::DB_GLPI)
@@ -3218,7 +3218,7 @@ JAVASCRIPT;
             echo "<input type='hidden' name='id' value='" . htmlescape($this->fields["id"]) . "'>";
             echo "</th></tr>";
 
-            $surnamerand = mt_rand();
+            $surnamerand = random_int();
             echo "<tr class='tab_bg_1'><td><label for='textfield_realname$surnamerand'>" . __s('Surname') . "</label></td><td>";
 
             if (
@@ -3253,7 +3253,7 @@ JAVASCRIPT;
                 echo "</tr>";
             }
 
-            $firstnamerand = mt_rand();
+            $firstnamerand = random_int();
             echo "<tr class='tab_bg_1'><td><label for='textfield_firstname$firstnamerand'>" . __s('First name') . "</label></td><td>";
             if (
                 $extauth
@@ -3290,7 +3290,7 @@ JAVASCRIPT;
 
             echo "<tr class='tab_bg_1'>";
 
-            $langrand = mt_rand();
+            $langrand = random_int();
             echo "<td><label for='dropdown_language$langrand'>" . __('Language') . "</label></td><td>";
            // Language is stored as null in DB if value is same as the global config.
             $language = $this->fields["language"];
@@ -3369,7 +3369,7 @@ JAVASCRIPT;
                 echo "</tr>";
             }
 
-            $phonerand = mt_rand();
+            $phonerand = random_int();
             echo "<tr class='tab_bg_1'><td><label for='textfield_phone$phonerand'>" .  htmlescape(Phone::getTypeName(1)) . "</label></td><td>";
 
             if (
@@ -3394,7 +3394,7 @@ JAVASCRIPT;
             echo "</td>";
             echo "</tr>";
 
-            $mobilerand = mt_rand();
+            $mobilerand = random_int();
             echo "<tr class='tab_bg_1'><td><label for='textfield_mobile$mobilerand'>" . __s('Mobile phone') . "</label></td><td>";
 
             if (
@@ -3414,7 +3414,7 @@ JAVASCRIPT;
             echo "</td>";
 
             if (count($_SESSION['glpiprofiles']) > 1) {
-                $profilerand = mt_rand();
+                $profilerand = random_int();
                 echo "<td><label for='dropdown_profiles_id$profilerand'>" . __s('Default profile') . "</label></td><td>";
 
                 $options = Dropdown::getDropdownArrayNames(
@@ -3435,7 +3435,7 @@ JAVASCRIPT;
             }
             echo "</tr>";
 
-            $phone2rand = mt_rand();
+            $phone2rand = random_int();
             echo "<tr class='tab_bg_1'><td><label for='textfield_phone2$phone2rand'>" .  __s('Phone 2') . "</label></td><td>";
 
             if (
@@ -3456,7 +3456,7 @@ JAVASCRIPT;
 
             $entities = $this->getEntities();
             if (count($_SESSION['glpiactiveentities']) > 1) {
-                $entrand = mt_rand();
+                $entrand = random_int();
                 echo "<td><label for='dropdown_entities_id$entrand'>" . __s('Default entity') . "</td><td>";
                 $toadd = [-1 => __('Full structure')];
                 Entity::dropdown([
@@ -3470,7 +3470,7 @@ JAVASCRIPT;
             }
             echo "</td></tr>";
 
-            $admnumrand = mt_rand();
+            $admnumrand = random_int();
             echo "<tr class='tab_bg_1'><td><label for='textfield_registration_number$admnumrand'>" . _sx('user', 'Administrative number') . "</label></td><td>";
             if (
                 $extauth
@@ -3488,7 +3488,7 @@ JAVASCRIPT;
             }
             echo "</td><td colspan='2'></td></tr>";
 
-            $locrand = mt_rand();
+            $locrand = random_int();
             echo "<tr class='tab_bg_1'><td><label for='dropdown_locations_id$locrand'>" . htmlescape(Location::getTypeName(1)) . "</label></td><td>";
             Location::dropdown(['value'  => $this->fields['locations_id'],
                 'rand'   => $locrand,
@@ -3496,7 +3496,7 @@ JAVASCRIPT;
             ]);
 
             if (Config::canUpdate()) {
-                $moderand = mt_rand();
+                $moderand = random_int();
                 echo "<td><label for='dropdown_use_mode$moderand'>" . __s('Use GLPI in mode') . "</label></td><td>";
                 $modes = [
                     Session::NORMAL_MODE => __('Normal'),
@@ -4736,7 +4736,7 @@ JAVASCRIPT;
             'used'                => [],
             'ldap_import'         => false,
             'toupdate'            => '',
-            'rand'                => mt_rand(),
+            'rand'                => random_int(),
             'display'             => true,
             '_user_index'         => 0,
             'specific_tags'       => [],
@@ -5291,7 +5291,7 @@ JAVASCRIPT;
             'showmassiveactions'    => true,
             'massiveactionparams'   => [
                 'num_displayed'    => min($_SESSION['glpilist_limit'], $number),
-                'container'        => 'mass' . __CLASS__ . mt_rand(),
+                'container'        => 'mass' . __CLASS__ . random_int(),
                 'specific_actions' => [
                     'update' => __('Update'),
                 ]
@@ -6774,10 +6774,10 @@ JAVASCRIPT;
         $options['candel'] = false;
         $options['canedit'] = self::canUpdate();
         $this->showFormHeader($options);
-        $rand = mt_rand();
+        $rand = random_int();
 
         echo "<tr class='tab_bg_1'>";
-        $surnamerand = mt_rand();
+        $surnamerand = random_int();
         echo "<td><label for='textfield_realname$surnamerand'>" . __s('Surname') . "</label></td>";
         echo "<td>";
         echo Html::input(
@@ -6798,7 +6798,7 @@ JAVASCRIPT;
         echo "</td>";
         echo "</tr>";
 
-        $firstnamerand = mt_rand();
+        $firstnamerand = random_int();
         echo "<tr class='tab_bg_1'><td><label for='textfield_firstname$firstnamerand'>" . __s('First name') . "</label></td><td>";
         echo Html::input(
             'firstname',

--- a/src/User.php
+++ b/src/User.php
@@ -2715,7 +2715,7 @@ HTML;
             $options['no_header'] = true;
         }
         $this->showFormHeader($options);
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
 
         echo "<tr class='tab_bg_1'>";
         echo "<td><label for='name'>" . __('Login') . "</label></td>";
@@ -2751,7 +2751,7 @@ HTML;
             && $this->fields['auths_id']
             && AuthLDAP::isSyncFieldConfigured($this->fields['auths_id'])
         ) {
-            $syncrand = random_int();
+            $syncrand = random_int(0, 2**32);
             echo "<tr class='tab_bg_1'><td><label for='textfield_sync_field$syncrand'>" . __s('Synchronization field') . "</label></td><td>";
             if (
                 self::canUpdate()
@@ -2776,7 +2776,7 @@ HTML;
             echo "<tr class='tab_bg_1'><td colspan='2'></td></tr>";
         }
 
-        $surnamerand = random_int();
+        $surnamerand = random_int(0, 2**32);
         echo "<tr class='tab_bg_1'><td><label for='textfield_realname$surnamerand'>" . __s('Surname') . "</label></td><td>";
         echo Html::input(
             'realname',
@@ -2787,7 +2787,7 @@ HTML;
         );
         echo "</td></tr>";
 
-        $firstnamerand = random_int();
+        $firstnamerand = random_int(0, 2**32);
         echo "<tr class='tab_bg_1'><td><label for='textfield_firstname$firstnamerand'>" . __s('First name') . "</label></td><td>";
         echo Html::input(
             'firstname',
@@ -2876,7 +2876,7 @@ JAVASCRIPT;
         }
 
         echo "<tr class='tab_bg_1'>";
-        $activerand = random_int();
+        $activerand = random_int(0, 2**32);
         echo "<td><label for='dropdown_is_active$activerand'>" . __s('Active') . "</label></td><td>";
         Dropdown::showYesNo('is_active', $this->fields['is_active'], -1, ['rand' => $activerand]);
         echo "</td>";
@@ -2888,7 +2888,7 @@ JAVASCRIPT;
         echo "</tr>";
 
         if (!$simplified_form) {
-            $sincerand = random_int();
+            $sincerand = random_int(0, 2**32);
             echo "<tr class='tab_bg_1'>";
             echo "<td><label for='showdate$sincerand'>" . __s('Valid since') . "</label></td><td>";
             Html::showDateTimeField("begin_date", ['value'       => $this->fields["begin_date"],
@@ -2897,7 +2897,7 @@ JAVASCRIPT;
             ]);
             echo "</td>";
 
-            $untilrand = random_int();
+            $untilrand = random_int(0, 2**32);
             echo "<td><label for='showdate$untilrand'>" . __s('Valid until') . "</label></td><td>";
             Html::showDateTimeField("end_date", ['value'       => $this->fields["end_date"],
                 'rand'        => $untilrand,
@@ -2906,7 +2906,7 @@ JAVASCRIPT;
             echo "</td></tr>";
         }
 
-        $phonerand = random_int();
+        $phonerand = random_int(0, 2**32);
         echo "<tr class='tab_bg_1'>";
         echo "<td><label for='textfield_phone$phonerand'>" .  htmlescape(Phone::getTypeName(1)) . "</label></td><td>";
         echo Html::input(
@@ -2957,7 +2957,7 @@ JAVASCRIPT;
 
         echo "</tr>";
 
-        $mobilerand = random_int();
+        $mobilerand = random_int(0, 2**32);
         echo "<tr class='tab_bg_1'>";
         echo "<td><label for='textfield_mobile$mobilerand'>" . __s('Mobile phone') . "</label></td><td>";
         echo Html::input(
@@ -2970,14 +2970,14 @@ JAVASCRIPT;
         echo "</td>";
         echo "<td>";
         if (!$simplified_form) {
-            $catrand = random_int();
+            $catrand = random_int(0, 2**32);
             echo "<label for='dropdown_usercategories_id$catrand'>" . _sn('Category', 'Categories', 1) . "</label></td><td>";
             UserCategory::dropdown(['value' => $this->fields["usercategories_id"], 'rand' => $catrand]);
         }
         echo "</td></tr>";
 
         if (!$simplified_form) {
-            $phone2rand = random_int();
+            $phone2rand = random_int(0, 2**32);
             echo "<tr class='tab_bg_1'>";
             echo "<td><label for='textfield_phone2$phone2rand'>" .  __s('Phone 2') . "</label></td><td>";
             echo Html::input(
@@ -2993,7 +2993,7 @@ JAVASCRIPT;
             echo "<textarea class='form-control' id='comment' name='comment' >" . htmlescape($this->fields["comment"]) . "</textarea>";
             echo "</td></tr>";
 
-            $admnumrand = random_int();
+            $admnumrand = random_int(0, 2**32);
             echo "<tr class='tab_bg_1'><td><label for='textfield_registration_number$admnumrand'>" . _sx('user', 'Administrative number') . "</label></td><td>";
             echo Html::input(
                 'registration_number',
@@ -3004,7 +3004,7 @@ JAVASCRIPT;
             );
             echo "</td></tr>";
 
-            $titlerand = random_int();
+            $titlerand = random_int(0, 2**32);
             echo "<tr class='tab_bg_1'><td><label for='dropdown_usertitles_id$titlerand'>" . _sx('person', 'Title') . "</label></td><td>";
             UserTitle::dropdown(['value' => $this->fields["usertitles_id"], 'rand' => $titlerand]);
             echo "</td></tr>";
@@ -3012,7 +3012,7 @@ JAVASCRIPT;
 
         echo "<tr class='tab_bg_1'>";
         if (!empty($ID)) {
-            $locrand = random_int();
+            $locrand = random_int(0, 2**32);
             echo "<td><label for='dropdown_locations_id$locrand'>" . htmlescape(Location::getTypeName(1)) . "</label></td><td>";
             $entities = $this->getEntities();
             if (count($entities) <= 0) {
@@ -3029,11 +3029,11 @@ JAVASCRIPT;
         if (empty($ID)) {
             echo "<tr class='tab_bg_1'>";
             echo "<th colspan='2'>" . _sn('Authorization', 'Authorizations', 1) . "</th>";
-            $recurrand = random_int();
+            $recurrand = random_int(0, 2**32);
             echo "<td><label for='dropdown__is_recursive$recurrand'>" .  __s('Recursive') . "</label></td><td>";
             Dropdown::showYesNo("_is_recursive", 0, -1, ['rand' => $recurrand]);
             echo "</td></tr>";
-            $profilerand = random_int();
+            $profilerand = random_int(0, 2**32);
             echo "<tr class='tab_bg_1'>";
             echo "<td><label for='dropdown__profiles_id$profilerand'>" .  htmlescape(Profile::getTypeName(1)) . "</label></td><td>";
             Profile::dropdownUnder(['name'  => '_profiles_id',
@@ -3041,7 +3041,7 @@ JAVASCRIPT;
                 'value' => Profile::getDefault()
             ]);
 
-            $entrand = random_int();
+            $entrand = random_int(0, 2**32);
             echo "</td><td><label for='dropdown__entities_id$entrand'>" .  htmlescape(Entity::getTypeName(1)) . "</label></td><td>";
             Entity::dropdown(['name'                => '_entities_id',
                 'display_emptychoice' => false,
@@ -3052,7 +3052,7 @@ JAVASCRIPT;
             echo "</td></tr>";
         } else {
             if ($higherrights || $ismyself) {
-                $profilerand = random_int();
+                $profilerand = random_int(0, 2**32);
                 echo "<tr class='tab_bg_1'>";
                 echo "<td><label for='dropdown_profiles_id$profilerand'>" .  __s('Default profile') . "</label></td><td>";
 
@@ -3071,7 +3071,7 @@ JAVASCRIPT;
                 );
             }
             if ($higherrights) {
-                $entrand = random_int();
+                $entrand = random_int(0, 2**32);
                 echo "</td><td><label for='dropdown_entities_id$entrand'>" .  __s('Default entity') . "</label></td><td>";
                 $entities = $this->getEntities();
                 $toadd = [-1 => __('Full structure')];
@@ -3083,7 +3083,7 @@ JAVASCRIPT;
                 ]);
                 echo "</td></tr>";
 
-                $grouprand = random_int();
+                $grouprand = random_int(0, 2**32);
                 echo "<tr class='tab_bg_1'>";
                 echo "<td><label for='dropdown_profiles_id$grouprand'>" .  __s('Default group') . "</label></td><td>";
 
@@ -3102,7 +3102,7 @@ JAVASCRIPT;
                 );
 
                 echo "</td>";
-                $userrand = random_int();
+                $userrand = random_int(0, 2**32);
                 echo "<td><label for='dropdown_users_id_supervisor_$userrand'>" .  __s('Supervisor') . "</label></td><td>";
 
                 User::dropdown(['name'   => 'users_id_supervisor',
@@ -3203,7 +3203,7 @@ JAVASCRIPT;
             return false;
         }
         if ($this->getFromDB($ID)) {
-            $rand     = random_int();
+            $rand     = random_int(0, 2**32);
             $authtype = $this->getAuthMethodsByID();
 
             $extauth  = !(($this->fields["authtype"] == Auth::DB_GLPI)
@@ -3218,7 +3218,7 @@ JAVASCRIPT;
             echo "<input type='hidden' name='id' value='" . htmlescape($this->fields["id"]) . "'>";
             echo "</th></tr>";
 
-            $surnamerand = random_int();
+            $surnamerand = random_int(0, 2**32);
             echo "<tr class='tab_bg_1'><td><label for='textfield_realname$surnamerand'>" . __s('Surname') . "</label></td><td>";
 
             if (
@@ -3253,7 +3253,7 @@ JAVASCRIPT;
                 echo "</tr>";
             }
 
-            $firstnamerand = random_int();
+            $firstnamerand = random_int(0, 2**32);
             echo "<tr class='tab_bg_1'><td><label for='textfield_firstname$firstnamerand'>" . __s('First name') . "</label></td><td>";
             if (
                 $extauth
@@ -3290,7 +3290,7 @@ JAVASCRIPT;
 
             echo "<tr class='tab_bg_1'>";
 
-            $langrand = random_int();
+            $langrand = random_int(0, 2**32);
             echo "<td><label for='dropdown_language$langrand'>" . __('Language') . "</label></td><td>";
            // Language is stored as null in DB if value is same as the global config.
             $language = $this->fields["language"];
@@ -3369,7 +3369,7 @@ JAVASCRIPT;
                 echo "</tr>";
             }
 
-            $phonerand = random_int();
+            $phonerand = random_int(0, 2**32);
             echo "<tr class='tab_bg_1'><td><label for='textfield_phone$phonerand'>" .  htmlescape(Phone::getTypeName(1)) . "</label></td><td>";
 
             if (
@@ -3394,7 +3394,7 @@ JAVASCRIPT;
             echo "</td>";
             echo "</tr>";
 
-            $mobilerand = random_int();
+            $mobilerand = random_int(0, 2**32);
             echo "<tr class='tab_bg_1'><td><label for='textfield_mobile$mobilerand'>" . __s('Mobile phone') . "</label></td><td>";
 
             if (
@@ -3414,7 +3414,7 @@ JAVASCRIPT;
             echo "</td>";
 
             if (count($_SESSION['glpiprofiles']) > 1) {
-                $profilerand = random_int();
+                $profilerand = random_int(0, 2**32);
                 echo "<td><label for='dropdown_profiles_id$profilerand'>" . __s('Default profile') . "</label></td><td>";
 
                 $options = Dropdown::getDropdownArrayNames(
@@ -3435,7 +3435,7 @@ JAVASCRIPT;
             }
             echo "</tr>";
 
-            $phone2rand = random_int();
+            $phone2rand = random_int(0, 2**32);
             echo "<tr class='tab_bg_1'><td><label for='textfield_phone2$phone2rand'>" .  __s('Phone 2') . "</label></td><td>";
 
             if (
@@ -3456,7 +3456,7 @@ JAVASCRIPT;
 
             $entities = $this->getEntities();
             if (count($_SESSION['glpiactiveentities']) > 1) {
-                $entrand = random_int();
+                $entrand = random_int(0, 2**32);
                 echo "<td><label for='dropdown_entities_id$entrand'>" . __s('Default entity') . "</td><td>";
                 $toadd = [-1 => __('Full structure')];
                 Entity::dropdown([
@@ -3470,7 +3470,7 @@ JAVASCRIPT;
             }
             echo "</td></tr>";
 
-            $admnumrand = random_int();
+            $admnumrand = random_int(0, 2**32);
             echo "<tr class='tab_bg_1'><td><label for='textfield_registration_number$admnumrand'>" . _sx('user', 'Administrative number') . "</label></td><td>";
             if (
                 $extauth
@@ -3488,7 +3488,7 @@ JAVASCRIPT;
             }
             echo "</td><td colspan='2'></td></tr>";
 
-            $locrand = random_int();
+            $locrand = random_int(0, 2**32);
             echo "<tr class='tab_bg_1'><td><label for='dropdown_locations_id$locrand'>" . htmlescape(Location::getTypeName(1)) . "</label></td><td>";
             Location::dropdown(['value'  => $this->fields['locations_id'],
                 'rand'   => $locrand,
@@ -3496,7 +3496,7 @@ JAVASCRIPT;
             ]);
 
             if (Config::canUpdate()) {
-                $moderand = random_int();
+                $moderand = random_int(0, 2**32);
                 echo "<td><label for='dropdown_use_mode$moderand'>" . __s('Use GLPI in mode') . "</label></td><td>";
                 $modes = [
                     Session::NORMAL_MODE => __('Normal'),
@@ -4736,7 +4736,7 @@ JAVASCRIPT;
             'used'                => [],
             'ldap_import'         => false,
             'toupdate'            => '',
-            'rand'                => random_int(),
+            'rand'                => random_int(0, 2**32),
             'display'             => true,
             '_user_index'         => 0,
             'specific_tags'       => [],
@@ -5291,7 +5291,7 @@ JAVASCRIPT;
             'showmassiveactions'    => true,
             'massiveactionparams'   => [
                 'num_displayed'    => min($_SESSION['glpilist_limit'], $number),
-                'container'        => 'mass' . __CLASS__ . random_int(),
+                'container'        => 'mass' . __CLASS__ . random_int(0, 2**32),
                 'specific_actions' => [
                     'update' => __('Update'),
                 ]
@@ -6774,10 +6774,10 @@ JAVASCRIPT;
         $options['candel'] = false;
         $options['canedit'] = self::canUpdate();
         $this->showFormHeader($options);
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
 
         echo "<tr class='tab_bg_1'>";
-        $surnamerand = random_int();
+        $surnamerand = random_int(0, 2**32);
         echo "<td><label for='textfield_realname$surnamerand'>" . __s('Surname') . "</label></td>";
         echo "<td>";
         echo Html::input(
@@ -6798,7 +6798,7 @@ JAVASCRIPT;
         echo "</td>";
         echo "</tr>";
 
-        $firstnamerand = random_int();
+        $firstnamerand = random_int(0, 2**32);
         echo "<tr class='tab_bg_1'><td><label for='textfield_firstname$firstnamerand'>" . __s('First name') . "</label></td><td>";
         echo Html::input(
             'firstname',

--- a/src/User.php
+++ b/src/User.php
@@ -2715,7 +2715,7 @@ HTML;
             $options['no_header'] = true;
         }
         $this->showFormHeader($options);
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
 
         echo "<tr class='tab_bg_1'>";
         echo "<td><label for='name'>" . __('Login') . "</label></td>";
@@ -2751,7 +2751,7 @@ HTML;
             && $this->fields['auths_id']
             && AuthLDAP::isSyncFieldConfigured($this->fields['auths_id'])
         ) {
-            $syncrand = random_int(0, 2**32);
+            $syncrand = random_int(0, 2 ** 32);
             echo "<tr class='tab_bg_1'><td><label for='textfield_sync_field$syncrand'>" . __s('Synchronization field') . "</label></td><td>";
             if (
                 self::canUpdate()
@@ -2776,7 +2776,7 @@ HTML;
             echo "<tr class='tab_bg_1'><td colspan='2'></td></tr>";
         }
 
-        $surnamerand = random_int(0, 2**32);
+        $surnamerand = random_int(0, 2 ** 32);
         echo "<tr class='tab_bg_1'><td><label for='textfield_realname$surnamerand'>" . __s('Surname') . "</label></td><td>";
         echo Html::input(
             'realname',
@@ -2787,7 +2787,7 @@ HTML;
         );
         echo "</td></tr>";
 
-        $firstnamerand = random_int(0, 2**32);
+        $firstnamerand = random_int(0, 2 ** 32);
         echo "<tr class='tab_bg_1'><td><label for='textfield_firstname$firstnamerand'>" . __s('First name') . "</label></td><td>";
         echo Html::input(
             'firstname',
@@ -2876,7 +2876,7 @@ JAVASCRIPT;
         }
 
         echo "<tr class='tab_bg_1'>";
-        $activerand = random_int(0, 2**32);
+        $activerand = random_int(0, 2 ** 32);
         echo "<td><label for='dropdown_is_active$activerand'>" . __s('Active') . "</label></td><td>";
         Dropdown::showYesNo('is_active', $this->fields['is_active'], -1, ['rand' => $activerand]);
         echo "</td>";
@@ -2888,7 +2888,7 @@ JAVASCRIPT;
         echo "</tr>";
 
         if (!$simplified_form) {
-            $sincerand = random_int(0, 2**32);
+            $sincerand = random_int(0, 2 ** 32);
             echo "<tr class='tab_bg_1'>";
             echo "<td><label for='showdate$sincerand'>" . __s('Valid since') . "</label></td><td>";
             Html::showDateTimeField("begin_date", ['value'       => $this->fields["begin_date"],
@@ -2897,7 +2897,7 @@ JAVASCRIPT;
             ]);
             echo "</td>";
 
-            $untilrand = random_int(0, 2**32);
+            $untilrand = random_int(0, 2 ** 32);
             echo "<td><label for='showdate$untilrand'>" . __s('Valid until') . "</label></td><td>";
             Html::showDateTimeField("end_date", ['value'       => $this->fields["end_date"],
                 'rand'        => $untilrand,
@@ -2906,7 +2906,7 @@ JAVASCRIPT;
             echo "</td></tr>";
         }
 
-        $phonerand = random_int(0, 2**32);
+        $phonerand = random_int(0, 2 ** 32);
         echo "<tr class='tab_bg_1'>";
         echo "<td><label for='textfield_phone$phonerand'>" .  htmlescape(Phone::getTypeName(1)) . "</label></td><td>";
         echo Html::input(
@@ -2957,7 +2957,7 @@ JAVASCRIPT;
 
         echo "</tr>";
 
-        $mobilerand = random_int(0, 2**32);
+        $mobilerand = random_int(0, 2 ** 32);
         echo "<tr class='tab_bg_1'>";
         echo "<td><label for='textfield_mobile$mobilerand'>" . __s('Mobile phone') . "</label></td><td>";
         echo Html::input(
@@ -2970,14 +2970,14 @@ JAVASCRIPT;
         echo "</td>";
         echo "<td>";
         if (!$simplified_form) {
-            $catrand = random_int(0, 2**32);
+            $catrand = random_int(0, 2 ** 32);
             echo "<label for='dropdown_usercategories_id$catrand'>" . _sn('Category', 'Categories', 1) . "</label></td><td>";
             UserCategory::dropdown(['value' => $this->fields["usercategories_id"], 'rand' => $catrand]);
         }
         echo "</td></tr>";
 
         if (!$simplified_form) {
-            $phone2rand = random_int(0, 2**32);
+            $phone2rand = random_int(0, 2 ** 32);
             echo "<tr class='tab_bg_1'>";
             echo "<td><label for='textfield_phone2$phone2rand'>" .  __s('Phone 2') . "</label></td><td>";
             echo Html::input(
@@ -2993,7 +2993,7 @@ JAVASCRIPT;
             echo "<textarea class='form-control' id='comment' name='comment' >" . htmlescape($this->fields["comment"]) . "</textarea>";
             echo "</td></tr>";
 
-            $admnumrand = random_int(0, 2**32);
+            $admnumrand = random_int(0, 2 ** 32);
             echo "<tr class='tab_bg_1'><td><label for='textfield_registration_number$admnumrand'>" . _sx('user', 'Administrative number') . "</label></td><td>";
             echo Html::input(
                 'registration_number',
@@ -3004,7 +3004,7 @@ JAVASCRIPT;
             );
             echo "</td></tr>";
 
-            $titlerand = random_int(0, 2**32);
+            $titlerand = random_int(0, 2 ** 32);
             echo "<tr class='tab_bg_1'><td><label for='dropdown_usertitles_id$titlerand'>" . _sx('person', 'Title') . "</label></td><td>";
             UserTitle::dropdown(['value' => $this->fields["usertitles_id"], 'rand' => $titlerand]);
             echo "</td></tr>";
@@ -3012,7 +3012,7 @@ JAVASCRIPT;
 
         echo "<tr class='tab_bg_1'>";
         if (!empty($ID)) {
-            $locrand = random_int(0, 2**32);
+            $locrand = random_int(0, 2 ** 32);
             echo "<td><label for='dropdown_locations_id$locrand'>" . htmlescape(Location::getTypeName(1)) . "</label></td><td>";
             $entities = $this->getEntities();
             if (count($entities) <= 0) {
@@ -3029,11 +3029,11 @@ JAVASCRIPT;
         if (empty($ID)) {
             echo "<tr class='tab_bg_1'>";
             echo "<th colspan='2'>" . _sn('Authorization', 'Authorizations', 1) . "</th>";
-            $recurrand = random_int(0, 2**32);
+            $recurrand = random_int(0, 2 ** 32);
             echo "<td><label for='dropdown__is_recursive$recurrand'>" .  __s('Recursive') . "</label></td><td>";
             Dropdown::showYesNo("_is_recursive", 0, -1, ['rand' => $recurrand]);
             echo "</td></tr>";
-            $profilerand = random_int(0, 2**32);
+            $profilerand = random_int(0, 2 ** 32);
             echo "<tr class='tab_bg_1'>";
             echo "<td><label for='dropdown__profiles_id$profilerand'>" .  htmlescape(Profile::getTypeName(1)) . "</label></td><td>";
             Profile::dropdownUnder(['name'  => '_profiles_id',
@@ -3041,7 +3041,7 @@ JAVASCRIPT;
                 'value' => Profile::getDefault()
             ]);
 
-            $entrand = random_int(0, 2**32);
+            $entrand = random_int(0, 2 ** 32);
             echo "</td><td><label for='dropdown__entities_id$entrand'>" .  htmlescape(Entity::getTypeName(1)) . "</label></td><td>";
             Entity::dropdown(['name'                => '_entities_id',
                 'display_emptychoice' => false,
@@ -3052,7 +3052,7 @@ JAVASCRIPT;
             echo "</td></tr>";
         } else {
             if ($higherrights || $ismyself) {
-                $profilerand = random_int(0, 2**32);
+                $profilerand = random_int(0, 2 ** 32);
                 echo "<tr class='tab_bg_1'>";
                 echo "<td><label for='dropdown_profiles_id$profilerand'>" .  __s('Default profile') . "</label></td><td>";
 
@@ -3071,7 +3071,7 @@ JAVASCRIPT;
                 );
             }
             if ($higherrights) {
-                $entrand = random_int(0, 2**32);
+                $entrand = random_int(0, 2 ** 32);
                 echo "</td><td><label for='dropdown_entities_id$entrand'>" .  __s('Default entity') . "</label></td><td>";
                 $entities = $this->getEntities();
                 $toadd = [-1 => __('Full structure')];
@@ -3083,7 +3083,7 @@ JAVASCRIPT;
                 ]);
                 echo "</td></tr>";
 
-                $grouprand = random_int(0, 2**32);
+                $grouprand = random_int(0, 2 ** 32);
                 echo "<tr class='tab_bg_1'>";
                 echo "<td><label for='dropdown_profiles_id$grouprand'>" .  __s('Default group') . "</label></td><td>";
 
@@ -3102,7 +3102,7 @@ JAVASCRIPT;
                 );
 
                 echo "</td>";
-                $userrand = random_int(0, 2**32);
+                $userrand = random_int(0, 2 ** 32);
                 echo "<td><label for='dropdown_users_id_supervisor_$userrand'>" .  __s('Supervisor') . "</label></td><td>";
 
                 User::dropdown(['name'   => 'users_id_supervisor',
@@ -3203,7 +3203,7 @@ JAVASCRIPT;
             return false;
         }
         if ($this->getFromDB($ID)) {
-            $rand     = random_int(0, 2**32);
+            $rand     = random_int(0, 2 ** 32);
             $authtype = $this->getAuthMethodsByID();
 
             $extauth  = !(($this->fields["authtype"] == Auth::DB_GLPI)
@@ -3218,7 +3218,7 @@ JAVASCRIPT;
             echo "<input type='hidden' name='id' value='" . htmlescape($this->fields["id"]) . "'>";
             echo "</th></tr>";
 
-            $surnamerand = random_int(0, 2**32);
+            $surnamerand = random_int(0, 2 ** 32);
             echo "<tr class='tab_bg_1'><td><label for='textfield_realname$surnamerand'>" . __s('Surname') . "</label></td><td>";
 
             if (
@@ -3253,7 +3253,7 @@ JAVASCRIPT;
                 echo "</tr>";
             }
 
-            $firstnamerand = random_int(0, 2**32);
+            $firstnamerand = random_int(0, 2 ** 32);
             echo "<tr class='tab_bg_1'><td><label for='textfield_firstname$firstnamerand'>" . __s('First name') . "</label></td><td>";
             if (
                 $extauth
@@ -3290,7 +3290,7 @@ JAVASCRIPT;
 
             echo "<tr class='tab_bg_1'>";
 
-            $langrand = random_int(0, 2**32);
+            $langrand = random_int(0, 2 ** 32);
             echo "<td><label for='dropdown_language$langrand'>" . __('Language') . "</label></td><td>";
            // Language is stored as null in DB if value is same as the global config.
             $language = $this->fields["language"];
@@ -3369,7 +3369,7 @@ JAVASCRIPT;
                 echo "</tr>";
             }
 
-            $phonerand = random_int(0, 2**32);
+            $phonerand = random_int(0, 2 ** 32);
             echo "<tr class='tab_bg_1'><td><label for='textfield_phone$phonerand'>" .  htmlescape(Phone::getTypeName(1)) . "</label></td><td>";
 
             if (
@@ -3394,7 +3394,7 @@ JAVASCRIPT;
             echo "</td>";
             echo "</tr>";
 
-            $mobilerand = random_int(0, 2**32);
+            $mobilerand = random_int(0, 2 ** 32);
             echo "<tr class='tab_bg_1'><td><label for='textfield_mobile$mobilerand'>" . __s('Mobile phone') . "</label></td><td>";
 
             if (
@@ -3414,7 +3414,7 @@ JAVASCRIPT;
             echo "</td>";
 
             if (count($_SESSION['glpiprofiles']) > 1) {
-                $profilerand = random_int(0, 2**32);
+                $profilerand = random_int(0, 2 ** 32);
                 echo "<td><label for='dropdown_profiles_id$profilerand'>" . __s('Default profile') . "</label></td><td>";
 
                 $options = Dropdown::getDropdownArrayNames(
@@ -3435,7 +3435,7 @@ JAVASCRIPT;
             }
             echo "</tr>";
 
-            $phone2rand = random_int(0, 2**32);
+            $phone2rand = random_int(0, 2 ** 32);
             echo "<tr class='tab_bg_1'><td><label for='textfield_phone2$phone2rand'>" .  __s('Phone 2') . "</label></td><td>";
 
             if (
@@ -3456,7 +3456,7 @@ JAVASCRIPT;
 
             $entities = $this->getEntities();
             if (count($_SESSION['glpiactiveentities']) > 1) {
-                $entrand = random_int(0, 2**32);
+                $entrand = random_int(0, 2 ** 32);
                 echo "<td><label for='dropdown_entities_id$entrand'>" . __s('Default entity') . "</td><td>";
                 $toadd = [-1 => __('Full structure')];
                 Entity::dropdown([
@@ -3470,7 +3470,7 @@ JAVASCRIPT;
             }
             echo "</td></tr>";
 
-            $admnumrand = random_int(0, 2**32);
+            $admnumrand = random_int(0, 2 ** 32);
             echo "<tr class='tab_bg_1'><td><label for='textfield_registration_number$admnumrand'>" . _sx('user', 'Administrative number') . "</label></td><td>";
             if (
                 $extauth
@@ -3488,7 +3488,7 @@ JAVASCRIPT;
             }
             echo "</td><td colspan='2'></td></tr>";
 
-            $locrand = random_int(0, 2**32);
+            $locrand = random_int(0, 2 ** 32);
             echo "<tr class='tab_bg_1'><td><label for='dropdown_locations_id$locrand'>" . htmlescape(Location::getTypeName(1)) . "</label></td><td>";
             Location::dropdown(['value'  => $this->fields['locations_id'],
                 'rand'   => $locrand,
@@ -3496,7 +3496,7 @@ JAVASCRIPT;
             ]);
 
             if (Config::canUpdate()) {
-                $moderand = random_int(0, 2**32);
+                $moderand = random_int(0, 2 ** 32);
                 echo "<td><label for='dropdown_use_mode$moderand'>" . __s('Use GLPI in mode') . "</label></td><td>";
                 $modes = [
                     Session::NORMAL_MODE => __('Normal'),
@@ -4736,7 +4736,7 @@ JAVASCRIPT;
             'used'                => [],
             'ldap_import'         => false,
             'toupdate'            => '',
-            'rand'                => random_int(0, 2**32),
+            'rand'                => random_int(0, 2 ** 32),
             'display'             => true,
             '_user_index'         => 0,
             'specific_tags'       => [],
@@ -5291,7 +5291,7 @@ JAVASCRIPT;
             'showmassiveactions'    => true,
             'massiveactionparams'   => [
                 'num_displayed'    => min($_SESSION['glpilist_limit'], $number),
-                'container'        => 'mass' . __CLASS__ . random_int(0, 2**32),
+                'container'        => 'mass' . __CLASS__ . random_int(0, 2 ** 32),
                 'specific_actions' => [
                     'update' => __('Update'),
                 ]
@@ -6774,10 +6774,10 @@ JAVASCRIPT;
         $options['candel'] = false;
         $options['canedit'] = self::canUpdate();
         $this->showFormHeader($options);
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
 
         echo "<tr class='tab_bg_1'>";
-        $surnamerand = random_int(0, 2**32);
+        $surnamerand = random_int(0, 2 ** 32);
         echo "<td><label for='textfield_realname$surnamerand'>" . __s('Surname') . "</label></td>";
         echo "<td>";
         echo Html::input(
@@ -6798,7 +6798,7 @@ JAVASCRIPT;
         echo "</td>";
         echo "</tr>";
 
-        $firstnamerand = random_int(0, 2**32);
+        $firstnamerand = random_int(0, 2 ** 32);
         echo "<tr class='tab_bg_1'><td><label for='textfield_firstname$firstnamerand'>" . __s('First name') . "</label></td><td>";
         echo Html::input(
             'firstname',

--- a/tests/GLPITestCase.php
+++ b/tests/GLPITestCase.php
@@ -368,7 +368,7 @@ class GLPITestCase extends atoum
     protected function getUniqueInteger()
     {
         if (is_null($this->int)) {
-            return $this->int = mt_rand(1000, 10000);
+            return $this->int = random_int(1000, 10000);
         }
         return $this->int++;
     }

--- a/tests/LDAP/AuthLdap.php
+++ b/tests/LDAP/AuthLdap.php
@@ -1542,7 +1542,7 @@ class AuthLDAP extends DbTestCase
         $CFG_GLPI['user_deleted_ldap_authorizations'] = $authorizations_option_value;
 
         // Unique user for each tests
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
         $uid = "toremovetest$rand";
 
         // Add a new user in directory

--- a/tests/LDAP/AuthLdap.php
+++ b/tests/LDAP/AuthLdap.php
@@ -1542,7 +1542,7 @@ class AuthLDAP extends DbTestCase
         $CFG_GLPI['user_deleted_ldap_authorizations'] = $authorizations_option_value;
 
         // Unique user for each tests
-        $rand = mt_rand();
+        $rand = random_int();
         $uid = "toremovetest$rand";
 
         // Add a new user in directory

--- a/tests/LDAP/AuthLdap.php
+++ b/tests/LDAP/AuthLdap.php
@@ -1542,7 +1542,7 @@ class AuthLDAP extends DbTestCase
         $CFG_GLPI['user_deleted_ldap_authorizations'] = $authorizations_option_value;
 
         // Unique user for each tests
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
         $uid = "toremovetest$rand";
 
         // Add a new user in directory

--- a/tests/functional/DBmysqlIterator.php
+++ b/tests/functional/DBmysqlIterator.php
@@ -129,7 +129,7 @@ class DBmysqlIterator extends DbTestCase
     {
         define('GLPI_SQL_DEBUG', true);
 
-        $id = random_int();
+        $id = random_int(0, 2**32);
         $this->it->execute(['FROM' => 'foo', 'FIELDS' => 'name', 'id = ' . $id]);
 
         $this->hasSqlLogRecordThatContains(

--- a/tests/functional/DBmysqlIterator.php
+++ b/tests/functional/DBmysqlIterator.php
@@ -129,7 +129,7 @@ class DBmysqlIterator extends DbTestCase
     {
         define('GLPI_SQL_DEBUG', true);
 
-        $id = random_int(0, 2**32);
+        $id = random_int(0, 2 ** 32);
         $this->it->execute(['FROM' => 'foo', 'FIELDS' => 'name', 'id = ' . $id]);
 
         $this->hasSqlLogRecordThatContains(

--- a/tests/functional/DBmysqlIterator.php
+++ b/tests/functional/DBmysqlIterator.php
@@ -129,7 +129,7 @@ class DBmysqlIterator extends DbTestCase
     {
         define('GLPI_SQL_DEBUG', true);
 
-        $id = mt_rand();
+        $id = random_int();
         $this->it->execute(['FROM' => 'foo', 'FIELDS' => 'name', 'id = ' . $id]);
 
         $this->hasSqlLogRecordThatContains(

--- a/tests/functional/Glpi/System/Requirement/ExtensionConstant.php
+++ b/tests/functional/Glpi/System/Requirement/ExtensionConstant.php
@@ -39,7 +39,7 @@ class ExtensionConstant extends \GLPITestCase
 {
     public function testCheckOnExistingConstant()
     {
-        $test_constant = 'TEST_CONSTANT' . random_int();
+        $test_constant = 'TEST_CONSTANT' . random_int(0, 2**32);
         define($test_constant, 'TEST');
         $this->newTestedInstance('Test constant', $test_constant, false, '');
         $this->boolean($this->testedInstance->isValidated())->isEqualTo(true);
@@ -49,7 +49,7 @@ class ExtensionConstant extends \GLPITestCase
 
     public function testCheckOnMissingMandatoryConstant()
     {
-        $test_constant = 'TEST_CONSTANT' . random_int();
+        $test_constant = 'TEST_CONSTANT' . random_int(0, 2**32);
         $this->newTestedInstance('Test constant', $test_constant, false, '');
         $this->boolean($this->testedInstance->isValidated())->isEqualTo(false);
         $this->array($this->testedInstance->getValidationMessages())
@@ -58,7 +58,7 @@ class ExtensionConstant extends \GLPITestCase
 
     public function testCheckOnMissingOptionalConstant()
     {
-        $test_constant = 'TEST_CONSTANT' . random_int();
+        $test_constant = 'TEST_CONSTANT' . random_int(0, 2**32);
         $this->newTestedInstance('Test constant', $test_constant, true, '');
         $this->boolean($this->testedInstance->isValidated())->isEqualTo(false);
         $this->array($this->testedInstance->getValidationMessages())

--- a/tests/functional/Glpi/System/Requirement/ExtensionConstant.php
+++ b/tests/functional/Glpi/System/Requirement/ExtensionConstant.php
@@ -39,7 +39,7 @@ class ExtensionConstant extends \GLPITestCase
 {
     public function testCheckOnExistingConstant()
     {
-        $test_constant = 'TEST_CONSTANT' . mt_rand();
+        $test_constant = 'TEST_CONSTANT' . random_int();
         define($test_constant, 'TEST');
         $this->newTestedInstance('Test constant', $test_constant, false, '');
         $this->boolean($this->testedInstance->isValidated())->isEqualTo(true);
@@ -49,7 +49,7 @@ class ExtensionConstant extends \GLPITestCase
 
     public function testCheckOnMissingMandatoryConstant()
     {
-        $test_constant = 'TEST_CONSTANT' . mt_rand();
+        $test_constant = 'TEST_CONSTANT' . random_int();
         $this->newTestedInstance('Test constant', $test_constant, false, '');
         $this->boolean($this->testedInstance->isValidated())->isEqualTo(false);
         $this->array($this->testedInstance->getValidationMessages())
@@ -58,7 +58,7 @@ class ExtensionConstant extends \GLPITestCase
 
     public function testCheckOnMissingOptionalConstant()
     {
-        $test_constant = 'TEST_CONSTANT' . mt_rand();
+        $test_constant = 'TEST_CONSTANT' . random_int();
         $this->newTestedInstance('Test constant', $test_constant, true, '');
         $this->boolean($this->testedInstance->isValidated())->isEqualTo(false);
         $this->array($this->testedInstance->getValidationMessages())

--- a/tests/functional/Glpi/System/Requirement/ExtensionConstant.php
+++ b/tests/functional/Glpi/System/Requirement/ExtensionConstant.php
@@ -39,7 +39,7 @@ class ExtensionConstant extends \GLPITestCase
 {
     public function testCheckOnExistingConstant()
     {
-        $test_constant = 'TEST_CONSTANT' . random_int(0, 2**32);
+        $test_constant = 'TEST_CONSTANT' . random_int(0, 2 ** 32);
         define($test_constant, 'TEST');
         $this->newTestedInstance('Test constant', $test_constant, false, '');
         $this->boolean($this->testedInstance->isValidated())->isEqualTo(true);
@@ -49,7 +49,7 @@ class ExtensionConstant extends \GLPITestCase
 
     public function testCheckOnMissingMandatoryConstant()
     {
-        $test_constant = 'TEST_CONSTANT' . random_int(0, 2**32);
+        $test_constant = 'TEST_CONSTANT' . random_int(0, 2 ** 32);
         $this->newTestedInstance('Test constant', $test_constant, false, '');
         $this->boolean($this->testedInstance->isValidated())->isEqualTo(false);
         $this->array($this->testedInstance->getValidationMessages())
@@ -58,7 +58,7 @@ class ExtensionConstant extends \GLPITestCase
 
     public function testCheckOnMissingOptionalConstant()
     {
-        $test_constant = 'TEST_CONSTANT' . random_int(0, 2**32);
+        $test_constant = 'TEST_CONSTANT' . random_int(0, 2 ** 32);
         $this->newTestedInstance('Test constant', $test_constant, true, '');
         $this->boolean($this->testedInstance->isValidated())->isEqualTo(false);
         $this->array($this->testedInstance->getValidationMessages())

--- a/tests/functional/Glpi/System/Status/StatusChecker.php
+++ b/tests/functional/Glpi/System/Status/StatusChecker.php
@@ -125,7 +125,7 @@ class StatusChecker extends DbTestCase
             'host'            => 'localhost',
             'is_active'       => 1,
             'rootdn'          => 'cn=Manager,dc=glpi,dc=org',
-            'rootdn_passwd'   => md5(mt_rand())
+            'rootdn_passwd'   => md5(random_int())
         ]);
         $this->integer($authlap_id)->isGreaterThan(0);
 

--- a/tests/functional/Glpi/System/Status/StatusChecker.php
+++ b/tests/functional/Glpi/System/Status/StatusChecker.php
@@ -125,7 +125,7 @@ class StatusChecker extends DbTestCase
             'host'            => 'localhost',
             'is_active'       => 1,
             'rootdn'          => 'cn=Manager,dc=glpi,dc=org',
-            'rootdn_passwd'   => md5(random_int(0, 2**32))
+            'rootdn_passwd'   => md5(random_int(0, 2 ** 32))
         ]);
         $this->integer($authlap_id)->isGreaterThan(0);
 

--- a/tests/functional/Glpi/System/Status/StatusChecker.php
+++ b/tests/functional/Glpi/System/Status/StatusChecker.php
@@ -125,7 +125,7 @@ class StatusChecker extends DbTestCase
             'host'            => 'localhost',
             'is_active'       => 1,
             'rootdn'          => 'cn=Manager,dc=glpi,dc=org',
-            'rootdn_passwd'   => md5(random_int())
+            'rootdn_passwd'   => md5(random_int(0, 2**32))
         ]);
         $this->integer($authlap_id)->isGreaterThan(0);
 

--- a/tests/functional/Session.php
+++ b/tests/functional/Session.php
@@ -300,7 +300,7 @@ class Session extends \DbTestCase
 
         $this->login();
         $user = new \User();
-        $username = 'test_must_change_pass_' . random_int();
+        $username = 'test_must_change_pass_' . random_int(0, 2**32);
         $user_id = (int)$user->add([
             'name'         => $username,
             'password'     => 'test',

--- a/tests/functional/Session.php
+++ b/tests/functional/Session.php
@@ -300,7 +300,7 @@ class Session extends \DbTestCase
 
         $this->login();
         $user = new \User();
-        $username = 'test_must_change_pass_' . mt_rand();
+        $username = 'test_must_change_pass_' . random_int();
         $user_id = (int)$user->add([
             'name'         => $username,
             'password'     => 'test',

--- a/tests/functional/Session.php
+++ b/tests/functional/Session.php
@@ -300,7 +300,7 @@ class Session extends \DbTestCase
 
         $this->login();
         $user = new \User();
-        $username = 'test_must_change_pass_' . random_int(0, 2**32);
+        $username = 'test_must_change_pass_' . random_int(0, 2 ** 32);
         $user_id = (int)$user->add([
             'name'         => $username,
             'password'     => 'test',

--- a/tests/web/APIRest.php
+++ b/tests/web/APIRest.php
@@ -3100,7 +3100,7 @@ class APIRest extends atoum
     public function test_ActorUpdate()
     {
         $headers = ['Session-Token' => $this->session_token];
-        $rand = random_int();
+        $rand = random_int(0, 2**32);
 
         // Group used for our tests
         $groups_id = getItemByTypeName("Group", "_test_group_1", true);

--- a/tests/web/APIRest.php
+++ b/tests/web/APIRest.php
@@ -3100,7 +3100,7 @@ class APIRest extends atoum
     public function test_ActorUpdate()
     {
         $headers = ['Session-Token' => $this->session_token];
-        $rand = random_int(0, 2**32);
+        $rand = random_int(0, 2 ** 32);
 
         // Group used for our tests
         $groups_id = getItemByTypeName("Group", "_test_group_1", true);

--- a/tests/web/APIRest.php
+++ b/tests/web/APIRest.php
@@ -3100,7 +3100,7 @@ class APIRest extends atoum
     public function test_ActorUpdate()
     {
         $headers = ['Session-Token' => $this->session_token];
-        $rand = mt_rand();
+        $rand = random_int();
 
         // Group used for our tests
         $groups_id = getItemByTypeName("Group", "_test_group_1", true);


### PR DESCRIPTION
## Description

- Avoid non-secure random generator
- with the last PHP versions (8.0+), speed should not be too much impacted anymore. (30% more time for random_int currently, where it was 13* more in earlier PHP versions)

It removes a lot of lines in sonarcloud.io reports; it's difficult to say at this point we have real issues, but I thought it was an easy win.

To note, javascript `Math.random()` is also considered an insecure random number generator (and generates a few issue in sonarcloud), but the replacement is a bit too much :
```js
const crypto = window.crypto || window.msCrypto;
var array = new Uint32Array(1);
crypto.getRandomValues(array); // Compliant for security-sensitive use cases
```
