### PR TITLE
Add the ability to implement a specific logic when a capacity is enabled

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -2474,12 +2474,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Asset/Asset.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Instanceof between Glpi\\\\Asset\\\\AssetDefinition and Glpi\\\\Asset\\\\AssetDefinition will always evaluate to true\\.$#',
-	'identifier' => 'instanceof.alwaysTrue',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Asset/Asset.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method Glpi\\\\Asset\\\\Asset\\:\\:getById\\(\\) should return static\\(Glpi\\\\Asset\\\\Asset\\)\\|false but returns object\\.$#',
 	'identifier' => 'return.type',
 	'count' => 1,
@@ -2504,22 +2498,10 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Asset/AssetDefinitionManager.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Instanceof between Glpi\\\\Asset\\\\AssetDefinition and Glpi\\\\Asset\\\\AssetDefinition will always evaluate to true\\.$#',
-	'identifier' => 'instanceof.alwaysTrue',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Asset/AssetModel.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method Glpi\\\\Asset\\\\AssetModel\\:\\:getById\\(\\) should return static\\(Glpi\\\\Asset\\\\AssetModel\\)\\|false but returns Glpi\\\\Asset\\\\AssetModel\\.$#',
 	'identifier' => 'return.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Glpi/Asset/AssetModel.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Instanceof between Glpi\\\\Asset\\\\AssetDefinition and Glpi\\\\Asset\\\\AssetDefinition will always evaluate to true\\.$#',
-	'identifier' => 'instanceof.alwaysTrue',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Asset/AssetType.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Method Glpi\\\\Asset\\\\AssetType\\:\\:getById\\(\\) should return static\\(Glpi\\\\Asset\\\\AssetType\\)\\|false but returns Glpi\\\\Asset\\\\AssetType\\.$#',
@@ -2544,30 +2526,6 @@ $ignoreErrors[] = [
 	'identifier' => 'parameter.notFound',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Glpi/Asset/Capacity/CapacityInterface.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Instanceof between Glpi\\\\Asset\\\\AssetDefinition and Glpi\\\\Asset\\\\AssetDefinition will always evaluate to true\\.$#',
-	'identifier' => 'instanceof.alwaysTrue',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Asset/RuleDictionaryModel.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Instanceof between Glpi\\\\Asset\\\\AssetDefinition and Glpi\\\\Asset\\\\AssetDefinition will always evaluate to true\\.$#',
-	'identifier' => 'instanceof.alwaysTrue',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Asset/RuleDictionaryModelCollection.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Instanceof between Glpi\\\\Asset\\\\AssetDefinition and Glpi\\\\Asset\\\\AssetDefinition will always evaluate to true\\.$#',
-	'identifier' => 'instanceof.alwaysTrue',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Asset/RuleDictionaryType.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Instanceof between Glpi\\\\Asset\\\\AssetDefinition and Glpi\\\\Asset\\\\AssetDefinition will always evaluate to true\\.$#',
-	'identifier' => 'instanceof.alwaysTrue',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Asset/RuleDictionaryTypeCollection.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Call to function is_string\\(\\) with string will always evaluate to true\\.$#',
@@ -2952,12 +2910,6 @@ $ignoreErrors[] = [
 	'identifier' => 'notIdentical.alwaysTrue',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Glpi/Debug/ProfilerSection.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Instanceof between Glpi\\\\Dropdown\\\\DropdownDefinition and Glpi\\\\Dropdown\\\\DropdownDefinition will always evaluate to true\\.$#',
-	'identifier' => 'instanceof.alwaysTrue',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Dropdown/Dropdown.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Method Glpi\\\\Dropdown\\\\Dropdown\\:\\:getById\\(\\) should return static\\(Glpi\\\\Dropdown\\\\Dropdown\\)\\|false but returns object\\.$#',

--- a/phpunit/DbTestCase.php
+++ b/phpunit/DbTestCase.php
@@ -397,20 +397,6 @@ class DbTestCase extends \GLPITestCase
             $this->callPrivateMethod($definition, 'getDecodedProfilesField')
         );
 
-        // Clear definition cache
-        $rc = new ReflectionClass(\Glpi\CustomObject\AbstractDefinitionManager::class);
-        $rc->getProperty('definitions_data')->setValue(\Glpi\Asset\AssetDefinitionManager::getInstance(), []);
-
-        $manager = \Glpi\Asset\AssetDefinitionManager::getInstance();
-        $this->callPrivateMethod($manager, 'loadConcreteClass', $definition);
-        $this->callPrivateMethod($manager, 'loadConcreteModelClass', $definition);
-        $this->callPrivateMethod($manager, 'loadConcreteTypeClass', $definition);
-        $this->callPrivateMethod($manager, 'loadConcreteModelDictionaryCollectionClass', $definition);
-        $this->callPrivateMethod($manager, 'loadConcreteModelDictionaryClass', $definition);
-        $this->callPrivateMethod($manager, 'loadConcreteTypeDictionaryCollectionClass', $definition);
-        $this->callPrivateMethod($manager, 'loadConcreteTypeDictionaryClass', $definition);
-        $this->callPrivateMethod($manager, 'boostrapConcreteClass', $definition);
-
         return $definition;
     }
 
