### PR TITLE
fix(empty_data): force include to not return true

### DIFF
--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -936,7 +936,7 @@ $empty_data_builder = new class
             ]
         ];
 
-        $dashboards_data = include_once __DIR__ . "/migrations/update_9.4.x_to_9.5.0/dashboards.php";
+        $dashboards_data = include __DIR__ . "/migrations/update_9.4.x_to_9.5.0/dashboards.php";
         $tables['glpi_dashboards_dashboards'] = [];
         $tables['glpi_dashboards_items'] = [];
         $i = $j = 1;

--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -936,7 +936,7 @@ $empty_data_builder = new class
             ]
         ];
 
-        $dashboards_data = include __DIR__ . "/migrations/update_9.4.x_to_9.5.0/dashboards.php";
+        $dashboards_data = require __DIR__ . "/migrations/update_9.4.x_to_9.5.0/dashboards.php";
         $tables['glpi_dashboards_dashboards'] = [];
         $tables['glpi_dashboards_items'] = [];
         $i = $j = 1;


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

I don't know if other actions trigger this error, but when we go to "Setup > General > Search result display," select one or more checkboxes, then "Actions > Reset to default," we encounter this error.

```
glpiphplog.WARNING:   *** PHP Warning (2): foreach() argument must be of type array|object, true given in /home/francois/www/glpi-core/main/htdocs/install/empty_data.php at line 943
  Backtrace :
  install/empty_data.php:9322                        class@anonymous /home/francois/www/glpi-core/main/htdocs/install/empty_data.php:42$1->getEmptyData()
  src/DisplayPreference.php:715                      require()
  src/DisplayPreference.php:129                      DisplayPreference::resetToDefaultOptions()
  src/MassiveAction.php:1462                         DisplayPreference::processMassiveActionsForOneItemtype()
  src/MassiveAction.php:1440                         MassiveAction->processForSeveralItemtypes()
  front/massiveaction.php:58                         MassiveAction->process()
  ...Glpi/Controller/LegacyFileLoadController.php:59 require()
  vendor/symfony/http-kernel/HttpKernel.php:101      Glpi\Controller\LegacyFileLoadController->Glpi\Controller\{closure}()
  ...ymfony/http-foundation/StreamedResponse.php:106 Symfony\Component\HttpKernel\HttpKernel::Symfony\Component\HttpKernel\{closure}()
  vendor/symfony/http-foundation/Response.php:423    Symfony\Component\HttpFoundation\StreamedResponse->sendContent()
  src/Glpi/Kernel/Kernel.php:255                     Symfony\Component\HttpFoundation\Response->send()
  public/index.php:58                                Glpi\Kernel\Kernel->sendResponse()
```

