### PR TITLE
Force database instances to be linked to asset

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -1604,12 +1604,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/DatabaseInstance.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Strict comparison using \\=\\=\\= between array and false will always evaluate to false\\.$#',
-	'identifier' => 'identical.alwaysFalse',
-	'count' => 1,
-	'path' => __DIR__ . '/src/DatabaseInstance.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Call to function is_int\\(\\) with int will always evaluate to true\\.$#',
 	'identifier' => 'function.alreadyNarrowedType',
 	'count' => 1,

--- a/install/migrations/update_10.0.x_to_11.0.0/databaseinstance.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/databaseinstance.php
@@ -40,3 +40,20 @@
 
 // The size field seems to be unsused and rather a copy-paste from the glpi_databases table
 $migration->dropField('glpi_databaseinstances', 'size');
+
+// Block update if any database instance is currently unlinked
+$unlinked_it = $DB->request([
+    'SELECT' => ['id'],
+    'FROM'   => 'glpi_databaseinstances',
+    'WHERE' => [
+        'OR' => [
+            'itemtype' => '',
+            'items_id' => 0
+        ]
+    ]
+]);
+
+if (count($unlinked_it)) {
+    $unlinked_id_string = implode(', ', array_column(iterator_to_array($unlinked_it), 'id'));
+    throw new \RuntimeException("Some database instances are not linked to an item: {$unlinked_id_string}");
+}

--- a/phpunit/functional/DatabaseInstanceTest.php
+++ b/phpunit/functional/DatabaseInstanceTest.php
@@ -164,4 +164,20 @@ class DatabaseInstanceTest extends DbTestCase
         $this->assertInstanceOf(\Agent::class, $computer_agent);
         $this->assertEquals($computer_agent->fields, $db_agent->fields);
     }
+
+    public function testMustBeLinked()
+    {
+        $this->login();
+
+        $this->assertFalse((new \DatabaseInstance())->add([
+            'name' => __FUNCTION__,
+            'entities_id' => $this->getTestRootEntity(true)
+        ]));
+        $this->assertTrue((new \DatabaseInstance())->add([
+            'name' => __FUNCTION__,
+            'entities_id' => $this->getTestRootEntity(true),
+            'itemtype' => \Computer::class,
+            'items_id' => getItemByTypeName('Computer', '_test_pc01')
+        ]));
+    }
 }

--- a/src/DatabaseInstance.php
+++ b/src/DatabaseInstance.php
@@ -139,6 +139,10 @@ class DatabaseInstance extends CommonDBTM
 
     public function prepareInputForAdd($input)
     {
+        if (empty($input['itemtype']) || empty($input['items_id'])) {
+            Session::addMessageAfterRedirect(__s('An item is required'), false, ERROR);
+            return false;
+        }
         $input = $this->prepareInputForAddAssignableItem($input);
         if ($input === false) {
             return false;
@@ -147,6 +151,15 @@ class DatabaseInstance extends CommonDBTM
             unset($input['date_lastbackup']);
         }
         return $input;
+    }
+
+    public function prepareInputForUpdate($input)
+    {
+        if ((array_key_exists('itemtype', $input) && empty($input['itemtype'])) || (array_key_exists('items_id', $input) && empty($input['items_id']))) {
+            Session::addMessageAfterRedirect(__s('An item is required'), false, ERROR);
+            return false;
+        }
+        return parent::prepareInputForUpdate($input);
     }
 
     public function rawSearchOptions()

--- a/templates/pages/management/databaseinstance.html.twig
+++ b/templates/pages/management/databaseinstance.html.twig
@@ -51,7 +51,7 @@
                 action: 'get_items_from_itemtype'
             }
         ]) %}
-        {{ fields.dropdownField(item.fields['itemtype'], 'items_id', item.fields['items_id'], _x('Item', 'Items', 1)) }}
+        {{ fields.dropdownField(item.fields['itemtype'], 'items_id', item.fields['items_id'], _n('Item', 'Items', 1)) }}
     {% else %}
         {% do call('Ajax::updateItemOnSelectEvent', [
             'dropdown_itemtype' ~ rand,
@@ -67,7 +67,7 @@
         {% set result_itemtype_field %}
             <span id="results_itemtype{{ rand }}"></span>
         {% endset %}
-        {{ fields.htmlField('', result_itemtype_field, _x('Item', 'Items', 1)) }}
+        {{ fields.htmlField('', result_itemtype_field, _n('Item', 'Items', 1)) }}
     {% endif %}
     {{ parent() }}
 {% endblock %}

--- a/tests/GLPITestCase.php
+++ b/tests/GLPITestCase.php
@@ -412,6 +412,10 @@ class GLPITestCase extends atoum
             case SoftwareLicense::class:
                 $input['softwares_id'] = getItemByTypeName(Software::class, '_test_soft', true);
                 break;
+            case DatabaseInstance::class:
+                $input['itemtype']          = Computer::class;
+                $input['items_id']          = getItemByTypeName(Computer::class, '_test_pc01', true);
+                break;
         }
 
         return $input;


### PR DESCRIPTION
Trying to add proper entity transfer support for database instances, and trying to navigate the confusion of a DatabaseInstance being treated like a standalone item rather than a child of a main asset. Found a closed PR from recently that definitively said db instances were supposed to always be linked, but no checks exist for that to be the case.

This PR adds add/update checks and blocks the update process to GLPI 11 if DB instances are unlinked.

DatabaseInstance probably should extend CommonDBChild not CommonDBTM, but that's going to be messier to handle. Also, not sure it makes sense for the main asset, database instance, and individual databases to all have separate entity columns. Again, a separate thing to handle.