### PR TITLE
Service catalog: add categories

### DIFF
--- a/css/includes/_base.scss
+++ b/css/includes/_base.scss
@@ -453,6 +453,13 @@ body pre {
     }
 }
 
+.remove-last-tinymce-margin {
+    // Remove annoying margin from tinymce's last paragraph
+    p:last-child {
+        margin-bottom: 0;
+    }
+}
+
 .accordion-button:hover, .accordion-button:focus {
     z-index: unset;
 }

--- a/inc/relation.constant.php
+++ b/inc/relation.constant.php
@@ -705,6 +705,11 @@ $RELATION = [
         "_glpi_forms_destinations_answerssets_formdestinationitems" => "forms_answerssets_id",
     ],
 
+    'glpi_forms_categories' => [
+        'glpi_forms_categories' => 'forms_categories_id',
+        'glpi_forms_forms' => 'forms_categories_id',
+    ],
+
     'glpi_forms_forms' => [
         "_glpi_forms_accesscontrols_formaccesscontrols" => "forms_forms_id",
         "_glpi_forms_answerssets"                       => "forms_forms_id",

--- a/install/migrations/update_10.0.x_to_11.0.0/form.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/form.php
@@ -43,6 +43,27 @@ $default_charset   = DBConnection::getDefaultCharset();
 $default_collation = DBConnection::getDefaultCollation();
 $default_key_sign  = DBConnection::getDefaultPrimaryKeySignOption();
 
+if (!$DB->tableExists('glpi_forms_categories')) {
+    $DB->doQuery(
+        "CREATE TABLE `glpi_forms_categories` (
+            `id` int unsigned NOT NULL AUTO_INCREMENT,
+            `name` varchar(255) NOT NULL DEFAULT '',
+            `description` longtext,
+            `illustration` varchar(255) NOT NULL DEFAULT '',
+            `forms_categories_id` int unsigned NOT NULL DEFAULT '0',
+            `completename` text,
+            `level` int NOT NULL DEFAULT '0',
+            `ancestors_cache` longtext,
+            `sons_cache` longtext,
+            `comment` text,
+            PRIMARY KEY (`id`),
+            KEY `name` (`name`),
+            KEY `level` (`level`),
+            KEY `forms_categories_id` (`forms_categories_id`)
+        ) ENGINE=InnoDB DEFAULT CHARSET={$default_charset} COLLATE={$default_collation} ROW_FORMAT=DYNAMIC;"
+    );
+}
+
 // Create tables
 if (!$DB->tableExists('glpi_forms_forms')) {
     $DB->doQuery(
@@ -57,6 +78,7 @@ if (!$DB->tableExists('glpi_forms_forms')) {
             `header` longtext,
             `illustration` varchar(255) NOT NULL DEFAULT '',
             `description` longtext,
+            `forms_categories_id` int unsigned NOT NULL DEFAULT '0',
             `date_mod` timestamp NULL DEFAULT NULL,
             `date_creation` timestamp NULL DEFAULT NULL,
             PRIMARY KEY (`id`),
@@ -67,7 +89,8 @@ if (!$DB->tableExists('glpi_forms_forms')) {
             KEY `is_deleted` (`is_deleted`),
             KEY `is_draft` (`is_draft`),
             KEY `date_mod` (`date_mod`),
-            KEY `date_creation` (`date_creation`)
+            KEY `date_creation` (`date_creation`),
+            KEY `forms_categories_id` (`forms_categories_id`)
         ) ENGINE=InnoDB DEFAULT CHARSET={$default_charset} COLLATE={$default_collation} ROW_FORMAT=DYNAMIC;"
     );
 }
@@ -233,6 +256,9 @@ if (GLPI_VERSION == "11.0.0-dev") {
 
     $migration->addField("glpi_forms_forms", "illustration", "string");
     $migration->addField("glpi_forms_forms", "description", "text");
+
+    $migration->addField("glpi_forms_forms", "forms_categories_id", "fkey");
+    $migration->addKey("glpi_forms_forms", "forms_categories_id");
 }
 
 CronTask::register('Glpi\Form\Form', 'purgedraftforms', DAY_TIMESTAMP, [

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -9405,6 +9405,24 @@ CREATE TABLE `glpi_snmpcredentials` (
    KEY `is_deleted` (`is_deleted`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
+DROP TABLE IF EXISTS `glpi_forms_categories`;
+CREATE TABLE `glpi_forms_categories` (
+    `id` int unsigned NOT NULL AUTO_INCREMENT,
+    `name` varchar(255) NOT NULL DEFAULT '',
+    `description` longtext,
+    `illustration` varchar(255) NOT NULL DEFAULT '',
+    `forms_categories_id` int unsigned NOT NULL DEFAULT '0',
+    `completename` text,
+    `level` int NOT NULL DEFAULT '0',
+    `ancestors_cache` longtext,
+    `sons_cache` longtext,
+    `comment` text,
+    PRIMARY KEY (`id`),
+    KEY `name` (`name`),
+    KEY `level` (`level`),
+    KEY `forms_categories_id` (`forms_categories_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+
 DROP TABLE IF EXISTS `glpi_forms_forms`;
 CREATE TABLE `glpi_forms_forms` (
     `id` int unsigned NOT NULL AUTO_INCREMENT,
@@ -9417,6 +9435,7 @@ CREATE TABLE `glpi_forms_forms` (
     `header` longtext,
     `illustration` varchar(255) NOT NULL DEFAULT '',
     `description` longtext,
+    `forms_categories_id` int unsigned NOT NULL DEFAULT '0',
     `date_mod` timestamp NULL DEFAULT NULL,
     `date_creation` timestamp NULL DEFAULT NULL,
     PRIMARY KEY (`id`),
@@ -9427,7 +9446,8 @@ CREATE TABLE `glpi_forms_forms` (
     KEY `is_deleted` (`is_deleted`),
     KEY `is_draft` (`is_draft`),
     KEY `date_mod` (`date_mod`),
-    KEY `date_creation` (`date_creation`)
+    KEY `date_creation` (`date_creation`),
+    KEY `forms_categories_id` (`forms_categories_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 DROP TABLE IF EXISTS `glpi_forms_sections`;

--- a/js/modules/Forms/ServiceCatalogController.js
+++ b/js/modules/Forms/ServiceCatalogController.js
@@ -1,0 +1,92 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+/* global _ */
+
+export class GlpiFormServiceCatalogController
+{
+    constructor()
+    {
+        const input = this.#getFilterInput();
+        const filterFormsDebounced = _.debounce(
+            this.#filterItems.bind(this), // .bind keep the correct "this" context
+            400,
+            false
+        );
+        input.addEventListener('input', filterFormsDebounced);
+
+        // Load children items when composite items are clicked
+        document
+            .querySelectorAll('[data-children-url-parameters]')
+            .forEach((composite) => composite.addEventListener(
+                'click',
+                (e) => this.#loadChildren(e)
+            ))
+        ;
+    }
+
+    async #filterItems()
+    {
+        const input = this.#getFilterInput();
+        const url = `${CFG_GLPI.root_doc}/ServiceCatalog/Items`;
+        const url_params = new URLSearchParams({
+            filter: input.value,
+        });
+        const response = await fetch(`${url}?${url_params}`);
+        this.#getFormsArea().innerHTML = await response.text();
+    }
+
+    async #loadChildren(e)
+    {
+        e.preventDefault();
+
+        // Clear search filter
+        const search_input = this.#getFilterInput();
+        search_input.value = '';
+
+        // Get children items from backend
+        const url = `${CFG_GLPI.root_doc}/ServiceCatalog/Items`;
+        const url_params = e.currentTarget.dataset['childrenUrlParameters']; // ref to data-children-url-parameters
+        const response = await fetch(`${url}?${url_params}`);
+        this.#getFormsArea().innerHTML = await response.text();
+    }
+
+    #getFilterInput()
+    {
+        return document.querySelector("[data-glpi-service-catalog-filter-items]");
+    }
+
+    #getFormsArea()
+    {
+        return document.querySelector("[data-glpi-service-catalog-items]");
+    }
+}

--- a/phpunit/functional/Glpi/Form/ServiceCatalog/ServiceCatalogManagerTest.php
+++ b/phpunit/functional/Glpi/Form/ServiceCatalog/ServiceCatalogManagerTest.php
@@ -389,7 +389,7 @@ final class ServiceCatalogManagerTest extends \DbTestCase
             $items
         );
 
-        // Assert: only items without categories must be found
+        // Assert: only root items must be found
         $this->assertEquals([
             "Root form 1",
             "Root form 2",

--- a/phpunit/functional/Glpi/Form/ServiceCatalog/ServiceCatalogManagerTest.php
+++ b/phpunit/functional/Glpi/Form/ServiceCatalog/ServiceCatalogManagerTest.php
@@ -39,6 +39,9 @@ use AbstractRightsDropdown;
 use Glpi\Form\AccessControl\ControlType\AllowList;
 use Glpi\Form\AccessControl\ControlType\AllowListConfig;
 use Glpi\Form\AccessControl\FormAccessParameters;
+use Glpi\Form\Category;
+use Glpi\Form\ServiceCatalog\ItemRequest;
+use Glpi\Form\ServiceCatalog\ServiceCatalogItemInterface;
 use Glpi\Form\ServiceCatalog\ServiceCatalogManager;
 use Glpi\Form\Form;
 use Glpi\Session\SessionInfo;
@@ -86,23 +89,30 @@ final class ServiceCatalogManagerTest extends \DbTestCase
 
         // Act: get the forms from the catalog manager and extract their names
         $access_parameters = $this->getDefaultParametersForTestUser();
-        $forms = self::$manager->getForms($access_parameters);
+        $item_request = new ItemRequest(access_parameters: $access_parameters);
+        $forms = self::$manager->getItems($item_request);
         $forms_names = array_map(fn (Form $form) => $form->fields['name'], $forms);
 
-        // Assert: only active forms must be found
+        // Assert: only active forms must be found.
         $this->assertEquals([
             "Active form 1",
             "Active form 2",
         ], $forms_names);
     }
 
-    public function testFormsAreOrderedByNames(): void
+    public function testItemsAreOrderedByNames(): void
     {
-        // Arrange: create forms with unordered names
+        // Arrange: create forms and categories with unordered names
+        $category_1 = $this->createItem(Category::class, ['name' => 'BBB']);
+        $category_2 = $this->createItem(Category::class, ['name' => 'QQQ']);
         $builders = [
             new FormBuilder("ZZZ"),
             new FormBuilder("AAA"),
             new FormBuilder("CCC"),
+            // This two forms won't be displayed, they are needed to make sure
+            // the categories are not empty.
+            (new FormBuilder("child 1"))->setCategory($category_1->getID()),
+            (new FormBuilder("child 2"))->setCategory($category_2->getID()),
         ];
         foreach ($builders as $builder) {
             $builder->allowAllUsers();
@@ -112,43 +122,18 @@ final class ServiceCatalogManagerTest extends \DbTestCase
 
         // Act: get the forms from the catalog manager and extract their names
         $access_parameters = $this->getDefaultParametersForTestUser();
-        $forms = self::$manager->getForms($access_parameters);
-        $forms_names = array_map(fn (Form $form) => $form->fields['name'], $forms);
+        $item_request = new ItemRequest(access_parameters: $access_parameters);
+        $forms = self::$manager->getItems($item_request);
+        $forms_names = array_map(fn (ServiceCatalogItemInterface $item) => $item->getServiceCatalogItemTitle(), $forms);
 
         // Assert: forms must be ordered by name
         $this->assertEquals([
             "AAA",
             "CCC",
             "ZZZ",
-        ], $forms_names);
-    }
-
-    public function testFormsNamesAreUniques(): void
-    {
-        // Arrange: create forms with duplicated names
-        $builders = [
-            new FormBuilder("My form"),
-            new FormBuilder("My form"),
-            new FormBuilder("My other form"),
-            new FormBuilder("My form"),
-        ];
-        foreach ($builders as $builder) {
-            $builder->allowAllUsers();
-            $builder->setIsActive(true);
-            $this->createForm($builder);
-        }
-
-        // Act: get the forms from the catalog manager and extract their names
-        $access_parameters = $this->getDefaultParametersForTestUser();
-        $forms = self::$manager->getForms($access_parameters);
-        $forms_names = array_map(fn (Form $form) => $form->fields['name'], $forms);
-
-        // Assert: names must be uniques
-        $this->assertEquals([
-            "My form",
-            "My form (1)",
-            "My form (2)",
-            "My other form",
+            // Categories are always at the end
+            "BBB",
+            "QQQ",
         ], $forms_names);
     }
 
@@ -168,7 +153,8 @@ final class ServiceCatalogManagerTest extends \DbTestCase
 
         // Act: get the forms from the catalog manager and extract their names
         $access_parameters = $this->getDefaultParametersForTestUser();
-        $forms = self::$manager->getForms($access_parameters);
+        $item_request = new ItemRequest(access_parameters: $access_parameters);
+        $forms = self::$manager->getItems($item_request);
         $forms_names = array_map(fn (Form $form) => $form->fields['name'], $forms);
 
         // Assert: our form must be found
@@ -184,7 +170,8 @@ final class ServiceCatalogManagerTest extends \DbTestCase
 
         // Act: get the forms from the catalog manager and extract their names
         $access_parameters = $this->getDefaultParametersForTestUser();
-        $forms = self::$manager->getForms($access_parameters);
+        $item_request = new ItemRequest(access_parameters: $access_parameters);
+        $forms = self::$manager->getItems($item_request);
         $forms_names = array_map(fn (Form $form) => $form->fields['name'], $forms);
 
         // Assert: our form must not be found
@@ -207,7 +194,8 @@ final class ServiceCatalogManagerTest extends \DbTestCase
 
         // Act: get the forms from the catalog manager and extract their names
         $access_parameters = $this->getDefaultParametersForTestUser();
-        $forms = self::$manager->getForms($access_parameters);
+        $item_request = new ItemRequest(access_parameters: $access_parameters);
+        $forms = self::$manager->getItems($item_request);
         $forms_names = array_map(fn (Form $form) => $form->fields['name'], $forms);
 
         // Assert: our form must not be found
@@ -265,7 +253,8 @@ final class ServiceCatalogManagerTest extends \DbTestCase
             user_id: getItemByTypeName(User::class, $user, true),
         );
         $access_parameters = new FormAccessParameters($session_info, []);
-        $forms = self::$manager->getForms($access_parameters);
+        $item_request = new ItemRequest(access_parameters: $access_parameters);
+        $forms = self::$manager->getItems($item_request);
         $nb_forms = count($forms);
 
         // Assert: list should be empty if we don't expect the user to see the form
@@ -360,10 +349,173 @@ final class ServiceCatalogManagerTest extends \DbTestCase
 
         // Act: filter the forms
         $access_parameters = $this->getDefaultParametersForTestUser();
-        $forms = self::$manager->getForms($access_parameters, $filter);
+        $item_request = new ItemRequest(
+            access_parameters: $access_parameters,
+            filter: $filter,
+        );
+        $forms = self::$manager->getItems($item_request);
 
         // Assert: only the expected forms must be found
         $forms_names = array_map(fn (Form $form) => $form->fields['name'], $forms);
         $this->assertEquals($expected_forms_names, $forms_names);
+    }
+
+    public function testRootContent(): void
+    {
+        // Arrange: create a few forms with and without categories
+        $category_a = $this->createItem(Category::class, ['name' => 'Category A']);
+        $category_b = $this->createItem(Category::class, [
+            'name' => 'Category B',
+            Category::getForeignKeyField() => $category_a->getID(),
+        ]);
+        $builders = [
+            new FormBuilder("Root form 1"),
+            new FormBuilder("Root form 2"),
+            (new FormBuilder("Form from category A"))->setCategory($category_a->getID()),
+            (new FormBuilder("Form from category B"))->setCategory($category_b->getID()),
+        ];
+        foreach ($builders as $builder) {
+            $builder->allowAllUsers();
+            $builder->setIsActive(true);
+            $this->createForm($builder);
+        }
+
+        // Act: get the root items from the catalog manager and extract their names
+        $access_parameters = $this->getDefaultParametersForTestUser();
+        $item_request = new ItemRequest(access_parameters: $access_parameters);
+        $items = self::$manager->getItems($item_request);
+        $items_names = array_map(
+            fn (ServiceCatalogItemInterface $item) => $item->getServiceCatalogItemTitle(),
+            $items
+        );
+
+        // Assert: only items without categories must be found
+        $this->assertEquals([
+            "Root form 1",
+            "Root form 2",
+            "Category A",
+        ], $items_names);
+    }
+
+    public function testCategoryContent(): void
+    {
+        // Arrange: create a few forms with and without categories
+        $category_a = $this->createItem(Category::class, ['name' => 'Category A']);
+        $category_b = $this->createItem(Category::class, [
+            'name' => 'Category B',
+            Category::getForeignKeyField() => $category_a->getID(),
+        ]);
+        $builders = [
+            new FormBuilder("Root form 1"),
+            new FormBuilder("Root form 2"),
+            (new FormBuilder("Form from category A"))->setCategory($category_a->getID()),
+            (new FormBuilder("Form from category B"))->setCategory($category_b->getID()),
+        ];
+        foreach ($builders as $builder) {
+            $builder->allowAllUsers();
+            $builder->setIsActive(true);
+            $this->createForm($builder);
+        }
+
+        // Act: get the items from the category A and extract their names
+        $access_parameters = $this->getDefaultParametersForTestUser();
+        $item_request = new ItemRequest(
+            access_parameters: $access_parameters,
+            category: $category_a,
+        );
+        $items = self::$manager->getItems($item_request);
+        $items_names = array_map(
+            fn (ServiceCatalogItemInterface $item) => $item->getServiceCatalogItemTitle(),
+            $items
+        );
+
+        // Assert: only forms and categories inside "Category A" must be found.
+        $this->assertEquals([
+            "Form from category A",
+            "Category B",
+        ], $items_names);
+    }
+
+    public function testCategoriesCanBeFiltered(): void
+    {
+        // Arrange: create a few forms with categories
+        $category_a = $this->createItem(Category::class, ['name' => 'A']);
+        $category_b = $this->createItem(Category::class, ['name' => 'B']);
+        $category_c1 = $this->createItem(Category::class, ['name' => 'C1']);
+        $category_c2 = $this->createItem(Category::class, ['name' => 'C2']);
+        $builders = [
+            (new FormBuilder("Form from category A"))->setCategory($category_a->getID()),
+            (new FormBuilder("Form from category B"))->setCategory($category_b->getID()),
+            (new FormBuilder("Form from category C1"))->setCategory($category_c1->getID()),
+            (new FormBuilder("Form from category C2"))->setCategory($category_c2->getID()),
+        ];
+        foreach ($builders as $builder) {
+            $builder->allowAllUsers();
+            $builder->setIsActive(true);
+            $this->createForm($builder);
+        }
+
+        // Act: get the items using a filter
+        $access_parameters = $this->getDefaultParametersForTestUser();
+        $item_request = new ItemRequest(
+            access_parameters: $access_parameters,
+            filter: 'C',
+        );
+        $items = self::$manager->getItems($item_request);
+        $items_names = array_map(
+            fn (ServiceCatalogItemInterface $item) => $item->getServiceCatalogItemTitle(),
+            $items
+        );
+
+        // Assert: only categories that contains "C" must be found
+        $this->assertEquals([
+            "C1",
+            "C2",
+        ], $items_names);
+    }
+
+    public function testEmptyCategoriesAreNotFound(): void
+    {
+        // Arrange: create a few forms with categories
+        // Category A -> has a form
+        // Category B -> no forms
+        // Category C -> Category C1 -> no forms
+        // Category D -> Category D1 -> has a form
+        $category_a = $this->createItem(Category::class, ['name' => 'Category A']);
+        $this->createItem(Category::class, ['name' => 'Category B']);
+        $category_c = $this->createItem(Category::class, ['name' => 'Category C']);
+        $this->createItem(Category::class, [
+            'name' => 'Category C1',
+            Category::getForeignKeyField() => $category_c->getID(),
+        ]);
+        $category_d = $this->createItem(Category::class, ['name' => 'Category D']);
+        $category_d1 = $this->createItem(Category::class, [
+            'name' => 'Category D1',
+            Category::getForeignKeyField() => $category_d->getID(),
+        ]);
+        $builders = [
+            (new FormBuilder("Form from category A"))->setCategory($category_a->getID()),
+            (new FormBuilder("Form from category D1"))->setCategory($category_d1->getID()),
+        ];
+        foreach ($builders as $builder) {
+            $builder->allowAllUsers();
+            $builder->setIsActive(true);
+            $this->createForm($builder);
+        }
+
+        // Act: get the root items
+        $access_parameters = $this->getDefaultParametersForTestUser();
+        $item_request = new ItemRequest(access_parameters: $access_parameters);
+        $items = self::$manager->getItems($item_request);
+        $items_names = array_map(
+            fn (ServiceCatalogItemInterface $item) => $item->getServiceCatalogItemTitle(),
+            $items
+        );
+
+        // Assert: only categories with (direct or indirect) children must be found
+        $this->assertEquals([
+            "Category A",
+            "Category D",
+        ], $items_names);
     }
 }

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -41,6 +41,7 @@ use Glpi\DBAL\QueryFunction;
 use Glpi\Dropdown\DropdownDefinitionManager;
 use Glpi\Features\DCBreadcrumb;
 use Glpi\Features\AssignableItem;
+use Glpi\Form\Category;
 use Glpi\Plugin\Hooks;
 use Glpi\SocketModel;
 
@@ -1219,6 +1220,7 @@ JAVASCRIPT;
                     'PlanningExternalEventTemplate' => null,
                     'PlanningEventCategory' => null,
                     'PendingReason' => null,
+                    Category::class => null,
                 ],
 
                 _n('Type', 'Types', Session::getPluralNumber()) => [

--- a/src/Glpi/Controller/ServiceCatalog/IndexController.php
+++ b/src/Glpi/Controller/ServiceCatalog/IndexController.php
@@ -32,10 +32,12 @@
  * ---------------------------------------------------------------------
  */
 
-namespace Glpi\Controller\Form;
+namespace Glpi\Controller\ServiceCatalog;
 
 use Glpi\Controller\AbstractController;
 use Glpi\Form\AccessControl\FormAccessParameters;
+use Glpi\Form\ServiceCatalog\ItemRequest;
+use Glpi\Form\ServiceCatalog\ServiceCatalogCompositeInterface;
 use Glpi\Form\ServiceCatalog\ServiceCatalogManager;
 use Glpi\Http\Firewall;
 use Glpi\Security\Attribute\SecurityStrategy;
@@ -44,7 +46,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
-final class FormListController extends AbstractController
+final class IndexController extends AbstractController
 {
     private ServiceCatalogManager $service_catalog_manager;
 
@@ -56,21 +58,26 @@ final class FormListController extends AbstractController
 
     #[SecurityStrategy(Firewall::STRATEGY_HELPDESK_ACCESS)]
     #[Route(
-        "/Forms",
-        name: "glpi_form_list",
-        methods: "GET",
+        "/ServiceCatalog",
+        name: "glpi_service_catalog",
+        methods: "GET"
     )]
     public function __invoke(Request $request): Response
     {
-        $filter = $request->query->getString('filter');
         $parameters = new FormAccessParameters(
             session_info: Session::getCurrentSessionInfo(),
             url_parameters: $request->query->all()
         );
-        $forms = $this->service_catalog_manager->getForms($parameters, $filter);
 
-        return $this->render('components/helpdesk_forms/forms_list.html.twig', [
-            'forms' => $forms,
+        $item_request = new ItemRequest(
+            access_parameters: $parameters,
+        );
+        $items = $this->service_catalog_manager->getItems($item_request);
+
+        return $this->render('pages/self-service/service_catalog.html.twig', [
+            'title' => __("New ticket"),
+            'menu'  => ["create_ticket"],
+            'items' => $items,
         ]);
     }
 }

--- a/src/Glpi/Controller/ServiceCatalog/ItemsController.php
+++ b/src/Glpi/Controller/ServiceCatalog/ItemsController.php
@@ -32,10 +32,13 @@
  * ---------------------------------------------------------------------
  */
 
-namespace Glpi\Controller\Form;
+namespace Glpi\Controller\ServiceCatalog;
 
 use Glpi\Controller\AbstractController;
+use Glpi\Exception\Http\BadRequestHttpException;
 use Glpi\Form\AccessControl\FormAccessParameters;
+use Glpi\Form\Category;
+use Glpi\Form\ServiceCatalog\ItemRequest;
 use Glpi\Form\ServiceCatalog\ServiceCatalogManager;
 use Glpi\Http\Firewall;
 use Glpi\Security\Attribute\SecurityStrategy;
@@ -44,7 +47,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
-final class ServiceCatalogController extends AbstractController
+final class ItemsController extends AbstractController
 {
     private ServiceCatalogManager $service_catalog_manager;
 
@@ -56,22 +59,42 @@ final class ServiceCatalogController extends AbstractController
 
     #[SecurityStrategy(Firewall::STRATEGY_HELPDESK_ACCESS)]
     #[Route(
-        "/ServiceCatalog",
-        name: "glpi_service_catalog",
-        methods: "GET"
+        "/ServiceCatalog/Items",
+        name: "glpi_form_list",
+        methods: "GET",
     )]
     public function __invoke(Request $request): Response
     {
+        // Read category
+        $category = null;
+        $category_id = $request->query->getInt('category');
+        if ($category_id > 0) {
+            $category = Category::getById($category_id);
+            if (!$category) {
+                throw new BadRequestHttpException();
+            }
+        }
+
+        // Read filter
+        $filter = $request->query->getString('filter');
+
+        // Build session + url params
         $parameters = new FormAccessParameters(
             session_info: Session::getCurrentSessionInfo(),
             url_parameters: $request->query->all()
         );
-        $forms = $this->service_catalog_manager->getForms($parameters);
 
-        return $this->render('pages/self-service/service_catalog.html.twig', [
-            'title'     => __("New ticket"),
-            'menu'      => ["create_ticket"],
-            'forms'     => $forms,
-        ]);
+        // Get items from the service catalog
+        $item_request = new ItemRequest(
+            access_parameters: $parameters,
+            filter: $filter,
+            category: $category,
+        );
+        $items = $this->service_catalog_manager->getItems($item_request);
+
+        return $this->render(
+            'components/helpdesk_forms/service_catalog_items.html.twig',
+            ['items' => $items]
+        );
     }
 }

--- a/src/Glpi/Controller/ServiceCatalog/ItemsController.php
+++ b/src/Glpi/Controller/ServiceCatalog/ItemsController.php
@@ -35,7 +35,7 @@
 namespace Glpi\Controller\ServiceCatalog;
 
 use Glpi\Controller\AbstractController;
-use Glpi\Exception\Http\BadRequestHttpException;
+use Glpi\Exception\Http\NotFoundHttpException;
 use Glpi\Form\AccessControl\FormAccessParameters;
 use Glpi\Form\Category;
 use Glpi\Form\ServiceCatalog\ItemRequest;
@@ -71,7 +71,7 @@ final class ItemsController extends AbstractController
         if ($category_id > 0) {
             $category = Category::getById($category_id);
             if (!$category) {
-                throw new BadRequestHttpException();
+                throw new NotFoundHttpException();
             }
         }
 

--- a/src/Glpi/Form/Category.php
+++ b/src/Glpi/Form/Category.php
@@ -1,0 +1,135 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Form;
+
+use CommonTreeDropdown;
+use Glpi\Form\ServiceCatalog\ItemRequest;
+use Glpi\Form\ServiceCatalog\ServiceCatalogCompositeInterface;
+use Glpi\Form\ServiceCatalog\ServiceCatalogItemInterface;
+use Override;
+
+final class Category extends CommonTreeDropdown implements ServiceCatalogCompositeInterface
+{
+    public $can_be_translated = true;
+
+    public static $rightname = 'form';
+
+    /** @var ServiceCatalogItemInterface[] $children */
+    private array $children;
+
+    #[Override]
+    public static function getTypeName($nb = 0): string
+    {
+        return _n('Service catalog category', 'Service catalog categories', $nb);
+    }
+
+    #[Override]
+    public static function getIcon(): string
+    {
+        return "ti ti-folder";
+    }
+
+    #[Override]
+    public function getAdditionalFields()
+    {
+        $fields = parent::getAdditionalFields();
+        $fields[] = [
+            'name'  => 'description',
+            'label' => __('Description'),
+            'type'  => 'richtext',
+            'list'  => false,
+        ];
+        $fields[] = [
+            'name'  => 'illustration',
+            'label' => __('Illustration'),
+            'type'  => 'text',
+            'list'  => false,
+        ];
+
+        return $fields;
+    }
+
+    #[Override]
+    public function getServiceCatalogItemTitle(): string
+    {
+        return $this->fields['name'];
+    }
+
+    #[Override]
+    public function getServiceCatalogItemDescription(): string
+    {
+        return $this->fields['description'];
+    }
+
+    #[Override]
+    public function getServiceCatalogItemIllustration(): string
+    {
+        return $this->fields['illustration'];
+    }
+
+    #[Override]
+    public function getServiceCatalogItemUniqueId(): string
+    {
+        return 'category-' . $this->getID();
+    }
+
+    #[Override]
+    public function getChildrenUrlParameters(): string
+    {
+        return http_build_query(['category' => $this->getID()]);
+    }
+
+    #[Override]
+    public function getChildrenItemRequest(
+        ItemRequest $item_request,
+    ): ItemRequest {
+        return new ItemRequest(
+            access_parameters: $item_request->getFormAccessParameters(),
+            category: $this,
+        );
+    }
+
+    #[Override]
+    public function setChildren(array $children): void
+    {
+        $this->children = $children;
+    }
+
+    #[Override]
+    public function getChildren(): array
+    {
+        return $this->children;
+    }
+}

--- a/src/Glpi/Form/Category.php
+++ b/src/Glpi/Form/Category.php
@@ -100,12 +100,6 @@ final class Category extends CommonTreeDropdown implements ServiceCatalogComposi
     }
 
     #[Override]
-    public function getServiceCatalogItemUniqueId(): string
-    {
-        return 'category-' . $this->getID();
-    }
-
-    #[Override]
     public function getChildrenUrlParameters(): string
     {
         return http_build_query(['category' => $this->getID()]);

--- a/src/Glpi/Form/Form.php
+++ b/src/Glpi/Form/Form.php
@@ -878,12 +878,6 @@ final class Form extends CommonDBTM implements ServiceCatalogLeafInterface
     }
 
     #[Override]
-    public function getServiceCatalogItemUniqueId(): string
-    {
-        return 'form-' . $this->getID();
-    }
-
-    #[Override]
     public function getServiceCatalogLink(): string
     {
         return "/Form/Render/" . $this->getID();

--- a/src/Glpi/Form/Form.php
+++ b/src/Glpi/Form/Form.php
@@ -47,6 +47,7 @@ use Glpi\Form\ServiceCatalog\ServiceCatalog;
 use Glpi\DBAL\QuerySubQuery;
 use Glpi\Form\AccessControl\FormAccessControlManager;
 use Glpi\Form\QuestionType\QuestionTypesManager;
+use Glpi\Form\ServiceCatalog\ServiceCatalogLeafInterface;
 use Html;
 use Log;
 use MassiveAction;
@@ -57,7 +58,7 @@ use Session;
 /**
  * Helpdesk form
  */
-final class Form extends CommonDBTM
+final class Form extends CommonDBTM implements ServiceCatalogLeafInterface
 {
     public static $rightname = 'form';
 
@@ -856,5 +857,35 @@ final class Form extends CommonDBTM
             is_a($class, QuestionTypeInterface::class, true)
             && !(new ReflectionClass($class))->isAbstract()
         ;
+    }
+
+    #[Override]
+    public function getServiceCatalogItemTitle(): string
+    {
+        return $this->fields['name'] ?? "";
+    }
+
+    #[Override]
+    public function getServiceCatalogItemDescription(): string
+    {
+        return $this->fields['description'] ?? "";
+    }
+
+    #[Override]
+    public function getServiceCatalogItemIllustration(): string
+    {
+        return $this->fields['illustration'] ?? "";
+    }
+
+    #[Override]
+    public function getServiceCatalogItemUniqueId(): string
+    {
+        return 'form-' . $this->getID();
+    }
+
+    #[Override]
+    public function getServiceCatalogLink(): string
+    {
+        return "/Form/Render/" . $this->getID();
     }
 }

--- a/src/Glpi/Form/ServiceCatalog/ItemRequest.php
+++ b/src/Glpi/Form/ServiceCatalog/ItemRequest.php
@@ -8,6 +8,7 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -32,44 +33,32 @@
  * ---------------------------------------------------------------------
  */
 
-namespace Glpi\Controller\Helpdesk;
+namespace Glpi\Form\ServiceCatalog;
 
-use Glpi\Controller\AbstractController;
-use Glpi\Helpdesk\HomePageTabs;
-use Glpi\Helpdesk\Tile\TilesManager;
-use Glpi\Http\Firewall;
-use Glpi\Security\Attribute\SecurityStrategy;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Attribute\Route;
-use User;
-use Session;
+use Glpi\Form\AccessControl\FormAccessParameters;
+use Glpi\Form\Category;
 
-final class IndexController extends AbstractController
+final class ItemRequest
 {
-    private TilesManager $tiles_manager;
-
-    public function __construct()
-    {
-        $this->tiles_manager = new TilesManager();
+    public function __construct(
+        private FormAccessParameters $access_parameters,
+        private string $filter = "",
+        private ?Category $category = null,
+    ) {
     }
 
-    #[SecurityStrategy(Firewall::STRATEGY_HELPDESK_ACCESS)]
-    #[Route(
-        "/Helpdesk",
-        name: "glpi_helpdesk_index",
-        methods: "GET"
-    )]
-    public function __invoke(Request $request): Response
+    public function getFormAccessParameters(): FormAccessParameters
     {
-        $user = User::getById(Session::getLoginUserID());
+        return $this->access_parameters;
+    }
 
-        return $this->render('pages/helpdesk/index.html.twig', [
-            'title' => __("Home"),
-            'menu'  => ['helpdesk-home'],
-            'tiles' => $this->tiles_manager->getTiles(),
-            'tabs'  => new HomePageTabs(),
-            'password_alert' => $user->getPasswordExpirationMessage(),
-        ]);
+    public function getFilter(): string
+    {
+        return $this->filter;
+    }
+
+    public function getCategory(): ?Category
+    {
+        return $this->category;
     }
 }

--- a/src/Glpi/Form/ServiceCatalog/Provider/CategoryProvider.php
+++ b/src/Glpi/Form/ServiceCatalog/Provider/CategoryProvider.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Form\ServiceCatalog\Provider;
+
+use Glpi\Form\Category;
+use Glpi\Form\ServiceCatalog\ItemRequest;
+use Glpi\FuzzyMatcher\FuzzyMatcher;
+use Glpi\FuzzyMatcher\PartialMatchStrategy;
+use Override;
+
+/** @implements CompositeProviderInterface<\Glpi\Form\Category> */
+final class CategoryProvider implements CompositeProviderInterface
+{
+    private FuzzyMatcher $matcher;
+
+    public function __construct()
+    {
+        $this->matcher = new FuzzyMatcher(new PartialMatchStrategy());
+    }
+
+    #[Override]
+    public function getItems(ItemRequest $item_request): array
+    {
+        $category = $item_request->getCategory();
+        $filter = $item_request->getFilter();
+
+        $categories = [];
+        $raw_categories = (new Category())->find([
+            'forms_categories_id' => $category ? $category->getID() : 0,
+        ], ['name']);
+
+        foreach ($raw_categories as $raw_categoriy) {
+            $category = new Category();
+            $category->getFromResultSet($raw_categoriy);
+            $category->post_getFromDB();
+
+            // Fuzzy matching
+            $name = $category->fields['name'] ?? "";
+            $description = $category->fields['description'] ?? "";
+            if (
+                !$this->matcher->match($name, $filter)
+                && !$this->matcher->match($description, $filter)
+            ) {
+                continue;
+            }
+
+            $categories[] = $category;
+        }
+
+        return $categories;
+    }
+}

--- a/src/Glpi/Form/ServiceCatalog/Provider/CompositeProviderInterface.php
+++ b/src/Glpi/Form/ServiceCatalog/Provider/CompositeProviderInterface.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Form\ServiceCatalog\Provider;
+
+/**
+ * @template T of \Glpi\Form\ServiceCatalog\ServiceCatalogCompositeInterface
+ */
+interface CompositeProviderInterface extends ItemProviderInterface
+{
+}

--- a/src/Glpi/Form/ServiceCatalog/Provider/FormProvider.php
+++ b/src/Glpi/Form/ServiceCatalog/Provider/FormProvider.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Form\ServiceCatalog\Provider;
+
+use Glpi\Form\AccessControl\FormAccessControlManager;
+use Glpi\Form\Form;
+use Glpi\Form\ServiceCatalog\ItemRequest;
+use Glpi\FuzzyMatcher\FuzzyMatcher;
+use Glpi\FuzzyMatcher\PartialMatchStrategy;
+use Override;
+
+/** @implements LeafProviderInterface<\Glpi\Form\Form> */
+final class FormProvider implements LeafProviderInterface
+{
+    private FormAccessControlManager $access_manager;
+    private FuzzyMatcher $matcher;
+
+    public function __construct()
+    {
+        $this->access_manager = FormAccessControlManager::getInstance();
+        $this->matcher = new FuzzyMatcher(new PartialMatchStrategy());
+    }
+
+    #[Override]
+    public function getItems(ItemRequest $item_request): array
+    {
+        $category = $item_request->getCategory();
+        $filter = $item_request->getFilter();
+        $parameters = $item_request->getFormAccessParameters();
+
+        $forms = [];
+        $raw_forms = (new Form())->find([
+            'is_active' => 1,
+            'forms_categories_id' => $category ? $category->getID() : 0,
+        ], ['name']);
+
+        foreach ($raw_forms as $raw_form) {
+            $form = new Form();
+            $form->getFromResultSet($raw_form);
+            $form->post_getFromDB();
+
+            // Fuzzy matching
+            $name = $form->fields['name'] ?? "";
+            $description = $form->fields['description'] ?? "";
+            if (
+                !$this->matcher->match($name, $filter)
+                && !$this->matcher->match($description, $filter)
+            ) {
+                continue;
+            }
+
+            /// Note: this is in theory less performant than applying the parameters
+            // directly to the SQL query (which would require more complicated code).
+            // However, the number of forms is expected to be low, so this is acceptable.
+            // If performance becomes an issue, we can revisit this and/or add a cache.
+            if (!$this->access_manager->canAnswerForm($form, $parameters)) {
+                continue;
+            }
+
+            $forms[] = $form;
+        }
+
+        return $forms;
+    }
+}

--- a/src/Glpi/Form/ServiceCatalog/Provider/ItemProviderInterface.php
+++ b/src/Glpi/Form/ServiceCatalog/Provider/ItemProviderInterface.php
@@ -1,3 +1,5 @@
+<?php
+
 /**
  * ---------------------------------------------------------------------
  *
@@ -6,6 +8,7 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -30,39 +33,15 @@
  * ---------------------------------------------------------------------
  */
 
-/* global _ */
+namespace Glpi\Form\ServiceCatalog\Provider;
 
-export class GlpiFormSelfServiceController
+use Glpi\Form\ServiceCatalog\ItemRequest;
+
+/**
+ * @template T of \Glpi\Form\ServiceCatalog\ServiceCatalogItemInterface
+ */
+interface ItemProviderInterface
 {
-    constructor()
-    {
-        const input = this.#getFilterInput();
-        const filterFormsDebounced = _.debounce(
-            this.#filterForms.bind(this), // .bind keep the correct "this" context
-            400,
-            false
-        );
-        input.addEventListener('input', filterFormsDebounced);
-    }
-
-    async #filterForms()
-    {
-        const input = this.#getFilterInput();
-        const url = `${CFG_GLPI.root_doc}/Forms`;
-        const url_params = new URLSearchParams({
-            filter: input.value,
-        });
-        const response = await fetch(`${url}?${url_params}`);
-        this.#getFormsArea().innerHTML = await response.text();
-    }
-
-    #getFilterInput()
-    {
-        return document.querySelector("[data-glpi-service-catalog-filter-forms]");
-    }
-
-    #getFormsArea()
-    {
-        return document.querySelector("[data-glpi-service-catalog-forms]");
-    }
+    /** @return T[] */
+    public function getItems(ItemRequest $item_request): array;
 }

--- a/src/Glpi/Form/ServiceCatalog/Provider/LeafProviderInterface.php
+++ b/src/Glpi/Form/ServiceCatalog/Provider/LeafProviderInterface.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Form\ServiceCatalog\Provider;
+
+use Glpi\Form\ServiceCatalog\ItemRequest;
+
+/**
+ * @template T of \Glpi\Form\ServiceCatalog\ServiceCatalogItemInterface
+ */
+interface LeafProviderInterface extends ItemProviderInterface
+{
+    /** @return T[] */
+    public function getItems(ItemRequest $item_request): array;
+}

--- a/src/Glpi/Form/ServiceCatalog/ServiceCatalogCompositeInterface.php
+++ b/src/Glpi/Form/ServiceCatalog/ServiceCatalogCompositeInterface.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Form\ServiceCatalog;
+
+/**
+ * Represent a composite of a the service catalog tree.
+ * When the user click on this item (e.g. a category), he goes down the tree
+ * and will see new leaves and composites items.
+ */
+interface ServiceCatalogCompositeInterface extends ServiceCatalogItemInterface
+{
+    /**
+     * Get the URL parameters needed to load this composite item's children using
+     * the `/ServiceCatalog/Item` endpoint.
+     */
+    public function getChildrenUrlParameters(): string;
+
+    /**
+     * Get the service catalog's item request that will return the children
+     * of the current composite item.
+     *
+     * The current request is available as the $item_request parameter as some
+     * common parameters like the form access rights are likely to be reused.
+     */
+    public function getChildrenItemRequest(
+        ItemRequest $item_request,
+    ): ItemRequest;
+
+    /** @param ServiceCatalogItemInterface[] $children */
+    public function setChildren(array $children): void;
+
+    /** @return ServiceCatalogItemInterface[] */
+    public function getChildren(): array;
+}

--- a/src/Glpi/Form/ServiceCatalog/ServiceCatalogItemInterface.php
+++ b/src/Glpi/Form/ServiceCatalog/ServiceCatalogItemInterface.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Form\ServiceCatalog;
+
+interface ServiceCatalogItemInterface
+{
+    /**
+     * Title that will be displayed in the service catalog
+     * @return string
+     */
+    public function getServiceCatalogItemTitle(): string;
+
+    /**
+     * Description that will be displayed in the service catalog
+     * @return string
+     */
+    public function getServiceCatalogItemDescription(): string;
+
+    /**
+     * Illustration that will be displayed in the service catalog
+     * @return string
+     */
+    public function getServiceCatalogItemIllustration(): string;
+
+    /**
+     * Unique ID that will be used to reference some DOM node using `id=xxx` and
+     * `aria-labelled-by=xxx`.
+     *
+     * Using some kind of unique prefix + the current item id is usually enough,
+     * e.g. 'form-41' or 'category-7845'.
+     * @return string
+     */
+    public function getServiceCatalogItemUniqueId(): string;
+}

--- a/src/Glpi/Form/ServiceCatalog/ServiceCatalogItemInterface.php
+++ b/src/Glpi/Form/ServiceCatalog/ServiceCatalogItemInterface.php
@@ -53,14 +53,4 @@ interface ServiceCatalogItemInterface
      * @return string
      */
     public function getServiceCatalogItemIllustration(): string;
-
-    /**
-     * Unique ID that will be used to reference some DOM node using `id=xxx` and
-     * `aria-labelled-by=xxx`.
-     *
-     * Using some kind of unique prefix + the current item id is usually enough,
-     * e.g. 'form-41' or 'category-7845'.
-     * @return string
-     */
-    public function getServiceCatalogItemUniqueId(): string;
 }

