### PR TITLE
fix(followup): is_private is true with empty template

### DIFF
--- a/templates/components/itilobject/timeline/form_followup.html.twig
+++ b/templates/components/itilobject/timeline/form_followup.html.twig
@@ -301,11 +301,13 @@
                var newOption = new Option(data.requesttypes_name, requesttypes_id, true, true);
                $("#dropdown_requesttypes_id{{ rand }}").append(newOption).trigger('change');
 
-               // set is_private
-               $("#is_private_{{ rand }}")
-                  .prop("checked", data.is_private == "0"
-                     ? false
-                     : true);
+               if (data.is_private !== undefined) {
+                  // set is_private
+                  $("#is_private_{{ rand }}")
+                     .prop("checked", data.is_private == "0"
+                           ? false
+                           : true);
+               }
             });
          }
       </script>


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

When selecting the empty template "-----", the `is_private` field was always activated.
_For tasks, this behavior is already correct._

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/d94ea07d-951e-40bf-beb7-07a318e052d8)
