### PR TITLE
Streamline search for solution process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ The present file will list all changes made to the project; according to the
 - "If software are no longer used" transfer option is now taken into account rather than always preserving.
 - Notifications can now specify exclusions for recipients.
 - Warranty expiration alerts no longer trigger for deleted items.
+- New UI for searching for Ticket/Change/Problem solutions from the Knowledgebase.
 
 ### Deprecated
 - Survey URL tags `TICKETCATEGORY_ID` and `TICKETCATEGORY_NAME` are deprecated and replaced by `ITILCATEGORY_ID` and `ITILCATEGORY_NAME` respectively.

--- a/ajax/timeline.php
+++ b/ajax/timeline.php
@@ -107,7 +107,6 @@ if (($_POST['action'] ?? null) === 'change_task_state') {
         $template = 'form_followup';
     } else if ($_REQUEST['type'] === ITILSolution::class) {
         $template = 'form_solution';
-        $params['kb_id_toload'] = $_REQUEST['load_kb_sol'] ?? 0;
     } else if (is_subclass_of($_REQUEST['type'], CommonITILTask::class)) {
         $template = 'form_task';
     } else if (is_subclass_of($_REQUEST['type'], CommonITILValidation::class)) {

--- a/front/commonitiltask.form.php
+++ b/front/commonitiltask.form.php
@@ -121,23 +121,6 @@ if (isset($_POST["add"])) {
 }
 
 if ($handled) {
-    if (isset($_POST['kb_linked_id'])) {
-       //if followup should be linked to selected KB entry
-        $params = [
-            'knowbaseitems_id' => $_POST['kb_linked_id'],
-            'itemtype'         => $itemtype,
-            'items_id'         => $task->getField($fk)
-        ];
-        $existing = $DB->request([
-            'FROM' => 'glpi_knowbaseitems_items',
-            'WHERE' => $params
-        ]);
-        if ($existing->numrows() == 0) {
-            $kb_item_item = new KnowbaseItem_Item();
-            $kb_item_item->add($params);
-        }
-    }
-
     if ($track->can($task->getField($fk), READ)) {
         $toadd = '';
        // Copy followup to KB redirect to KB

--- a/front/itilfollowup.form.php
+++ b/front/itilfollowup.form.php
@@ -112,23 +112,6 @@ if (isset($_POST["add"])) {
 }
 
 if ($handled) {
-    if (isset($_POST['kb_linked_id'])) {
-       //if followup should be linked to selected KB entry
-        $params = [
-            'knowbaseitems_id' => $_POST['kb_linked_id'],
-            'itemtype'         => $track->getType(),
-            'items_id'         => $track->getID()
-        ];
-        $existing = $DB->request([
-            'FROM' => 'glpi_knowbaseitems_items',
-            'WHERE' => $params
-        ]);
-        if ($existing->numrows() == 0) {
-            $kb_item_item = new KnowbaseItem_Item();
-            $kb_item_item->add($params);
-        }
-    }
-
     if ($track->can($_POST["items_id"], READ)) {
         $toadd = '';
        // Copy followup to KB redirect to KB

--- a/front/ticket.form.php
+++ b/front/ticket.form.php
@@ -233,7 +233,7 @@ if (isset($_POST["add"])) {
 }
 
 if (isset($_GET["id"]) && ($_GET["id"] > 0)) {
-    $available_options = ['load_kb_sol', '_openfollowup'];
+    $available_options = ['_openfollowup'];
     $options = [];
 
     foreach ($available_options as $key) {

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -645,7 +645,6 @@ abstract class CommonITILObject extends CommonDBTM
             'canpriority'             => $canupdate,
             'canassign'               => $canupdate,
             'has_pending_reason'      => PendingReason_Item::getForItem($this) !== false,
-            'load_kb_sol'             => $options['load_kb_sol'] ?? 0,
         ]);
 
         return true;

--- a/src/Glpi/Controller/Knowbase/KnowbaseItemController.php
+++ b/src/Glpi/Controller/Knowbase/KnowbaseItemController.php
@@ -1,0 +1,187 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Controller\Knowbase;
+
+use Glpi\Application\View\TemplateRenderer;
+use Glpi\Controller\AbstractController;
+use Glpi\Exception\Http\AccessDeniedHttpException;
+use Glpi\Exception\Http\NotFoundHttpException;
+use Glpi\RichText\RichText;
+use KnowbaseItem;
+use Session;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+use Symfony\Component\Routing\Attribute\Route;
+
+final class KnowbaseItemController extends AbstractController
+{
+    #[Route(
+        "/Knowbase/KnowbaseItem/{knowbaseitems_id}/Content",
+        name: "knowbaseitem_content",
+        requirements: [
+            'knowbaseitems_id' => '\d+',
+        ]
+    )]
+    public function content(Request $request): Response
+    {
+        $id = $request->get('knowbaseitems_id');
+        if (!KnowbaseItem::canView()) {
+            throw new AccessDeniedHttpException();
+        }
+        $kbitem = new KnowbaseItem();
+        if (!$kbitem->getFromDB((int) $id)) {
+            throw new NotFoundHttpException();
+        } else if (!$kbitem->canViewItem()) {
+            throw new AccessDeniedHttpException();
+        }
+        return new Response($kbitem->fields['answer']);
+    }
+
+    #[Route(
+        "/Knowbase/KnowbaseItem/{knowbaseitems_id}/Full",
+        name: "knowbaseitem_full",
+        requirements: [
+            'knowbaseitems_id' => '\d+',
+        ]
+    )]
+    public function full(Request $request): Response
+    {
+        $id = $request->get('knowbaseitems_id');
+        if (!KnowbaseItem::canView()) {
+            throw new AccessDeniedHttpException();
+        }
+        $kbitem = new KnowbaseItem();
+        if (!$kbitem->getFromDB((int) $id)) {
+            throw new NotFoundHttpException();
+        } else if (!$kbitem->canViewItem()) {
+            throw new AccessDeniedHttpException();
+        }
+        return new StreamedResponse(static function () use ($kbitem) {
+            $kbitem->showFull();
+        });
+    }
+
+    #[Route(
+        "/Knowbase/KnowbaseItem/SearchSolution/{itemtype}/{items_id}",
+        name: "knowbaseitem_search_solution",
+        requirements: [
+            'items_id' => '\d+',
+        ]
+    )]
+    public function searchSolution(Request $request): Response
+    {
+        /**
+         * @var array $CFG_GLPI
+         * @var \DBmysql $DB
+         */
+        global $CFG_GLPI, $DB;
+
+        $itemtype = $request->get('itemtype');
+        $items_id = $request->get('items_id');
+        $start = (int) $request->get('start', 0);
+        $contains = $request->get('contains');
+
+        // Search a solution
+        if (empty($contains)) {
+            if (in_array($itemtype, $CFG_GLPI['kb_types'], true) && $item = getItemForItemtype($itemtype)) {
+                if ($item->can($items_id, READ)) {
+                    $contains = $item->getField('name');
+                }
+            }
+        }
+
+        $criteria = KnowbaseItem::getListRequest([
+            'contains' => $contains,
+        ]);
+        $count_criteria = $criteria;
+        $criteria['START'] = $start;
+        $criteria['LIMIT'] = $_SESSION['glpilist_limit'];
+        unset($count_criteria['SELECT'], $count_criteria['ORDERBY'], $count_criteria['GROUPBY']);
+        $count_criteria['COUNT'] = 'cpt';
+
+        $it = $DB->request($criteria);
+        $total_count = $DB->request($count_criteria)->current()['cpt'] ?? 0;
+        $results = [];
+
+        foreach ($it as $data) {
+            $fa_class = "";
+            $fa_title = "";
+            if (
+                $data['is_faq']
+                && (!Session::isMultiEntitiesMode()
+                    || (isset($data['visibility_count'])
+                        && $data['visibility_count'] > 0))
+            ) {
+                $fa_class = "fa-question-circle faq";
+                $fa_title = __s("This item is part of the FAQ");
+            } else if (
+                isset($data['visibility_count'])
+                && $data['visibility_count'] <= 0
+            ) {
+                $fa_class = "fa-eye-slash not-published";
+                $fa_title = __s("This item is not published yet");
+            }
+
+            $results[] = [
+                'id' => $data['id'],
+                'name' => $data['name'],
+                'content_preview' => mb_substr(
+                    RichText::getTextFromHtml(
+                        content: $data['answer'],
+                        preserve_line_breaks: true
+                    ), 0, GLPI_TEXT_MAXSIZE
+                ),
+                'url' => KnowbaseItem::getFormURLWithID($data['id']),
+                'icon' => $fa_class,
+                'icon_title' => $fa_title,
+            ];
+        }
+
+        $twig_params = [
+            'contains' => $contains,
+            'results' => $results,
+            'itemtype' => $itemtype,
+            'items_id' => $items_id,
+            'is_ajax' => $request->get('ajax_reload', 0),
+            'count' => $total_count,
+            'start' => $start,
+        ];
+
+        return new StreamedResponse(static function () use ($twig_params) {
+            TemplateRenderer::getInstance()->display('pages/tools/search_solution.twig', $twig_params);
+        });
+    }
+}

