### PR TITLE
Redirect on new asset after unmanaged conversion

### DIFF
--- a/src/Unmanaged.php
+++ b/src/Unmanaged.php
@@ -248,8 +248,13 @@ class Unmanaged extends CommonDBTM
                 $unmanaged = new self();
                 foreach ($ids as $id) {
                     $itemtype = $_POST['itemtype'];
-                    $unmanaged->convert($id, $itemtype);
+                    $new_asset_id = $unmanaged->convert($id, $itemtype);
                     $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+                    if (count($ids) === 1) {
+                        $ma->setRedirect($itemtype::getFormURLWithID($new_asset_id));
+                    } else {
+                        $ma->setRedirect($item::getSearchURL());
+                    }
                 }
                 break;
         }
@@ -261,7 +266,7 @@ class Unmanaged extends CommonDBTM
      * @param int         $items_id ID of Unmanaged equipment
      * @param string|null $itemtype Item type to convert to. Will take Unmanaged value if null
      */
-    public function convert(int $items_id, ?string $itemtype = null)
+    public function convert(int $items_id, ?string $itemtype = null): int
     {
         /** @var \DBmysql $DB */
         global $DB;
@@ -339,6 +344,7 @@ class Unmanaged extends CommonDBTM
             $lockfield->update(Toolbox::addslashes_deep($row));
         }
         $this->deleteFromDB(1);
+        return $assets_id;
     }
 
     public function useDeletedToLockIfDynamic()


### PR DESCRIPTION
Fixes #18372 

One problem left: if we convert only one Unmanaged from the list, we'll be redirected to the new asset form instead of unmanaged list; I did not find how to know if we were called from the form or from the list.