### PR TITLE
Use formatUserName for dashboard actor labels

### DIFF
--- a/src/Glpi/Dashboard/Provider.php
+++ b/src/Glpi/Dashboard/Provider.php
@@ -1440,6 +1440,7 @@ class Provider
         $n_fields = [
             "$ug_table.firstname as first",
             "$ug_table.realname as second",
+            "$ug_table.name as username"
         ];
 
         $where = [
@@ -1543,7 +1544,7 @@ class Provider
             $s_params['criteria'][0]['value'] = $result['actor_id'];
             $data[] = [
                 'number' => $result['nb_tickets'],
-                'label'  => $result['first'] . " " . ($result['second'] ?? ""),
+                'label'  => formatUserName($result['actor_id'], $result['username'], $result['second'], $result['first']),
                 'url'    => Ticket::getSearchURL() . "?" . Toolbox::append_params($s_params),
             ];
         }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Previously, actor labels were statically set as "firstname lastname". If there were no names, the label was blank.
Now, the username will be displayed if no names exist and also respect the user preference for name order.