### PR TITLE
TicketValidation pre_item_form hook

### DIFF
--- a/templates/components/itilobject/timeline/timeline.html.twig
+++ b/templates/components/itilobject/timeline/timeline.html.twig
@@ -169,7 +169,7 @@
                         {% if matching_types|length > 0 %}
                            {% set timeline_itemtype = matching_types|first %}
                            {% if timeline_itemtype.template is defined %}
-                              {{ include(timeline_itemtype.template, {'form_mode': 'view'}) }}
+                              {{ include(timeline_itemtype.template, {'form_mode': 'view', 'subitem': timeline_itemtype.item}}) }}
                            {% endif %}
                         {% endif %}
                      {% else %}

--- a/templates/components/itilobject/timeline/timeline.html.twig
+++ b/templates/components/itilobject/timeline/timeline.html.twig
@@ -169,7 +169,7 @@
                         {% if matching_types|length > 0 %}
                            {% set timeline_itemtype = matching_types|first %}
                            {% if timeline_itemtype.template is defined %}
-                              {{ include(timeline_itemtype.template, {'form_mode': 'view', 'subitem': timeline_itemtype.item}}) }}
+                              {{ include(timeline_itemtype.template, {'form_mode': 'view', 'subitem': timeline_itemtype.item}) }}
                            {% endif %}
                         {% endif %}
                      {% else %}


### PR DESCRIPTION
# Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] This change requires a documentation update.

## Description

If we want to use the pre_item_form hook for a validation request, GLPI does not pass the subitem to the Twig template during the timeline rendering.
If the subitem is not passed, the item is empty in the hook, making it impossible to use the data.

**Solution**: Add the subitem to the include of the item type template.

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/7682db10-f515-4a91-84dc-81fa81961c24)




---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208836526605807