--- a/src/Glpi/Form/ServiceCatalog/ServiceCatalogLeafInterface.php
+++ b/src/Glpi/Form/ServiceCatalog/ServiceCatalogLeafInterface.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Form\ServiceCatalog;
+
+/**
+ * Represent a leaf of the service catalog tree.
+ * When the user click on this item (e.g. a form), he is redirected to the item
+ * dedicated page.
+ */
+interface ServiceCatalogLeafInterface extends ServiceCatalogItemInterface
+{
+    /**
+     * Get the URL to the target page represented by this leaf.
+     * @return string
+     */
+    public function getServiceCatalogLink(): string;
+}

--- a/src/Glpi/Form/ServiceCatalog/ServiceCatalogManager.php
+++ b/src/Glpi/Form/ServiceCatalog/ServiceCatalogManager.php
@@ -35,110 +35,220 @@
 
 namespace Glpi\Form\ServiceCatalog;
 
-use Glpi\Form\AccessControl\FormAccessControlManager;
-use Glpi\Form\AccessControl\FormAccessParameters;
-use Glpi\Form\Form;
-use Glpi\FuzzyMatcher\FuzzyMatcher;
-use Glpi\FuzzyMatcher\PartialMatchStrategy;
+use Glpi\Form\ServiceCatalog\Provider\CategoryProvider;
+use Glpi\Form\ServiceCatalog\Provider\CompositeProviderInterface;
+use Glpi\Form\ServiceCatalog\Provider\FormProvider;
+use Glpi\Form\ServiceCatalog\Provider\LeafProviderInterface;
 
 final class ServiceCatalogManager
 {
-    private FormAccessControlManager $access_manager;
-    private FuzzyMatcher $matcher;
+    /** @var \Glpi\Form\ServiceCatalog\Provider\ItemProviderInterface[] */
+    private array $providers;
 
     public function __construct()
     {
-        $this->access_manager = FormAccessControlManager::getInstance();
-        $this->matcher = new FuzzyMatcher(new PartialMatchStrategy());
+        $this->providers = [
+            new FormProvider(),
+            new CategoryProvider(),
+        ];
     }
 
     /**
-     * Return all available forms for the given user.
+     * Return all available forms and non empties categories for the given user.
      *
-     * Forms names may be altered to ensure uniqueness.
-     * This is done by by adding suffixes to forms with the same name :
-     * "My form", "My form (1)", "My form (2)", ...
-     *
-     * This is required to comply with accessibility requirements (<sections>
-     * names must be unique).
-     *
-     * @return Form[]
+     * @return ServiceCatalogItemInterface[]
      */
-    public function getForms(
-        FormAccessParameters $parameters,
-        string $filter = "",
-    ): array {
-        $forms = $this->getFormsFromDatabase($parameters, $filter);
-        $forms = $this->addSuffixesToIdenticalFormNames($forms);
-
-        return $forms;
-    }
-
-    /** @return Form[] */
-    private function getFormsFromDatabase(
-        FormAccessParameters $parameters,
-        string $filter = "",
-    ): array {
-        $forms = [];
-        $raw_forms = (new Form())->find([
-            'is_active' => 1,
-        ], ['name']);
-
-        foreach ($raw_forms as $raw_form) {
-            $form = new Form();
-            $form->getFromResultSet($raw_form);
-            $form->post_getFromDB();
-
-            // Fuzzy matching
-            $name = $form->fields['name'] ?? "";
-            $description = $form->fields['description'] ?? "";
-            if (
-                !$this->matcher->match($name, $filter)
-                && !$this->matcher->match($description, $filter)
-            ) {
-                continue;
-            }
-
-            /// Note: this is in theory less performant than applying the parameters
-            // directly to the SQL query (which would require more complicated code).
-            // However, the number of forms is expected to be low, so this is acceptable.
-            // If performance becomes an issue, we can revisit this and/or add a cache.
-            if (!$this->access_manager->canAnswerForm($form, $parameters)) {
-                continue;
-            }
-
-            $forms[] = $form;
-        };
-
-        return $forms;
-    }
-
-    /** @return Form[] */
-    private function addSuffixesToIdenticalFormNames(array $forms): array
+    public function getItems(ItemRequest $item_request): array
     {
-        // Group forms by names
-        $forms_grouped_by_names = [];
-        foreach ($forms as $form) {
-            if (!isset($forms_grouped_by_names[$form->fields['name']])) {
-                $forms_grouped_by_names[$form->fields['name']] = [];
-            }
+        $items = [];
 
-            $forms_grouped_by_names[$form->fields['name']][] = $form;
+        // Load root items
+        foreach ($this->providers as $provider) {
+            array_push($items, ...$provider->getItems($item_request));
         }
 
-        // Add suffixes to forms with identical names
-        $forms_with_unique_names = [];
-        foreach ($forms_grouped_by_names as $forms) {
-            foreach ($forms as $i => $form) {
-                if ($i == 0) {
-                    $forms_with_unique_names[] = $form;
-                } else {
-                    $form->fields['name'] = "{$form->fields['name']} ($i)";
-                    $forms_with_unique_names[] = $form;
+        // Load children for composite (non recursive, only for the first level)
+        foreach ($items as $item) {
+            if (!($item instanceof ServiceCatalogCompositeInterface)) {
+                continue;
+            }
+
+            $children = [];
+            $children_request = $item->getChildrenItemRequest($item_request);
+            foreach ($this->providers as $provider) {
+                array_push($children, ...$provider->getItems($children_request));
+            }
+
+            // We don't want to display empty categories
+            $children = $this->removeChildrenCompositeWithoutChildren(
+                $children_request,
+                $children
+            );
+            $children = $this->sortChildItems($children);
+            $item->setChildren($children);
+        }
+
+        // Remove empty composite, must be done after the children has been loaded.
+        $items = $this->removeRootCompositeWithoutChildren($items);
+        $items = $this->sortRootItems($items);
+
+        return $items;
+    }
+
+    /**
+     * Remove composite items from the root level of the tree that do not have
+     * any children.
+     *
+     * Since children have already been computed at this point, we only need to
+     * check for the result of `getChildren`.
+     *
+     * @param ServiceCatalogItemInterface[] $items
+     * @return ServiceCatalogItemInterface[]
+     */
+    private function removeRootCompositeWithoutChildren(
+        array $items,
+    ): array {
+        return array_filter(
+            $items,
+            function (ServiceCatalogItemInterface $item) {
+                // Not a composite, do not remove it from the list.
+                if ($item instanceof ServiceCatalogLeafInterface) {
+                    return true;
+                }
+
+                // Is a composite, we must check if it has any children.
+                // Since children have already been computed at this point, we
+                // only need to check for the result of `getChildren()`.
+                if ($item instanceof ServiceCatalogCompositeInterface) {
+                    return count($item->getChildren()) > 0;
+                }
+
+                // Unknown implementation, should never happen.
+                throw new \RuntimeException("Unsupported item: " . get_class($item));
+            }
+        );
+    }
+
+    /**
+     * Remove composite items from the second level of the tree that do not have
+     * any children.
+     *
+     * @param ServiceCatalogItemInterface[] $items
+     * @return ServiceCatalogItemInterface[]
+     */
+    private function removeChildrenCompositeWithoutChildren(
+        ItemRequest $item_request,
+        array $items,
+    ): array {
+        return array_filter(
+            $items,
+            function (ServiceCatalogItemInterface $item) use ($item_request) {
+                // Not a composite, do not remove it from the list.
+                if ($item instanceof ServiceCatalogLeafInterface) {
+                    return true;
+                }
+
+                // Is a composite, we must check if it has any children.
+                if ($item instanceof ServiceCatalogCompositeInterface) {
+                    return $this->hasChildren($item_request, $item);
+                }
+
+                // Unknown implementation, should never happen.
+                throw new \RuntimeException("Unsupported item: " . get_class($item));
+            }
+        );
+    }
+
+    private function hasChildren(
+        ItemRequest $item_request,
+        ServiceCatalogCompositeInterface $composite = null,
+    ): bool {
+        $leaf_providers = array_filter(
+            $this->providers,
+            fn($p) => $p instanceof LeafProviderInterface
+        );
+        $composite_providers = array_filter(
+            $this->providers,
+            fn($p) => $p instanceof CompositeProviderInterface
+        );
+        $child_request = $composite->getChildrenItemRequest($item_request);
+
+        // Check if the composite has at least one direct children (any leaf)
+        foreach ($leaf_providers as $provider) {
+            $items = $provider->getItems($child_request);
+            if (count($items)) {
+                return true;
+            }
+        }
+
+        // Load sub composites to look for indirect children
+        foreach ($composite_providers as $provider) {
+            $items = $provider->getItems($child_request);
+
+            // Can't have any indirect children if we have no sub composites
+            if (count($items) === 0) {
+                return false;
+            }
+
+            foreach ($items as $item) {
+                // Look for indirect children using recursion
+                if ($this->hasChildren($item_request, $item)) {
+                    return true;
                 }
             }
+
+            // No leaf found in all sub composites
+            return false;
         }
 
-        return $forms_with_unique_names;
+        return false;
+    }
+
+    /**
+     * @param ServiceCatalogItemInterface[] $items
+     * @return ServiceCatalogItemInterface[]
+     */
+    private function sortChildItems(array $items): array
+    {
+        usort($items, function (
+            ServiceCatalogItemInterface $a,
+            ServiceCatalogItemInterface $b,
+        ) {
+            return $a->getServiceCatalogItemTitle() <=> $b->getServiceCatalogItemTitle();
+        });
+
+        return $items;
+    }
+
+    /**
+     * @param ServiceCatalogItemInterface[] $items
+     * @return ServiceCatalogItemInterface[]
+     */
+    private function sortRootItems(array $items): array
+    {
+        // Root items are sorted with categories at the end as they will be
+        // displayed differently
+        usort($items, function (
+            ServiceCatalogItemInterface $a,
+            ServiceCatalogItemInterface $b,
+        ) {
+            if (
+                $a instanceof ServiceCatalogCompositeInterface
+                && !($b instanceof ServiceCatalogCompositeInterface)
+            ) {
+                return 1;
+            }
+
+            if (
+                !($a instanceof ServiceCatalogCompositeInterface)
+                && $b instanceof ServiceCatalogCompositeInterface
+            ) {
+                return -1;
+            }
+
+            return $a->getServiceCatalogItemTitle() <=> $b->getServiceCatalogItemTitle();
+        });
+
+        return $items;
     }
 }

--- a/templates/components/helpdesk_forms/service_catalog_item.html.twig
+++ b/templates/components/helpdesk_forms/service_catalog_item.html.twig
@@ -6,7 +6,6 @@
  # http://glpi-project.org
  #
  # @copyright 2015-2024 Teclib' and contributors.
- # @copyright 2003-2014 by the INDEPNET Development Team.
  # @licence   https://www.gnu.org/licenses/gpl-3.0.html
  #
  # ---------------------------------------------------------------------
@@ -31,25 +30,34 @@
  # ---------------------------------------------------------------------
  #}
 
-{% for form in forms %}
-    <div class="col-12 col-sm-6 col-md-4 d-flex">
-        <a
-            class="card mx-1 my-2 flex-grow-1"
-            href="{{ path("/Form/Render/" ~ form.fields.id) }}"
+<div class="col-12 col-sm-6 col-md-4 d-flex">
+    <a
+        class="card mx-1 my-2 flex-grow-1"
+        {% if item is instanceof("Glpi\\Form\\ServiceCatalog\\ServiceCatalogLeafInterface") %}
+            href="{{ path(item.getServiceCatalogLink()) }}"
+        {% endif %}
+    >
+        <section
+            class="card-body"
+            aria-labelledby="{{ item.getServiceCatalogItemUniqueId() }}"
         >
-            <section class="card-body" aria-labelledby="form-{{ form.fields.id }}">
-                <div class="d-flex">
-                    {{ render_illustration(form.fields.illustration ?? 'report-issue.svg', 100) }}
-                    <div class="ms-4">
-                        <h2 id="form-{{ form.fields.id }}" class="card-title mb-2">
-                            {{ form.fields.name }}
-                        </h2>
-                        <div class="text-secondary">
-                            {{ form.fields.description|safe_html }}
-                        </div>
+            <div class="d-flex">
+                {{ render_illustration(
+                    item.getServiceCatalogItemIllustration() ?? 'report-issue.svg',
+                    100
+                ) }}
+                <div class="ms-4">
+                    <h2
+                        id="{{ item.getServiceCatalogItemUniqueId() }}"
+                        class="card-title mb-2"
+                    >
+                        {{ item.getServiceCatalogItemTitle() }}
+                    </h2>
+                    <div class="text-secondary remove-last-tinymce-margin">
+                        {{ item.getServiceCatalogItemDescription()|safe_html }}
                     </div>
                 </div>
-            </section>
-        </a>
-    </div>
-{% endfor %}
+            </div>
+        </section>
+    </a>
+</div>

--- a/templates/components/helpdesk_forms/service_catalog_item.html.twig
+++ b/templates/components/helpdesk_forms/service_catalog_item.html.twig
@@ -30,6 +30,8 @@
  # ---------------------------------------------------------------------
  #}
 
+{% set unique_dom_id = 'service-catalog-tree-' ~ random() %}
+
 <div class="col-12 col-sm-6 col-md-4 d-flex">
     <a
         class="card mx-1 my-2 flex-grow-1"
@@ -39,7 +41,7 @@
     >
         <section
             class="card-body"
-            aria-labelledby="{{ item.getServiceCatalogItemUniqueId() }}"
+            aria-labelledby="{{ unique_dom_id }}"
         >
             <div class="d-flex">
                 {{ render_illustration(
@@ -48,7 +50,7 @@
                 ) }}
                 <div class="ms-4">
                     <h2
-                        id="{{ item.getServiceCatalogItemUniqueId() }}"
+                        id="{{ unique_dom_id }}"
                         class="card-title mb-2"
                     >
                         {{ item.getServiceCatalogItemTitle() }}

--- a/templates/components/helpdesk_forms/service_catalog_items.html.twig
+++ b/templates/components/helpdesk_forms/service_catalog_items.html.twig
@@ -41,13 +41,14 @@
     {% endif %}
     {% if item is instanceof("Glpi\\Form\\ServiceCatalog\\ServiceCatalogCompositeInterface") %}
         <div class="col-12 d-flex">
+            {% set unique_dom_id = 'service-catalog-tree-' ~ random() %}
             <section
                 class="card mx-1 my-2 flex-grow-1"
-                aria-labelledby="{{ item.getServiceCatalogItemUniqueId() }}"
+                aria-labelledby="{{ unique_dom_id }}"
             >
                 <div class="card-body">
                     <div class="card-title mb-0 d-flex align-items-center w-100">
-                        <h2 id="{{ item.getServiceCatalogItemUniqueId() }}" class="mb-0 fs-2">
+                        <h2 id="{{ unique_dom_id }}" class="mb-0 fs-2">
                             {{ item.getServiceCatalogItemTitle() }}
                         </h2>
                         <div class="card-subtitle ms-2 remove-last-tinymce-margin">

--- a/templates/components/helpdesk_forms/service_catalog_items.html.twig
+++ b/templates/components/helpdesk_forms/service_catalog_items.html.twig
@@ -1,0 +1,72 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2024 Teclib' and contributors.
+ # @copyright 2003-2014 by the INDEPNET Development Team.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+{% for item in items %}
+    {% if item is instanceof("Glpi\\Form\\ServiceCatalog\\ServiceCatalogLeafInterface") %}
+        {{ include(
+            'components/helpdesk_forms/service_catalog_item.html.twig',
+            {item: item},
+            with_context = false
+        ) }}
+    {% endif %}
+    {% if item is instanceof("Glpi\\Form\\ServiceCatalog\\ServiceCatalogCompositeInterface") %}
+        <div class="col-12 d-flex">
+            <section
+                class="card mx-1 my-2 flex-grow-1"
+                aria-labelledby="{{ item.getServiceCatalogItemUniqueId() }}"
+            >
+                <div class="card-body">
+                    <div class="card-title mb-0 d-flex align-items-center w-100">
+                        <h2 id="{{ item.getServiceCatalogItemUniqueId() }}" class="mb-0 fs-2">
+                            {{ item.getServiceCatalogItemTitle() }}
+                        </h2>
+                        <div class="card-subtitle ms-2 remove-last-tinymce-margin">
+                            {{ item.getServiceCatalogItemDescription()|safe_html }}
+                        </div>
+                    </div>
+                </div>
+                <div class="card-body p-0">
+                    <div class="row g-0">
+                        {% for child in item.getChildren() %}
+                            {{ include(
+                                'components/helpdesk_forms/service_catalog_nested_item.html.twig',
+                                {child: child},
+                                with_context = false
+                            ) }}
+                        {% endfor %}
+                    </div>
+                </div>
+            </section>
+        </div>
+    {% endif %}
+{% endfor %}

--- a/templates/components/helpdesk_forms/service_catalog_nested_item.html.twig
+++ b/templates/components/helpdesk_forms/service_catalog_nested_item.html.twig
@@ -1,0 +1,66 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2024 Teclib' and contributors.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+<div class="col-12 col-sm-6 col-md-4 d-flex">
+    <a
+        class="card mx-2 my-2 flex-grow-1 border-0 rounded-4"
+        {% if child is instanceof("Glpi\\Form\\ServiceCatalog\\ServiceCatalogLeafInterface") %}
+            href="{{ path(child.getServiceCatalogLink()) }}"
+        {% elseif child is instanceof("Glpi\\Form\\ServiceCatalog\\ServiceCatalogCompositeInterface") %}
+            href="?{{ child.getChildrenUrlParameters() }}"
+            data-children-url-parameters="{{ child.getChildrenUrlParameters() }}"
+        {% endif %}
+    >
+        <section
+            class="card-body"
+            aria-labelledby="{{ child.getServiceCatalogItemUniqueId() }}"
+        >
+            <div class="d-flex">
+                {{ render_illustration(
+                    child.getServiceCatalogItemIllustration() ?? 'report-issue.svg',
+                    100
+                ) }}
+                <div class="ms-4">
+                    <h2
+                        id="{{ child.getServiceCatalogItemUniqueId() }}"
+                        class="card-title mb-2"
+                    >
+                        {{ child.getServiceCatalogItemTitle() }}
+                    </h2>
+                    <div class="text-secondary remove-last-tinymce-margin">
+                        {{ child.getServiceCatalogItemDescription()|safe_html }}
+                    </div>
+                </div>
+            </div>
+        </section>
+    </a>
+</div>

--- a/templates/components/helpdesk_forms/service_catalog_nested_item.html.twig
+++ b/templates/components/helpdesk_forms/service_catalog_nested_item.html.twig
@@ -30,6 +30,8 @@
  # ---------------------------------------------------------------------
  #}
 
+{% set unique_dom_id = 'service-catalog-tree-' ~ random() %}
+
 <div class="col-12 col-sm-6 col-md-4 d-flex">
     <a
         class="card mx-2 my-2 flex-grow-1 border-0 rounded-4"
@@ -42,7 +44,7 @@
     >
         <section
             class="card-body"
-            aria-labelledby="{{ child.getServiceCatalogItemUniqueId() }}"
+            aria-labelledby="{{ unique_dom_id }}"
         >
             <div class="d-flex">
                 {{ render_illustration(
@@ -51,7 +53,7 @@
                 ) }}
                 <div class="ms-4">
                     <h2
-                        id="{{ child.getServiceCatalogItemUniqueId() }}"
+                        id="{{ unique_dom_id }}"
                         class="card-title mb-2"
                     >
                         {{ child.getServiceCatalogItemTitle() }}

--- a/templates/dropdown_form.html.twig
+++ b/templates/dropdown_form.html.twig
@@ -114,6 +114,16 @@
                         {{ fields.autoNameField(field['name'], item, field['label'], withtemplate, fields_params) }}
                     {% elseif type == 'textarea' %}
                         {{ fields.textareaField(field['name'], item.fields[field['name']], field['label'], fields_params) }}
+                     {% elseif type == 'richtext' %}
+                        {{ fields.textareaField(
+                            field['name'],
+                            item.fields[field['name']],
+                            field['label'],
+                            fields_params|merge({
+                                'enable_richtext': true,
+                                'enable_images': false,
+                            })
+                        ) }}
                     {% elseif type == 'integer' %}
                         {% set fields_params = {
                             'value': item.fields[field['name']]

--- a/templates/pages/admin/form/service_catalog_tab.html.twig
+++ b/templates/pages/admin/form/service_catalog_tab.html.twig
@@ -66,6 +66,17 @@
             }
         ) }}
 
+        {{ fields.dropdownField(
+            'Glpi\\Form\\Category',
+            'forms_categories_id',
+            form.fields.forms_categories_id,
+            _n('Category', 'Categories', 1),
+            {
+                'is_horizontal': false,
+                'full_width' : true,
+            }
+        ) }}
+
         {# Hidden values #}
         <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}" />
         <input type="hidden" name="id" value="{{ form.getID() }}" />

--- a/templates/pages/self-service/service_catalog.html.twig
+++ b/templates/pages/self-service/service_catalog.html.twig
@@ -42,7 +42,7 @@
             <input
                 class="form-control"
                 placeholder="{{ __("Search for forms...") }}"
-                data-glpi-service-catalog-filter-forms
+                data-glpi-service-catalog-filter-items
             >
             <span class="input-icon-addon" style="font-size: 18px;">
                 <i class="ti ti-search"></i>
@@ -55,11 +55,11 @@
     <section
         aria-label="{{ __("Forms") }}"
         class="row mb-5"
-        data-glpi-service-catalog-forms
+        data-glpi-service-catalog-items
     >
         {{ include(
-            'components/helpdesk_forms/forms_list.html.twig',
-            {forms: forms},
+            'components/helpdesk_forms/service_catalog_items.html.twig',
+            {items: items},
             with_context = false
         ) }}
     </section>
@@ -67,9 +67,9 @@
     <script>
         (async function() {
             const module = await import(
-                "{{ js_path('js/modules/Forms/SelfServiceController.js') }}"
+                "{{ js_path('js/modules/Forms/ServiceCatalogController.js') }}"
             );
-            new module.GlpiFormSelfServiceController();
+            new module.GlpiFormServiceCatalogController();
         })();
     </script>
 {% endblock content_body %}

--- a/tests/cypress/e2e/form/service_catalog/service_catalog_tab.cy.js
+++ b/tests/cypress/e2e/form/service_catalog/service_catalog_tab.cy.js
@@ -42,14 +42,25 @@ describe('Service catalog tab', () => {
     });
 
     it('can configure service catalog', () => {
+        const uid = new Date().getTime();
+        const category_name = `Category ${uid}`;
+        const category_dropdown_value = `»${category_name}`; // GLPI add "»" prefix to common tree dropdown values
+
+        cy.createWithAPI('Glpi\\Form\\Category', {
+            'name': category_name,
+            'description': "my description",
+        });
+
         // Make sure the values we are about to apply are are not already set to
         // prevent false negative.
         cy.findByRole("textbox", {'name': 'Illustration'}).should('not.contain.text', 'request-service.svg');
         cy.findByLabelText("Description").awaitTinyMCE().should('not.contain.text', 'My description');
+        cy.getDropdownByLabelText("Category").should('not.have.text', category_name);
 
         // Set values
         cy.findByRole("textbox", {'name': 'Illustration'}).type('request-service.svg');
         cy.findByLabelText("Description").awaitTinyMCE().type('My description');
+        cy.getDropdownByLabelText('Category').selectDropdownValue(category_dropdown_value);
 
         // Save changes
         cy.findByRole('button', {'name': "Save changes"}).click();
@@ -58,5 +69,6 @@ describe('Service catalog tab', () => {
         // Validate values
         cy.findByRole("textbox", {'name': 'Illustration'}).should('have.value', 'request-service.svg');
         cy.findByLabelText("Description").awaitTinyMCE().should('contain.text', 'My description');
+        cy.getDropdownByLabelText("Category").should('have.text', category_name);
     });
 });

--- a/tests/src/FormBuilder.php
+++ b/tests/src/FormBuilder.php
@@ -96,6 +96,11 @@ class FormBuilder
     protected array $access_control;
 
     /**
+     * Form category
+     */
+    protected int $category;
+
+    /**
      * Constructor
      *
      * @param string $name Form name
@@ -112,6 +117,7 @@ class FormBuilder
         $this->sections = [];
         $this->destinations = [];
         $this->access_control = [];
+        $this->category = 0;
     }
 
     /**
@@ -440,6 +446,29 @@ class FormBuilder
             ),
             is_active: true,
         );
+        return $this;
+    }
+
+    /**
+     * Get form category
+     *
+     * @return int Form category
+     */
+    public function getCategory(): int
+    {
+        return $this->category;
+    }
+
+    /**
+     * Set form category
+     *
+     * @param int Form category
+     *
+     * @return self To allow chain calls
+     */
+    public function setCategory(int $category): self
+    {
+        $this->category = $category;
         return $this;
     }
 }

--- a/tests/src/FormTesterTrait.php
+++ b/tests/src/FormTesterTrait.php
@@ -75,6 +75,7 @@ trait FormTesterTrait
             'is_active'             => $builder->getIsActive(),
             'header'                => $builder->getHeader(),
             'is_draft'              => $builder->getIsDraft(),
+            'forms_categories_id'   => $builder->getCategory(),
             '_do_not_init_sections' => true, // We will handle sections ourselves
         ]);
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Add categories to the service catalog.
The service catalog will display on its first page the items without categories + the root categories + the items inside the root categories.

If there are sub categories inside the root categories, they are also displayed but without their content (thus we display only 2 levels on the service catalog at a time).

Right now we only use categories and form in the tree but we are very likely to display other data later on (like FAQ articles) so I've made the design generic using the standard leaf/composite pattern.
This increased the size of these changes as it required a bit more interface/provider to set up the code but hopefully it should make it simple to add new item types to the tree later on.

Breadcrumbs will be added later (so if you enter a category you can't back out currently).

## Screenshots :

![image](https://github.com/user-attachments/assets/02854d86-7a13-46d8-81ba-6bad6ab6a5a1)

