### PR TITLE
Fix(LockedField): prevent purge of lockedField without authorization on the linked object entity

### DIFF
--- a/phpunit/functional/LockedfieldTest.php
+++ b/phpunit/functional/LockedfieldTest.php
@@ -909,4 +909,72 @@ class LockedfieldTest extends DbTestCase
         $this->assertSame($newmanufacturers_id, $database->fields['manufacturers_id']);
         $this->assertSame(['manufacturers_id' => 'PostgreSQL'], $lockedfield->getLockedValues($database->getType(), $database->fields['id']));
     }
+
+    public function testPurgeLockedField()
+    {
+        $this->login('glpi', 'glpi');
+
+        $computer = new \Computer();
+        $cid = (int)$computer->add([
+            'name'         => 'Computer from inventory',
+            'serial'       => '123456',
+            'otherserial'  => '789012',
+            'entities_id'  => 0,
+            'is_dynamic'   => 1
+        ]);
+        $this->assertGreaterThan(0, $cid);
+
+        $lockedfield = new \Lockedfield();
+        $this->assertTrue($lockedfield->isHandled($computer));
+        $this->assertEmpty($lockedfield->getLockedValues($computer->getType(), $cid));
+
+        //update computer manually, to add a locked field
+        $this->assertTrue(
+            $computer->update(['id' => $cid, 'otherserial' => 'AZERTY'])
+        );
+
+        $global_lockedfield = new \Lockedfield();
+        $global_lockedfield_id = (int)$global_lockedfield->add([
+            'item' => 'Computer - manufacturers_id'
+        ]);
+        $this->assertGreaterThan(0, $global_lockedfield_id);
+
+        $this->assertTrue($computer->getFromDB($cid));
+        $this->assertSame(['manufacturers_id' => null, 'otherserial' => null], $lockedfield->getLockedValues($computer->getType(), $cid));
+
+        // change to child entity
+        $entities_id_child = getItemByTypeName(\Entity::class, '_test_child_1', true);
+        $this->assertTrue(\Session::changeActiveEntities($entities_id_child));
+
+        // Check for computer lockedfield
+        $this->assertTrue($lockedfield->getFromDBByCrit(['itemtype' => \Computer::class, "items_id" => $cid]));
+        $this->assertFalse($lockedfield->canPurgeItem());
+        $this->assertFalse($lockedfield->can($lockedfield->fields['id'], PURGE));
+        // check if massive action is displayed
+        $this->assertFalse(\Lockedfield::isMassiveActionAllowed($lockedfield->fields['id']));
+
+        //check for global lockedfield
+        $this->assertTrue($global_lockedfield->canPurgeItem());
+        $this->assertTrue($global_lockedfield->can($global_lockedfield->fields['id'], PURGE));
+        // check if massive action is displayed
+        $this->assertTrue(\Lockedfield::isMassiveActionAllowed($global_lockedfield->fields['id']));
+
+        $this->login('glpi', 'glpi');
+
+        // move back to root entity
+        $this->assertTrue(\Session::changeActiveEntities(0));
+
+        // Check for computer lockedfield
+        $this->assertTrue($lockedfield->getFromDBByCrit(['itemtype' => \Computer::class, "items_id" => $cid]));
+        $this->assertTrue($lockedfield->canPurgeItem());
+        $this->assertTrue($lockedfield->can($lockedfield->fields['id'], PURGE));
+        // check if massive action is displayed
+        $this->assertTrue(\Lockedfield::isMassiveActionAllowed($lockedfield->fields['id']));
+
+        //check for global lockedfield
+        $this->assertTrue($global_lockedfield->canPurgeItem());
+        $this->assertTrue($global_lockedfield->can($global_lockedfield->fields['id'], PURGE));
+        // check if massive action is displayed
+        $this->assertTrue(\Lockedfield::isMassiveActionAllowed($global_lockedfield->fields['id']));
+    }
 }

--- a/src/Lockedfield.php
+++ b/src/Lockedfield.php
@@ -68,6 +68,52 @@ class Lockedfield extends CommonDBTM
         return Session::haveRight(self::$rightname, UPDATE);
     }
 
+    public function canCreateItem()
+    {
+        return $this->canAccessItemEntity($this->fields['itemtype'], $this->fields['items_id']);
+    }
+
+    public function canUpdateItem()
+    {
+        return $this->canAccessItemEntity($this->fields['itemtype'], $this->fields['items_id']);
+    }
+
+    public function canPurgeItem()
+    {
+        return $this->canAccessItemEntity($this->fields['itemtype'], $this->fields['items_id']);
+    }
+
+    public static function isMassiveActionAllowed(int $items_id): bool
+    {
+        $lock = new self();
+        $lock->getFromDB($items_id);
+        if ($lock->canAccessItemEntity($lock->fields['itemtype'], $lock->fields['items_id'])) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Check if user can access main item entity
+     *
+     * @param string $itemtype
+     * @param int    $items_id
+     *
+     * @return bool
+     */
+    private function canAccessItemEntity(string $itemtype, int $items_id): bool
+    {
+        $item = new $itemtype();
+        if (
+            $item->getFromDB($items_id) //not a global lock
+            && $item->isEntityAssign()
+            && !Session::haveAccessToEntity($item->getEntityID(), $item->isRecursive()) // no access to main item entity
+        ) {
+            return false;
+        }
+        return true;
+    }
+
     public function rawSearchOptions()
     {
         $tab = parent::rawSearchOptions();


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

GLPI does not respect the current user's permissions when deleting (purging) a `LockedField`.

This allows a `LockedField` linked to an object from another entity to be deleted.

I am also questioning the handling of `global` `LockedFields`.
Currently, anyone with the `UPDATE` permission can delete a global lock  (with or without this `PR`), regardless of the entity, as the `LockedField` object does not include an `entities_id`.



- It fixes !35279


## Screenshots (if appropriate):