--- a/src/Glpi/Controller/Knowbase/KnowbaseItemController.php
+++ b/src/Glpi/Controller/Knowbase/KnowbaseItemController.php
@@ -159,10 +159,12 @@ final class KnowbaseItemController extends AbstractController
                 'id' => $data['id'],
                 'name' => $data['name'],
                 'content_preview' => mb_substr(
-                    RichText::getTextFromHtml(
+                    string: RichText::getTextFromHtml(
                         content: $data['answer'],
                         preserve_line_breaks: true
-                    ), 0, GLPI_TEXT_MAXSIZE
+                    ),
+                    start: 0,
+                    length: GLPI_TEXT_MAXSIZE
                 ),
                 'url' => KnowbaseItem::getFormURLWithID($data['id']),
                 'icon' => $fa_class,

--- a/src/ITILSolution.php
+++ b/src/ITILSolution.php
@@ -140,7 +140,6 @@ class ITILSolution extends CommonDBChild
      * @param $ID integer ID of the item
      * @param $options array
      *     - item: CommonITILObject instance
-     *     - kb_id_toload: load new item content from KB entry
      *
      * @return boolean item found
      **/
@@ -148,13 +147,6 @@ class ITILSolution extends CommonDBChild
     {
         if ($this->isNewItem()) {
             $this->getEmpty();
-        }
-
-        if (isset($options['kb_id_toload']) && $options['kb_id_toload'] > 0) {
-            $kb = new KnowbaseItem();
-            if ($kb->getFromDB($options['kb_id_toload'])) {
-                $this->fields['content'] = $kb->getField('answer');
-            }
         }
 
         TemplateRenderer::getInstance()->display('components/itilobject/timeline/form_solution.html.twig', [

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -3757,7 +3757,6 @@ JAVASCRIPT;
             'canpriority'               => $canpriority,
             'canassign'                 => $canassign,
             'canassigntome'             => $canassigntome,
-            'load_kb_sol'               => $options['load_kb_sol'] ?? 0,
             'userentities'              => $userentities,
             'cancreateuser'             => $cancreateuser,
             'canreadnote'               => Session::haveRight('entity', READNOTE),

--- a/templates/components/itilobject/answer.html.twig
+++ b/templates/components/itilobject/answer.html.twig
@@ -33,10 +33,9 @@
 
 <div id="new-itilobject-form" class="d-flex">
    {% for timeline_itemtype in timeline_itemtypes %}
-      {% set show_kb_sol = load_kb_sol > 0 and timeline_itemtype.type == 'ITILSolution' %}
       {% set is_private = timeline_itemtype.item.fields['is_private'] ?? false %}
       {% set is_private_class = is_private ? "private-item" : "" %}
-      <div class="timeline-item mb-1 ms-auto {{ is_private_class }} {{ timeline_itemtype.type }} collapse {{ show_kb_sol ? 'show' : '' }}"
+      <div class="timeline-item mb-1 ms-auto {{ is_private_class }} {{ timeline_itemtype.type }} collapse"
         id="new-{{ timeline_itemtype.class }}-block" aria-expanded="false" data-bs-parent="#new-itilobject-form">
          <div class="row">
             <div class="col-auto todo-list-state"></div>
@@ -56,16 +55,10 @@
                         {% if timeline_itemtype.template is defined %}
                            {{ include(timeline_itemtype.template, {
                               'item': item,
-                              'subitem': timeline_itemtype.item,
-                              'kb_id_toload': load_kb_sol
+                              'subitem': timeline_itemtype.item
                            }) }}
                         {% else %}
                            {% set sf_options = {'parent': item} %}
-                           {% if show_kb_sol %}
-                              {% set sf_options = sf_options|merge({
-                                 'kb_id_toload': load_kb_sol
-                              }) %}
-                           {% endif %}
                            {{ timeline_itemtype.item.showForm(-1, sf_options) }}
                         {% endif %}
                      </div>

--- a/templates/components/itilobject/footer.html.twig
+++ b/templates/components/itilobject/footer.html.twig
@@ -52,7 +52,7 @@
             {% if item.isNotSolved() and default_action_data != false %}
                {% if main_actions_itemtypes|length > 1 %}
                   {% set btn_class = timeline_btn_layout == constant('Config::TIMELINE_ACTION_BTN_SPLITTED') ? "" : "btn-group" %}
-                  <div class="{{ btn_class }} me-2 main-actions" style="{{ load_kb_sol > 0 ? 'display:none;' : '' }}">
+                  <div class="{{ btn_class }} me-2 main-actions">
                {% else %}
                   {# Don't use d-inline-flex class as it add an '!important' tag that mess with our javascript that will hide this div #}
                   <div class="main-actions" style="display:inline-flex">

--- a/templates/components/itilobject/timeline/form_followup.html.twig
+++ b/templates/components/itilobject/timeline/form_followup.html.twig
@@ -178,24 +178,6 @@
                            }
                         ) }}
 
