### PR TITLE
Fix creating socket without item linked

### DIFF
--- a/phpunit/functional/Glpi/SocketTest.php
+++ b/phpunit/functional/Glpi/SocketTest.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi;
+
+use DbTestCase;
+
+class SocketTest extends DbTestCase
+{
+    public function testCreateNoItem()
+    {
+        $socket = new \Glpi\Socket();
+        $sockets_id = $socket->add([
+            'name' => __FUNCTION__,
+            'items_id' => '',
+            'itemtype' => 'Computer',
+        ]);
+        $this->assertTrue($socket->getFromDB($sockets_id));
+        $this->assertSame(null, $socket->fields['itemtype']);
+        $this->assertSame(0, $socket->fields['items_id']);
+    }
+}

--- a/src/Socket.php
+++ b/src/Socket.php
@@ -215,10 +215,8 @@ class Socket extends CommonDBChild
 
     public function prepareInputForAdd($input)
     {
-        // If no items_id is set, do not store itemtype or items_id
-        if (!isset($input['items_id']) || empty($input['items_id'])) {
-            unset($input['itemtype']);
-            unset($input['items_id']);
+        if (empty($input['items_id'])) {
+            unset($input['itemtype'], $input['items_id']);
         }
         $input = $this->retrievedataFromNetworkPort($input);
         return $input;
@@ -227,10 +225,8 @@ class Socket extends CommonDBChild
 
     public function prepareInputForUpdate($input)
     {
-        // If no items_id is set, do not store itemtype or items_id
-        if (!isset($input['items_id']) || empty($input['items_id'])) {
-            unset($input['itemtype']);
-            unset($input['items_id']);
+        if (isset($input['items_id']) && empty($input['items_id'])) {
+            unset($input['itemtype'], $input['items_id']);
         }
         $input = $this->retrievedataFromNetworkPort($input);
         return $input;

--- a/templates/pages/assets/socket.html.twig
+++ b/templates/pages/assets/socket.html.twig
@@ -66,7 +66,7 @@
    {% set networkports %}
       {% do call('Glpi\\Socket::showNetworkPortForm', [
          item.fields['itemtype'],
-         item.fields['items_id'],
+         item.fields['items_id'] ?? 0,
          item.fields['networkports_id'],
          params
       ]) %}


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

Fixes #18202

Sockets are supposed to be allowed to exist without being connected to an item, but it was trying to save an empty string to the `items_id` column. Default selection for "Item" was an empty string instead of 0.
Fix ensures that if the items_id field is an empty value, the itemtype and items_id values are not saved.
