### PR TITLE
Fix(Inventory): take car of 'default_software_helpdesk_visible' from software inventory

### DIFF
--- a/phpunit/functional/Glpi/Inventory/Assets/SoftwareTest.php
+++ b/phpunit/functional/Glpi/Inventory/Assets/SoftwareTest.php
@@ -1632,4 +1632,92 @@ class SoftwareTest extends AbstractInventoryAsset
 
         $this->assertSame($categories_id, $first_soft['softwarecategories_id']);
     }
+
+    public function testIsHelpdeskVisible()
+    {
+        /** @var array $CFG_GLPI */
+        global $CFG_GLPI;
+
+        $this->login();
+
+        $computer = new \Computer();
+        $soft = new \Software();
+
+        $xml_source = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
+<REQUEST>
+  <CONTENT>
+    <SOFTWARES>
+      <ARCH>x86_64</ARCH>
+      <COMMENTS>GNU Image Manipulation Program</COMMENTS>
+      <FILESIZE>67382735</FILESIZE>
+      <FROM>rpm</FROM>
+      <INSTALLDATE>03/10/2021</INSTALLDATE>
+      <NAME>gimp</NAME>
+      <PUBLISHER>Fedora Project</PUBLISHER>
+      <SYSTEM_CATEGORY>Web App</SYSTEM_CATEGORY>
+      <VERSION>2.10.28-1.fc34</VERSION>
+    </SOFTWARES>
+    <HARDWARE>
+      <NAME>pc012302</NAME>
+    </HARDWARE>
+    <BIOS>
+      <SSN>sd65f4sd6f4</SSN>
+    </BIOS>
+    <VERSIONCLIENT>FusionInventory-Agent_v2.3.19</VERSIONCLIENT>
+  </CONTENT>
+  <DEVICEID>test-pc002</DEVICEID>
+  <QUERY>INVENTORY</QUERY>
+</REQUEST>";
+
+        //software import behave differently: non-dynamic are not handled at all.
+        //create manually a computer
+        $computers_id = $computer->add([
+            'name'   => 'pc012302',
+            'serial' => 'sd65f4sd6f4',
+            'entities_id' => 0
+        ]);
+        $this->assertGreaterThan(0, $computers_id);
+
+        // set software to not be helpdesk visible
+        $CFG_GLPI["default_software_helpdesk_visible"] = 0;
+        $this->doInventory($xml_source, true);
+
+        //check that software has been created and is_helpdesk_visible false
+        $softs = $soft->find(['is_helpdesk_visible' => false, 'name' => 'gimp']);
+        $this->assertCount(1, $softs);
+
+        $xml_source = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
+        <REQUEST>
+          <CONTENT>
+            <SOFTWARES>
+              <ARCH>x86_64</ARCH>
+              <COMMENTS>GNU Image Manipulation Program</COMMENTS>
+              <FILESIZE>67382735</FILESIZE>
+              <FROM>rpm</FROM>
+              <INSTALLDATE>03/10/2021</INSTALLDATE>
+              <NAME>other_soft</NAME>
+              <PUBLISHER>Fedora Project</PUBLISHER>
+              <SYSTEM_CATEGORY>Web App</SYSTEM_CATEGORY>
+              <VERSION>2.10.28-1.fc34</VERSION>
+            </SOFTWARES>
+            <HARDWARE>
+              <NAME>pc012302</NAME>
+            </HARDWARE>
+            <BIOS>
+              <SSN>sd65f4sd6f4</SSN>
+            </BIOS>
+            <VERSIONCLIENT>FusionInventory-Agent_v2.3.19</VERSIONCLIENT>
+          </CONTENT>
+          <DEVICEID>test-pc002</DEVICEID>
+          <QUERY>INVENTORY</QUERY>
+        </REQUEST>";
+
+        // retry with default_software_helpdesk_visible = 1
+        $CFG_GLPI["default_software_helpdesk_visible"] = 1;
+        $this->doInventory($xml_source, true);
+
+        //check that software has been created and is_helpdesk_visible false
+        $softs = $soft->find(['is_helpdesk_visible' => true, 'name' => 'other_soft']);
+        $this->assertCount(1, $softs);
+    }
 }

