### PR TITLE
fix: return 403 when inventory is disabled

### DIFF
--- a/front/inventory.php
+++ b/front/inventory.php
@@ -44,6 +44,7 @@ if (!defined('GLPI_ROOT')) {
 
 $conf = new Conf();
 if ($conf->enabled_inventory != 1) {
+    http_response_code(403);
     die("Inventory is disabled");
 }
 


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

I think it's better to return a 403 error rather than a classic 200 code (the current behavior), making it seem like everything is OK.
