### PR TITLE
fix: Execute rules when a new tracking is received via the mail collector

### DIFF
--- a/src/MailCollector.php
+++ b/src/MailCollector.php
@@ -960,6 +960,11 @@ class MailCollector extends CommonDBTM
                             $rejinput['reason'] = NotImportedEmail::NOT_ENOUGH_RIGHTS;
                             $rejected->add($rejinput);
                         } else if ($fup->add($fup_input)) {
+                            // Update ticket to apply rules
+                            $ticket->update([
+                                'id' => $tkt['tickets_id'],
+                                ...$tkt
+                            ]);
                             $delete[$uid] =  self::ACCEPTED_FOLDER;
                         } else {
                             $error++;
@@ -1161,6 +1166,8 @@ class MailCollector extends CommonDBTM
             $subject = '';
         }
         $tkt['name'] = $this->cleanSubject($subject);
+        $tkt['_subject'] = $this->cleanSubject($subject);
+        $tkt['_from'] = $requester;
         if (!Toolbox::seems_utf8($tkt['name'])) {
             $tkt['name'] = Toolbox::encodeInUtf8($tkt['name']);
         }
@@ -1207,6 +1214,7 @@ class MailCollector extends CommonDBTM
                      $requester
                  )))
             ) {
+                unset($tkt['name']);
                 if ($tkt['_supplier_email']) {
                     $tkt['content'] = sprintf(__('From %s'), $requester)
                     . ($this->body_is_html ? '<br /><br />' : "\n\n")


### PR DESCRIPTION

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.

## Description

- It fixes !35427
- If the mail collector does not create a new ticket but creates a new follow-up, the ticket rules are not triggered.

## Screenshots (if appropriate):

![RuleTicket](https://github.com/user-attachments/assets/f721e665-08de-474a-8623-9f036a190e76)


