### PR TITLE
Force some session settings to ease the server configuration

### DIFF
--- a/src/Auth.php
+++ b/src/Auth.php
@@ -1742,7 +1742,6 @@ class Auth extends CommonGLPI
         $cookie_path     = ini_get('session.cookie_path');
         $cookie_domain   = ini_get('session.cookie_domain');
         $cookie_secure   = filter_var(ini_get('session.cookie_secure'), FILTER_VALIDATE_BOOLEAN);
-        $cookie_httponly = filter_var(ini_get('session.cookie_httponly'), FILTER_VALIDATE_BOOLEAN);
         $cookie_samesite = ini_get('session.cookie_samesite');
 
         if (empty($cookie_value) && !isset($_COOKIE[$cookie_name])) {
@@ -1757,7 +1756,7 @@ class Auth extends CommonGLPI
                 'path'     => $cookie_path,
                 'domain'   => $cookie_domain,
                 'secure'   => $cookie_secure,
-                'httponly' => $cookie_httponly,
+                'httponly' => true,
                 'samesite' => $cookie_samesite,
             ]
         );

--- a/src/Glpi/Application/SystemConfigurator.php
+++ b/src/Glpi/Application/SystemConfigurator.php
@@ -233,7 +233,11 @@ final class SystemConfigurator
     private function setSessionConfiguration(): void
     {
         // Force session to use cookies.
+        ini_set('session.use_trans_sid', '0');
         ini_set('session.use_only_cookies', '1');
+
+        // Force session cookie security.
+        ini_set('session.cookie_httponly', '1');
 
         // Force session cookie name.
         // The cookie name contains the root dir + HTTP host + HTTP port to ensure that it is unique

--- a/src/Glpi/System/Requirement/SessionsConfiguration.php
+++ b/src/Glpi/System/Requirement/SessionsConfiguration.php
@@ -57,22 +57,11 @@ class SessionsConfiguration extends AbstractRequirement
         }
 
        // Check configuration values
-        $is_autostart_on   = ini_get('session.auto_start') == 1;
-        $is_usetranssid_on = ini_get('session.use_trans_sid') == 1
-         || isset($_POST[session_name()]) || isset($_GET[session_name()]);
+        $is_autostart_on = filter_var(ini_get('session.auto_start'), FILTER_VALIDATE_BOOLEAN);
 
-        if ($is_autostart_on || $is_usetranssid_on) {
-            if ($is_autostart_on && $is_usetranssid_on) {
-                $this->validation_messages[] = __('"session.auto_start" and "session.use_trans_sid" must be set to off.');
-            } else if ($is_autostart_on) {
-                $this->validation_messages[] = __('"session.auto_start" must be set to off.');
-            } else {
-                $this->validation_messages[] = __('"session.use_trans_sid" must be set to off.');
-            }
-
+        if ($is_autostart_on) {
+            $this->validation_messages[] = __('"session.auto_start" must be set to off.');
             $this->validated = false;
-            $this->validation_messages[] = __('See .htaccess file in the GLPI root for more information.');
-
             return;
         }
 

--- a/src/Glpi/System/Requirement/SessionsSecurityConfiguration.php
+++ b/src/Glpi/System/Requirement/SessionsSecurityConfiguration.php
@@ -56,7 +56,6 @@ class SessionsSecurityConfiguration extends AbstractRequirement
         $is_cli = isCommandLine();
 
         $cookie_secure   = filter_var(ini_get('session.cookie_secure'), FILTER_VALIDATE_BOOLEAN);
-        $cookie_httponly = filter_var(ini_get('session.cookie_httponly'), FILTER_VALIDATE_BOOLEAN);
         $cookie_samesite = ini_get('session.cookie_samesite');
 
         $is_https_request = ($_SERVER['HTTPS'] ?? 'off') === 'on' || (int)($_SERVER['SERVER_PORT'] ?? null) == 443;
@@ -68,10 +67,6 @@ class SessionsSecurityConfiguration extends AbstractRequirement
         $cookie_secure_ko = $is_https_request && !$cookie_secure;
         if ($is_cli || $cookie_secure_ko) {
             $this->validation_messages[] = __('PHP directive "session.cookie_secure" should be set to "on" when GLPI can be accessed on HTTPS protocol.');
-        }
-        $cookie_httponly_ko = !$cookie_httponly;
-        if ($is_cli || $cookie_httponly_ko) {
-            $this->validation_messages[] = __('PHP directive "session.cookie_httponly" should be set to "on" to prevent client-side script to access cookie values.');
         }
 
         // 'session.cookie_samesite' can be:
@@ -89,7 +84,7 @@ class SessionsSecurityConfiguration extends AbstractRequirement
             $this->validation_messages[] = __('PHP directive "session.cookie_samesite" should be set, at least, to "Lax", to prevent cookie to be sent on cross-origin POST requests.');
         }
 
