### PR TITLE
Fix `AND NOT`/`OR NOT` `view` `contains` search filter

### DIFF
--- a/phpunit/functional/SearchTest.php
+++ b/phpunit/functional/SearchTest.php
@@ -520,7 +520,6 @@ class SearchTest extends DbTestCase
             "/OR\s*\(`glpi_computertypes`\.`name`\s*LIKE '%test%'\s*\)/",
             "/OR\s*\(`glpi_computermodels`\.`name`\s*LIKE '%test%'\s*\)/",
             "/OR\s*\(`glpi_locations`\.`completename`\s*LIKE '%test%'\s*\)/",
-            "/OR\s*\(1=0\s*\)/"
         ];
 
         foreach ($regexps as $regexp) {
@@ -599,7 +598,7 @@ class SearchTest extends DbTestCase
                 ],
                 'expected' => 0
             ],
-            /*[
+            [
                 'itemtype' => 'Computer',
                 'criteria' => [
                     [
@@ -610,7 +609,7 @@ class SearchTest extends DbTestCase
                     ],
                 ],
                 'expected' => 8
-            ],*/
+            ],
             [
                 'itemtype' => 'Computer',
                 'criteria' => [
@@ -695,7 +694,7 @@ class SearchTest extends DbTestCase
                 ],
                 'expected' => 0
             ],
-            /*[
+            [
                 'itemtype' => 'Computer',
                 'criteria' => [
                     [
@@ -706,7 +705,7 @@ class SearchTest extends DbTestCase
                     ],
                 ],
                 'expected' => 8
-            ],*/
+            ],
             [
                 'itemtype' => 'Computer',
                 'criteria' => [

--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -4425,6 +4425,12 @@ final class SQLProvider implements SearchProviderInterface
                     if (isset($val2['nosearch']) && $val2['nosearch']) {
                         continue;
                     }
+                    if (!preg_match(QueryBuilder::getInputValidationPattern($val2['datatype'] ?? '')['pattern'], $criterion['value'])) {
+                        // Do not add a clause on the current field if the searched term does not match the exepected pattern.
+                        // For instance, do not filter on date fields if the searched value is a word.
+                        continue;
+                    }
+
                     if (is_array($val2)) {
                         // Add Where clause if not to be done in HAVING CLAUSE
                         if (!$is_having && !isset($val2["usehaving"])) {


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

Alternative to #18386.
The `Items seen` criteria should add a `WHERE` condition for a displayed field only when the searched term matches the expected pattern of the corresponding search option.