### PR TITLE
Feat add project tab in asset

### DIFF
--- a/phpunit/functional/Item_ProjectTest.php
+++ b/phpunit/functional/Item_ProjectTest.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units;
+
+use DbTestCase;
+
+/* Test for inc/itil_project.class.php */
+
+class Item_ProjectTest extends DbTestCase
+{
+    /**
+     * Test the presence of the Item_Project tab in the $CFG_GLPI["project_asset_types"]
+     *
+     * @return void
+     */
+    public function testItemProjectTab()
+    {
+        /** @var array $CFG_GLPI */
+        global $CFG_GLPI;
+
+        foreach ($CFG_GLPI["project_asset_types"] as $itemtype) {
+            $item = new $itemtype();
+            $item_id = $item->add(
+                [
+                    'name' => 'Test project',
+                    'entities_id' => 0
+                ]
+            );
+            $this->assertGreaterThan(0, $item_id);
+
+            $item->getFromDB($item_id);
+            $tabs = $item->defineTabs();
+            if (!in_array("Item_Project", $tabs)) {
+                var_dump($tabs);
+                $this->fail("Item_Project tab not found in $itemtype");
+            }
+        }
+    }
+}

--- a/phpunit/functional/Item_ProjectTest.php
+++ b/phpunit/functional/Item_ProjectTest.php
@@ -51,6 +51,8 @@ class Item_ProjectTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
+        $this->login();
+
         foreach ($CFG_GLPI["project_asset_types"] as $itemtype) {
             $item = new $itemtype();
             $item_id = $item->add(
@@ -63,10 +65,7 @@ class Item_ProjectTest extends DbTestCase
 
             $item->getFromDB($item_id);
             $tabs = $item->defineTabs();
-            if (!in_array("Item_Project", $tabs)) {
-                var_dump($tabs);
-                $this->fail("Item_Project tab not found in $itemtype");
-            }
+            $this->assertArrayHasKey('Item_Project$1', $tabs);
         }
     }
 }

--- a/src/Appliance.php
+++ b/src/Appliance.php
@@ -97,6 +97,7 @@ class Appliance extends CommonDBTM
          ->addStandardTab('Item_Ticket', $ong, $options)
          ->addStandardTab('Item_Problem', $ong, $options)
          ->addStandardTab('Change_Item', $ong, $options)
+         ->addStandardTab('Item_Project', $ong, $options)
          ->addStandardTab('ManualLink', $ong, $options)
          ->addStandardTab('DatabaseInstance', $ong, $options)
          ->addStandardTab('Notepad', $ong, $options)

--- a/src/Certificate.php
+++ b/src/Certificate.php
@@ -492,6 +492,7 @@ class Certificate extends CommonDBTM
          ->addStandardTab('Item_Ticket', $ong, $options)
          ->addStandardTab('Item_Problem', $ong, $options)
          ->addStandardTab('Change_Item', $ong, $options)
+         ->addStandardTab('Item_Project', $ong, $options)
          ->addStandardTab('ManualLink', $ong, $options)
          ->addStandardTab('Lock', $ong, $options)
          ->addStandardTab('Notepad', $ong, $options)

--- a/src/CommonDevice.php
+++ b/src/CommonDevice.php
@@ -541,6 +541,7 @@ abstract class CommonDevice extends CommonDropdown
         $this->addDefaultFormTab($ong);
         $this->addImpactTab($ong, $options);
         $this->addStandardTab(static::getItem_DeviceType(), $ong, $options);
+        $this->addStandardTab('Item_Project', $ong, $options);
         $this->addStandardTab('Document_Item', $ong, $options);
         $this->addStandardTab('Log', $ong, $options);
 

--- a/src/Computer.php
+++ b/src/Computer.php
@@ -140,6 +140,7 @@ class Computer extends CommonDBTM
          ->addStandardTab('Item_Ticket', $ong, $options)
          ->addStandardTab('Item_Problem', $ong, $options)
          ->addStandardTab('Change_Item', $ong, $options)
+         ->addStandardTab('Item_Project', $ong, $options)
          ->addStandardTab('ManualLink', $ong, $options)
          ->addStandardTab('Certificate_Item', $ong, $options)
          ->addStandardTab('Lock', $ong, $options)

