### PR TITLE
Fix add inventory task info

### DIFF
--- a/src/Inventory/Request.php
+++ b/src/Inventory/Request.php
@@ -329,8 +329,7 @@ class Request extends AbstractRequest
                 !empty(array_intersect($raw_data->{'enabled-tasks'}, $taskneededinv)) &&
                 !in_array('inventory', $raw_data->{'enabled-tasks'})
             ) {
-                $handle = $this->handleTask('inventory');
-                $response['tasks']['inventory'] = $handle;
+                $response['tasks']['inventory'] = $this->handleTask('inventory');
             }
             foreach ($raw_data->{'enabled-tasks'} as $task) {
                 $handle = $this->handleTask($task);

--- a/src/Inventory/Request.php
+++ b/src/Inventory/Request.php
@@ -319,6 +319,19 @@ class Request extends AbstractRequest
         //For the moment it's the Agent who informs us about the active tasks
         $raw_data = $this->inventory->getRawData();
         if ($raw_data !== null && property_exists($raw_data, 'enabled-tasks')) {
+            $taskneededinv = [
+                'esx',
+                'netdiscovery',
+                'netinventory',
+                'remoteinventory'
+            ];
+            if (
+                !empty(array_intersect($raw_data->{'enabled-tasks'}, $taskneededinv)) &&
+                !in_array('inventory', $raw_data->{'enabled-tasks'})
+            ) {
+                $handle = $this->handleTask('inventory');
+                $response['tasks']['inventory'] = $handle;
+            }
             foreach ($raw_data->{'enabled-tasks'} as $task) {
                 $handle = $this->handleTask($task);
                 if (is_array($handle) && count($handle)) {

--- a/src/Inventory/Request.php
+++ b/src/Inventory/Request.php
@@ -319,19 +319,24 @@ class Request extends AbstractRequest
         //For the moment it's the Agent who informs us about the active tasks
         $raw_data = $this->inventory->getRawData();
         if ($raw_data !== null && property_exists($raw_data, 'enabled-tasks')) {
+            $enabled_tasks = $raw_data->{'enabled-tasks'};
+
+            // The following tasks depends on inventory.
+            // When they are enabled, we assume that inventory is enabled.
             $taskneededinv = [
                 'esx',
                 'netdiscovery',
                 'netinventory',
-                'remoteinventory'
+                'remoteinventory',
             ];
             if (
-                !empty(array_intersect($raw_data->{'enabled-tasks'}, $taskneededinv)) &&
-                !in_array('inventory', $raw_data->{'enabled-tasks'})
+                !empty(array_intersect($enabled_tasks, $taskneededinv)) &&
+                !in_array('inventory', $enabled_tasks)
             ) {
-                $response['tasks']['inventory'] = $this->handleTask('inventory');
+                $enabled_tasks[] = 'inventory';
             }
-            foreach ($raw_data->{'enabled-tasks'} as $task) {
+
+            foreach ($enabled_tasks as $task) {
                 $handle = $this->handleTask($task);
                 if (is_array($handle) && count($handle)) {
                     // Insert related task information under tasks list property


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description
- Here is a brief description of what this PR does

During the exchange between the agent and the server, it was observed that the support for the **"inventory"** task is not included in the server's response, even though it is required for certain planned tasks such as **"esx"**, **"netdiscovery"**, **"netinventory"**, and **"remoteinventory"**. For example, the current response:

```json
{
   "expiration": "4",
   "status": "ok",
   "tasks": {
      "esx": {
         "version": "1.4.0",
         "server": "glpiinventory"
      }
   }
}
```

should also include the **"inventory"** task, as follows:

```json
{
   "expiration": "4",
   "status": "ok",
   "tasks": {
      "esx": {
         "version": "1.4.0",
         "server": "glpiinventory"
      },
      "inventory": {
         "version": "10.0.17",
         "server": "glpi"
      }
   }
}
```

This would ensure that dependent tasks function properly. The solution is to ensure that **"inventory"** is included in the server's response whenever tasks that depend on it are planned.

## Screenshots (if appropriate):


