### PR TITLE
fix border radius of last tab in vertical layout

### DIFF
--- a/css/includes/components/_tabs.scss
+++ b/css/includes/components/_tabs.scss
@@ -71,6 +71,7 @@
     &.vertical {
         .nav-link {
             border-bottom: $card-border-width solid $card-border-color;
+            border-top-right-radius: 0;
 
             &.active {
                 border-left-width: 5px;


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

The last tab (usually "All"), has a bad top-left radius with a vertical presentation

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/4f1c5dd0-344b-48c5-93ce-d9ef9939aadf)

