### PR TITLE
Fix tickets users added after webhook filter check

### DIFF
--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -1374,7 +1374,6 @@ class CommonDBTM extends CommonGLPI
             if ($this->checkUnicity(true, $options)) {
                 if ($this->addToDB() !== false) {
                     $this->post_addItem();
-                    Webhook::raise('new', $this);
                     if ($this instanceof CacheableListInterface) {
                         $this->invalidateListCache();
                     }
@@ -1422,6 +1421,7 @@ class CommonDBTM extends CommonGLPI
                         //Check if we have to automatically fill dates
                         Infocom::manageDateOnStatusChange($this);
                     }
+                    Webhook::raise('new', $this);
                     Plugin::doHook(Hooks::ITEM_ADD, $this);
 
                     // As add have succeeded, clean the old input value

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -1421,8 +1421,8 @@ class CommonDBTM extends CommonGLPI
                         //Check if we have to automatically fill dates
                         Infocom::manageDateOnStatusChange($this);
                     }
-                    Webhook::raise('new', $this);
                     Plugin::doHook(Hooks::ITEM_ADD, $this);
+                    Webhook::raise('new', $this);
 
                     // As add have succeeded, clean the old input value
                     if (isset($this->input['_add'])) {

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -1373,8 +1373,8 @@ class CommonDBTM extends CommonGLPI
 
             if ($this->checkUnicity(true, $options)) {
                 if ($this->addToDB() !== false) {
-                    Webhook::raise('new', $this);
                     $this->post_addItem();
+                    Webhook::raise('new', $this);
                     if ($this instanceof CacheableListInterface) {
                         $this->invalidateListCache();
                     }

--- a/tests/functional/Migration.php
+++ b/tests/functional/Migration.php
@@ -146,13 +146,13 @@ class Migration extends \GLPITestCase
             'SELECT `id` FROM `glpi_configs` WHERE `context` = \'core\' AND `name` = \'one\'',
             'INSERT INTO `glpi_configs` (`context`, `name`, `value`) VALUES (\'core\', \'one\', \'key\')',
             'SELECT * FROM `glpi_configs` WHERE `glpi_configs`.`id` = \'0\' LIMIT 1',
-            'SELECT `table_name` AS `TABLE_NAME` FROM `information_schema`.`tables` WHERE `table_schema` = \'' . $DB->dbdefault . '\' AND `table_type` = \'BASE TABLE\' AND `table_name` LIKE \'glpi_webhooks\'',
             'INSERT INTO `glpi_logs` (`items_id`, `itemtype`, `itemtype_link`, `linked_action`, `user_name`, `date_mod`, `id_search_option`, `old_value`, `new_value`) VALUES (\'1\', \'Config\', \'\', \'0\', \'\', \'' . $_SESSION['glpi_currenttime'] . '\', \'1\', \'one \', \'key\')',
+            'SELECT `table_name` AS `TABLE_NAME` FROM `information_schema`.`tables` WHERE `table_schema` = \'' . $DB->dbdefault . '\' AND `table_type` = \'BASE TABLE\' AND `table_name` LIKE \'glpi_webhooks\'',
             'SELECT `id` FROM `glpi_configs` WHERE `context` = \'core\' AND `name` = \'two\'',
             'INSERT INTO `glpi_configs` (`context`, `name`, `value`) VALUES (\'core\', \'two\', \'value\')',
             'SELECT * FROM `glpi_configs` WHERE `glpi_configs`.`id` = \'0\' LIMIT 1',
-            'SELECT `table_name` AS `TABLE_NAME` FROM `information_schema`.`tables` WHERE `table_schema` = \'' . $DB->dbdefault . '\' AND `table_type` = \'BASE TABLE\' AND `table_name` LIKE \'glpi_webhooks\'',
             'INSERT INTO `glpi_logs` (`items_id`, `itemtype`, `itemtype_link`, `linked_action`, `user_name`, `date_mod`, `id_search_option`, `old_value`, `new_value`) VALUES (\'1\', \'Config\', \'\', \'0\', \'\', \'' . $_SESSION['glpi_currenttime'] . '\', \'1\', \'two \', \'value\')',
+            'SELECT `table_name` AS `TABLE_NAME` FROM `information_schema`.`tables` WHERE `table_schema` = \'' . $DB->dbdefault . '\' AND `table_type` = \'BASE TABLE\' AND `table_name` LIKE \'glpi_webhooks\'',
         ];
         $this->array($this->queries)->isIdenticalTo($core_queries, print_r($this->queries, true));
 
@@ -174,13 +174,13 @@ class Migration extends \GLPITestCase
             'SELECT `id` FROM `glpi_configs` WHERE `context` = \'test-context\' AND `name` = \'one\'',
             'INSERT INTO `glpi_configs` (`context`, `name`, `value`) VALUES (\'test-context\', \'one\', \'key\')',
             'SELECT * FROM `glpi_configs` WHERE `glpi_configs`.`id` = \'0\' LIMIT 1',
-            'SELECT `table_name` AS `TABLE_NAME` FROM `information_schema`.`tables` WHERE `table_schema` = \'' . $DB->dbdefault . '\' AND `table_type` = \'BASE TABLE\' AND `table_name` LIKE \'glpi_webhooks\'',
             'INSERT INTO `glpi_logs` (`items_id`, `itemtype`, `itemtype_link`, `linked_action`, `user_name`, `date_mod`, `id_search_option`, `old_value`, `new_value`) VALUES (\'1\', \'Config\', \'\', \'0\', \'\', \'' . $_SESSION['glpi_currenttime'] . '\', \'1\', \'one (test-context) \', \'key\')',
+            'SELECT `table_name` AS `TABLE_NAME` FROM `information_schema`.`tables` WHERE `table_schema` = \'' . $DB->dbdefault . '\' AND `table_type` = \'BASE TABLE\' AND `table_name` LIKE \'glpi_webhooks\'',
             'SELECT `id` FROM `glpi_configs` WHERE `context` = \'test-context\' AND `name` = \'two\'',
             'INSERT INTO `glpi_configs` (`context`, `name`, `value`) VALUES (\'test-context\', \'two\', \'value\')',
             'SELECT * FROM `glpi_configs` WHERE `glpi_configs`.`id` = \'0\' LIMIT 1',
-            'SELECT `table_name` AS `TABLE_NAME` FROM `information_schema`.`tables` WHERE `table_schema` = \'' . $DB->dbdefault . '\' AND `table_type` = \'BASE TABLE\' AND `table_name` LIKE \'glpi_webhooks\'',
             'INSERT INTO `glpi_logs` (`items_id`, `itemtype`, `itemtype_link`, `linked_action`, `user_name`, `date_mod`, `id_search_option`, `old_value`, `new_value`) VALUES (\'1\', \'Config\', \'\', \'0\', \'\', \'' . $_SESSION['glpi_currenttime'] . '\', \'1\', \'two (test-context) \', \'value\')',
+            'SELECT `table_name` AS `TABLE_NAME` FROM `information_schema`.`tables` WHERE `table_schema` = \'' . $DB->dbdefault . '\' AND `table_type` = \'BASE TABLE\' AND `table_name` LIKE \'glpi_webhooks\'',
         ]);
 
        //test with one existing value => only new key should be inserted


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !35208
- Here is a brief description of what this PR does

In the webhook filters, when targeting ticket creations (e.g., "Technician assigned is Jon Doe"), the webhook is not triggered for a ticket that meets the valid conditions.
The issue lies in the fact that post_add elements (such as adding a user to the ticket) are processed only after the filtering criteria are evaluated to determine whether the webhook should be triggered.

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/d76911b8-f3d3-47f7-94cb-2f8593bb95ec)


