### PR TITLE
fix(user): can not update is_active field via massive action

### DIFF
--- a/phpunit/functional/UserTest.php
+++ b/phpunit/functional/UserTest.php
@@ -625,7 +625,18 @@ class UserTest extends \DbTestCase
 
                 foreach ($inputs as $key => $value) {
                     $output = $target_user->prepareInputForUpdate(['id' => $target_user->getID(), $key => $value]);
-                    $this->assertEquals($can, \array_key_exists($key, $output));
+                    if (is_array($output)) {
+                        $this->assertEquals($can, \array_key_exists($key, $output));
+                    } else {
+                        $this->assertFalse($can);
+                        $this->assertFalse($output);
+                        $this->hasSessionMessages(ERROR, [
+                            sprintf(
+                                __('You are not allowed to update the following fields: %s'),
+                                $key
+                            )
+                        ]);
+                    }
                 }
             }
         }

--- a/src/User.php
+++ b/src/User.php
@@ -1076,8 +1076,27 @@ class User extends CommonDBTM
                 count(array_intersect($protected_input_keys, array_keys($input))) > 0
                 && !$this->currentUserHaveMoreRightThan($input['id'])
             ) {
+                $ignored_fields = [];
                 foreach ($protected_input_keys as $input_key) {
+                    if (
+                        isset($input[$input_key])
+                        && $input_key != '_useremails' // Always in $input
+                        && $input[$input_key] != $this->getField($input_key)
+                    ) {
+                        $ignored_fields[] = $input_key;
+                    }
                     unset($input[$input_key]);
+                }
+                if (!empty($ignored_fields)) {
+                    Session::addMessageAfterRedirect(
+                        sprintf(
+                            __('You are not allowed to update the following fields: %s'),
+                            implode(', ', $ignored_fields)
+                        ),
+                        false,
+                        ERROR
+                    );
+                    return false;
                 }
             }
         }

--- a/src/User.php
+++ b/src/User.php
@@ -1080,7 +1080,7 @@ class User extends CommonDBTM
                 foreach ($protected_input_keys as $input_key) {
                     if (
                         isset($input[$input_key])
-                        && $input_key != '_useremails' // Always in $input
+                        && !str_starts_with($input_key, '_') // virtual field
                         && $input[$input_key] != $this->getField($input_key)
                     ) {
                         $ignored_fields[] = $input_key;


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description


- It fixes !35356
- Here is a brief description of what this PR does

Following https://github.com/glpi-project/glpi/pull/18441, the `is_active` field can still be modified by massive actions, a success message is displayed saying that the user has been modified, but the field was not modified in base. This PR is designed to display an error message while maintaining this security control.

## Screenshots (if appropriate):