-        $this->validated = !$cookie_secure_ko && !$cookie_httponly_ko && !$cookie_samesite_ko;
+        $this->validated = !$cookie_secure_ko && !$cookie_samesite_ko;
 
         if (!$is_cli && $this->validated) {
             $this->validation_messages[] = __('Sessions configuration is secured.');

--- a/tests/functional/Glpi/System/Requirement/SessionsConfiguration.php
+++ b/tests/functional/Glpi/System/Requirement/SessionsConfiguration.php
@@ -70,41 +70,6 @@ class SessionsConfiguration extends \GLPITestCase
          ->isEqualTo(
              [
                  '"session.auto_start" must be set to off.',
-                 'See .htaccess file in the GLPI root for more information.',
-             ]
-         );
-    }
-
-    public function testCheckWithUseTransId()
-    {
-
-        $this->function->ini_get = function ($name) {
-            return $name == 'session.use_trans_sid' ? '1' : '0';
-        };
-
-        $this->newTestedInstance();
-        $this->boolean($this->testedInstance->isValidated())->isEqualTo(false);
-        $this->array($this->testedInstance->getValidationMessages())
-         ->isEqualTo(
-             [
-                 '"session.use_trans_sid" must be set to off.',
-                 'See .htaccess file in the GLPI root for more information.',
-             ]
-         );
-    }
-
-    public function testCheckWithAutostartAndUseTransId()
-    {
-
-        $this->function->ini_get = '1';
-
-        $this->newTestedInstance();
-        $this->boolean($this->testedInstance->isValidated())->isEqualTo(false);
-        $this->array($this->testedInstance->getValidationMessages())
-         ->isEqualTo(
-             [
-                 '"session.auto_start" and "session.use_trans_sid" must be set to off.',
-                 'See .htaccess file in the GLPI root for more information.',
              ]
          );
     }

--- a/tests/functional/Glpi/System/Requirement/SessionsSecurityConfiguration.php
+++ b/tests/functional/Glpi/System/Requirement/SessionsSecurityConfiguration.php
@@ -74,7 +74,6 @@ class SessionsSecurityConfiguration extends \GLPITestCase
             // Totally unsecure config
             yield [
                 'cookie_secure'   => $false,
-                'cookie_httponly' => $false,
                 'cookie_samesite' => 'none',
                 'server_https'    => 'on',
                 'server_port'     => '443',
@@ -84,7 +83,6 @@ class SessionsSecurityConfiguration extends \GLPITestCase
             // Strict config
             yield [
                 'cookie_secure'   => $true,
-                'cookie_httponly' => $true,
                 'cookie_samesite' => 'strict',
                 'server_https'    => 'on',
                 'server_port'     => '443',
@@ -94,7 +92,6 @@ class SessionsSecurityConfiguration extends \GLPITestCase
             // cookie_secure can be 0 if query is not on HTTPS
             yield [
                 'cookie_secure'   => $false,
-                'cookie_httponly' => $true,
                 'cookie_samesite' => 'strict',
                 'server_https'    => 'off',
                 'server_port'     => '80',
@@ -104,7 +101,6 @@ class SessionsSecurityConfiguration extends \GLPITestCase
             // cookie_secure should be 1 if query is on HTTPS (detected from $_SERVER['HTTPS'])
             yield [
                 'cookie_secure'   => $false,
-                'cookie_httponly' => $true,
                 'cookie_samesite' => 'strict',
                 'server_https'    => 'on',
                 'server_port'     => null,
@@ -114,20 +110,9 @@ class SessionsSecurityConfiguration extends \GLPITestCase
             // cookie_secure should be 1 if query is on HTTPS (detected from $_SERVER['SERVER_PORT'])
             yield [
                 'cookie_secure'   => $false,
-                'cookie_httponly' => $true,
                 'cookie_samesite' => 'strict',
                 'server_https'    => null,
                 'server_port'     => '443',
-                'is_valid'        => false,
-            ];
-
-            // cookie_httponly should be 1
-            yield [
-                'cookie_secure'   => $false,
-                'cookie_httponly' => $false,
-                'cookie_samesite' => 'strict',
-                'server_https'    => 'off',
-                'server_port'     => '80',
                 'is_valid'        => false,
             ];
 
@@ -142,7 +127,6 @@ class SessionsSecurityConfiguration extends \GLPITestCase
             foreach ($samesite_is_valid as $samesite => $is_valid) {
                 yield [
                     'cookie_secure'   => $false,
-                    'cookie_httponly' => $true,
                     'cookie_samesite' => $samesite,
                     'server_https'    => 'off',
                     'server_port'     => '80',
@@ -150,7 +134,6 @@ class SessionsSecurityConfiguration extends \GLPITestCase
                 ];
                 yield [
                     'cookie_secure'   => $false,
-                    'cookie_httponly' => $true,
                     'cookie_samesite' => strtolower($samesite),
                     'server_https'    => 'off',
                     'server_port'     => '80',
@@ -165,19 +148,15 @@ class SessionsSecurityConfiguration extends \GLPITestCase
      */
     public function testCheckWithLowercaseLaxSameSiteConfig(
         string $cookie_secure,
-        string $cookie_httponly,
         string $cookie_samesite,
         ?string $server_https,
         ?string $server_port,
         bool $is_valid
     ) {
-        $this->function->ini_get = function ($name) use ($cookie_secure, $cookie_httponly, $cookie_samesite) {
+        $this->function->ini_get = function ($name) use ($cookie_secure, $cookie_samesite) {
             switch ($name) {
                 case 'session.cookie_secure':
                     return $cookie_secure;
-                    break;
-                case 'session.cookie_httponly':
-                    return $cookie_httponly;
                     break;
                 case 'session.cookie_samesite':
                     return $cookie_samesite;
@@ -200,7 +179,6 @@ class SessionsSecurityConfiguration extends \GLPITestCase
                 'Checking the session cookie configuration of the web server cannot be done in the CLI context.',
                 'You should apply the following recommendations for configuring the web server.',
                 'PHP directive "session.cookie_secure" should be set to "on" when GLPI can be accessed on HTTPS protocol.',
-                'PHP directive "session.cookie_httponly" should be set to "on" to prevent client-side script to access cookie values.',
                 'PHP directive "session.cookie_samesite" should be set, at least, to "Lax", to prevent cookie to be sent on cross-origin POST requests.',
             ]
         );


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

We are now sure that the GLPI bootstrapping made in the `SystemConfigurator` class will be done prior to any core front/ajax script and any plugin file inclusion and therefore before any possibility that a session was manually started. We can therefore force some session configuration in order to simplify the configuration requirements.