-                        {% if can_read_kb and kb_id_toload > 0 %}
-                           {% set link_kb_lbl %}
-                              <i class="fas fa-link fa-fw me-1" data-bs-toggle="tooltip" data-bs-placement="top"
-                                 title="{{ __('Link to knowledge base entry #%id')|replace({'%id': kb_id_toload}) }}"></i>
-                           {% endset %}
-                           {{ fields.sliderField(
-                              'kb_linked_id',
-                              1,
-                              link_kb_lbl,
-                              {
-                                 'full_width': true,
-                                 'icon_label': true,
-                                 'rand': rand,
-                                 'yes_value': kb_id_toload,
-                              }
-                           ) }}
-                        {% endif %}
-
                         {% if candedit and can_update_kb and not nokb %}
                            {% set fup_to_kb_lbl %}
                               <i class="far fa-save fa-fw me-1" title="{{ __('Save and add to the knowledge base') }}"

--- a/templates/components/itilobject/timeline/form_solution.html.twig
+++ b/templates/components/itilobject/timeline/form_solution.html.twig
@@ -100,10 +100,6 @@
             <div class="row mx-n3 mx-xxl-auto">
                <div class="col-12 col-xl-7 col-xxl-8">
                   {% set content = subitem.fields['content'] %}
-                  {% if kb_id_toload > 0 %}
-                     {% set kb_item = get_item("KnowbaseItem", kb_id_toload) %}
-                     {% set content = (kb_item.fields['answer'] ?? "") %}
-                  {% endif %}
 
                   {{ fields.textareaField(
                      'content',
@@ -126,12 +122,10 @@
                      {% if candedit %}
                         {% if can_read_kb and not nokb %}
                            {% set search_solution_button %}
-                              <a href="{{ path('/front/knowbaseitem.php?item_itemtype=' ~ item.getType() ~ '&item_items_id=' ~ item.getID() ~ '&forcetab=Knowbase$1') }}"
-                                 class="btn btn-secondary overflow-hidden text-nowrap" type="submit"
-                                 title="{{ __('Search a solution') }}"
-                                 data-bs-toggle="tooltip" data-bs-placement="top">
-                                 <i class="fas fa-search"></i>
-                              </a>
+                               <button type="button" class="btn btn-secondary overflow-hidden text-nowrap" name="search_solution"
+                                       title="{{ __('Search a solution') }}" data-bs-toggle="tooltip" data-bs-placement="top">
+                                   <i class="ti ti-search"></i>
+                               </button>
                            {% endset %}
                            {{ fields.field(
                               '',
@@ -196,23 +190,23 @@
                         }
                      ) }}
 
-                     {% if can_read_kb and kb_id_toload > 0 %}
-                        {% set link_kb_lbl %}
-                           <i class="fas fa-link fa-fw me-1" data-bs-toggle="tooltip" data-bs-placement="top"
-                              title="{{ __('Link to knowledge base entry #%id')|replace({'%id': kb_id_toload}) }}"></i>
-                        {% endset %}
-                        {{ fields.sliderField(
-                           'kb_linked_id',
-                           1,
-                           link_kb_lbl,
-                           {
-                              'full_width': true,
-                              'icon_label': true,
-                              'rand': rand,
-                              'yes_value': kb_id_toload,
-                           }
-                        ) }}
-                     {% endif %}
+                    {% set link_kb_lbl %}
+                        <i class="fas fa-link fa-fw me-1" data-bs-toggle="tooltip" data-bs-placement="top"
+                           title="{{ __('Link to knowledge base entry #%id')|replace({'%id': ''}) }}"></i>
+                    {% endset %}
+                    {{ fields.sliderField(
+                       'kb_linked_id',
+                       1,
+                       link_kb_lbl,
+                       {
+                          'full_width': true,
+                          'icon_label': true,
+                          'rand': rand,
+                          'yes_value': 0,
+                          'add_field_class': 'd-none',
+                           'disabled': true,
+                       }
+                    ) }}
 
                      {% if candedit and can_update_kb and not nokb %}
                         {% set sol_to_kb_lbl %}
@@ -281,6 +275,32 @@
                $("#dropdown_solutiontypes_id{{ rand }}").append(newOption).trigger('change');
             });
          }
