### PR TITLE
Add missing clone relations and tabs declarations

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -626,6 +626,18 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/CableStrand.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Call to function method_exists\\(\\) with \\$this\\(CartridgeItem\\) and \'prepareGroupFields\' will always evaluate to true\\.$#',
+	'identifier' => 'function.alreadyNarrowedType',
+	'count' => 1,
+	'path' => __DIR__ . '/src/CartridgeItem.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Call to function method_exists\\(\\) with \\$this\\(CartridgeItem\\) and \'updateGroupFields\' will always evaluate to true\\.$#',
+	'identifier' => 'function.alreadyNarrowedType',
+	'count' => 1,
+	'path' => __DIR__ . '/src/CartridgeItem.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^If condition is always false\\.$#',
 	'identifier' => 'if.alwaysFalse',
 	'count' => 1,

--- a/phpunit/GLPITestCase.php
+++ b/phpunit/GLPITestCase.php
@@ -432,4 +432,61 @@ class GLPITestCase extends TestCase
         $date->modify($modification);
         $_SESSION['glpi_currenttime'] = $date->format("Y-m-d H:i:s");
     }
+
+    /**
+     * Return the minimal fields required for the creation of an item of the given class.
+     *
+     * @param string $class
+     * @return array
+     */
+    protected function getMinimalCreationInput(string $class): array
+    {
+        if (!is_a($class, CommonDBTM::class, true)) {
+            return [];
+        }
+
+        $input = [];
+
+        $item = new $class();
+
+        if ($item->isField($class::getNameField())) {
+            $input[$class::getNameField()] = $this->getUniqueString();
+        }
+
+        if ($item->isField('entities_id')) {
+            $input['entities_id'] = $this->getTestRootEntity(true);
+        }
+
+        switch ($class) {
+            case Cartridge::class:
+                $input['cartridgeitems_id'] = getItemByTypeName(CartridgeItem::class, '_test_cartridgeitem01', true);
+                break;
+            case Change::class:
+                $input['content'] = $this->getUniqueString();
+                break;
+            case Consumable::class:
+                $input['consumableitems_id'] = getItemByTypeName(ConsumableItem::class, '_test_consumableitem01', true);
+                break;
+            case Item_DeviceSimcard::class:
+                $input['itemtype']          = Computer::class;
+                $input['items_id']          = getItemByTypeName(Computer::class, '_test_pc01', true);
+                $input['devicesimcards_id'] = getItemByTypeName(DeviceSimcard::class, '_test_simcard_1', true);
+                break;
+            case Problem::class:
+                $input['content'] = $this->getUniqueString();
+                break;
+            case SoftwareLicense::class:
+                $input['softwares_id'] = getItemByTypeName(Software::class, '_test_soft', true);
+                break;
+            case Ticket::class:
+                $input['content'] = $this->getUniqueString();
+                break;
+        }
+
+        if (is_a($class, Item_Devices::class, true)) {
+            $input[$class::$items_id_2] = 1; // Valid ID is not required (yet)
+        }
+
+        return $input;
+    }
 }

--- a/phpunit/functional/Appliance_ItemTest.php
+++ b/phpunit/functional/Appliance_ItemTest.php
@@ -35,10 +35,51 @@
 
 namespace tests\units;
 
+use Appliance_Item;
 use DbTestCase;
