### PR TITLE
fix: authmail connection test form

### DIFF
--- a/src/AuthMail.php
+++ b/src/AuthMail.php
@@ -206,10 +206,11 @@ class AuthMail extends CommonDBTM
 
         if ($this->getFromDB($ID)) {
             $twig_params = [
-                'title' => __('Test connection to email server'),
-                'login' => __('Login'),
-                'password' => __('Password'),
-                'test' => _x('button', 'Test'),
+                'title'          => __('Test connection to email server'),
+                'login'          => __('Login'),
+                'password'       => __('Password'),
+                'test'           => _x('button', 'Test'),
+                'connect_string' => $this->fields['connect_string'] ?? ''
             ];
             // language=Twig
             echo TemplateRenderer::getInstance()->renderFromStringTemplate(<<<TWIG
@@ -232,6 +233,7 @@ class AuthMail extends CommonDBTM
                                 autocomplete: 'password'
                             }
                         }) }}
+                        {{ fields.hiddenField('imap_string', connect_string) }}
                         <div>
                             <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}">
                             <button type="submit" name="test" class="btn btn-primary">{{ test }}</button>

--- a/templates/pages/setup/authentication/mail.html.twig
+++ b/templates/pages/setup/authentication/mail.html.twig
@@ -41,7 +41,7 @@
     {% set connect_opts = call('Toolbox::parseMailServerConnectString', [item.fields['connect_string']]) %}
     {{ include('pages/setup/mailcollector/server_config_fields.html.twig', {
         'connect_opts': connect_opts,
-        'host': item.fields['connect_string']
+        'connect_string': item.fields['connect_string']
     }) }}
 
     {{ fields.smallTitle(__('Email options')) }}

--- a/templates/pages/setup/mailcollector/server_config_fields.html.twig
+++ b/templates/pages/setup/mailcollector/server_config_fields.html.twig
@@ -32,7 +32,6 @@
  #}
 
 {% import 'components/form/fields_macros.html.twig' as fields %}
-{% import 'components/form/basic_inputs_macros.html.twig' as inputs %}
 
 {{ fields.textField(
    'mail_server',
@@ -119,9 +118,8 @@
    connection_options_fields,
    __('Connection options')
 ) }}
-{{ inputs.hidden('imap_string', host) }}
-{% if host is not empty %}
-   {{ fields.htmlField('', host, __('Connection string'), {
+{% if connect_string is not empty %}
+   {{ fields.htmlField('', connect_string, __('Connection string'), {
       add_field_class: 'fw-bold'
    }) }}
 {% endif %}

--- a/templates/pages/setup/mailcollector/setup_form.html.twig
+++ b/templates/pages/setup/mailcollector/setup_form.html.twig
@@ -89,7 +89,7 @@
 
    {{ include('pages/setup/mailcollector/server_config_fields.html.twig', {
       'connect_opts': connect_opts,
-      'host': host
+      'connect_string': host
    }) }}
 
    {{ fields.smallTitle(__('Authentication')) }}


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] My feature works.

## Description

Based on #18409

The "Test" tab in the form to configure email authentication (/front/authmail.form.php?id=1), does not work anymore: the hidden field "imap_string" was no longer in the form.

I also removed this "imap_string" field from the MailCollector part, it is not useful.
