### PR TITLE
fix(user): can not update is_active field

### DIFF
--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -2180,7 +2180,7 @@ JAVASCRIPT;
             }
             $output .= '<span class="form-control" readonly style="width: ' . $param["width"] . '"';
             if ($param['tooltip']) {
-                $output .= ' title="' . Html::entities_deep($param['tooltip']) . '"';
+                $output .= ' title="' . htmlspecialchars($param['tooltip'], ENT_QUOTES) . '"';
             }
             $output .= '>' . implode(', ', $to_display) . '</span>';
         } else {

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -2178,7 +2178,11 @@ JAVASCRIPT;
                     $to_display[] = $elements[$value];
                 }
             }
-            $output .= '<span class="form-control" readonly style="width: ' . $param["width"] . '">' . implode(', ', $to_display) . '</span>';
+            $output .= '<span class="form-control" readonly style="width: ' . $param["width"] . '"';
+            if ($param['tooltip']) {
+                $output .= ' title="' . Html::entities_deep($param['tooltip']) . '"';
+            }
+            $output .= '>' . implode(', ', $to_display) . '</span>';
         } else {
             $output  .= "<select name='$field_name' id='$field_id'";
 

--- a/src/User.php
+++ b/src/User.php
@@ -2765,7 +2765,12 @@ HTML;
         if (!GLPI_DEMO_MODE) {
             $activerand = mt_rand();
             echo "<td><label for='dropdown_is_active$activerand'>" . __('Active') . "</label></td><td>";
-            Dropdown::showYesNo('is_active', $this->fields['is_active'], -1, ['rand' => $activerand]);
+            $params = ['rand' => $activerand];
+            if (!$higherrights) {
+                $params['readonly'] = true;
+                $params['tooltip'] = __('Not enough rights to change this field');
+            }
+            Dropdown::showYesNo('is_active', $this->fields['is_active'], -1, $params);
             echo "</td>";
         } else {
             echo "<td colspan='2'></td>";

--- a/src/UserEmail.php
+++ b/src/UserEmail.php
@@ -257,7 +257,12 @@ class UserEmail extends CommonDBChild
         ) {
             return;
         }
-        $canedit = ($user->can($users_id, UPDATE) || ($users_id == Session::getLoginUserID()));
+        $canedit = (
+            (
+                $user->can($users_id, UPDATE)
+                && ($user->currentUserHaveMoreRightThan($users_id)))
+            || ($users_id == Session::getLoginUserID())
+        );
 
         parent::showChildsForItemForm($user, '_useremails', $canedit);
     }
@@ -273,7 +278,12 @@ class UserEmail extends CommonDBChild
         if (!$user->can($users_id, READ) && ($users_id != Session::getLoginUserID())) {
             return false;
         }
-        $canedit = ($user->can($users_id, UPDATE) || ($users_id == Session::getLoginUserID()));
+        $canedit = (
+            (
+                $user->can($users_id, UPDATE)
+                && ($user->currentUserHaveMoreRightThan($users_id)))
+            || ($users_id == Session::getLoginUserID())
+        );
 
         parent::showAddChildButtonForItemForm($user, '_useremails', $canedit);
 


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !35356
- Here is a brief description of what this PR does

`is_active` field cannot be updated by a user with a profile with fewer rights.
The field could be modified, a confirmation message said the user was updated without error, but the field was unchanged, suggesting a bug.
The PR sets the field to readonly (as well as any e-mails in the same situation).

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/ac00daf2-0bd8-4761-9830-a6c806b8527a)