--- a/src/DeviceCamera.php
+++ b/src/DeviceCamera.php
@@ -51,6 +51,7 @@ class DeviceCamera extends CommonDevice
          ->addStandardTab('Item_DeviceCamera_ImageFormat', $ong, $options)
          ->addStandardTab('Infocom', $ong, $options)
          ->addStandardTab('Contract_Item', $ong, $options)
+         ->addStandardTab('Item_Project', $ong, $options)
          ->addStandardTab('Log', $ong, $options);
         return $ong;
     }

--- a/src/Html.php
+++ b/src/Html.php
@@ -1008,19 +1008,6 @@ TWIG,
         );
     }
 
-    public static function getBadgeBlock(string $text, ?string $color = '#000000'): string
-    {
-        return TemplateRenderer::getInstance()->renderFromStringTemplate(
-            <<<TWIG
-              <div class="badge_block" style="border-color: {{ color }}"><span class="me-1" style="background: {{ color }}"></span>{{ text }}
-TWIG,
-            [
-                'text' => $text,
-                'color'      => $color,
-            ]
-        );
-    }
-
     /**
      * Include common HTML headers
      *

--- a/src/Html.php
+++ b/src/Html.php
@@ -1008,6 +1008,19 @@ TWIG,
         );
     }
 
+    public static function getBadgeBlock(string $text, ?string $color = '#000000'): string
+    {
+        return TemplateRenderer::getInstance()->renderFromStringTemplate(
+            <<<TWIG
+              <div class="badge_block" style="border-color: {{ color }}"><span class="me-1" style="background: {{ color }}"></span>{{ text }}
+TWIG,
+            [
+                'text' => $text,
+                'color'      => $color,
+            ]
+        );
+    }
+
     /**
      * Include common HTML headers
      *

--- a/src/Item_Project.php
+++ b/src/Item_Project.php
@@ -239,7 +239,7 @@ class Item_Project extends CommonDBRelation
                 default:
                    // Not used now
                     if (
-                        Session::haveRight("project", Project::READALL)
+                        Session::haveRight("project", Project::READMY)
                         && $item instanceof CommonDBTM
                         && in_array($item->getType(), $CFG_GLPI["project_asset_types"])
                     ) {
@@ -280,7 +280,7 @@ class Item_Project extends CommonDBRelation
 
             default:
                 if (
-                    Session::haveRight("project", Project::READALL)
+                    Session::haveRight("project", Project::READMY)
                     && $item instanceof CommonDBTM
                     && in_array($item->getType(), $CFG_GLPI["project_asset_types"])
                 ) {
@@ -307,7 +307,7 @@ class Item_Project extends CommonDBRelation
             $project = new Project();
             $result = $project->getFromDB($value['projects_id']);
 
-            if ($result === false) {
+            if ($result === false || !$project->can($project->fields['id'], READ)) {
                 continue;
             }
 
@@ -352,19 +352,18 @@ class Item_Project extends CommonDBRelation
 
         TemplateRenderer::getInstance()->display('pages/tools/item_project.html.twig', [
             'item' => $item,
-            'used' => $used
-        ]);
-
-        TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
-            'is_tab' => true,
-            'nopager' => true,
-            'nofilter' => true,
-            'nosort' => true,
-            'columns' => $cols['columns'],
-            'formatters' => $cols['formatters'],
-            'entries' => $entries,
-            'total_number' => count($entries),
-            'filtered_number' => count($entries),
+            'used' => $used,
+            'datatable_params' => [
+                'is_tab' => true,
+                'nopager' => true,
+                'nofilter' => true,
+                'nosort' => true,
+                'columns' => $cols['columns'],
+                'formatters' => $cols['formatters'],
+                'entries' => $entries,
+                'total_number' => count($entries),
+                'filtered_number' => count($entries),
+            ]
         ]);
     }
 }

--- a/src/Item_Project.php
+++ b/src/Item_Project.php
@@ -329,7 +329,7 @@ class Item_Project extends CommonDBRelation
                 "name" => __('Name'),
                 "priority" => __('Priority'),
                 "code" => __('Code'),
-                "projectstates_id" => __('State'),
+                "projectstates_id" => _n('State', 'States', 1),
                 "percent_done" => __('Percent done'),
                 "creation_date" => __('Creation date'),
                 "content" => __('Description'),

--- a/src/Item_Project.php
+++ b/src/Item_Project.php
@@ -237,9 +237,8 @@ class Item_Project extends CommonDBRelation
                     return self::createTabEntry(_n('Item', 'Items', Session::getPluralNumber()), $nb, $item::getType(), 'ti ti-package');
 
                 default:
-                   // Not used now
                     if (
-                        Session::haveRight("project", Project::READMY)
+                        Project::canView()
                         && $item instanceof CommonDBTM
                         && in_array($item->getType(), $CFG_GLPI["project_asset_types"])
                     ) {
@@ -280,7 +279,7 @@ class Item_Project extends CommonDBRelation
 
             default:
                 if (
-                    Session::haveRight("project", Project::READMY)
+                    Project::canView()
                     && $item instanceof CommonDBTM
                     && in_array($item->getType(), $CFG_GLPI["project_asset_types"])
                 ) {

--- a/src/Item_Project.php
+++ b/src/Item_Project.php
@@ -307,30 +307,16 @@ class Item_Project extends CommonDBRelation
             }
 
             $priority = CommonITILObject::getPriorityName($project->fields['priority']);
+            $prioritycolor  = $_SESSION["glpipriority_" . $project->fields['priority']];
             $state = ProjectState::getById($project->fields['projectstates_id']);
 
             $data = [
                 'name' => $project->getLink(),
                 'projectstates_id' => $state !== false
-                        ? sprintf(
-                            '<div class="badge_block" style="border-color:%s"><span class="me-1" style="background:%s"></span>%s',
-                            htmlescape($state->fields['color']),
-                            htmlescape($state->fields['color']),
-                            htmlescape($state->fields['name']),
-                        )
-                        : '',
-                'priority' => sprintf(
-                    '<div class="badge_block" style="border-color: #ffcece"><span class="me-1" style="background: #ffcece"></span>%s',
-                    htmlescape($priority)
-                ),
-                'percent_done' => '<div class="progress bg-light border border-secondary-subtle" style="height: 22px">
-                        <div class="progress-bar progress-bar-striped text-body" role="progressbar"
-                            style="width: ' . $project->fields['percent_done'] . '%; background-color: primary;"
-                            aria-valuenow="' . $project->fields['percent_done'] . '"
-                            aria-valuemin="0" aria-valuemax="100">
-                        ' . $project->fields['percent_done'] . '%
-                        </div>
-                    </div>'
+                    ? Html::getBadgeBlock($state->fields['name'], $state->fields['color'])
+                    : '',
+                'priority' => Html::getBadgeBlock($priority, $prioritycolor),
+                'percent_done' => Html::getProgressBar((float)$project->fields['percent_done'])
             ];
             $entries[] = array_merge($project->fields, $data);
         }

--- a/src/Item_Project.php
+++ b/src/Item_Project.php
@@ -300,9 +300,9 @@ class Item_Project extends CommonDBRelation
         foreach ($item_projects as $value) {
             $used[] = $value['projects_id'];
             $project = new Project();
-            $project->getFromDB($value['projects_id']);
+            $result = $project->getFromDB($value['projects_id']);
 
-            if ($project === false) {
+            if ($result === false) {
                 continue;
             }
 

--- a/src/Item_Project.php
+++ b/src/Item_Project.php
@@ -240,7 +240,7 @@ class Item_Project extends CommonDBRelation
                    // Not used now
                     if (
                         Session::haveRight("project", Project::READALL)
-                        && ($item instanceof CommonDBTM || in_array($item->getType(), $CFG_GLPI["project_asset_types"]))
+                        && ($item instanceof CommonDBTM)
                     ) {
                         if ($_SESSION['glpishow_count_on_tabs']) {
                               // Direct one

--- a/src/Item_Project.php
+++ b/src/Item_Project.php
@@ -306,7 +306,7 @@ class Item_Project extends CommonDBRelation
             $project = new Project();
             $result = $project->getFromDB($value['projects_id']);
 
-            if ($result === false || !$project->can($project->fields['id'], READ)) {
+            if ($result === false) {
                 continue;
             }
 
@@ -314,19 +314,28 @@ class Item_Project extends CommonDBRelation
             $prioritycolor  = $_SESSION["glpipriority_" . $project->fields['priority']];
             $state = ProjectState::getById($project->fields['projectstates_id']);
 
-            $data = [
-                'name' => $project->getLink(),
-                'projectstates_id' => $state !== false
-                    ? [
-                        'content' => $state->fields['name'],
-                        'color' => $state->fields['color']
-                    ] : '',
-                'priority' => [
-                    'content' => $priority,
-                    'color' => $prioritycolor
-                ],
-                'percent_done' => Html::getProgressBar((float)$project->fields['percent_done'])
-            ];
+            if (!$project->can($project->fields['id'], READ)) {
+                $data = [
+                    'name' => $project->getLink(),
+                    'projectstates_id' => '',
+                    'priority' => '',
+                    'percent_done' => '',
+                ];
+            } else {
+                $data = [
+                    'name' => $project->getLink(),
+                    'projectstates_id' => $state !== false
+                        ? [
+                            'content' => $state->fields['name'],
+                            'color' => $state->fields['color']
+                        ] : '',
+                    'priority' => [
+                        'content' => $priority,
+                        'color' => $prioritycolor
+                    ],
+                    'percent_done' => Html::getProgressBar((float)$project->fields['percent_done'])
+                ];
+            }
             $entries[] = array_merge($project->fields, $data);
         }
 

--- a/src/Item_Project.php
+++ b/src/Item_Project.php
@@ -240,7 +240,8 @@ class Item_Project extends CommonDBRelation
                    // Not used now
                     if (
                         Session::haveRight("project", Project::READALL)
-                        && ($item instanceof CommonDBTM && in_array($item->getType(), $CFG_GLPI["project_asset_types"]))
+                        && $item instanceof CommonDBTM
+                        && in_array($item->getType(), $CFG_GLPI["project_asset_types"])
                     ) {
                         if ($_SESSION['glpishow_count_on_tabs']) {
                               // Direct one
@@ -278,7 +279,11 @@ class Item_Project extends CommonDBRelation
                 break;
 
             default:
-                if (in_array($item->getType(), $CFG_GLPI["project_asset_types"])) {
+                if (
+                    Session::haveRight("project", Project::READALL)
+                    && $item instanceof CommonDBTM
+                    && in_array($item->getType(), $CFG_GLPI["project_asset_types"])
+                ) {
                     self::showForAsset($item);
                 }
                 break;

--- a/src/Item_Project.php
+++ b/src/Item_Project.php
@@ -240,7 +240,7 @@ class Item_Project extends CommonDBRelation
                    // Not used now
                     if (
                         Session::haveRight("project", Project::READALL)
-                        && ($item instanceof CommonDBTM)
+                        && ($item instanceof CommonDBTM && in_array($item->getType(), $CFG_GLPI["project_asset_types"]))
                     ) {
                         if ($_SESSION['glpishow_count_on_tabs']) {
                               // Direct one
@@ -313,9 +313,14 @@ class Item_Project extends CommonDBRelation
             $data = [
                 'name' => $project->getLink(),
                 'projectstates_id' => $state !== false
-                    ? Html::getBadgeBlock($state->fields['name'], $state->fields['color'])
-                    : '',
-                'priority' => Html::getBadgeBlock($priority, $prioritycolor),
+                    ? [
+                        'content' => $state->fields['name'],
+                        'color' => $state->fields['color']
+                    ] : '',
+                'priority' => [
+                    'content' => $priority,
+                    'color' => $prioritycolor
+                ],
                 'percent_done' => Html::getProgressBar((float)$project->fields['percent_done'])
             ];
             $entries[] = array_merge($project->fields, $data);
@@ -333,8 +338,8 @@ class Item_Project extends CommonDBRelation
             ],
             'formatters' => [
                 'name' => 'raw_html',
-                'priority' => 'raw_html',
-                'projectstates_id' => 'raw_html',
+                'priority' => 'badge',
+                'projectstates_id' => 'badge',
                 'percent_done' => 'raw_html',
                 'creation_date' => 'date',
             ]

--- a/src/Item_Project.php
+++ b/src/Item_Project.php
@@ -284,7 +284,7 @@ class Item_Project extends CommonDBRelation
         return true;
     }
 
-    public static function showForAsset(CommonDBTM $item)
+    private static function showForAsset(CommonDBTM $item): void
     {
 
         $item_project = new self();

--- a/src/Monitor.php
+++ b/src/Monitor.php
@@ -120,6 +120,7 @@ class Monitor extends CommonDBTM
         $this->addStandardTab('Item_Ticket', $ong, $options);
         $this->addStandardTab('Item_Problem', $ong, $options);
         $this->addStandardTab('Change_Item', $ong, $options);
+        $this->addStandardTab('Item_Project', $ong, $options);
         $this->addStandardTab('ManualLink', $ong, $options);
         $this->addStandardTab('Lock', $ong, $options);
         $this->addStandardTab('Notepad', $ong, $options);

--- a/src/NetworkEquipment.php
+++ b/src/NetworkEquipment.php
@@ -138,6 +138,7 @@ class NetworkEquipment extends CommonDBTM
          ->addStandardTab('Item_Ticket', $ong, $options)
          ->addStandardTab('Item_Problem', $ong, $options)
          ->addStandardTab('Change_Item', $ong, $options)
+         ->addStandardTab('Item_Project', $ong, $options)
          ->addStandardTab('ManualLink', $ong, $options)
          ->addStandardTab('Lock', $ong, $options)
          ->addStandardTab('Notepad', $ong, $options)

--- a/src/Peripheral.php
+++ b/src/Peripheral.php
@@ -124,6 +124,7 @@ class Peripheral extends CommonDBTM
         $this->addStandardTab('Item_Ticket', $ong, $options);
         $this->addStandardTab('Item_Problem', $ong, $options);
         $this->addStandardTab('Change_Item', $ong, $options);
+        $this->addStandardTab('Item_Project', $ong, $options);
         $this->addStandardTab('ManualLink', $ong, $options);
         $this->addStandardTab('Lock', $ong, $options);
         $this->addStandardTab('Notepad', $ong, $options);

--- a/src/Phone.php
+++ b/src/Phone.php
@@ -132,6 +132,7 @@ class Phone extends CommonDBTM
         $this->addStandardTab('Item_Ticket', $ong, $options);
         $this->addStandardTab('Item_Problem', $ong, $options);
         $this->addStandardTab('Change_Item', $ong, $options);
+        $this->addStandardTab('Item_Project', $ong, $options);
         $this->addStandardTab('ManualLink', $ong, $options);
         $this->addStandardTab('Lock', $ong, $options);
         $this->addStandardTab('Notepad', $ong, $options);

--- a/src/Printer.php
+++ b/src/Printer.php
@@ -130,6 +130,7 @@ class Printer extends CommonDBTM
         $this->addStandardTab('Item_Ticket', $ong, $options);
         $this->addStandardTab('Item_Problem', $ong, $options);
         $this->addStandardTab('Change_Item', $ong, $options);
+        $this->addStandardTab('Item_Project', $ong, $options);
         $this->addStandardTab('ManualLink', $ong, $options);
         $this->addStandardTab('Lock', $ong, $options);
         $this->addStandardTab('Notepad', $ong, $options);

--- a/src/Project.php
+++ b/src/Project.php
@@ -2831,7 +2831,6 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria
 
             $project = self::getById($raw_project['id']);
             $priority = CommonITILObject::getPriorityName($project->fields['priority']);
-            $prioritycolor  = $_SESSION["glpipriority_" . $project->fields['priority']];
             $state = ProjectState::getById($project->fields['projectstates_id']);
 
             $twig_params['rows'][] = [

--- a/src/Project.php
+++ b/src/Project.php
@@ -2831,6 +2831,7 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria
 
             $project = self::getById($raw_project['id']);
             $priority = CommonITILObject::getPriorityName($project->fields['priority']);
+            $prioritycolor  = $_SESSION["glpipriority_" . $project->fields['priority']];
             $state = ProjectState::getById($project->fields['projectstates_id']);
 
             $twig_params['rows'][] = [
@@ -2840,22 +2841,14 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria
                     ],
                     [
                         'content' => $state !== false
-                            ? sprintf(
-                                '<div class="badge_block" style="border-color:%s"><span class="me-1" style="background:%s"></span>%s',
-                                htmlescape($state->fields['color']),
-                                htmlescape($state->fields['color']),
-                                htmlescape($state->fields['name']),
-                            )
+                            ? Html::getBadgeBlock($state->fields['name'], $state->fields['color'])
                             : '',
                     ],
                     [
-                        'content' => sprintf(
-                            '<div class="badge_block" style="border-color: #ffcece"><span class="me-1" style="background: #ffcece"></span>%s',
-                            htmlescape($priority)
-                        ),
+                        'content' => Html::getBadgeBlock($priority, $prioritycolor),
                     ],
                     [
-                        'content' => $project->fields['percent_done'] . '%',
+                        'content' => Html::getProgressBar((float)$project->fields['percent_done'])
                     ]
                 ]
             ];

--- a/src/Project.php
+++ b/src/Project.php
@@ -2841,11 +2841,19 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria
                     ],
                     [
                         'content' => $state !== false
-                            ? Html::getBadgeBlock($state->fields['name'], $state->fields['color'])
+                            ? sprintf(
+                                '<div class="badge_block" style="border-color:%s"><span class="me-1" style="background:%s"></span>%s',
+                                htmlescape($state->fields['color']),
+                                htmlescape($state->fields['color']),
+                                htmlescape($state->fields['name']),
+                            )
                             : '',
                     ],
                     [
-                        'content' => Html::getBadgeBlock($priority, $prioritycolor),
+                        'content' => sprintf(
+                            '<div class="badge_block" style="border-color: #ffcece"><span class="me-1" style="background: #ffcece"></span>%s',
+                            htmlescape($priority)
+                        ),
                     ],
                     [
                         'content' => Html::getProgressBar((float)$project->fields['percent_done'])

--- a/src/ProjectTask.php
+++ b/src/ProjectTask.php
@@ -1805,7 +1805,12 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
                     ],
                     [
                         'content' => $state !== false
-                            ? Html::getBadgeBlock($state->fields['name'], $state->fields['color'])
+                            ? sprintf(
+                                '<div class="badge_block" style="border-color:%s"><span class="me-1" style="background:%s"></span>%s',
+                                htmlescape($state->fields['color']),
+                                htmlescape($state->fields['color']),
+                                htmlescape($state->fields['name']),
+                            )
                             : '',
                     ],
                     [

--- a/src/ProjectTask.php
+++ b/src/ProjectTask.php
@@ -1805,19 +1805,14 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
                     ],
                     [
                         'content' => $state !== false
-                            ? sprintf(
-                                '<div class="badge_block" style="border-color:%s"><span class="me-1" style="background:%s"></span>%s',
-                                htmlescape($state->fields['color']),
-                                htmlescape($state->fields['color']),
-                                htmlescape($state->fields['name']),
-                            )
+                            ? Html::getBadgeBlock($state->fields['name'], $state->fields['color'])
                             : '',
                     ],
                     [
                         'content' => $project->getLink(),
                     ],
                     [
-                        'content' => $projecttask->fields['percent_done'] . '%'
+                        'content' => Html::getProgressBar((float)$projecttask->fields['percent_done'])
                     ]
                 ]
             ];

--- a/src/Software.php
+++ b/src/Software.php
@@ -123,6 +123,7 @@ class Software extends CommonDBTM
         $this->addStandardTab('Item_Ticket', $ong, $options);
         $this->addStandardTab('Item_Problem', $ong, $options);
         $this->addStandardTab('Change_Item', $ong, $options);
+        $this->addStandardTab('Item_Project', $ong, $options);
         $this->addStandardTab('ManualLink', $ong, $options);
         $this->addStandardTab('Notepad', $ong, $options);
         $this->addStandardTab('Reservation', $ong, $options);

--- a/templates/components/datatable.html.twig
+++ b/templates/components/datatable.html.twig
@@ -260,11 +260,22 @@
                                             {% set initials = entry_data['initials'] %}
                                             {% set bg_color = img is not empty ? 'inherit' : entry_data['initials_bg'] %}
                                             <span class="avatar {{ avatar_size }} rounded"
-                                                  style="{% if img is not null %} background-image: url({{ img }}); {% endif %} background-color: {{ bg_color }}">
-                                                   {% if img is empty %}
-                                                       {{ initials }}
-                                                   {% endif %}
-                                                </span>
+                                                style="{% if img is not null %} background-image: url({{ img }}); {% endif %} background-color: {{ bg_color }}">
+                                                {% if img is empty %}
+                                                    {{ initials }}
+                                                {% endif %}
+                                            </span>
+                                        {% elseif formatter == "badge" %}
+                                            {% set entry_data = entry[colkey] %}
+                                            {% set content = entry_data['content'] %}
+                                            {% set color = entry_data['color'] ?? '#BBBBBB' %}
+                                            {% if not (color matches '/^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/') %}
+                                                {% set color = '#BBBBBB' %}
+                                            {% endif %}
+                                            <div class="badge_block" style="border-color: {{ color }}">
+                                                <span class="me-1" style="background: {{ color }}"></span>
+                                                {{ content }}
+                                            </div>
                                         {% else %}
                                             {{ entry[colkey] }}
                                         {% endif %}

--- a/templates/components/datatable.html.twig
+++ b/templates/components/datatable.html.twig
@@ -272,10 +272,12 @@
                                             {% if not (color matches '/^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/') %}
                                                 {% set color = '#BBBBBB' %}
                                             {% endif %}
-                                            <div class="badge_block" style="border-color: {{ color }}">
-                                                <span class="me-1" style="background: {{ color }}"></span>
-                                                {{ content }}
-                                            </div>
+                                            {% if content is not empty %}
+                                                <div class="badge_block" style="border-color: {{ color }}">
+                                                    <span class="me-1" style="background: {{ color }}"></span>
+                                                    {{ content }}
+                                                </div>
+                                            {% endif %}
                                         {% else %}
                                             {{ entry[colkey] }}
                                         {% endif %}

--- a/templates/pages/tools/item_project.html.twig
+++ b/templates/pages/tools/item_project.html.twig
@@ -1,4 +1,35 @@
-{% import 'components/form/fields_macros.html.twig' as fields %}
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2024 Teclib' and contributors.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
 {% import 'components/form/basic_inputs_macros.html.twig' as inputs %}
 
 <form method="post" action="{{ 'Item_Project'|itemtype_form_path }}" class="mb-2">

--- a/templates/pages/tools/item_project.html.twig
+++ b/templates/pages/tools/item_project.html.twig
@@ -46,3 +46,5 @@
         {{ inputs.submit('add', _x('button', 'Add'), 1) }}
     </div>
 </form>
+
+{{ include('components/datatable.html.twig', datatable_params, with_context = false) }}

--- a/templates/pages/tools/item_project.html.twig
+++ b/templates/pages/tools/item_project.html.twig
@@ -1,0 +1,17 @@
+{% import 'components/form/fields_macros.html.twig' as fields %}
+{% import 'components/form/basic_inputs_macros.html.twig' as inputs %}
+
+<form method="post" action="{{ 'Item_Project'|itemtype_form_path }}" class="mb-2">
+    {{ inputs.hidden('_glpi_csrf_token', csrf_token()) }}
+    {{ inputs.hidden('items_id', item.getID()) }}
+    {{ inputs.hidden('itemtype', get_class(item)) }}
+    <div class="d-flex">
+        {{ 'Project'|itemtype_dropdown({
+            'entity': item.getEntity(),
+            'used': used,
+        }) }}
+    </div>
+    <div class="d-flex flex-row-reverse pe-2">
+        {{ inputs.submit('add', _x('button', 'Add'), 1) }}
+    </div>
+</form>


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !35418
- Here is a brief description of what this PR does

A “project” tab has been added to the objects page, featuring a dropdown with a button for linking a new project to the object, as well as a table of projects already associated with the object.

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/746eb0d5-7868-43c6-8f9a-73de61861281)



