### PR TITLE
Reset user default group when link between user and group is deleted

### DIFF
--- a/phpunit/functional/Group_UserTest.php
+++ b/phpunit/functional/Group_UserTest.php
@@ -213,4 +213,48 @@ class Group_UserTest extends \DbTestCase
         $this->assertTrue(\Group_User::isUserInGroup(getItemByTypeName('User', 'tech', true), $groups_id));
         $this->assertFalse(\Group_User::isUserInGroup(getItemByTypeName('User', 'glpi', true), $groups_id));
     }
+
+    public function testDeleteUserDefaultGroup()
+    {
+        $group = new \Group();
+        $gid = (int)$group->add([
+            'name' => 'Test group'
+        ]);
+        $this->assertGreaterThan(0, $gid);
+
+        $user = getItemByTypeName('User', 'tech');
+
+        $group_user = new \Group_User();
+        $this->assertGreaterThan(
+            0,
+            (int)$group_user->add(
+                [
+                    'groups_id' => $gid,
+                    'users_id'  => $user->getID()
+                ]
+            )
+        );
+
+        $this->assertTrue(
+            $user->update(
+                [
+                    'id' => $user->getID(),
+                    'groups_id' => $gid
+                ]
+            )
+        );
+
+        $group_users = \Group_User::getGroupUsers($gid);
+        $this->assertCount(1, $group_users);
+        $this->assertSame($user->getID(), (int)$group_users[0]['id']);
+
+        //cleanup
+        $this->assertTrue($group->delete(['id' => $gid], true));
+
+        $group_users = \Group_User::getGroupUsers($gid);
+        $this->assertCount(0, $group_users);
+
+        $user = getItemByTypeName('User', 'tech');
+        $this->assertEquals(0, $user->fields['groups_id']);
+    }
 }

--- a/src/Group_User.php
+++ b/src/Group_User.php
@@ -954,7 +954,19 @@ class Group_User extends CommonDBRelation
 
        // remove user from plannings
         $groups_id  = $this->fields['groups_id'];
+        $users_id = $this->fields['users_id'];
         $planning_k = 'group_' . $groups_id . '_users';
+
+        // If user's default group is affected, remove it from user
+        $user_inst = new User();
+        if ($user_inst->getFromDB($users_id) && $user_inst->fields['groups_id'] == $groups_id) {
+            $user_inst->update(
+                [
+                    'id'        => $users_id,
+                    'groups_id' => 0,
+                ]
+            );
+        }
 
        // find users with the current group in their plannings
         $user_inst = new User();

--- a/src/Group_User.php
+++ b/src/Group_User.php
@@ -952,13 +952,12 @@ class Group_User extends CommonDBRelation
 
         parent::post_purgeItem();
 
-       // remove user from plannings
         $groups_id  = $this->fields['groups_id'];
         $users_id = $this->fields['users_id'];
-        $planning_k = 'group_' . $groups_id . '_users';
+
+        $user_inst = new User();
 
         // If user's default group is affected, remove it from user
-        $user_inst = new User();
         if ($user_inst->getFromDB($users_id) && $user_inst->fields['groups_id'] == $groups_id) {
             $user_inst->update(
                 [
@@ -968,7 +967,8 @@ class Group_User extends CommonDBRelation
             );
         }
 
-       // find users with the current group in their plannings
+        // remove user from plannings
+        $planning_k = 'group_' . $groups_id . '_users';
         $users = $user_inst->find([
             'plannings' => ['LIKE', "%$planning_k%"]
         ]);

--- a/src/Group_User.php
+++ b/src/Group_User.php
@@ -969,7 +969,6 @@ class Group_User extends CommonDBRelation
         }
 
        // find users with the current group in their plannings
-        $user_inst = new User();
         $users = $user_inst->find([
             'plannings' => ['LIKE', "%$planning_k%"]
         ]);

--- a/src/User.php
+++ b/src/User.php
@@ -1127,9 +1127,10 @@ class User extends CommonDBTM
             }
         }
 
-       // Security on default group  update
+        // Security on default group update
         if (
             isset($input['groups_id'])
+            && $input['groups_id'] > 0
             && !Group_User::isUserInGroup($input['id'], $input['groups_id'])
         ) {
             unset($input['groups_id']);


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !35654
- Here is a brief description of what this PR does

When you delete the link between a user and a group, if this group is the user's default group, it remains so even after the link has been deleted.

## Screenshots (if appropriate):

![396580549-7cc06cfc-e3eb-4d07-a33e-f93b6b268864](https://github.com/user-attachments/assets/49dae2ed-447d-407d-bdd2-0c481ae00524)

