### PR TITLE
Fix validationresponse ticket close

### DIFF
--- a/front/ticket.form.php
+++ b/front/ticket.form.php
@@ -88,44 +88,6 @@ if (isset($_POST["add"])) {
         Html::displayRightError();
     }
 
-    if (isset($_POST['validation_percent'])) {
-        $nb = countElementsInTable(TicketValidation::getTable(), ['tickets_id' => $_POST['id']]);
-
-        $rejections = countElementsInTable(TicketValidation::getTable(), [
-            'tickets_id' => $_POST['id'],
-            'status' => CommonITILValidation::REFUSED
-        ]);
-
-        $validations = countElementsInTable(TicketValidation::getTable(), [
-            'tickets_id' => $_POST['id'],
-            'status' => CommonITILValidation::ACCEPTED
-        ]);
-
-        if ($rejections == $nb) {
-            $_POST['global_validation'] = CommonITILValidation::REFUSED;
-        } else if ($validations > 0) {
-            switch ($_POST['validation_percent']) {
-                case 0:
-                    $_POST['global_validation'] = CommonITILValidation::ACCEPTED;
-                    break;
-                case 100:
-                    if ($rejections > 0) {
-                        $_POST['global_validation'] = CommonITILValidation::REFUSED;
-                    } else {
-                        $_POST['global_validation'] = ($validations == $nb) ? CommonITILValidation::ACCEPTED : CommonITILValidation::WAITING;
-                    }
-                    break;
-                case 50:
-                    if ($rejections >= $nb / 2) {
-                        $_POST['global_validation'] = CommonITILValidation::REFUSED;
-                    } else {
-                        $_POST['global_validation'] = ($validations >= $nb / 2) ? CommonITILValidation::ACCEPTED : CommonITILValidation::WAITING;
-                    }
-                    break;
-            }
-        }
-    }
-
     $track->update($_POST);
 
     if (isset($_POST['kb_linked_id'])) {

--- a/front/ticket.form.php
+++ b/front/ticket.form.php
@@ -87,6 +87,45 @@ if (isset($_POST["add"])) {
     if (!$track::canUpdate()) {
         Html::displayRightError();
     }
+
+    if (isset($_POST['validation_percent'])) {
+        $nb = countElementsInTable(TicketValidation::getTable(), ['tickets_id' => $_POST['id']]);
+
+        $rejections = countElementsInTable(TicketValidation::getTable(), [
+            'tickets_id' => $_POST['id'],
+            'status' => CommonITILValidation::REFUSED
+        ]);
+
+        $validations = countElementsInTable(TicketValidation::getTable(), [
+            'tickets_id' => $_POST['id'],
+            'status' => CommonITILValidation::ACCEPTED
+        ]);
+
+        if ($rejections == $nb) {
+            $_POST['global_validation'] = CommonITILValidation::REFUSED;
+        } else if ($validations > 0) {
+            switch ($_POST['validation_percent']) {
+                case 0:
+                    $_POST['global_validation'] = CommonITILValidation::ACCEPTED;
+                    break;
+                case 100:
+                    if ($rejections > 0) {
+                        $_POST['global_validation'] = CommonITILValidation::REFUSED;
+                    } else {
+                        $_POST['global_validation'] = ($validations == $nb) ? CommonITILValidation::ACCEPTED : CommonITILValidation::WAITING;
+                    }
+                    break;
+                case 50:
+                    if ($rejections >= $nb / 2) {
+                        $_POST['global_validation'] = CommonITILValidation::REFUSED;
+                    } else {
+                        $_POST['global_validation'] = ($validations >= $nb / 2) ? CommonITILValidation::ACCEPTED : CommonITILValidation::WAITING;
+                    }
+                    break;
+            }
+        }
+    }
+
     $track->update($_POST);
 
     if (isset($_POST['kb_linked_id'])) {

--- a/front/ticket.form.php
+++ b/front/ticket.form.php
@@ -87,7 +87,6 @@ if (isset($_POST["add"])) {
     if (!$track::canUpdate()) {
         Html::displayRightError();
     }
-
     $track->update($_POST);
 
     if (isset($_POST['kb_linked_id'])) {

--- a/phpunit/functional/CommonITILValidationTest.php
+++ b/phpunit/functional/CommonITILValidationTest.php
@@ -466,14 +466,10 @@ class CommonITILValidationTest extends DbTestCase
         /** Create a ticket, approval requested */
         $ticket = $this->createItem('Ticket', $input);
 
-        $this->assertTrue($ticket->getID() > 0 );
-
         $validation_item = $this->createItem('TicketValidation', [
             'tickets_id'        => $ticket->getID(),
             'users_id_validate' => $user_id,
         ]);
-
-        $this->assertTrue($validation_item->getID() > 0 );
 
         $this->assertEquals($expected, \TicketValidation::getNumberToValidate($user_id));
     }

--- a/phpunit/functional/CommonITILValidationTest.php
+++ b/phpunit/functional/CommonITILValidationTest.php
@@ -35,6 +35,7 @@
 
 namespace tests\units;
 
+use CommonITILObject;
 use DbTestCase;
 
 /* Test for inc/commonitilvalidation.class.php */
@@ -427,5 +428,53 @@ class CommonITILValidationTest extends DbTestCase
         );
 
         $this->assertEquals($result, $test_result);
+    }
+
+    public static function testgetNumberToValidateProvider(): array
+    {
+        return [
+            [
+                'input'     => [
+                    'name'      => 'Ticket_Closed_With_Validation_Request',
+                    'content'   => 'Ticket_Closed_With_Validation_Request',
+                ],
+                'expected'  => 1,
+                'user_id'   => getItemByTypeName('User', 'glpi', true)
+            ],
+            [
+                'input'     => [
+                    'name' => 'Ticket_With_Validation_Request',
+                    'content' => 'Ticket_With_Validation_Request',
+                    'status' =>  CommonITILObject::CLOSED
+                ],
+                'expected'  => 0,
+                'user_id'   => getItemByTypeName('User', 'glpi', true)
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider testgetNumberToValidateProvider
+     */
+    public function testgetNumberToValidate(
+        array $input,
+        int $expected,
+        int $user_id
+    ): void {
+        $this->login();
+
+        /** Create a ticket, approval requested */
+        $ticket = $this->createItem('Ticket', $input);
+
+        $this->assertTrue($ticket->getID() > 0 );
+
+        $validation_item = $this->createItem('TicketValidation', [
+            'tickets_id'        => $ticket->getID(),
+            'users_id_validate' => $user_id,
+        ]);
+
+        $this->assertTrue($validation_item->getID() > 0 );
+
+        $this->assertEquals($expected, \TicketValidation::getNumberToValidate($user_id));
     }
 }

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -7192,7 +7192,7 @@ abstract class CommonITILObject extends CommonDBTM
                 $canedit = $valitation_obj->can($validations_id, UPDATE);
                 $cananswer = ($validation_row['users_id_validate'] === Session::getLoginUserID() &&
                 $validation_row['status'] == CommonITILValidation::WAITING &&
-                $this->fields['status'] != CommonITILObject::CLOSED);
+                !in_array($this->fields['status'], $this->getClosedStatusArray()));
                 $user = new User();
                 $user->getFromDB($validation_row['users_id_validate']);
 

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -7191,7 +7191,8 @@ abstract class CommonITILObject extends CommonDBTM
 
                 $canedit = $valitation_obj->can($validations_id, UPDATE);
                 $cananswer = ($validation_row['users_id_validate'] === Session::getLoginUserID() &&
-                $validation_row['status'] == CommonITILValidation::WAITING);
+                $validation_row['status'] == CommonITILValidation::WAITING &&
+                $this->fields['status'] != CommonITILObject::CLOSED);
                 $user = new User();
                 $user->getFromDB($validation_row['users_id_validate']);
 

--- a/src/CommonITILValidation.php
+++ b/src/CommonITILValidation.php
@@ -670,7 +670,20 @@ abstract class CommonITILValidation extends CommonDBChild
             'COUNT'  => 'cpt',
             'WHERE'  => [
                 'status'             => self::WAITING,
-                'users_id_validate'  => $users_id
+                'users_id_validate'  => $users_id,
+                'NOT' => [
+                    'AND' => [
+                        [
+                            'tickets_id' => new QuerySubQuery([
+                                'SELECT' => 'id',
+                                'FROM'   => 'glpi_tickets',
+                                'WHERE'  => [
+                                    'status' => CommonITILObject::CLOSED
+                                ]
+                            ])
+                        ]
+                    ]
+                ]
             ]
         ])->current();
 