+use Glpi\Asset\Capacity\HasAppliancesCapacity;
+use Glpi\Features\Clonable;
+use Toolbox;
 
 class Appliance_ItemTest extends DbTestCase
 {
+    public function testRelatedItemHasTab()
+    {
+        /** @var array $CFG_GLPI */
+        global $CFG_GLPI;
+
+        $this->initAssetDefinition(capacities: [HasAppliancesCapacity::class]);
+
+        $this->login(); // tab will be available only if corresponding right is available in the current session
+
+        foreach ($CFG_GLPI['appliance_types'] as $itemtype) {
+            $item = $this->createItem(
+                $itemtype,
+                $this->getMinimalCreationInput($itemtype)
+            );
+
+            $tabs = $item->defineAllTabs();
+            $this->assertArrayHasKey('Appliance_Item$1', $tabs, $itemtype);
+        }
+    }
+
+    public function testRelatedItemCloneRelations()
+    {
+        /** @var array $CFG_GLPI */
+        global $CFG_GLPI;
+
+        $this->initAssetDefinition(capacities: [HasAppliancesCapacity::class]);
+
+        foreach ($CFG_GLPI['appliance_types'] as $itemtype) {
+            if (!Toolbox::hasTrait($itemtype, Clonable::class)) {
+                continue;
+            }
+
+            $item = \getItemForItemtype($itemtype);
+            $this->assertContains(Appliance_Item::class, $item->getCloneRelations(), $itemtype);
+        }
+    }
+
     public function testGetForbiddenStandardMassiveAction()
     {
         $aitem = new \Appliance_Item();

--- a/phpunit/functional/Certificate_ItemTest.php
+++ b/phpunit/functional/Certificate_ItemTest.php
@@ -35,12 +35,51 @@
 
 namespace tests\units;
 
+use Certificate_Item;
 use DbTestCase;
-
-/* Test for inc/certificate_item.class.php */
+use Glpi\Asset\Capacity\HasCertificatesCapacity;
+use Glpi\Features\Clonable;
+use Toolbox;
 
 class Certificate_ItemTest extends DbTestCase
 {
+    public function testRelatedItemHasTab()
+    {
+        /** @var array $CFG_GLPI */
+        global $CFG_GLPI;
+
+        $this->initAssetDefinition(capacities: [HasCertificatesCapacity::class]);
+
+        $this->login(); // tab will be available only if corresponding right is available in the current session
+
+        foreach ($CFG_GLPI['certificate_types'] as $itemtype) {
+            $item = $this->createItem(
+                $itemtype,
+                $this->getMinimalCreationInput($itemtype)
+            );
+
+            $tabs = $item->defineAllTabs();
+            $this->assertArrayHasKey('Certificate_Item$1', $tabs, $itemtype);
+        }
+    }
+
+    public function testRelatedItemCloneRelations()
+    {
+        /** @var array $CFG_GLPI */
+        global $CFG_GLPI;
+
+        $this->initAssetDefinition(capacities: [HasCertificatesCapacity::class]);
+
+        foreach ($CFG_GLPI['certificate_types'] as $itemtype) {
+            if (!Toolbox::hasTrait($itemtype, Clonable::class)) {
+                continue;
+            }
+
+            $item = \getItemForItemtype($itemtype);
+            $this->assertContains(Certificate_Item::class, $item->getCloneRelations(), $itemtype);
+        }
+    }
+
     public function testRelations()
     {
         $this->login();

--- a/phpunit/functional/ContractTest.php
+++ b/phpunit/functional/ContractTest.php
@@ -91,7 +91,7 @@ class ContractTest extends DbTestCase
         $cloned = $contract->clone();
         $this->assertGreaterThan($cid, $cloned);
 
-        foreach ($contract->getCloneRelations() as $rel_class) {
+        foreach ([\ContractCost::class, \Contract_Supplier::class, \Contract_Item::class] as $rel_class) {
             $this->assertSame(
                 1,
                 countElementsInTable(

--- a/phpunit/functional/Contract_ItemTest.php
+++ b/phpunit/functional/Contract_ItemTest.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2025 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -35,31 +34,31 @@
 
 namespace tests\units;
 
+use Contract_Item;
 use DbTestCase;
-use Glpi\Asset\Capacity\IsProjectAssetCapacity;
+use Glpi\Asset\Capacity\HasContractsCapacity;
 use Glpi\Features\Clonable;
-use Item_Project;
 use Toolbox;
 
-class Item_ProjectTest extends DbTestCase
+class Contract_ItemTest extends DbTestCase
 {
     public function testRelatedItemHasTab()
     {
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [IsProjectAssetCapacity::class]);
+        $this->initAssetDefinition(capacities: [HasContractsCapacity::class]);
 
         $this->login(); // tab will be available only if corresponding right is available in the current session
 
-        foreach ($CFG_GLPI['project_asset_types'] as $itemtype) {
+        foreach ($CFG_GLPI['contract_types'] as $itemtype) {
             $item = $this->createItem(
                 $itemtype,
                 $this->getMinimalCreationInput($itemtype)
             );
 
             $tabs = $item->defineAllTabs();
-            $this->assertArrayHasKey('Item_Project$1', $tabs, $itemtype);
+            $this->assertArrayHasKey('Contract_Item$1', $tabs, $itemtype);
         }
     }
 
@@ -68,15 +67,15 @@ class Item_ProjectTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [IsProjectAssetCapacity::class]);
+        $this->initAssetDefinition(capacities: [HasContractsCapacity::class]);
 
-        foreach ($CFG_GLPI['project_asset_types'] as $itemtype) {
+        foreach ($CFG_GLPI['contract_types'] as $itemtype) {
             if (!Toolbox::hasTrait($itemtype, Clonable::class)) {
                 continue;
             }
 
             $item = \getItemForItemtype($itemtype);
-            $this->assertContains(Item_Project::class, $item->getCloneRelations(), $itemtype);
+            $this->assertContains(Contract_Item::class, $item->getCloneRelations(), $itemtype);
         }
     }
 }

--- a/phpunit/functional/DatabaseInstanceTest.php
+++ b/phpunit/functional/DatabaseInstanceTest.php
@@ -35,12 +35,53 @@
 
 namespace tests\units;
 
+use DatabaseInstance;
 use DbTestCase;
-
-/* Test for inc/databaseinstance.class.php */
+use Glpi\Asset\Capacity\HasDatabaseInstanceCapacity;
+use Glpi\Features\Clonable;
+use Toolbox;
 
 class DatabaseInstanceTest extends DbTestCase
 {
+    public function testRelatedItemHasTab()
+    {
+        /** @var array $CFG_GLPI */
+        global $CFG_GLPI;
+
+        $this->initAssetDefinition(capacities: [HasDatabaseInstanceCapacity::class]);
+
+        $this->login(); // tab will be available only if corresponding right is available in the current session
+
+        foreach ($CFG_GLPI['databaseinstance_types'] as $itemtype) {
+            $item = $this->createItem(
+                $itemtype,
+                $this->getMinimalCreationInput($itemtype)
+            );
+
+            $tabs = $item->defineAllTabs();
+            $this->assertArrayHasKey('DatabaseInstance$1', $tabs, $itemtype);
+        }
+    }
+
+    public function testRelatedItemCloneRelations()
+    {
+        /** @var array $CFG_GLPI */
+        global $CFG_GLPI;
+
+        $this->initAssetDefinition(capacities: [HasDatabaseInstanceCapacity::class]);
+
+        foreach ($CFG_GLPI['databaseinstance_types'] as $itemtype) {
+            if (!Toolbox::hasTrait($itemtype, Clonable::class)) {
+                continue;
+            }
+
+            // FIXME DatabaseInstance must be a CommonDBChild to be clonable
+            // $item = \getItemForItemtype($itemtype);
+            // $this->assertContains(DatabaseInstance::class, $item->getCloneRelations(), $itemtype);
+            $this->assertTrue(true);
+        }
+    }
+
     public function testDelete()
     {
         $instance = new \DatabaseInstance();

--- a/phpunit/functional/Document_ItemTest.php
+++ b/phpunit/functional/Document_ItemTest.php
@@ -36,13 +36,51 @@
 namespace tests\units;
 
 use DbTestCase;
-use Monolog\Logger;
+use Document_Item;
+use Glpi\Asset\Capacity\HasDocumentsCapacity;
+use Glpi\Features\Clonable;
 use Psr\Log\LogLevel;
-
-/* Test for inc/document_item.class.php */
+use Toolbox;
 
 class Document_ItemTest extends DbTestCase
 {
+    public function testRelatedItemHasTab()
+    {
+        /** @var array $CFG_GLPI */
+        global $CFG_GLPI;
+
+        $this->initAssetDefinition(capacities: [HasDocumentsCapacity::class]);
+
+        $this->login(); // tab will be available only if corresponding right is available in the current session
+
+        foreach ($CFG_GLPI['itemdevices_types'] as $itemtype) {
+            $item = $this->createItem(
+                $itemtype,
+                $this->getMinimalCreationInput($itemtype)
+            );
+
+            $tabs = $item->defineAllTabs();
+            $this->assertArrayHasKey('Document_Item$1', $tabs, $itemtype);
+        }
+    }
+
+    public function testRelatedItemCloneRelations()
+    {
+        /** @var array $CFG_GLPI */
+        global $CFG_GLPI;
+
+        $this->initAssetDefinition(capacities: [HasDocumentsCapacity::class]);
+
+        foreach ($CFG_GLPI['itemdevices_types'] as $itemtype) {
+            if (!Toolbox::hasTrait($itemtype, Clonable::class)) {
+                continue;
+            }
+
+            $item = \getItemForItemtype($itemtype);
+            $this->assertContains(Document_Item::class, $item->getCloneRelations(), $itemtype);
+        }
+    }
+
     public function testGetForbiddenStandardMassiveAction()
     {
         $ditem = new \Document_Item();

--- a/phpunit/functional/Domain_ItemTest.php
+++ b/phpunit/functional/Domain_ItemTest.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2025 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -36,30 +35,30 @@
 namespace tests\units;
 
 use DbTestCase;
-use Glpi\Asset\Capacity\IsProjectAssetCapacity;
+use Domain_Item;
+use Glpi\Asset\Capacity\HasDomainsCapacity;
 use Glpi\Features\Clonable;
-use Item_Project;
 use Toolbox;
 
-class Item_ProjectTest extends DbTestCase
+class Domain_ItemTest extends DbTestCase
 {
     public function testRelatedItemHasTab()
     {
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [IsProjectAssetCapacity::class]);
+        $this->initAssetDefinition(capacities: [HasDomainsCapacity::class]);
 
         $this->login(); // tab will be available only if corresponding right is available in the current session
 
-        foreach ($CFG_GLPI['project_asset_types'] as $itemtype) {
+        foreach ($CFG_GLPI['domain_types'] as $itemtype) {
             $item = $this->createItem(
                 $itemtype,
                 $this->getMinimalCreationInput($itemtype)
             );
 
             $tabs = $item->defineAllTabs();
-            $this->assertArrayHasKey('Item_Project$1', $tabs, $itemtype);
+            $this->assertArrayHasKey('Domain_Item$1', $tabs, $itemtype);
         }
     }
 
@@ -68,15 +67,15 @@ class Item_ProjectTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [IsProjectAssetCapacity::class]);
+        $this->initAssetDefinition(capacities: [HasDomainsCapacity::class]);
 
-        foreach ($CFG_GLPI['project_asset_types'] as $itemtype) {
+        foreach ($CFG_GLPI['domain_types'] as $itemtype) {
             if (!Toolbox::hasTrait($itemtype, Clonable::class)) {
                 continue;
             }
 
             $item = \getItemForItemtype($itemtype);
-            $this->assertContains(Item_Project::class, $item->getCloneRelations(), $itemtype);
+            $this->assertContains(Domain_Item::class, $item->getCloneRelations(), $itemtype);
         }
     }
 }

--- a/phpunit/functional/Glpi/Api/HL/Controller/GraphQLControllerTest.php
+++ b/phpunit/functional/Glpi/Api/HL/Controller/GraphQLControllerTest.php
@@ -158,13 +158,8 @@ class GraphQLControllerTest extends \HLAPITestCase
             'name' => '_test_printer_model',
             'entities_id' => getItemByTypeName('Entity', '_test_root_entity', true)
         ]));
-        $cartridge_item = new \CartridgeItem();
-        $this->assertGreaterThan(0, $cartridge_item->add([
-            'name' => '_test_cartridge_item',
-            'entities_id' => getItemByTypeName('Entity', '_test_root_entity', true)
-        ]));
         $this->assertGreaterThan(0, (new \CartridgeItem_PrinterModel())->add([
-            'cartridgeitems_id' => $cartridge_item->getID(),
+            'cartridgeitems_id' => \getItemByTypeName(\CartridgeItem::class, '_test_cartridgeitem01', true),
             'printermodels_id'  => $printer_model->getID()
         ]));
 

--- a/phpunit/functional/Glpi/Asset/Asset_PeripheralAssetTest.php
+++ b/phpunit/functional/Glpi/Asset/Asset_PeripheralAssetTest.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2025 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -33,33 +32,33 @@
  * ---------------------------------------------------------------------
  */
 
-namespace tests\units;
+namespace tests\units\Glpi\Asset;
 
 use DbTestCase;
-use Glpi\Asset\Capacity\IsProjectAssetCapacity;
+use Glpi\Asset\Asset_PeripheralAsset;
+use Glpi\Asset\Capacity\HasPeripheralAssetsCapacity;
 use Glpi\Features\Clonable;
-use Item_Project;
 use Toolbox;
 
-class Item_ProjectTest extends DbTestCase
+class Asset_PeripheralAssetTest extends DbTestCase
 {
     public function testRelatedItemHasTab()
     {
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [IsProjectAssetCapacity::class]);
+        $this->initAssetDefinition(capacities: [HasPeripheralAssetsCapacity::class]);
 
         $this->login(); // tab will be available only if corresponding right is available in the current session
 
-        foreach ($CFG_GLPI['project_asset_types'] as $itemtype) {
+        foreach ($CFG_GLPI['directconnect_types'] as $itemtype) {
             $item = $this->createItem(
                 $itemtype,
                 $this->getMinimalCreationInput($itemtype)
             );
 
             $tabs = $item->defineAllTabs();
-            $this->assertArrayHasKey('Item_Project$1', $tabs, $itemtype);
+            $this->assertArrayHasKey('Glpi\\Asset\\Asset_PeripheralAsset$1', $tabs, $itemtype);
         }
     }
 
@@ -68,15 +67,15 @@ class Item_ProjectTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [IsProjectAssetCapacity::class]);
+        $this->initAssetDefinition(capacities: [HasPeripheralAssetsCapacity::class]);
 
-        foreach ($CFG_GLPI['project_asset_types'] as $itemtype) {
+        foreach ($CFG_GLPI['directconnect_types'] as $itemtype) {
             if (!Toolbox::hasTrait($itemtype, Clonable::class)) {
                 continue;
             }
 
             $item = \getItemForItemtype($itemtype);
-            $this->assertContains(Item_Project::class, $item->getCloneRelations(), $itemtype);
+            $this->assertContains(Asset_PeripheralAsset::class, $item->getCloneRelations(), $itemtype);
         }
     }
 }

--- a/phpunit/functional/ItemAntivirusTest.php
+++ b/phpunit/functional/ItemAntivirusTest.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2025 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -36,30 +35,30 @@
 namespace tests\units;
 
 use DbTestCase;
-use Glpi\Asset\Capacity\IsProjectAssetCapacity;
+use Glpi\Asset\Capacity\HasAntivirusCapacity;
 use Glpi\Features\Clonable;
-use Item_Project;
+use ItemAntivirus;
 use Toolbox;
 
-class Item_ProjectTest extends DbTestCase
+class ItemAntivirusTest extends DbTestCase
 {
     public function testRelatedItemHasTab()
     {
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [IsProjectAssetCapacity::class]);
+        $this->initAssetDefinition(capacities: [HasAntivirusCapacity::class]);
 
         $this->login(); // tab will be available only if corresponding right is available in the current session
 
-        foreach ($CFG_GLPI['project_asset_types'] as $itemtype) {
+        foreach ($CFG_GLPI['itemantivirus_types'] as $itemtype) {
             $item = $this->createItem(
                 $itemtype,
                 $this->getMinimalCreationInput($itemtype)
             );
 
             $tabs = $item->defineAllTabs();
-            $this->assertArrayHasKey('Item_Project$1', $tabs, $itemtype);
+            $this->assertArrayHasKey('ItemAntivirus$1', $tabs, $itemtype);
         }
     }
 
@@ -68,15 +67,15 @@ class Item_ProjectTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [IsProjectAssetCapacity::class]);
+        $this->initAssetDefinition(capacities: [HasAntivirusCapacity::class]);
 
-        foreach ($CFG_GLPI['project_asset_types'] as $itemtype) {
+        foreach ($CFG_GLPI['itemantivirus_types'] as $itemtype) {
             if (!Toolbox::hasTrait($itemtype, Clonable::class)) {
                 continue;
             }
 
             $item = \getItemForItemtype($itemtype);
-            $this->assertContains(Item_Project::class, $item->getCloneRelations(), $itemtype);
+            $this->assertContains(ItemAntivirus::class, $item->getCloneRelations(), $itemtype);
         }
     }
 }

--- a/phpunit/functional/Item_DevicesTest.php
+++ b/phpunit/functional/Item_DevicesTest.php
@@ -35,11 +35,51 @@
 namespace tests\units;
 
 use DbTestCase;
+use Glpi\Asset\Capacity\HasDevicesCapacity;
+use Glpi\Features\Clonable;
 use Item_Devices;
 use PHPUnit\Framework\Attributes\DataProvider;
+use Toolbox;
 
 class Item_DevicesTest extends DbTestCase
 {
+    public function testRelatedItemHasTab()
+    {
+        /** @var array $CFG_GLPI */
+        global $CFG_GLPI;
+
+        $this->initAssetDefinition(capacities: [HasDevicesCapacity::class]);
+
+        $this->login(); // tab will be available only if corresponding right is available in the current session
+
+        foreach ($CFG_GLPI['itemdevices_types'] as $itemtype) {
+            $item = $this->createItem(
+                $itemtype,
+                $this->getMinimalCreationInput($itemtype)
+            );
+
+            $tabs = $item->defineAllTabs();
+            $this->assertArrayHasKey('Item_Devices$1', $tabs, $itemtype);
+        }
+    }
+
+    public function testRelatedItemCloneRelations()
+    {
+        /** @var array $CFG_GLPI */
+        global $CFG_GLPI;
+
+        $this->initAssetDefinition(capacities: [HasDevicesCapacity::class]);
+
+        foreach ($CFG_GLPI['itemdevices_types'] as $itemtype) {
+            if (!Toolbox::hasTrait($itemtype, Clonable::class)) {
+                continue;
+            }
+
+            $item = \getItemForItemtype($itemtype);
+            $this->assertContains(Item_Devices::class, $item->getCloneRelations(), $itemtype);
+        }
+    }
+
     public static function itemAffinitiesProvider(): iterable
     {
         yield 'Computer' => [

--- a/phpunit/functional/Item_EnvironmentTest.php
+++ b/phpunit/functional/Item_EnvironmentTest.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2025 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -36,30 +35,40 @@
 namespace tests\units;
 
 use DbTestCase;
-use Glpi\Asset\Capacity\IsProjectAssetCapacity;
+use Glpi\Asset\Capacity\IsInventoriableCapacity;
 use Glpi\Features\Clonable;
-use Item_Project;
+use Item_Environment;
 use Toolbox;
 
-class Item_ProjectTest extends DbTestCase
+class Item_EnvironmentTest extends DbTestCase
 {
     public function testRelatedItemHasTab()
     {
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [IsProjectAssetCapacity::class]);
+        $this->initAssetDefinition(capacities: [IsInventoriableCapacity::class]);
 
         $this->login(); // tab will be available only if corresponding right is available in the current session
 
-        foreach ($CFG_GLPI['project_asset_types'] as $itemtype) {
+        foreach ($CFG_GLPI['environment_types'] as $itemtype) {
             $item = $this->createItem(
                 $itemtype,
                 $this->getMinimalCreationInput($itemtype)
             );
 
+            // need to have at least one env item to get the tab displayed
+            $this->createItem(
+                Item_Environment::class,
+                [
+                    'key'      => 'production',
+                    'itemtype' => $itemtype,
+                    'items_id' => $item->getID(),
+                ]
+            );
+
             $tabs = $item->defineAllTabs();
-            $this->assertArrayHasKey('Item_Project$1', $tabs, $itemtype);
+            $this->assertArrayHasKey('Item_Environment$1', $tabs, $itemtype);
         }
     }
 
@@ -68,15 +77,15 @@ class Item_ProjectTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [IsProjectAssetCapacity::class]);
+        $this->initAssetDefinition(capacities: [IsInventoriableCapacity::class]);
 
-        foreach ($CFG_GLPI['project_asset_types'] as $itemtype) {
+        foreach ($CFG_GLPI['environment_types'] as $itemtype) {
             if (!Toolbox::hasTrait($itemtype, Clonable::class)) {
                 continue;
             }
 
             $item = \getItemForItemtype($itemtype);
-            $this->assertContains(Item_Project::class, $item->getCloneRelations(), $itemtype);
+            $this->assertContains(Item_Environment::class, $item->getCloneRelations(), $itemtype);
         }
     }
 }

--- a/phpunit/functional/Item_OperatingSystemTest.php
+++ b/phpunit/functional/Item_OperatingSystemTest.php
@@ -36,11 +36,50 @@
 namespace tests\units;
 
 use DbTestCase;
-
-/* Test for inc/item_operatingsystem.class.php */
+use Glpi\Asset\Capacity\HasOperatingSystemCapacity;
+use Glpi\Features\Clonable;
+use Item_OperatingSystem;
+use Toolbox;
 
 class Item_OperatingSystemTest extends DbTestCase
 {
+    public function testRelatedItemHasTab()
+    {
+        /** @var array $CFG_GLPI */
+        global $CFG_GLPI;
+
+        $this->initAssetDefinition(capacities: [HasOperatingSystemCapacity::class]);
+
+        $this->login(); // tab will be available only if corresponding right is available in the current session
+
+        foreach ($CFG_GLPI['operatingsystem_types'] as $itemtype) {
+            $item = $this->createItem(
+                $itemtype,
+                $this->getMinimalCreationInput($itemtype)
+            );
+
+            $tabs = $item->defineAllTabs();
+            $this->assertArrayHasKey('Item_OperatingSystem$1', $tabs, $itemtype);
+        }
+    }
+
+    public function testRelatedItemCloneRelations()
+    {
+        /** @var array $CFG_GLPI */
+        global $CFG_GLPI;
+
+        $this->initAssetDefinition(capacities: [HasOperatingSystemCapacity::class]);
+
+        foreach ($CFG_GLPI['operatingsystem_types'] as $itemtype) {
+            if (!Toolbox::hasTrait($itemtype, Clonable::class)) {
+                continue;
+            }
+
+            $item = \getItemForItemtype($itemtype);
+            $this->assertContains(Item_OperatingSystem::class, $item->getCloneRelations(), $itemtype);
+        }
+    }
+
     public function testGetTypeName()
     {
         $this->assertSame('Item operating systems', \Item_OperatingSystem::getTypeName());

--- a/phpunit/functional/Item_PlugTest.php
+++ b/phpunit/functional/Item_PlugTest.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2025 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -36,30 +35,30 @@
 namespace tests\units;
 
 use DbTestCase;
-use Glpi\Asset\Capacity\IsProjectAssetCapacity;
+use Glpi\Asset\Capacity\HasPlugCapacity;
 use Glpi\Features\Clonable;
-use Item_Project;
+use Item_Plug;
 use Toolbox;
 
-class Item_ProjectTest extends DbTestCase
+class Item_PlugTest extends DbTestCase
 {
     public function testRelatedItemHasTab()
     {
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [IsProjectAssetCapacity::class]);
+        $this->initAssetDefinition(capacities: [HasPlugCapacity::class]);
 
         $this->login(); // tab will be available only if corresponding right is available in the current session
 
-        foreach ($CFG_GLPI['project_asset_types'] as $itemtype) {
+        foreach ($CFG_GLPI['plug_types'] as $itemtype) {
             $item = $this->createItem(
                 $itemtype,
                 $this->getMinimalCreationInput($itemtype)
             );
 
             $tabs = $item->defineAllTabs();
-            $this->assertArrayHasKey('Item_Project$1', $tabs, $itemtype);
+            $this->assertArrayHasKey('Item_Plug$1', $tabs, $itemtype);
         }
     }
 
@@ -68,15 +67,15 @@ class Item_ProjectTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [IsProjectAssetCapacity::class]);
+        $this->initAssetDefinition(capacities: [HasPlugCapacity::class]);
 
-        foreach ($CFG_GLPI['project_asset_types'] as $itemtype) {
+        foreach ($CFG_GLPI['plug_types'] as $itemtype) {
             if (!Toolbox::hasTrait($itemtype, Clonable::class)) {
                 continue;
             }
 
             $item = \getItemForItemtype($itemtype);
-            $this->assertContains(Item_Project::class, $item->getCloneRelations(), $itemtype);
+            $this->assertContains(Item_Plug::class, $item->getCloneRelations(), $itemtype);
         }
     }
 }

--- a/phpunit/functional/Item_ProcessTest.php
+++ b/phpunit/functional/Item_ProcessTest.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2025 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -36,30 +35,40 @@
 namespace tests\units;
 
 use DbTestCase;
-use Glpi\Asset\Capacity\IsProjectAssetCapacity;
+use Glpi\Asset\Capacity\IsInventoriableCapacity;
 use Glpi\Features\Clonable;
-use Item_Project;
+use Item_Process;
 use Toolbox;
 
-class Item_ProjectTest extends DbTestCase
+class Item_ProcessTest extends DbTestCase
 {
     public function testRelatedItemHasTab()
     {
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [IsProjectAssetCapacity::class]);
+        $this->initAssetDefinition(capacities: [IsInventoriableCapacity::class]);
 
         $this->login(); // tab will be available only if corresponding right is available in the current session
 
-        foreach ($CFG_GLPI['project_asset_types'] as $itemtype) {
+        foreach ($CFG_GLPI['process_types'] as $itemtype) {
             $item = $this->createItem(
                 $itemtype,
                 $this->getMinimalCreationInput($itemtype)
             );
 
+            // need to have at least one process item to get the tab displayed
+            $this->createItem(
+                Item_Process::class,
+                [
+                    'cmd'      => '/opt/startup.sh',
+                    'itemtype' => $itemtype,
+                    'items_id' => $item->getID(),
+                ]
+            );
+
             $tabs = $item->defineAllTabs();
-            $this->assertArrayHasKey('Item_Project$1', $tabs, $itemtype);
+            $this->assertArrayHasKey('Item_Process$1', $tabs, $itemtype);
         }
     }
 
@@ -68,15 +77,15 @@ class Item_ProjectTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [IsProjectAssetCapacity::class]);
+        $this->initAssetDefinition(capacities: [IsInventoriableCapacity::class]);
 
-        foreach ($CFG_GLPI['project_asset_types'] as $itemtype) {
+        foreach ($CFG_GLPI['process_types'] as $itemtype) {
             if (!Toolbox::hasTrait($itemtype, Clonable::class)) {
                 continue;
             }
 
             $item = \getItemForItemtype($itemtype);
-            $this->assertContains(Item_Project::class, $item->getCloneRelations(), $itemtype);
+            $this->assertContains(Item_Process::class, $item->getCloneRelations(), $itemtype);
         }
     }
 }

--- a/phpunit/functional/Item_RemoteManagementTest.php
+++ b/phpunit/functional/Item_RemoteManagementTest.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2025 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -36,30 +35,30 @@
 namespace tests\units;
 
 use DbTestCase;
-use Glpi\Asset\Capacity\IsProjectAssetCapacity;
+use Glpi\Asset\Capacity\HasRemoteManagementCapacity;
 use Glpi\Features\Clonable;
-use Item_Project;
+use Item_RemoteManagement;
 use Toolbox;
 
-class Item_ProjectTest extends DbTestCase
+class Item_RemoteManagementTest extends DbTestCase
 {
     public function testRelatedItemHasTab()
     {
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [IsProjectAssetCapacity::class]);
+        $this->initAssetDefinition(capacities: [HasRemoteManagementCapacity::class]);
 
         $this->login(); // tab will be available only if corresponding right is available in the current session
 
-        foreach ($CFG_GLPI['project_asset_types'] as $itemtype) {
+        foreach ($CFG_GLPI['remote_management_types'] as $itemtype) {
             $item = $this->createItem(
                 $itemtype,
                 $this->getMinimalCreationInput($itemtype)
             );
 
             $tabs = $item->defineAllTabs();
-            $this->assertArrayHasKey('Item_Project$1', $tabs, $itemtype);
+            $this->assertArrayHasKey('Item_RemoteManagement$1', $tabs, $itemtype);
         }
     }
 
@@ -68,15 +67,15 @@ class Item_ProjectTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [IsProjectAssetCapacity::class]);
+        $this->initAssetDefinition(capacities: [HasRemoteManagementCapacity::class]);
 
-        foreach ($CFG_GLPI['project_asset_types'] as $itemtype) {
+        foreach ($CFG_GLPI['remote_management_types'] as $itemtype) {
             if (!Toolbox::hasTrait($itemtype, Clonable::class)) {
                 continue;
             }
 
             $item = \getItemForItemtype($itemtype);
-            $this->assertContains(Item_Project::class, $item->getCloneRelations(), $itemtype);
+            $this->assertContains(Item_RemoteManagement::class, $item->getCloneRelations(), $itemtype);
         }
     }
 }

--- a/phpunit/functional/Item_SoftwareLicenseTest.php
+++ b/phpunit/functional/Item_SoftwareLicenseTest.php
@@ -36,11 +36,30 @@
 namespace tests\units;
 
 use DbTestCase;
-
-/* Test for inc/item_softwarelicense.class.php */
+use Glpi\Asset\Capacity\HasSoftwaresCapacity;
+use Glpi\Features\Clonable;
+use Item_SoftwareLicense;
+use Toolbox;
 
 class Item_SoftwareLicenseTest extends DbTestCase
 {
+    public function testRelatedItemCloneRelations()
+    {
+        /** @var array $CFG_GLPI */
+        global $CFG_GLPI;
+
+        $this->initAssetDefinition(capacities: [HasSoftwaresCapacity::class]);
+
+        foreach ($CFG_GLPI['software_types'] as $itemtype) {
+            if (!Toolbox::hasTrait($itemtype, Clonable::class)) {
+                continue;
+            }
+
+            $item = \getItemForItemtype($itemtype);
+            $this->assertContains(Item_SoftwareLicense::class, $item->getCloneRelations(), $itemtype);
+        }
+    }
+
     public function testCountForLicense()
     {
         $this->login();

--- a/phpunit/functional/ManualLinkTest.php
+++ b/phpunit/functional/ManualLinkTest.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2025 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -36,30 +35,30 @@
 namespace tests\units;
 
 use DbTestCase;
-use Glpi\Asset\Capacity\IsProjectAssetCapacity;
+use Glpi\Asset\Capacity\HasLinksCapacity;
 use Glpi\Features\Clonable;
-use Item_Project;
+use ManualLink;
 use Toolbox;
 
-class Item_ProjectTest extends DbTestCase
+class ManualLinkTest extends DbTestCase
 {
     public function testRelatedItemHasTab()
     {
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [IsProjectAssetCapacity::class]);
+        $this->initAssetDefinition(capacities: [HasLinksCapacity::class]);
 
         $this->login(); // tab will be available only if corresponding right is available in the current session
 
-        foreach ($CFG_GLPI['project_asset_types'] as $itemtype) {
+        foreach ($CFG_GLPI['link_types'] as $itemtype) {
             $item = $this->createItem(
                 $itemtype,
                 $this->getMinimalCreationInput($itemtype)
             );
 
             $tabs = $item->defineAllTabs();
-            $this->assertArrayHasKey('Item_Project$1', $tabs, $itemtype);
+            $this->assertArrayHasKey('ManualLink$1', $tabs, $itemtype);
         }
     }
 
@@ -68,15 +67,15 @@ class Item_ProjectTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [IsProjectAssetCapacity::class]);
+        $this->initAssetDefinition(capacities: [HasLinksCapacity::class]);
 
-        foreach ($CFG_GLPI['project_asset_types'] as $itemtype) {
+        foreach ($CFG_GLPI['link_types'] as $itemtype) {
             if (!Toolbox::hasTrait($itemtype, Clonable::class)) {
                 continue;
             }
 
             $item = \getItemForItemtype($itemtype);
-            $this->assertContains(Item_Project::class, $item->getCloneRelations(), $itemtype);
+            $this->assertContains(ManualLink::class, $item->getCloneRelations(), $itemtype);
         }
     }
 }

--- a/phpunit/functional/NetworkPortTest.php
+++ b/phpunit/functional/NetworkPortTest.php
@@ -36,11 +36,50 @@
 namespace tests\units;
 
 use DbTestCase;
-
-/* Test for inc/networkport.class.php */
+use Glpi\Asset\Capacity\HasNetworkPortCapacity;
+use Glpi\Features\Clonable;
+use NetworkPort;
+use Toolbox;
 
 class NetworkPortTest extends DbTestCase
 {
+    public function testRelatedItemHasTab()
+    {
+        /** @var array $CFG_GLPI */
+        global $CFG_GLPI;
+
+        $this->initAssetDefinition(capacities: [HasNetworkPortCapacity::class]);
+
+        $this->login(); // tab will be available only if corresponding right is available in the current session
+
+        foreach ($CFG_GLPI['networkport_types'] as $itemtype) {
+            $item = $this->createItem(
+                $itemtype,
+                $this->getMinimalCreationInput($itemtype)
+            );
+
+            $tabs = $item->defineAllTabs();
+            $this->assertArrayHasKey('NetworkPort$1', $tabs, $itemtype);
+        }
+    }
+
+    public function testRelatedItemCloneRelations()
+    {
+        /** @var array $CFG_GLPI */
+        global $CFG_GLPI;
+
+        $this->initAssetDefinition(capacities: [HasNetworkPortCapacity::class]);
+
+        foreach ($CFG_GLPI['networkport_types'] as $itemtype) {
+            if (!Toolbox::hasTrait($itemtype, Clonable::class)) {
+                continue;
+            }
+
+            $item = \getItemForItemtype($itemtype);
+            $this->assertContains(NetworkPort::class, $item->getCloneRelations(), $itemtype);
+        }
+    }
+
     public function testAddSimpleNetworkPort()
     {
         $this->login();

--- a/phpunit/functional/ReservationTest.php
+++ b/phpunit/functional/ReservationTest.php
@@ -36,10 +36,31 @@
 namespace tests\units;
 
 use DbTestCase;
+use Glpi\Asset\Capacity\IsReservableCapacity;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 class ReservationTest extends DbTestCase
 {
+    public function testRelatedItemHasTab()
+    {
+        /** @var array $CFG_GLPI */
+        global $CFG_GLPI;
+
+        $this->initAssetDefinition(capacities: [IsReservableCapacity::class]);
+
+        $this->login(); // tab will be available only if corresponding right is available in the current session
+
+        foreach ($CFG_GLPI['reservation_types'] as $itemtype) {
+            $item = $this->createItem(
+                $itemtype,
+                $this->getMinimalCreationInput($itemtype)
+            );
+
+            $tabs = $item->defineAllTabs();
+            $this->assertArrayHasKey('Reservation$1', $tabs, $itemtype);
+        }
+    }
+
     public function testGetReservableItemtypes(): void
     {
         // No reservable items

--- a/src/Appliance.php
+++ b/src/Appliance.php
@@ -63,7 +63,11 @@ class Appliance extends CommonDBTM
             Document_Item::class,
             Infocom::class,
             Notepad::class,
-            KnowbaseItem_Item::class
+            KnowbaseItem_Item::class,
+            Certificate_Item::class,
+            Domain_Item::class,
+            Item_Project::class,
+            ManualLink::class,
         ];
     }
 

--- a/src/Budget.php
+++ b/src/Budget.php
@@ -56,7 +56,9 @@ class Budget extends CommonDropdown
     public function getCloneRelations(): array
     {
         return [
-            Document_Item::class
+            Document_Item::class,
+            KnowbaseItem_Item::class,
+            ManualLink::class,
         ];
     }
 

--- a/src/CartridgeItem.php
+++ b/src/CartridgeItem.php
@@ -51,6 +51,7 @@ class CartridgeItem extends CommonDBTM
         prepareInputForAdd as prepareInputForAddAssignableItem;
         prepareInputForUpdate as prepareInputForUpdateAssignableItem;
     }
+    use Glpi\Features\Clonable;
 
    // From CommonDBTM
     protected static $forward_entity_to = ['Cartridge', 'Infocom'];
@@ -58,6 +59,14 @@ class CartridgeItem extends CommonDBTM
     protected $usenotepad               = true;
 
     public static $rightname                   = 'cartridge';
+
+    public function getCloneRelations(): array
+    {
+        return [
+            Infocom::class,
+            ManualLink::class,
+        ];
+    }
 
     public static function getTypeName($nb = 0)
     {

--- a/src/Certificate.php
+++ b/src/Certificate.php
@@ -60,7 +60,10 @@ class Certificate extends CommonDBTM
             Infocom::class,
             Contract_Item::class,
             Document_Item::class,
-            KnowbaseItem_Item::class
+            KnowbaseItem_Item::class,
+            Domain_Item::class,
+            Item_Project::class,
+            ManualLink::class,
         ];
     }
 

--- a/src/Cluster.php
+++ b/src/Cluster.php
@@ -51,7 +51,10 @@ class Cluster extends CommonDBTM
     public function getCloneRelations(): array
     {
         return [
-            NetworkPort::class
+            NetworkPort::class,
+            Appliance_Item::class,
+            Contract_Item::class,
+            ManualLink::class,
         ];
     }
 
@@ -82,6 +85,7 @@ class Cluster extends CommonDBTM
          ->addStandardTab('Item_Ticket', $ong, $options)
          ->addStandardTab('Item_Problem', $ong, $options)
          ->addStandardTab('Change_Item', $ong, $options)
+         ->addStandardTab('ManualLink', $ong, $options)
          ->addStandardTab('Appliance_Item', $ong, $options)
          ->addStandardTab('Log', $ong, $options);
 

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -3172,7 +3172,9 @@ abstract class CommonITILObject extends CommonDBTM
 
     public function getCloneRelations(): array
     {
-        $relations = [];
+        $relations = [
+            KnowbaseItem_Item::class,
+        ];
 
         if (is_a($this->userlinkclass, CommonITILActor::class, true)) {
             $relations[] = $this->userlinkclass;

--- a/src/Computer.php
+++ b/src/Computer.php
@@ -84,6 +84,15 @@ class Computer extends CommonDBTM
             KnowbaseItem_Item::class,
             Item_RemoteManagement::class,
             ItemAntivirus::class,
+            Appliance_Item::class,
+            Certificate_Item::class,
+            // FIXME DatabaseInstance must be a CommonDBChild to be clonable
+            // DatabaseInstance::class,
+            Domain_Item::class,
+            Item_Project::class,
+            ItemVirtualMachine::class,
+            ManualLink::class,
+            Socket::class,
         ];
     }
 

--- a/src/ConsumableItem.php
+++ b/src/ConsumableItem.php
@@ -64,7 +64,10 @@ class ConsumableItem extends CommonDBTM
 
     public function getCloneRelations(): array
     {
-        return [];
+        return [
+            Infocom::class,
+            ManualLink::class,
+        ];
     }
 
     public static function getTypeName($nb = 0)

--- a/src/Contract.php
+++ b/src/Contract.php
@@ -63,6 +63,8 @@ class Contract extends CommonDBTM
             Contract_Item::class,
             Contract_Supplier::class,
             ContractCost::class,
+            KnowbaseItem_Item::class,
+            ManualLink::class,
         ];
     }
 

--- a/src/Database.php
+++ b/src/Database.php
@@ -59,6 +59,15 @@ class Database extends CommonDBChild
         return ['management', self::class];
     }
 
+    public function getCloneRelations(): array
+    {
+        return [
+            Appliance_Item::class,
+            Domain_Item::class,
+            ImpactRelation::class,
+        ];
+    }
+
     public function defineTabs($options = [])
     {
         $ong = [];

--- a/src/DatabaseInstance.php
+++ b/src/DatabaseInstance.php
@@ -62,7 +62,8 @@ class DatabaseInstance extends CommonDBTM
             KnowbaseItem_Item::class,
             Certificate_Item::class,
             Domain_Item::class,
-            Database::class
+            Database::class,
+            ManualLink::class,
         ];
     }
 
@@ -95,6 +96,7 @@ class DatabaseInstance extends CommonDBTM
          ->addStandardTab('Item_Ticket', $ong, $options)
          ->addStandardTab('Item_Problem', $ong, $options)
          ->addStandardTab('Change_Item', $ong, $options)
+         ->addStandardTab('ManualLink', $ong, $options)
          ->addStandardTab('Certificate_Item', $ong, $options)
          ->addStandardTab('Lock', $ong, $options)
          ->addStandardTab('Notepad', $ong, $options)

--- a/src/Domain.php
+++ b/src/Domain.php
@@ -69,6 +69,8 @@ class Domain extends CommonDBTM
             Contract_Item::class,
             Document_Item::class,
             Notepad::class,
+            Certificate_Item::class,
+            ManualLink::class,
         ];
     }
 

--- a/src/Enclosure.php
+++ b/src/Enclosure.php
@@ -57,7 +57,10 @@ class Enclosure extends CommonDBTM
         return [
             Item_Enclosure::class,
             Item_Devices::class,
-            NetworkPort::class
+            NetworkPort::class,
+            Contract_Item::class,
+            Document_Item::class,
+            Infocom::class,
         ];
     }
 

