### PR TITLE
Exclude `SessionProgress` from DI

### DIFF
--- a/dependency_injection/services.php
+++ b/dependency_injection/services.php
@@ -58,7 +58,7 @@ return static function (ContainerConfigurator $container): void {
     $services->load('Glpi\Controller\\', $projectDir . '/src/Glpi/Controller');
     $services->load('Glpi\Http\\', $projectDir . '/src/Glpi/Http');
     $services->load('Glpi\DependencyInjection\\', $projectDir . '/src/Glpi/DependencyInjection');
-    $services->load('Glpi\Progress\\', $projectDir . '/src/Glpi/Progress');
+    $services->load('Glpi\Progress\\', $projectDir . '/src/Glpi/Progress')->exclude($projectDir . '/src/Glpi/Progress/SessionProgress.php');
 
     /**
      * Override Symfony's logger.


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

See https://github.com/glpi-project/glpi/pull/18296#discussion_r1861844945

Not sure it is necessary. There is no reference to this class in any service, so the DI will probably never try to instanciate it.

