### PR TITLE
Fix(LockedField): display lock for 'sysdescr'

### DIFF
--- a/templates/generic_show_form.html.twig
+++ b/templates/generic_show_form.html.twig
@@ -457,7 +457,7 @@
                      {% endif %}
 
                      {% if item.isField('sysdescr') %}
-                        {{ fields.textareaField('sysdescr', item.fields['sysdescr'], __('sysdescr'), field_options) }}
+                        {{ fields.textareaField('sysdescr', item.fields['sysdescr'], __('Sysdescr'), field_options) }}
                      {% endif %}
 
                      {% if item.isField('snmpcredentials_id') %}

--- a/templates/generic_show_form.html.twig
+++ b/templates/generic_show_form.html.twig
@@ -457,7 +457,7 @@
                      {% endif %}
 
                      {% if item.isField('sysdescr') %}
-                        {{ fields.textareaField('sysdescr', item.fields['sysdescr'], __('Sysdescr')) }}
+                        {{ fields.textareaField('sysdescr', item.fields['sysdescr'], __('sysdescr'), field_options) }}
                      {% endif %}
 
                      {% if item.isField('snmpcredentials_id') %}


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !35334

A lock set on the sysdescr field is correctly recorded in the database and appears in the list of locks. 

![image](https://github.com/user-attachments/assets/d98f3731-15ef-4f3c-a692-ba401d25c33a)

However, in the object, the lock icon is not displayed next to the field.

![image](https://github.com/user-attachments/assets/8e448a85-f5a7-415e-982a-5b6a127c2be4)




## Screenshots (if appropriate):