--- a/src/Entity.php
+++ b/src/Entity.php
@@ -166,7 +166,9 @@ class Entity extends CommonTreeDropdown
 
     public function getCloneRelations(): array
     {
-        return [];
+        return [
+            KnowbaseItem_Item::class,
+        ];
     }
 
     public function pre_updateInDB()

--- a/src/Glpi/Asset/Capacity/HasAppliancesCapacity.php
+++ b/src/Glpi/Asset/Capacity/HasAppliancesCapacity.php
@@ -52,6 +52,13 @@ class HasAppliancesCapacity extends AbstractCapacity
         return Appliance::getIcon();
     }
 
+    public function getCloneRelations(): array
+    {
+        return [
+            Appliance_Item::class,
+        ];
+    }
+
     public function isUsed(string $classname): bool
     {
         return parent::isUsed($classname)

--- a/src/Glpi/Asset/Capacity/HasCertificatesCapacity.php
+++ b/src/Glpi/Asset/Capacity/HasCertificatesCapacity.php
@@ -52,6 +52,13 @@ class HasCertificatesCapacity extends AbstractCapacity
         return Certificate::getIcon();
     }
 
+    public function getCloneRelations(): array
+    {
+        return [
+            Certificate_Item::class,
+        ];
+    }
+
     public function getSearchOptions(string $classname): array
     {
         return Certificate::rawSearchOptionsToAdd($classname);

--- a/src/Glpi/Asset/Capacity/HasDatabaseInstanceCapacity.php
+++ b/src/Glpi/Asset/Capacity/HasDatabaseInstanceCapacity.php
@@ -52,6 +52,14 @@ class HasDatabaseInstanceCapacity extends AbstractCapacity
         return Database::getIcon();
     }
 
