### PR TITLE
Don't use `exit` anymore for Html::redirect

### DIFF
--- a/src/Glpi/Exception/Http/RedirectException.php
+++ b/src/Glpi/Exception/Http/RedirectException.php
@@ -34,6 +34,7 @@
 
 namespace Glpi\Exception\Http;
 
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpKernel\Exception\HttpException as BaseException;
 
 /**
@@ -48,6 +49,10 @@ class RedirectException extends BaseException implements HttpExceptionInterface
     public function __construct(string $url, int $http_code = 302, string $message = '')
     {
         $this->url = $url;
+
+        // Will automatically trigger an exception if the HTTP code isn't a Redirect one.
+        new RedirectResponse('', $http_code);
+
         parent::__construct($http_code, $message);
     }
 }

--- a/src/Glpi/Exception/Http/RedirectException.php
+++ b/src/Glpi/Exception/Http/RedirectException.php
@@ -46,13 +46,16 @@ class RedirectException extends BaseException implements HttpExceptionInterface
 
     public readonly string $url;
 
-    public function __construct(string $url, int $http_code = 302, string $message = '')
+    public function __construct(string $url, int $http_code = 302)
     {
         $this->url = $url;
 
-        // Will automatically trigger an exception if the HTTP code isn't a Redirect one.
+        /**
+         * Will automatically trigger an exception if the HTTP code isn't a Redirect one.
+         * @see RedirectResponse::isRedirect
+         */
         new RedirectResponse('', $http_code);
 
-        parent::__construct($http_code, $message);
+        parent::__construct($http_code);
     }
 }

--- a/src/Glpi/Exception/Http/RedirectException.php
+++ b/src/Glpi/Exception/Http/RedirectException.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Exception\Http;
+
+use Symfony\Component\HttpKernel\Exception\HttpException as BaseException;
+
+/**
+ * @internal Not to be used unless you absolutely know what you are doing. This will be removed in the future when all the code is under Dependency Injection and proper HTTP routing.
+ */
+class RedirectException extends BaseException implements HttpExceptionInterface
+{
+    use HttpExceptionTrait;
+
+    public readonly string $url;
+
+    public function __construct(string $url, int $http_code = 302, string $message = '')
+    {
+        $this->url = $url;
+        parent::__construct($http_code, $message);
+    }
+}

--- a/src/Glpi/Exception/RedirectException.php
+++ b/src/Glpi/Exception/RedirectException.php
@@ -32,30 +32,26 @@
  * ---------------------------------------------------------------------
  */
 
-namespace Glpi\Exception\Http;
+namespace Glpi\Exception;
 
+use Exception;
 use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\HttpKernel\Exception\HttpException as BaseException;
 
 /**
- * @internal Not to be used unless you absolutely know what you are doing. This will be removed in the future when all the code is under Dependency Injection and proper HTTP routing.
+ * @internal Not to be used unless you absolutely know what you are doing.
+ *           This will be removed in the future when all the code is under Dependency Injection and proper HTTP routing.
  */
-class RedirectException extends BaseException implements HttpExceptionInterface
+class RedirectException extends Exception
 {
-    use HttpExceptionTrait;
-
-    public readonly string $url;
+    private RedirectResponse $response;
 
     public function __construct(string $url, int $http_code = 302)
     {
-        $this->url = $url;
+        $this->response = new RedirectResponse($url, $http_code);
+    }
 
-        /**
-         * Will automatically trigger an exception if the HTTP code isn't a Redirect one.
-         * @see RedirectResponse::isRedirect
-         */
-        new RedirectResponse('', $http_code);
-
-        parent::__construct($http_code);
+    public function getResponse(): RedirectResponse
+    {
+        return $this->response;
     }
 }

--- a/src/Glpi/Http/AccessErrorListener.php
+++ b/src/Glpi/Http/AccessErrorListener.php
@@ -37,7 +37,7 @@ namespace Glpi\Http;
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\Exception\Http\AccessDeniedHttpException;
 use Glpi\Exception\AuthenticationFailedException;
-use Glpi\Exception\Http\RedirectException;
+use Glpi\Exception\RedirectException;
 use Glpi\Exception\SessionExpiredException;
 use Session;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -64,6 +64,12 @@ final class AccessErrorListener implements EventSubscriberInterface
         }
 
         $request = $event->getRequest();
