### PR TITLE
Load styles before scripts in install pages

### DIFF
--- a/install/install.php
+++ b/install/install.php
@@ -62,6 +62,11 @@ function header_html($etape)
     echo "<meta charset='utf-8'>";
     echo "<title>Setup GLPI</title>";
 
+    // CSS
+    echo Html::css('lib/tabler.css');
+    echo Html::css('lib/base.css');
+    echo Html::scss("css/install", [], true);
+
    // CFG
     echo Html::getCoreVariablesForJavascript();
 
@@ -71,10 +76,6 @@ function header_html($etape)
     echo Html::script("js/common.js");
     echo Html::script("js/glpi_dialog.js");
 
-    // CSS
-    echo Html::css('lib/tabler.css');
-    echo Html::css('lib/base.css');
-    echo Html::scss("css/install", [], true);
     echo "</head>";
     echo "<body>";
     echo "<div id='principal'>";


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

It may fix a blinking effect on the install page.
@trasher reported that the page seems to be displayed without styles then some milliseconds after, displayed wih correct styles.