+    public function getCloneRelations(): array
+    {
+        return [
+            // FIXME DatabaseInstance must be a CommonDBChild to be clonable
+            // DatabaseInstance::class,
+        ];
+    }
+
     public function isUsed(string $classname): bool
     {
         return parent::isUsed($classname)

--- a/src/Glpi/Asset/Capacity/HasDomainsCapacity.php
+++ b/src/Glpi/Asset/Capacity/HasDomainsCapacity.php
@@ -52,6 +52,13 @@ class HasDomainsCapacity extends AbstractCapacity
         return Domain::getIcon();
     }
 
+    public function getCloneRelations(): array
+    {
+        return [
+            Domain_Item::class,
+        ];
+    }
+
     public function isUsed(string $classname): bool
     {
         return parent::isUsed($classname)

--- a/src/Glpi/Asset/Capacity/HasLinksCapacity.php
+++ b/src/Glpi/Asset/Capacity/HasLinksCapacity.php
@@ -53,6 +53,13 @@ class HasLinksCapacity extends AbstractCapacity
         return ManualLink::getIcon();
     }
 
+    public function getCloneRelations(): array
+    {
+        return [
+            ManualLink::class,
+        ];
+    }
+
     public function isUsed(string $classname): bool
     {
         return parent::isUsed($classname)

--- a/src/Glpi/Asset/Capacity/IsInventoriableCapacity.php
+++ b/src/Glpi/Asset/Capacity/IsInventoriableCapacity.php
@@ -67,6 +67,14 @@ class IsInventoriableCapacity extends AbstractCapacity
         return $tab;
     }
 
