### PR TITLE
Fix adding dashbaord cards HTML content

### DIFF
--- a/js/modules/Dashboard/Dashboard.js
+++ b/js/modules/Dashboard/Dashboard.js
@@ -103,6 +103,10 @@ class GLPIDashboard {
         this.filters = "{}";
         this.filters_selector = "";
 
+        GridStack.renderCB = (el, w) => {
+            el.innerHTML = w.content;
+        };
+
         // get passed options and merge it with default ones
         let options = (typeof params !== 'undefined') ? params: {};
         /** @type {GLPIDashboardParams} */
@@ -636,13 +640,14 @@ class GLPIDashboard {
       </div>';
 
         // add the widget to the grid
-        const widget = this.grid.addWidget(html, {
+        const widget = this.grid.addWidget({
             'x': x,
             'y': y,
             'w': width,
             'h': height,
             'autoPosition': x < 0 || y < 0,
             'id': gridstack_id,
+            'content': html
         });
 
         // append options

--- a/tests/js/modules/Dashboard/Dashboard.test.js
+++ b/tests/js/modules/Dashboard/Dashboard.test.js
@@ -392,15 +392,16 @@ describe('Dashboard', () => {
         dashboard.addWidget(widget_params);
 
         expect(dashboard.grid.addWidget).toHaveBeenCalledWith(
-            expect.toSatisfy((html) => {
-                const html_el = $(html);
+            expect.toSatisfy((widget_info) => {
+                const html_el = $(widget_info.content);
                 const has_refresh = html_el.find('.controls i.refresh-item').length === 1;
                 const has_edit = html_el.find('.controls i.edit-item').length === 1;
                 const has_delete = html_el.find('.controls i.delete-item').length === 1;
                 const has_content = html_el.find('div.grid-stack-item-content').length === 1;
-                return has_refresh && has_edit && has_delete && has_content;
+                return widget_info.x === 1 && widget_info.y === 2 && widget_info.w === 3 && widget_info.h === 4
+                    && widget_info.autoPosition === false && widget_info.id === 'mycard_12345678-1234-1234-1234-123456789012'
+                    && has_refresh && has_edit && has_delete && has_content;
             }),
-            {x: 1, y: 2, w: 3, h: 4, autoPosition: false, id: 'mycard_12345678-1234-1234-1234-123456789012'}
         );
     });
 
@@ -416,15 +417,16 @@ describe('Dashboard', () => {
         dashboard.addWidget(widget_params);
 
         expect(dashboard.grid.addWidget).toHaveBeenCalledWith(
-            expect.toSatisfy((html) => {
-                const html_el = $(html);
+            expect.toSatisfy((widget_info) => {
+                const html_el = $(widget_info.content);
                 const has_refresh = html_el.find('.controls i.refresh-item').length === 1;
                 const has_edit = html_el.find('.controls i.edit-item').length === 1;
                 const has_delete = html_el.find('.controls i.delete-item').length === 1;
                 const has_content = html_el.find('div.grid-stack-item-content').length === 1;
-                return has_refresh && has_edit && has_delete && has_content;
+                return widget_info.x === -1 && widget_info.y === -1 && widget_info.w === 2 && widget_info.h === 2
+                    && widget_info.autoPosition === true && widget_info.id === 'mycard_12345678-1234-1234-1234-123456789012'
+                    && has_refresh && has_edit && has_delete && has_content;
             }),
-            {x: -1, y: -1, w: 2, h: 2, autoPosition: true, id: 'mycard_12345678-1234-1234-1234-123456789012',}
         );
     });
 
@@ -448,15 +450,16 @@ describe('Dashboard', () => {
         const created_widget = dashboard.addWidget(widget_params);
 
         expect(dashboard.grid.addWidget).toHaveBeenCalledWith(
-            expect.toSatisfy((html) => {
-                const html_el = $(html);
+            expect.toSatisfy((widget_info) => {
+                const html_el = $(widget_info.content);
                 const has_refresh = html_el.find('.controls i.refresh-item').length === 1;
                 const has_edit = html_el.find('.controls i.edit-item').length === 1;
                 const has_delete = html_el.find('.controls i.delete-item').length === 1;
                 const has_content = html_el.find('div.grid-stack-item-content').length === 1;
-                return has_refresh && has_edit && has_delete && has_content;
+                return widget_info.x === 1 && widget_info.y === 2 && widget_info.w === 3 && widget_info.h === 4
+                    && widget_info.autoPosition === false && widget_info.id === 'mycard_12345678-1234-1234-1234-123456789012'
+                    && has_refresh && has_edit && has_delete && has_content;
             }),
-            {x: 1, y: 2, w: 3, h: 4, autoPosition: false, id: 'mycard_12345678-1234-1234-1234-123456789012'}
         );
 
         expect(created_widget.attr('data-card-options')).toBe(JSON.stringify(widget_params.card_options));


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description
GridStack 11 removed the ability to add widgets with HTML content directly and they also changed the signature for `GridStack.addWidget`. This PR fixes the usage of `GridStack.addWidget` and overrides the default `GridStack.renderCB` to assign the content to the innerHTML again instead of innerText.

Fixes #18462

