### PR TITLE
Fix add solution when mandatory fields empty

### DIFF
--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -361,6 +361,7 @@ $empty_data_builder = new class
             'projecttask_unstarted_states_id' => 0,
             'projecttask_inprogress_states_id' => 0,
             'projecttask_completed_states_id' => 0,
+            'add_solution_invalid_tickets' => 1
         ];
 
         $tables['glpi_configs'] = [];

--- a/install/migrations/update_10.0.x_to_11.0.0/configs.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/configs.php
@@ -44,6 +44,7 @@ $migration->addConfig([
     'set_followup_tech' => '0',
     'set_solution_tech' => '0',
     'is_demo_dashboards' => '0',
+    'add_solution_invalid_tickets' => '1'
 ]);
 $migration->addField('glpi_users', 'toast_location', 'string');
 

--- a/phpunit/functional/ITILSolutionTest.php
+++ b/phpunit/functional/ITILSolutionTest.php
@@ -646,15 +646,15 @@ HTML,
 
         // Create a ticket with category
         $ticket = $this->createItem('Ticket', [
-            'name'                  => 'Ticket Mandatory Fields',
-            'content'               => 'Ticket Mandatory Fields description',
+            'name'                  => 'Ticket1 Mandatory Fields',
+            'content'               => 'Ticket1 Mandatory Fields description',
             'itilcategories_id'     => $category->getID(),
         ]);
 
         // Create a ticket without category
         $ticket2 = $this->createItem('Ticket', [
-            'name'                  => 'Ticket Mandatory Fields',
-            'content'               => 'Ticket Mandatory Fields description',
+            'name'                  => 'Ticket2 Mandatory Fields',
+            'content'               => 'Ticket2 Mandatory Fields description',
         ]);
 
         // Add a mandatory field (category) to the default template ticket
@@ -670,14 +670,21 @@ HTML,
             'content'            => 'Ticket1 Mandatory Fields solution',
         ]);
 
+        \Config::setConfigurationValues('core', ['add_solution_invalid_tickets' => 0]);
+        $conf = \Config::getConfigurationValues('core', ['add_solution_invalid_tickets']);
+
+        $this->assertEquals($conf['add_solution_invalid_tickets'], 0);
+
         // Failed solution addition because ticket category is not filled
         $solution = new \ITILSolution();
-        $solution->add([
+        $result = $solution->add([
             'itemtype'           => $ticket2::getType(),
             'items_id'           => $ticket2->getID(),
             'content'            => 'Ticket2 Mandatory Fields solution',
         ]);
 
         $this->hasSessionMessages(ERROR, ['Mandatory fields are not filled. Please correct: Category']);
+
+        $this->assertFalse($result);
     }
 }

--- a/phpunit/functional/ITILSolutionTest.php
+++ b/phpunit/functional/ITILSolutionTest.php
@@ -686,5 +686,14 @@ HTML,
         $this->hasSessionMessages(ERROR, ['Mandatory fields are not filled. Please correct: Category']);
 
         $this->assertFalse($result);
+
+        \Config::setConfigurationValues('core', ['add_solution_invalid_tickets' => 1]);
+        $conf = \Config::getConfigurationValues('core', ['add_solution_invalid_tickets']);
+
+        $this->createItem('ITILSolution', [
+            'itemtype'           => $ticket::getType(),
+            'items_id'           => $ticket->getID(),
+            'content'            => 'Ticket3 Mandatory Fields solution',
+        ]);
     }
 }

--- a/phpunit/functional/ITILSolutionTest.php
+++ b/phpunit/functional/ITILSolutionTest.php
@@ -631,4 +631,53 @@ HTML,
         ]);
         $this->assertGreaterThan(0, $solution_id);
     }
+
+    public function testSendSolutionWithMandatoryFields()
+    {
+        $this->login();
+
+        $tt = new \TicketTemplate();
+        $tt->getFromDB(1);
+        $this->assertGreaterThan(0, $tt->getID());
+
+        $category = $this->createItem('ITILCategory', [
+            'name' => 'Category Mandatory Fields',
+        ]);
+
+        // Create a ticket with category
+        $ticket = $this->createItem('Ticket', [
+            'name'                  => 'Ticket Mandatory Fields',
+            'content'               => 'Ticket Mandatory Fields description',
+            'itilcategories_id'     => $category->getID(),
+        ]);
+
+        // Create a ticket without category
+        $ticket2 = $this->createItem('Ticket', [
+            'name'                  => 'Ticket Mandatory Fields',
+            'content'               => 'Ticket Mandatory Fields description',
+        ]);
+
+        // Add a mandatory field (category) to the default template ticket
+        $this->createItem('TicketTemplateMandatoryField', [
+            'tickettemplates_id' => $tt->getID(),
+            'num'                => 7, // category
+        ]);
+
+        // Successful solution addition because ticket category is filled
+        $this->createItem('ITILSolution', [
+            'itemtype'           => $ticket::getType(),
+            'items_id'           => $ticket->getID(),
+            'content'            => 'Ticket1 Mandatory Fields solution',
+        ]);
+
+        // Failed solution addition because ticket category is not filled
+        $solution = new \ITILSolution();
+        $solution->add([
+            'itemtype'           => $ticket2::getType(),
+            'items_id'           => $ticket2->getID(),
+            'content'            => 'Ticket2 Mandatory Fields solution',
+        ]);
+
+        $this->hasSessionMessages(ERROR, ['Mandatory fields are not filled. Please correct: Category']);
+    }
 }

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -1873,7 +1873,8 @@ abstract class CommonITILObject extends CommonDBTM
         return $input;
     }
 
