### PR TITLE
Simplify `$CFG_GLPI['root_doc']` initialization

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -1280,12 +1280,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Computer.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Instanceof between DBmysql and DBmysql will always evaluate to true\\.$#',
-	'identifier' => 'instanceof.alwaysTrue',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Config.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^PHPDoc tag @phpstan\\-return has invalid value \\(\\$expanded_info \\? array\\<string, \\{name\\: string, dark\\: boolean\\}\\> \\: array\\<string, string\\>\\)\\: Unexpected token "\\$expanded_info", expected type at offset 154 on line 6$#',
 	'identifier' => 'phpDoc.parseError',
 	'count' => 1,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -356,6 +356,7 @@ The present file will list all changes made to the project; according to the
 - `Computer_Item::showForItem()`
 - `ComputerAntivirus::showForComputer()`
 - `ComputerVirtualMachine::showForComputer()`
+- `Config::detectRootDoc()`
 - `Config::getCurrentDBVersion()`
 - `Config::showDebug()`
 - `Config::validatePassword()`

--- a/install/install.php
+++ b/install/install.php
@@ -47,10 +47,6 @@ use Glpi\Toolbox\Filesystem;
  */
 global $CFG_GLPI, $GLPI_CACHE;
 
-// Force `root_doc` value
-$request = \Symfony\Component\HttpFoundation\Request::createFromGlobals();
-$CFG_GLPI['root_doc'] = $request->getBasePath();
-
 $GLPI_CACHE = (new CacheManager())->getInstallerCacheInstance();
 
 if (isset($_POST["language"]) && isset($CFG_GLPI["languages"][$_POST["language"]])) {

--- a/phpunit/functional/ConfigTest.php
+++ b/phpunit/functional/ConfigTest.php
@@ -885,38 +885,6 @@ class ConfigTest extends DbTestCase
         }
     }
 
