### PR TITLE
[HLAPI] Fail search on invalid filters

### DIFF
--- a/src/Glpi/Api/HL/Controller/AbstractController.php
+++ b/src/Glpi/Api/HL/Controller/AbstractController.php
@@ -226,12 +226,12 @@ abstract class AbstractController
      * @param string $status
      * @phpstan-param self::ERROR_* $status
      * @param string $title
-     * @param ?string $detail
+     * @param string|array|null $detail
      * @param AdditionalErrorMessage[] $additionalMessages
      * @return array
      * @phpstan-return ErrorResponseBody
      */
-    public static function getErrorResponseBody(string $status, string $title, ?string $detail = null, array $additionalMessages = []): array
+    public static function getErrorResponseBody(string $status, string $title, string|array|null $detail = null, array $additionalMessages = []): array
     {
         $body = [
             'status' => $status,

--- a/src/Glpi/Api/HL/Controller/AdministrationController.php
+++ b/src/Glpi/Api/HL/Controller/AdministrationController.php
@@ -729,8 +729,14 @@ final class AdministrationController extends AbstractController
     {
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
+
         // Create a union schema with all relevant item types
-        $schema = Doc\Schema::getUnionSchemaForItemtypes($CFG_GLPI['assignable_types'], $api_version);
+        $schema = Doc\Schema::getUnionSchemaForItemtypes(
+            itemtypes: array_filter($CFG_GLPI['assignable_types'], static function ($t) use ($is_managed) {
+                return (new $t())->isField($is_managed ? 'users_id_tech' : 'users_id');
+            }),
+            api_version: $api_version
+        );
         $rsql_filter = $request_params['filter'] ?? '';
         if (!empty($rsql_filter)) {
             $rsql_filter = "($rsql_filter);";

--- a/src/Glpi/Api/HL/Controller/AssetController.php
+++ b/src/Glpi/Api/HL/Controller/AssetController.php
@@ -564,6 +564,8 @@ final class AssetController extends AbstractController
                 'comment' => ['type' => Doc\Schema::TYPE_STRING],
                 'date_creation' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
                 'date_mod' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
+                'user' => self::getDropdownTypeSchema(class: User::class, full_schema: 'User'),
+                'user_tech' => self::getDropdownTypeSchema(class: User::class, field: 'users_id_tech', full_schema: 'User'),
                 'printer_models' => [
                     'type' => Doc\Schema::TYPE_ARRAY,
                     'description' => 'List of printer models that can use this cartridge',
@@ -671,6 +673,8 @@ final class AssetController extends AbstractController
                 'comment' => ['type' => Doc\Schema::TYPE_STRING],
                 'date_creation' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
                 'date_mod' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
+                'user' => self::getDropdownTypeSchema(class: User::class, full_schema: 'User'),
+                'user_tech' => self::getDropdownTypeSchema(class: User::class, field: 'users_id_tech', full_schema: 'User'),
                 'consumables' => [
                     'type' => Doc\Schema::TYPE_ARRAY,
                     'description' => 'List of consumables',

--- a/src/Glpi/Api/HL/Controller/ComponentController.php
+++ b/src/Glpi/Api/HL/Controller/ComponentController.php
@@ -615,6 +615,7 @@ class ComponentController extends AbstractController
                     'msin' => ['type' => Doc\Schema::TYPE_STRING],
                     'line' => self::getDropdownTypeSchema(class: \Line::class, full_schema: 'Line'),
                     'user' => self::getDropdownTypeSchema(class: \User::class, full_schema: 'User'),
+                    'user_tech' => self::getDropdownTypeSchema(class: \User::class, field: 'users_id_tech', full_schema: 'User'),
                     'group' => self::getDropdownTypeSchema(class: \Group::class, full_schema: 'Group'),
                 ]
             ],

--- a/src/Glpi/Api/HL/RSQL/Error.php
+++ b/src/Glpi/Api/HL/RSQL/Error.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2024 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -33,41 +32,20 @@
  * ---------------------------------------------------------------------
  */
 
-namespace Glpi\Api\HL;
+namespace Glpi\Api\HL\RSQL;
 
-use Throwable;
-
-/**
- * An exception thrown by the API.
- * A user message can be provided to be displayed to the user.
- * Otherwise, only a generic message will be displayed to the user.
- */
-class APIException extends \Exception
+enum Error: int
 {
-    private string $user_message;
+    case UNKNOWN_PROPERTY = 1;
+    case UNKNOWN_OPERATOR = 2;
+    case MAPPED_PROPERTY = 3;
 
-    private string|array|null $details;
-
-    public function __construct(string $message = '', string $user_message = '', string|array|null $details = null, int $code = 0, ?Throwable $previous = null)
+    public function getMessage(): string
     {
-        if ($user_message === '') {
-            $user_message = __('An error occurred while processing your request.');
-        }
-        if ($message === '') {
-            $message = $user_message;
-        }
-        $this->user_message = $user_message;
-        $this->details = $details;
-        parent::__construct($message, $code, $previous);
-    }
-
-    public function getUserMessage(): string
-    {
-        return $this->user_message;
-    }
-
-    public function getDetails(): string|array|null
-    {
-        return $this->details;
+        return match ($this) {
+            self::UNKNOWN_PROPERTY => 'Unknown property',
+            self::UNKNOWN_OPERATOR => 'Unknown operator',
+            self::MAPPED_PROPERTY => 'Mapped properties cannot be used in RSQL',
+        };
     }
 }

--- a/src/Glpi/Api/HL/RSQL/Parser.php
+++ b/src/Glpi/Api/HL/RSQL/Parser.php
@@ -213,9 +213,9 @@ final class Parser
 
     /**
      * @param array $tokens Tokens from the RSQL lexer.
-     * @return QueryExpression SQL criteria
+     * @return Result RSQL query result
      */
-    public function parse(array $tokens): QueryExpression
+    public function parse(array $tokens): Result
     {
         $it = new \DBmysqlIterator($this->db);
         // We are building a SQL string instead of criteria array because it isn't worth the complexity or overhead.
@@ -230,6 +230,7 @@ final class Parser
         $operators = array_combine(array_column($operators, 'operator'), $operators);
 
         $flat_props = $this->search->getFlattenedProperties();
+        $invalid_filters = [];
 
         $buffer = [];
         while ($position < $token_count) {
@@ -238,6 +239,14 @@ final class Parser
                 // If the property isn't in the flattened properties array, the filter should be ignored (not valid)
                 if (!isset($flat_props[$value])) {
                     // Not valid. Just fill the buffer and continue to the next token. This will be handled once the value token is reached.
+                    $invalid_filters[$value] = Error::UNKNOWN_PROPERTY;
+                    $buffer = [
+                        'property' => null,
+                        'field' => null,
+                    ];
+                } else if (isset($flat_props[$value]['x-mapped-from'])) {
+                    // Mapped properties cannot be used in RSQL currently since they are calculated after the query is executed
+                    $invalid_filters[$value] = Error::MAPPED_PROPERTY;
                     $buffer = [
                         'property' => null,
                         'field' => null,
@@ -249,9 +258,16 @@ final class Parser
                     ];
                 }
             } else if ($type === Lexer::T_OPERATOR) {
-                $buffer['operator'] = $operators[$value]['sql_where_callable'];
+                if (!isset($operators[$value])) {
+                    if ($buffer['property'] !== null) {
+                        $invalid_filters[$buffer['property']] = Error::UNKNOWN_OPERATOR;
+                    }
+                    $buffer['operator'] = null;
+                } else {
+                    $buffer['operator'] = $operators[$value]['sql_where_callable'];
+                }
             } else if ($type === Lexer::T_VALUE) {
-                if ($buffer['property'] !== null && $buffer['field'] !== null) {
+                if ($buffer['property'] !== null && $buffer['operator'] !== null && $buffer['field'] !== null) {
                     // Unquote value if it is quoted
                     if (preg_match('/^".*"$/', $value) || preg_match("/^'.*'$/", $value)) {
                         $value = substr($value, 1, -1);
@@ -285,6 +301,6 @@ final class Parser
             $sql_string = '1';
         }
 
-        return new QueryExpression($sql_string);
+        return new Result(new QueryExpression($sql_string), $invalid_filters);
     }
 }

--- a/src/Glpi/Api/HL/RSQL/Result.php
+++ b/src/Glpi/Api/HL/RSQL/Result.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2024 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -33,41 +32,29 @@
  * ---------------------------------------------------------------------
  */
 
-namespace Glpi\Api\HL;
+namespace Glpi\Api\HL\RSQL;
 
-use Throwable;
+use Glpi\DBAL\QueryExpression;
 
-/**
- * An exception thrown by the API.
- * A user message can be provided to be displayed to the user.
- * Otherwise, only a generic message will be displayed to the user.
- */
-class APIException extends \Exception
+class Result
 {
-    private string $user_message;
-
-    private string|array|null $details;
-
-    public function __construct(string $message = '', string $user_message = '', string|array|null $details = null, int $code = 0, ?Throwable $previous = null)
-    {
-        if ($user_message === '') {
-            $user_message = __('An error occurred while processing your request.');
-        }
-        if ($message === '') {
-            $message = $user_message;
-        }
-        $this->user_message = $user_message;
-        $this->details = $details;
-        parent::__construct($message, $code, $previous);
+    /**
+     * @param QueryExpression $sql_criteria
+     * @param array<string, Error> $invalid_filters
+     */
+    public function __construct(
+        private QueryExpression $sql_criteria,
+        private array $invalid_filters = []
+    ) {
     }
 
-    public function getUserMessage(): string
+    public function getSQLCriteria(): QueryExpression
     {
-        return $this->user_message;
+        return $this->sql_criteria;
     }
 
-    public function getDetails(): string|array|null
+    public function getInvalidFilters(): array
     {
-        return $this->details;
+        return $this->invalid_filters;
     }
 }

--- a/src/Glpi/Api/HL/Search.php
+++ b/src/Glpi/Api/HL/Search.php
@@ -380,7 +380,7 @@ final class Search
             if (!empty($filter_result->getInvalidFilters())) {
                 throw new RSQLException(
                     message: 'RSQL query has invalid filters',
-                    details: array_map(static fn ($rsql_error) => $rsql_error->getMessage(),$filter_result->getInvalidFilters())
+                    details: array_map(static fn ($rsql_error) => $rsql_error->getMessage(), $filter_result->getInvalidFilters())
                 );
             }
             $criteria['WHERE'] = [$filter_result->getSQLCriteria()];


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

Instead of silently ignoring invalid RSQL filters, this PR causes a 400 response to be returned with details about the invalid filters. Previously, the search only errored from RSQL filters if the filter couldn't be tokenized.

The following cases are handled:
- Filter is on an unknown property
- Filter has an unknown operator
- Filter is for a mapped property (Since mappings are done after the query and there is nothing to reverse the mapping back to SQL criteria yet. For example, ticket status 1 is mapped to "New", but there isn't info to convert "New" to "_.status.id=1")