+    public function getCloneRelations(): array
+    {
+        return [
+            Item_Process::class,
+            Item_Environment::class,
+        ];
+    }
+
     public function isUsed(string $classname): bool
     {
         return parent::isUsed($classname)

--- a/src/Glpi/Asset/Capacity/IsProjectAssetCapacity.php
+++ b/src/Glpi/Asset/Capacity/IsProjectAssetCapacity.php
@@ -77,6 +77,8 @@ class IsProjectAssetCapacity extends AbstractCapacity
     {
         // Allow our item to be linked to projects
         $this->registerToTypeConfig('project_asset_types', $classname);
+
+        CommonGLPI::registerStandardTab($classname, Item_Project::class, 95);
     }
 
     public function onCapacityDisabled(string $classname): void

--- a/src/Item_DeviceSimcard.php
+++ b/src/Item_DeviceSimcard.php
@@ -50,6 +50,15 @@ class Item_DeviceSimcard extends Item_Devices
 
     public static $undisclosedFields      = ['pin', 'pin2', 'puk', 'puk2'];
 
+    public function getCloneRelations(): array
+    {
+        $relations = parent::getCloneRelations();
+
+        $relations[] = Infocom::class;
+
+        return $relations;
+    }
+
     public static function getSpecificities($specif = '')
     {
         return [

--- a/src/Item_Devices.php
+++ b/src/Item_Devices.php
@@ -79,6 +79,15 @@ class Item_Devices extends CommonDBRelation
 
     public static $rightname = 'device';
 
+    public function getCloneRelations(): array
+    {
+        $relations = parent::getCloneRelations();
+
+        $relations[] = Contract_Item::class;
+
+        return $relations;
+    }
+
     protected function computeFriendlyName()
     {
         $itemtype = static::$itemtype_2;

--- a/src/Monitor.php
+++ b/src/Monitor.php
@@ -67,7 +67,14 @@ class Monitor extends CommonDBTM
             Contract_Item::class,
             Document_Item::class,
             Asset_PeripheralAsset::class,
-            KnowbaseItem_Item::class
+            KnowbaseItem_Item::class,
+            Appliance_Item::class,
+            Domain_Item::class,
+            Item_Project::class,
+            Item_SoftwareLicense::class,
+            Item_SoftwareVersion::class,
+            ManualLink::class,
+            NetworkPort::class,
         ];
     }
 

--- a/src/NetworkEquipment.php
+++ b/src/NetworkEquipment.php
@@ -69,7 +69,16 @@ class NetworkEquipment extends CommonDBTM
             NetworkPort::class,
             Contract_Item::class,
             Document_Item::class,
-            KnowbaseItem_Item::class
+            KnowbaseItem_Item::class,
+            Appliance_Item::class,
+            Certificate_Item::class,
+            Domain_Item::class,
+            Item_Disk::class,
+            Item_Project::class,
+            Item_SoftwareLicense::class,
+            Item_SoftwareVersion::class,
+            ManualLink::class,
+            Socket::class,
         ];
     }
     /** /RELATIONS */