+         $('button[name="search_solution"]').on('click', () => {
+            window.glpi_ajax_dialog({
+                id: 'modal_searchSolution',
+                modalclass: 'modal-xl',
+                title: '{{ __('Search a solution') }}',
+                url: '{{ path('/Knowbase/KnowbaseItem/SearchSolution/') ~ (item.getType() ~ '/' ~ item.getID())|e('js') }}'
+            });
+            $(document).off('click', '#modal_searchSolution button.use-solution').on('click', '#modal_searchSolution button.use-solution', (e) => {
+                const solutions_id = $(e.target).attr('data-solution-id') ?? $(e.target).closest('.list-group-item').attr('data-solution-id');
+                $('#modal_searchSolution').modal('hide');
+                if (solutions_id) {
+                    $.ajax({
+                        url: `{{ path('/Knowbase/KnowbaseItem/') }}${solutions_id}/Content`
+                    }).then((data) => {
+                        if (data) {
+                            setRichTextEditorContent("content_{{ rand }}", data);
+                            const link_kb = $('.itilsolution input[type="checkbox"][name="kb_linked_id"]');
+                            link_kb.val(solutions_id);
+                            link_kb.removeAttr('disabled');
+                            link_kb.closest('.form-field').find('label.col-form-label > i').attr('data-bs-original-title', __('Link to knowledge base entry #%id').replace('%id', solutions_id));
+                            link_kb.closest('.form-field').removeClass('d-none');
+                        }
+                    });
+                }
+            })
+         });
       </script>
    {% endif %}
 {% endblock %}