@@ -472,14 +458,6 @@ class DbTestCase extends \GLPITestCase
             $this->callPrivateMethod($definition, 'getDecodedCapacitiesField')
         );
 
-        // Force boostrap to trigger methods such as "onClassBootstrap"
-        $manager = AssetDefinitionManager::getInstance();
-        $this->callPrivateMethod(
-            $manager,
-            'boostrapConcreteClass',
-            $definition
-        );
-
         return $definition;
     }
 
@@ -518,14 +496,6 @@ class DbTestCase extends \GLPITestCase
         $this->assertNotContains(
             $capacity,
             $this->callPrivateMethod($definition, 'getDecodedCapacitiesField')
-        );
-
-        // Force boostrap to trigger methods such as "onClassBootstrap"
-        $manager = AssetDefinitionManager::getInstance();
-        $this->callPrivateMethod(
-            $manager,
-            'boostrapConcreteClass',
-            $definition
         );
 
         return $definition;

--- a/phpunit/GLPITestCase.php
+++ b/phpunit/GLPITestCase.php
@@ -34,6 +34,7 @@
  */
 
 use Glpi\Asset\AssetDefinitionManager;
+use Glpi\Dropdown\DropdownDefinitionManager;
 use Glpi\Tests\Log\TestHandler;
 use Monolog\Level;
 use Monolog\Logger;
@@ -87,6 +88,9 @@ class GLPITestCase extends TestCase
         $SQLLOGGER->setHandlers([$this->sql_log_handler]);
 
         vfsStreamWrapper::register();
+
+        AssetDefinitionManager::getInstance()->registerAutoload();
+        DropdownDefinitionManager::getInstance()->registerAutoload();
     }
 
     public function tearDown(): void

--- a/src/Glpi/Asset/Asset.php
+++ b/src/Glpi/Asset/Asset.php
@@ -62,13 +62,13 @@ abstract class Asset extends CommonDBTM
     use \Glpi\Features\Inventoriable;
 
     /**
-     * Asset definition.
+     * Asset definition system name.
      *
      * Must be defined here to make PHPStan happy (see https://github.com/phpstan/phpstan/issues/8808).
      * Must be defined by child class too to ensure that assigning a value to this property will affect
      * each child classe independently.
      */
