### PR TITLE
Fix redirect exception handling

### DIFF
--- a/src/Glpi/Http/AccessErrorListener.php
+++ b/src/Glpi/Http/AccessErrorListener.php
@@ -84,8 +84,6 @@ final class AccessErrorListener implements EventSubscriberInterface
                     \rawurlencode($request->getPathInfo() . '?' . $request->getQueryString())
                 )
             );
-        } elseif ($throwable instanceof RedirectException) {
-            $response = $throwable->getResponse();
         } elseif (
             $throwable instanceof AccessDeniedHttpException
             && ($_SESSION['_redirected_from_profile_selector'] ?? false)

--- a/src/Glpi/Http/RedirectExceptionListener.php
+++ b/src/Glpi/Http/RedirectExceptionListener.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Http;
+
+use Glpi\Exception\RedirectException;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+final class RedirectExceptionListener implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            // priority = 1 to be executed before the default Symfony listeners
+            KernelEvents::EXCEPTION => ['onKernelException', 1],
+        ];
+    }
+
+    public function onKernelException(ExceptionEvent $event): void
+    {
+        $throwable = $event->getThrowable();
+
+        if ($throwable instanceof RedirectException) {
+            $event->setResponse($throwable->getResponse());
+        }
+    }
+}


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

`RedirectException` should always trigger a redirection, even for ajax requests. The `AccessErrorListener` is only handling excpetion for main and non-ajax requests, so I moved the logic into a dedicated listener that would handle `RedirectException` regardless the request context.