### PR TITLE
Fix: Preserve Redirection Links for Images in Emails

### DIFF
--- a/phpunit/functional/ToolboxTest.php
+++ b/phpunit/functional/ToolboxTest.php
@@ -968,6 +968,58 @@ HTML;
             $expected_result,
             \Toolbox::convertTagToImage($content_text, $item, $docs_data)
         );
+
+        $content_text2 = <<<HTML
+            <a href="http://example.org/" target="_blank"><img id="{$img_1_tag}" width="10" height="10" /></a>
+        HTML;
+
+        $expected_result2 = <<<HTML
+            <a href="http://example.org/" target="_blank"><img alt="{$img_1_tag}" width="10" src="{$image_1_src}" /></a>
+        HTML;
+
+        // Processed data is expected to be sanitized, and expected result should remain sanitized
+        $this->assertEquals(
+            Sanitizer::sanitize($expected_result2),
+            \Toolbox::convertTagToImage(Sanitizer::sanitize($content_text2), $item, $docs_data)
+        );
+
+        // Processed data may also be escaped using Toolbox::addslashes_deep(), and expected result should be escaped too
+        $this->assertEquals(
+            \Toolbox::addslashes_deep($expected_result2),
+            \Toolbox::convertTagToImage(\Toolbox::addslashes_deep($content_text2), $item, $docs_data)
+        );
+
+        // Processed data may also be not sanitized, and expected result should not be sanitized
+        $this->assertEquals(
+            $expected_result2,
+            \Toolbox::convertTagToImage($content_text2, $item, $docs_data)
+        );
+
+        $content_text3 = <<<HTML
+            <a href="http://example.org/">Some Content<div><img id="{$img_1_tag}" width="10" height="10" /><p>Content</p></div></a>
+        HTML;
+
+        $expected_result3 = <<<HTML
+            <a href="http://example.org/">Some Content<div><img alt="{$img_1_tag}" width="10" src="{$image_1_src}" /><p>Content</p></div></a>
+        HTML;
+
+        // Processed data is expected to be sanitized, and expected result should remain sanitized
+        $this->assertEquals(
+            Sanitizer::sanitize($expected_result3),
+            \Toolbox::convertTagToImage(Sanitizer::sanitize($content_text3), $item, $docs_data)
+        );
+
+        // Processed data may also be escaped using Toolbox::addslashes_deep(), and expected result should be escaped too
+        $this->assertEquals(
+            \Toolbox::addslashes_deep($expected_result3),
+            \Toolbox::convertTagToImage(\Toolbox::addslashes_deep($content_text3), $item, $docs_data)
+        );
+
+        // Processed data may also be not sanitized, and expected result should not be sanitized
+        $this->assertEquals(
+            $expected_result3,
+            \Toolbox::convertTagToImage($content_text3, $item, $docs_data)
+        );
     }
 
     public static function shortenNumbers()

--- a/phpunit/functional/ToolboxTest.php
+++ b/phpunit/functional/ToolboxTest.php
@@ -943,7 +943,7 @@ HTML;
         $expected_result  = <<<HTML
             Some contents with <a href="http://example.org/">a link</a>
             and a first image <a href="{$expected_url_1}" target="_blank"><img alt="{$img_1_tag}" width="10" src="{$image_1_src}" /></a> inside a link