--- a/templates/components/itilobject/timeline/form_solution.html.twig
+++ b/templates/components/itilobject/timeline/form_solution.html.twig
@@ -283,7 +283,8 @@
                 url: '{{ path('/Knowbase/KnowbaseItem/SearchSolution/') ~ (item.getType() ~ '/' ~ item.getID())|e('js') }}'
             });
             $(document).off('click', '#modal_searchSolution button.use-solution').on('click', '#modal_searchSolution button.use-solution', (e) => {
-                const solutions_id = $(e.target).attr('data-solution-id') ?? $(e.target).closest('.list-group-item').attr('data-solution-id');
+                const btn = $(e.target).closest('button.use-solution');
+                const solutions_id = btn.attr('data-solution-id') ?? btn.closest('.list-group-item').attr('data-solution-id');
                 $('#modal_searchSolution').modal('hide');
                 if (solutions_id) {
                     $.ajax({

--- a/templates/components/itilobject/timeline/form_task_main_form.html.twig
+++ b/templates/components/itilobject/timeline/form_task_main_form.html.twig
@@ -42,7 +42,6 @@
 {% set nokb = nokb|default(params['nokb'] is defined or params['nokb'] == true) %}
 {% set rand = rand|default(random()) %}
 {% set formoptions = formoptions|default(params['formoptions'] ?? '') %}
-{% set kb_id_toload = kb_id_toload|default(0) %}
 
 {# In some cases, we may already have an HTML form (massive actions) #}
 {% set add_html_form = no_form is not defined or no_form == false %}
@@ -179,24 +178,6 @@
                         }
                     }
                 ) }}
-
-                {% if can_read_kb and kb_id_toload > 0 %}
-                {% set link_kb_lbl %}
-                    <i class="fas fa-link fa-fw me-1" data-bs-toggle="tooltip" data-bs-placement="top"
-                        title="{{ __('Link to knowledge base entry #%id')|replace({'%id': kb_id_toload}) }}"></i>
-                {% endset %}
-                {{ fields.sliderField(
-                    'kb_linked_id',
-                    1,
-                    link_kb_lbl,
-                    {
-                        'full_width': true,
-                        'icon_label': true,
-                        'rand': rand,
-                        'yes_value': kb_id_toload,
-                    }
-                ) }}
-                {% endif %}
 
                 {% if candedit and can_update_kb and not nokb %}
                 {% set task_to_kb_lbl %}

--- a/templates/components/pager.html.twig
+++ b/templates/components/pager.html.twig
@@ -65,6 +65,7 @@
 {% set current_page = ((current_start - 1) / limit)|round(0, 'ceil') + 1 %}
 
 {% set short_display = short_display|default(false) %}
+{% set no_limit_display = no_limit_display|default(false) %}
 
 {# limit the number of adjacents links displayed #}
 {% set adjacents = 2 %}
@@ -72,29 +73,31 @@
 {% set rand = rand|default(random()) %}
 
 <div class="flex-grow-1 d-flex flex-wrap flex-md-nowrap  align-items-center justify-content-between mb-2 search-pager">
-    {% if not short_display %}
-        <span class="search-limit d-none d-md-block">
+    {% if not no_limit_display %}
+        {% if not short_display %}
+            <span class="search-limit d-none d-md-block">
+                {% include 'components/dropdown/limit.html.twig' with {
+                    'no_onchange': fluid_search|default(false),
+                    'select_class': 'search-limit-dropdown',
+                    'href': href|replace({'%start%': start}),
+                    'additional_attributes': short_display ? {
+                        'title': __('Rows per page'),
+                    } : {
+                        'aria-labelledby': 'list_limit' ~ rand ~ '_label',
+                    },
+                    'rand': rand,
+                } %}
+                <span id="list_limit{{ rand }}_label">{{ __('rows / page') }}</span>
+            </span>
+        {% endif %}
+        <span class="search-limit {{ short_display ? "" : "d-block d-md-none" }}">
             {% include 'components/dropdown/limit.html.twig' with {
                 'no_onchange': fluid_search|default(false),
                 'select_class': 'search-limit-dropdown',
                 'href': href|replace({'%start%': start}),
-                'additional_attributes': short_display ? {
-                    'title': __('Rows per page'),
-                } : {
-                    'aria-labelledby': 'list_limit' ~ rand ~ '_label',
-                },
-                'rand': rand,
             } %}
-            <span id="list_limit{{ rand }}_label">{{ __('rows / page') }}</span>
         </span>
     {% endif %}
-    <span class="search-limit {{ short_display ? "" : "d-block d-md-none" }}">
-        {% include 'components/dropdown/limit.html.twig' with {
-            'no_onchange': fluid_search|default(false),
-            'select_class': 'search-limit-dropdown',
-            'href': href|replace({'%start%': start}),
-        } %}
-    </span>
 
     {% if not short_display %}
         <p class="m-0 text-muted d-none d-md-block page-infos">

--- a/templates/pages/tools/search_solution.twig
+++ b/templates/pages/tools/search_solution.twig
@@ -1,0 +1,205 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2025 Teclib' and contributors.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+{% import 'components/form/basic_inputs_macros.html.twig' as inputs %}
+
+{% set container_id = 'container' ~ random() %}
+
+{% if not is_ajax %}
+    <div id="{{ container_id }}">
+{% endif %}
+        <div class="card search-card border-0">
+            <div id="search_solution_form" class="d-flex mb-3 mt-3">
+                {{ inputs.text('contains', contains, {
+                    additional_attributes: {
+                        'aria-label': __('Search…'),
+                    },
+                    input_addclass: 'me-1'
+                }) }}
+                {{ inputs.button('search', _x('button', 'Search')) }}
+                {{ inputs.hidden('start', start) }}
+            </div>
+            {% if results|length %}
+                <div class="search-solution-results list-group list-group-flush list-group-hoverable" role="list">
+                    {% for result in results %}
+                        <div class="list-group-item d-flex" data-solution-id="{{ result.id }}" role="listitem">
+                            <div class="col-auto">
+                                <i class="{{ result.icon }}" title="{{ result.icon_title }}"></i>
+                            </div>
+                            <div class="col">
+                                <div class="fs-2">{{ result.name }}</div>
+                                <div class="fs-4 solution-content-preview">{{ result.content_preview }}</div>
+                            </div>
+                            <div class="col-auto">
+                                <button type="button" class="btn btn-ghost-secondary btn-sm btn-icon use-solution" title="{{ __('Use as a solution') }}">
+                                    <i class="ti ti-check"></i>
+                                </button>
+                                <button type="button" class="btn btn-ghost-secondary btn-sm btn-icon view-solution" title="{{ __('Preview') }}">
+                                    <i class="ti ti-eye"></i>
+                                </button>
+                            </div>
+                        </div>
+                    {% endfor %}
+                </div>
+                {{ include('components/pager.html.twig', {
+                    no_limit_display: true,
+                }) }}
+            {% else %}
+                <div class="alert alert-info">
+                    {{ __('No data') }}
+                </div>
+            {% endif %}
+
+        </div>
+        <div class="card preview-card border-0" style="display: none">
+            <div class="d-flex">
+                <button type="button" class="btn btn-ghost-secondary back-to-results">
+                    <i class="ti ti-arrow-left"></i>
+                    {{ __('Back to results') }}
+                </button>
+                <button type="button" class="btn btn-primary use-solution ms-auto">
+                    <i class="ti ti-check"></i>
+                    {{ __('Use as a solution') }}
+                </button>
+            </div>
+            <div class="kbi-form-container card-body"></div>
+        </div>
+{% if not is_ajax %}
+    </div>
+    <style>
+       div.spinner-overlay {
+          position: absolute;
+          top: 0;
+          left: 0;
+          width: 100%;
+          height: 100%;
+          background: #80808033;
+          z-index: 20;
+
+          div.spinner-border {
+             width: 50px;
+             height: 50px;
+             position: absolute;
+             top: 50%;
+             left: 50%;
+             border-width: 4px;
+          }
+       }
+
+       .solution-content-preview {
+          white-space: break-spaces;
+          max-height: 150px;
+          overflow: hidden;
+       }
+
+       @supports (display: -webkit-box) and (-webkit-line-clamp: 7) and (-webkit-box-orient: vertical) {
+          .solution-content-preview {
+             display: -webkit-box;
+             -webkit-line-clamp: 7;
+             -webkit-box-orient: vertical;
+             max-height: none;
+          }
+       }
+    </style>
+    <script type="module">
+        function showLoading() {
+            const loading_overlay = $('#{{ container_id }}').find('div.spinner-overlay');
+            if (loading_overlay.length === 0) {
+                $('#{{ container_id }}').append(`
+                    <div class="spinner-overlay text-center">
+                        <div class="spinner-border" role="status">
+                            <span class="sr-only">{{ __('Loading...') }}</span>
+                        </div>
+                    </div>`);
+            } else {
+                loading_overlay.css('visibility', 'visible');
+            }
+        }
+
+        function hideLoading() {
+            $('#{{ container_id }}').find('div.spinner-overlay').css('visibility', 'hidden');
+        }
+
+        function refreshResults() {
+            showLoading();
+            $.ajax({
+                url: '{{ path('/Knowbase/KnowbaseItem/SearchSolution/') ~ (itemtype ~ '/' ~ items_id)|e('js') }}',
+                method: 'GET',
+                data: {
+                    contains: $('#{{ container_id }} #search_solution_form input[name="contains"]').val(),
+                    ajax_reload: 1,
+                    start: $('#{{ container_id }} #search_solution_form input[name="start"]').val(),
+                }
+            }).then((html) => {
+                $('#{{ container_id }}').html(html);
+                hideLoading();
+            }, () => {
+                window.glpi_toast_error('{{ __('An error occurred while searching for solutions') }}');
+                hideLoading();
+            });
+        }
+
+        // Use Solution button handled by whatever loads this template (form_solution.html.twig for example)
+        $('#{{ container_id }}').on('click', 'button.view-solution', (e) => {
+            const kbi_id = $(e.target).closest('.list-group-item').attr('data-solution-id');
+            showLoading();
+            $.ajax({
+                method: 'GET',
+                url: '{{ path('/Knowbase/KnowbaseItem/') }}' + kbi_id + '/Full',
+            }).then((html) => {
+                $('#{{ container_id }} .kbi-form-container').html(html);
+                $('#{{ container_id }} .preview-card .use-solution').attr('data-solution-id', kbi_id);
+                hideLoading();
+                $('#{{ container_id }} .search-card').hide();
+                $('#{{ container_id }} .preview-card').show();
+            }, () => {
+                window.glpi_toast_error('{{ __('An error occurred while loading the solution') }}');
+                hideLoading();
+            });
+        }).on('click', 'button[name="search"]', () => {
+            refreshResults();
+        }).on('click', 'button.back-to-results', () => {
+            $('#{{ container_id }} .preview-card').hide();
+            $('#{{ container_id }} .search-card').show();
+        }).on('keyup', 'input[name="contains"]', (e) => {
+            if (e.key === 'Enter') {
+                refreshResults();
+            }
+        }).on('click', '.search-pager .page-link', (e) => {
+            e.preventDefault();
+            const clicked_link = $(e.target).closest('.page-link');
+            const new_start = clicked_link.attr('data-start');
+            $('#{{ container_id }} input[name="start"]').val(new_start);
+            refreshResults();
+        });
+    </script>
+{% endif %}

--- a/templates/pages/tools/search_solution.twig
+++ b/templates/pages/tools/search_solution.twig
@@ -163,7 +163,7 @@
                 $('#{{ container_id }}').html(html);
                 hideLoading();
             }, () => {
-                window.glpi_toast_error('{{ __('An error occurred while searching for solutions') }}');
+                window.glpi_toast_error('{{ __('An error occurred while searching for solutions')|e('js') }}');
                 hideLoading();
             });
         }

