### PR TITLE
Fix webhook execution permissions in cron context

### DIFF
--- a/src/Webhook.php
+++ b/src/Webhook.php
@@ -479,7 +479,7 @@ class Webhook extends CommonDBTM implements FilterableInterface
         $router->registerAuthMiddleware(new \Glpi\Api\HL\Middleware\InternalAuthMiddleware());
         $path = rtrim($path, '/');
         $request = new Request('GET', $path);
-        $response = $router->handleRequest($request);
+        $response = Session::callAsSystem(static fn () => $router->handleRequest($request));
         if ($response->getStatusCode() === 200) {
             $body = (string)$response->getBody();
             try {


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.

## Description

- Bypass user permission checks when webhooks fetch data from the new API.
- ~~Abort the session in the `/front/cron.php` endpoint and then make all entities active. The session may need to be initialized, but I don't know a reason for it to ever be saved so `session_abort` makes sense even without the entity changes being done here.~~