### PR TITLE
fix(save-search): correct total calculation for itemtype

### DIFF
--- a/src/SavedSearch.php
+++ b/src/SavedSearch.php
@@ -1318,12 +1318,20 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
         ) {
             $search = new Search();
            //Do the same as self::getParameters() but getFromDB is useless
-            $query_tab = [];
-            parse_str($this->getField('query'), $query_tab);
 
             $params = null;
             if (class_exists($this->getField('itemtype'))) {
-                $params = $search::manageParams($this->getField('itemtype'), $_GET);
+                $query_tab = null;
+                $save_search_params = $this->getParameters($this->getID());
+                if (isset($save_search_params['criteria'])) {
+                    $query_tab = $save_search_params['criteria'];
+                }
+                $params = Search::manageParams($this->getField('itemtype'), [
+                    'is_deleted'    => 0,
+                    'savedsearches_id' => $this->getID(),
+                    'itemtype'      => $this->getField('itemtype'),
+                    'criteria'      => $query_tab
+                ], false);
             }
 
             if (!$params) {

--- a/src/SavedSearch.php
+++ b/src/SavedSearch.php
@@ -1323,11 +1323,7 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
 
             $params = null;
             if (class_exists($this->getField('itemtype'))) {
-                $params = $this->prepareQueryToUse(
-                    $this->getField('type'),
-                    $query_tab,
-                    $enable_partial_warnings
-                );
+                $params = $search::manageParams($this->getField('itemtype'), $_GET);
             }
 
             if (!$params) {


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

- It fixes !35211
- Fix the counter in saved searches. Previously, the counter displayed the total number of all item types instead of reflecting the actual results of the search. With this fix, the counter now correctly represents the search results based on the specified criteria.

## Screenshots (if appropriate):


![Capture d’écran du 2024-11-25 14-37-28](https://github.com/user-attachments/assets/cbd18af8-768c-485d-8a75-fdd5f374f2e8)
![Capture d’écran du 2024-11-25 14-37-56](https://github.com/user-attachments/assets/49b9260b-b55a-4e0d-97ee-e45f69c1e542)

