### PR TITLE
Prevent plugins routes loader to fail if a plugin has no controllers

### DIFF
--- a/src/Glpi/Routing/PluginRoutesLoader.php
+++ b/src/Glpi/Routing/PluginRoutesLoader.php
@@ -50,20 +50,20 @@ class PluginRoutesLoader extends Loader
 
         $plugins = Plugin::getPlugins();
 
-        $paths = [];
+        foreach ($plugins as $plugin_key) {
+            $plugin_path = Plugin::getPhpDir($plugin_key) . '/src/Controller/';
 
-        foreach ($plugins as $k => $plugin_name) {
-            $paths[$k] = Plugin::getPhpDir($plugin_name) . '/src/Controller/';
-        }
+            if (!\file_exists($plugin_path)) {
+                // No controller directory found in the plugin
+                continue;
+            }
 
-        $loader = new AttributeDirectoryLoader(
-            new FileLocator($paths),
-            new AttributeRouteControllerLoader($this->env),
-        );
-
-        foreach ($plugins as $k => $plugin_name) {
-            $plugin_path = $paths[$k];
+            $loader = new AttributeDirectoryLoader(
+                new FileLocator($plugin_path),
+                new AttributeRouteControllerLoader($this->env),
+            );
             $plugin_routes = $loader->load($plugin_path, 'attribute');
+
             if (!$plugin_routes) {
                 // No route found in the plugin
                 continue;
@@ -71,7 +71,7 @@ class PluginRoutesLoader extends Loader
 
             foreach ($plugin_routes as $route) {
                 /** @var Route $route */
-                $prefix = '/plugins/' . $plugin_name . '/';
+                $prefix = '/plugins/' . $plugin_key . '/';
                 if (!\str_starts_with($route->getPath(), $prefix)) {
                     $route->setPath($prefix . \ltrim($route->getPath(), '/'));
                 }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

The plugins routes loader was trying to load routes from plugins that had no `src/Controller` directory. This was resulting in the following error:
```
The file "/var/www/glpi/plugins/xxx/src/Controller/" does not exist.
In /var/www/glpi/vendor/symfony/config/FileLocator.php(46)
#0 /var/www/glpi/vendor/symfony/routing/Loader/AttributeDirectoryLoader.php(31): Symfony\Component\Config\FileLocator->locate('/var/www/glpi/p...')
#1 /var/www/glpi/src/Glpi/Routing/PluginRoutesLoader.php(66): Symfony\Component\Routing\Loader\AttributeDirectoryLoader->load('/var/www/glpi/p...', 'attribute')
#2 /var/www/glpi/vendor/symfony/routing/Router.php(186): Glpi\Routing\PluginRoutesLoader->load('plugins_routes', NULL)
#3 /var/www/glpi/vendor/symfony/routing/Router.php(250): Symfony\Component\Routing\Router->getRouteCollection()
#4 /var/www/glpi/vendor/symfony/routing/Router.php(231): Symfony\Component\Routing\Router->getMatcher()
#5 /var/www/glpi/src/Glpi/Http/PluginsRouterListener.php(92): Symfony\Component\Routing\Router->matchRequest(Object(Symfony\Component\HttpFoundation\Request))
#6 /var/www/glpi/vendor/symfony/event-dispatcher/Debug/WrappedListener.php(116): Glpi\Http\PluginsRouterListener->onKernelRequest(Object(Symfony\Component\HttpKernel\Event\RequestEvent), 'kernel.request', Object(Symfony\Component\HttpKernel\Debug\TraceableEventDispatcher))
#7 /var/www/glpi/vendor/symfony/event-dispatcher/EventDispatcher.php(220): Symfony\Component\EventDispatcher\Debug\WrappedListener->__invoke(Object(Symfony\Component\HttpKernel\Event\RequestEvent), 'kernel.request', Object(Symfony\Component\HttpKernel\Debug\TraceableEventDispatcher))
#8 /var/www/glpi/vendor/symfony/event-dispatcher/EventDispatcher.php(56): Symfony\Component\EventDispatcher\EventDispatcher->callListeners(Array, 'kernel.request', Object(Symfony\Component\HttpKernel\Event\RequestEvent))
#9 /var/www/glpi/vendor/symfony/event-dispatcher/Debug/TraceableEventDispatcher.php(139): Symfony\Component\EventDispatcher\EventDispatcher->dispatch(Object(Symfony\Component\HttpKernel\Event\RequestEvent), 'kernel.request')
#10 /var/www/glpi/vendor/symfony/http-kernel/HttpKernel.php(157): Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcher->dispatch(Object(Symfony\Component\HttpKernel\Event\RequestEvent), 'kernel.request')
#11 /var/www/glpi/vendor/symfony/http-kernel/HttpKernel.php(76): Symfony\Component\HttpKernel\HttpKernel->handleRaw(Object(Symfony\Component\HttpFoundation\Request), 1)
#12 /var/www/glpi/vendor/symfony/http-kernel/Kernel.php(197): Symfony\Component\HttpKernel\HttpKernel->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#13 /var/www/glpi/public/index.php(56): Symfony\Component\HttpKernel\Kernel->handle(Object(Symfony\Component\HttpFoundation\Request))
#14 {main}
```