### PR TITLE
Stream only specific responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -233,6 +233,7 @@ The present file will list all changes made to the project; according to the
 - `Hooks::SHOW_IN_TIMELINE`/`show_in_timeline` plugin hook has been renamed to `Hooks::TIMELINE_ITEMS`/`timeline_items`.
 - `Auth::getMethodName()` now only returns the name without a link. Use `Auth::getMethodLink()` to get a HTML-safe link.
 - `GLPI_STRICT_DEPRECATED` constant is now know as `GLPI_STRICT_ENV`
+- `Software::merge()` method is now private.
 
 #### Deprecated
 - Usage of the `/marketplace` path for plugins URLs. All plugins URLs should now start with `/plugins`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,7 @@ The present file will list all changes made to the project; according to the
   Building and executing raw queries using `DBmysql::request()`, `DBmysqlIterator::buildQuery()` and `DBmysqlIterator::execute()` methods is also prohibited.
   To execute DB queries, either `DBmysql::request()` can be used to craft query using the GLPI query builder,
   or `DBmysql::doQuery()` can be used for safe queries to execute DB query using a self-crafted a SQL string.
+- The dynamic progress bar provided by the `Html` class no longer works. The `ProgressIndicator` JS module can be used as a replacement to display the progress of a process.
 - `js/fuzzysearch.js` replaced with `FuzzySearch/Modal` Vue component.
 - `Html::fuzzySearch()` replaced with `Html::getMenuFuzzySearchList()` function.
 - `NotificationEvent::raiseEvent()` signature cahnged. A new `$trigger` parameter has been added at 4th position, and `$label` is now the 5th parameter.
@@ -279,17 +280,22 @@ The present file will list all changes made to the project; according to the
 - `Glpi\Toolbox\Sanitizer::sanitize()`
 - `Glpi\Toolbox\Sanitizer::unsanitize()`
 - `Html::ajaxFooter()`
+- `Html::changeProgressBarMessage()`
+- `Html::changeProgressBarPosition()`
 - `Html::cleanInputText()`
 - `Html::cleanPostForTextArea()`
 - `Html::createProgressBar()`
 - `Html::displayErrorAndDie()`. Throw a `Glpi\Exception\Http\BadRequestHttpException` exception instead.
 - `Html::displayNotFoundError()`. Throw a `Glpi\Exception\Http\NotFoundHttpException` exception instead.
+- `Html::displayProgressBar()`
 - `Html::displayRightError()`. Throw a `Glpi\Exception\Http\AccessDeniedHttpException` exception instead.
 - `Html::entities_deep()`
 - `Html::entity_decode_deep()`
+- `Html::glpi_flush()`
 - `Html::jsGetElementbyID()`
 - `Html::jsGetDropdownValue()`
 - `Html::jsSetDropdownValue()`
+- `Html::progressBar()`
 - `HookManager::enableCSRF()`
 - `ITILFollowup::ADDMYTICKET` constant. Use `ITILFollowup::ADDMY`.
 - `ITILFollowup::ADDGROUPTICKET` constant. Use `ITILFollowup::ADD_AS_GROUP`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -487,6 +487,7 @@ The present file will list all changes made to the project; according to the
 - `Link_Itemtype::showForLink()`
 - `MailCollector::listEncodings()`
 - `MailCollector::title()`
+- `MassiveAction::updateProgressBars()`
 - `ManualLink::showForItem()`
 - `MigrationCleaner` class
 - `Netpoint` class