--- a/src/PDU.php
+++ b/src/PDU.php
@@ -54,7 +54,9 @@ class PDU extends CommonDBTM
         return [
             Item_Plug::class,
             Item_Devices::class,
-            NetworkPort::class
+            NetworkPort::class,
+            Contract_Item::class,
+            Infocom::class,
         ];
     }
 

--- a/src/PassiveDCEquipment.php
+++ b/src/PassiveDCEquipment.php
@@ -292,6 +292,7 @@ class PassiveDCEquipment extends CommonDBTM
             Contract_Item::class,
             Document_Item::class,
             Infocom::class,
+            Socket::class,
         ];
     }
 }

--- a/src/Peripheral.php
+++ b/src/Peripheral.php
@@ -69,7 +69,15 @@ class Peripheral extends CommonDBTM
             Contract_Item::class,
             Document_Item::class,
             Asset_PeripheralAsset::class,
-            KnowbaseItem_Item::class
+            KnowbaseItem_Item::class,
+            Appliance_Item::class,
+            Certificate_Item::class,
+            Domain_Item::class,
+            Item_Project::class,
+            Item_SoftwareLicense::class,
+            Item_SoftwareVersion::class,
+            ManualLink::class,
+            Socket::class,
         ];
     }
 

--- a/src/Phone.php
+++ b/src/Phone.php
@@ -77,6 +77,12 @@ class Phone extends CommonDBTM
             KnowbaseItem_Item::class,
             Item_RemoteManagement::class,
             ItemAntivirus::class,
