### PR TITLE
fix: remote connections removal and display of deleted dynamic connec…

### DIFF
--- a/src/Item_RemoteManagement.php
+++ b/src/Item_RemoteManagement.php
@@ -97,7 +97,8 @@ class Item_RemoteManagement extends CommonDBChild
             'FROM'      => self::getTable(),
             'WHERE'     => [
                 'itemtype'     => $item->getType(),
-                'items_id'     => $item->fields['id']
+                'items_id'     => $item->fields['id'],
+                'is_deleted'   => 0,
             ]
         ]);
         return $iterator;

--- a/src/Lock.php
+++ b/src/Lock.php
@@ -474,7 +474,8 @@ class Lock extends CommonGLPI
             ];
             $params['FIELDS'] = ['id', 'remoteid'];
             $first  = true;
-            foreach ($DB->request($remote_management->getTable(), $params) as $line) {
+            $data = $DB->request($remote_management->getTable(), $params);
+            foreach ($data as $line) {
                 if ($first) {
                     echo "<tr>";
                     echo "<th width='10'></th>";

--- a/src/Lock.php
+++ b/src/Lock.php
@@ -479,6 +479,7 @@ class Lock extends CommonGLPI
                     echo "<tr>";
                     echo "<th width='10'></th>";
                     echo "<th>" . $remote_management->getTypeName(Session::getPluralNumber()) . "</th>";
+                    echo "<th>" . __('Type') . "</th>";
                     echo "<th>" . __('Automatic inventory') . "</th>";
                     echo "</tr>";
                     $first = false;
@@ -493,6 +494,7 @@ class Lock extends CommonGLPI
                 }
                 echo "</td>";
                 echo "<td class='left'><a href='" . $remote_management->getLinkURL() . "'>" . $remote_management->fields['remoteid'] . "</a></td>";
+                echo "<td class='left'>" . $remote_management->fields['type'] . "</td>";
                 echo "<td class='left'>" . Dropdown::getYesNo($remote_management->fields['is_dynamic']) . "</td>";
                 echo "</tr>\n";
             }

--- a/src/Lock.php
+++ b/src/Lock.php
@@ -480,7 +480,7 @@ class Lock extends CommonGLPI
                     echo "<tr>";
                     echo "<th width='10'></th>";
                     echo "<th>" . $remote_management->getTypeName(Session::getPluralNumber()) . "</th>";
-                    echo "<th>" . __('Type') . "</th>";
+                    echo "<th>" . _n('Type', 'Types', 1) . "</th>";
                     echo "<th>" . __('Automatic inventory') . "</th>";
                     echo "</tr>";
                     $first = false;

--- a/src/Lock.php
+++ b/src/Lock.php
@@ -464,6 +464,38 @@ class Lock extends CommonGLPI
                 echo "<td class='left'>" . Dropdown::getYesNo($computer_vm->fields['is_dynamic']) . "</td>";
                 echo "</tr>\n";
             }
+
+            $remote_management = new Item_RemoteManagement();
+            $params = [
+                'is_dynamic'   => 1,
+                'is_deleted'   => 1,
+                'items_id'     => $ID,
+                'itemtype'     => $itemtype
+            ];
+            $params['FIELDS'] = ['id', 'remoteid'];
+            $first  = true;
+            foreach ($DB->request($remote_management->getTable(), $params) as $line) {
+                if ($first) {
+                    echo "<tr>";
+                    echo "<th width='10'></th>";
+                    echo "<th>" . $remote_management->getTypeName(Session::getPluralNumber()) . "</th>";
+                    echo "<th>" . __('Automatic inventory') . "</th>";
+                    echo "</tr>";
+                    $first = false;
+                }
+
+                $remote_management->getFromDB($line['id']);
+                echo "<tr class='tab_bg_1'>";
+                echo "<td class='center' width='10'>";
+                if ($remote_management->can($line['id'], UPDATE) || $remote_management->can($line['id'], PURGE)) {
+                    $header = true;
+                    echo "<input type='checkbox' name='Item_RemoteManagement[" . $line['id'] . "]'>";
+                }
+                echo "</td>";
+                echo "<td class='left'><a href='" . $remote_management->getLinkURL() . "'>" . $remote_management->fields['remoteid'] . "</a></td>";
+                echo "<td class='left'>" . Dropdown::getYesNo($remote_management->fields['is_dynamic']) . "</td>";
+                echo "</tr>\n";
+            }
         }
 
         //Software versions


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.

## Description

- It fixes !35523
- This PR fixes a bug that prevented the removal of dynamic remote connections from a computer. Deleted dynamic connections are now displayed in blocked objects.

## Screenshots (if appropriate):

![Image PR](https://github.com/user-attachments/assets/46517c4d-3266-4d80-ac52-b8931b84cfea)



