### PR TITLE
Set 1 hour timeout for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,7 @@ jobs:
     name: "Test on PHP ${{ matrix.php-version }} using ${{ matrix.db-image }}"
     needs: "generate-tests-matrix"
     runs-on: "ubuntu-latest"
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.generate-tests-matrix.outputs.matrix) }}


### PR DESCRIPTION
To prevent tests to run for too long, we'll be warned if a job is cancelled.