### PR TITLE
Drop dead code executed during GLPI boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -358,6 +358,7 @@ The present file will list all changes made to the project; according to the
 - `ComputerVirtualMachine::showForComputer()`
 - `Config::getCurrentDBVersion()`
 - `Config::showDebug()`
+- `Config::showLibrariesInformation()`
 - `Config::validatePassword()`
 - `Consumable::showAddForm()`
 - `Consumable::showForConsumableItem()`
@@ -375,6 +376,7 @@ The present file will list all changes made to the project; according to the
 - `Document_Item::showSimpleAddForItem()`
 - `Dropdown::showAdvanceDateRestrictionSwitch()`
 - `DropdownTranslation::canBeTranslated()`. Translations are now always active.
+- `DropdownTranslation::getTranslationByName()`
 - `DropdownTranslation::isDropdownTranslationActive()`. Translations are now always active.
 - `Entity::getDefaultContractValues()`
 - `Entity::cleanEntitySelectorCache()`
@@ -549,12 +551,11 @@ The present file will list all changes made to the project; according to the
 - Javascript file upload functions `dataURItoBlob`, `extractSrcFromImgTag`, `insertImgFromFile()`, `insertImageInTinyMCE`, `isImageBlobFromPaste`, `isImageFromPaste`.
 - `CommonDBTM::$fkfield` property.
 - `getHTML` action for `ajax/fuzzysearch.php` endpoint.
-- `Config::showLibrariesInformation()`
 - `DisplayPreference::showFormGlobal` `target` parameter.
 - `DisplayPreference::showFormPerso` `target_id` parameter.
+- `$_SESSION['glpiroot']` session variable.
 - `$DEBUG_SQL, `$SQL_TOTAL_REQUEST`, `$TIMER_DEBUG` and `$TIMER` global variables.
 - `$CFG_GLPI['debug_sql']` and `$CFG_GLPI['debug_vars']` configuration options.
-- `DropdownTranslation::getTranslationByName()`
 - `addgroup` and `deletegroup` actions in `front/user.form.php`.
 - `ajax/ldapdaterestriction.php` script.
 - `ajax/ticketassigninformation.php` script. Use `ajax/actorinformation.php` instead.

--- a/src/Glpi/Config/LegacyConfigurators/StandardIncludes.php
+++ b/src/Glpi/Config/LegacyConfigurators/StandardIncludes.php
@@ -180,16 +180,6 @@ final readonly class StandardIncludes implements LegacyConfigProviderInterface
         }
         Toolbox::setDebugMode();
 
-        if (isset($_SESSION["glpiroot"]) && $CFG_GLPI["root_doc"] != $_SESSION["glpiroot"]) {
-            // When `$_SESSION["glpiroot"]` differs from `$CFG_GLPI["root_doc"]`, it means that
-            // either web server configuration changed,
-            // either session was initialized on another GLPI instance.
-            // Destroy session and redirect to login to ensure that session from another GLPI instance is not reused.
-            Session::destroy();
-            Auth::setRememberMeCookie('');
-            Html::redirectToLogin();
-        }
-
         if (!isset($_SESSION["glpilanguage"])) {
             $_SESSION["glpilanguage"] = Session::getPreferredLanguage();
         }

--- a/src/Glpi/Config/LegacyConfigurators/StandardIncludes.php
+++ b/src/Glpi/Config/LegacyConfigurators/StandardIncludes.php
@@ -179,10 +179,6 @@ final readonly class StandardIncludes implements LegacyConfigProviderInterface
             }
         }
 
-        if (!isset($_SESSION["glpilanguage"])) {
-            $_SESSION["glpilanguage"] = Session::getPreferredLanguage();
-        }
-
         // Override cfg_features by session value
         foreach ($CFG_GLPI['user_pref_field'] as $field) {
             if (!isset($_SESSION["glpi$field"]) && isset($CFG_GLPI[$field])) {

--- a/src/Glpi/Config/LegacyConfigurators/StandardIncludes.php
+++ b/src/Glpi/Config/LegacyConfigurators/StandardIncludes.php
@@ -178,7 +178,6 @@ final readonly class StandardIncludes implements LegacyConfigProviderInterface
                 $_SERVER['argc']--;
             }
         }
-        Toolbox::setDebugMode();
 
         if (!isset($_SESSION["glpilanguage"])) {
             $_SESSION["glpilanguage"] = Session::getPreferredLanguage();

--- a/src/Session.php
+++ b/src/Session.php
@@ -159,7 +159,6 @@ class Session
                     } else {
                         $_SESSION["glpiauthtype"]     = $auth->user->fields['authtype'];
                     }
-                    $_SESSION["glpiroot"]            = $CFG_GLPI["root_doc"];
                     $_SESSION["glpi_use_mode"]       = $auth->user->fields['use_mode'];
                     $_SESSION["glpi_plannings"]      = importArrayFromDB($auth->user->fields['plannings']);
                     $_SESSION["glpicrontimer"]       = time();

--- a/tests/web/APIRest.php
+++ b/tests/web/APIRest.php
@@ -319,7 +319,6 @@ class APIRest extends atoum
         $this->array($data['session'])
             ->hasKey('glpiID')
             ->hasKey('glpiname')
-            ->hasKey('glpiroot')
             ->hasKey('glpilanguage')
             ->hasKey('glpilist_limit');
     }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

1. Drop the `$_SESSION['glpiroot']` variable. The session cookie name is already generated using a hash of `$CFG_GLPI['root_doc']`. Therefore, the `$CFG_GLPI['root_doc'] != $_SESSION['glpiroot']` condition will always be `false`.
2. Drop useless call to `Toolbox::setDebugMode()`. Calling this method with no parameters has not any effect.
3. Drop unneeded initialization of `$_SESSION['glpilanguage']`. The same initialization is made in the `Session::loadLanguage()` method that will be anyway call a few lines later.