--- a/src/CommonITILValidation.php
+++ b/src/CommonITILValidation.php
@@ -680,7 +680,7 @@ abstract class CommonITILValidation extends CommonDBChild
                     ])
                 ],
                 'NOT' => [
-                    'status' => Ticket::getClosedStatusArray(),
+                    'status' => static::$itemtype::getClosedStatusArray(),
                 ],
             ]
         ])->current();

--- a/src/CommonITILValidation.php
+++ b/src/CommonITILValidation.php
@@ -666,12 +666,12 @@ abstract class CommonITILValidation extends CommonDBChild
         global $DB;
 
         $row = $DB->request([
-            'FROM'   => Ticket::getTable(),
+            'FROM'   => static::$itemtype::getTable(),
             'COUNT'  => 'cpt',
             'WHERE'  => [
                 [
                     'id' => new QuerySubQuery([
-                        'SELECT' => 'tickets_id',
+                        'SELECT' => static::$items_id,
                         'FROM'   => self::getTable(),
                         'WHERE'  => [
                             'status' => self::WAITING,
@@ -680,12 +680,8 @@ abstract class CommonITILValidation extends CommonDBChild
                     ])
                 ],
                 'NOT' => [
-                    'AND' => [
-                        [
-                            'status' => Ticket::getClosedStatusArray()
-                        ]
-                    ]
-                ]
+                    'status' => Ticket::getClosedStatusArray(),
+                ],
             ]
         ])->current();
 

