### PR TITLE
Review custom object system name and label

### DIFF
--- a/ajax/asset/assetdefinition.php
+++ b/ajax/asset/assetdefinition.php
@@ -73,7 +73,7 @@ if ($_REQUEST['action'] === 'get_all_fields') {
                 throw new NotFoundHttpException();
             }
         } else {
-            $custom_field->fields['name'] = '';
+            $custom_field->fields['system_name'] = '';
             $custom_field->fields['label'] = $field['label'];
             $custom_field->fields['type'] = $field['type'];
             $custom_field->fields['itemtype'] = 'Computer'; // Doesn't matter what it is as long as it's not empty

--- a/install/migrations/update_10.0.x_to_11.0.0/assets.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/assets.php
@@ -48,6 +48,7 @@ if (!$DB->tableExists('glpi_assets_assetdefinitions')) {
         CREATE TABLE `glpi_assets_assetdefinitions` (
             `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
             `system_name` varchar(255) DEFAULT NULL,
+            `label` varchar(255) NOT NULL,
             `icon` varchar(255) DEFAULT NULL,
             `comment` text,
             `is_active` tinyint NOT NULL DEFAULT '0',
@@ -69,9 +70,13 @@ SQL;
     foreach (['profiles', 'translations', 'fields_display'] as $field) {
         $migration->addField('glpi_assets_assetdefinitions', $field, 'JSON NOT NULL', ['update' => "'[]'"]);
     }
+    $migration->addField('glpi_assets_assetdefinitions', 'label', 'string', [
+        'after' => 'system_name',
+        'update' => $DB::quoteName('system_name'),
+    ]);
 }
 
-$ADDTODISPLAYPREF['Glpi\\Asset\\AssetDefinition'] = [3, 4, 5, 6];
+$ADDTODISPLAYPREF['Glpi\\Asset\\AssetDefinition'] = [2, 3, 4, 5, 6];
 
 if (!$DB->tableExists('glpi_assets_assets')) {
     $query = <<<SQL
@@ -201,7 +206,7 @@ if (!$DB->tableExists('glpi_assets_customfielddefinitions')) {
         CREATE TABLE `glpi_assets_customfielddefinitions` (
           `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
           `assets_assetdefinitions_id` int {$default_key_sign} NOT NULL,
-          `name` varchar(255) NOT NULL,
+          `system_name` varchar(255) NOT NULL,
           `label` varchar(255) NOT NULL,
           `type` varchar(255) NOT NULL,
           `field_options` json,
@@ -209,13 +214,14 @@ if (!$DB->tableExists('glpi_assets_customfielddefinitions')) {
           `default_value` text,
           `translations` JSON NOT NULL,
           PRIMARY KEY (`id`),
-          UNIQUE KEY `unicity` (`assets_assetdefinitions_id`, `name`),
-          KEY `name` (`name`)
+          UNIQUE KEY `unicity` (`assets_assetdefinitions_id`, `system_name`),
+          KEY `system_name` (`system_name`)
         ) ENGINE=InnoDB DEFAULT CHARSET={$default_charset} COLLATE={$default_collation} ROW_FORMAT=DYNAMIC;
 SQL;
     $DB->doQuery($query);
 } else {
     $migration->addField('glpi_assets_customfielddefinitions', 'translations', 'JSON NOT NULL', ['update' => "'[]'"]);
+    $migration->changeField('glpi_assets_customfielddefinitions', 'name', 'system_name', 'string');
 }
 
 // Dev migration

--- a/install/migrations/update_10.0.x_to_11.0.0/dropdowns.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/dropdowns.php
@@ -47,6 +47,7 @@ if (!$DB->tableExists('glpi_dropdowns_dropdowndefinitions')) {
         CREATE TABLE `glpi_dropdowns_dropdowndefinitions` (
             `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
             `system_name` varchar(255) DEFAULT NULL,
+            `label` varchar(255) NOT NULL,
             `icon` varchar(255) DEFAULT NULL,
             `comment` text,
             `is_active` tinyint NOT NULL DEFAULT '0',
@@ -62,6 +63,11 @@ if (!$DB->tableExists('glpi_dropdowns_dropdowndefinitions')) {
     ) ENGINE=InnoDB DEFAULT CHARSET={$default_charset} COLLATE={$default_collation} ROW_FORMAT=DYNAMIC;
 SQL;
     $DB->doQuery($query);
+} else {
+    $migration->addField('glpi_dropdowns_dropdowndefinitions', 'label', 'string', [
+        'after' => 'system_name',
+        'update' => $DB::quoteName('system_name'),
+    ]);
 }
 
 if (!$DB->tableExists('glpi_dropdowns_dropdowns')) {

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -9894,6 +9894,7 @@ DROP TABLE IF EXISTS `glpi_assets_assetdefinitions`;
 CREATE TABLE `glpi_assets_assetdefinitions` (
   `id` int unsigned NOT NULL AUTO_INCREMENT,
   `system_name` varchar(255) DEFAULT NULL,
+  `label` varchar(255) NOT NULL,
   `icon` varchar(255) DEFAULT NULL,
   `comment` text,
   `is_active` tinyint NOT NULL DEFAULT '0',
@@ -10018,6 +10019,7 @@ DROP TABLE IF EXISTS `glpi_dropdowns_dropdowndefinitions`;
 CREATE TABLE `glpi_dropdowns_dropdowndefinitions` (
   `id` int unsigned NOT NULL AUTO_INCREMENT,
   `system_name` varchar(255) DEFAULT NULL,
+  `label` varchar(255) NOT NULL,
   `icon` varchar(255) DEFAULT NULL,
   `comment` text,
   `is_active` tinyint NOT NULL DEFAULT '0',
@@ -10062,7 +10064,7 @@ DROP TABLE IF EXISTS `glpi_assets_customfielddefinitions`;
 CREATE TABLE `glpi_assets_customfielddefinitions` (
   `id` int unsigned NOT NULL AUTO_INCREMENT,
   `assets_assetdefinitions_id` int unsigned NOT NULL,
-  `name` varchar(255) NOT NULL,
+  `system_name` varchar(255) NOT NULL,
   `label` varchar(255) NOT NULL,
   `type` varchar(255) NOT NULL,
   `field_options` json,
@@ -10070,8 +10072,8 @@ CREATE TABLE `glpi_assets_customfielddefinitions` (
   `default_value` text,
   `translations` JSON NOT NULL,
   PRIMARY KEY (`id`),
-  UNIQUE KEY `unicity` (`assets_assetdefinitions_id`, `name`),
-  KEY `name` (`name`)
+  UNIQUE KEY `unicity` (`assets_assetdefinitions_id`, `system_name`),
+  KEY `system_name` (`system_name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 SET FOREIGN_KEY_CHECKS=1;

--- a/js/src/vue/CustomObject/FieldPreview/FieldDisplay.vue
+++ b/js/src/vue/CustomObject/FieldPreview/FieldDisplay.vue
@@ -217,7 +217,7 @@
         create_edit_field_modal.on('glpi:submit:success', 'form', (e, data) => {
             const btn_submit = data.submitter;
             const form_data = new FormData(e.target);
-            const field_key = `custom_${form_data.get('name')}`;
+            const field_key = `custom_${form_data.get('system_name')}`;
 
             if (btn_submit.attr('name') === 'add') {
                 new_field_dropdown.data('select2').dataAdapter.query('', (data) => {

--- a/phpunit/functional/Glpi/Asset/CustomFieldDefinitionTest.php
+++ b/phpunit/functional/Glpi/Asset/CustomFieldDefinitionTest.php
@@ -64,7 +64,7 @@ class CustomFieldDefinitionTest extends DbTestCase
 
         $custom_field_definition = $this->createItem(\Glpi\Asset\CustomFieldDefinition::class, [
             'assets_assetdefinitions_id' => $asset_definition->getID(),
-            'name' => 'test_string',
+            'system_name' => 'test_string',
             'label' => 'Test string',
             'type' => StringType::class,
             'default_value' => 'default',
@@ -72,7 +72,7 @@ class CustomFieldDefinitionTest extends DbTestCase
 
         $custom_field_definition_2 = $this->createItem(\Glpi\Asset\CustomFieldDefinition::class, [
             'assets_assetdefinitions_id' => $asset_definition->getID(),
-            'name' => 'test_text',
+            'system_name' => 'test_text',
             'label' => 'Test text',
             'type' => TextType::class,
             'default_value' => 'default text',
@@ -282,7 +282,7 @@ class CustomFieldDefinitionTest extends DbTestCase
 
         $custom_field_definition = $this->createItem(\Glpi\Asset\CustomFieldDefinition::class, [
             'assets_assetdefinitions_id' => $asset_definition->getID(),
-            'name' => 'test_string',
+            'system_name' => 'test_string',
             'label' => 'Test string',
             'type' => StringType::class,
             'default_value' => 'default',
@@ -296,7 +296,7 @@ class CustomFieldDefinitionTest extends DbTestCase
 
         $custom_field_definition_2 = $this->createItem(\Glpi\Asset\CustomFieldDefinition::class, [
             'assets_assetdefinitions_id' => $asset_definition->getID(),
-            'name' => 'test_text',
+            'system_name' => 'test_text',
             'label' => 'Test text',
             'type' => TextType::class,
             'default_value' => 'default text',
@@ -311,7 +311,7 @@ class CustomFieldDefinitionTest extends DbTestCase
 
         $custom_field_definition_4 = $this->createItem(\Glpi\Asset\CustomFieldDefinition::class, [
             'assets_assetdefinitions_id' => $asset_definition->getID(),
-            'name' => 'test_number',
+            'system_name' => 'test_number',
             'label' => 'Test number',
             'type' => NumberType::class,
             'default_value' => 420,
@@ -325,7 +325,7 @@ class CustomFieldDefinitionTest extends DbTestCase
 
         $custom_field_definition_5 = $this->createItem(\Glpi\Asset\CustomFieldDefinition::class, [
             'assets_assetdefinitions_id' => $asset_definition->getID(),
-            'name' => 'test_date',
+            'system_name' => 'test_date',
             'label' => 'Test date',
             'type' => DateType::class,
             'default_value' => '2021-01-01',
@@ -339,7 +339,7 @@ class CustomFieldDefinitionTest extends DbTestCase
 
         $custom_field_definition_6 = $this->createItem(\Glpi\Asset\CustomFieldDefinition::class, [
             'assets_assetdefinitions_id' => $asset_definition->getID(),
-            'name' => 'test_datetime',
+            'system_name' => 'test_datetime',
             'label' => 'Test datetime',
             'type' => DateTimeType::class,
             'default_value' => '2021-01-01 03:25:15',
@@ -353,7 +353,7 @@ class CustomFieldDefinitionTest extends DbTestCase
 
         $custom_field_definition_7 = $this->createItem(\Glpi\Asset\CustomFieldDefinition::class, [
             'assets_assetdefinitions_id' => $asset_definition->getID(),
-            'name' => 'test_dropdown',
+            'system_name' => 'test_dropdown',
             'label' => 'Test dropdown',
             'type' => DropdownType::class,
             'itemtype' => \Computer::class,
@@ -366,7 +366,7 @@ class CustomFieldDefinitionTest extends DbTestCase
 
         $custom_field_definition_8 = $this->createItem(\Glpi\Asset\CustomFieldDefinition::class, [
             'assets_assetdefinitions_id' => $asset_definition->getID(),
-            'name' => 'test_url',
+            'system_name' => 'test_url',
             'label' => 'Test url',
             'type' => URLType::class,
             'default_value' => 'https://glpi-project.org',
@@ -380,7 +380,7 @@ class CustomFieldDefinitionTest extends DbTestCase
 
         $custom_field_definition_9 = $this->createItem(\Glpi\Asset\CustomFieldDefinition::class, [
             'assets_assetdefinitions_id' => $asset_definition->getID(),
-            'name' => 'test_bool',
+            'system_name' => 'test_bool',
             'label' => 'Test bool',
             'type' => BooleanType::class,
             'default_value' => '1',
@@ -401,7 +401,7 @@ class CustomFieldDefinitionTest extends DbTestCase
 
         $this->assertGreaterThan(0, $field->add([
             'assets_assetdefinitions_id' => $asset_definition->getID(),
-            'name' => 'test',
+            'system_name' => 'test',
             'label' => 'Test',
             'type' => StringType::class,
             'default_value' => 'default',
@@ -409,7 +409,7 @@ class CustomFieldDefinitionTest extends DbTestCase
 
         $this->assertFalse($field->add([
             'assets_assetdefinitions_id' => $asset_definition->getID(),
-            'name' => 'test',
+            'system_name' => 'test',
             'label' => 'Test',
             'type' => StringType::class,
             'default_value' => 'default',
@@ -437,7 +437,7 @@ class CustomFieldDefinitionTest extends DbTestCase
 
         $fields_id = $field->add([
             'assets_assetdefinitions_id' => $asset_definition->getID(),
-            'name' => 'test_datetime',
+            'system_name' => 'test_datetime',
             'label' => 'Test datetime',
             'type' => DateTimeType::class,
             'default_value' => '2021-01-01 03:25:15',
@@ -494,14 +494,14 @@ class CustomFieldDefinitionTest extends DbTestCase
 
         $field_1->add([
             'assets_assetdefinitions_id' => $asset_definition->getID(),
-            'name' => 'test',
+            'system_name' => 'test',
             'label' => 'Test',
             'type' => StringType::class,
             'default_value' => 'default',
         ]);
         $field_2->add([
             'assets_assetdefinitions_id' => $asset_definition->getID(),
-            'name' => 'test_two',
+            'system_name' => 'test_two',
             'label' => 'Test2',
             'type' => DropdownType::class,
             'itemtype' => \Computer::class,
@@ -542,7 +542,7 @@ class CustomFieldDefinitionTest extends DbTestCase
         $field = new \Glpi\Asset\CustomFieldDefinition();
         $this->assertGreaterThan(0, $field->add([
             'assets_assetdefinitions_id' => $asset_definition->getID(),
-            'name' => 'test',
+            'system_name' => 'test',
             'label' => 'Test',
             'type' => StringType::class,
             'translations' => [
@@ -559,7 +559,7 @@ class CustomFieldDefinitionTest extends DbTestCase
         $field = new \Glpi\Asset\CustomFieldDefinition();
         $this->assertGreaterThan(0, $field->add([
             'assets_assetdefinitions_id' => $asset_definition->getID(),
-            'name' => 'test',
+            'system_name' => 'test',
             'label' => 'Test',
             'type' => StringType::class,
         ]));

--- a/src/Glpi/Asset/Asset.php
+++ b/src/Glpi/Asset/Asset.php
@@ -333,7 +333,7 @@ abstract class Asset extends CommonDBTM
     {
         $this->initForm($ID, $options);
         $custom_fields = static::getDefinition()->getCustomFieldDefinitions();
-        $custom_fields = array_combine(array_map(static fn ($f) => 'custom_' . $f->fields['name'], $custom_fields), $custom_fields);
+        $custom_fields = array_combine(array_map(static fn ($f) => 'custom_' . $f->fields['system_name'], $custom_fields), $custom_fields);
         $fields_display = static::getDefinition()->getDecodedFieldsField();
         $core_field_options = [];
 

--- a/src/Glpi/Asset/Asset.php
+++ b/src/Glpi/Asset/Asset.php
@@ -377,7 +377,7 @@ abstract class Asset extends CommonDBTM
         $custom_fields = $this->getDecodedCustomFields();
 
         foreach (static::getDefinition()->getCustomFieldDefinitions() as $custom_field) {
-            $custom_field_name = 'custom_' . $custom_field->fields['name'];
+            $custom_field_name = 'custom_' . $custom_field->fields['system_name'];
             if (!isset($input[$custom_field_name])) {
                 continue;
             }
@@ -406,7 +406,7 @@ abstract class Asset extends CommonDBTM
         }
 
         foreach (static::getDefinition()->getCustomFieldDefinitions() as $custom_field) {
-            $f_name = 'custom_' . $custom_field->fields['name'];
+            $f_name = 'custom_' . $custom_field->fields['system_name'];
             $this->fields[$f_name] = $custom_field->fields['default_value'];
         }
         return true;
@@ -422,7 +422,7 @@ abstract class Asset extends CommonDBTM
         $custom_field_values = $this->getDecodedCustomFields();
 
         foreach ($custom_field_definitions as $custom_field) {
-            $custom_field_name = 'custom_' . $custom_field->fields['name'];
+            $custom_field_name = 'custom_' . $custom_field->fields['system_name'];
             $value = $custom_field_values[$custom_field->getID()] ?? $custom_field->fields['default_value'];
 
             $this->fields[$custom_field_name] = $custom_field->getFieldType()->formatValueFromDB($value);
@@ -435,7 +435,7 @@ abstract class Asset extends CommonDBTM
         // Fill old values for custom fields
         $custom_field_definitions = static::getDefinition()->getCustomFieldDefinitions();
         foreach ($custom_field_definitions as $custom_field) {
-            $custom_field_name = 'custom_' . $custom_field->fields['name'];
+            $custom_field_name = 'custom_' . $custom_field->fields['system_name'];
             $this->oldvalues[$custom_field_name] = $this->fields[$custom_field_name];
         }
     }
@@ -445,7 +445,7 @@ abstract class Asset extends CommonDBTM
         $this->post_updateItemFromAssignableItem($history);
         if ($this->dohistory && $history && in_array('custom_fields', $this->updates, true)) {
             foreach (static::getDefinition()->getCustomFieldDefinitions() as $custom_field) {
-                $custom_field_name = 'custom_' . $custom_field->fields['name'];
+                $custom_field_name = 'custom_' . $custom_field->fields['system_name'];
                 $field_type = $custom_field->getFieldType();
                 $old_value = $field_type->formatValueFromDB($this->oldvalues[$custom_field_name] ?? $field_type->getDefaultValue());
                 $current_value = $field_type->formatValueFromDB($this->fields[$custom_field_name] ?? null);
@@ -470,7 +470,7 @@ abstract class Asset extends CommonDBTM
     public function getNonLoggedFields(): array
     {
         $ignored_fields = array_map(
-            static fn (CustomFieldDefinition $field) => 'custom_' . $field->fields['name'],
+            static fn (CustomFieldDefinition $field) => 'custom_' . $field->fields['system_name'],
             static::getDefinition()->getCustomFieldDefinitions()
         );
         $ignored_fields[] = 'custom_fields';

--- a/src/Glpi/Asset/AssetDefinition.php
+++ b/src/Glpi/Asset/AssetDefinition.php
@@ -686,7 +686,7 @@ TWIG, $twig_params);
         ];
 
         foreach ($this->getCustomFieldDefinitions() as $custom_field_def) {
-            $fields['custom_' . $custom_field_def->fields['name']] = [
+            $fields['custom_' . $custom_field_def->fields['system_name']] = [
                 'customfields_id'    => $custom_field_def->getID(),
                 'text' => $custom_field_def->computeFriendlyName(),
                 'type' => $custom_field_def->fields['type'],

--- a/src/Glpi/Asset/CustomFieldDefinition.php
+++ b/src/Glpi/Asset/CustomFieldDefinition.php
@@ -157,12 +157,15 @@ final class CustomFieldDefinition extends CommonDBChild
         /** @var \DBmysql $DB */
         global $DB;
 
-        // Spaces are replaced with underscores and the name is made lowercase. Only lowercase letters and underscores are kept.
-        $input['system_name'] = preg_replace('/[^a-z_]/', '', strtolower(str_replace(' ', '_', $input['system_name'])));
-        // The name cannot start with an underscore
-        $input['system_name'] = ltrim($input['system_name'], '_');
-        if ($input['system_name'] === '') {
-            Session::addMessageAfterRedirect(__s('The system name must not be empty'), false, ERROR);
+        if (!is_string($input['system_name']) || preg_match('/^[A-Za-z_]+$/i', $input['system_name']) !== 1) {
+            Session::addMessageAfterRedirect(
+                htmlescape(sprintf(
+                    __('The following field has an incorrect value: "%s".'),
+                    __('System name')
+                )),
+                false,
+                ERROR
+            );
             return false;
         }
 

--- a/src/Glpi/Asset/CustomFieldDefinition.php
+++ b/src/Glpi/Asset/CustomFieldDefinition.php
@@ -89,7 +89,7 @@ final class CustomFieldDefinition extends CommonDBChild
         $fields_display = json_decode($it->current()['fields_display'] ?? '[]', true) ?? [];
         $order = 0;
         foreach ($fields_display as $k => $field) {
-            if ($field['key'] === 'custom_' . $this->fields['name']) {
+            if ($field['key'] === 'custom_' . $this->fields['system_name']) {
                 $order = $field['order'];
                 unset($fields_display[$k]);
                 break;
@@ -158,10 +158,10 @@ final class CustomFieldDefinition extends CommonDBChild
         global $DB;
 
         // Spaces are replaced with underscores and the name is made lowercase. Only lowercase letters and underscores are kept.
-        $input['name'] = preg_replace('/[^a-z_]/', '', strtolower(str_replace(' ', '_', $input['name'])));
+        $input['system_name'] = preg_replace('/[^a-z_]/', '', strtolower(str_replace(' ', '_', $input['system_name'])));
         // The name cannot start with an underscore
-        $input['name'] = ltrim($input['name'], '_');
-        if ($input['name'] === '') {
+        $input['system_name'] = ltrim($input['system_name'], '_');
+        if ($input['system_name'] === '') {
             Session::addMessageAfterRedirect(__s('The system name must not be empty'), false, ERROR);
             return false;
         }
@@ -171,7 +171,7 @@ final class CustomFieldDefinition extends CommonDBChild
             'COUNT' => 'cpt',
             'FROM' => self::getTable(),
             'WHERE' => [
-                'name' => $input['name'],
+                'system_name' => $input['system_name'],
                 AssetDefinition::getForeignKeyField() => $input[self::$items_id],
             ],
         ]);
@@ -237,8 +237,8 @@ final class CustomFieldDefinition extends CommonDBChild
 
     public function prepareInputForUpdate($input)
     {
-        // Cannot change type or name of existing field
-        unset($input['type'], $input['name']);
+        // Cannot change type or system_name of existing field
+        unset($input['type'], $input['system_name']);
         $input = $this->prepareInputForAddAndUpdate($input);
         if ($input === false) {
             return false;

--- a/src/Glpi/Asset/CustomFieldDefinition.php
+++ b/src/Glpi/Asset/CustomFieldDefinition.php
@@ -157,7 +157,7 @@ final class CustomFieldDefinition extends CommonDBChild
         /** @var \DBmysql $DB */
         global $DB;
 
-        if (!is_string($input['system_name']) || preg_match('/^[A-Za-z_]+$/i', $input['system_name']) !== 1) {
+        if (!is_string($input['system_name']) || preg_match('/^[a-z_]+$/', $input['system_name']) !== 1) {
             Session::addMessageAfterRedirect(
                 htmlescape(sprintf(
                     __('The following field has an incorrect value: "%s".'),

--- a/templates/pages/admin/customobjects/main.html.twig
+++ b/templates/pages/admin/customobjects/main.html.twig
@@ -43,37 +43,27 @@
         {{ alerts.alert_warning(__('There is currently no profile with access to items with current definition.')) }}
     {% endif %}
 
-    {% if item.isNewItem() %}
-        {% set helper %}
-            {{ __('The system name corresponds to the customizable part of the item class which will correspond to the current definition. For example, items linked to the system name "%s" will have the class "%s".')|format('Example', customobj_ns ~ '\\Example') }}
-            {{ __('The value must contains only letters and must not end by "Model" or "Type".') }}
-            {{ __('Also, the value must not be one of the following reserved names: %s.')|format('"' ~ reserved_system_names|join('", "') ~ '"') }}
-        {% endset %}
-        {{ fields.textField(
-            'system_name',
-            item.fields['system_name'],
-            __('System name'),
-            {
-                'required': true,
-                'pattern': '^(?!(' ~ reserved_system_names|join('|') ~ ')$)[A-Za-z]+(?<!Model|Type)$',
-                'helper': helper
-            }
-        ) }}
-    {% else %}
+    {% set helper %}
+        {{ __('The system name corresponds to the customizable part of the item class which will correspond to the current definition. For example, items linked to the system name "%s" will have the class "%s".')|format('Example', customobj_ns ~ '\\Example') }}
+        {{ __('The value must contains only letters and must not end with "Model" or "Type".') }}
+        {{ __('Also, the value must not be one of the reserved names.') }}
+    {% endset %}
+    {{ fields.textField('label', item.fields['label'], __('Label')) }}
+    {{ fields.textField(
+        'system_name',
+        item.fields['system_name'],
+        __('System name'),
+        {
+            readonly: not item.isNewItem(),
+            'helper': helper
+        }
+    ) }}
+    {% if not item.isNewItem() %}
         {% set helper_html %}
             <em class="text-muted">
                 {{ __('The class of items related to current definition is "%s".')|format(customobj_ns ~ '\\%s'|format(item.fields['system_name'])) }}
             </em>
         {% endset %}
-        {{ fields.textField(
-            'system_name',
-            item.fields['system_name'],
-            __('System name'),
-            {
-                'disabled': true,
-                'add_field_html': helper_html,
-            }
-        ) }}
     {% endif %}
 
     {% if not item.isNewItem() %}
@@ -116,7 +106,7 @@
                 </div>
             </div>
         </div>
-        <script>
+        <script defer>
             $('#mainformtable button[name="purge"]').on('click', { is_from_modal: false }, (event, data) => {
                 data = data || event.data;
 
@@ -137,6 +127,36 @@
             });
         </script>
     {% endif %}
+    <script type="module">
+        $('#mainformtable input[name="system_name"]').on('input', () => {
+            if ($('input[name="system_name"]').val() === '') {
+                $('input[name="system_name"]').data('manually_changed', false);
+            } else {
+                $('input[name="system_name"]').data('manually_changed', true);
+            }
+        });
+        function autoUpdateNameField() {
+            if ({{ not item.isNewItem() ? 'true' : 'false' }} || $('#mainformtable input[name="system_name"]').data('manually_changed')) {
+                return;
+            }
+            const reserved_names = {{ reserved_system_names|json_encode()|raw }}.map((n) => n.toLowerCase());
+            const existing_names = {{ existing_system_names|json_encode()|raw }}.map((n) => n.toLowerCase());
+            // label is made lowercase and spaces are replaced with underscores. All other characters are removed
+            $('#mainformtable input[name="system_name"]')
+                .val($('#mainformtable input[name="label"]').val().normalize('NFD').toLowerCase().replace(/ /g, '_').replace(/[^a-z_]/g, ''));
+            const system_name = $('#mainformtable input[name="system_name"]').val();
+            if (reserved_names.includes(system_name) || system_name.endsWith('type') || system_name.endsWith('model')) {
+                $('#mainformtable input[name="system_name"]').get(0).setCustomValidity('{{ __('The system name is a reserved name. Please enter a different label or manually change the system name.') }}');
+            } else if (existing_names.includes(system_name)) {
+                $('#mainformtable input[name="system_name"]').get(0).setCustomValidity('{{ __('The system name is already in use. Please enter a different label or manually change the system name.') }}');
+            } else {
+                $('#mainformtable input[name="system_name"]').get(0).setCustomValidity('');
+            }
+        };
+        $('#mainformtable input[name="label"]').on('input', () => {
+            autoUpdateNameField();
+        });
+    </script>
     {{ parent() }}
 {% endblock %}
 

--- a/templates/pages/admin/customobjects/main.html.twig
+++ b/templates/pages/admin/customobjects/main.html.twig
@@ -45,7 +45,7 @@
 
     {% set helper %}
         {{ __('The system name field corresponds to what will be used when development is involved. Examples: API calls, webhooks, etc.') }}
-        {{  _('It can be personalized, but some words are reserved such as classes from GLPI like Computer, Monitor, etc.') }}
+        {{ __('It can be personalized, but some words are reserved such as classes from GLPI like Computer, Monitor, etc.') }}
         {{ __('Items linked to the system name "%s" will have the class "%s".')|format('Example', customobj_ns ~ '\\Example') }}
     {% endset %}
     {{ fields.textField('label', item.fields['label'], __('Label')) }}

--- a/templates/pages/admin/customobjects/main.html.twig
+++ b/templates/pages/admin/customobjects/main.html.twig
@@ -54,7 +54,7 @@
         item.fields['system_name'],
         __('System name'),
         {
-            readonly: not item.isNewItem(),
+            disabled: not item.isNewItem(),
             'helper': helper
         }
     ) }}
@@ -143,12 +143,12 @@
             const existing_names = {{ existing_system_names|json_encode()|raw }}.map((n) => n.toLowerCase());
             // label is made lowercase and spaces are replaced with underscores. All other characters are removed
             $('#mainformtable input[name="system_name"]')
-                .val($('#mainformtable input[name="label"]').val().normalize('NFD').toLowerCase().replace(/ /g, '_').replace(/[^a-z_]/g, ''));
-            const system_name = $('#mainformtable input[name="system_name"]').val();
+                .val($('#mainformtable input[name="label"]').val().normalize('NFD').replace(/ /g, '_').replace(/[^a-z_]/g, ''));
+            const system_name = $('#mainformtable input[name="system_name"]').val().toLowerCase();
             if (reserved_names.includes(system_name) || system_name.endsWith('type') || system_name.endsWith('model')) {
-                $('#mainformtable input[name="system_name"]').get(0).setCustomValidity('{{ __('The system name is a reserved name. Please enter a different label or manually change the system name.') }}');
+                $('#mainformtable input[name="system_name"]').get(0).setCustomValidity(__('The system name is a reserved name. Please enter a different label or manually change the system name.'));
             } else if (existing_names.includes(system_name)) {
-                $('#mainformtable input[name="system_name"]').get(0).setCustomValidity('{{ __('The system name is already in use. Please enter a different label or manually change the system name.') }}');
+                $('#mainformtable input[name="system_name"]').get(0).setCustomValidity(__('The system name is already in use. Please enter a different label or manually change the system name.'));
             } else {
                 $('#mainformtable input[name="system_name"]').get(0).setCustomValidity('');
             }

--- a/templates/pages/admin/customobjects/main.html.twig
+++ b/templates/pages/admin/customobjects/main.html.twig
@@ -44,9 +44,9 @@
     {% endif %}
 
     {% set helper %}
-        {{ __('The system name corresponds to the customizable part of the item class which will correspond to the current definition. For example, items linked to the system name "%s" will have the class "%s".')|format('Example', customobj_ns ~ '\\Example') }}
-        {{ __('The value must contains only letters and must not end with "Model" or "Type".') }}
-        {{ __('Also, the value must not be one of the reserved names.') }}
+        {{ __('The system name field corresponds to what will be used when development is involved. Examples: API calls, webhooks, etc.') }}
+        {{  _('It can be personalized, but some words are reserved such as classes from GLPI like Computer, Monitor, etc.') }}
+        {{ __('Items linked to the system name "%s" will have the class "%s".')|format('Example', customobj_ns ~ '\\Example') }}
     {% endset %}
     {{ fields.textField('label', item.fields['label'], __('Label')) }}
     {{ fields.textField(
@@ -143,7 +143,7 @@
             const existing_names = {{ existing_system_names|json_encode()|raw }}.map((n) => n.toLowerCase());
             // label is made lowercase and spaces are replaced with underscores. All other characters are removed
             $('#mainformtable input[name="system_name"]')
-                .val($('#mainformtable input[name="label"]').val().normalize('NFD').replace(/ /g, '_').replace(/[^a-z_]/g, ''));
+                .val($('#mainformtable input[name="label"]').val().normalize('NFD').replace(/ /g, '_').replace(/[^a-z_]/gi, ''));
             const system_name = $('#mainformtable input[name="system_name"]').val().toLowerCase();
             if (reserved_names.includes(system_name) || system_name.endsWith('type') || system_name.endsWith('model')) {
                 $('#mainformtable input[name="system_name"]').get(0).setCustomValidity(__('The system name is a reserved name. Please enter a different label or manually change the system name.'));

--- a/templates/pages/assets/customfield.html.twig
+++ b/templates/pages/assets/customfield.html.twig
@@ -37,7 +37,7 @@
     <input type="hidden" name="{{ 'Glpi\\Asset\\AssetDefinition'|itemtype_foreign_key }}" value="{{ assetdefinitions_id }}">
 
     {{ fields.textField('label', item.fields['label'], __('Label')) }}
-    {{ fields.textField('name', item.fields['name'], __('System name'), {
+    {{ fields.textField('system_name', item.fields['system_name'], __('System name'), {
         readonly: not item.isNewItem()
     }) }}
     {{ fields.dropdownArrayField('type', item.fields['type']|default('Glpi\\Asset\\CustomFieldType\\StringType'), field_types, _n('Type', 'Types', 1), {
@@ -63,8 +63,12 @@
 
     <script>
         $(() => {
-            $('#customfield_form_container input[name="name"]').on('input', () => {
-                $('input[name="name"]').data('manually_changed', true);
+            $('#customfield_form_container input[name="system_name"]').on('input', () => {
+                if ($('input[name="system_name"]').val() === '') {
+                    $('input[name="system_name"]').data('manually_changed', false);
+                } else {
+                    $('input[name="system_name"]').data('manually_changed', true);
+                }
             });
             const getSelectedType = () => {
                 return $('#customfield_form_container select[name="type"], #customfield_form_container input[name="type"]').first().val();
@@ -87,12 +91,12 @@
                     // System name shouldn't be changed for existing custom fields
                     return;
                 {% endif %}
-                if ($('#customfield_form_container input[name="name"]').data('manually_changed')) {
+                if ($('#customfield_form_container input[name="system_name"]').data('manually_changed')) {
                     return;
                 }
                 // label is made lowercase and spaces are replaced with underscores. All other characters are removed
-                $('#customfield_form_container input[name="name"]')
-                    .val($('#customfield_form_container input[name="label"]').val().toLowerCase().replace(/ /g, '_').replace(/[^a-z_]/g, ''));
+                $('#customfield_form_container input[name="system_name"]')
+                    .val($('#customfield_form_container input[name="label"]').val().normalize('NFD').toLowerCase().replace(/ /g, '_').replace(/[^a-z_]/g, ''));
             };
             const updateDefaultValueField = () => {
                 // get all inputs with name starting with field_options and create an object with the values

--- a/templates/pages/assets/customfield.html.twig
+++ b/templates/pages/assets/customfield.html.twig
@@ -37,8 +37,13 @@
     <input type="hidden" name="{{ 'Glpi\\Asset\\AssetDefinition'|itemtype_foreign_key }}" value="{{ assetdefinitions_id }}">
 
     {{ fields.textField('label', item.fields['label'], __('Label')) }}
+    {% set helper %}
+        {{ __('The system name field corresponds to what will be used when development is involved. Examples: API calls, webhooks, etc.') }}
+        {{ __('In the legacy API, the field name is prefixed by "custom_" to avoid conflicts with standard fields.') }}
+    {% endset %}
     {{ fields.textField('system_name', item.fields['system_name'], __('System name'), {
-        readonly: not item.isNewItem()
+        readonly: not item.isNewItem(),
+        helper: helper
     }) }}
     {{ fields.dropdownArrayField('type', item.fields['type']|default('Glpi\\Asset\\CustomFieldType\\StringType'), field_types, _n('Type', 'Types', 1), {
         readonly: not item.isNewItem()

--- a/tests/functional/Glpi/Asset/Asset.php
+++ b/tests/functional/Glpi/Asset/Asset.php
@@ -162,7 +162,7 @@ class Asset extends DbTestCase
         $asset_definition = $this->initAssetDefinition();
         $string_field = $this->createItem(\Glpi\Asset\CustomFieldDefinition::class, [
             'assets_assetdefinitions_id' => $asset_definition->getID(),
-            'name' => 'test_string',
+            'system_name' => 'test_string',
             'label' => 'Test string',
             'type' => StringType::class,
             'default_value' => 'default',
@@ -183,7 +183,7 @@ class Asset extends DbTestCase
         $asset_definition = $this->initAssetDefinition();
         $string_field = $this->createItem(\Glpi\Asset\CustomFieldDefinition::class, [
             'assets_assetdefinitions_id' => $asset_definition->getID(),
-            'name' => 'test_string',
+            'system_name' => 'test_string',
             'label' => 'Test string',
             'type' => StringType::class,
             'default_value' => 'default',
@@ -204,7 +204,7 @@ class Asset extends DbTestCase
         $asset_definition = $this->initAssetDefinition();
         $this->createItem(\Glpi\Asset\CustomFieldDefinition::class, [
             'assets_assetdefinitions_id' => $asset_definition->getID(),
-            'name' => 'test_string',
+            'system_name' => 'test_string',
             'label' => 'Test string',
             'type' => StringType::class,
             'default_value' => 'default',
@@ -220,21 +220,21 @@ class Asset extends DbTestCase
         $asset_definition = $this->initAssetDefinition();
         $this->createItem(\Glpi\Asset\CustomFieldDefinition::class, [
             'assets_assetdefinitions_id' => $asset_definition->getID(),
-            'name' => 'test_string',
+            'system_name' => 'test_string',
             'label' => 'Test string',
             'type' => StringType::class,
             'default_value' => 'default',
         ]);
         $this->createItem(\Glpi\Asset\CustomFieldDefinition::class, [
             'assets_assetdefinitions_id' => $asset_definition->getID(),
-            'name' => 'test_string_two',
+            'system_name' => 'test_string_two',
             'label' => 'Test string 2',
             'type' => StringType::class,
             'default_value' => 'default2',
         ]);
         $this->createItem(\Glpi\Asset\CustomFieldDefinition::class, [
             'assets_assetdefinitions_id' => $asset_definition->getID(),
-            'name' => 'test_dropdown',
+            'system_name' => 'test_dropdown',
             'label' => 'Test dropdown',
             'type' => DropdownType::class,
             'itemtype' => \Computer::class,

--- a/tests/functional/Glpi/Asset/AssetDefinition.php
+++ b/tests/functional/Glpi/Asset/AssetDefinition.php
@@ -248,19 +248,6 @@ class AssetDefinition extends DbTestCase
             'messages' => [],
         ];
 
-        yield [
-            'input'    => [
-                'system_name' => 'TestAsset',
-                'label'       => 'Test Asset',
-            ],
-            'output'   => false,
-            'messages' => [
-                ERROR => [
-                    'The system name must be unique.'
-                ]
-            ],
-        ];
-
         // start at 32 to ignore control chars
         // stop at 8096, no need to test the whole UTF-8 charset
         for ($i = 32; $i < 8096; $i++) {
@@ -444,6 +431,20 @@ class AssetDefinition extends DbTestCase
         foreach ($messages as $level => $level_messages) {
             $this->hasSessionMessages($level, $level_messages);
         }
+    }
+
+    public function testUniqueSystemName(): void
+    {
+        $definition = $this->newTestedInstance();
+        $this->integer($definition->add([
+            'system_name' => 'test',
+            'label' => 'Test',
+        ]))->isGreaterThan(0);
+        $this->boolean($definition->add([
+            'system_name' => 'test',
+            'label' => 'Test',
+        ]))->isFalse();
+        $this->hasSessionMessages(ERROR, ['The system name must be unique.']);
     }
 
     public function testSystemNameUpdate(): void

--- a/tests/functional/Glpi/Asset/AssetDefinition.php
+++ b/tests/functional/Glpi/Asset/AssetDefinition.php
@@ -232,6 +232,35 @@ class AssetDefinition extends DbTestCase
             ],
         ];
 
+        yield [
+            'input'    => [
+                'system_name' => 'TestAsset',
+                'label'       => 'Test Asset',
+            ],
+            'output'   => [
+                'system_name'  => 'TestAsset',
+                'label'        => 'Test Asset',
+                'capacities'   => '[]',
+                'profiles'     => '[]',
+                'translations' => '[]',
+                'fields_display' => '[]',
+            ],
+            'messages' => [],
+        ];
+
+        yield [
+            'input'    => [
+                'system_name' => 'TestAsset',
+                'label'       => 'Test Asset',
+            ],
+            'output'   => false,
+            'messages' => [
+                ERROR => [
+                    'The system name must be unique.'
+                ]
+            ],
+        ];
+
         // start at 32 to ignore control chars
         // stop at 8096, no need to test the whole UTF-8 charset
         for ($i = 32; $i < 8096; $i++) {
@@ -251,6 +280,7 @@ class AssetDefinition extends DbTestCase
                     ],
                     'output'   => [
                         'system_name'  => $system_name,
+                        'label'        => $system_name,
                         'capacities'   => '[]',
                         'profiles'     => '[]',
                         'translations' => '[]',
@@ -293,6 +323,7 @@ class AssetDefinition extends DbTestCase
                 ],
                 'output'   => [
                     'system_name'  => 'My' . $system_name,
+                    'label'        => 'My' . $system_name,
                     'capacities'   => '[]',
                     'profiles'     => '[]',
                     'translations' => '[]',
@@ -307,6 +338,7 @@ class AssetDefinition extends DbTestCase
                 ],
                 'output'   => [
                     'system_name'  => $system_name . 'NG',
+                    'label'        => $system_name . 'NG',
                     'capacities'   => '[]',
                     'profiles'     => '[]',
                     'translations' => '[]',
@@ -335,6 +367,7 @@ class AssetDefinition extends DbTestCase
             ],
             'output'   => [
                 'system_name'  => 'TestAssetModeling',
+                'label'        => 'TestAssetModeling',
                 'capacities'   => '[]',
                 'profiles'     => '[]',
                 'translations' => '[]',
@@ -362,6 +395,7 @@ class AssetDefinition extends DbTestCase
             ],
             'output'   => [
                 'system_name'  => 'TestAssetTyped',
+                'label'        => 'TestAssetTyped',
                 'capacities'   => '[]',
                 'profiles'     => '[]',
                 'translations' => '[]',
@@ -376,6 +410,7 @@ class AssetDefinition extends DbTestCase
                 $data['input']['system_name'] = __FUNCTION__;
                 if (is_array($data['output'])) {
                     $data['output']['system_name'] = __FUNCTION__;
+                    $data['output']['label'] = __FUNCTION__;
                 }
             }
             if (is_array($data['output']) && !array_key_exists('capacities', $data['output'])) {
@@ -605,6 +640,7 @@ class AssetDefinition extends DbTestCase
             \Glpi\Asset\AssetDefinition::class,
             [
                 'system_name' => 'test',
+                'label' => 'Test',
                 'translations' => [
                     'en_US' => [
                         'one' => 'Test',
@@ -629,8 +665,8 @@ class AssetDefinition extends DbTestCase
 
         // untranslated language
         $_SESSION['glpilanguage'] = 'es_ES';
-        $this->string($definition->getTranslatedName(1))->isEqualTo("test");
-        $this->string($definition->getTranslatedName(10))->isEqualTo('test');
+        $this->string($definition->getTranslatedName(1))->isEqualTo("Test");
+        $this->string($definition->getTranslatedName(10))->isEqualTo('Test');
     }
 
     protected function pluralFormProvider(): iterable

--- a/tests/functional/Glpi/Dropdown/DropdownDefinition.php
+++ b/tests/functional/Glpi/Dropdown/DropdownDefinition.php
@@ -199,19 +199,6 @@ class DropdownDefinition extends DbTestCase
             'messages' => [],
         ];
 
-        yield [
-            'input'    => [
-                'system_name' => 'testsystemname',
-                'label'       => 'Test Label',
-            ],
-            'output'   => false,
-            'messages' => [
-                ERROR => [
-                    'The system name must be unique.'
-                ]
-            ],
-        ];
-
         // start at 32 to ignore control chars
         // stop at 8096, no need to test the whole UTF-8 charset
         for ($i = 32; $i < 8096; $i++) {
@@ -378,6 +365,20 @@ class DropdownDefinition extends DbTestCase
         foreach ($messages as $level => $level_messages) {
             $this->hasSessionMessages($level, $level_messages);
         }
+    }
+
+    public function testUniqueSystemName(): void
+    {
+        $definition = $this->newTestedInstance();
+        $this->integer($definition->add([
+            'system_name' => 'test',
+            'label' => 'Test',
+        ]))->isGreaterThan(0);
+        $this->boolean($definition->add([
+            'system_name' => 'test',
+            'label' => 'Test',
+        ]))->isFalse();
+        $this->hasSessionMessages(ERROR, ['The system name must be unique.']);
     }
 
     public function testSystemNameUpdate(): void

--- a/tests/functional/Glpi/Dropdown/DropdownDefinition.php
+++ b/tests/functional/Glpi/Dropdown/DropdownDefinition.php
@@ -185,6 +185,33 @@ class DropdownDefinition extends DbTestCase
             ],
         ];
 
+        yield [
+            'input'    => [
+                'system_name' => 'testsystemname',
+                'label'       => 'Test Label',
+            ],
+            'output'   => [
+                'system_name'  => 'testsystemname',
+                'label'        => 'Test Label',
+                'profiles'     => '[]',
+                'translations' => '[]',
+            ],
+            'messages' => [],
+        ];
+
+        yield [
+            'input'    => [
+                'system_name' => 'testsystemname',
+                'label'       => 'Test Label',
+            ],
+            'output'   => false,
+            'messages' => [
+                ERROR => [
+                    'The system name must be unique.'
+                ]
+            ],
+        ];
+
         // start at 32 to ignore control chars
         // stop at 8096, no need to test the whole UTF-8 charset
         for ($i = 32; $i < 8096; $i++) {
@@ -204,6 +231,7 @@ class DropdownDefinition extends DbTestCase
                     ],
                     'output'   => [
                         'system_name'  => $system_name,
+                        'label'        => $system_name,
                         'profiles'     => '[]',
                         'translations' => '[]',
                     ],
@@ -244,6 +272,7 @@ class DropdownDefinition extends DbTestCase
                 ],
                 'output'   => [
                     'system_name'  => 'My' . $system_name,
+                    'label'        => 'My' . $system_name,
                     'profiles'     => '[]',
                     'translations' => '[]',
                 ],
@@ -256,6 +285,7 @@ class DropdownDefinition extends DbTestCase
                 ],
                 'output'   => [
                     'system_name'  => $system_name . 'NG',
+                    'label'        => $system_name . 'NG',
                     'profiles'     => '[]',
                     'translations' => '[]',
                 ],
@@ -282,6 +312,7 @@ class DropdownDefinition extends DbTestCase
             ],
             'output'   => [
                 'system_name'  => 'TestDropdownModeling',
+                'label'        => 'TestDropdownModeling',
                 'profiles'     => '[]',
                 'translations' => '[]',
             ],
@@ -307,6 +338,7 @@ class DropdownDefinition extends DbTestCase
             ],
             'output'   => [
                 'system_name'  => 'TestDropdownTyped',
+                'label'        => 'TestDropdownTyped',
                 'profiles'     => '[]',
                 'translations' => '[]',
             ],
@@ -319,6 +351,7 @@ class DropdownDefinition extends DbTestCase
                 $data['input']['system_name'] = __FUNCTION__;
                 if (is_array($data['output'])) {
                     $data['output']['system_name'] = __FUNCTION__;
+                    $data['output']['label'] = __FUNCTION__;
                 }
             }
             if (is_array($data['output']) && !array_key_exists('profiles', $data['output'])) {


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

Adjust how Custom Assets and Custom Dropdowns have their system name / default label handled to match closer to what was done with Custom Fields.

- [x] Add a "Label" field which is shown before the system name field and is the primary input for users
- [x] The "system name" field is automatically calculated from the label field unless the user overrides it by typing in the system name field manually
- [x] Use the "Label" as the fallback translation
- [x] Keep the tooltip helper for the system name, but keep it simple
- [x] Have a proper transliteration, accented characters should transform to their non-accented version (ex é -> e)
- [x] Rename the `name` column for Custom Field definitions to `system_name`