-    protected static AssetDefinition $definition;
+    protected static string $definition_system_name;
 
     final public function __construct()
     {
@@ -84,11 +84,12 @@ abstract class Asset extends CommonDBTM
      */
     public static function getDefinition(): AssetDefinition
     {
-        if (!(static::$definition instanceof AssetDefinition)) {
+        $definition = AssetDefinitionManager::getInstance()->getDefinition(static::$definition_system_name);
+        if (!($definition instanceof AssetDefinition)) {
             throw new \RuntimeException('Asset definition is expected to be defined in concrete class.');
         }
 
-        return static::$definition;
+        return $definition;
     }
 
     public static function getDefinitionClass(): string

--- a/src/Glpi/Asset/AssetDefinitionManager.php
+++ b/src/Glpi/Asset/AssetDefinitionManager.php
@@ -178,7 +178,7 @@ final class AssetDefinitionManager extends AbstractDefinitionManager
         return $names;
     }
 
-    protected function boostrapConcreteClass(AbstractDefinition $definition): void
+    public function bootstrapDefinition(AbstractDefinition $definition): void
     {
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
@@ -197,12 +197,18 @@ final class AssetDefinitionManager extends AbstractDefinitionManager
             'unicity_types'
         ];
         foreach ($config_keys as $config_key) {
-            $CFG_GLPI[$config_key][] = $asset_class_name;
+            if (!in_array($asset_class_name, $CFG_GLPI[$config_key], true)) {
+                $CFG_GLPI[$config_key][] = $asset_class_name;
+            }
         }
 
         // Add type and model to dictionnary config entry
-        $CFG_GLPI['dictionnary_types'][] = $definition->getAssetTypeClassName();
-        $CFG_GLPI['dictionnary_types'][] = $definition->getAssetModelClassName();
+        if (!in_array($definition->getAssetTypeClassName(), $CFG_GLPI['dictionnary_types'], true)) {
+            $CFG_GLPI['dictionnary_types'][] = $definition->getAssetTypeClassName();
+        }
+        if (!in_array($definition->getAssetModelClassName(), $CFG_GLPI['dictionnary_types'], true)) {
+            $CFG_GLPI['dictionnary_types'][] = $definition->getAssetModelClassName();
+        }
 
         // Bootstrap capacities
         foreach ($capacities as $capacity) {
@@ -378,20 +384,13 @@ final class AssetDefinitionManager extends AbstractDefinitionManager
 namespace Glpi\\CustomAsset;
 
 use Glpi\\Asset\\Asset;
-use Glpi\\Asset\\AssetDefinition;
 
 final class {$definition->getAssetClassName(false)} extends Asset {
-    protected static AssetDefinition \$definition;
+    protected static string \$definition_system_name = '{$definition->fields['system_name']}';
     public static \$rightname = '{$rightname}';
 }
 PHP
         );
-
-        // Set the definition of the concrete class using reflection API.
-        // It permits to directly store a pointer to the definition on the object without having
-        // to make the property publicly writable.
-        $reflected_class = new ReflectionClass($definition->getAssetClassName());
-        $reflected_class->setStaticPropertyValue('definition', $definition);
     }
 
     /**
@@ -407,16 +406,12 @@ PHP
 namespace Glpi\\CustomAsset;
 
 use Glpi\\Asset\\AssetModel;
-use Glpi\\Asset\\AssetDefinition;
 
 final class {$definition->getAssetModelClassName(false)} extends AssetModel {
-    protected static AssetDefinition \$definition;
+    protected static string \$definition_system_name = '{$definition->fields['system_name']}';
 }
 PHP
         );
-
-        $reflected_class = new ReflectionClass($definition->getAssetModelClassName());
-        $reflected_class->setStaticPropertyValue('definition', $definition);
     }
 
     /**
@@ -432,16 +427,12 @@ PHP
 namespace Glpi\\CustomAsset;
 
 use Glpi\\Asset\\AssetType;
-use Glpi\\Asset\\AssetDefinition;
 
 final class {$definition->getAssetTypeClassName(false)} extends AssetType {
-    protected static AssetDefinition \$definition;
+    protected static string \$definition_system_name = '{$definition->fields['system_name']}';
 }
 PHP
         );
-
-        $reflected_class = new ReflectionClass($definition->getAssetTypeClassName());
-        $reflected_class->setStaticPropertyValue('definition', $definition);
     }
 
     private function loadConcreteModelDictionaryClass(AssetDefinition $definition): void
@@ -449,18 +440,14 @@ PHP
         eval(<<<PHP
 namespace Glpi\\CustomAsset;
 
-use Glpi\\Asset\\AssetDefinition;
 use Glpi\\Asset\\RuleDictionaryModel;
 
 final class {$definition->getAssetModelDictionaryClassName(false)} extends RuleDictionaryModel
 {
-    protected static AssetDefinition \$definition;
+    protected static string \$definition_system_name = '{$definition->fields['system_name']}';
 }
 PHP
         );
-
-        $reflected_class = new ReflectionClass($definition->getAssetModelDictionaryClassName());
-        $reflected_class->setStaticPropertyValue('definition', $definition);
     }
 
     private function loadConcreteTypeDictionaryClass(AssetDefinition $definition): void
@@ -468,18 +455,14 @@ PHP
         eval(<<<PHP
 namespace Glpi\\CustomAsset;
 
-use Glpi\\Asset\\AssetDefinition;
 use Glpi\\Asset\\RuleDictionaryType;
 
 final class {$definition->getAssetTypeDictionaryClassName(false)} extends RuleDictionaryType
 {
-    protected static AssetDefinition \$definition;
+    protected static string \$definition_system_name = '{$definition->fields['system_name']}';
 }
 PHP
         );
-
-        $reflected_class = new ReflectionClass($definition->getAssetTypeDictionaryClassName());
-        $reflected_class->setStaticPropertyValue('definition', $definition);
     }
 
     private function loadConcreteModelDictionaryCollectionClass(AssetDefinition $definition): void
@@ -487,18 +470,14 @@ PHP
         eval(<<<PHP
 namespace Glpi\\CustomAsset;
 
-use Glpi\\Asset\\AssetDefinition;
 use Glpi\\Asset\\RuleDictionaryModelCollection;
 
 final class {$definition->getAssetModelDictionaryCollectionClassName(false)} extends RuleDictionaryModelCollection
 {
-    protected static AssetDefinition \$definition;
+    protected static string \$definition_system_name = '{$definition->fields['system_name']}';
 }
 PHP
         );
-
-        $reflected_class = new ReflectionClass($definition->getAssetModelDictionaryCollectionClassName());
-        $reflected_class->setStaticPropertyValue('definition', $definition);
     }
 
     private function loadConcreteTypeDictionaryCollectionClass(AssetDefinition $definition): void
@@ -506,17 +485,13 @@ PHP
         eval(<<<PHP
 namespace Glpi\\CustomAsset;
 
-use Glpi\\Asset\\AssetDefinition;
 use Glpi\\Asset\\RuleDictionaryTypeCollection;
 
 final class {$definition->getAssetTypeDictionaryCollectionClassName(false)} extends RuleDictionaryTypeCollection
 {
-    protected static AssetDefinition \$definition;
+    protected static string \$definition_system_name = '{$definition->fields['system_name']}';
 }
 PHP
         );
-
-        $reflected_class = new ReflectionClass($definition->getAssetTypeDictionaryCollectionClassName());
-        $reflected_class->setStaticPropertyValue('definition', $definition);
     }
 }

--- a/src/Glpi/Asset/AssetModel.php
+++ b/src/Glpi/Asset/AssetModel.php
@@ -42,13 +42,13 @@ use Toolbox;
 abstract class AssetModel extends \CommonDCModelDropdown
 {
     /**
-     * Asset definition.
+     * Asset definition system name.
      *
      * Must be defined here to make PHPStan happy (see https://github.com/phpstan/phpstan/issues/8808).
      * Must be defined by child class too to ensure that assigning a value to this property will affect
      * each child classe independently.
      */