+
+        if ($request->isXmlHttpRequest()) {
+            // Do not redirect AJAX requests.
+            return;
+        }
+
         $throwable = $event->getThrowable();
 
         $response = null;
@@ -79,7 +85,7 @@ final class AccessErrorListener implements EventSubscriberInterface
                 )
             );
         } elseif ($throwable instanceof RedirectException) {
-            $response = new RedirectResponse($throwable->url, $throwable->getStatusCode());
+            $response = $throwable->getResponse();
         } elseif (
             $throwable instanceof AccessDeniedHttpException
             && ($_SESSION['_redirected_from_profile_selector'] ?? false)

--- a/src/Glpi/Http/AccessErrorListener.php
+++ b/src/Glpi/Http/AccessErrorListener.php
@@ -37,6 +37,7 @@ namespace Glpi\Http;
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\Exception\Http\AccessDeniedHttpException;
 use Glpi\Exception\AuthenticationFailedException;
+use Glpi\Exception\Http\RedirectException;
 use Glpi\Exception\SessionExpiredException;
 use Session;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -77,6 +78,8 @@ final class AccessErrorListener implements EventSubscriberInterface
                     \rawurlencode($request->getPathInfo() . '?' . $request->getQueryString())
                 )
             );
+        } elseif ($throwable instanceof RedirectException) {
+            $response = new RedirectResponse($throwable->url, $throwable->getStatusCode());
         } elseif (
             $throwable instanceof AccessDeniedHttpException
             && ($_SESSION['_redirected_from_profile_selector'] ?? false)

--- a/src/Html.php
+++ b/src/Html.php
@@ -42,7 +42,7 @@ use Glpi\Console\Application;
 use Glpi\Exception\Http\AccessDeniedHttpException;
 use Glpi\Exception\Http\BadRequestHttpException;
 use Glpi\Exception\Http\NotFoundHttpException;
-use Glpi\Exception\Http\RedirectException;
+use Glpi\Exception\RedirectException;
 use Glpi\Plugin\Hooks;
 use Glpi\Toolbox\FrontEnd;
 use Glpi\Toolbox\URL;
@@ -434,7 +434,7 @@ class Html
      **/
     public static function redirect($dest, $http_response_code = 302): never
     {
-        throw new RedirectException(\addslashes($dest), $http_response_code);
+        throw new RedirectException($dest, $http_response_code);
     }
 
     /**

--- a/src/Html.php
+++ b/src/Html.php
@@ -431,8 +431,6 @@ class Html
      * @param string $http_response_code Forces the HTTP response code to the specified value
      *
      * @return never
-     *
-     * @TODO: check if $http_response_code is still used.
      **/
     public static function redirect($dest, $http_response_code = 302): never
     {

--- a/src/Html.php
+++ b/src/Html.php
@@ -42,6 +42,7 @@ use Glpi\Console\Application;
 use Glpi\Exception\Http\AccessDeniedHttpException;
 use Glpi\Exception\Http\BadRequestHttpException;
 use Glpi\Exception\Http\NotFoundHttpException;
+use Glpi\Exception\Http\RedirectException;
 use Glpi\Plugin\Hooks;
 use Glpi\Toolbox\FrontEnd;
 use Glpi\Toolbox\URL;
@@ -430,32 +431,12 @@ class Html
      * @param string $http_response_code Forces the HTTP response code to the specified value
      *
      * @return never
+     *
+     * @TODO: check if $http_response_code is still used.
      **/
     public static function redirect($dest, $http_response_code = 302): never
     {
-
-        $toadd = '';
-
-        if (!headers_sent() && !Toolbox::isAjax()) {
-            header("Location: " . addslashes($dest), true, $http_response_code);
-            exit();
-        }
-
-        if (strpos($dest, "?") !== false) {
-            $toadd = '&tokonq=' . Toolbox::getRandomString(5);
-        } else {
-            $toadd = '?tokonq=' . Toolbox::getRandomString(5);
-        }
-
-        echo "<script type='text/javascript'>
-            NomNav = navigator.appName;
-            if (NomNav=='Konqueror') {
-               window.location=" . json_encode($dest . $toadd) . ";
-            } else {
-               window.location=" . json_encode($dest) . ";
-            }
-         </script>";
-        exit();
+        throw new RedirectException(\addslashes($dest), $http_response_code);
     }
 
     /**


### PR DESCRIPTION
Converts "exit" into an exception that will be converted by a proper redirection by the existing exception listener in the project