### PR TITLE
Missing Location search options in item_devices; closes #18529

### DIFF
--- a/src/Item_Devices.php
+++ b/src/Item_Devices.php
@@ -165,6 +165,8 @@ class Item_Devices extends CommonDBRelation
             ]
         ];
 
+        $tab = array_merge($tab, Location::rawSearchOptionsToAdd());
+
         $tab[] = [
             'id'                 => '5',
             'table'              => $this->getTable(),


### PR DESCRIPTION
Same as #18531; but for 10.0