--- a/front/cron.php
+++ b/front/cron.php
@@ -33,6 +33,8 @@
  * ---------------------------------------------------------------------
  */
 
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
 /**
  * @var \DBmysql|null $DB
  * @var array $CFG_GLPI
@@ -109,20 +111,39 @@ if (!is_writable(GLPI_LOCK_DIR)) {
 }
 
 if (!isCommandLine()) {
-   //The advantage of using background-image is that cron is called in a separate
-   //request and thus does not slow down output of the main page as it would if called
-   //from there.
+    // The advantage of using background-image is that cron is called in a separate
+    // request and thus does not slow down output of the main page as it would if called
+    // from there.
     $image = pack("H*", "47494638396118001800800000ffffff00000021f90401000000002c0000000" .
                        "018001800000216848fa9cbed0fa39cb4da8bb3debcfb0f86e248965301003b");
-    header("Content-Type: image/gif");
-    header("Content-Length: " . strlen($image));
-    header("Cache-Control: no-cache,no-store");
-    header("Pragma: no-cache");
-    header("Connection: close");
-    echo $image;
-    flush();
 
-    CronTask::launch(CronTask::MODE_INTERNAL);
+    // Be sure to remove any unexpected header value.
+    header_remove();
+
+    return new StreamedResponse(
+        function () use ($image) {
+            // Be sure to disable the output buffering.
+            while (ob_get_level() > 0) {
+                ob_end_clean();
+            }
+
+            echo $image;
+
+            // Send headers and image content.
+            // The browser will consider that the response is complete due to the `Connection: close` header
+            // and will not have to wait for the cron tasks to be processed to consider the request as ended.
+            flush();
+
+            CronTask::launch(CronTask::MODE_INTERNAL);
+        },
+        headers: [
+            'Content-Type'   => 'image/gif',
+            'Content-Length' => strlen($image),
+            'Cache-Control'  => 'no-cache,no-store',
+            'Pragma'         => 'no-cache',
+            'Connection'     => 'close',
+        ]
+    );
 } else if (isset($_SERVER['argc']) && ($_SERVER['argc'] > 1)) {
    // Parse command line options
 

--- a/front/massiveaction.php
+++ b/front/massiveaction.php
@@ -53,7 +53,11 @@ try {
     Html::popFooter();
     return;
 }
-Html::popHeader(__('Bulk modification'));
+Html::includeHeader(__('Bulk modification'));
+echo '<body><div id="page">';
+$ma->displayProgressBar();
+echo '</div></body></html>';
+flush(); // force displaying the output
 
 $results   = $ma->process();
 

--- a/phpunit/functional/Glpi/Inventory/Assets/OperatingSystemTest.php
+++ b/phpunit/functional/Glpi/Inventory/Assets/OperatingSystemTest.php
@@ -1194,7 +1194,6 @@ class OperatingSystemTest extends AbstractInventoryAsset
         $this->login('glpi', 'glpi');
 
         $os_dictionnary = new \RuleDictionnaryOperatingSystemCollection();
-        $this->expectOutputRegex('/.*Replay rules on existing database started on.*/');
         $os_dictionnary->replayRulesOnExistingDB(0, 0, [], []);
 
         $list = $cos->find(['itemtype' => 'Computer', 'items_id' => $computers_id]);

--- a/src/Glpi/Controller/LegacyFileLoadController.php
+++ b/src/Glpi/Controller/LegacyFileLoadController.php
@@ -55,11 +55,58 @@ final class LegacyFileLoadController implements PublicService
             throw new \RuntimeException('Cannot load legacy controller without specifying a file to load.');
         }
 
-        $callback = function () use ($target_file) {
-            require $target_file;
-        };
+        \ob_start();
+        $response = require($target_file);
+        $content = \ob_get_clean();
 
