### PR TITLE
Fix plugin routing no longer working for static assets

### DIFF
--- a/src/Glpi/Http/LegacyRouterTrait.php
+++ b/src/Glpi/Http/LegacyRouterTrait.php
@@ -88,8 +88,12 @@ trait LegacyRouterTrait
                 // legacy scripts located in the `/ajax`, `/front` or `/report` directory
                 $filename = $plugin_dir . $relative_path;
             } else {
-                // preprend `/public` to expose the public resources only
-                $filename = $plugin_dir . '/public' . $relative_path;
+                if (\is_file($plugin_dir . '/public' . $relative_path)) {
+                    // preprend `/public` to expose the public resources only
+                    $filename = $plugin_dir . '/public' . $relative_path;
+                } else {
+                    $filename = $plugin_dir . $relative_path;
+                }
             }
         } elseif (
             (


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

- It fixes #18419

**Question:** Should we allow static assets only for `.css` and `.js` files? Or a few other extensions?
