### PR TITLE
Ignore PHPStan error related to optional config files

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -164,12 +164,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/install/install.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Path in include_once\\(\\) "/config_db\\.php" is not a file or it does not exist\\.$#',
-	'identifier' => 'includeOnce.fileNotFound',
-	'count' => 3,
-	'path' => __DIR__ . '/install/install.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Strict comparison using \\!\\=\\= between mixed~\'\' and \'\' will always evaluate to true\\.$#',
 	'identifier' => 'notIdentical.alwaysTrue',
 	'count' => 1,
@@ -322,12 +316,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Instanceof between DBmysql and DBmysql will always evaluate to true\\.$#',
 	'identifier' => 'instanceof.alwaysTrue',
-	'count' => 1,
-	'path' => __DIR__ . '/install/update.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Path in include_once\\(\\) "/config_db\\.php" is not a file or it does not exist\\.$#',
-	'identifier' => 'includeOnce.fileNotFound',
 	'count' => 1,
 	'path' => __DIR__ . '/install/update.php',
 ];
@@ -1478,18 +1466,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/DBConnection.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Path in include_once\\(\\) "/config_db\\.php" is not a file or it does not exist\\.$#',
-	'identifier' => 'includeOnce.fileNotFound',
-	'count' => 1,
-	'path' => __DIR__ . '/src/DBConnection.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Path in include_once\\(\\) "/config_db_slave\\.php" is not a file or it does not exist\\.$#',
-	'identifier' => 'includeOnce.fileNotFound',
-	'count' => 5,
-	'path' => __DIR__ . '/src/DBConnection.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Call to function is_string\\(\\) with string will always evaluate to true\\.$#',
 	'identifier' => 'function.alreadyNarrowedType',
 	'count' => 1,
@@ -2012,12 +1988,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Api/API.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Path in include_once\\(\\) "/var/www/glpi/inc/downstream\\.php" is not a file or it does not exist\\.$#',
-	'identifier' => 'includeOnce.fileNotFound',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/API.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method Glpi\\\\Api\\\\APIRest\\:\\:getItemtype\\(\\) should return bool but returns string\\.$#',
 	'identifier' => 'return.type',
 	'count' => 2,
@@ -2260,12 +2230,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Method Glpi\\\\Api\\\\HL\\\\Router\\:\\:resumeSession\\(\\) is unused\\.$#',
 	'identifier' => 'method.unused',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Router.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Path in include_once\\(\\) "/var/www/glpi/inc/downstream\\.php" is not a file or it does not exist\\.$#',
-	'identifier' => 'includeOnce.fileNotFound',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Glpi/Api/HL/Router.php',
 ];
@@ -2562,12 +2526,6 @@ $ignoreErrors[] = [
 	'identifier' => 'method.notFound',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Glpi/CalDAV/Plugin/CalDAV.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Path in include_once\\(\\) "/config_db\\.php" is not a file or it does not exist\\.$#',
-	'identifier' => 'includeOnce.fileNotFound',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Config/LegacyConfigurators/InitializeDbConnection.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Call to an undefined method Symfony\\\\Component\\\\Console\\\\Helper\\\\HelperInterface\\:\\:ask\\(\\)\\.$#',
@@ -5758,12 +5716,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Parameter &\\$curl_info by\\-ref type of method Toolbox\\:\\:callCurl\\(\\) expects array\\|null, \\(array\\<string, array\\<int, array\\<string, string\\>\\>\\|float\\|int\\|string\\|null\\>\\|false\\) given\\.$#',
 	'identifier' => 'parameterByRef.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Toolbox.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Path in include\\(\\) "/config_db\\.php" is not a file or it does not exist\\.$#',
-	'identifier' => 'include.fileNotFound',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Toolbox.php',
 ];

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -60,15 +60,15 @@ parameters:
         - PLUGINS_DIRECTORIES
         - TU_USER
     ignoreErrors:
-        - '/Instantiated class (DB|DBSlave) not found/'
-        - '/Instantiated class XHProfRuns_Default not found/'
-        - '/Instantiation of deprecated class Glpi\\Http\\HeaderlessStreamedResponse/'
-        - { message: '/Variable \$this might not be defined/', paths: [ 'inc/includes.php' ] }
-        - { message: '/Call to protected method setAjax\(\) of class Glpi\\Controller\\LegacyFileLoadController./', paths: [ 'ajax/*', 'front/*', 'inc/includes.php' ] }
-        - { message: '/Access to protected property/', paths: [ 'front/dropdown.common.form.php' ] }
-        - { message: '/LDAP\\Connection/', reportUnmatched: false }
+        - '~Instantiated class (DB|DBSlave) not found~'
+        - '~Instantiated class XHProfRuns_Default not found~'
+        - '~Instantiation of deprecated class Glpi\\Http\\HeaderlessStreamedResponse~'
+        - { message: '~Variable \$this might not be defined~', paths: [ 'inc/includes.php' ] }
+        - { message: '~Call to protected method setAjax\(\) of class Glpi\\Controller\\LegacyFileLoadController.~', paths: [ 'ajax/*', 'front/*', 'inc/includes.php' ] }
+        - { message: '~Access to protected property~', paths: [ 'front/dropdown.common.form.php' ] }
+        - { message: '~LDAP\\Connection~', reportUnmatched: false }
         -
-            message: '/\/config\/config_db.php" is not a file or it does not exist./'
+            message: '~/(downstream\.php|config_db\.php|config_db_slave\.php)" is not a file or it does not exist.~'
             reportUnmatched: false
 rules:
     - GlpiProject\Tools\PHPStan\Rules\GlobalVarTypeRule


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

PHPStan results may differ depending on the presence of `inc/downstream.php`, `config/config_db.php`, or `config/config_db_slave.php` files. I moved the ignored errors into the `phpstan.neon.dist` file to be able to add a `reportUnmatched: false` that will prevent having an PHPStan invalidation due to unmatched error when the files are present.