### PR TITLE
Remove unused parameter from `DBConnection::establishDBConnection()`

### DIFF
--- a/src/DBConnection.php
+++ b/src/DBConnection.php
@@ -477,11 +477,12 @@ class DBConnection extends CommonDBTM
      * @param boolean $use_slave try to connect to slave server first not to main server
      * @param boolean $required  connection to the specified server is required
      *                           (if connection failed, do not try to connect to the other server)
-     * @param boolean $display   display error message (true by default)
      *
      * @return boolean True if successfull, false otherwise
-     **/
-    public static function establishDBConnection($use_slave, $required, $display = true)
+     *
+     * @since 11.0.0 The `$display` parameter has been removed.
+     */
+    public static function establishDBConnection($use_slave, $required)
     {
         /** @var \DBmysql $DB */
         global $DB;
@@ -524,10 +525,6 @@ class DBConnection extends CommonDBTM
             }
         }
 
-       // Display error if needed
-        if (!$res && $display) {
-            self::displayMySQLError();
-        }
         return $res;
     }
 

--- a/src/Glpi/Config/LegacyConfigurators/StandardIncludes.php
+++ b/src/Glpi/Config/LegacyConfigurators/StandardIncludes.php
@@ -115,7 +115,7 @@ final readonly class StandardIncludes implements LegacyConfigProviderInterface
         if (!$missing_db_config) {
             //Database connection
             if (
-                !DBConnection::establishDBConnection(false, false, false)
+                !DBConnection::establishDBConnection(false, false)
                 && !$skip_db_checks
             ) {
                 DBConnection::displayMySQLError();

--- a/src/Glpi/System/Status/StatusChecker.php
+++ b/src/Glpi/System/Status/StatusChecker.php
@@ -206,7 +206,7 @@ final class StatusChecker
             }
 
            // Check main server connection
-            if (!@DBConnection::establishDBConnection(false, true, false)) {
+            if (!@DBConnection::establishDBConnection(false, true)) {
                 $status['main'] = [
                     'status' => self::STATUS_PROBLEM,
                     'status_msg' => _x('glpi_status', 'Unable to connect to the main database')


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

The `$display` parameter of the `DBConnection::establishDBConnection()` method is never used. It could be removed to simplify future refactoring.

Seen while reviewing #18497.