--- a/src/CommonITILValidation.php
+++ b/src/CommonITILValidation.php
@@ -666,21 +666,23 @@ abstract class CommonITILValidation extends CommonDBChild
         global $DB;
 
         $row = $DB->request([
-            'FROM'   => static::getTable(),
+            'FROM'   => Ticket::getTable(),
             'COUNT'  => 'cpt',
             'WHERE'  => [
-                'status'             => self::WAITING,
-                'users_id_validate'  => $users_id,
+                [
+                    'id' => new QuerySubQuery([
+                        'SELECT' => 'tickets_id',
+                        'FROM'   => self::getTable(),
+                        'WHERE'  => [
+                            'status' => self::WAITING,
+                            'users_id_validate'  => $users_id,
+                        ]
+                    ])
+                ],
                 'NOT' => [
                     'AND' => [
                         [
-                            'tickets_id' => new QuerySubQuery([
-                                'SELECT' => 'id',
-                                'FROM'   => 'glpi_tickets',
-                                'WHERE'  => [
-                                    'status' => CommonITILObject::CLOSED
-                                ]
-                            ])
+                            'status' => Ticket::getClosedStatusArray()
                         ]
                     ]
                 ]

--- a/src/Dashboard/Provider.php
+++ b/src/Dashboard/Provider.php
@@ -324,6 +324,11 @@ class Provider
                         'field'      => 55,
                         'searchtype' => 'equals',
                         'value'      => CommonITILValidation::WAITING,
+                    ],
+                    [
+                        'field'      => 12,
+                        'searchtype' => 'equals',
+                        'value'      => Ticket::CLOSED,
                     ]
                 ];
 
@@ -338,6 +343,7 @@ class Provider
 
                 $where = [
                     'glpi_ticketvalidations.status' => CommonITILValidation::WAITING,
+                    'NOT' => ['glpi_tickets.status' => Ticket::CLOSED],
                 ];
 
                 if ($params['validation_check_user']) {

--- a/src/Dashboard/Provider.php
+++ b/src/Dashboard/Provider.php
@@ -326,6 +326,7 @@ class Provider
                         'value'      => CommonITILValidation::WAITING,
                     ],
                     [
+                        'link'       => 'AND NOT',
                         'field'      => 12,
                         'searchtype' => 'equals',
                         'value'      => Ticket::CLOSED,

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -5328,6 +5328,11 @@ JAVASCRIPT;
             $opt['criteria'][1]['value']      = Session::getLoginUserID();
             $opt['criteria'][1]['link']       = 'AND';
 
+            $opt['criteria'][2]['field']      = 12; // ticket status
+            $opt['criteria'][2]['searchtype'] = 'equals';
+            $opt['criteria'][2]['value']      = Ticket::CLOSED;
+            $opt['criteria'][2]['link']       = 'AND NOT';
+
             $twig_params['items'][] = [
                 'link'    => self::getSearchURL() . "?" . Toolbox::append_params($opt),
                 'text'    => __('Tickets waiting for your approval'),


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !35135
- Here is a brief description of what this PR does

When the ticket is closed and there are validation requests waiting for a response, it is still possible to validate them, but this does not update the global status.

So I deactivated the possibility of accepting a validation request once the ticket has been closed.

## Screenshots (if appropriate):
**Before**
![image](https://github.com/user-attachments/assets/e4d679f0-f8eb-42b9-abbd-cc6929f60bf9)

**After**
![image](https://github.com/user-attachments/assets/1d44a2c6-e7d3-4b91-bff4-815a468932e8)