--- a/tests/cypress/e2e/ITILObject/ticket_form.cy.js
+++ b/tests/cypress/e2e/ITILObject/ticket_form.cy.js
@@ -77,4 +77,34 @@ describe("Ticket Form", () => {
             cy.get('.timeline-item.ITILReminder').should('be.visible');
         });
     });
+
+    it('Search for Solution', () => {
+        cy.createWithAPI('Ticket', {
+            name: 'apple',
+            content: 'apple',
+        }).as('ticket_id');
+        cy.get('@ticket_id').then((ticket_id) => {
+            cy.visit(`/front/ticket.form.php?id=${ticket_id}`);
+            cy.get('.timeline-buttons .main-actions button.dropdown-toggle-split').click();
+            cy.findByText('Add a solution').click();
+            cy.findByLabelText('Search a solution').click();
+            cy.get('#modal_searchSolution').within(() => {
+                cy.findByLabelText('Search…').should('have.value', 'apple');
+                cy.findAllByRole('listitem').should('have.length.at.least', 2);
+
+                cy.findAllByTitle('Preview').first().click();
+                cy.findByText('Subject').should('be.visible');
+                cy.findByText('Content').should('be.visible');
+                cy.findByText('Content').parent().next().invoke('text').should('not.be.empty').as('content');
+                cy.findAllByRole('listitem').should('have.length', 0);
+                cy.findByText('Back to results').click();
+
+                cy.findAllByTitle('Use as a solution').first().click();
+            });
+            cy.get('#modal_searchSolution').should('not.exist');
+            cy.get('@content').then((content) => {
+                cy.get('textarea[name="content"]').awaitTinyMCE().should('contain.text', content.trim());
+            });
+        });
+    });
 });


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

When using object locks, there was an opportunity for a technician to lose the lock on a ticket when searching for a solution because the process redirects out of the ticket for the solution search/selection part.

This PR moves the solution selection to a modal and allows adding the article content directly to the solution content without any redirects/page reloads.

Fixes #18490