-            then a second image surrounded by links <a href="http://www.example.org/">link1</a> <a href="{$image_2_src}" target="_blank" ><img alt="{$img_2_tag}" width="10" src="{$image_2_src}" /></a> <a href="http://www.example.org/2">link2</a>
+            then a second image surrounded by links <a href="http://www.example.org/">link1</a> <img alt="{$img_2_tag}" width="10" src="{$image_2_src}" /> <a href="http://www.example.org/2">link2</a>
 HTML;
 
         $docs_data = [

--- a/phpunit/functional/ToolboxTest.php
+++ b/phpunit/functional/ToolboxTest.php
@@ -943,7 +943,7 @@ HTML;
         $expected_result  = <<<HTML
             Some contents with <a href="http://example.org/">a link</a>
             and a first image <a href="{$expected_url_1}" target="_blank"><img alt="{$img_1_tag}" width="10" src="{$image_1_src}" /></a> inside a link
-            then a second image surrounded by links <a href="http://www.example.org/">link1</a> <img alt="{$img_2_tag}" width="10" src="{$image_2_src}" /> <a href="http://www.example.org/2">link2</a>
+            then a second image surrounded by links <a href="http://www.example.org/">link1</a> <a href="{$image_2_src}" target="_blank" ><img alt="{$img_2_tag}" width="10" src="{$image_2_src}" /></a> <a href="http://www.example.org/2">link2</a>
 HTML;
 
         $docs_data = [

--- a/src/RichText/RichText.php
+++ b/src/RichText/RichText.php
@@ -542,6 +542,16 @@ HTML;
          $('.pswp-img{$p['rand']}').on('click', 'figure', function(event) {
             event.preventDefault();
 
+            const documentChildren = Array.from(pswp.parentNode.children);
+            const hasLinkRedirection = documentChildren.length > 0 && documentChildren[0].tagName.toLowerCase() === 'a';
+
+            if (hasLinkRedirection) {
+                let url = documentChildren[0].getAttribute('href');
+                if (url) {
+                    window.open(url, '_blank');
+                }
+            }
+
             var options = {
                 index: $(this).index(),
                 bgOpacity: 0.7,

--- a/src/RichText/RichText.php
+++ b/src/RichText/RichText.php
@@ -542,16 +542,6 @@ HTML;
          $('.pswp-img{$p['rand']}').on('click', 'figure', function(event) {
             event.preventDefault();
 
-            const documentChildren = Array.from(pswp.parentNode.children);
-            const hasLinkRedirection = documentChildren.length > 0 && documentChildren[0].tagName.toLowerCase() === 'a';
-
-            if (hasLinkRedirection) {
-                let url = documentChildren[0].getAttribute('href');
-                if (url) {
-                    window.open(url, '_blank');
-                }
-            }
-
             var options = {
                 index: $(this).index(),
                 bgOpacity: 0.7,

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -2837,7 +2837,8 @@ class Toolbox
                             // Avoids creating a link within a link, when the image is already in an <a> tag
                             $add_link_tmp = $add_link;
                             if ($add_link) {
-                                $pattern = '/<a[^>]*>(?![^<]*<a)(?:(?!<\/a>)[\s\S])*?<img[^>]*' . preg_quote($image['tag'], '/') . '[^>]*>[\s\S]*?<\/a>/s';
+                                // Try to detect any unclosed `<a>` tag that preced the `<img>` tag
+                                $pattern = '/<a[^>]*>((?!<\/a>).)*<img[^>]*' . preg_quote($image['tag'], '/') . '/s';
                                 if (preg_match($pattern, $content_text)) {
                                     $add_link_tmp = false;
                                 }

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -2838,7 +2838,7 @@ class Toolbox
                             // Avoids creating a link within a link, when the image is already in an <a> tag
                             $add_link_tmp = $add_link;
                             if ($add_link) {
-                                $pattern = '/<a[^>]*>[^<>]*?<img[^>]+' . preg_quote($image['tag'], '/') . '[^<]+>[^<>]*?<\/a>/s';
+                                $pattern = '/<a[^>]*>.*?<img[^>]*' . preg_quote($image['tag'], '/') . '[^>]*>.*?<\/a>/s';
                                 if (preg_match($pattern, $content_text)) {
                                     $add_link_tmp = false;
                                 }

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -2838,7 +2838,7 @@ class Toolbox
                             // Avoids creating a link within a link, when the image is already in an <a> tag
                             $add_link_tmp = $add_link;
                             if ($add_link) {
-                                $pattern = '/<a[^>]*>.*?<img[^>]*' . preg_quote($image['tag'], '/') . '[^>]*>.*?<\/a>/s';
+                                $pattern = '/<a[^>]*>[^<>]*?<img[^>]+' . preg_quote($image['tag'], '/') . '[^<]+>[^<>]*?<\/a>/s';
                                 if (preg_match($pattern, $content_text)) {
                                     $add_link_tmp = false;
                                 }
@@ -2849,7 +2849,7 @@ class Toolbox
                                 $width,
                                 $height,
                                 $add_link_tmp,
-                                $object_url_param
+                                $object_url_param,
                             );
                             if (empty($new_image)) {
                                   $new_image = '#' . $image['tag'] . '#';

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -2834,11 +2834,10 @@ class Toolbox
                                 $width = $img_infos[0];
                                 $height = $img_infos[1];
                             }
-
                             // Avoids creating a link within a link, when the image is already in an <a> tag
                             $add_link_tmp = $add_link;
                             if ($add_link) {
-                                $pattern = '/<a[^>]*>[^<>]*?<img[^>]+' . preg_quote($image['tag'], '/') . '[^<]+>[^<>]*?<\/a>/s';
+                                $pattern = '/<a[^>]*>(?![^<]*<a)(?:(?!<\/a>)[\s\S])*?<img[^>]*' . preg_quote($image['tag'], '/') . '[^>]*>[\s\S]*?<\/a>/s';
                                 if (preg_match($pattern, $content_text)) {
                                     $add_link_tmp = false;
                                 }


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.

## Description

It fixes !35308 and !36506

When an image is sent by email, it is possible to link it in order to redirect the user to another page. SharePoint uses this system which links to images. The problem is that if the user sends an image containing a redirect link, GLPI displays the image in the DOM but does not redirect the user to the associated link.


