### PR TITLE
Remove CommonAjaxController error handler

### DIFF
--- a/src/Glpi/Controller/CommonAjaxController.php
+++ b/src/Glpi/Controller/CommonAjaxController.php
@@ -80,10 +80,6 @@ class CommonAjaxController
             return $this->handleAction($input);
         } catch (\Glpi\Controller\RequestException $e) {
             return $this->errorReponse($e->getHttpCode(), $e->getMessage());
-        } catch (\Throwable $e) {
-            // Log error
-            trigger_error($e->getMessage(), E_USER_WARNING);
-            return $this->errorReponse(500, __('An unexpected error occurred.'));
         }
     }
 


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.

## Description

This `catch` block is no longer needed as we now already have a global `catch` block inside GLPI's kernel that is doing a better job than this one.

