### PR TITLE
Fix(SavedSearch): Force user to validate criteria before saved search

### DIFF
--- a/js/modules/Search/Table.js
+++ b/js/modules/Search/Table.js
@@ -44,6 +44,19 @@ window.GLPI.Search.Table = class Table extends GenericView {
         super(element_id);
 
         this.shiftSelectAllCheckbox();
+        this.toggleSavedSearch(true);
+    }
+
+    toggleSavedSearch(isDisable) {
+        if (isDisable) {
+            $('.bookmark_record')
+                .attr('title', __('Submit current search before saving it'))
+                .prop('disabled', true);
+        } else {
+            $('.bookmark_record')
+                .attr('title', __('Save current search'))
+                .prop('disabled', false);
+        }
     }
 
     getElement() {
@@ -199,6 +212,7 @@ window.GLPI.Search.Table = class Table extends GenericView {
                 this.getElement().trigger('search_refresh', [this.getElement()]);
                 this.hideLoadingSpinner();
                 this.shiftSelectAllCheckbox();
+                this.toggleSavedSearch(false);
             }, () => {
                 handle_search_failure();
             });


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !35211

Perhaps an alternative to https://github.com/glpi-project/glpi/pull/18376. 

After further review, I believe the issue here is that the saved search system expects the user to execute a search based on their criteria at least once (to include them in the URL).

See `GenericView.js L102`

```js
const bs_modal = new bootstrap.Modal(modal.get(0), {show: false});
modal.on('show.bs.modal', () => {
    const params = JSON.parse(modal.attr('data-params'));
    params['url'] = window.location.pathname + window.location.search;
    modal.find('.modal-body').load(CFG_GLPI.root_doc + '/ajax/savedsearch.php', params);
});
```

If the user does not execute a search at least once, the default search for the item type is used and saved in the database.

Since I don’t see how to extract the search 

![image](https://github.com/user-attachments/assets/aec55cba-e034-4311-9048-f6be6ed50f65)


convert it into a URL as shown here

![image](https://github.com/user-attachments/assets/18fdf1d8-34bc-4e27-93b0-d62abdb94bcf)


 and then pass it to the modal (from `GenericView.js L102`)

 I simply propose checking whether `window.location.search` is not empty or does not correspond to a search reset (`reset=reset`).


## Screenshots (if appropriate):


