### PR TITLE
Do not include downstream file from tests

### DIFF
--- a/inc/based_config.php
+++ b/inc/based_config.php
@@ -123,7 +123,7 @@ include_once(GLPI_ROOT . "/inc/autoload.function.php");
     }
 
    // Define constants values from downstream distribution file
-    if (file_exists(GLPI_ROOT . '/inc/downstream.php')) {
+    if (!defined('TU_USER') && file_exists(GLPI_ROOT . '/inc/downstream.php')) {
         include_once(GLPI_ROOT . '/inc/downstream.php');
     }
 


### PR DESCRIPTION
This prevents "already defined constants" errors when `inc/downstream.php` file is configured. This file should not be used from tests.