### PR TITLE
Make Domain_Item purgeable with the delete right

### DIFF
--- a/src/Domain_Item.php
+++ b/src/Domain_Item.php
@@ -35,7 +35,7 @@
 
 class Domain_Item extends CommonDBRelation
 {
-   // From CommonDBRelation
+    // From CommonDBRelation
     public static $itemtype_1 = "Domain";
     public static $items_id_1 = 'domains_id';
 

--- a/src/Domain_Item.php
+++ b/src/Domain_Item.php
@@ -42,8 +42,6 @@ class Domain_Item extends CommonDBRelation
     public static $itemtype_2 = 'itemtype';
     public static $items_id_2 = 'items_id';
 
-    public static $rightname = 'domain';
-
     public static function getTypeName($nb = 0)
     {
         return _n('Domain item', 'Domain items', $nb);


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !35411
- Here is a brief description of what this PR does

To remove a relationship between two items (e.g., Domain -> Computer), the system currently requires purge rights on the source item (Domain in this case). This behavior is problematic because granting purge rights not only allows the removal of relationships but also permits the deletion of items themselves. This creates a security concern when the intent is solely to manage relationships without affecting the items involved.

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/bfc4ccb8-4e51-4c8b-9bcc-e94bb6989816)

![image](https://github.com/user-attachments/assets/60ef6c2b-f237-4b93-a7fa-d9dd8d2debd2)