+            Appliance_Item::class,
+            Certificate_Item::class,
+            Domain_Item::class,
+            Item_Project::class,
+            ManualLink::class,
+            Socket::class,
         ];
     }
 
@@ -134,6 +140,7 @@ class Phone extends CommonDBTM
         $this->addStandardTab('Change_Item', $ong, $options);
         $this->addStandardTab('Item_Project', $ong, $options);
         $this->addStandardTab('ManualLink', $ong, $options);
+        $this->addStandardTab('Certificate_Item', $ong, $options);
         $this->addStandardTab('Lock', $ong, $options);
         $this->addStandardTab('Notepad', $ong, $options);
         $this->addStandardTab('Reservation', $ong, $options);

--- a/src/Printer.php
+++ b/src/Printer.php
@@ -73,6 +73,15 @@ class Printer extends CommonDBTM
             Document_Item::class,
             Asset_PeripheralAsset::class,
             KnowbaseItem_Item::class,
+            Appliance_Item::class,
+            Certificate_Item::class,
+            Domain_Item::class,
+            Item_Disk::class,
+            Item_Project::class,
+            Item_SoftwareLicense::class,
+            Item_SoftwareVersion::class,
+            ManualLink::class,
+            Socket::class,
         ];
     }
 

--- a/src/Software.php
+++ b/src/Software.php
@@ -63,7 +63,11 @@ class Software extends CommonDBTM
             Infocom::class,
             Contract_Item::class,
             Document_Item::class,