-    protected static AssetDefinition $definition;
+    protected static string $definition_system_name;
 
     /**
      * Get the asset definition related to concrete class.
@@ -57,12 +57,14 @@ abstract class AssetModel extends \CommonDCModelDropdown
      */
     public static function getDefinition(): AssetDefinition
     {
-        if (!(static::$definition instanceof AssetDefinition)) {
+        $definition = AssetDefinitionManager::getInstance()->getDefinition(static::$definition_system_name);
+        if (!($definition instanceof AssetDefinition)) {
             throw new \RuntimeException('Asset definition is expected to be defined in concrete class.');
         }
 
-        return static::$definition;
+        return $definition;
     }
+
     public static function getTypeName($nb = 0)
     {
         return sprintf(_n('%s model', '%s models', $nb), static::getDefinition()->getTranslatedName());

--- a/src/Glpi/Asset/AssetType.php
+++ b/src/Glpi/Asset/AssetType.php
@@ -41,13 +41,13 @@ use Toolbox;
 abstract class AssetType extends CommonType
 {
     /**
-     * Asset definition.
+     * Asset definition system name.
      *
      * Must be defined here to make PHPStan happy (see https://github.com/phpstan/phpstan/issues/8808).
      * Must be defined by child class too to ensure that assigning a value to this property will affect
      * each child classe independently.
      */
-    protected static AssetDefinition $definition;
+    protected static string $definition_system_name;
 
     /**
      * Get the asset definition related to concrete class.
@@ -56,11 +56,12 @@ abstract class AssetType extends CommonType
      */
     public static function getDefinition(): AssetDefinition
     {
-        if (!(static::$definition instanceof AssetDefinition)) {
+        $definition = AssetDefinitionManager::getInstance()->getDefinition(static::$definition_system_name);
+        if (!($definition instanceof AssetDefinition)) {
             throw new \RuntimeException('Asset definition is expected to be defined in concrete class.');
         }
 
-        return static::$definition;
+        return $definition;
     }
 
     public static function getTypeName($nb = 0)

--- a/src/Glpi/Asset/Capacity/AbstractCapacity.php
+++ b/src/Glpi/Asset/Capacity/AbstractCapacity.php
@@ -186,6 +186,10 @@ abstract class AbstractCapacity implements CapacityInterface
     {
     }
 
+    public function onCapacityEnabled(string $classname): void
+    {
+    }
+
     public function onCapacityDisabled(string $classname): void
     {
     }

--- a/src/Glpi/Asset/Capacity/CapacityInterface.php
+++ b/src/Glpi/Asset/Capacity/CapacityInterface.php
@@ -110,6 +110,14 @@ interface CapacityInterface
     public function onClassBootstrap(string $classname): void;
 
     /**
+     * Method executed when capacity is enabled on given asset class.
+     *
+     * @param class-string<\Glpi\Asset\Asset> $classname
+     * @return void
+     */
+    public function onCapacityEnabled(string $classname): void;
+
+    /**
      * Method executed when capacity is disabled on given asset class.
      *
      * @param class-string<\Glpi\Asset\Asset> $classname

--- a/src/Glpi/Asset/Capacity/IsInventoriableCapacity.php
+++ b/src/Glpi/Asset/Capacity/IsInventoriableCapacity.php
@@ -100,7 +100,10 @@ class IsInventoriableCapacity extends AbstractCapacity
 
         CommonGLPI::registerStandardTab($classname, Item_Environment::class, 85);
         CommonGLPI::registerStandardTab($classname, Item_Process::class, 85);
+    }
 
+    public function onCapacityEnabled(string $classname): void
+    {
         //create rules
         $rules = new \RuleImportAsset();
         $rules->initRules(true, $classname);

--- a/src/Glpi/Asset/RuleDictionaryModel.php
+++ b/src/Glpi/Asset/RuleDictionaryModel.php
@@ -41,13 +41,13 @@ use Toolbox;
 abstract class RuleDictionaryModel extends RuleDictionnaryDropdown
 {
     /**
-     * Asset definition.
+     * Asset definition system name.
      *
      * Must be defined here to make PHPStan happy (see https://github.com/phpstan/phpstan/issues/8808).
      * Must be defined by child class too to ensure that assigning a value to this property will affect
      * each child classe independently.
      */
-    protected static AssetDefinition $definition;
+    protected static string $definition_system_name;
 
     /**
      * Get the asset definition related to concrete class.
@@ -56,11 +56,12 @@ abstract class RuleDictionaryModel extends RuleDictionnaryDropdown
      */
     public static function getDefinition(): AssetDefinition
     {
-        if (!(static::$definition instanceof AssetDefinition)) {
+        $definition = AssetDefinitionManager::getInstance()->getDefinition(static::$definition_system_name);
+        if (!($definition instanceof AssetDefinition)) {
             throw new \RuntimeException('Asset definition is expected to be defined in concrete class.');
         }
 
-        return static::$definition;
+        return $definition;
     }
 
     public function getCriterias()

--- a/src/Glpi/Asset/RuleDictionaryModelCollection.php
+++ b/src/Glpi/Asset/RuleDictionaryModelCollection.php
@@ -39,13 +39,13 @@ use RuleDictionnaryDropdownCollection;
 abstract class RuleDictionaryModelCollection extends RuleDictionnaryDropdownCollection
 {
     /**
-     * Asset definition.
+     * Asset definition system name.
      *
      * Must be defined here to make PHPStan happy (see https://github.com/phpstan/phpstan/issues/8808).
      * Must be defined by child class too to ensure that assigning a value to this property will affect
      * each child classe independently.
      */
-    protected static AssetDefinition $definition;
+    protected static string $definition_system_name;
 
     /**
      * Get the asset definition related to concrete class.
@@ -54,11 +54,12 @@ abstract class RuleDictionaryModelCollection extends RuleDictionnaryDropdownColl
      */
     public static function getDefinition(): AssetDefinition
     {
-        if (!(static::$definition instanceof AssetDefinition)) {
+        $definition = AssetDefinitionManager::getInstance()->getDefinition(static::$definition_system_name);
+        if (!($definition instanceof AssetDefinition)) {
             throw new \RuntimeException('Asset definition is expected to be defined in concrete class.');
         }
 
-        return static::$definition;
+        return $definition;
     }
 
     public function __construct()

--- a/src/Glpi/Asset/RuleDictionaryType.php
+++ b/src/Glpi/Asset/RuleDictionaryType.php
@@ -40,13 +40,13 @@ use Toolbox;
 abstract class RuleDictionaryType extends RuleDictionnaryDropdown
 {
     /**
-     * Asset definition.
+     * Asset definition system name.
      *
      * Must be defined here to make PHPStan happy (see https://github.com/phpstan/phpstan/issues/8808).
      * Must be defined by child class too to ensure that assigning a value to this property will affect
      * each child classe independently.
      */
-    protected static AssetDefinition $definition;
+    protected static string $definition_system_name;
 
     /**
      * Get the asset definition related to concrete class.
@@ -55,11 +55,12 @@ abstract class RuleDictionaryType extends RuleDictionnaryDropdown
      */
     public static function getDefinition(): AssetDefinition
     {
-        if (!(static::$definition instanceof AssetDefinition)) {
+        $definition = AssetDefinitionManager::getInstance()->getDefinition(static::$definition_system_name);
+        if (!($definition instanceof AssetDefinition)) {
             throw new \RuntimeException('Asset definition is expected to be defined in concrete class.');
         }
 
-        return static::$definition;
+        return $definition;
     }
 
     public function getCriterias()

--- a/src/Glpi/Asset/RuleDictionaryTypeCollection.php
+++ b/src/Glpi/Asset/RuleDictionaryTypeCollection.php
@@ -39,13 +39,13 @@ use RuleDictionnaryDropdownCollection;
 abstract class RuleDictionaryTypeCollection extends RuleDictionnaryDropdownCollection
 {
     /**
-     * Asset definition.
+     * Asset definition system name.
      *
      * Must be defined here to make PHPStan happy (see https://github.com/phpstan/phpstan/issues/8808).
      * Must be defined by child class too to ensure that assigning a value to this property will affect
      * each child classe independently.
      */
-    protected static AssetDefinition $definition;
+    protected static string $definition_system_name;
 
     /**
      * Get the asset definition related to concrete class.
@@ -54,11 +54,12 @@ abstract class RuleDictionaryTypeCollection extends RuleDictionnaryDropdownColle
      */
     public static function getDefinition(): AssetDefinition
     {
-        if (!(static::$definition instanceof AssetDefinition)) {
+        $definition = AssetDefinitionManager::getInstance()->getDefinition(static::$definition_system_name);
+        if (!($definition instanceof AssetDefinition)) {
             throw new \RuntimeException('Asset definition is expected to be defined in concrete class.');
         }
 
-        return static::$definition;
+        return $definition;
     }
 
     public function __construct()

--- a/src/Glpi/Config/LegacyConfigurators/CustomObjectsBootstrap.php
+++ b/src/Glpi/Config/LegacyConfigurators/CustomObjectsBootstrap.php
@@ -50,8 +50,8 @@ final readonly class CustomObjectsBootstrap implements LegacyConfigProviderInter
         }
 
         Profiler::getInstance()->start('CustomObjectsBootstrap::execute', Profiler::CATEGORY_BOOT);
-        AssetDefinitionManager::getInstance()->bootstrapClasses();
-        DropdownDefinitionManager::getInstance()->bootstrapClasses();
+        AssetDefinitionManager::getInstance()->bootstrapDefinitions();
+        DropdownDefinitionManager::getInstance()->bootstrapDefinitions();
         Profiler::getInstance()->stop('CustomObjectsBootstrap::execute');
     }
 }

--- a/src/Glpi/CustomObject/AbstractDefinition.php
+++ b/src/Glpi/CustomObject/AbstractDefinition.php
@@ -490,6 +490,13 @@ abstract class AbstractDefinition extends CommonDBTM
 
     public function post_addItem()
     {
+        // Clear the definitions cache to ensure that the code triggerred by the capacities hooks
+        // will not use an outdated definition list.
+        static::getDefinitionManagerClass()::getInstance()->clearDefinitionsCache();
+
+        // Bootstrap the definition to make it usable right now.
+        static::getDefinitionManagerClass()::getInstance()->bootstrapDefinition($this);
+
         if ($this->isActive()) {
             $this->syncProfilesRights();
             unset($_SESSION['menu']);
@@ -498,6 +505,13 @@ abstract class AbstractDefinition extends CommonDBTM
 
     public function post_updateItem($history = true)
     {
+        // Clear the definitions cache to ensure that the code triggerred by the capacities hooks
+        // will not use an outdated definition list.
+        static::getDefinitionManagerClass()::getInstance()->clearDefinitionsCache();
+
+        // Bootstrap the definition to make it usable right now.
+        static::getDefinitionManagerClass()::getInstance()->bootstrapDefinition($this);
+
         if (in_array('is_active', $this->updates, true)) {
             // Force menu refresh when active state change
             unset($_SESSION['menu']);

--- a/src/Glpi/CustomObject/AbstractDefinitionManager.php
+++ b/src/Glpi/CustomObject/AbstractDefinitionManager.php
@@ -78,26 +78,24 @@ abstract class AbstractDefinitionManager
      */
     abstract public function autoloadClass(string $classname): void;
 
-    final public function bootstrapClasses(): void
+    /**
+     * Boostrap all the active definitions.
+     */
+    final public function bootstrapDefinitions(): void
     {
-        foreach ($this->getDefinitions() as $definition) {
-            if (!$definition->isActive()) {
-                continue;
-            }
-
-            $this->boostrapConcreteClass($definition);
+        foreach ($this->getDefinitions(true) as $definition) {
+            $this->bootstrapDefinition($definition);
         }
     }
 
     /**
-     * Bootstrap the concrete class.
+     * Bootstrap the definition.
      * @param AbstractDefinition $definition
      * @phpstan-param ConcreteDefinition $definition
      * @return void
      */
-    protected function boostrapConcreteClass(AbstractDefinition $definition): void
+    public function bootstrapDefinition(AbstractDefinition $definition)
     {
-        // Intentionally left blank
     }
 
     final public function getCustomObjectClassNames(bool $with_namespace = true): array
@@ -115,18 +113,27 @@ abstract class AbstractDefinitionManager
     }
 
     /**
-     * Get the dropdown definition corresponding to given system name.
+     * Get the definition corresponding to given system name.
      *
      * @param string $system_name
      * @phpstan-return ConcreteDefinition|null
      */
-    final protected function getDefinition(string $system_name): ?AbstractDefinition
+    final public function getDefinition(string $system_name): ?AbstractDefinition
     {
         return $this->getDefinitions()[$system_name] ?? null;
     }
 
     /**
-     * Get all the dropdown definitions.
+     * Clear the definitions cache.
+     */
+    final public function clearDefinitionsCache(): void
+    {
+        $definition_class = static::getDefinitionClass();
+        unset($this->definitions_data[$definition_class]);
+    }
+
+    /**
+     * Get all the definitions.
      *
      * @param bool $only_active
      * @return AbstractDefinition[]

--- a/src/Glpi/Dropdown/Dropdown.php
+++ b/src/Glpi/Dropdown/Dropdown.php
@@ -43,13 +43,13 @@ abstract class Dropdown extends CommonTreeDropdown
     use CustomObjectTrait;
 
     /**
-     * Dropdown definition.
+     * Dropdown definition system name.
      *
      * Must be defined here to make PHPStan happy (see https://github.com/phpstan/phpstan/issues/8808).
      * Must be defined by child class too to ensure that assigning a value to this property will affect
      * each child classe independently.
      */
-    protected static DropdownDefinition $definition;
+    protected static string $definition_system_name;
 
     /**
      * Get the dropdown definition related to concrete class.
@@ -58,11 +58,12 @@ abstract class Dropdown extends CommonTreeDropdown
      */
     public static function getDefinition(): DropdownDefinition
     {
-        if (!(static::$definition instanceof DropdownDefinition)) {
+        $definition = DropdownDefinitionManager::getInstance()->getDefinition(static::$definition_system_name);
+        if (!($definition instanceof DropdownDefinition)) {
             throw new \RuntimeException('Dropdown definition is expected to be defined in concrete class.');
         }
 
-        return static::$definition;
+        return $definition;
     }
 
     /**

--- a/src/Glpi/Dropdown/DropdownDefinition.php
+++ b/src/Glpi/Dropdown/DropdownDefinition.php
@@ -156,6 +156,8 @@ final class DropdownDefinition extends AbstractDefinition
 
     public function post_addItem()
     {
+        parent::post_addItem();
+
         // Add default display preferences for the new definition
         $prefs = [
             14, // Name
@@ -168,8 +170,6 @@ final class DropdownDefinition extends AbstractDefinition
                 'users_id' => 0,
             ]);
         }
-
-        parent::post_addItem();
     }
 
     public function cleanDBonPurge()

--- a/src/Glpi/Dropdown/DropdownDefinitionManager.php
+++ b/src/Glpi/Dropdown/DropdownDefinitionManager.php
@@ -120,19 +120,12 @@ final class DropdownDefinitionManager extends AbstractDefinitionManager
 namespace Glpi\\CustomDropdown;
 
 use Glpi\\Dropdown\\Dropdown;
-use Glpi\\Dropdown\\DropdownDefinition;
 
 final class {$definition->getDropdownClassName(false)} extends Dropdown {
-    protected static DropdownDefinition \$definition;
+    protected static string \$definition_system_name = '{$definition->fields['system_name']}';
     public static \$rightname = '{$rightname}';
 }
 PHP
         );
-
-        // Set the definition of the concrete class using reflection API.
-        // It permits to directly store a pointer to the definition on the object without having
-        // to make the property publicly writable.
-        $reflected_class = new ReflectionClass($definition->getDropdownClassName());
-        $reflected_class->setStaticPropertyValue('definition', $definition);
     }
 }

--- a/tests/DbTestCase.php
+++ b/tests/DbTestCase.php
@@ -354,20 +354,6 @@ class DbTestCase extends \GLPITestCase
         $this->array($this->callPrivateMethod($definition, 'getDecodedCapacitiesField'))->isEqualTo($capacities);
         $this->array($this->callPrivateMethod($definition, 'getDecodedProfilesField'))->isEqualTo($profiles);
 
-        // Clear definition cache
-        $rc = new ReflectionClass(\Glpi\CustomObject\AbstractDefinitionManager::class);
-        $rc->getProperty('definitions_data')->setValue(\Glpi\Asset\AssetDefinitionManager::getInstance(), []);
-
-        $manager = \Glpi\Asset\AssetDefinitionManager::getInstance();
-        $this->callPrivateMethod($manager, 'loadConcreteClass', $definition);
-        $this->callPrivateMethod($manager, 'loadConcreteModelClass', $definition);
-        $this->callPrivateMethod($manager, 'loadConcreteTypeClass', $definition);
-        $this->callPrivateMethod($manager, 'loadConcreteModelDictionaryCollectionClass', $definition);
-        $this->callPrivateMethod($manager, 'loadConcreteModelDictionaryClass', $definition);
-        $this->callPrivateMethod($manager, 'loadConcreteTypeDictionaryCollectionClass', $definition);
-        $this->callPrivateMethod($manager, 'loadConcreteTypeDictionaryClass', $definition);
-        $this->callPrivateMethod($manager, 'boostrapConcreteClass', $definition);
-
         return $definition;
     }
 
@@ -401,14 +387,6 @@ class DbTestCase extends \GLPITestCase
             skip_fields: ['profiles'] // JSON encoded fields cannot be automatically checked
         );
         $this->array($this->callPrivateMethod($definition, 'getDecodedProfilesField'))->isEqualTo($profiles);
-
-        // Clear definition cache
-        $rc = new ReflectionClass(\Glpi\CustomObject\AbstractDefinitionManager::class);
-        $rc->getProperty('definitions_data')->setValue(\Glpi\Dropdown\DropdownDefinitionManager::getInstance(), []);
-
-        $manager = \Glpi\Dropdown\DropdownDefinitionManager::getInstance();
-        $this->callPrivateMethod($manager, 'loadConcreteClass', $definition);
-        $this->callPrivateMethod($manager, 'boostrapConcreteClass', $definition);
 
         return $definition;
     }
@@ -470,14 +448,6 @@ class DbTestCase extends \GLPITestCase
             $this->callPrivateMethod($definition, 'getDecodedCapacitiesField')
         )->contains($capacity);
 
-        // Force boostrap to trigger methods such as "onClassBootstrap"
-        $manager = AssetDefinitionManager::getInstance();
-        $this->callPrivateMethod(
-            $manager,
-            'boostrapConcreteClass',
-            $definition
-        );
-
         return $definition;
     }
 
@@ -516,14 +486,6 @@ class DbTestCase extends \GLPITestCase
         $this->array(
             $this->callPrivateMethod($definition, 'getDecodedCapacitiesField')
         )->notContains($capacity);
-
-        // Force boostrap to trigger methods such as "onClassBootstrap"
-        $manager = AssetDefinitionManager::getInstance();
-        $this->callPrivateMethod(
-            $manager,
-            'boostrapConcreteClass',
-            $definition
-        );
 
         return $definition;
     }

--- a/tests/functional/Glpi/Asset/AssetDefinition.php
+++ b/tests/functional/Glpi/Asset/AssetDefinition.php
@@ -432,7 +432,6 @@ class AssetDefinition extends DbTestCase
     {
         /** @var \Glpi\Asset\AssetDefinition $definition */
         $definition = $this->initAssetDefinition('test');
-        \Glpi\Asset\AssetDefinitionManager::getInstance()->bootstrapClasses();
 
         $this->createItem(
             $definition->getAssetClassName(),

--- a/tests/functional/Glpi/Asset/AssetDefinitionManager.php
+++ b/tests/functional/Glpi/Asset/AssetDefinitionManager.php
@@ -56,7 +56,7 @@ class AssetDefinitionManager extends DbTestCase
 
         foreach ($mapping as $expected_classname => $definition) {
             $this->boolean(class_exists($expected_classname))->isTrue();
-            $this->object($expected_classname::getDefinition())->isEqualTo($definition);
+            $this->array($expected_classname::getDefinition()->fields)->isEqualTo($definition->fields);
         }
     }
 
@@ -196,15 +196,6 @@ class AssetDefinitionManager extends DbTestCase
         Asset $asset,
         array $expected_tabs
     ): void {
-        // Force the boostrap process to be recomputed (it is only computed once
-        // per execution in normal circumstances)
-        $manager = \Glpi\Asset\AssetDefinitionManager::getInstance();
-        $this->callPrivateMethod(
-            $manager,
-            'boostrapConcreteClass',
-            $definition
-        );
-
         // Get all tabs
         $tabs = $asset->defineAllTabs();
 

--- a/tests/functional/Glpi/Dropdown/DropdownDefinition.php
+++ b/tests/functional/Glpi/Dropdown/DropdownDefinition.php
@@ -368,7 +368,6 @@ class DropdownDefinition extends DbTestCase
     {
         /** @var \Glpi\Dropdown\DropdownDefinition $definition */
         $definition = $this->initDropdownDefinition('test');
-        \Glpi\Dropdown\DropdownDefinitionManager::getInstance()->bootstrapClasses();
 
         $this->createItem(
             $definition->getDropdownClassName(),

--- a/tests/functional/Glpi/Dropdown/DropdownDefinitionManager.php
+++ b/tests/functional/Glpi/Dropdown/DropdownDefinitionManager.php
@@ -37,7 +37,6 @@ namespace tests\units\Glpi\Dropdown;
 
 use DbTestCase;
 use Glpi\Dropdown\Dropdown;
-use Glpi\Dropdown\DropdownDefinition;
 
 class DropdownDefinitionManager extends DbTestCase
 {
@@ -52,7 +51,7 @@ class DropdownDefinitionManager extends DbTestCase
 
         foreach ($mapping as $expected_classname => $definition) {
             $this->boolean(class_exists($expected_classname))->isTrue();
-            $this->object($expected_classname::getDefinition())->isEqualTo($definition);
+            $this->array($expected_classname::getDefinition()->fields)->isEqualTo($definition->fields);
         }
     }
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

It is based on #18306 and replaces it. It fixes #18304.

The purpose of this PR is to add a `CapacityInterface::onCapacityEnabled()` method that can be used to define a logic that has to be call only at the moment a capacity is enabled. For instance, the loading of the default import rules has to be done only once.

I had to review a bit the custom assets/dropdowns definition handling to be able to reload a definition at runtime. This was already done in the tests with some kind of hacky code, but now it is done in a more proper way, and this is no longer necessary to use the reflection API to do this.

I also added a call to `CapacityInterface::onCapacityDisabled()` in the `AssetDefinition::cleanDbOnPurge()`. It is probably unecessary for the most common cases, but it permits to be sure that the cleaning logic implemented by each capacity is executed when a definition is removed.