### PR TITLE
Fix incorrect method name

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -3056,12 +3056,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Form/Form.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Return type \\(array\\<Glpi\\\\Form\\\\Comment\\>\\) of method Glpi\\\\Form\\\\Form\\:\\:getComments\\(\\) should be compatible with return type \\(string\\) of method CommonDBTM\\:\\:getComments\\(\\)$#',
-	'identifier' => 'method.childReturnType',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Form/Form.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Call to function is_array\\(\\) with array will always evaluate to true\\.$#',
 	'identifier' => 'function.alreadyNarrowedType',
 	'count' => 1,
@@ -3108,12 +3102,6 @@ $ignoreErrors[] = [
 	'identifier' => 'varTag.nativeType',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Glpi/Form/QuestionType/QuestionTypesManager.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Return type \\(array\\<Glpi\\\\Form\\\\Comment\\>\\) of method Glpi\\\\Form\\\\Section\\:\\:getComments\\(\\) should be compatible with return type \\(string\\) of method CommonDBTM\\:\\:getComments\\(\\)$#',
-	'identifier' => 'method.childReturnType',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Form/Section.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Method Glpi\\\\Form\\\\ServiceCatalog\\\\ServiceCatalog\\:\\:getTabNameForItem\\(\\) never returns array\\<string\\> so it can be removed from the return type\\.$#',

--- a/phpunit/functional/Glpi/Form/Export/FormSerializerTest.php
+++ b/phpunit/functional/Glpi/Form/Export/FormSerializerTest.php
@@ -306,7 +306,7 @@ final class FormSerializerTest extends \DbTestCase
         $form_copy = $this->exportAndImportForm($form);
 
         // Assert: validate comments fields
-        $comments = array_values($form_copy->getComments());
+        $comments = array_values($form_copy->getFormComments());
         $comments_data = array_map(function (Comment $comment) {
             return [
                 'name'              => $comment->fields['name'],

--- a/phpunit/functional/Glpi/Form/FormTest.php
+++ b/phpunit/functional/Glpi/Form/FormTest.php
@@ -167,14 +167,14 @@ class FormTest extends DbTestCase
         );
         $this->assertCount(2, $form->getSections());
         $this->assertCount(3, $form->getQuestions());
-        $this->assertCount(2, $form->getComments());
+        $this->assertCount(2, $form->getFormComments());
 
         // Delete content
         foreach ($form->getSections() as $section) {
             foreach ($section->getQuestions() as $question) {
                 $this->deleteItem(Question::class, $question->getID());
             }
-            foreach ($section->getComments() as $comment) {
+            foreach ($section->getFormComments() as $comment) {
                 $this->deleteItem(Comment::class, $comment->getID());
             }
             $this->deleteItem(Section::class, $section->getID());
@@ -184,13 +184,13 @@ class FormTest extends DbTestCase
         // shouldn't change
         $this->assertCount(2, $form->getSections());
         $this->assertCount(3, $form->getQuestions());
-        $this->assertCount(2, $form->getComments());
+        $this->assertCount(2, $form->getFormComments());
 
         // Reload form
         $form->getFromDB($form->getID());
         $this->assertCount(0, $form->getSections());
         $this->assertCount(0, $form->getQuestions());
-        $this->assertCount(0, $form->getComments());
+        $this->assertCount(0, $form->getFormComments());
     }
 
     /**
@@ -269,7 +269,7 @@ class FormTest extends DbTestCase
             ],
         ]);
         $this->assertCount(1, $form->getQuestions());
-        $this->assertCount(1, $form->getComments());
+        $this->assertCount(1, $form->getFormComments());
 
         $id = $form->getID();
         $this->hasSessionMessages(INFO, ['Item successfully updated: <a href="/glpi/front/form/form.form.php?id=' . $id . '" title="Form with first section">Form with first section</a>']);
@@ -360,7 +360,7 @@ class FormTest extends DbTestCase
         array $expected_comment_names,
         array $expected_comment_descriptions
     ): void {
-        $comments = $form->getComments();
+        $comments = $form->getFormComments();
         $names = array_map(fn($comment) => $comment->getName(), $comments);
         $names = array_values($names); // Strip keys
         $this->assertEquals($expected_comment_names, $names);

--- a/src/Glpi/Form/Export/Serializer/FormSerializer.php
+++ b/src/Glpi/Form/Export/Serializer/FormSerializer.php
@@ -372,7 +372,7 @@ final class FormSerializer extends AbstractFormSerializer
         Form $form,
         FormContentSpecification $form_spec,
     ): FormContentSpecification {
-        foreach ($form->getComments() as $comment) {
+        foreach ($form->getFormComments() as $comment) {
             $comment_spec = new CommentContentSpecification();
             $comment_spec->name = $comment->fields['name'];
             $comment_spec->rank = $comment->fields['rank'];

--- a/src/Glpi/Form/Form.php
+++ b/src/Glpi/Form/Form.php
@@ -369,13 +369,13 @@ final class Form extends CommonDBTM implements ServiceCatalogLeafInterface
      *
      * @return Comment[]
      */
-    public function getComments(): array
+    public function getFormComments(): array
     {
         $comments = [];
         foreach ($this->getSections() as $section) {
             // Its important to use the "+" operator here and not array_merge
             // because the keys must be preserved
-            $comments = $comments + $section->getComments();
+            $comments = $comments + $section->getFormComments();
         }
         return $comments;
     }

--- a/src/Glpi/Form/Section.php
+++ b/src/Glpi/Form/Section.php
@@ -55,7 +55,7 @@ final class Section extends CommonDBChild
 
     /**
      * Lazy loaded array of comments
-     * Should always be accessed through getComments()
+     * Should always be accessed through getFormComments()
      * @var Comment[]|null
      */
     protected ?array $comments = null;
@@ -93,7 +93,7 @@ final class Section extends CommonDBChild
      */
     public function getBlocks(): array
     {
-        $blocks = array_merge($this->getQuestions(), $this->getComments());
+        $blocks = array_merge($this->getQuestions(), $this->getFormComments());
         usort($blocks, fn($a, $b) => $a->fields['rank'] <=> $b->fields['rank']);
 
         return $blocks;
@@ -137,11 +137,8 @@ final class Section extends CommonDBChild
      *
      * @return Comment[]
      */
-    public function getComments(): array
+    public function getFormComments(): array
     {
-        // TODO: getComments is already a method part of the CommonDBTM interface.
-        // We need another name for this.
-
         // Lazy loading
         if ($this->comments === null) {
             $this->comments = [];

--- a/src/Glpi/Form/Tag/CommentDescriptionTagProvider.php
+++ b/src/Glpi/Form/Tag/CommentDescriptionTagProvider.php
@@ -52,7 +52,7 @@ final class CommentDescriptionTagProvider implements TagProviderInterface
     public function getTags(Form $form): array
     {
         $tags = [];
-        foreach ($form->getComments() as $comment) {
+        foreach ($form->getFormComments() as $comment) {
             $tags[] = $this->getDescriptionTagForComment($comment);
         }
 

--- a/src/Glpi/Form/Tag/CommentTitleTagProvider.php
+++ b/src/Glpi/Form/Tag/CommentTitleTagProvider.php
@@ -52,7 +52,7 @@ final class CommentTitleTagProvider implements TagProviderInterface
     public function getTags(Form $form): array
     {
         $tags = [];
-        foreach ($form->getComments() as $comment) {
+        foreach ($form->getFormComments() as $comment) {
             $tags[] = $this->getTitleTagForComment($comment);
         }
 

--- a/tests/src/FormTesterTrait.php
+++ b/tests/src/FormTesterTrait.php
@@ -245,7 +245,7 @@ trait FormTesterTrait
         $form->getFromDB($form->getID());
 
         // Get comments
-        $comments = $form->getComments();
+        $comments = $form->getFormComments();
 
         if ($section_name === null) {
             // Search by name


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.

## Description

There was a `getComments` method added for forms a while ago, this is incorrect because there is already a method with the same name from `CommonDBTM`.

I've changed the name to `getFormComments` to avoid this issue.

