### PR TITLE
Fix missing controls after editing dashboard card

### DIFF
--- a/js/modules/Dashboard/Dashboard.js
+++ b/js/modules/Dashboard/Dashboard.js
@@ -104,7 +104,7 @@ class GLPIDashboard {
         this.filters_selector = "";
 
         GridStack.renderCB = (el, w) => {
-            el.innerHTML = w.content;
+            el.parentElement.innerHTML = w.content;
         };
 
         // get passed options and merge it with default ones
@@ -628,16 +628,13 @@ class GLPIDashboard {
         const height       = parseInt(p.height || 2);
         const options      = p.card_options || {};
 
-        const html = ' \
-      <div class="grid-stack-item"> \
-         <span class="controls"> \
-            <i class="refresh-item ti ti-refresh" title="'+__("Refresh this card")+'"></i> \
-            <i class="edit-item ti ti-edit" title="'+__("Edit this card")+'"></i> \
-            <i class="delete-item ti ti-x" title="'+__("Delete this card")+'"></i> \
-         </span> \
-         <div class="grid-stack-item-content"> \
-         </div> \
-      </div>';
+        const html = `
+            <span class="controls">
+                <i class="refresh-item ti ti-refresh" title="${__("Refresh this card")}"></i>
+                <i class="edit-item ti ti-edit" title="${__("Edit this card")}"></i>
+                <i class="delete-item ti ti-x" title="${__("Delete this card")}"></i>
+            </span>
+            <div class="grid-stack-item-content"></div>`;
 
         // add the widget to the grid
         const widget = this.grid.addWidget({

--- a/tests/js/modules/Dashboard/Dashboard.test.js
+++ b/tests/js/modules/Dashboard/Dashboard.test.js
@@ -393,7 +393,7 @@ describe('Dashboard', () => {
 
         expect(dashboard.grid.addWidget).toHaveBeenCalledWith(
             expect.toSatisfy((widget_info) => {
-                const html_el = $(widget_info.content);
+                const html_el = $(`<div>${widget_info.content}</div>`);
                 const has_refresh = html_el.find('.controls i.refresh-item').length === 1;
                 const has_edit = html_el.find('.controls i.edit-item').length === 1;
                 const has_delete = html_el.find('.controls i.delete-item').length === 1;
@@ -418,7 +418,7 @@ describe('Dashboard', () => {
 
         expect(dashboard.grid.addWidget).toHaveBeenCalledWith(
             expect.toSatisfy((widget_info) => {
-                const html_el = $(widget_info.content);
+                const html_el = $(`<div>${widget_info.content}</div>`);
                 const has_refresh = html_el.find('.controls i.refresh-item').length === 1;
                 const has_edit = html_el.find('.controls i.edit-item').length === 1;
                 const has_delete = html_el.find('.controls i.delete-item').length === 1;
@@ -451,7 +451,7 @@ describe('Dashboard', () => {
 
         expect(dashboard.grid.addWidget).toHaveBeenCalledWith(
             expect.toSatisfy((widget_info) => {
-                const html_el = $(widget_info.content);
+                const html_el = $(`<div>${widget_info.content}</div>`);
                 const has_refresh = html_el.find('.controls i.refresh-item').length === 1;
                 const has_edit = html_el.find('.controls i.edit-item').length === 1;
                 const has_delete = html_el.find('.controls i.delete-item').length === 1;


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

With the gridstack content rendering changes in version 11, the content refers to the `.gridstack-item-content` rather than `.gridstack-item`. The controls were being placed within the content and then overwritten when the card HTML was retrieved from the server.