--- a/src/Inventory/Asset/Software.php
+++ b/src/Inventory/Asset/Software.php
@@ -302,6 +302,7 @@ class Software extends InventoryAsset
 
         $db_software = [];
         $db_software_wo_version = [];
+        $db_software_data = [];
 
         //Load existing software versions from db. Grab required fields
         //to build comparison key @see getFullCompareKey
@@ -393,19 +394,8 @@ class Software extends InventoryAsset
 
             $dedup_vkey = $key_w_version . $this->getVersionKey($val, 0);
 
-            //update softwarecategories if needed
-            //reconciles the software without the version (no needed here)
-            $sckey = md5('softwarecategories_id' . ($val->softwarecategories_id ?? 0));
-            if (
-                isset($db_software_data[$key_wo_version])
-                && $db_software_data[$key_wo_version]['softwarecategories'] != ($this->known_links[$sckey] ?? 0)
-            ) {
-                $software_to_update = new GSoftware();
-                $software_to_update->update([
-                    "id" => $db_software_data[$key_wo_version]['softid'],
-                    "softwarecategories_id" => ($this->known_links[$sckey] ?? 0)
-                ], 0);
-            }
+
+            $this->updateSoftwareFieldsIfNeeded($db_software_data, $key_wo_version, $val);
 
             if (isset($db_software[$key_w_version])) {
                 // software exist with the same version
@@ -466,6 +456,40 @@ class Software extends InventoryAsset
             $this->storeAssetLink();
         } catch (\Throwable $e) {
             throw $e;
+        }
+    }
+
+
+    /**
+     * Updates software fields if needed.
+     *
+     * @param array $db_software_data The current database data for the software.
+     * @param string $key_wo_version The key to access software data without version information.
+     * @param object $val The current software data being processed.
+     */
+    private function updateSoftwareFieldsIfNeeded(array $db_software_data, string $key_wo_version, object $val): void
+    {
+        /** @var array $CFG_GLPI */
+        global $CFG_GLPI;
+
+        if (!isset($db_software_data[$key_wo_version])) {
+            return; // No data to process
+        }
+
+        $fields_to_update = [];
+        $soft_id = $db_software_data[$key_wo_version]['softid'];
+
+        // Check if the softwarecategories_id needs to be updated
+        $sckey = md5('softwarecategories_id' . ($val->softwarecategories_id ?? 0));
+        if ($db_software_data[$key_wo_version]['softwarecategories'] != ($this->known_links[$sckey] ?? 0)) {
+            $fields_to_update['softwarecategories_id'] = ($this->known_links[$sckey] ?? 0);
+        }
+
+        // Perform the update if there are fields to update
+        if (!empty($fields_to_update)) {
+            $fields_to_update['id'] = $soft_id;
+            $software_to_update = new GSoftware();
+            $software_to_update->update($fields_to_update, 0);
         }
     }
 
@@ -713,6 +737,9 @@ class Software extends InventoryAsset
         /** @var \DBmysql $DB */
         global $DB;
 
+        /** @var array $CFG_GLPI */
+        global $CFG_GLPI;
+
         $software = new GSoftware();
         $soft_fields = $DB->listFields($software->getTable());
         $stmt = $stmt_types = null;
@@ -725,6 +752,7 @@ class Software extends InventoryAsset
                 $software->handleCategoryRules($stmt_columns, true);
                 //set create date
                 $stmt_columns['date_creation'] = $_SESSION["glpi_currenttime"];
+                $stmt_columns['is_helpdesk_visible'] = $CFG_GLPI["default_software_helpdesk_visible"];
 
                 if ($stmt === null) {
                     $stmt_types = str_repeat('s', count($stmt_columns));


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !35300

Currently, the software inventory does not take into account the `is_helpdesk_visible` option in GLPI's general configuration.

![image](https://github.com/user-attachments/assets/31b88081-d48d-40db-a691-d754a349d002)

This option is now managed both during the creation of the software and when it is updated.

I took the opportunity in this PR to simplify the code with a dedicated function (We may have other cases to handle in the future)



## Screenshots (if appropriate):