-    public function testDetectRooDoc(): void
-    {
-        global $CFG_GLPI;
-        $bkp_root_doc = $CFG_GLPI['root_doc'];
-
-        $uri_to_scriptname = [
-            '/'                        => '/index.php',
-            '/front/index.php?a=b'     => '/front/index.php',
-            '/api.php/endpoint/method' => '/api.php',
-            '//whatever/path/is'       => '/index.php', // considered as `path=/` + `pathinfo=/whatever/path/is` by GLPI router
-        ];
-
-        foreach (['', '/glpi', '/whatever/alias/is'] as $prefix) {
-            foreach ($uri_to_scriptname as $uri => $script_name) {
-                unset($CFG_GLPI['root_doc']);
-
-                chdir(GLPI_ROOT . dirname($script_name)); // cwd is expected to be the executed script dir
-
-                $server_bck = $_SERVER;
-                $_SERVER['REQUEST_URI'] = $prefix . $uri;
-                $_SERVER['SCRIPT_NAME'] = $prefix . $script_name;
-                \Config::detectRootDoc();
-                $_SERVER = $server_bck;
-
-                $this->assertEquals($prefix, $CFG_GLPI['root_doc']);
-            }
-        }
-
-        //reset root_doc
-        $CFG_GLPI['root_doc'] = $bkp_root_doc;
-    }
-
     public function testConfigLogNotEmpty()
     {
         $itemtype = 'Config';

--- a/src/Config.php
+++ b/src/Config.php
@@ -1650,7 +1650,7 @@ class Config extends CommonDBTM
         if (!isset($_SERVER['REQUEST_URI'])) {
             // $_SERVER['REQUEST_URI'] is not set, meaning that GLPI is probably acces from CLI.
             // In this case, `$CFG_GLPI['root_doc']` has to be extracted from `$CFG_GLPI['url_base']`,
-            // and it cannot be done only once configuration is loaded.
+            // and it can only be done once configuration is loaded.
 
             // `$CFG_GLPI['root_doc']` is not supposed to be used in a CLI context,
             // but it is likely to be used indirectly by cron tasks.

--- a/src/Config.php
+++ b/src/Config.php
@@ -41,6 +41,7 @@ use Glpi\System\RequirementsManager;
 use Glpi\Toolbox\ArrayNormalizer;
 use Glpi\UI\ThemeManager;
 use SimplePie\SimplePie;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  *  Config class
@@ -1185,86 +1186,6 @@ class Config extends CommonDBTM
         return "";
     }
 
-
-    public static function detectRootDoc()
-    {
-        /**
-         * @var array $CFG_GLPI
-         * @var \DBmysql $DB
-         */
-        global $CFG_GLPI, $DB;
-
-        if (isset($CFG_GLPI['root_doc'])) {
-            return; // already computed
-        }
-
-        if (isset($_SERVER['REQUEST_URI'])) {
-            // $_SERVER['REQUEST_URI'] is set, meaning that GLPI is accessed from web server.
-
-            // In this case, `$CFG_GLPI['root_doc']` corresponds to the piece of path
-            // that is common between `GLPI_ROOT` and $_SERVER['SCRIPT_NAME']
-            // e.g. GLPI_ROOT=/var/www/glpi and $_SERVER['SCRIPT_NAME']=/glpi/front/index.php -> $CFG_GLPI['root_doc']=/glpi
-
-            // We cannot rely on $_SERVER['REQUEST_URI'] value as it is a value defined by HTTP client.
-            // $_SERVER['SCRIPT_NAME'] is consider safe as it is either set by GLPI router (see `/public/index.php`),
-            // either it contains the path of PHP script executed by the web server.
-            $script_path = $_SERVER['SCRIPT_NAME'];
-
-            // Extract relative path of entry script directory
-            // e.g. /var/www/mydomain.org/glpi/front/index.php -> /front
-            $current_dir_relative = str_replace(
-                str_replace(DIRECTORY_SEPARATOR, '/', realpath(GLPI_ROOT)),
-                '',
-                str_replace(DIRECTORY_SEPARATOR, '/', realpath(getcwd()))
-            );
-
-            // Extract relative path of script directory
-            // e.g. /glpi/front/index.php -> /glpi/front
-            $script_dir_relative = preg_replace(
-                '/\/[0-9a-zA-Z\.\-\_]+\.php/',
-                '',
-                $script_path
-            );
-            // API exception (handles `RewriteRule api/(.*)$ apirest.php/$1`)
-            if (strpos($script_dir_relative, 'api/') !== false) {
-                $script_dir_relative = preg_replace("/(.*\/)api\/.*/", "$1", $script_dir_relative);
-            }
-
-            // Remove relative path of entry script directory
-            // e.g. /glpi/front -> /glpi
-            $root_doc = str_replace($current_dir_relative, '', $script_dir_relative);
-            $root_doc = rtrim($root_doc, '/');
-
-            $CFG_GLPI['root_doc'] = $root_doc;
-        } else {
-            // $_SERVER['REQUEST_URI'] is not set, meaning that GLPI is probably acces from CLI.
-            // In this case, `$CFG_GLPI['root_doc']` has to be extracted from `$CFG_GLPI['url_base']`.
-
-            $url_base = $CFG_GLPI['url_base'] ?? null;
-            // $CFG_GLPI may have not been loaded yet, load value form DB if `$CFG_GLPI['url_base']` is not set.
-            if (
-                $url_base === null
-                && $DB instanceof DBmysql
-                && $DB->connected
-                // table/field may not exists in edge case (e.g. update from GLPI < 0.85)
-                && $DB->tableExists('glpi_configs')
-                && $DB->fieldExists('glpi_configs', 'context')
-            ) {
-                $url_base = Config::getConfigurationValue('core', 'url_base');
-            }
-
-            if ($url_base !== null) {
-                $CFG_GLPI['root_doc'] = parse_url($url_base, PHP_URL_PATH) ?? '';
-            }
-        }
-
-        // Path for icon of document type (web mode only)
-        if (isset($CFG_GLPI['root_doc'])) {
-            $CFG_GLPI['typedoc_icon_dir'] = $CFG_GLPI['root_doc'] . '/pics/icones';
-        }
-    }
-
-
     /**
      * Display field unicity criterias form
      **/
@@ -1664,6 +1585,15 @@ class Config extends CommonDBTM
          */
         global $CFG_GLPI, $DB;
 
+        // Compute URLs base path.
+        $root_doc = '';
+        if (isset($_SERVER['REQUEST_URI'])) {
+            // $_SERVER['REQUEST_URI'] is set, meaning that GLPI is accessed from web server.
+            $root_doc = Request::createFromGlobals()->getBasePath();
+        }
+        $CFG_GLPI['root_doc'] = $root_doc;
+        $CFG_GLPI['typedoc_icon_dir'] = $root_doc . '/pics/icones';
+
         if (
             !($DB instanceof DBmysql)
             || !$DB->connected
@@ -1715,6 +1645,21 @@ class Config extends CommonDBTM
 
         if (isset($CFG_GLPI['planning_work_days'])) {
             $CFG_GLPI['planning_work_days'] = importArrayFromDB($CFG_GLPI['planning_work_days']);
+        }
+
+        if (!isset($_SERVER['REQUEST_URI'])) {
+            // $_SERVER['REQUEST_URI'] is not set, meaning that GLPI is probably acces from CLI.
+            // In this case, `$CFG_GLPI['root_doc']` has to be extracted from `$CFG_GLPI['url_base']`,
+            // and it cannot be done only once configuration is loaded.
+
+            // `$CFG_GLPI['root_doc']` is not supposed to be used in a CLI context,
+            // but it is likely to be used indirectly by cron tasks.
+
+            if (isset($CFG_GLPI['url_base'])) {
+                $root_doc = parse_url($CFG_GLPI['url_base'], PHP_URL_PATH) ?: '';
+                $CFG_GLPI['root_doc'] = $root_doc;
+                $CFG_GLPI['typedoc_icon_dir'] = $root_doc . '/pics/icones';
+            }
         }
 
         self::$loaded = true;

--- a/src/Glpi/Config/LegacyConfigurators/LoadLegacyConfiguration.php
+++ b/src/Glpi/Config/LegacyConfigurators/LoadLegacyConfiguration.php
@@ -41,7 +41,15 @@ final readonly class LoadLegacyConfiguration implements LegacyConfigProviderInte
 {
     public function execute(): void
     {
+        /**
+         * @var array $CFG_GLPI
+         */
+        global $CFG_GLPI;
+
         if (isset($_SESSION['is_installing'])) {
+            // Force `root_doc` value
+            $request = \Symfony\Component\HttpFoundation\Request::createFromGlobals();
+            $CFG_GLPI['root_doc'] = $request->getBasePath();
             return;
         }
 

--- a/src/Glpi/Config/LegacyConfigurators/StandardIncludes.php
+++ b/src/Glpi/Config/LegacyConfigurators/StandardIncludes.php
@@ -70,17 +70,11 @@ final readonly class StandardIncludes implements LegacyConfigProviderInterface
         ;
 
         if (isset($_SESSION['is_installing'])) {
-            // Force `root_doc` value
-            $request = \Symfony\Component\HttpFoundation\Request::createFromGlobals();
-            $CFG_GLPI['root_doc'] = $request->getBasePath();
-
             $GLPI_CACHE = (new CacheManager())->getInstallerCacheInstance();
 
             Session::loadLanguage(with_plugins: false);
             return;
         }
-
-        Config::detectRootDoc();
 
         $skip_db_checks = false;
         $skip_maintenance_checks = false;
@@ -306,13 +300,6 @@ TWIG, $twig_params);
             Html::nullFooter();
             $_SESSION['glpi_use_mode'] = $debug_mode;
             exit();
-        }
-
-        // First call to `Config::detectRootDoc()` cannot compute the value
-        // in CLI context, as it requires DB connection to be up.
-        // Now DB is up, so value can be computed.
-        if (!isset($CFG_GLPI['root_doc'])) {
-            Config::detectRootDoc();
         }
 
         // Load Language file

--- a/src/Glpi/Console/Application.php
+++ b/src/Glpi/Console/Application.php
@@ -433,7 +433,6 @@ class Application extends BaseApplication
         global $CFG_GLPI;
         $this->config = &$CFG_GLPI;
 
-        Config::detectRootDoc();
         Config::loadLegacyConfiguration();
     }
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

I refactored the  definition of the `$CFG_GLPI['root_doc']` configuration entry to :
1. in the web context, rely on the computation made by Symfony instead of our own logic;
2. move it in the `Config::loadLegacyConfiguration()` method to save a DB query when it has to be computed from the `url_base` configuration entry;
3. do it in a centralized method instead of doing it from 3 different places. 