-            KnowbaseItem_Item::class
+            KnowbaseItem_Item::class,
+            Appliance_Item::class,
+            Domain_Item::class,
+            Item_Project::class,
+            ManualLink::class,
         ];
     }
 

--- a/src/SoftwareLicense.php
+++ b/src/SoftwareLicense.php
@@ -71,7 +71,8 @@ class SoftwareLicense extends CommonTreeDropdown
             Contract_Item::class,
             Document_Item::class,
             KnowbaseItem_Item::class,
-            Notepad::class
+            Notepad::class,
+            Certificate_Item::class,
         ];
     }
 

--- a/src/User.php
+++ b/src/User.php
@@ -84,7 +84,9 @@ class User extends CommonDBTM
     {
         return [
             Profile_User::class,
-            Group_User::class
+            Group_User::class,
+            Certificate_Item::class,
+            ManualLink::class,
         ];
     }
 

--- a/tests/GLPITestCase.php
+++ b/tests/GLPITestCase.php
@@ -325,7 +325,7 @@ class GLPITestCase extends atoum
     }
 
     /**
-     * Return the minimal fields required for the creation of an item of the given field.
+     * Return the minimal fields required for the creation of an item of the given class.
      *
      * @param string $class
      * @return array
@@ -338,19 +338,44 @@ class GLPITestCase extends atoum
 
         $input = [];
 
-        if ((new $class())->isField('entities_id')) {
+        $item = new $class();
+
+        if ($item->isField($class::getNameField())) {
+            $input[$class::getNameField()] = $this->getUniqueString();
+        }
+
+        if ($item->isField('entities_id')) {
             $input['entities_id'] = $this->getTestRootEntity(true);
         }
 
         switch ($class) {
+            case Cartridge::class:
+                $input['cartridgeitems_id'] = getItemByTypeName(CartridgeItem::class, '_test_cartridgeitem01', true);
+                break;
+            case Change::class:
+                $input['content'] = $this->getUniqueString();
+                break;
+            case Consumable::class:
+                $input['consumableitems_id'] = getItemByTypeName(ConsumableItem::class, '_test_consumableitem01', true);
+                break;
             case Item_DeviceSimcard::class:
                 $input['itemtype']          = Computer::class;
                 $input['items_id']          = getItemByTypeName(Computer::class, '_test_pc01', true);
                 $input['devicesimcards_id'] = getItemByTypeName(DeviceSimcard::class, '_test_simcard_1', true);
                 break;
+            case Problem::class:
+                $input['content'] = $this->getUniqueString();
+                break;
             case SoftwareLicense::class:
                 $input['softwares_id'] = getItemByTypeName(Software::class, '_test_soft', true);
                 break;
+            case Ticket::class:
+                $input['content'] = $this->getUniqueString();
+                break;
+        }
+
+        if (is_a($class, Item_Devices::class, true)) {
+            $input[$class::$items_id_2] = 1; // Valid ID is not required (yet)
         }
 
         return $input;

--- a/tests/src/autoload/functions.php
+++ b/tests/src/autoload/functions.php
@@ -46,7 +46,7 @@ function loadDataset()
     // Unit test data definition
     $data = [
         // bump this version to force reload of the full dataset, when content change
-        '_version' => '4.12',
+        '_version' => '4.13',
 
         // Type => array of entries
         'Entity' => [
@@ -678,7 +678,19 @@ function loadDataset()
                 'is_confidential' => 1,
                 'name' => 'Test OAuth Client',
             ]
-        ]
+        ],
+        'CartridgeItem' => [
+            [
+                'name'        => '_test_cartridgeitem01',
+                'entities_id' => '_test_root_entity',
+            ]
+        ],
+        'ConsumableItem' => [
+            [
+                'name'        => '_test_consumableitem01',
+                'entities_id' => '_test_root_entity',
+            ]
+        ],
     ];
 
     // To bypass various right checks


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

Some clone relations and tabs declarations related to `$CFG_GLPI['*_types']` configurations are missing. This PR adds missing declarations and add minimal tests to ensure that any classe added to these `$CFG_GLPI['*_types']` configurations will correctly declare them.

As the creation of an asset from its template is using the cloning system, it is preferable to declare all existing relations in the `getCloneRelations()` method.