### PR TITLE
Move HTTP listeners to a sub-namespace

### DIFF
--- a/phpunit/functional/Glpi/Http/LegacyItemtypeRouteListenerTest.php
+++ b/phpunit/functional/Glpi/Http/LegacyItemtypeRouteListenerTest.php
@@ -36,7 +36,7 @@ namespace tests\units\Glpi\Http;
 
 use Glpi\Controller\GenericListController;
 use Glpi\Controller\DropdownFormController;
-use Glpi\Http\LegacyItemtypeRouteListener;
+use Glpi\Http\Listener\LegacyItemtypeRouteListener;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\TestCase;

--- a/phpunit/functional/Glpi/Http/RedirectLegacyRouteListenerTest.php
+++ b/phpunit/functional/Glpi/Http/RedirectLegacyRouteListenerTest.php
@@ -34,7 +34,7 @@
 
 namespace tests\units\Glpi\Http;
 
-use Glpi\Http\RedirectLegacyRouteListener;
+use Glpi\Http\Listener\RedirectLegacyRouteListener;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\RedirectResponse;

--- a/src/Glpi/Http/Listener/AccessErrorListener.php
+++ b/src/Glpi/Http/Listener/AccessErrorListener.php
@@ -32,12 +32,11 @@
  * ---------------------------------------------------------------------
  */
 
-namespace Glpi\Http;
+namespace Glpi\Http\Listener;
 
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\Exception\Http\AccessDeniedHttpException;
 use Glpi\Exception\AuthenticationFailedException;
-use Glpi\Exception\RedirectException;
 use Glpi\Exception\SessionExpiredException;
 use Session;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;

--- a/src/Glpi/Http/Listener/LegacyAssetsListener.php
+++ b/src/Glpi/Http/Listener/LegacyAssetsListener.php
@@ -32,8 +32,10 @@
  * ---------------------------------------------------------------------
  */
 
-namespace Glpi\Http;
+namespace Glpi\Http\Listener;
 
+use Glpi\Http\LegacyRouterTrait;
+use Glpi\Http\ListenersPriority;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;

--- a/src/Glpi/Http/Listener/LegacyItemtypeRouteListener.php
+++ b/src/Glpi/Http/Listener/LegacyItemtypeRouteListener.php
@@ -32,7 +32,7 @@
  * ---------------------------------------------------------------------
  */
 
-namespace Glpi\Http;
+namespace Glpi\Http\Listener;
 
 use CommonDevice;
 use CommonDropdown;
@@ -46,6 +46,7 @@ use Glpi\Controller\GenericListController;
 use Glpi\Controller\DropdownFormController;
 use Glpi\Dropdown\Dropdown;
 use Glpi\Dropdown\DropdownDefinition;
+use Glpi\Http\ListenersPriority;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;

--- a/src/Glpi/Http/Listener/LegacyPostRequestActionsListener.php
+++ b/src/Glpi/Http/Listener/LegacyPostRequestActionsListener.php
@@ -32,35 +32,23 @@
  * ---------------------------------------------------------------------
  */
 
-namespace Glpi\Http;
+namespace Glpi\Http\Listener;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
-final readonly class RedirectLegacyRouteListener implements EventSubscriberInterface
+class LegacyPostRequestActionsListener implements EventSubscriberInterface
 {
-    private const URLS_MAPPING = [
-        '/front/helpdesk.public.php' => '/Helpdesk',
-    ];
-
     public static function getSubscribedEvents(): array
     {
         return [
-            KernelEvents::REQUEST => ['onKernelRequest', ListenersPriority::LEGACY_LISTENERS_PRIORITIES[self::class]],
+            KernelEvents::FINISH_REQUEST => ['onFinishRequest'],
         ];
     }
 
-    public function onKernelRequest(RequestEvent $event): void
+    public function onFinishRequest(): void
     {
-        if (!$event->isMainRequest()) {
-            return;
-        }
-        $request = $event->getRequest();
-
-        if (\array_key_exists($request->getPathInfo(), self::URLS_MAPPING)) {
-            $event->setResponse(new RedirectResponse($request->getBasePath() . self::URLS_MAPPING[$request->getPathInfo()]));
-        }
+        \Html::resetAjaxParam();
+        \Session::resetAjaxParam();
     }
 }

--- a/src/Glpi/Http/Listener/LegacyRouterListener.php
+++ b/src/Glpi/Http/Listener/LegacyRouterListener.php
@@ -32,9 +32,11 @@
  * ---------------------------------------------------------------------
  */
 
-namespace Glpi\Http;
+namespace Glpi\Http\Listener;
 
 use Glpi\Controller\LegacyFileLoadController;
+use Glpi\Http\LegacyRouterTrait;
+use Glpi\Http\ListenersPriority;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\RequestEvent;

--- a/src/Glpi/Http/Listener/PluginsRouterListener.php
+++ b/src/Glpi/Http/Listener/PluginsRouterListener.php
@@ -32,11 +32,12 @@
  * ---------------------------------------------------------------------
  */
 
-namespace Glpi\Http;
+namespace Glpi\Http\Listener;
 
 use Glpi\Controller\AbstractController;
 use Glpi\DependencyInjection\PluginContainer;
 use Glpi\DependencyInjection\PublicService;
+use Glpi\Http\ListenersPriority;
 use Plugin;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\RequestEvent;

--- a/src/Glpi/Http/ListenersPriority.php
+++ b/src/Glpi/Http/ListenersPriority.php
@@ -35,6 +35,11 @@
 namespace Glpi\Http;
 
 use Glpi\Config\LegacyConfigProviderListener;
+use Glpi\Http\Listener\LegacyAssetsListener;
+use Glpi\Http\Listener\LegacyItemtypeRouteListener;
+use Glpi\Http\Listener\LegacyRouterListener;
+use Glpi\Http\Listener\PluginsRouterListener;
+use Glpi\Http\Listener\RedirectLegacyRouteListener;
 
 final class ListenersPriority
 {

--- a/src/Glpi/Kernel/Kernel.php
+++ b/src/Glpi/Kernel/Kernel.php
@@ -39,7 +39,7 @@ use Glpi\Application\SystemConfigurator;
 use Glpi\Config\ConfigProviderConsoleExclusiveInterface;
 use Glpi\Config\ConfigProviderWithRequestInterface;
 use Glpi\Config\LegacyConfigProviders;
-use Glpi\Http\PluginsRouterListener;
+use Glpi\Http\Listener\PluginsRouterListener;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Bundle\TwigBundle\TwigBundle;

--- a/tests/functional/Glpi/Http/Listener/LegacyAssetsListener.php
+++ b/tests/functional/Glpi/Http/Listener/LegacyAssetsListener.php
@@ -32,7 +32,7 @@
  * ---------------------------------------------------------------------
  */
 
-namespace tests\units\Glpi\Http;
+namespace tests\units\Glpi\Http\Listener;
 
 use org\bovigo\vfs\vfsStream;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;

--- a/tests/functional/Glpi/Http/Listener/LegacyRouterListener.php
+++ b/tests/functional/Glpi/Http/Listener/LegacyRouterListener.php
@@ -32,7 +32,7 @@
  * ---------------------------------------------------------------------
  */
 
-namespace tests\units\Glpi\Http;
+namespace tests\units\Glpi\Http\Listener;
 
 use org\bovigo\vfs\vfsStream;
 use Symfony\Component\HttpFoundation\Request;


### PR DESCRIPTION
This was messed up, between services and DTOs, so a sub-dir is easier to maintain