-    public static function checkEmptyMandatoryFields(CommonDBTM $item, ITILTemplate $item_template) {
+    public static function checkEmptyMandatoryFields(CommonDBTM $item, ITILTemplate $item_template)
+    {
         if (count($item_template->mandatory)) {
             $mandatory_missing = [];
             $fieldsname        = $item_template->getAllowedFieldsNames(true);

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -1866,16 +1866,19 @@ abstract class CommonITILObject extends CommonDBTM
 
         $tt = $this->getITILTemplateToUse(0, $type, $categid, $entid);
 
-        if (count($tt->mandatory)) {
+        if (!self::checkEmptyMandatoryFields($this, $tt)) {
+            return false;
+        }
+
+        return $input;
+    }
+
+    public static function checkEmptyMandatoryFields(CommonDBTM $item, ITILTemplate $item_template) {
+        if (count($item_template->mandatory)) {
             $mandatory_missing = [];
-            $fieldsname        = $tt->getAllowedFieldsNames(true);
-            foreach ($tt->mandatory as $key => $val) {
-                if (
-                    (!$check_allowed_fields_for_template || in_array($key, $allowed_fields))
-                    && (isset($input[$key])
-                    && (empty($input[$key]) || ($input[$key] == 'NULL'))
-                    )
-                ) {
+            $fieldsname        = $item_template->getAllowedFieldsNames(true);
+            foreach ($item_template->mandatory as $key => $val) {
+                if (empty($item->fields[$key]) || ($item->fields[$key] == 'NULL')) {
                     $mandatory_missing[$key] = $fieldsname[$val];
                 }
             }
@@ -1885,12 +1888,10 @@ abstract class CommonITILObject extends CommonDBTM
                     __('Mandatory fields are not filled. Please correct: %s'),
                     implode(", ", $mandatory_missing)
                 );
-                Session::addMessageAfterRedirect(htmlescape($message), false, ERROR);
+                Session::addMessageAfterRedirect($message, false, ERROR);
                 return false;
             }
         }
-
-        return $input;
     }
 
     protected function manageITILObjectLinkInput($input)

--- a/src/ITILSolution.php
+++ b/src/ITILSolution.php
@@ -189,6 +189,9 @@ class ITILSolution extends CommonDBChild
 
     public function prepareInputForAdd($input)
     {
+        /** @var array $CFG_GLPI */
+        global $CFG_GLPI;
+
         if (!isset($input['users_id']) && !(Session::isCron() || strpos($_SERVER['REQUEST_URI'] ?? '', 'crontask.form.php') !== false)) {
             $input['users_id'] = Session::getLoginUserID();
         }
@@ -199,6 +202,16 @@ class ITILSolution extends CommonDBChild
         ) {
             $this->item = new $input['itemtype']();
             $this->item->getFromDB($input['items_id']);
+        }
+
+        // Check ticket mandatory fields
+        if (!$CFG_GLPI['add_solution_invalid_tickets']) {
+            $ticket = $this->item;
+            $tt = $ticket->getITILTemplateToUse(0, $ticket->fields['type'] ?? '', $ticket->fields['itilcategories_id'] ?? '', $ticket->fields['entities_id'] ?? '');
+
+            if (!CommonITILObject::checkEmptyMandatoryFields($ticket, $tt)) {
+                return false;
+            }
         }
 
         // Handle template

--- a/templates/pages/setup/general/assistance_setup.html.twig
+++ b/templates/pages/setup/general/assistance_setup.html.twig
@@ -119,6 +119,13 @@
       multiple: true,
    })) }}
 
+   {{ fields.dropdownYesNo(
+      'add_solution_invalid_tickets',
+      config['add_solution_invalid_tickets'],
+      __('Allow solutions for invalid tickets'),
+      field_options
+   ) }}
+
    {{ fields.smallTitle(__('Matrix of calculus for priority')) }}
    {{ inputs.hidden('_matrix', 1) }}
    <table class="table table-borderless table-sm">


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes Linked to this !35349
- Here is a brief description of what this PR does

Corrected the possibility of adding a solution to resolve/close the ticket when a mandatory ticket field is not filled in.

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/0649da5d-03f4-4663-9136-566e3997dab4)
Now, when you try to add a solution, you get this message if a mandatory field is empty
![image](https://github.com/user-attachments/assets/583bf115-dd8c-4533-b6a1-73e8132754c5)