-        return new HeaderlessStreamedResponse($callback->bindTo($this, self::class));
+        if ($response instanceof Response) {
+            // The legacy file contains a return value that corresponds to a valid Symfony response.
+            // This response is returned and any output is discarded.
+
+            if ($content !== '') {
+                \trigger_error(
+                    sprintf('Unexpected output detected in `%s`.', $target_file),
+                    E_USER_WARNING
+                );
+            }
+
+            return $response;
+        }
+
+        if (\headers_sent()) {
+            // Headers are already sent, so we have to use a streamed response without headers.
+            // This may happen when `flush()`/`ob_flush()`/`ob_clean()`/`ob_end_clean()` functions are used
+            // in the legacy script. The script should be fixed to prevent this.
+
+            \trigger_error(
+                sprintf('Unexpected output detected in `%s`.', $target_file),
+                E_USER_WARNING
+            );
+
+            return new HeaderlessStreamedResponse(function () use ($content) {
+                echo $content;
+            });
+        }
+
+        // Extract already defined headers to set them in the Symfony response.
+        // This is required as Symfony will set default values for some of them if we do not provide them.
+        // see `Symfony\Component\HttpFoundation\ResponseHeaderBag`
+        $headers = [];
+        foreach (\headers_list() as $header_line) {
+            [$header_name, $header_value] = \explode(':', $header_line, 2);
+
+            $header_name = \trim($header_name);
+            $header_value = \trim($header_value);
+
+            if (!\array_key_exists($header_name, $headers)) {
+                $headers[$header_name] = [];
+            }
+
+            $headers[$header_name][] = $header_value;
+        }
+        \header_remove();
+
+        return new Response($content, status: \http_response_code(), headers: $headers);
     }
 
     /**

--- a/src/Glpi/Marketplace/View.php
+++ b/src/Glpi/Marketplace/View.php
@@ -305,11 +305,6 @@ class View extends CommonGLPI
             $nb_plugins
         );
 
-        // Clear all output buffers
-        while (ob_get_level()) {
-            ob_end_clean();
-        }
-
         header("X-GLPI-Marketplace-Total: $nb_plugins");
         self::displayList($plugins, "discover", $only_lis, $nb_plugins, $sort, $api->isListTruncated());
     }

--- a/src/Glpi/Search/Output/Spreadsheet.php
+++ b/src/Glpi/Search/Output/Spreadsheet.php
@@ -104,16 +104,6 @@ abstract class Spreadsheet extends ExportSearchOutput
             return false;
         }
 
-        // Clear output buffers
-        $ob_config = ini_get('output_buffering');
-        $max_level = filter_var($ob_config, FILTER_VALIDATE_BOOLEAN) ? 1 : 0;
-        while (ob_get_level() > $max_level) {
-            ob_end_clean();
-        }
-        if (ob_get_level() > 0) {
-            ob_clean();
-        }
-
         $spread = $this->getSpreasheet();
         $writer = $this->getWriter();
 

--- a/src/Html.php
+++ b/src/Html.php
@@ -706,9 +706,17 @@ class Html
      *
      *
      * @return string|void Generated HTML if `display` param is true, void otherwise.
-     **/
+     *
+     * @deprecated 11.0.0
+     */
     public static function progressBar($id, array $options = [])
     {
+        Toolbox::deprecated(
+            '`Html::progressBar()` is deprecated.'
+            . ' Use the `Html::getProgressBar()` method to get a static progress bar HTML snippet,'
+            . ' or the `ProgressIndicator` JS module to display a progress bar related to a process progression.'
+        );
+
         $params = [
             'create'    => false,
             'message'   => null,
@@ -809,12 +817,17 @@ HTML;
      * @param array  $options See {@link Html::progressBar()} for available options (excluding message)
      *
      * @return string|void
+     *
      * @deprecated 11.0.0
-     * @see Html::progressBar()
-     **/
+     */
     public static function createProgressBar($msg = null, array $options = [])
     {
-        Toolbox::deprecated('Html::createProgressBar is deprecated. Use Html::progressBar instead.');
+        Toolbox::deprecated(
+            '`Html::createProgressBar()` is deprecated.'
+            . ' Use the `Html::getProgressBar()` method to get a static progress bar HTML snippet,'
+            . ' or the `ProgressIndicator` JS module to display a progress bar related to a process progression.'
+        );
+
         $options = array_replace([
             'create' => true,
             'display' => true
@@ -833,9 +846,16 @@ HTML;
      * @param string $msg message under the bar
      *
      * @return void
-     **/
+     *
+     * @deprecated 11.0.0
+     */
     public static function changeProgressBarMessage($msg = "&nbsp;")
     {
+        Toolbox::deprecated(
+            '`Html::changeProgressBarMessage()` is deprecated.'
+            . ' Use the `ProgressIndicator` JS module to display a progress bar related to a process progression.'
+        );
+
         self::progressBar('doaction_progress', ['message' => $msg]);
         self::glpi_flush();
     }
@@ -849,9 +869,16 @@ HTML;
      * @param string $msg   message inside the bar (default is %)
      *
      * @return void
-     **/
+     *
+     * @deprecated 11.0.0
+     */
     public static function changeProgressBarPosition($crt, $tot, $msg = "")
     {
+        Toolbox::deprecated(
+            '`Html::changeProgressBarPosition()` is deprecated.'
+            . ' Use the `ProgressIndicator` JS module to display a progress bar related to a process progression.'
+        );
+
         $options = [];
 
         if (!$tot) {
@@ -882,9 +909,17 @@ HTML;
      *            - forcepadding : boolean force str_pad to force refresh (default true)
      *
      * @return void
-     **/
+     *
+     * @deprecated 11.0.0
+     */
     public static function displayProgressBar($width, $percent, $options = [])
     {
+        Toolbox::deprecated(
+            '`Html::displayProgressBar()` is deprecated.'
+            . ' Use the `Html::getProgressBar()` method to get a static progress bar HTML snippet,'
+            . ' or the `ProgressIndicator` JS module to display a progress bar related to a process progression.'
+        );
+
         $param['title']        = __('Progress');
         $param['simple']       = false;
         $param['forcepadding'] = true;
@@ -1983,18 +2018,15 @@ TWIG,
      * Flushes the system write buffers of PHP and whatever backend PHP is using (CGI, a web server, etc).
      * This attempts to push current output all the way to the browser with a few caveats.
      * @see https://www.sitepoint.com/php-streaming-output-buffering-explained/
-     **/
+     *
+     * @deprecated 11.0.0
+     */
     public static function glpi_flush()
     {
-
-        if (
-            function_exists("ob_flush")
-            && (ob_get_length() !== false)
-        ) {
-            ob_flush();
-        }
-
-        flush();
+        trigger_error(
+            '`Html::glpi_glush()` no longer has any effect.',
+            E_USER_WARNING
+        );
     }
 
 

--- a/src/Item_Devices.php
+++ b/src/Item_Devices.php
@@ -1082,12 +1082,7 @@ class Item_Devices extends CommonDBRelation
                                     $percent = round(100 * $this->fields[$field] / $device->fields[$attributs['max']]);
                                     $message = sprintf(__('%1$s (%2$d%%) '), Html::formatNumber($this->fields[$field], false, 0), $percent);
                                 }
-                                $content = Html::progressBar("percent" . mt_rand(), [
-                                    'create'  => true,
-                                    'percent' => $percent,
-                                    'message' => htmlescape($message),
-                                    'display' => false
-                                ]);
+                                $content = Html::getProgressBar($percent, $message);
                                 break;
 
                             default:

--- a/src/Item_Rack.php
+++ b/src/Item_Rack.php
@@ -509,25 +509,19 @@ JAVASCRIPT;
 
         echo "<div class='rack_side_block_content'>";
         echo "<h3>" . __s("Space") . "</h3>";
-        Html::progressBar('rack_space', [
-            'create' => true,
-            'percent' => $space_prct,
-            'message' => htmlescape($space_prct . "%"),
-        ]);
+        echo Html::getProgressBar($space_prct);
 
         echo "<h3>" . __s("Weight") . "</h3>";
-        Html::progressBar('rack_weight', [
-            'create' => true,
-            'percent' => $weight_prct,
-            'message' => htmlescape($weight . " / " . $rack->fields['max_weight'])
-        ]);
+        echo Html::getProgressBar(
+            $weight_prct,
+            $weight . " / " . $rack->fields['max_weight']
+        );
 
         echo "<h3>" . __s("Power") . "</h3>";
-        Html::progressBar('rack_power', [
-            'create' => true,
-            'percent' => $power_prct,
-            'message' => htmlescape($power . " / " . $rack->fields['max_power'])
-        ]);
+        echo Html::getProgressBar(
+            $power_prct,
+            $power . " / " . $rack->fields['max_power']
+        );
         echo "</div>";
         echo "</div>";
     }

--- a/src/RuleCollection.php
+++ b/src/RuleCollection.php
@@ -334,6 +334,16 @@ class RuleCollection extends CommonDBTM
     }
 
     /**
+     * Count the total items that will be processed if rules are replayed.
+     *
+     * @param array $params Specific parameters used when rules are replayed.
+     */
+    public function countTotalItemsForRulesReplay(array $params = []): int
+    {
+        return 0;
+    }
+
+    /**
      * Replay Collection on DB
      *
      * @param integer $offset  first row to work on (default 0)

--- a/src/Software.php
+++ b/src/Software.php
@@ -1004,37 +1004,18 @@ class Software extends CommonDBTM
     }
 
     /**
-     * Merge software with current
+     * Merge software with current.
      *
      * @param array   $item array of software ID to be merged
-     * @param boolean $html display html progress bar
      *
      * @return boolean about success
-     **/
-    public function merge($item, $html = true)
+     */
+    private function merge($item): bool
     {
         /** @var \DBmysql $DB */
         global $DB;
 
         $ID = $this->getField('id');
-
-        if ($html) {
-            $twig_params = [
-                'merge_msg' => __('Merging'),
-                'progress' => Html::progressBar('doaction_progress', [
-                    'message' => __s('Work in progress...'),
-                    'create' => true,
-                    'display' => false
-                ])
-            ];
-            // language=Twig
-            echo TemplateRenderer::getInstance()->renderFromStringTemplate(<<<TWIG
-                {% import 'components/form/fields_macros.html.twig' as fields %}
-                <div class="text-center">
-                    {{ fields.htmlField('', progress, merge_msg) }}
-                </div>
-TWIG, $twig_params);
-        }
 
         $item = array_keys($item);
 
@@ -1112,9 +1093,6 @@ TWIG, $twig_params);
                 if ($result) {
                     $i++;
                 }
-                if ($html) {
-                    Html::changeProgressBarPosition($i, $nb + 1);
-                }
             }
         }
 
@@ -1138,9 +1116,6 @@ TWIG, $twig_params);
             foreach ($item as $old) {
                 $soft->putInTrash($old, __('Software deleted after merging'));
             }
-        }
-        if ($html) {
-            Html::changeProgressBarPosition($i, $nb + 1, __('Task completed.'));
         }
         return $i === ($nb + 1);
     }

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -559,24 +559,6 @@ class Toolbox
         $etag = md5_file($file);
         $lastModified = filemtime($file);
 
