### PR TITLE
Fix loadings of JS locales on install/update pages

### DIFF
--- a/install/install.php
+++ b/install/install.php
@@ -56,26 +56,29 @@ function header_html($etape)
    // Send UTF8 Headers
     header("Content-Type: text/html; charset=UTF-8");
 
-    echo "<!DOCTYPE html'>";
-    echo "<html lang='en_GB'>";
-    echo "<head>";
-    echo "<meta charset='utf-8'>";
-    echo "<title>Setup GLPI</title>";
+    TemplateRenderer::getInstance()->display('layout/parts/head.html.twig', [
+        'lang'  => $_SESSION['glpilanguage'],
+        'title' => __('GLPI setup'),
+        'css_files' => [
+            ['path' => 'lib/tabler.css'],
+            ['path' => 'lib/base.css'],
+            ['path' => 'css/install.scss'],
+        ],
+        'js_files' => [
+            ['path' => 'lib/base.js'],
+            ['path' => 'js/glpi_dialog.js'],
 
-   // CFG
+            // required for the language dropdown
+            ['path' => 'lib/fuzzy.js'],
+            ['path' => 'js/common.js'],
+        ],
+        'js_modules' => [],
+        'custom_header_tags' => [],
+    ]);
+
+    // CFG
     echo Html::getCoreVariablesForJavascript();
 
-    // LIBS
-    echo Html::script("lib/base.js");
-    echo Html::script("lib/fuzzy.js");
-    echo Html::script("js/common.js");
-    echo Html::script("js/glpi_dialog.js");
-
-    // CSS
-    echo Html::css('lib/tabler.css');
-    echo Html::css('lib/base.css');
-    echo Html::scss("css/install", [], true);
-    echo "</head>";
     echo "<body>";
     echo "<div id='principal'>";
     echo "<div id='bloc'>";
@@ -548,9 +551,6 @@ if (!isset($_SESSION['can_process_install']) || !isset($_POST["install"])) {
 
         case "Etape_1": // check ok, go import mysql settings.
             checkConfigFile();
-           // check system ok, we can use specific parameters for debug
-            Toolbox::setDebugMode(Session::DEBUG_MODE, 0, 0, 1);
-
             header_html(sprintf(__('Step %d'), 1));
             step2($_POST["update"]);
             break;

--- a/install/update.php
+++ b/install/update.php
@@ -95,10 +95,6 @@ function doUpdateDb()
      */
     global $migration, $update;
 
-    // Init debug variable
-    // Only show errors
-    Toolbox::setDebugMode(Session::DEBUG_MODE, 0, 0, 1);
-
     $currents            = $update->getCurrents();
     $current_version     = $currents['version'];
     $current_db_version  = $currents['dbversion'];
@@ -172,19 +168,27 @@ Session::loadLanguage('', false);
 // Send UTF8 Headers
 header("Content-Type: text/html; charset=UTF-8");
 
-echo "<!DOCTYPE html>";
-echo "<html lang='fr'>";
-echo "<head>";
-echo "<meta charset='utf-8'>";
-echo "<title>" . __s('GLPI setup') . "</title>";
-//JS
-echo Html::script("lib/base.js");
-echo Html::script("js/glpi_dialog.js");
-// CSS
-echo Html::css('lib/tabler.css');
-echo Html::css('lib/base.css');
-echo Html::scss("css/install", [], true);
-echo "</head>";
+TemplateRenderer::getInstance()->display('layout/parts/head.html.twig', [
+    'lang'  => $_SESSION['glpilanguage'],
+    'title' => __('GLPI setup'),
+    'css_files' => [
+        ['path' => 'lib/tabler.css'],
+        ['path' => 'lib/base.css'],
+        ['path' => 'css/install.scss'],
+    ],
+    'js_files' => [
+        ['path' => 'lib/base.js'],
+        ['path' => 'lib/fuzzy.js'],
+        ['path' => 'js/common.js'],
+        ['path' => 'js/glpi_dialog.js'],
+    ],
+    'js_modules' => [],
+    'custom_header_tags' => [],
+]);
+
+// CFG
+echo Html::getCoreVariablesForJavascript();
+
 echo "<body>";
 echo "<div id='principal'>";
 echo "<div id='bloc'>";

--- a/src/Html.php
+++ b/src/Html.php
@@ -5102,24 +5102,25 @@ HTML;
      *
      * @param string  $url      File to include (relative to GLPI_ROOT)
      * @param array   $options  Array of HTML attributes
-     * @param bool    $no_debug Ignore the debug mode of GLPI (usefull for install/update process)
      *
      * @return string CSS link tag
+     *
+     * @since 11.0.0 The `$no_debug` parameter has bbeen removed.
      **/
-    public static function scss($url, $options = [], bool $no_debug = false)
+    public static function scss($url, $options = [])
     {
         $prod_file = self::getScssCompilePath($url);
 
         if (
             file_exists($prod_file)
-            && ($no_debug || $_SESSION['glpi_use_mode'] != Session::DEBUG_MODE)
+            && $_SESSION['glpi_use_mode'] != Session::DEBUG_MODE
         ) {
             $url = self::getPrefixedUrl(str_replace(GLPI_ROOT, '', $prod_file));
         } else {
             $file = $url;
             $url = self::getPrefixedUrl('/front/css.php');
             $url .= '?file=' . $file;
-            if (!$no_debug && $_SESSION['glpi_use_mode'] == Session::DEBUG_MODE) {
+            if ($_SESSION['glpi_use_mode'] == Session::DEBUG_MODE) {
                 $url .= '&debug';
             }
         }

--- a/templates/layout/parts/head.html.twig
+++ b/templates/layout/parts/head.html.twig
@@ -32,9 +32,18 @@
  #}
 
 <!DOCTYPE html>
-<html lang="{{ lang }}" {% if high_contrast %}data-high-contrast="1"{% endif %}
-      data-glpi-theme="{{ theme.getKey() }}" data-glpi-theme-dark="{{ theme.isDarkTheme() ? '1' : '0' }}"
-      {{ glpi_request_id is defined ? 'data-glpi-request-id=' ~ glpi_request_id : '' }}>
+<html lang="{{ lang }}"
+    {% if high_contrast %}
+        data-high-contrast="1"
+    {% endif %}
+    {% if theme is defined %}
+        data-glpi-theme="{{ theme.getKey() }}"
+        data-glpi-theme-dark="{{ theme.isDarkTheme() ? '1' : '0' }}"
+    {% endif %}
+    {% if glpi_request_id is defined %}
+        data-glpi-request-id="{{ glpi_request_id }}"
+    {% endif %}
+>
 <head>
    <title>{{ title }} - {{ config('app_name') }}</title>
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Required for #18296 .

The locales were not loaded on the JS side in the install/update process. Instead of implementing a custom piece of code, I reused the `layout/parts/head.html.twig` template that contains a call to `{{ locales_js() }}`.

It also replaces #18400.