### PR TITLE
Rely on composer to autoload all GLPI classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -165,7 +165,8 @@
             "src/autoload/misc-functions.php"
         ],
         "psr-4": {
-            "Glpi\\": "src/Glpi/"
+            "Glpi\\": "src/Glpi/",
+            "": "src/"
         }
     },
     "autoload-dev": {

--- a/phpunit/functional/AutoloadTest.php
+++ b/phpunit/functional/AutoloadTest.php
@@ -74,14 +74,6 @@ class AutoloadTest extends DbTestCase
         }
     }
 
-    /**
-     * Checks autoload of some class located in Glpi namespace.
-     */
-    public function testAutoloadGlpiEvent()
-    {
-        $this->assertTrue(class_exists('Glpi\\Event'));
-    }
-
     #[RunInSeparateProcess]
     public function testPluginAutoloading()
     {

--- a/src/autoload/legacy-autoloader.php
+++ b/src/autoload/legacy-autoloader.php
@@ -42,18 +42,16 @@
  */
 function glpi_autoload($classname)
 {
-    $plug = isPluginItemType($classname);
-    if (!$plug) {
-        // PSR-4 styled autoloading for classes without namespace
-        $path = sprintf('%s/src/%s.php', dirname(__FILE__, 3), $classname);
-        if (strpos($classname, NS_GLPI) !== 0 && file_exists($path)) {
-            include_once($path);
-        }
+    if (!str_starts_with($classname, 'Plugin')) {
         return;
     }
 
-    $plugin_name  = $plug['plugin'];
-    $plugin_key   = strtolower($plugin_name);
+    $plug = isPluginItemType($classname);
+    if (!$plug) {
+        return;
+    }
+
+    $plugin_key   = strtolower($plug['plugin']);
     $plugin_class = $plug['class'];
 
     if (!Plugin::isPluginLoaded($plugin_key)) {
@@ -70,12 +68,12 @@ function glpi_autoload($classname)
     }
 
     // Legacy class path, e.g. `PluginMyPluginFoo` -> `plugins/myplugin/inc/foo.class.php`
-    $legacy_path          = sprintf('%s/inc/%s.class.php', $plugin_path, str_replace('\\', '/', strtolower($plugin_class)));
+    $legacy_path      = sprintf('%s/inc/%s.class.php', $plugin_path, str_replace('\\', '/', strtolower($plugin_class)));
     // PSR-4 styled path for class without namespace, e.g. `PluginMyPluginFoo` -> `plugins/myplugin/src/PluginMyPluginFoo.php`
-    $psr4_styled_path     = sprintf('%s/src/%s.php', $plugin_path, str_replace('\\', '/', $classname));
+    $psr4_styled_path = sprintf('%s/src/%s.php', $plugin_path, str_replace('\\', '/', $classname));
     if (file_exists($legacy_path)) {
         include_once($legacy_path);
-    } else if (strpos($classname, NS_PLUG) !== 0 && file_exists($psr4_styled_path)) {
+    } else if (file_exists($psr4_styled_path)) {
         include_once($psr4_styled_path);
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Since we now have all our namespaced classes located in the `src/Glpi` directory, we can safely rely on composer to use the `"": "src/"` fallback in order to load all our classes that have no namespace.

As we use the `"optimize-autoloader": true` option, the autoloading will be based on an optimized logic, using a classname<>filename mapping (generated automatically during `composer install/update` operations) that will, most of the time, be more efficient than our custom checks.
