### PR TITLE
fix(webhook): wrap long text in preview

### DIFF
--- a/templates/pages/setup/webhook/webhooktest.html.twig
+++ b/templates/pages/setup/webhook/webhooktest.html.twig
@@ -109,7 +109,7 @@
                                {% set raw_output_field %}
                                    <div class="row flex-row justify-content-center">
                                        <div class="tab-content p-2 flex-grow-1 card">
-                                           <pre class="bg-white text-dark" name="webhook_result"></pre>
+                                           <pre class="bg-white text-dark" name="webhook_result" style="white-space: pre-wrap;"></pre>
                                        </div>
                                    </div>
                                {% endset %}
@@ -125,7 +125,7 @@
                                {% set payload_output_field %}
                                    <div class="row flex-row justify-content-center">
                                        <div class="tab-content p-2 flex-grow-1 card">
-                                           <pre class="bg-white text-dark" name="webhook_payload_result"></pre>
+                                           <pre class="bg-white text-dark" name="webhook_payload_result" style="white-space: pre-wrap;"></pre>
                                        </div>
                                    </div>
                                {% endset %}


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] >My feature works.

## Description

Very long ticket content, completely breaks the webhook preview display.

## Before

![image](https://github.com/user-attachments/assets/71abc98f-d6df-42ae-b249-16acfa0238a2)

## After

![image](https://github.com/user-attachments/assets/d7c18043-3ae4-4a58-8681-156f694f443e)


