### PR TITLE
Fix networkport inventory

### DIFF
--- a/src/Inventory/Asset/InventoryNetworkPort.php
+++ b/src/Inventory/Asset/InventoryNetworkPort.php
@@ -345,14 +345,13 @@ trait InventoryNetworkPort
         $db_ports = [];
         $networkport = new NetworkPort();
 
-        $np_dyn_props = ['logical_number', 'ifstatus', 'ifinternalstatus', 'ifalias'];
+        $np_dyn_props = ['logical_number', 'ifstatus', 'ifinternalstatus', 'ifalias', 'is_dynamic'];
         $iterator = $DB->request([
             'SELECT' => array_merge(['id', 'name', 'mac', 'instantiation_type'], $np_dyn_props),
             'FROM'   => 'glpi_networkports',
             'WHERE'  => [
                 'items_id'     => $this->items_id,
                 'itemtype'     => $this->itemtype,
-                'is_dynamic'   => 1
             ]
         ]);
         foreach ($iterator as $row) {
@@ -404,7 +403,8 @@ trait InventoryNetworkPort
                     }
                 }
 
-                if (count($criteria)) {
+                // force dynamic for manually added NetworkPort
+                if (count($criteria) || !$dbdata_copy['is_dynamic']) {
                     $criteria['id'] = $keydb;
                     $criteria['is_dynamic'] = 1;
                     $networkport->update(Sanitizer::sanitize($criteria));


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !35403

An asset can be added manually to GLPI with a `NetworkPortAggregate` for managing network ports.

Typically, assets are added through the SNMP discovery process, which creates a `NetworkPortAggregate` with `is_dynamic = 1`. However, in some cases, GLPI administrators may prefer to skip the discovery phase and directly perform an SNMP inventory.

GLPI supports this approach by allowing the manual addition of assets with dedicated `NetworkPortAggregate` entries, enabling compatibility with the SNMP inventory task.

Currently, during the SNMP inventory process, GLPI only compares and updates entries where `is_dynamic = 1`. This limitation prevents the system from updating manually added `NetworkPortAggregate` entries (`is_dynamic = 0`), causing inconsistencies and duplicate `NetworkPort` entries.

This enhancement resolves the issue by allowing updates and modifications to both dynamic (`is_dynamic = 1`) and manually added (`is_dynamic = 0`) `NetworkPortAggregate` entries during the SNMP inventory process. This ensures consistency and prevents duplicate `NetworkPort` records.



## Screenshots (if appropriate):