-        // No need to clear the output buffer if we are returning a Response object.
-        if (!$return_response) {
-            // Make sure there is nothing in the output buffer (In case stuff was added by core or misbehaving plugin).
-            // If there is any extra data, the sent file will be corrupted.
-            // 1. Turn off any extra buffering level. Keep one buffering level if PHP output_buffering directive is not "off".
-            $ob_config = ini_get('output_buffering');
-            $max_buffering_level = $ob_config !== false && (strtolower($ob_config) === 'on' || (is_numeric($ob_config) && (int)$ob_config > 0))
-                ? 1
-                : 0;
-            while (ob_get_level() > $max_buffering_level) {
-                ob_end_clean();
-            }
-            // 2. Clean any buffered output in remaining level (output_buffering="on" case).
-            if (ob_get_level() > 0) {
-                ob_clean();
-            }
-        }
-
         $headers = [
             'Last-Modified' => gmdate("D, d M Y H:i:s", $lastModified) . " GMT",
             'Etag'          => $etag,


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

The proposed changes should permit to limit the usage of streamed responses to the endpoints that actually really require it.

These changes will also permit:
 - to detect unexpected `flush()`/`ob_flush()`/`ob_clean()`/`ob_end_clean()` operations;
 - to add the Symfony profiler in all GLPI pages, unless an `exit()`/`die()` instruction is used.

It is still possible to use a `flush()` operation to flush the current buffer to the browser, do some processing, and then redirect the request. It will not be detected as the redirection in a legacy script stops the execution before the output content is actually converted to a response. I had to use this for massive actions and rules replay progress bar, but both of them should be refactored later to use the new progress indicator system.

It should be reviewed commit by commit.