### PR TITLE
Remove useless mysqlnd driver compatibility check

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -1456,7 +1456,7 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Instanceof between DBmysql and DBmysql will always evaluate to true\\.$#',
 	'identifier' => 'instanceof.alwaysTrue',
-	'count' => 5,
+	'count' => 4,
 	'path' => __DIR__ . '/src/DBConnection.php',
 ];
 $ignoreErrors[] = [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -364,6 +364,7 @@ The present file will list all changes made to the project; according to the
 - `Contract::showShort()`
 - `DbUtils::closeDBConnections()`
 - `DbUtils::regenerateTreeCompleteName()`
+- `DBmysql::error` property.
 - `Document::getImage()`
 - `Document::showUploadedFilesDropdown()`
 - `Document::uploadDocument()`

--- a/install/update.php
+++ b/install/update.php
@@ -72,20 +72,6 @@ if (isset($_POST['update_end'])) {
 }
 
 
-//test la connection a la base de donn???.
-function test_connect()
-{
-    /** @var \DBmysql $DB */
-    global $DB;
-
-    if ($DB->error == 0) {
-        return true;
-    }
-    return false;
-}
-
-
-
 //update database
 function doUpdateDb()
 {
@@ -224,7 +210,7 @@ if (empty($_POST["continuer"]) && empty($_POST["from_update"])) {
     }
 } else {
    // Step 2
-    if (test_connect()) {
+    if ($DB->connected) {
         echo "<h3>" . __s('Database connection successful') . "</h3>";
         echo "<p class='text-center'>";
         $result = Config::displayCheckDbEngine(true);

--- a/src/DBConnection.php
+++ b/src/DBConnection.php
@@ -654,18 +654,8 @@ class DBConnection extends CommonDBTM
         /** @var \DBmysql $DB */
         global $DB;
 
-        $error = $DB instanceof DBmysql ? $DB->error : 1;
-        switch ($error) {
-            case 2:
-                $en_msg = "Use of mysqlnd driver is required for exchanges with the MySQL server.";
-                $fr_msg = "L'utilisation du driver mysqlnd est requise pour les échanges avec le serveur MySQL.";
-                break;
-            case 1:
-            default:
-                $fr_msg = "Le serveur Mysql est inaccessible. Vérifiez votre configuration.";
-                $en_msg = "A link to the SQL server could not be established. Please check your configuration.";
-                break;
-        }
+        $fr_msg = "Le serveur Mysql est inaccessible. Vérifiez votre configuration.";
+        $en_msg = "A link to the SQL server could not be established. Please check your configuration.";
 
         if (!isCommandLine()) {
             Html::nullHeader("Mysql Error", '');

--- a/src/DBmysql.php
+++ b/src/DBmysql.php
@@ -71,9 +71,6 @@ class DBmysql
      */
     protected $dbh;
 
-    //! Database Error
-    public $error              = 0;
-
     // Slave management
     public $slave              = false;
     private $in_transaction;
@@ -269,13 +266,7 @@ class DBmysql
             $this->dbh->real_connect($hostport[0], $this->dbuser, rawurldecode($this->dbpassword), $this->dbdefault, ini_get('mysqli.default_port'), $hostport[1]);
         }
 
-        if ($this->dbh->connect_error) {
-            $this->connected = false;
-            $this->error     = 1;
-        } else if (!defined('MYSQLI_OPT_INT_AND_FLOAT_NATIVE')) {
-            $this->connected = false;
-            $this->error     = 2;
-        } else {
+        if (!$this->dbh->connect_error) {
             $this->setConnectionCharset();
 
             // force mysqlnd to return int and float types correctly (not as strings)


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Since PHP 8.2, the `MySQLi` extension always use the `mysqlnd` driver, see https://php.watch/versions/8.2/mysqli-libmysql-no-longer-supported. It is therefore not anymore required to check if the `MYSQLI_OPT_INT_AND_FLOAT_NATIVE` is defined, as it will be always defined.