### PR TITLE
fix(search): Items seen notcontains

### DIFF
--- a/phpunit/functional/SearchTest.php
+++ b/phpunit/functional/SearchTest.php
@@ -533,6 +533,221 @@ class SearchTest extends DbTestCase
         }
     }
 
+    public static function testViewCriterionProvider(): array
+    {
+        return [
+            [
+                'itemtype' => 'Computer',
+                'criteria' => [
+                    [
+                        'link'       => 'AND',
+                        'field'      => 'view',
+                        'searchtype' => 'contains',
+                        'value'      => 'test',
+                    ],
+                ],
+                'expected' => 9
+            ],
+            [
+                'itemtype' => 'Computer',
+                'criteria' => [
+                    [
+                        'link'       => 'AND',
+                        'field'      => 'view',
+                        'searchtype' => 'contains',
+                        'value'      => '_test_pc01',
+                    ],
+                ],
+                'expected' => 1
+            ],
+            [
+                'itemtype' => 'Computer',
+                'criteria' => [
+                    [
+                        'link'       => 'AND',
+                        'field'      => 'view',
+                        'searchtype' => 'notcontains',
+                        'value'      => 'test',
+                    ],
+                ],
+                'expected' => 0
+            ],
+            [
+                'itemtype' => 'Computer',
+                'criteria' => [
+                    [
+                        'link'       => 'AND',
+                        'field'      => 'view',
+                        'searchtype' => 'notcontains',
+                        'value'      => '_test_pc01',
+                    ],
+                ],
+                'expected' => 8
+            ],
+            [
+                'itemtype' => 'Computer',
+                'criteria' => [
+                    [
+                        'link'       => 'AND NOT',
+                        'field'      => 'view',
+                        'searchtype' => 'contains',
+                        'value'      => 'test',
+                    ],
+                ],
+                'expected' => 0
+            ],
+            [
+                'itemtype' => 'Computer',
+                'criteria' => [
+                    [
+                        'link'       => 'AND NOT',
+                        'field'      => 'view',
+                        'searchtype' => 'contains',
+                        'value'      => '_test_pc01',
+                    ],
+                ],
+                'expected' => 8
+            ],
+            [
+                'itemtype' => 'Computer',
+                'criteria' => [
+                    [
+                        'link'       => 'AND NOT',
+                        'field'      => 'view',
+                        'searchtype' => 'notcontains',
+                        'value'      => 'test',
+                    ],
+                ],
+                'expected' => 9
+            ],
+            [
+                'itemtype' => 'Computer',
+                'criteria' => [
+                    [
+                        'link'       => 'AND NOT',
+                        'field'      => 'view',
+                        'searchtype' => 'notcontains',
+                        'value'      => '_test_pc01',
+                    ],
+                ],
+                'expected' => 1
+            ],
+            [
+                'itemtype' => 'Computer',
+                'criteria' => [
+                    [
+                        'link'       => 'OR',
+                        'field'      => 'view',
+                        'searchtype' => 'contains',
+                        'value'      => 'test',
+                    ],
+                ],
+                'expected' => 9
+            ],
+            [
+                'itemtype' => 'Computer',
+                'criteria' => [
+                    [
+                        'link'       => 'OR',
+                        'field'      => 'view',
+                        'searchtype' => 'contains',
+                        'value'      => '_test_pc01',
+                    ],
+                ],
+                'expected' => 1
+            ],
+            [
+                'itemtype' => 'Computer',
+                'criteria' => [
+                    [
+                        'link'       => 'OR',
+                        'field'      => 'view',
+                        'searchtype' => 'notcontains',
+                        'value'      => 'test',
+                    ],
+                ],
+                'expected' => 0
+            ],
+            [
+                'itemtype' => 'Computer',
+                'criteria' => [
+                    [
+                        'link'       => 'OR',
+                        'field'      => 'view',
+                        'searchtype' => 'notcontains',
+                        'value'      => '_test_pc01',
+                    ],
+                ],
+                'expected' => 8
+            ],
+            [
+                'itemtype' => 'Computer',
+                'criteria' => [
+                    [
+                        'link'       => 'OR NOT',
+                        'field'      => 'view',
+                        'searchtype' => 'contains',
+                        'value'      => 'test',
+                    ],
+                ],
+                'expected' => 0
+            ],
+            [
+                'itemtype' => 'Computer',
+                'criteria' => [
+                    [
+                        'link'       => 'OR NOT',
+                        'field'      => 'view',
+                        'searchtype' => 'contains',
+                        'value'      => '_test_pc01',
+                    ],
+                ],
+                'expected' => 8
+            ],
+            [
+                'itemtype' => 'Computer',
+                'criteria' => [
+                    [
+                        'link'       => 'OR NOT',
+                        'field'      => 'view',
+                        'searchtype' => 'notcontains',
+                        'value'      => 'test',
+                    ],
+                ],
+                'expected' => 9
+            ],
+            [
+                'itemtype' => 'Computer',
+                'criteria' => [
+                    [
+                        'link'       => 'OR NOT',
+                        'field'      => 'view',
+                        'searchtype' => 'notcontains',
+                        'value'      => '_test_pc01',
+                    ],
+                ],
+                'expected' => 1
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider testViewCriterionProvider
+     */
+    public function testViewCriterionNew(string $itemtype, array $criteria, int $expected)
+    {
+        $data = $this->doSearch($itemtype, [
+            'reset'      => 'reset',
+            'is_deleted' => 0,
+            'start'      => 0,
+            'search'     => 'Search',
+            'criteria'   => $criteria
+        ]);
+
+        $this->assertSame($expected, $data['data']['totalcount']);
+    }
+
+
     public function testSearchOnRelationTable()
     {
         $data = $this->doSearch(\Change_Ticket::class, [

--- a/src/Search.php
+++ b/src/Search.php
@@ -1283,16 +1283,16 @@ class Search
                             $globallink = " AND ";
                             break;
                         case "AND NOT":
-                            $LINK       = " AND ";
+                            $LINK       = ($criterion['searchtype'] == 'notcontains') ? ' OR ' : ' AND ';
                             $NOT        = 1;
                             $globallink = " AND ";
                             break;
                         case "OR":
-                            $LINK       = " OR ";
+                            $LINK       = ($criterion['searchtype'] == 'notcontains') ? ' AND ' : ' OR ';
                             $globallink = " OR ";
                             break;
                         case "OR NOT":
-                            $LINK       = " AND ";
+                            $LINK       = ($criterion['searchtype'] == 'notcontains') ? ' OR ' : ' AND ';
                             $NOT        = 1;
                             $globallink = " OR ";
                             break;


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !35070

The search filter “Items seen not contains ...” did not work

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/960a3650-dbf6-4521-a8b0-7a571d05592c)
