### PR TITLE
Prevent HL API to close existing output buffers

### DIFF
--- a/src/Glpi/Api/HL/Middleware/DebugResponseMiddleware.php
+++ b/src/Glpi/Api/HL/Middleware/DebugResponseMiddleware.php
@@ -57,23 +57,19 @@ class DebugResponseMiddleware extends AbstractMiddleware implements ResponseMidd
             $next($input);
             return;
         }
-        $outputs = [];
-        // Go through all output buffers
-        while (ob_get_level() > 0) {
-            $outputs[] = ob_get_clean();
-        }
+
         $debug_messages = [];
+
         // If the output matches an HTML debug alert, extract the inner text and add it to the array
-        foreach ($outputs as $output) {
-            if (!is_string($output)) {
-                continue;
-            }
+        $output = ob_get_contents(); // Get the current buffer content without closing it
+        if (is_string($output)) {
             $crawler = new Crawler($output);
             $node = $crawler->filter('div.glpi-debug-alert');
             if ($node->count() > 0) {
                 $debug_messages[] = $node->text();
             }
         }
+
         // If there are debug messages, add them to the response
         if (count($debug_messages) > 0) {
             $header_value = '';

--- a/src/Glpi/Api/HL/Router.php
+++ b/src/Glpi/Api/HL/Router.php
@@ -578,6 +578,7 @@ EOT;
     {
         // Start an output buffer to capture any potential debug errors
         ob_start();
+
         $response = null;
         $original_method = $request->getMethod();
         if ($original_method === 'HEAD') {
@@ -686,15 +687,10 @@ EOT;
         if ($original_method === 'HEAD') {
             $response = $response->withBody(Utils::streamFor(''));
         }
-        // Clear output buffers
-        $ob_config = ini_get('output_buffering');
-        $max_level = filter_var($ob_config, FILTER_VALIDATE_BOOLEAN) ? 1 : 0;
-        while (ob_get_level() > $max_level) {
-            ob_end_clean();
-        }
-        if (ob_get_level() > 0) {
-            ob_clean();
-        }
+
+        // Clean the current output buffer
+        ob_end_clean();
+
         return $response;
     }
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

The HL API debug middleware fetches the debug messages by crawling the output. The problem is that it closes more than its own output buffer, and it may have unexpected side effects.

I propose to only close the buffer opened by the `Router::handleRequest()` itself.

It fixes #18563.

I am not sure how I could test it, maybe an end-to-end test should be added for this.

Also, the `Router::handleRequest()` method may exit before the `ob_end_clean()` call, and in that case, the output will not be correctly closed. I did not fixed this part as I just wanted to fix the initial issue.