### PR TITLE
Allow multiple strategies to be defined at once for certain destination fields

### DIFF
--- a/css/includes/components/form/_form-destination.scss
+++ b/css/includes/components/form/_form-destination.scss
@@ -31,31 +31,191 @@
  * ---------------------------------------------------------------------
  */
 
-[data-glpi-specific-values-extra-field-container] {
-    [data-glpi-specific-values-extra-field-item] {
-        padding-left: 1px;
+[data-glpi-associated-items-specific-values-extra-field] {
+    [data-glpi-associated-items-specific-values-extra-field-container] {
+        [data-glpi-associated-items-specific-values-extra-field-item] {
+            padding-left: 1px;
 
-        >span:last-of-type {
-            flex-grow: 1;
+            >span:last-of-type {
+                flex-grow: 1;
 
-            .select2-container {
-                width: 100% !important;
+                .select2-container {
+                    width: 100% !important;
+                }
+            }
+
+            &:last-of-type {
+                [data-glpi-remove-associated-item-button] {
+                    border-bottom-right-radius: var(--tblr-btn-border-radius) !important;
+                }
+            }
+
+            &:not(:has([data-glpi-associated-items-items-id-dropdown])) {
+                .select2-container {
+                    width: 100% !important;
+                }
+            }
+        }
+
+        .input-group[data-glpi-associated-items-specific-values-extra-field-item] {
+            >span:first-of-type {
+                .select2-selection {
+                    border-top-right-radius: 0 !important;
+                    border-bottom-right-radius: 0 !important;
+                }
+            }
+
+            >span:not(:first-of-type) {
+                .select2-selection {
+                    border-radius: 0 !important;
+                }
             }
         }
     }
 
-    .input-group[data-glpi-specific-values-extra-field-item] {
-        >span:first-of-type {
-            .select2-selection {
-                border-top-right-radius: 0 !important;
-                border-bottom-right-radius: 0 !important;
+    [data-glpi-add-associated-item-button] {
+        position: relative;
+        margin-left: 1px;
+        margin-top: calc(-1 * var(--tblr-border-width));
+        border-top-left-radius: 0 !important;
+        border-top-right-radius: 0 !important;
+    }
+}
+
+[data-glpi-itildestination-field-configs] {
+    &:not(:has(> [data-glpi-itildestination-field-config]:nth-child(2))) {
+        [data-glpi-itildestination-remove-field-config] {
+            display: none !important;
+        }
+    }
+
+    &:has(> [data-glpi-itildestination-field-config]:nth-child(2)) {
+        &:has([data-glpi-itildestination-remove-field-config]) {
+            [data-glpi-itildestination-field-config] {
+                &:not(:has([data-glpi-associated-items-specific-values-extra-field]:not(.d-none))) {
+                    .select2-selection {
+                        border-top-right-radius: 0 !important;
+                        border-bottom-right-radius: 0 !important;
+                    }
+                }
+
+                &:has([data-glpi-associated-items-specific-values-extra-field]:not(.d-none)) {
+                    &:has([data-glpi-itildestination-field-config-display-condition="specific_values"]) {
+                        >div {
+                            &:first-child {
+                                .select2-selection {
+                                    border-top-right-radius: 0 !important;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    [data-glpi-itildestination-field-config] {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: stretch;
+
+        &:has(div[data-glpi-itildestination-field-config-display-condition]:not(.d-none)) {
+            &:not(:has([data-glpi-associated-items-specific-values-extra-field]:not(.d-none))) {
+                >div {
+                    &:first-child {
+                        .select2-selection {
+                            border-top-right-radius: 0 !important;
+                            border-bottom-right-radius: 0 !important;
+                        }
+                    }
+                }
             }
         }
 
-        >span:not(:first-of-type) {
-            .select2-selection {
-                border-radius: 0 !important;
+        >div {
+            flex: 1;
+
+            // Fix height issue with multiple select2
+            &:has(.select2-selection--multiple) {
+                >div {
+                    height: 100%;
+
+                    >div.btn-group.btn-group-sm {
+                        height: 100%;
+                    }
+
+                    .select2-container {
+                        height: 100%;
+
+                        .select2-selection {
+                            height: 100%;
+                        }
+                    }
+                }
             }
+        }
+
+        &:not(:has([data-glpi-associated-items-specific-values-extra-field]:not(.d-none))) {
+            >div {
+                &[data-glpi-itildestination-field-config-display-condition] {
+                    margin-left: calc(-1 * var(--tblr-border-width));
+
+                    .select2-selection {
+                        border-top-left-radius: 0 !important;
+                        border-bottom-left-radius: 0 !important;
+                    }
+                }
+            }
+        }
+
+        // Specific layout for associated items
+        &:has([data-glpi-associated-items-specific-values-extra-field]:not(.d-none)) {
+            &:has([data-glpi-itildestination-field-config-display-condition="specific_values"]) {
+                >div {
+                    &:first-child {
+                        .select2-selection {
+                            border-bottom-left-radius: 0 !important;
+                            border-bottom-right-radius: 0 !important;
+                        }
+                    }
+                }
+            }
+
+            // Make the strategy select fill the whole line
+            [data-glpi-associated-items-specific-values-extra-field] {
+                flex-basis: 100%;
+                order: 1;
+
+                [data-glpi-associated-items-specific-values-extra-field-item] {
+                    .select2-selection {
+                        border-bottom-right-radius: 0 !important;
+                        border-top-left-radius: 0 !important;
+                    }
+
+                    &:not(:last-of-type) {
+                        .select2-selection {
+                            border-bottom-left-radius: 0 !important;
+                        }
+                    }
+                }
+            }
+
+            [data-glpi-associated-items-specific-values-extra-field-item] {
+                margin-top: calc(-1 * var(--tblr-border-width));
+            }
+        }
+
+        [data-glpi-itildestination-remove-field-config] {
+            border-top-left-radius: 0 !important;
+            border-bottom-left-radius: 0 !important;
+            margin-left: calc(-1 * var(--tblr-border-width));
+        }
+    }
+
+    [data-glpi-itildestination-remove-field-config],
+    [data-glpi-remove-associated-item-button] {
+        &:hover {
+            z-index: 99;
         }
     }
 }

--- a/js/modules/Forms/FieldDestinationAssociatedItem.js
+++ b/js/modules/Forms/FieldDestinationAssociatedItem.js
@@ -59,12 +59,6 @@ export class GlpiFormFieldDestinationAssociatedItem {
     #specific_values_template;
 
     /**
-     * Button to add associated items (jquery selector)
-     * @type {jQuery<HTMLElement>}
-     */
-    #add_associated_item_button;
-
-    /**
      * @param {jQuery<HTMLElement>} specific_values_extra_field
      */
     constructor(
@@ -74,16 +68,32 @@ export class GlpiFormFieldDestinationAssociatedItem {
     ) {
         this.#itemtype_name = itemtype_name;
         this.#items_id_name = items_id_name;
-        this.#associated_items_container = specific_values_extra_field.find('[data-glpi-specific-values-extra-field-container]');
-        this.#specific_values_template = specific_values_extra_field.find('[data-glpi-specific-values-extra-field-template]');
-        this.#add_associated_item_button = specific_values_extra_field.find('[data-glpi-add-associated-item-button]');
+        this.#associated_items_container = specific_values_extra_field.find('[data-glpi-associated-items-specific-values-extra-field-container]');
+        this.#specific_values_template = specific_values_extra_field.find('[data-glpi-associated-items-specific-values-extra-field-template]');
 
-        this.#add_associated_item_button.on('click', () => {
-            this.#addAssociatedItemField();
-        });
+        this.#associated_items_container.on('change', `select[name="${this.#items_id_name}"]`, () => this.#handleChanges());
 
         this.#associated_items_container.find('[data-glpi-remove-associated-item-button]')
             .each((index, button) => this.#registerOnRemoveAssociatedItem($(button)));
+
+        this.#associated_items_container
+            .find('[data-glpi-associated-items-specific-values-extra-field-item]')
+            .each((index, field) => this.#initDropdowns($(field)));
+    }
+
+    #handleChanges() {
+        const empty_fields = this.#associated_items_container.find(`[data-glpi-associated-items-specific-values-extra-field-item]`)
+            .filter((index, field) => ($(field).find(`select[name="${this.#items_id_name}"]`).val() ?? "0") === "0");
+
+        // Always keep one empty field
+        if (empty_fields.length > 1) {
+            // Remove fields that are not filled, except the first one
+            empty_fields.filter((index) => index !== 0)
+                .closest('[data-glpi-associated-items-specific-values-extra-field-item]')
+                .remove();
+        } else if (empty_fields.length === 0) {
+            this.#addAssociatedItemField();
+        }
     }
 
     #addAssociatedItemField() {
@@ -92,7 +102,7 @@ export class GlpiFormFieldDestinationAssociatedItem {
         this.#associated_items_container.append(template_content);
 
         // Get the last item added
-        const template = this.#associated_items_container.find('[data-glpi-specific-values-extra-field-item]').last();
+        const template = this.#associated_items_container.find('[data-glpi-associated-items-specific-values-extra-field-item]').last();
 
         // Initialize dropdowns and register events
         this.#initDropdowns(template);
@@ -101,7 +111,14 @@ export class GlpiFormFieldDestinationAssociatedItem {
 
     #registerOnRemoveAssociatedItem(button) {
         button.on('click', () => {
-            button.closest('[data-glpi-specific-values-extra-field-item]').remove();
+            if (
+                (button.closest('[data-glpi-associated-items-specific-values-extra-field-item]')
+                    .find(`select[name="${this.#items_id_name}"]`).val() ?? "0") !== "0"
+                    || this.#associated_items_container.find(`select[name="${this.#items_id_name}"]`)
+                        .filter((index, field) => $(field).val() === "0").length > 1
+            ) {
+                button.closest('[data-glpi-associated-items-specific-values-extra-field-item]').remove();
+            }
         });
     }
 

--- a/js/modules/Forms/FieldDestinationMultipleConfig.js
+++ b/js/modules/Forms/FieldDestinationMultipleConfig.js
@@ -5,7 +5,7 @@
  *
  * http://glpi-project.org
  *
- * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2015-2025 Teclib' and contributors.
  * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *

--- a/js/modules/Forms/FieldDestinationMultipleConfig.js
+++ b/js/modules/Forms/FieldDestinationMultipleConfig.js
@@ -1,0 +1,172 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+/* global getUUID, setupAjaxDropdown, setupAdaptDropdown */
+
+export class GlpiFormFieldDestinationMultipleConfig {
+    /** @type {jQuery<HTMLElement>} */
+    #container;
+
+    /** @type {jQuery<HTMLElement>} */
+    #template;
+
+    /** @type {jQuery<HTMLElement>} */
+    #add_button;
+
+    constructor(container) {
+        this.#container = container;
+        this.#template = container.find('[data-glpi-itildestination-field-config-template]');
+        this.#add_button = container.find('[data-glpi-itildestination-add-field-config]');
+
+        // Register events
+        this.#container.find('[data-glpi-itildestination-remove-field-config]')
+            .on('click', (e) => this.#removeFieldConfig(e.target.closest('[data-glpi-itildestination-field-config]')));
+        this.#add_button.on('click', () => this.#addFieldConfig());
+        this.#container.find('[data-glpi-itildestination-field-config]')
+            .each((index, field) => $(field).find('select').first().on('change', (e) => this.#handleStrategyChange(e)));
+
+        // Trigger change event to initialize the display
+        this.#container.find('[data-glpi-itildestination-field-config]').each((index, field) => {
+            $(field).find('select').first().trigger('change');
+        });
+
+        this.#handleAddButtonVisibility();
+    }
+
+    /**
+     * Add a new field config
+     */
+    #addFieldConfig() {
+        const selected_strategies = [];
+        this.#container.find('[data-glpi-itildestination-field-config]').each((index, field) => {
+            selected_strategies.push($(field).find('select').first().find('option').filter(':selected').val());
+        });
+
+        const new_config_field = $(this.#template.html()).insertBefore(this.#add_button);
+
+        new_config_field.find('[data-glpi-itildestination-remove-field-config]')
+            .on('click', (e) => this.#removeFieldConfig(e.target.closest('[data-glpi-itildestination-field-config]')));
+
+        new_config_field.find('select').find('option').each((index, option) => {
+            if ($(option).val() != 0 && selected_strategies.includes($(option).val())) {
+                $(option).prop('disabled', true);
+            }
+        });
+
+        new_config_field.find('select').first().on('change', (e) => this.#handleStrategyChange(e));
+
+        this.#initDropdowns(new_config_field);
+        this.#handleAddButtonVisibility();
+    }
+
+    /**
+     * Remove a field config
+     * @param {jQuery<HTMLElement>} field
+     */
+    #removeFieldConfig(field) {
+        field.remove();
+
+        this.#handleStrategyChange();
+        this.#handleAddButtonVisibility();
+    }
+
+    #initDropdowns(field) {
+        field.find("select").each(function () {
+            const id = $(this).attr("id");
+            const config = window.select2_configs[id];
+
+            if (id !== undefined && config !== undefined) {
+                // Rename id to ensure it is unique
+                const uid = getUUID();
+                $(this).attr("id", uid);
+
+                // Check if a select2 isn't already initialized
+                // and if a configuration is available
+                if (
+                    $(this).hasClass("select2-hidden-accessible") === false
+                    && config !== undefined
+                ) {
+                    config.field_id = uid;
+                    if (config.type === "ajax") {
+                        setupAjaxDropdown(config);
+                    } else if (config.type === "adapt") {
+                        setupAdaptDropdown(config);
+                    }
+                }
+            }
+        });
+    }
+
+    #handleAddButtonVisibility() {
+        const count_options = this.#container.find('[data-glpi-itildestination-field-config]')
+            .find('select').first().find('option').length;
+        const count_field_configs = this.#container.find('[data-glpi-itildestination-field-config]').length;
+
+        this.#add_button.toggleClass('d-none', count_field_configs >= count_options);
+    }
+
+    /**
+     * Handle the change of a strategy
+     * @param {Event} [event]
+     */
+    #handleStrategyChange(event = null) {
+        const selected_strategies = [];
+        this.#container.find('[data-glpi-itildestination-field-config]').each((index, field) => {
+            selected_strategies.push($(field).find('select').first().find('option').filter(':selected').val());
+        });
+
+        this.#container.find('select').find('option').each((index, option) => {
+            $(option).prop(
+                'disabled',
+                !option.selected && $(option).val() != 0 && selected_strategies.includes($(option).val())
+            );
+        });
+
+        if (event) {
+            const selected_value = $(event.target).val();
+
+            // Compute display conditions
+            $(event.target).closest('[data-glpi-itildestination-field-config]')
+                .find(`[data-glpi-itildestination-field-config-display-condition]`)
+                .toggleClass('d-none', true)
+                .filter(`[data-glpi-itildestination-field-config-display-condition="${selected_value}"]`)
+                .toggleClass('d-none', false);
+
+            // Compute disabled state of the fields
+            $(event.target).closest('[data-glpi-itildestination-field-config]')
+                .find(`[data-glpi-itildestination-field-config-display-condition]`).each((index, field) => {
+                    $(field).find(':input').prop('disabled', $(field).hasClass('d-none'));
+                });
+        }
+    }
+}

--- a/phpunit/functional/Glpi/Form/Destination/CommonITILField/AssociatedItemsFieldTest.php
+++ b/phpunit/functional/Glpi/Form/Destination/CommonITILField/AssociatedItemsFieldTest.php
@@ -63,7 +63,7 @@ final class AssociatedItemsFieldTest extends DbTestCase
         $monitors = $this->createMonitors(2);
 
         $specific_values = new AssociatedItemsFieldConfig(
-            strategy: AssociatedItemsFieldStrategy::SPECIFIC_VALUES,
+            strategies: [AssociatedItemsFieldStrategy::SPECIFIC_VALUES],
             specific_associated_items: [
                 Computer::getType() => [
                     $computers[0]->getID(),
@@ -131,7 +131,7 @@ final class AssociatedItemsFieldTest extends DbTestCase
 
         $form = $this->createAndGetFormWithMultipleItemQuestions();
         $specific_answers = new AssociatedItemsFieldConfig(
-            strategy: AssociatedItemsFieldStrategy::SPECIFIC_ANSWERS,
+            strategies: [AssociatedItemsFieldStrategy::SPECIFIC_ANSWERS],
             specific_question_ids: [
                 $this->getQuestionId($form, "Your Computer"),
                 $this->getQuestionId($form, "Your Monitors"),
@@ -187,7 +187,7 @@ final class AssociatedItemsFieldTest extends DbTestCase
 
         $form = $this->createAndGetFormWithMultipleItemQuestions();
         $last_valid_answer = new AssociatedItemsFieldConfig(
-            strategy: AssociatedItemsFieldStrategy::LAST_VALID_ANSWER
+            strategies: [AssociatedItemsFieldStrategy::LAST_VALID_ANSWER]
         );
 
         // Test with no answers
@@ -254,7 +254,7 @@ final class AssociatedItemsFieldTest extends DbTestCase
 
         $form = $this->createAndGetFormWithMultipleItemQuestions();
         $all_valid_answers = new AssociatedItemsFieldConfig(
-            strategy: AssociatedItemsFieldStrategy::ALL_VALID_ANSWERS
+            strategies: [AssociatedItemsFieldStrategy::ALL_VALID_ANSWERS]
         );
 
         // Test with no answers
@@ -327,6 +327,54 @@ final class AssociatedItemsFieldTest extends DbTestCase
                     'itemtype' => Computer::getType(),
                     'items_id' => $computers[0]->getID(),
                 ]
+            ],
+            expected_associated_items: [
+                Computer::getType() => [
+                    $computers[0]->getID() => $computers[0]->getID(),
+                ],
+                Monitor::getType() => [
+                    $monitors[0]->getID() => $monitors[0]->getID(),
+                    $monitors[1]->getID() => $monitors[1]->getID(),
+                ],
+            ]
+        );
+    }
+
+    public function testMultipleStrategies(): void
+    {
+        $this->login();
+
+        // Create computers and monitors
+        $computers = $this->createComputers(2);
+        $monitors = $this->createMonitors(2);
+
+        $form = $this->createAndGetFormWithMultipleItemQuestions();
+
+        // Multiple strategies: SPECIFIC_VALUES and SPECIFIC_ANSWERS
+        $this->sendFormAndAssertAssociatedItems(
+            form: $form,
+            config: new AssociatedItemsFieldConfig(
+                strategies: [
+                    AssociatedItemsFieldStrategy::SPECIFIC_VALUES,
+                    AssociatedItemsFieldStrategy::SPECIFIC_ANSWERS
+                ],
+                specific_associated_items: [
+                    Computer::getType() => [
+                        $computers[0]->getID(),
+                    ],
+                ],
+                specific_question_ids: [
+                    $this->getQuestionId($form, "Your Monitors"),
+                ]
+            ),
+            answers: [
+                "Your Computer" => [
+                    'Computer_' . $computers[1]->getID(),
+                ],
+                "Your Monitors" => [
+                    'Monitor_' . $monitors[0]->getID(),
+                    'Monitor_' . $monitors[1]->getID(),
+                ],
             ],
             expected_associated_items: [
                 Computer::getType() => [

--- a/phpunit/functional/Glpi/Form/Destination/CommonITILField/RequesterFieldTest.php
+++ b/phpunit/functional/Glpi/Form/Destination/CommonITILField/RequesterFieldTest.php
@@ -61,7 +61,7 @@ final class RequesterFieldTest extends DbTestCase
     {
         $form = $this->createAndGetFormWithMultipleActorsQuestions();
         $from_template_config = new RequesterFieldConfig(
-            ITILActorFieldStrategy::FROM_TEMPLATE
+            [ITILActorFieldStrategy::FROM_TEMPLATE]
         );
 
         // The default GLPI's template doesn't have a predefined location
@@ -106,7 +106,7 @@ final class RequesterFieldTest extends DbTestCase
     {
         $form = $this->createAndGetFormWithMultipleActorsQuestions();
         $form_filler_config = new RequesterFieldConfig(
-            ITILActorFieldStrategy::FORM_FILLER
+            [ITILActorFieldStrategy::FORM_FILLER]
         );
 
         // The default GLPI's template doesn't have a predefined location
@@ -140,7 +140,7 @@ final class RequesterFieldTest extends DbTestCase
         $this->sendFormAndAssertTicketActors(
             form: $form,
             config: new RequesterFieldConfig(
-                strategy: ITILActorFieldStrategy::SPECIFIC_VALUES,
+                strategies: [ITILActorFieldStrategy::SPECIFIC_VALUES],
                 specific_itilactors_ids: [
                     User::getForeignKeyField() . '-' . $user->getID()
                 ]
@@ -153,7 +153,7 @@ final class RequesterFieldTest extends DbTestCase
         $this->sendFormAndAssertTicketActors(
             form: $form,
             config: new RequesterFieldConfig(
-                strategy: ITILActorFieldStrategy::SPECIFIC_VALUES,
+                strategies: [ITILActorFieldStrategy::SPECIFIC_VALUES],
                 specific_itilactors_ids: [
                     User::getForeignKeyField() . '-' . $user->getID(),
                     Group::getForeignKeyField() . '-' . $group->getID()
@@ -176,7 +176,7 @@ final class RequesterFieldTest extends DbTestCase
         $this->sendFormAndAssertTicketActors(
             form: $form,
             config: new RequesterFieldConfig(
-                strategy: ITILActorFieldStrategy::SPECIFIC_ANSWERS,
+                strategies: [ITILActorFieldStrategy::SPECIFIC_ANSWERS],
                 specific_question_ids: [$this->getQuestionId($form, "Requester 1")]
             ),
             answers: [
@@ -195,7 +195,7 @@ final class RequesterFieldTest extends DbTestCase
         $this->sendFormAndAssertTicketActors(
             form: $form,
             config: new RequesterFieldConfig(
-                strategy: ITILActorFieldStrategy::SPECIFIC_ANSWERS,
+                strategies: [ITILActorFieldStrategy::SPECIFIC_ANSWERS],
                 specific_question_ids: [
                     $this->getQuestionId($form, "Requester 1"),
                     $this->getQuestionId($form, "Requester 2")
@@ -218,7 +218,7 @@ final class RequesterFieldTest extends DbTestCase
     {
         $form = $this->createAndGetFormWithMultipleActorsQuestions();
         $last_valid_answer_config = new RequesterFieldConfig(
-            ITILActorFieldStrategy::LAST_VALID_ANSWER
+            [ITILActorFieldStrategy::LAST_VALID_ANSWER]
         );
 
         $user1 = $this->createItem(User::class, ['name' => 'testLocationFromSpecificQuestions User']);
@@ -285,6 +285,38 @@ final class RequesterFieldTest extends DbTestCase
             config: $last_valid_answer_config,
             answers: [],
             expected_actors_ids: [$user1->getID()]
+        );
+    }
+
+    public function testMultipleStrategies(): void
+    {
+        // Login is required to assign actors
+        $this->login();
+
+        $form = $this->createAndGetFormWithMultipleActorsQuestions();
+        $user1 = $this->createItem(User::class, ['name' => 'testMultipleStrategies User 1']);
+        $user2 = $this->createItem(User::class, ['name' => 'testMultipleStrategies User 2']);
+        $group = $this->createItem(Group::class, ['name' => 'testMultipleStrategies Group']);
+
+        // Set the user as default requester using predefined fields
+        $this->createItem(TicketTemplatePredefinedField::class, [
+            'tickettemplates_id' => getItemByTypeName(TicketTemplate::class, "Default", true),
+            'num' => 4, // User requester
+            'value' => $user1->getID(),
+        ]);
+
+        // Multiple strategies: FROM_TEMPLATE and SPECIFIC_VALUES
+        $this->sendFormAndAssertTicketActors(
+            form: $form,
+            config: new RequesterFieldConfig(
+                strategies: [ITILActorFieldStrategy::FROM_TEMPLATE, ITILActorFieldStrategy::SPECIFIC_VALUES],
+                specific_itilactors_ids: [
+                    User::getForeignKeyField() . '-' . $user2->getID(),
+                    Group::getForeignKeyField() . '-' . $group->getID()
+                ]
+            ),
+            answers: [],
+            expected_actors_ids: [$user1->getID(), $user2->getID(), $group->getID()]
         );
     }
 

--- a/phpunit/functional/Glpi/Form/Export/FormSerializerDestinationTest.php
+++ b/phpunit/functional/Glpi/Form/Export/FormSerializerDestinationTest.php
@@ -202,7 +202,7 @@ final class FormSerializerDestinationTest extends \DbTestCase
         yield 'AssociatedItemsField' => [
             'field_key'        => AssociatedItemsField::getKey(),
             'config_fn'        => fn($created_items) => new AssociatedItemsFieldConfig(
-                strategy: AssociatedItemsFieldStrategy::SPECIFIC_VALUES,
+                strategies: [AssociatedItemsFieldStrategy::SPECIFIC_VALUES],
                 specific_associated_items: [
                     \Computer::class => [$created_items[0]->getId()],
                     \Monitor::class  => [$created_items[1]->getId()],
@@ -260,7 +260,7 @@ final class FormSerializerDestinationTest extends \DbTestCase
         yield 'ValidationField' => [
             'field_key'        => ValidationField::getKey(),
             'config_fn'        => fn($created_items) => new ValidationFieldConfig(
-                strategy: ValidationFieldStrategy::SPECIFIC_ACTORS,
+                strategies: [ValidationFieldStrategy::SPECIFIC_ACTORS],
                 specific_actors: [
                     getForeignKeyFieldForItemType(\User::class) . '-' . $created_items[0]->getId(),
                     getForeignKeyFieldForItemType(\Group::class) . '-' . $created_items[1]->getId(),
@@ -284,7 +284,7 @@ final class FormSerializerDestinationTest extends \DbTestCase
                 assertEquals(
                     array_diff_key(
                         (new ValidationFieldConfig(
-                            strategy: ValidationFieldStrategy::SPECIFIC_ACTORS,
+                            strategies: [ValidationFieldStrategy::SPECIFIC_ACTORS],
                             specific_actors: [
                                 \User::class => [$created_items[0]->getId()],
                                 \Group::class => [$created_items[1]->getId()],
@@ -316,7 +316,7 @@ final class FormSerializerDestinationTest extends \DbTestCase
         yield 'RequesterField' => [
             'field_key' => RequesterField::getKey(),
             'config_fn' => fn($created_items) => new RequesterFieldConfig(
-                strategy: ITILActorFieldStrategy::SPECIFIC_VALUES,
+                strategies: [ITILActorFieldStrategy::SPECIFIC_VALUES],
                 specific_itilactors_ids: [
                     getForeignKeyFieldForItemType(\User::class) . '-' . $created_items[0]->getId(),
                     getForeignKeyFieldForItemType(\Group::class) . '-' . $created_items[1]->getId(),
@@ -347,7 +347,7 @@ final class FormSerializerDestinationTest extends \DbTestCase
                 assertEquals(
                     array_diff_key(
                         (new RequesterFieldConfig(
-                            strategy: ITILActorFieldStrategy::SPECIFIC_VALUES,
+                            strategies: [ITILActorFieldStrategy::SPECIFIC_VALUES],
                             specific_itilactors_ids: [
                                 \User::class => [$created_items[0]->getId()],
                                 \Group::class => [$created_items[1]->getId()],
@@ -364,7 +364,7 @@ final class FormSerializerDestinationTest extends \DbTestCase
         yield 'ObserverField' => [
             'field_key' => ObserverField::getKey(),
             'config_fn' => fn($created_items) => new ObserverFieldConfig(
-                strategy: ITILActorFieldStrategy::SPECIFIC_VALUES,
+                strategies: [ITILActorFieldStrategy::SPECIFIC_VALUES],
                 specific_itilactors_ids: [
                     getForeignKeyFieldForItemType(\User::class) . '-' . $created_items[0]->getId(),
                     getForeignKeyFieldForItemType(\Group::class) . '-' . $created_items[1]->getId(),
@@ -388,7 +388,7 @@ final class FormSerializerDestinationTest extends \DbTestCase
                 assertEquals(
                     array_diff_key(
                         (new ObserverFieldConfig(
-                            strategy: ITILActorFieldStrategy::SPECIFIC_VALUES,
+                            strategies: [ITILActorFieldStrategy::SPECIFIC_VALUES],
                             specific_itilactors_ids: [
                                 \User::class => [$created_items[0]->getId()],
                                 \Group::class => [$created_items[1]->getId()],
@@ -404,7 +404,7 @@ final class FormSerializerDestinationTest extends \DbTestCase
         yield 'AssigneeField' => [
             'field_key' => AssigneeField::getKey(),
             'config_fn' => fn($created_items) => new AssigneeFieldConfig(
-                strategy: ITILActorFieldStrategy::SPECIFIC_VALUES,
+                strategies: [ITILActorFieldStrategy::SPECIFIC_VALUES],
                 specific_itilactors_ids: [
                     getForeignKeyFieldForItemType(\User::class) . '-' . $created_items[0]->getId(),
                     getForeignKeyFieldForItemType(\Group::class) . '-' . $created_items[1]->getId(),
@@ -428,7 +428,7 @@ final class FormSerializerDestinationTest extends \DbTestCase
                 assertEquals(
                     array_diff_key(
                         (new AssigneeFieldConfig(
-                            strategy: ITILActorFieldStrategy::SPECIFIC_VALUES,
+                            strategies: [ITILActorFieldStrategy::SPECIFIC_VALUES],
                             specific_itilactors_ids: [
                                 \User::class => [$created_items[0]->getId()],
                                 \Group::class => [$created_items[1]->getId()],
@@ -633,7 +633,7 @@ final class FormSerializerDestinationTest extends \DbTestCase
         yield 'AssociatedItemsField' => [
             'field_key' => AssociatedItemsField::getKey(),
             'config_fn'    => fn($questions) => new AssociatedItemsFieldConfig(
-                strategy: AssociatedItemsFieldStrategy::SPECIFIC_ANSWERS,
+                strategies: [AssociatedItemsFieldStrategy::SPECIFIC_ANSWERS],
                 specific_question_ids: [
                     current($questions)->getId(),
                     next($questions)->getId(),
@@ -656,7 +656,7 @@ final class FormSerializerDestinationTest extends \DbTestCase
         yield 'ValidationField' => [
             'field_key' => ValidationField::getKey(),
             'config_fn'    => fn($questions) => new ValidationFieldConfig(
-                strategy: ValidationFieldStrategy::SPECIFIC_ANSWERS,
+                strategies: [ValidationFieldStrategy::SPECIFIC_ANSWERS],
                 specific_question_ids: [
                     current($questions)->getId(),
                     next($questions)->getId(),
@@ -690,7 +690,7 @@ final class FormSerializerDestinationTest extends \DbTestCase
         yield 'RequesterField' => [
             'field_key' => RequesterField::getKey(),
             'config_fn' => fn($questions) => new RequesterFieldConfig(
-                strategy: ITILActorFieldStrategy::SPECIFIC_ANSWERS,
+                strategies: [ITILActorFieldStrategy::SPECIFIC_ANSWERS],
                 specific_question_ids: [
                     current($questions)->getId(),
                     next($questions)->getId(),
@@ -713,7 +713,7 @@ final class FormSerializerDestinationTest extends \DbTestCase
         yield 'ObserverField' => [
             'field_key' => ObserverField::getKey(),
             'config_fn' => fn($questions) => new ObserverFieldConfig(
-                strategy: ITILActorFieldStrategy::SPECIFIC_ANSWERS,
+                strategies: [ITILActorFieldStrategy::SPECIFIC_ANSWERS],
                 specific_question_ids: [
                     current($questions)->getId(),
                     next($questions)->getId(),
@@ -736,7 +736,7 @@ final class FormSerializerDestinationTest extends \DbTestCase
         yield 'AssigneeField' => [
             'field_key' => AssigneeField::getKey(),
             'config_fn' => fn($questions) => new AssigneeFieldConfig(
-                strategy: ITILActorFieldStrategy::SPECIFIC_ANSWERS,
+                strategies: [ITILActorFieldStrategy::SPECIFIC_ANSWERS],
                 specific_question_ids: [
                     current($questions)->getId(),
                     next($questions)->getId(),

--- a/phpunit/functional/Glpi/Form/Export/FormSerializerTest.php
+++ b/phpunit/functional/Glpi/Form/Export/FormSerializerTest.php
@@ -509,7 +509,7 @@ final class FormSerializerTest extends \DbTestCase
             specific_question_id: $this->getQuestionId($form, "My ITIL Category question")
         );
         $associated_items_config = new AssociatedItemsFieldConfig(
-            AssociatedItemsFieldStrategy::SPECIFIC_VALUES,
+            strategies: [AssociatedItemsFieldStrategy::SPECIFIC_VALUES],
             specific_associated_items: [
                 Computer::class => [
                     $computer->getID()

--- a/src/Glpi/Form/Destination/AbstractConfigField.php
+++ b/src/Glpi/Form/Destination/AbstractConfigField.php
@@ -41,7 +41,7 @@ use LogicException;
 use Override;
 use Toolbox;
 
-abstract class AbstractConfigField implements ConfigFieldInterface
+abstract class AbstractConfigField implements DestinationFieldInterface
 {
     #[Override]
     final public static function getKey(): string
@@ -97,6 +97,32 @@ abstract class AbstractConfigField implements ConfigFieldInterface
     #[Override]
     public function prepareInput(array $input): array
     {
+        $config_class = $this->getConfigClass();
+
+        /**
+         * All strategies are submitted as an array, even if the field can only have one strategy at a time.
+         * The field should handle this and only use the first strategy if it can only have one.
+         */
+        if (is_subclass_of($config_class, ConfigFieldWithStrategiesInterface::class)) {
+            /** @var class-string<ConfigFieldWithStrategiesInterface> $config_class */
+            if (
+                $this->canHaveMultipleStrategies() === false
+                && is_array($input[$this->getKey()][$config_class::getStrategiesInputName()] ?? null)
+            ) {
+                $input[$this->getKey()][$config_class::getStrategiesInputName()] = $input[$this->getKey()][$config_class::getStrategiesInputName()][0];
+            }
+        }
+
         return $input;
+    }
+
+    public function getStrategiesForDropdown(): array
+    {
+        return [];
+    }
+
+    public function canHaveMultipleStrategies(): bool
+    {
+        return false;
     }
 }

--- a/src/Glpi/Form/Destination/CommonITILField/AssigneeFieldConfig.php
+++ b/src/Glpi/Form/Destination/CommonITILField/AssigneeFieldConfig.php
@@ -54,13 +54,16 @@ final class AssigneeFieldConfig extends ITILActorFieldConfig
     #[Override]
     public static function jsonDeserialize(array $data): self
     {
-        $strategy = ITILActorFieldStrategy::tryFrom($data[self::STRATEGY] ?? "");
-        if ($strategy === null) {
-            $strategy = ITILActorFieldStrategy::FROM_TEMPLATE;
+        $strategies = array_map(
+            fn (string $strategy) => ITILActorFieldStrategy::tryFrom($strategy),
+            $data[self::STRATEGIES] ?? []
+        );
+        if (empty($strategies)) {
+            $strategies = [ITILActorFieldStrategy::FROM_TEMPLATE];
         }
 
         return new self(
-            strategy: $strategy,
+            strategies: $strategies,
             specific_itilactors_ids: $data[self::SPECIFIC_ITILACTORS_IDS] ?? [],
             specific_question_ids: $data[self::SPECIFIC_QUESTION_IDS] ?? [],
         );

--- a/src/Glpi/Form/Destination/CommonITILField/AssociatedItemsField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/AssociatedItemsField.php
@@ -203,7 +203,7 @@ class AssociatedItemsField extends AbstractConfigField
     {
         $input = parent::prepareInput($input);
 
-        if (!isset($input[$this->getKey()][AssociatedItemsFieldConfig::STRATEGY])) {
+        if (!isset($input[$this->getKey()][AssociatedItemsFieldConfig::STRATEGIES])) {
             return $input;
         }
 

--- a/src/Glpi/Form/Destination/CommonITILField/AssociatedItemsFieldConfig.php
+++ b/src/Glpi/Form/Destination/CommonITILField/AssociatedItemsFieldConfig.php
@@ -35,22 +35,32 @@
 
 namespace Glpi\Form\Destination\CommonITILField;
 
+use CommonITILObject;
 use Glpi\DBAL\JsonFieldInterface;
+use Glpi\Form\Destination\ConfigFieldWithStrategiesInterface;
 use Glpi\Form\Export\Context\ConfigWithForeignKeysInterface;
 use Glpi\Form\Export\Context\ForeignKey\ForeignKeyItemsArrayHandler;
 use Glpi\Form\Export\Context\ForeignKey\QuestionArrayForeignKeyHandler;
 use Glpi\Form\Export\Specification\ContentSpecificationInterface;
 use Override;
 
-final class AssociatedItemsFieldConfig implements JsonFieldInterface, ConfigWithForeignKeysInterface
+final class AssociatedItemsFieldConfig implements
+    JsonFieldInterface,
+    ConfigWithForeignKeysInterface,
+    ConfigFieldWithStrategiesInterface
 {
     // Unique reference to hardcoded names used for serialization and forms input names
-    public const STRATEGY = 'strategy';
+    public const STRATEGIES = 'strategies';
     public const SPECIFIC_QUESTION_IDS = 'specific_question_ids';
     public const SPECIFIC_ASSOCIATED_ITEMS = 'specific_associated_items';
 
+    /**
+     * @param array<AssociatedItemsFieldStrategy> $strategies
+     * @param array<int> $specific_question_ids
+     * @param array<CommonITILObject> $specific_associated_items
+     */
     public function __construct(
-        private AssociatedItemsFieldStrategy $strategy,
+        private array $strategies,
         private array $specific_question_ids = [],
         private array $specific_associated_items = [],
     ) {
@@ -68,13 +78,16 @@ final class AssociatedItemsFieldConfig implements JsonFieldInterface, ConfigWith
     #[Override]
     public static function jsonDeserialize(array $data): self
     {
-        $strategy = AssociatedItemsFieldStrategy::tryFrom($data[self::STRATEGY] ?? "");
-        if ($strategy === null) {
-            $strategy = AssociatedItemsFieldStrategy::ALL_VALID_ANSWERS;
+        $strategies = array_map(
+            fn (string $strategy) => AssociatedItemsFieldStrategy::tryFrom($strategy),
+            $data[self::STRATEGIES] ?? []
+        );
+        if (empty($strategies)) {
+            $strategies = [AssociatedItemsFieldStrategy::ALL_VALID_ANSWERS];
         }
 
         return new self(
-            strategy: $strategy,
+            strategies: $strategies,
             specific_question_ids: $data[self::SPECIFIC_QUESTION_IDS] ?? [],
             specific_associated_items: $data[self::SPECIFIC_ASSOCIATED_ITEMS] ?? [],
         );
@@ -84,15 +97,27 @@ final class AssociatedItemsFieldConfig implements JsonFieldInterface, ConfigWith
     public function jsonSerialize(): array
     {
         return [
-            self::STRATEGY => $this->strategy->value,
-            self::SPECIFIC_QUESTION_IDS => $this->specific_question_ids,
+            self::STRATEGIES                => array_map(
+                fn (AssociatedItemsFieldStrategy $strategy) => $strategy->value,
+                $this->strategies
+            ),
+            self::SPECIFIC_QUESTION_IDS     => $this->specific_question_ids,
             self::SPECIFIC_ASSOCIATED_ITEMS => $this->specific_associated_items,
         ];
     }
 
-    public function getStrategy(): AssociatedItemsFieldStrategy
+    #[Override]
+    public static function getStrategiesInputName(): string
     {
-        return $this->strategy;
+        return self::STRATEGIES;
+    }
+
+    /**
+     * @return array<AssociatedItemsFieldStrategy>
+     */
+    public function getStrategies(): array
+    {
+        return $this->strategies;
     }
 
     public function getSpecificQuestionIds(): array

--- a/src/Glpi/Form/Destination/CommonITILField/ContentField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ContentField.php
@@ -78,8 +78,10 @@ class ContentField extends AbstractConfigField
             {{ fields.textareaField(
                 input_name,
                 value,
-                label,
+                '',
                 options|merge({
+                    'field_class'      : '',
+                    'no_label'         : true,
                     'enable_richtext'  : true,
                     'enable_images'    : false,
                     'enable_form_tags' : true,
@@ -92,7 +94,6 @@ TWIG;
         $twig = TemplateRenderer::getInstance();
         return $twig->renderFromStringTemplate($template, [
             'form_id'    => $form->fields['id'],
-            'label'      => $this->getLabel(),
             'value'      => $config->getValue(),
             'input_name' => $input_name . "[" . SimpleValueConfig::VALUE . "]",
             'options'    => $display_options,

--- a/src/Glpi/Form/Destination/CommonITILField/EntityField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/EntityField.php
@@ -79,14 +79,6 @@ class EntityField extends AbstractConfigField
             // General display options
             'options' => $display_options,
 
-            // Main config field
-            'main_config_field' => [
-                'label'           => $this->getLabel(),
-                'value'           => $config->getStrategy()->value,
-                'input_name'      => $input_name . "[" . EntityFieldConfig::STRATEGY . "]",
-                'possible_values' => $this->getMainConfigurationValuesforDropdown(),
-            ],
-
             // Specific additional config for SPECIFIC_VALUE strategy
             'specific_value_extra_field' => [
                 'aria_label'      => __("Select an entity..."),
@@ -114,8 +106,11 @@ class EntityField extends AbstractConfigField
             throw new InvalidArgumentException("Unexpected config class");
         }
 
+        // Only one strategy is allowed
+        $strategy = current($config->getStrategies());
+
         // Compute value according to strategy
-        $entity_id = $config->getStrategy()->getEntityID($config, $answers_set);
+        $entity_id = $strategy->getEntityID($config, $answers_set);
 
         // Do not edit input if invalid value was found
         if (Entity::getById($entity_id) === false) {
@@ -150,7 +145,7 @@ class EntityField extends AbstractConfigField
         );
     }
 
-    private function getMainConfigurationValuesforDropdown(): array
+    public function getStrategiesForDropdown(): array
     {
         $values = [];
         foreach (EntityFieldStrategy::cases() as $strategies) {

--- a/src/Glpi/Form/Destination/CommonITILField/EntityFieldConfig.php
+++ b/src/Glpi/Form/Destination/CommonITILField/EntityFieldConfig.php
@@ -37,13 +37,17 @@ namespace Glpi\Form\Destination\CommonITILField;
 
 use Entity;
 use Glpi\DBAL\JsonFieldInterface;
+use Glpi\Form\Destination\ConfigFieldWithStrategiesInterface;
 use Glpi\Form\Export\Context\ConfigWithForeignKeysInterface;
 use Glpi\Form\Export\Context\ForeignKey\ForeignKeyHandler;
 use Glpi\Form\Export\Context\ForeignKey\QuestionForeignKeyHandler;
 use Glpi\Form\Export\Specification\ContentSpecificationInterface;
 use Override;
 
-final class EntityFieldConfig implements JsonFieldInterface, ConfigWithForeignKeysInterface
+final class EntityFieldConfig implements
+    JsonFieldInterface,
+    ConfigWithForeignKeysInterface,
+    ConfigFieldWithStrategiesInterface
 {
     // Unique reference to hardcoded names used for serialization and forms input names
     public const STRATEGY = 'strategy';
@@ -91,9 +95,18 @@ final class EntityFieldConfig implements JsonFieldInterface, ConfigWithForeignKe
         ];
     }
 
-    public function getStrategy(): EntityFieldStrategy
+    #[Override]
+    public static function getStrategiesInputName(): string
     {
-        return $this->strategy;
+        return self::STRATEGY;
+    }
+
+    /**
+     * @return array<EntityFieldStrategy>
+     */
+    public function getStrategies(): array
+    {
+        return [$this->strategy];
     }
 
     public function getSpecificQuestionId(): ?int

--- a/src/Glpi/Form/Destination/CommonITILField/ITILActorField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ITILActorField.php
@@ -78,14 +78,6 @@ abstract class ITILActorField extends AbstractConfigField
             // General display options
             'options' => $display_options,
 
-            // Main config field
-            'main_config_field' => [
-                'label'           => $this->getLabel(),
-                'value'           => $config->getStrategy()->value,
-                'input_name'      => $input_name . "[" . ITILActorFieldConfig::STRATEGY . "]",
-                'possible_values' => $this->getMainConfigurationValuesforDropdown(),
-            ],
-
             // Specific additional config for SPECIFIC_VALUES strategy
             'specific_value_extra_field' => [
                 'aria_label'      => __("Select actors..."),
@@ -114,20 +106,18 @@ abstract class ITILActorField extends AbstractConfigField
             throw new InvalidArgumentException("Unexpected config class");
         }
 
-        // Compute value according to strategy
-        $itilactors_ids = $config->getStrategy()->getITILActorsIDs(
-            $this,
-            $config,
-            $answers_set
-        );
+        // Compute value according to strategies
+        foreach ($config->getStrategies() as $strategy) {
+            $itilactors_ids = $strategy->getITILActorsIDs($this, $config, $answers_set);
 
-        if (!empty($itilactors_ids)) {
-            foreach ($itilactors_ids as $itemtype => $ids) {
-                foreach ($ids as $id) {
-                    $input['_actors'][$this->getActorType()][] = [
-                        'itemtype' => $itemtype,
-                        'items_id' => $id,
-                    ];
+            if (!empty($itilactors_ids)) {
+                foreach ($itilactors_ids as $itemtype => $ids) {
+                    foreach ($ids as $id) {
+                        $input['_actors'][$this->getActorType()][] = [
+                            'itemtype' => $itemtype,
+                            'items_id' => $id,
+                        ];
+                    }
                 }
             }
         }
@@ -167,7 +157,7 @@ abstract class ITILActorField extends AbstractConfigField
         return $input;
     }
 
-    private function getMainConfigurationValuesforDropdown(): array
+    public function getStrategiesForDropdown(): array
     {
         $values = [];
         foreach (ITILActorFieldStrategy::cases() as $strategies) {
@@ -186,5 +176,11 @@ abstract class ITILActorField extends AbstractConfigField
             },
             []
         );
+    }
+
+    #[Override]
+    public function canHaveMultipleStrategies(): bool
+    {
+        return true;
     }
 }

--- a/src/Glpi/Form/Destination/CommonITILField/ITILActorField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ITILActorField.php
@@ -130,7 +130,7 @@ abstract class ITILActorField extends AbstractConfigField
     {
         $input = parent::prepareInput($input);
 
-        if (!isset($input[$this->getKey()][ITILActorFieldConfig::STRATEGY])) {
+        if (!isset($input[$this->getKey()][ITILActorFieldConfig::STRATEGIES])) {
             return $input;
         }
 

--- a/src/Glpi/Form/Destination/CommonITILField/ITILActorFieldConfig.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ITILActorFieldConfig.php
@@ -36,18 +36,27 @@
 namespace Glpi\Form\Destination\CommonITILField;
 
 use Glpi\DBAL\JsonFieldInterface;
+use Glpi\Form\Destination\ConfigFieldWithStrategiesInterface;
 use Glpi\Form\Export\Context\ConfigWithForeignKeysInterface;
 use Override;
 
-abstract class ITILActorFieldConfig implements JsonFieldInterface, ConfigWithForeignKeysInterface
+abstract class ITILActorFieldConfig implements
+    JsonFieldInterface,
+    ConfigWithForeignKeysInterface,
+    ConfigFieldWithStrategiesInterface
 {
     // Unique reference to hardcoded names used for serialization and forms input names
-    public const STRATEGY                = 'strategy';
+    public const STRATEGIES              = 'strategies';
     public const SPECIFIC_ITILACTORS_IDS = 'specific_itilactors_ids';
     public const SPECIFIC_QUESTION_IDS   = 'specific_question_ids';
 
+    /**
+     * @param array<ITILActorFieldStrategy> $strategies
+     * @param array<int>                   $specific_itilactors_ids
+     * @param array<int>                   $specific_question_ids
+     */
     public function __construct(
-        private ITILActorFieldStrategy $strategy,
+        private array $strategies,
         private array $specific_itilactors_ids = [],
         private array $specific_question_ids = [],
     ) {
@@ -57,15 +66,25 @@ abstract class ITILActorFieldConfig implements JsonFieldInterface, ConfigWithFor
     public function jsonSerialize(): array
     {
         return [
-            self::STRATEGY => $this->strategy->value,
+            self::STRATEGIES              => array_map(
+                fn (ITILActorFieldStrategy $strategy) => $strategy->value,
+                $this->strategies
+            ),
             self::SPECIFIC_ITILACTORS_IDS => $this->specific_itilactors_ids,
-            self::SPECIFIC_QUESTION_IDS => $this->specific_question_ids,
+            self::SPECIFIC_QUESTION_IDS   => $this->specific_question_ids,
         ];
     }
 
-    public function getStrategy(): ITILActorFieldStrategy
+    #[Override]
+    public static function getStrategiesInputName(): string
     {
-        return $this->strategy;
+        return self::STRATEGIES;
+    }
+
+    #[Override]
+    public function getStrategies(): array
+    {
+        return $this->strategies;
     }
 
     public function getSpecificITILActorsIds(): ?array

--- a/src/Glpi/Form/Destination/CommonITILField/ITILCategoryField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ITILCategoryField.php
@@ -79,14 +79,6 @@ class ITILCategoryField extends AbstractConfigField
             // General display options
             'options' => $display_options,
 
-            // Main config field
-            'main_config_field' => [
-                'label'           => $this->getLabel(),
-                'value'           => $config->getStrategy()->value,
-                'input_name'      => $input_name . "[" . ITILCategoryFieldConfig::STRATEGY . "]",
-                'possible_values' => $this->getMainConfigurationValuesforDropdown(),
-            ],
-
             // Specific additional config for SPECIFIC_ANSWER strategy
             'specific_value_extra_field' => [
                 'empty_label'     => __("Select an ITIL category..."),
@@ -114,8 +106,11 @@ class ITILCategoryField extends AbstractConfigField
             throw new InvalidArgumentException("Unexpected config class");
         }
 
+        // Only one strategy is allowed
+        $strategy = current($config->getStrategies());
+
         // Compute value according to strategy
-        $itilcategory_id = $config->getStrategy()->getITILCategory($config, $answers_set);
+        $itilcategory_id = $strategy->getITILCategory($config, $answers_set);
 
         // Do not edit input if invalid value was found
         if (!ITILCategory::getById($itilcategory_id)) {
@@ -135,7 +130,7 @@ class ITILCategoryField extends AbstractConfigField
         );
     }
 
-    private function getMainConfigurationValuesforDropdown(): array
+    public function getStrategiesForDropdown(): array
     {
         $values = [];
         foreach (ITILCategoryFieldStrategy::cases() as $strategies) {

--- a/src/Glpi/Form/Destination/CommonITILField/ITILCategoryFieldConfig.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ITILCategoryFieldConfig.php
@@ -36,6 +36,7 @@
 namespace Glpi\Form\Destination\CommonITILField;
 
 use Glpi\DBAL\JsonFieldInterface;
+use Glpi\Form\Destination\ConfigFieldWithStrategiesInterface;
 use Glpi\Form\Export\Context\ConfigWithForeignKeysInterface;
 use Glpi\Form\Export\Context\ForeignKey\ForeignKeyHandler;
 use Glpi\Form\Export\Context\ForeignKey\QuestionForeignKeyHandler;
@@ -43,7 +44,10 @@ use Glpi\Form\Export\Specification\ContentSpecificationInterface;
 use ITILCategory;
 use Override;
 
-final class ITILCategoryFieldConfig implements JsonFieldInterface, ConfigWithForeignKeysInterface
+final class ITILCategoryFieldConfig implements
+    JsonFieldInterface,
+    ConfigWithForeignKeysInterface,
+    ConfigFieldWithStrategiesInterface
 {
     // Unique reference to hardcoded names used for serialization and forms input names
     public const STRATEGY = 'strategy';
@@ -91,9 +95,18 @@ final class ITILCategoryFieldConfig implements JsonFieldInterface, ConfigWithFor
         ];
     }
 
-    public function getStrategy(): ITILCategoryFieldStrategy
+    #[Override]
+    public static function getStrategiesInputName(): string
     {
-        return $this->strategy;
+        return self::STRATEGY;
+    }
+
+    /**
+     * @return array<ITILCategoryFieldStrategy>
+     */
+    public function getStrategies(): array
+    {
+        return [$this->strategy];
     }
 
     public function getSpecificQuestionId(): ?int

--- a/src/Glpi/Form/Destination/CommonITILField/ITILFollowupField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ITILFollowupField.php
@@ -77,14 +77,6 @@ class ITILFollowupField extends AbstractConfigField
             // General display options
             'options' => $display_options,
 
-            // Main config field
-            'main_config_field' => [
-                'label'           => $this->getLabel(),
-                'value'           => $config->getStrategy()->value,
-                'input_name'      => $input_name . "[" . ITILFollowupFieldConfig::STRATEGY . "]",
-                'possible_values' => $this->getMainConfigurationValuesforDropdown(),
-            ],
-
             // Specific additional config for SPECIFIC_VALUES strategy
             'specific_value_extra_field' => [
                 'aria_label'     => __("Select followup templates..."),
@@ -104,8 +96,11 @@ class ITILFollowupField extends AbstractConfigField
             throw new InvalidArgumentException("Unexpected config class");
         }
 
+        // Only one strategy is allowed
+        $strategy = current($config->getStrategies());
+
         // Compute value according to strategy
-        $itilfollowuptemplates_ids = $config->getStrategy()->getITILFollowupTemplatesIDs($config);
+        $itilfollowuptemplates_ids = $strategy->getITILFollowupTemplatesIDs($config);
 
         if (!empty($itilfollowuptemplates_ids)) {
             $input['_itilfollowuptemplates_id'] = $itilfollowuptemplates_ids;
@@ -122,7 +117,7 @@ class ITILFollowupField extends AbstractConfigField
         );
     }
 
-    private function getMainConfigurationValuesforDropdown(): array
+    public function getStrategiesForDropdown(): array
     {
         $values = [];
         foreach (ITILFollowupFieldStrategy::cases() as $strategies) {

--- a/src/Glpi/Form/Destination/CommonITILField/ITILFollowupFieldConfig.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ITILFollowupFieldConfig.php
@@ -36,13 +36,17 @@
 namespace Glpi\Form\Destination\CommonITILField;
 
 use Glpi\DBAL\JsonFieldInterface;
+use Glpi\Form\Destination\ConfigFieldWithStrategiesInterface;
 use Glpi\Form\Export\Context\ConfigWithForeignKeysInterface;
 use Glpi\Form\Export\Context\ForeignKey\ForeignKeyArrayHandler;
 use Glpi\Form\Export\Specification\ContentSpecificationInterface;
 use ITILFollowupTemplate;
 use Override;
 
-final class ITILFollowupFieldConfig implements JsonFieldInterface, ConfigWithForeignKeysInterface
+final class ITILFollowupFieldConfig implements
+    JsonFieldInterface,
+    ConfigWithForeignKeysInterface,
+    ConfigFieldWithStrategiesInterface
 {
     // Unique reference to hardcoded names used for serialization and forms input names
     public const STRATEGY = 'strategy';
@@ -86,9 +90,18 @@ final class ITILFollowupFieldConfig implements JsonFieldInterface, ConfigWithFor
         ];
     }
 
-    public function getStrategy(): ITILFollowupFieldStrategy
+    #[Override]
+    public static function getStrategiesInputName(): string
     {
-        return $this->strategy;
+        return self::STRATEGY;
+    }
+
+    /**
+     * @return array<ITILFollowupFieldStrategy>
+     */
+    public function getStrategies(): array
+    {
+        return [$this->strategy];
     }
 
     public function getSpecificITILFollowupTemplatesIds(): ?array

--- a/src/Glpi/Form/Destination/CommonITILField/ITILTaskField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ITILTaskField.php
@@ -77,14 +77,6 @@ class ITILTaskField extends AbstractConfigField
             // General display options
             'options' => $display_options,
 
-            // Main config field
-            'main_config_field' => [
-                'label'           => $this->getLabel(),
-                'value'           => $config->getStrategy()->value,
-                'input_name'      => $input_name . "[" . ITILTaskFieldConfig::STRATEGY . "]",
-                'possible_values' => $this->getMainConfigurationValuesforDropdown(),
-            ],
-
             // Specific additional config for SPECIFIC_VALUES strategy
             'specific_value_extra_field' => [
                 'aria_label'     => __("Select task templates..."),
@@ -104,8 +96,11 @@ class ITILTaskField extends AbstractConfigField
             throw new InvalidArgumentException("Unexpected config class");
         }
 
+        // Only one strategy is allowed
+        $strategy = current($config->getStrategies());
+
         // Compute value according to strategy
-        $tasktemplates_ids = $config->getStrategy()->getTaskTemplatesIDs($config);
+        $tasktemplates_ids = $strategy->getTaskTemplatesIDs($config);
 
         if (!empty($tasktemplates_ids)) {
             $input['_tasktemplates_id'] = $tasktemplates_ids;
@@ -122,7 +117,7 @@ class ITILTaskField extends AbstractConfigField
         );
     }
 
-    private function getMainConfigurationValuesforDropdown(): array
+    public function getStrategiesForDropdown(): array
     {
         $values = [];
         foreach (ITILTaskFieldStrategy::cases() as $strategies) {

--- a/src/Glpi/Form/Destination/CommonITILField/ITILTaskFieldConfig.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ITILTaskFieldConfig.php
@@ -36,13 +36,17 @@
 namespace Glpi\Form\Destination\CommonITILField;
 
 use Glpi\DBAL\JsonFieldInterface;
+use Glpi\Form\Destination\ConfigFieldWithStrategiesInterface;
 use Glpi\Form\Export\Context\ConfigWithForeignKeysInterface;
 use Glpi\Form\Export\Context\ForeignKey\ForeignKeyArrayHandler;
 use Glpi\Form\Export\Specification\ContentSpecificationInterface;
 use Override;
 use TaskTemplate;
 
-final class ITILTaskFieldConfig implements JsonFieldInterface, ConfigWithForeignKeysInterface
+final class ITILTaskFieldConfig implements
+    JsonFieldInterface,
+    ConfigWithForeignKeysInterface,
+    ConfigFieldWithStrategiesInterface
 {
     // Unique reference to hardcoded names used for serialization and forms input names
     public const STRATEGY = 'strategy';
@@ -85,9 +89,18 @@ final class ITILTaskFieldConfig implements JsonFieldInterface, ConfigWithForeign
         ];
     }
 
-    public function getStrategy(): ITILTaskFieldStrategy
+    #[Override]
+    public static function getStrategiesInputName(): string
     {
-        return $this->strategy;
+        return self::STRATEGY;
+    }
+
+    /**
+     * @return array<ITILTaskFieldStrategy>
+     */
+    public function getStrategies(): array
+    {
+        return [$this->strategy];
     }
 
     public function getSpecificTaskTemplatesIds(): ?array

--- a/src/Glpi/Form/Destination/CommonITILField/LocationField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/LocationField.php
@@ -79,14 +79,6 @@ class LocationField extends AbstractConfigField
             // General display options
             'options' => $display_options,
 
-            // Main config field
-            'main_config_field' => [
-                'label'           => $this->getLabel(),
-                'value'           => $config->getStrategy()->value,
-                'input_name'      => $input_name . "[" . LocationFieldConfig::STRATEGY . "]",
-                'possible_values' => $this->getMainConfigurationValuesforDropdown(),
-            ],
-
             // Specific additional config for SPECIFIC_ANSWER strategy
             'specific_value_extra_field' => [
                 'empty_label'     => __("Select a location..."),
@@ -114,8 +106,11 @@ class LocationField extends AbstractConfigField
             throw new InvalidArgumentException("Unexpected config class");
         }
 
+        // Only one strategy is allowed
+        $strategy = current($config->getStrategies());
+
         // Compute value according to strategy
-        $location_id = $config->getStrategy()->getLocationID($config, $answers_set);
+        $location_id = $strategy->getLocationID($config, $answers_set);
 
         // Do not edit input if invalid value was found
         if (Location::getById($location_id) === false) {
@@ -135,7 +130,7 @@ class LocationField extends AbstractConfigField
         );
     }
 
-    private function getMainConfigurationValuesforDropdown(): array
+    public function getStrategiesForDropdown(): array
     {
         $values = [];
         foreach (LocationFieldStrategy::cases() as $strategies) {

--- a/src/Glpi/Form/Destination/CommonITILField/LocationFieldConfig.php
+++ b/src/Glpi/Form/Destination/CommonITILField/LocationFieldConfig.php
@@ -36,6 +36,7 @@
 namespace Glpi\Form\Destination\CommonITILField;
 
 use Glpi\DBAL\JsonFieldInterface;
+use Glpi\Form\Destination\ConfigFieldWithStrategiesInterface;
 use Glpi\Form\Export\Context\ConfigWithForeignKeysInterface;
 use Glpi\Form\Export\Context\ForeignKey\ForeignKeyHandler;
 use Glpi\Form\Export\Context\ForeignKey\QuestionForeignKeyHandler;
@@ -43,7 +44,10 @@ use Glpi\Form\Export\Specification\ContentSpecificationInterface;
 use Location;
 use Override;
 
-final class LocationFieldConfig implements JsonFieldInterface, ConfigWithForeignKeysInterface
+final class LocationFieldConfig implements
+    JsonFieldInterface,
+    ConfigWithForeignKeysInterface,
+    ConfigFieldWithStrategiesInterface
 {
     // Unique reference to hardcoded names used for serialization and forms input names
     public const STRATEGY = 'strategy';
@@ -91,9 +95,18 @@ final class LocationFieldConfig implements JsonFieldInterface, ConfigWithForeign
         ];
     }
 
-    public function getStrategy(): LocationFieldStrategy
+    #[Override]
+    public static function getStrategiesInputName(): string
     {
-        return $this->strategy;
+        return self::STRATEGY;
+    }
+
+    /**
+     * @return array<LocationFieldStrategy>
+     */
+    public function getStrategies(): array
+    {
+        return [$this->strategy];
     }
 
     public function getSpecificQuestionId(): ?int

--- a/src/Glpi/Form/Destination/CommonITILField/ObserverField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ObserverField.php
@@ -76,7 +76,7 @@ class ObserverField extends ITILActorField
     public function getDefaultConfig(Form $form): ObserverFieldConfig
     {
         return new ObserverFieldConfig(
-            ITILActorFieldStrategy::FROM_TEMPLATE,
+            [ITILActorFieldStrategy::FROM_TEMPLATE],
         );
     }
 }

--- a/src/Glpi/Form/Destination/CommonITILField/ObserverFieldConfig.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ObserverFieldConfig.php
@@ -54,13 +54,16 @@ final class ObserverFieldConfig extends ITILActorFieldConfig
     #[Override]
     public static function jsonDeserialize(array $data): self
     {
-        $strategy = ITILActorFieldStrategy::tryFrom($data[self::STRATEGY] ?? "");
-        if ($strategy === null) {
-            $strategy = ITILActorFieldStrategy::FROM_TEMPLATE;
+        $strategies = array_map(
+            fn (string $strategy) => ITILActorFieldStrategy::tryFrom($strategy),
+            $data[self::STRATEGIES] ?? []
+        );
+        if (empty($strategies)) {
+            $strategies = [ITILActorFieldStrategy::FROM_TEMPLATE];
         }
 
         return new self(
-            strategy: $strategy,
+            strategies: $strategies,
             specific_itilactors_ids: $data[self::SPECIFIC_ITILACTORS_IDS] ?? [],
             specific_question_ids: $data[self::SPECIFIC_QUESTION_IDS] ?? [],
         );

--- a/src/Glpi/Form/Destination/CommonITILField/RequestSourceField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/RequestSourceField.php
@@ -77,14 +77,6 @@ class RequestSourceField extends AbstractConfigField
             // General display options
             'options' => $display_options,
 
-            // Main config field
-            'main_config_field' => [
-                'label'           => $this->getLabel(),
-                'value'           => $config->getStrategy()->value,
-                'input_name'      => $input_name . "[" . RequestSourceFieldConfig::STRATEGY . "]",
-                'possible_values' => $this->getMainConfigurationValuesforDropdown(),
-            ],
-
             // Specific additional config for SPECIFIC_VALUE strategy
             'specific_value_extra_field' => [
                 'empty_label'     => __("Select a request source..."),
@@ -108,11 +100,13 @@ class RequestSourceField extends AbstractConfigField
             throw new InvalidArgumentException("Unexpected config class");
         }
 
+        // Only one strategy is allowed
+        $strategy = current($config->getStrategies());
+
         // Compute value according to strategy
-        $request_source = $config->getStrategy()->getRequestSource($config, $answers_set);
+        $request_source = $strategy->getRequestSource($config, $answers_set);
 
         // Do not edit input if invalid value was found
-
         $db_values = $DB->request(['FROM' => 'glpi_requesttypes', 'WHERE' => ['is_active' => 1]]);
         $valid_values = [];
         foreach ($db_values as $data) {
@@ -136,7 +130,7 @@ class RequestSourceField extends AbstractConfigField
         );
     }
 
-    private function getMainConfigurationValuesforDropdown(): array
+    public function getStrategiesForDropdown(): array
     {
         $values = [];
         foreach (RequestSourceFieldStrategy::cases() as $strategies) {

--- a/src/Glpi/Form/Destination/CommonITILField/RequestSourceFieldConfig.php
+++ b/src/Glpi/Form/Destination/CommonITILField/RequestSourceFieldConfig.php
@@ -36,9 +36,10 @@
 namespace Glpi\Form\Destination\CommonITILField;
 
 use Glpi\DBAL\JsonFieldInterface;
+use Glpi\Form\Destination\ConfigFieldWithStrategiesInterface;
 use Override;
 
-final class RequestSourceFieldConfig implements JsonFieldInterface
+final class RequestSourceFieldConfig implements JsonFieldInterface, ConfigFieldWithStrategiesInterface
 {
     // Unique reference to hardcoded names used for serialization and forms input names
     public const STRATEGY = 'strategy';
@@ -73,9 +74,18 @@ final class RequestSourceFieldConfig implements JsonFieldInterface
         ];
     }
 
-    public function getStrategy(): RequestSourceFieldStrategy
+    #[Override]
+    public static function getStrategiesInputName(): string
     {
-        return $this->strategy;
+        return self::STRATEGY;
+    }
+
+    /**
+     * @return array<RequestSourceFieldStrategy>
+     */
+    public function getStrategies(): array
+    {
+        return [$this->strategy];
     }
 
     public function getSpecificRequestSource(): ?int

--- a/src/Glpi/Form/Destination/CommonITILField/RequestTypeField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/RequestTypeField.php
@@ -79,14 +79,6 @@ class RequestTypeField extends AbstractConfigField
             // General display options
             'options' => $display_options,
 
-            // Main config field
-            'main_config_field' => [
-                'label'           => $this->getLabel(),
-                'value'           => $config->getStrategy()->value,
-                'input_name'      => $input_name . "[" . RequestTypeFieldConfig::STRATEGY . "]",
-                'possible_values' => $this->getMainConfigurationValuesforDropdown(),
-            ],
-
             // Specific additional config for SPECIFIC_ANSWER strategy
             'specific_value_extra_field' => [
                 'empty_label'     => __("Select a request type..."),
@@ -115,8 +107,11 @@ class RequestTypeField extends AbstractConfigField
             throw new InvalidArgumentException("Unexpected config class");
         }
 
+        // Only one strategy is allowed
+        $strategy = current($config->getStrategies());
+
         // Compute value according to strategy
-        $request_type = $config->getStrategy()->getRequestType($config, $answers_set);
+        $request_type = $strategy->getRequestType($config, $answers_set);
 
         // Do not edit input if invalid value was found
         $valid_values = [Ticket::INCIDENT_TYPE, Ticket::DEMAND_TYPE];
@@ -137,7 +132,7 @@ class RequestTypeField extends AbstractConfigField
         );
     }
 
-    private function getMainConfigurationValuesforDropdown(): array
+    public function getStrategiesForDropdown(): array
     {
         $values = [];
         foreach (RequestTypeFieldStrategy::cases() as $strategies) {

--- a/src/Glpi/Form/Destination/CommonITILField/RequestTypeFieldConfig.php
+++ b/src/Glpi/Form/Destination/CommonITILField/RequestTypeFieldConfig.php
@@ -36,12 +36,16 @@
 namespace Glpi\Form\Destination\CommonITILField;
 
 use Glpi\DBAL\JsonFieldInterface;
+use Glpi\Form\Destination\ConfigFieldWithStrategiesInterface;
 use Glpi\Form\Export\Context\ConfigWithForeignKeysInterface;
 use Glpi\Form\Export\Context\ForeignKey\QuestionForeignKeyHandler;
 use Glpi\Form\Export\Specification\ContentSpecificationInterface;
 use Override;
 
-final class RequestTypeFieldConfig implements JsonFieldInterface, ConfigWithForeignKeysInterface
+final class RequestTypeFieldConfig implements
+    JsonFieldInterface,
+    ConfigWithForeignKeysInterface,
+    ConfigFieldWithStrategiesInterface
 {
     // Unique reference to hardcoded names used for serialization and forms input names
     public const STRATEGY = 'strategy';
@@ -88,9 +92,18 @@ final class RequestTypeFieldConfig implements JsonFieldInterface, ConfigWithFore
         ];
     }
 
-    public function getStrategy(): RequestTypeFieldStrategy
+    #[Override]
+    public static function getStrategiesInputName(): string
     {
-        return $this->strategy;
+        return self::STRATEGY;
+    }
+
+    /**
+     * @return array<RequestTypeFieldStrategy>
+     */
+    public function getStrategies(): array
+    {
+        return [$this->strategy];
     }
 
     public function getSpecificQuestionId(): ?int

--- a/src/Glpi/Form/Destination/CommonITILField/RequesterField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/RequesterField.php
@@ -70,7 +70,7 @@ class RequesterField extends ITILActorField
     public function getDefaultConfig(Form $form): RequesterFieldConfig
     {
         return new RequesterFieldConfig(
-            ITILActorFieldStrategy::FORM_FILLER,
+            [ITILActorFieldStrategy::FORM_FILLER],
         );
     }
 

--- a/src/Glpi/Form/Destination/CommonITILField/RequesterFieldConfig.php
+++ b/src/Glpi/Form/Destination/CommonITILField/RequesterFieldConfig.php
@@ -54,13 +54,16 @@ final class RequesterFieldConfig extends ITILActorFieldConfig
     #[Override]
     public static function jsonDeserialize(array $data): self
     {
-        $strategy = ITILActorFieldStrategy::tryFrom($data[self::STRATEGY] ?? "");
-        if ($strategy === null) {
-            $strategy = ITILActorFieldStrategy::FROM_TEMPLATE;
+        $strategies = array_map(
+            fn (string $strategy) => ITILActorFieldStrategy::tryFrom($strategy),
+            $data[self::STRATEGIES] ?? []
+        );
+        if (empty($strategies)) {
+            $strategies = [ITILActorFieldStrategy::FROM_TEMPLATE];
         }
 
         return new self(
-            strategy: $strategy,
+            strategies: $strategies,
             specific_itilactors_ids: $data[self::SPECIFIC_ITILACTORS_IDS] ?? [],
             specific_question_ids: $data[self::SPECIFIC_QUESTION_IDS] ?? [],
         );

--- a/src/Glpi/Form/Destination/CommonITILField/SLMField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/SLMField.php
@@ -70,14 +70,6 @@ abstract class SLMField extends AbstractConfigField
             // General display options
             'options' => $display_options,
 
-            // Main config field
-            'main_config_field' => [
-                'label'           => $this->getLabel(),
-                'value'           => $config->getStrategy()->value,
-                'input_name'      => $input_name . "[" . SLMFieldConfig::STRATEGY . "]",
-                'possible_values' => $this->getMainConfigurationValuesforDropdown(),
-            ],
-
             // Specific additional config for SPECIFIC_ANSWER strategy
             'specific_value_extra_field' => [
                 'slm_class' => $this->getSLMClass(),
@@ -99,8 +91,11 @@ abstract class SLMField extends AbstractConfigField
             throw new InvalidArgumentException("Unexpected config class");
         }
 
+        // Only one strategy is allowed
+        $strategy = current($config->getStrategies());
+
         // Compute value according to strategy
-        $slm_id = $config->getStrategy()->getSLMID($config);
+        $slm_id = $strategy->getSLMID($config);
 
         // Do not edit input if invalid value was found
         $slm_class = $this->getSLMClass();
@@ -121,7 +116,7 @@ abstract class SLMField extends AbstractConfigField
         );
     }
 
-    private function getMainConfigurationValuesforDropdown(): array
+    public function getStrategiesForDropdown(): array
     {
         $values = [];
         foreach (SLMFieldStrategy::cases() as $strategies) {

--- a/src/Glpi/Form/Destination/CommonITILField/SLMFieldConfig.php
+++ b/src/Glpi/Form/Destination/CommonITILField/SLMFieldConfig.php
@@ -36,10 +36,14 @@
 namespace Glpi\Form\Destination\CommonITILField;
 
 use Glpi\DBAL\JsonFieldInterface;
+use Glpi\Form\Destination\ConfigFieldWithStrategiesInterface;
 use Glpi\Form\Export\Context\ConfigWithForeignKeysInterface;
 use Override;
 
-abstract class SLMFieldConfig implements JsonFieldInterface, ConfigWithForeignKeysInterface
+abstract class SLMFieldConfig implements
+    JsonFieldInterface,
+    ConfigWithForeignKeysInterface,
+    ConfigFieldWithStrategiesInterface
 {
     // Unique reference to hardcoded names used for serialization and forms input names
     public const STRATEGY = 'strategy';
@@ -60,9 +64,18 @@ abstract class SLMFieldConfig implements JsonFieldInterface, ConfigWithForeignKe
         ];
     }
 
-    public function getStrategy(): SLMFieldStrategy
+    #[Override]
+    public static function getStrategiesInputName(): string
     {
-        return $this->strategy;
+        return self::STRATEGY;
+    }
+
+    /**
+     * @return array<SLMFieldStrategy>
+     */
+    public function getStrategies(): array
+    {
+        return [$this->strategy];
     }
 
     public function getSpecificSLMID(): ?int

--- a/src/Glpi/Form/Destination/CommonITILField/TemplateField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/TemplateField.php
@@ -87,14 +87,6 @@ class TemplateField extends AbstractConfigField
             // General display options
             'options' => $display_options,
 
-            // Main config field
-            'main_config_field' => [
-                'label'           => $this->getLabel(),
-                'value'           => $config->getStrategy()->value,
-                'input_name'      => $input_name . "[" . TemplateFieldConfig::STRATEGY . "]",
-                'possible_values' => $this->getMainConfigurationValuesforDropdown(),
-            ],
-
             // Specific additional config for CONFIG_SPECIFIC_TEMPLATE
             'specific_template_extra_field' => [
                 'empty_label'     => __("Select a template..."),
@@ -107,20 +99,11 @@ class TemplateField extends AbstractConfigField
         $template = <<<TWIG
             {% import 'components/form/fields_macros.html.twig' as fields %}
 
-            {{ fields.dropdownArrayField(
-                main_config_field.input_name,
-                main_config_field.value,
-                main_config_field.possible_values,
-                main_config_field.label,
-                options
-            ) }}
-
             <div
                 {% if main_config_field.value != CONFIG_SPECIFIC_TEMPLATE %}
                     class="d-none"
                 {% endif %}
-                data-glpi-parent-dropdown="{{ main_config_field.input_name }}"
-                data-glpi-parent-dropdown-condition="{{ CONFIG_SPECIFIC_TEMPLATE }}"
+                data-glpi-itildestination-field-config-display-condition="{{ CONFIG_SPECIFIC_TEMPLATE }}"
             >
                 {{ fields.dropdownArrayField(
                     specific_template_extra_field.input_name,
@@ -128,6 +111,8 @@ class TemplateField extends AbstractConfigField
                     specific_template_extra_field.possible_values,
                     "",
                     options|merge({
+                        field_class: '',
+                        mb: '',
                         no_label: true,
                         display_emptychoice: true,
                         emptylabel: specific_template_extra_field.empty_label,
@@ -151,8 +136,11 @@ TWIG;
             throw new InvalidArgumentException("Unexpected config class");
         }
 
+        // Only one strategy is allowed
+        $strategy = current($config->getStrategies());
+
         // Compute value according to strategy
-        $template_id = $config->getStrategy()->getTemplateID($config, $answers_set);
+        $template_id = $strategy->getTemplateID($config, $answers_set);
 
         // Do not edit the input if invalid value was found
         if (!$this->itil_template_class::getById($template_id)) {
@@ -172,7 +160,7 @@ TWIG;
         );
     }
 
-    private function getMainConfigurationValuesforDropdown(): array
+    public function getStrategiesForDropdown(): array
     {
         $values = [];
         foreach (TemplateFieldStrategy::cases() as $strategies) {

--- a/src/Glpi/Form/Destination/CommonITILField/TemplateFieldConfig.php
+++ b/src/Glpi/Form/Destination/CommonITILField/TemplateFieldConfig.php
@@ -36,13 +36,17 @@
 namespace Glpi\Form\Destination\CommonITILField;
 
 use Glpi\DBAL\JsonFieldInterface;
+use Glpi\Form\Destination\ConfigFieldWithStrategiesInterface;
 use Glpi\Form\Export\Context\ConfigWithForeignKeysInterface;
 use Glpi\Form\Export\Context\ForeignKey\ForeignKeyHandler;
 use Glpi\Form\Export\Specification\ContentSpecificationInterface;
 use Glpi\Form\Export\Specification\DestinationContentSpecification;
 use Override;
 
-final class TemplateFieldConfig implements JsonFieldInterface, ConfigWithForeignKeysInterface
+final class TemplateFieldConfig implements
+    JsonFieldInterface,
+    ConfigWithForeignKeysInterface,
+    ConfigFieldWithStrategiesInterface
 {
     // Unique reference to hardcoded names used for serialization and forms input names
     public const STRATEGY = 'strategy';
@@ -93,9 +97,18 @@ final class TemplateFieldConfig implements JsonFieldInterface, ConfigWithForeign
         ];
     }
 
-    public function getStrategy(): TemplateFieldStrategy
+    #[Override]
+    public static function getStrategiesInputName(): string
     {
-        return $this->strategy;
+        return self::STRATEGY;
+    }
+
+    /**
+     * @return array<TemplateFieldStrategy>
+     */
+    public function getStrategies(): array
+    {
+        return [$this->strategy];
     }
 
     public function getSpecificTemplateID(): ?int

--- a/src/Glpi/Form/Destination/CommonITILField/TitleField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/TitleField.php
@@ -73,13 +73,13 @@ class TitleField extends AbstractConfigField
         $template = <<<TWIG
             {% import 'components/form/fields_macros.html.twig' as fields %}
 
-            {% set rand = random() %}
-
             {{ fields.textareaField(
                 input_name,
                 value,
-                label,
+                '',
                 options|merge({
+                    'field_class'      : '',
+                    'no_label'         : true,
                     'enable_richtext'  : true,
                     'enable_images'    : false,
                     'enable_form_tags' : true,
@@ -87,13 +87,12 @@ class TitleField extends AbstractConfigField
                     'toolbar'          : false,
                     'editor_height'    : 0,
                     'statusbar'        : false,
-                    'rand'             : rand,
                 })
             ) }}
 
             <script>
                 tinymce.on('AddEditor', (e) => {
-                    if (e.editor.id === '{{ input_name ~ '_' ~ rand }}') {
+                    if (e.editor.id === '{{ input_name ~ '_' ~ options.rand }}') {
                         e.editor.on('keydown', (e) => {
                             if (e.keyCode === 13) {
                                 e.preventDefault();
@@ -107,7 +106,6 @@ TWIG;
         $twig = TemplateRenderer::getInstance();
         return $twig->renderFromStringTemplate($template, [
             'form_id'    => $form->fields['id'],
-            'label'      => $this->getLabel(),
             'value'      => $config->getValue(),
             'input_name' => $input_name . "[" . SimpleValueConfig::VALUE . "]",
             'options'    => $display_options,

--- a/src/Glpi/Form/Destination/CommonITILField/UrgencyField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/UrgencyField.php
@@ -85,14 +85,6 @@ class UrgencyField extends AbstractConfigField
             // General display options
             'options' => $display_options,
 
-            // Main config field
-            'main_config_field' => [
-                'label'           => $this->getLabel(),
-                'value'           => $config->getStrategy()->value,
-                'input_name'      => $input_name . "[" . UrgencyFieldConfig::STRATEGY . "]",
-                'possible_values' => $this->getMainConfigurationValuesforDropdown(),
-            ],
-
             // Specific additional config for SPECIFIC_VALUE strategy
             'specific_value_extra_field' => [
                 'empty_label'     => __("Select an urgency level..."),
@@ -121,8 +113,11 @@ class UrgencyField extends AbstractConfigField
             throw new InvalidArgumentException("Unexpected config class");
         }
 
+        // Only one strategy is allowed
+        $strategy = current($config->getStrategies());
+
         // Compute value according to strategy
-        $urgency = $config->getStrategy()->computeUrgency($config, $answers_set);
+        $urgency = $strategy->computeUrgency($config, $answers_set);
 
         // Do not edit input if invalid value was found
         $valid_values = array_keys($this->getUrgencyLevels());
@@ -167,7 +162,7 @@ class UrgencyField extends AbstractConfigField
         return $urgency_levels;
     }
 
-    private function getMainConfigurationValuesforDropdown(): array
+    public function getStrategiesForDropdown(): array
     {
         $values = [];
         foreach (UrgencyFieldStrategy::cases() as $strategies) {

--- a/src/Glpi/Form/Destination/CommonITILField/UrgencyFieldConfig.php
+++ b/src/Glpi/Form/Destination/CommonITILField/UrgencyFieldConfig.php
@@ -36,12 +36,16 @@
 namespace Glpi\Form\Destination\CommonITILField;
 
 use Glpi\DBAL\JsonFieldInterface;
+use Glpi\Form\Destination\ConfigFieldWithStrategiesInterface;
 use Glpi\Form\Export\Context\ConfigWithForeignKeysInterface;
 use Glpi\Form\Export\Context\ForeignKey\QuestionForeignKeyHandler;
 use Glpi\Form\Export\Specification\ContentSpecificationInterface;
 use Override;
 
-final class UrgencyFieldConfig implements JsonFieldInterface, ConfigWithForeignKeysInterface
+final class UrgencyFieldConfig implements
+    JsonFieldInterface,
+    ConfigWithForeignKeysInterface,
+    ConfigFieldWithStrategiesInterface
 {
     // Unique reference to hardcoded names used for serialization and forms input names
     public const STRATEGY = 'strategy';
@@ -88,9 +92,19 @@ final class UrgencyFieldConfig implements JsonFieldInterface, ConfigWithForeignK
         ];
     }
 
-    public function getStrategy(): UrgencyFieldStrategy
+    #[Override]
+    public static function getStrategiesInputName(): string
     {
-        return $this->strategy;
+        return self::STRATEGY;
+    }
+
+    /**
+     * @return array<UrgencyFieldStrategy>
+     */
+    #[Override]
+    public function getStrategies(): array
+    {
+        return [$this->strategy];
     }
 
     public function getSpecificUrgency(): ?int

--- a/src/Glpi/Form/Destination/CommonITILField/ValidationField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ValidationField.php
@@ -193,7 +193,7 @@ class ValidationField extends AbstractConfigField
     {
         $input = parent::prepareInput($input);
 
-        if (!isset($input[$this->getKey()][ValidationFieldConfig::STRATEGY])) {
+        if (!isset($input[$this->getKey()][ValidationFieldConfig::STRATEGIES])) {
             return $input;
         }
 

--- a/src/Glpi/Form/Destination/CommonITILField/ValidationField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ValidationField.php
@@ -90,14 +90,6 @@ class ValidationField extends AbstractConfigField
             // General display options
             'options' => $display_options,
 
-            // Main config field
-            'main_config_field' => [
-                'label'           => $this->getLabel(),
-                'value'           => $config->getStrategy()->value,
-                'input_name'      => $input_name . "[" . ValidationFieldConfig::STRATEGY . "]",
-                'possible_values' => $this->getMainConfigurationValuesforDropdown(),
-            ],
-
             // Specific additional config for SPECIFIC_ACTORS strategy
             'specific_values_extra_field' => [
                 'values'        => $specific_actors,
@@ -126,17 +118,19 @@ class ValidationField extends AbstractConfigField
             throw new InvalidArgumentException("Unexpected config class");
         }
 
-        // Compute value according to strategy
-        $validations = $config->getStrategy()->getValidation($config, $answers_set);
+        // Compute value according to strategies
+        foreach ($config->getStrategies() as $strategy) {
+            $validations = $strategy->getValidation($config, $answers_set);
 
-        if (!empty($validations)) {
-            foreach ($validations as $validation) {
-                $input['_add_validation'] = 0;
-                $input['_validation_targets'][] = [
-                    'validatortype'   => $validation['itemtype'],
-                    'itemtype_target' => $validation['itemtype'],
-                    'items_id_target' => $validation['items_id'],
-                ];
+            if (!empty($validations)) {
+                foreach ($validations as $validation) {
+                    $input['_add_validation'] = 0;
+                    $input['_validation_targets'][] = [
+                        'validatortype'   => $validation['itemtype'],
+                        'itemtype_target' => $validation['itemtype'],
+                        'items_id_target' => $validation['items_id'],
+                    ];
+                }
             }
         }
 
@@ -147,11 +141,11 @@ class ValidationField extends AbstractConfigField
     public function getDefaultConfig(Form $form): ValidationFieldConfig
     {
         return new ValidationFieldConfig(
-            ValidationFieldStrategy::NO_VALIDATION
+            [ValidationFieldStrategy::NO_VALIDATION]
         );
     }
 
-    private function getMainConfigurationValuesforDropdown(): array
+    public function getStrategiesForDropdown(): array
     {
         $values = [];
         foreach (ValidationFieldStrategy::cases() as $strategies) {
@@ -242,5 +236,11 @@ class ValidationField extends AbstractConfigField
         }
 
         return $input;
+    }
+
+    #[Override]
+    public function canHaveMultipleStrategies(): bool
+    {
+        return true;
     }
 }

--- a/src/Glpi/Form/Destination/ConfigFieldWithStrategiesInterface.php
+++ b/src/Glpi/Form/Destination/ConfigFieldWithStrategiesInterface.php
@@ -7,7 +7,7 @@
  *
  * http://glpi-project.org
  *
- * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2015-2025 Teclib' and contributors.
  * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *

--- a/src/Glpi/Form/Destination/ConfigFieldWithStrategiesInterface.php
+++ b/src/Glpi/Form/Destination/ConfigFieldWithStrategiesInterface.php
@@ -7,7 +7,7 @@
  *
  * http://glpi-project.org
  *
- * @copyright 2015-2025 Teclib' and contributors.
+ * @copyright 2015-2024 Teclib' and contributors.
  * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
@@ -33,50 +33,19 @@
  * ---------------------------------------------------------------------
  */
 
-namespace Glpi\Form\Destination\CommonITILField;
+namespace Glpi\Form\Destination;
 
-use Glpi\Form\Form;
-use Glpi\Form\QuestionType\QuestionTypeAssignee;
-use Override;
-use Session;
-
-class AssigneeField extends ITILActorField
+interface ConfigFieldWithStrategiesInterface
 {
-    #[Override]
-    public function getAllowedQuestionType(): string
-    {
-        return QuestionTypeAssignee::class;
-    }
+    /**
+     * Get strategies input name
+     */
+    public static function getStrategiesInputName(): string;
 
-    #[Override]
-    public function getActorType(): string
-    {
-        return 'assign';
-    }
-
-    #[Override]
-    public function getLabel(): string
-    {
-        return _n('Assignee', 'Assignees', Session::getPluralNumber());
-    }
-
-    #[Override]
-    public function getWeight(): int
-    {
-        return 30;
-    }
-
-    #[Override]
-    public function getConfigClass(): string
-    {
-        return AssigneeFieldConfig::class;
-    }
-
-    #[Override]
-    public function getDefaultConfig(Form $form): AssigneeFieldConfig
-    {
-        return new AssigneeFieldConfig(
-            [ITILActorFieldStrategy::FROM_TEMPLATE],
-        );
-    }
+    /**
+     * Get actual strategies
+     *
+     * @return array
+     */
+    public function getStrategies(): array;
 }

--- a/src/Glpi/Form/Destination/DestinationFieldInterface.php
+++ b/src/Glpi/Form/Destination/DestinationFieldInterface.php
@@ -39,7 +39,7 @@ use Glpi\DBAL\JsonFieldInterface;
 use Glpi\Form\AnswersSet;
 use Glpi\Form\Form;
 
-interface ConfigFieldInterface
+interface DestinationFieldInterface
 {
     /**
      * Get the unique key used to set/get this field configuration in the
@@ -127,4 +127,18 @@ interface ConfigFieldInterface
      * @return array
      */
     public function prepareInput(array $input): array;
+
+    /**
+     * Get the possible values for the main configuration dropdown.
+     *
+     * @return array
+     */
+    public function getStrategiesForDropdown(): array;
+
+    /**
+     * Check if this field can have multiple strategies at the same time.
+     *
+     * @return bool
+     */
+    public function canHaveMultipleStrategies(): bool;
 }

--- a/src/Glpi/Helpdesk/DefaultDataManager.php
+++ b/src/Glpi/Helpdesk/DefaultDataManager.php
@@ -200,7 +200,7 @@ final class DefaultDataManager
 
             // Set last valid answer as observer
             ObserverField::getKey() => (new ObserverFieldConfig(
-                strategy: ITILActorFieldStrategy::LAST_VALID_ANSWER,
+                strategies: [ITILActorFieldStrategy::LAST_VALID_ANSWER],
             ))->jsonSerialize(),
         ];
 
@@ -263,7 +263,7 @@ final class DefaultDataManager
 
             // Set last valid answer as observer
             ObserverField::getKey() => (new ObserverFieldConfig(
-                strategy: ITILActorFieldStrategy::LAST_VALID_ANSWER,
+                strategies: [ITILActorFieldStrategy::LAST_VALID_ANSWER],
             ))->jsonSerialize(),
         ];
 

--- a/templates/pages/admin/form/form_destination.html.twig
+++ b/templates/pages/admin/form/form_destination.html.twig
@@ -149,9 +149,6 @@
     import("{{ js_path('js/modules/Forms/DestinationAutoConfigController.js') }}").then((m) => {
         new m.GlpiFormDestinationAutoConfigController();
     });
-    import("{{ js_path('js/modules/DynamicDropdownController.js') }}").then((m) => {
-        new m.DynamicDropdownController();
-    });
 </script>
 
 

--- a/templates/pages/admin/form/form_destination_commonitil_config.html.twig
+++ b/templates/pages/admin/form/form_destination_commonitil_config.html.twig
@@ -167,11 +167,11 @@
                         <button
                             type="button"
                             class="btn btn-outline"
-                            aria-label="{{ __('Add strategy') }}"
+                            aria-label="{{ __('Combine with another option') }}"
                             data-glpi-itildestination-add-field-config
                         >
                             <i class="ti ti-plus me-2"></i>
-                            {{ __('Add another strategy') }}
+                            {{ __('Combine with another option') }}
                         </button>
                     {% endif %}
                 {% else %}

--- a/templates/pages/admin/form/form_destination_commonitil_config.html.twig
+++ b/templates/pages/admin/form/form_destination_commonitil_config.html.twig
@@ -31,14 +31,16 @@
  # ---------------------------------------------------------------------
  #}
 
+{% import 'components/form/fields_macros.html.twig' as fields %}
+
 {# @var Glpi\Form\Destination\AbstractCommonITILFormDestination item #}
 {# @var Glpi\Form\Form\                                         form #}
 {# @var array                                                   config #}
 
 <div>
-    {# @var Glpi\Form\Destination\ConfigFieldInterface field #}
+    {# @var Glpi\Form\Destination\DestinationFieldInterface field #}
     {% for field in item.getConfigurableFields()|sort((a, b) => a.getWeight() <=> b.getWeight()) %}
-
+        {% set config_field = field.getConfig(form, config) %}
         {% set extra_options = {} %}
         {% if field.supportAutoConfiguration() %}
             {% set use_auto_configuration = field.isAutoConfigurated(config) %}
@@ -73,19 +75,171 @@
                 </div>
             {% endset %}
 
-            {% set extra_options = {
-                'insert_content_after_label': auto_configuration_checkbox,
+            {% set extra_options = extra_options|merge({
                 'disabled': use_auto_configuration,
-            } %}
+            }) %}
         {% endif %}
 
-        <section data-glpi-itildestination-field aria-label="{{ field.getLabel() ~ " configuration" }}">
-            {{ field.renderConfigForm(
-                form,
-                field.getConfig(form, config),
-                item.formatConfigInputName(field.getKey()),
-                {'is_horizontal': false}|merge(extra_options)
-            )|raw }}
+        {% set field_container_rand = random() %}
+        {% set rand = random() %}
+        <section class="col-12 col-sm-6" data-glpi-itildestination-field="{{ field_container_rand }}" aria-label="{{ field.getLabel() ~ " configuration" }}">
+            {% if config_field is instanceof('Glpi\\Form\\Destination\\ConfigFieldWithStrategiesInterface') %}
+                {% set label_for = call('Html::cleanId', [
+                    'dropdown_' ~ '%s[%s][]'|format(
+                        item.formatConfigInputName(field.getKey()),
+                        config_field.getStrategiesInputName()
+                    ) ~ rand
+                ]) %}
+            {% elseif config_field is instanceof('Glpi\\Form\\Destination\\CommonITILField\\SimpleValueConfig') %}
+                {% set label_for = '%s[%s]_%s'|format(
+                    item.formatConfigInputName(field.getKey()),
+                    constant('Glpi\\Form\\Destination\\CommonITILField\\SimpleValueConfig::VALUE'),
+                    rand
+                ) %}
+            {% endif %}
+
+            <div class="d-flex align-items-center">
+                <label
+                    class="form-label"
+                    for="{{ label_for }}"
+                >
+                    {{ field.getLabel() }}
+                </label>
+                {% if field.supportAutoConfiguration() %}
+                    {{ auto_configuration_checkbox }}
+                {% endif %}
+            </div>
+            <section
+                class="mb-3"
+                data-glpi-itildestination-field-configs
+            >
+                {% if config_field is instanceof('Glpi\\Form\\Destination\\ConfigFieldWithStrategiesInterface') %}
+                    {% for strategy in config_field.getStrategies() %}
+                        {# Update the random value for each iteration except the first one, to avoid conflicts with labels #}
+                        {% if not loop.first %}
+                            {% set rand = random() %}
+                        {% endif %}
+
+                        <section
+                            class="mb-2"
+                            data-glpi-itildestination-field-config
+                        >
+                            {{ fields.dropdownArrayField(
+                                '%s[%s][]'|format(
+                                    item.formatConfigInputName(field.getKey()),
+                                    config_field.getStrategiesInputName()
+                                ),
+                                strategy.value,
+                                field.getStrategiesForDropdown(),
+                                '',
+                                {
+                                    is_horizontal: false,
+                                    field_class: '',
+                                    no_label: true,
+                                    mb: '',
+                                    rand: rand,
+                                    aria_label: __('Select strategy...'),
+                                }|merge(extra_options)
+                            ) }}
+                            {{ field.renderConfigForm(
+                                form,
+                                config_field,
+                                item.formatConfigInputName(field.getKey()),
+                                {
+                                    'is_horizontal': false,
+                                    'rand': rand,
+                                }|merge(extra_options)
+                            )|raw }}
+                            {% if field.canHaveMultipleStrategies() %}
+                                <button
+                                    type="button"
+                                    class="btn btn-outline"
+                                    title="{{ __('Remove strategy') }}"
+                                    aria-label="{{ __('Remove strategy') }}"
+                                    data-glpi-itildestination-remove-field-config
+                                >
+                                    <i class="fas fa-times"></i>
+                                </button>
+                            {% endif %}
+                        </section>
+                    {% endfor %}
+                    {% if field.canHaveMultipleStrategies() %}
+                        <button
+                            type="button"
+                            class="btn btn-outline"
+                            aria-label="{{ __('Add strategy') }}"
+                            data-glpi-itildestination-add-field-config
+                        >
+                            <i class="ti ti-plus me-2"></i>
+                            {{ __('Add another strategy') }}
+                        </button>
+                    {% endif %}
+                {% else %}
+                    {{ field.renderConfigForm(
+                        form,
+                        config_field,
+                        item.formatConfigInputName(field.getKey()),
+                        {
+                            'is_horizontal': true,
+                            'rand': rand,
+                        }|merge(extra_options)
+                    )|raw }}
+                {% endif %}
+            </section>
+
+            {% if field.canHaveMultipleStrategies() %}
+                <template data-glpi-itildestination-field-config-template>
+                    <section
+                        class="mb-2"
+                        data-glpi-itildestination-field-config
+                    >
+                        {{ fields.dropdownArrayField(
+                            '%s[%s][]'|format(
+                                item.formatConfigInputName(field.getKey()),
+                                config_field.getStrategiesInputName()
+                            ),
+                            '',
+                            field.getStrategiesForDropdown(),
+                            '',
+                            {
+                                is_horizontal: false,
+                                field_class: '',
+                                no_label: true,
+                                mb: '',
+                                display_emptychoice: true,
+                                init: false,
+                                aria_label: __('Select strategy...'),
+                            }|merge(extra_options)
+                        ) }}
+                        {{ field.renderConfigForm(
+                            form,
+                            config_field,
+                            item.formatConfigInputName(field.getKey()),
+                            {
+                                'is_horizontal': false,
+                                'init': false,
+                            }|merge(extra_options)
+                        )|raw }}
+                        <button
+                            type="button"
+                            class="btn btn-outline"
+                            title="{{ __('Remove strategy') }}"
+                            aria-label="{{ __('Remove strategy') }}"
+                            data-glpi-itildestination-remove-field-config
+                        >
+                            <i class="fas fa-times"></i>
+                        </button>
+                    </section>
+                </template>
+            {% endif %}
         </section>
+
+        <script>
+            import("{{ js_path('js/modules/Forms/FieldDestinationMultipleConfig.js') }}").then((m) => {
+                new m.GlpiFormFieldDestinationMultipleConfig(
+                    $('[data-glpi-itildestination-field="{{ field_container_rand }}"]'),
+                );
+            });
+        </script>
     {% endfor %}
 </div>

--- a/templates/pages/admin/form/itil_config_fields/associated_items.html.twig
+++ b/templates/pages/admin/form/itil_config_fields/associated_items.html.twig
@@ -35,54 +35,18 @@
 
 {% set rand = random() %}
 
-{{ fields.dropdownArrayField(
-    main_config_field.input_name,
-    main_config_field.value,
-    main_config_field.possible_values,
-    main_config_field.label,
-    options
-) }}
-
 <div
-    data-glpi-parent-dropdown="{{ main_config_field.input_name }}"
-    data-glpi-parent-dropdown-condition="{{ CONFIG_SPECIFIC_VALUES }}"
-    data-glpi-specific-values-extra-field
-    class="form-field col-12 col-sm-6 mb-2 {% if main_config_field.value != CONFIG_SPECIFIC_VALUES %}d-none{% endif %}"
+    data-glpi-itildestination-field-config-display-condition="{{ CONFIG_SPECIFIC_VALUES }}"
+    data-glpi-associated-items-specific-values-extra-field="{{ rand }}"
+    class="form-field col-12 col-sm-6 d-none"
 >
     {% set remove_button %}
-        <button type="button" class="btn btn-outline" data-glpi-remove-associated-item-button aria-label="{{ __('Remove item') }}">
+        <button type="button" class="btn btn-outline rounded-0" data-glpi-remove-associated-item-button aria-label="{{ __('Remove item') }}">
             <i class="fas fa-times"></i>
         </button>
     {% endset %}
 
-    <section data-glpi-specific-values-extra-field-container>
-        {% if specific_values_extra_field.associated_items is empty %}
-            {{ fields.dropdownItemsFromItemtypes(
-                specific_values_extra_field.input_name,
-                '',
-                {
-                    'init'               : true,
-                    'itemtypes'          : specific_values_extra_field.itemtypes,
-                    'no_label'           : true,
-                    'display_emptychoice': false,
-                    'itemtype_name'      : specific_values_extra_field.input_name ~ '[itemtype][]',
-                    'items_id_name'      : specific_values_extra_field.input_name ~ '[items_id][]',
-                    'default_itemtype'   : specific_values_extra_field.itemtypes|first,
-                    'width'              : '30%',
-                    'add_field_class'    : 'd-flex input-group flex-nowrap',
-                    'mb'                 : 'mb-2',
-                    'add_field_html'     : remove_button,
-                    'add_field_attribs'  : {
-                        'data-glpi-specific-values-extra-field-item': ''
-                    },
-                    'aria_label'         : specific_values_extra_field.itemtype_aria_label,
-                    'specific_tags_items_id_dropdown': {
-                        'aria-label': specific_values_extra_field.items_id_aria_label,
-                    }
-                }
-            ) }}
-        {% endif %}
-
+    <section data-glpi-associated-items-specific-values-extra-field-container>
         {% for itemtype, items_ids in specific_values_extra_field.associated_items %}
             {% for items_id in items_ids %}
                 {{ fields.dropdownItemsFromItemtypes(
@@ -99,58 +63,81 @@
                         'default_items_id'   : items_id,
                         'width'              : '30%',
                         'add_field_class'    : 'd-flex input-group flex-nowrap',
-                        'mb'                 : 'mb-2',
+                        'mb'                 : '',
                         'add_field_html'     : remove_button,
                         'add_field_attribs'  : {
-                            'data-glpi-specific-values-extra-field-item': ''
+                            'data-glpi-associated-items-specific-values-extra-field-item': ''
                         },
                         'aria_label'         : specific_values_extra_field.itemtype_aria_label,
                         'specific_tags_items_id_dropdown': {
                             'aria-label': specific_values_extra_field.items_id_aria_label,
+                            'data-glpi-associated-items-items-id-dropdown': ''
                         }
                     }
                 ) }}
             {% endfor %}
         {% endfor %}
-    </section>
 
-    <button type="button" class="btn btn-outline" data-glpi-add-associated-item-button aria-label="{{ __('Add item') }}">
-        <i class="ti ti-plus me-2"></i>
-        {{ __('Add item') }}
-    </button>
-
-    <template class="d-none" data-glpi-specific-values-extra-field-template>
         {{ fields.dropdownItemsFromItemtypes(
             specific_values_extra_field.input_name,
             '',
             {
-                'init'                           : false,
-                'itemtypes'                      : specific_values_extra_field.itemtypes,
-                'no_label'                       : true,
-                'display_emptychoice'            : false,
-                'itemtype_name'                  : specific_values_extra_field.input_name ~ '[itemtype][]',
-                'items_id_name'                  : specific_values_extra_field.input_name ~ '[items_id][]',
-                'default_itemtype'               : 'Computer',
-                'width'                          : '30%',
-                'add_field_class'                : 'd-flex input-group flex-nowrap',
-                'mb'                             : 'mb-2',
-                'add_field_html'                 : remove_button,
-                'add_field_attribs'              : {
-                    'data-glpi-specific-values-extra-field-item': ''
+                'init'               : true,
+                'itemtypes'          : specific_values_extra_field.itemtypes,
+                'no_label'           : true,
+                'display_emptychoice': true,
+                'emptylabel'         : specific_values_extra_field.empty_label,
+                'itemtype_name'      : specific_values_extra_field.input_name ~ '[itemtype][]',
+                'items_id_name'      : specific_values_extra_field.input_name ~ '[items_id][]',
+                'width'              : '30%',
+                'add_field_class'    : 'd-flex input-group flex-nowrap',
+                'mb'                 : '',
+                'add_field_html'     : remove_button,
+                'add_field_attribs'  : {
+                    'data-glpi-associated-items-specific-values-extra-field-item': ''
                 },
                 'aria_label'         : specific_values_extra_field.itemtype_aria_label,
                 'specific_tags_items_id_dropdown': {
                     'aria-label': specific_values_extra_field.items_id_aria_label,
+                    'data-glpi-associated-items-items-id-dropdown': ''
                 }
+            }
+        ) }}
+    </section>
+
+    <template class="d-none" data-glpi-associated-items-specific-values-extra-field-template>
+        {{ fields.dropdownItemsFromItemtypes(
+            specific_values_extra_field.input_name,
+            '',
+            {
+                'init'               : false,
+                'itemtypes'          : specific_values_extra_field.itemtypes,
+                'no_label'           : true,
+                'display_emptychoice': true,
+                'emptylabel'         : specific_values_extra_field.empty_label,
+                'itemtype_name'      : specific_values_extra_field.input_name ~ '[itemtype][]',
+                'items_id_name'      : specific_values_extra_field.input_name ~ '[items_id][]',
+                'width'              : '30%',
+                'add_field_class'    : 'd-flex input-group flex-nowrap',
+                'mb'                 : '',
+                'add_field_html'     : remove_button,
+                'add_field_attribs'  : {
+                    'data-glpi-associated-items-specific-values-extra-field-item': ''
+                },
+                'aria_label'         : specific_values_extra_field.itemtype_aria_label,
+                'specific_tags_items_id_dropdown': {
+                    'aria-label': specific_values_extra_field.items_id_aria_label,
+                    'data-glpi-associated-items-items-id-dropdown': ''
+                },
+                'disabled'                       : true
             }
         ) }}
     </template>
 </div>
 
 <div
-    {% if main_config_field.value != CONFIG_SPECIFIC_ANSWERS %} class="d-none" {% endif %}
-    data-glpi-parent-dropdown="{{ main_config_field.input_name }}"
-    data-glpi-parent-dropdown-condition="{{ CONFIG_SPECIFIC_ANSWERS }}"
+    class="d-none"
+    data-glpi-itildestination-field-config-display-condition="{{ CONFIG_SPECIFIC_ANSWERS }}"
 >
 	{{ fields.dropdownArrayField(
         specific_answer_extra_field.input_name,
@@ -158,12 +145,13 @@
         specific_answer_extra_field.possible_values,
         "",
         options|merge({
+            field_class: '',
             no_label: true,
             display_emptychoice: true,
             values: specific_answer_extra_field.values ?? [],
             multiple: true,
             aria_label: specific_answer_extra_field.aria_label,
-            mb: 'mb-2'
+            mb: ''
         })
     ) }}
 </div>
@@ -171,7 +159,7 @@
 <script>
     import("{{ js_path('js/modules/Forms/FieldDestinationAssociatedItem.js') }}").then((m) => {
         new m.GlpiFormFieldDestinationAssociatedItem(
-            $('[data-glpi-specific-values-extra-field]'),
+            $('[data-glpi-associated-items-specific-values-extra-field="{{ rand }}"]'),
             '{{ specific_values_extra_field.input_name ~ "[itemtype][]" }}',
             '{{ specific_values_extra_field.input_name ~ "[items_id][]" }}'
         );

--- a/templates/pages/admin/form/itil_config_fields/entity.html.twig
+++ b/templates/pages/admin/form/itil_config_fields/entity.html.twig
@@ -33,20 +33,11 @@
 
 {% import 'components/form/fields_macros.html.twig' as fields %}
 
-{{ fields.dropdownArrayField(
-    main_config_field.input_name,
-    main_config_field.value,
-    main_config_field.possible_values,
-    main_config_field.label,
-    options
-) }}
-
 <div
     {% if main_config_field.value != CONFIG_SPECIFIC_VALUE %}
         class="d-none"
     {% endif %}
-    data-glpi-parent-dropdown="{{ main_config_field.input_name }}"
-    data-glpi-parent-dropdown-condition="{{ CONFIG_SPECIFIC_VALUE }}"
+    data-glpi-itildestination-field-config-display-condition="{{ CONFIG_SPECIFIC_VALUE }}"
 >
     {{ fields.dropdownField(
         'Entity',
@@ -54,6 +45,8 @@
         specific_value_extra_field.value,
         "",
         options|merge({
+            field_class: '',
+            mb: '',
             no_label: true,
             aria_label: specific_value_extra_field.aria_label,
         })
@@ -64,8 +57,7 @@
     {% if main_config_field.value != CONFIG_SPECIFIC_ANSWER %}
         class="d-none"
     {% endif %}
-    data-glpi-parent-dropdown="{{ main_config_field.input_name }}"
-    data-glpi-parent-dropdown-condition="{{ CONFIG_SPECIFIC_ANSWER }}"
+    data-glpi-itildestination-field-config-display-condition="{{ CONFIG_SPECIFIC_ANSWER }}"
 >
     {{ fields.dropdownArrayField(
         specific_answer_extra_field.input_name,
@@ -73,6 +65,8 @@
         specific_answer_extra_field.possible_values,
         "",
         options|merge({
+            field_class: '',
+            mb: '',
             no_label: true,
             display_emptychoice: true,
             emptylabel: specific_answer_extra_field.empty_label,

--- a/templates/pages/admin/form/itil_config_fields/itilactor.html.twig
+++ b/templates/pages/admin/form/itil_config_fields/itilactor.html.twig
@@ -33,20 +33,9 @@
 
 {% import 'components/form/fields_macros.html.twig' as fields %}
 
-{{ fields.dropdownArrayField(
-    main_config_field.input_name,
-    main_config_field.value,
-    main_config_field.possible_values,
-    main_config_field.label,
-    options
-) }}
-
 <div
-    {% if main_config_field.value != CONFIG_SPECIFIC_VALUE %}
-        class="d-none"
-    {% endif %}
-    data-glpi-parent-dropdown="{{ main_config_field.input_name }}"
-    data-glpi-parent-dropdown-condition="{{ CONFIG_SPECIFIC_VALUE }}"
+    class="d-none"
+    data-glpi-itildestination-field-config-display-condition="{{ CONFIG_SPECIFIC_VALUE }}"
 >
     {% set actors_dropdown = call('Glpi\\Form\\Dropdown\\FormActorsDropdown::show', [
         specific_value_extra_field.input_name,
@@ -63,18 +52,17 @@
         actors_dropdown,
         '',
         {
+            field_class: '',
             no_label: true,
             wrapper_class: '',
+            mb: '',
         }
     ) }}
 </div>
 
 <div
-    {% if main_config_field.value != CONFIG_SPECIFIC_ANSWER %}
-        class="d-none"
-    {% endif %}
-    data-glpi-parent-dropdown="{{ main_config_field.input_name }}"
-    data-glpi-parent-dropdown-condition="{{ CONFIG_SPECIFIC_ANSWER }}"
+    class="d-none"
+    data-glpi-itildestination-field-config-display-condition="{{ CONFIG_SPECIFIC_ANSWER }}"
 >
     {{ fields.dropdownArrayField(
         specific_answer_extra_field.input_name,
@@ -82,10 +70,12 @@
         specific_answer_extra_field.possible_values,
         "",
         options|merge({
+            field_class: '',
             no_label: true,
             multiple: true,
             values: specific_answer_extra_field.values,
             aria_label: specific_answer_extra_field.aria_label,
+            mb: '',
         })
     ) }}
 </div>

--- a/templates/pages/admin/form/itil_config_fields/itilcategory.html.twig
+++ b/templates/pages/admin/form/itil_config_fields/itilcategory.html.twig
@@ -33,20 +33,11 @@
 
 {% import 'components/form/fields_macros.html.twig' as fields %}
 
-{{ fields.dropdownArrayField(
-    main_config_field.input_name,
-    main_config_field.value,
-    main_config_field.possible_values,
-    main_config_field.label,
-    options
-) }}
-
 <div
     {% if main_config_field.value != CONFIG_SPECIFIC_VALUE %}
         class="d-none"
     {% endif %}
-    data-glpi-parent-dropdown="{{ main_config_field.input_name }}"
-    data-glpi-parent-dropdown-condition="{{ CONFIG_SPECIFIC_VALUE }}"
+    data-glpi-itildestination-field-config-display-condition="{{ CONFIG_SPECIFIC_VALUE }}"
 >
     {{ fields.dropdownField(
         'ITILCategory',
@@ -54,6 +45,8 @@
         specific_value_extra_field.value,
         "",
         options|merge({
+            field_class: '',
+            mb: '',
             no_label: true,
             display_emptychoice: true,
             emptylabel: specific_value_extra_field.empty_label,
@@ -66,8 +59,7 @@
     {% if main_config_field.value != CONFIG_SPECIFIC_ANSWER %}
         class="d-none"
     {% endif %}
-    data-glpi-parent-dropdown="{{ main_config_field.input_name }}"
-    data-glpi-parent-dropdown-condition="{{ CONFIG_SPECIFIC_ANSWER }}"
+    data-glpi-itildestination-field-config-display-condition="{{ CONFIG_SPECIFIC_ANSWER }}"
 >
     {{ fields.dropdownArrayField(
         specific_answer_extra_field.input_name,
@@ -75,6 +67,8 @@
         specific_answer_extra_field.possible_values,
         "",
         options|merge({
+            field_class: '',
+            mb: '',
             no_label: true,
             display_emptychoice: true,
             emptylabel: specific_answer_extra_field.empty_label,

--- a/templates/pages/admin/form/itil_config_fields/itilfollowuptemplate.html.twig
+++ b/templates/pages/admin/form/itil_config_fields/itilfollowuptemplate.html.twig
@@ -33,20 +33,11 @@
 
 {% import 'components/form/fields_macros.html.twig' as fields %}
 
-{{ fields.dropdownArrayField(
-    main_config_field.input_name,
-    main_config_field.value,
-    main_config_field.possible_values,
-    main_config_field.label,
-    options
-) }}
-
 <div
     {% if main_config_field.value != CONFIG_SPECIFIC_VALUES %}
         class="d-none"
     {% endif %}
-    data-glpi-parent-dropdown="{{ main_config_field.input_name }}"
-    data-glpi-parent-dropdown-condition="{{ CONFIG_SPECIFIC_VALUES }}"
+    data-glpi-itildestination-field-config-display-condition="{{ CONFIG_SPECIFIC_VALUES }}"
 >
     {{ fields.dropdownField(
         "ITILFollowupTemplate",
@@ -54,6 +45,8 @@
         specific_value_extra_field.value,
         "",
         options|merge({
+            field_class: '',
+            mb: '',
             multiple: true,
             no_label: true,
             aria_label: specific_value_extra_field.aria_label,

--- a/templates/pages/admin/form/itil_config_fields/itiltasktemplate.html.twig
+++ b/templates/pages/admin/form/itil_config_fields/itiltasktemplate.html.twig
@@ -33,20 +33,11 @@
 
 {% import 'components/form/fields_macros.html.twig' as fields %}
 
-{{ fields.dropdownArrayField(
-    main_config_field.input_name,
-    main_config_field.value,
-    main_config_field.possible_values,
-    main_config_field.label,
-    options
-) }}
-
 <div
     {% if main_config_field.value != CONFIG_SPECIFIC_VALUES %}
         class="d-none"
     {% endif %}
-    data-glpi-parent-dropdown="{{ main_config_field.input_name }}"
-    data-glpi-parent-dropdown-condition="{{ CONFIG_SPECIFIC_VALUES }}"
+    data-glpi-itildestination-field-config-display-condition="{{ CONFIG_SPECIFIC_VALUES }}"
 >
     {{ fields.dropdownField(
         'TaskTemplate',
@@ -54,6 +45,8 @@
         specific_value_extra_field.value,
         "",
         options|merge({
+            field_class: '',
+            mb: '',
             multiple: true,
             no_label: true,
             aria_label: specific_value_extra_field.aria_label,

--- a/templates/pages/admin/form/itil_config_fields/location.html.twig
+++ b/templates/pages/admin/form/itil_config_fields/location.html.twig
@@ -33,20 +33,11 @@
 
 {% import 'components/form/fields_macros.html.twig' as fields %}
 
-{{ fields.dropdownArrayField(
-    main_config_field.input_name,
-    main_config_field.value,
-    main_config_field.possible_values,
-    main_config_field.label,
-    options
-) }}
-
 <div
     {% if main_config_field.value != CONFIG_SPECIFIC_VALUE %}
         class="d-none"
     {% endif %}
-    data-glpi-parent-dropdown="{{ main_config_field.input_name }}"
-    data-glpi-parent-dropdown-condition="{{ CONFIG_SPECIFIC_VALUE }}"
+    data-glpi-itildestination-field-config-display-condition="{{ CONFIG_SPECIFIC_VALUE }}"
 >
     {{ fields.dropdownField(
         'Location',
@@ -54,6 +45,8 @@
         specific_value_extra_field.value,
         "",
         options|merge({
+            field_class: '',
+            mb: '',
             no_label: true,
             display_emptychoice: true,
             emptylabel: specific_value_extra_field.empty_label,
@@ -66,8 +59,7 @@
     {% if main_config_field.value != CONFIG_SPECIFIC_ANSWER %}
         class="d-none"
     {% endif %}
-    data-glpi-parent-dropdown="{{ main_config_field.input_name }}"
-    data-glpi-parent-dropdown-condition="{{ CONFIG_SPECIFIC_ANSWER }}"
+    data-glpi-itildestination-field-config-display-condition="{{ CONFIG_SPECIFIC_ANSWER }}"
 >
     {{ fields.dropdownArrayField(
         specific_answer_extra_field.input_name,
@@ -75,6 +67,8 @@
         specific_answer_extra_field.possible_values,
         "",
         options|merge({
+            field_class: '',
+            mb: '',
             no_label: true,
             display_emptychoice: true,
             emptylabel: specific_answer_extra_field.empty_label,

--- a/templates/pages/admin/form/itil_config_fields/request_source.html.twig
+++ b/templates/pages/admin/form/itil_config_fields/request_source.html.twig
@@ -33,26 +33,19 @@
 
 {% import 'components/form/fields_macros.html.twig' as fields %}
 
-{{ fields.dropdownArrayField(
-    main_config_field.input_name,
-    main_config_field.value,
-    main_config_field.possible_values,
-    main_config_field.label,
-    options
-) }}
-
 <div
     {% if main_config_field.value != CONFIG_SPECIFIC_VALUE %}
         class="d-none"
     {% endif %}
-    data-glpi-parent-dropdown="{{ main_config_field.input_name }}"
-    data-glpi-parent-dropdown-condition="{{ CONFIG_SPECIFIC_VALUE }}">
+    data-glpi-itildestination-field-config-display-condition="{{ CONFIG_SPECIFIC_VALUE }}">
     {{ fields.dropdownField(
             specific_value_extra_field.itemtype,
             specific_value_extra_field.input_name,
             specific_value_extra_field.value ?? 0,
             "",
             options|merge({
+                field_class: '',
+                mb: '',
                 no_label: true,
                 display_emptychoice: true,
                 emptylabel: specific_value_extra_field.empty_label,

--- a/templates/pages/admin/form/itil_config_fields/request_type.html.twig
+++ b/templates/pages/admin/form/itil_config_fields/request_type.html.twig
@@ -33,20 +33,11 @@
 
 {% import 'components/form/fields_macros.html.twig' as fields %}
 
-{{ fields.dropdownArrayField(
-    main_config_field.input_name,
-    main_config_field.value,
-    main_config_field.possible_values,
-    main_config_field.label,
-    options
-) }}
-
 <div
     {% if main_config_field.value != CONFIG_SPECIFIC_VALUE %}
         class="d-none"
     {% endif %}
-    data-glpi-parent-dropdown="{{ main_config_field.input_name }}"
-    data-glpi-parent-dropdown-condition="{{ CONFIG_SPECIFIC_VALUE }}"
+    data-glpi-itildestination-field-config-display-condition="{{ CONFIG_SPECIFIC_VALUE }}"
 >
     {{ fields.dropdownArrayField(
         specific_value_extra_field.input_name,
@@ -54,6 +45,8 @@
         specific_value_extra_field.possible_values,
         "",
         options|merge({
+            field_class: '',
+            mb: '',
             no_label: true,
             display_emptychoice: true,
             emptylabel: specific_value_extra_field.empty_label,
@@ -66,8 +59,7 @@
     {% if main_config_field.value != CONFIG_SPECIFIC_ANSWER %}
         class="d-none"
     {% endif %}
-    data-glpi-parent-dropdown="{{ main_config_field.input_name }}"
-    data-glpi-parent-dropdown-condition="{{ CONFIG_SPECIFIC_ANSWER }}"
+    data-glpi-itildestination-field-config-display-condition="{{ CONFIG_SPECIFIC_ANSWER }}"
 >
     {{ fields.dropdownArrayField(
         specific_answer_extra_field.input_name,
@@ -75,6 +67,8 @@
         specific_answer_extra_field.possible_values,
         "",
         options|merge({
+            field_class: '',
+            mb: '',
             no_label: true,
             display_emptychoice: true,
             emptylabel: specific_answer_extra_field.empty_label,

--- a/templates/pages/admin/form/itil_config_fields/slm.html.twig
+++ b/templates/pages/admin/form/itil_config_fields/slm.html.twig
@@ -33,20 +33,11 @@
 
 {% import 'components/form/fields_macros.html.twig' as fields %}
 
-{{ fields.dropdownArrayField(
-    main_config_field.input_name,
-    main_config_field.value,
-    main_config_field.possible_values,
-    main_config_field.label,
-    options
-) }}
-
 <div
     {% if main_config_field.value != CONFIG_SPECIFIC_VALUE %}
         class="d-none"
     {% endif %}
-    data-glpi-parent-dropdown="{{ main_config_field.input_name }}"
-    data-glpi-parent-dropdown-condition="{{ CONFIG_SPECIFIC_VALUE }}"
+    data-glpi-itildestination-field-config-display-condition="{{ CONFIG_SPECIFIC_VALUE }}"
 >
     {{ fields.dropdownField(
         specific_value_extra_field.slm_class,
@@ -54,6 +45,8 @@
         specific_value_extra_field.value,
         "",
         options|merge({
+            field_class: '',
+            mb: '',
             no_label: true,
             display_emptychoice: true,
             emptylabel: specific_value_extra_field.empty_label,

--- a/templates/pages/admin/form/itil_config_fields/urgency.html.twig
+++ b/templates/pages/admin/form/itil_config_fields/urgency.html.twig
@@ -33,20 +33,11 @@
 
 {% import 'components/form/fields_macros.html.twig' as fields %}
 
-{{ fields.dropdownArrayField(
-    main_config_field.input_name,
-    main_config_field.value,
-    main_config_field.possible_values,
-    main_config_field.label,
-    options
-) }}
-
 <div
     {% if main_config_field.value != CONFIG_SPECIFIC_VALUE %}
         class="d-none"
     {% endif %}
-    data-glpi-parent-dropdown="{{ main_config_field.input_name }}"
-    data-glpi-parent-dropdown-condition="{{ CONFIG_SPECIFIC_VALUE }}"
+    data-glpi-itildestination-field-config-display-condition="{{ CONFIG_SPECIFIC_VALUE }}"
 >
     {{ fields.dropdownArrayField(
         specific_value_extra_field.input_name,
@@ -54,6 +45,8 @@
         specific_value_extra_field.possible_values,
         "",
         options|merge({
+            field_class: '',
+            mb: '',
             no_label: true,
             display_emptychoice: true,
             emptylabel: specific_value_extra_field.empty_label,
@@ -66,8 +59,7 @@
     {% if main_config_field.value != CONFIG_SPECIFIC_ANSWER %}
         class="d-none"
     {% endif %}
-    data-glpi-parent-dropdown="{{ main_config_field.input_name }}"
-    data-glpi-parent-dropdown-condition="{{ CONFIG_SPECIFIC_ANSWER }}"
+    data-glpi-itildestination-field-config-display-condition="{{ CONFIG_SPECIFIC_ANSWER }}"
 >
     {{ fields.dropdownArrayField(
         specific_answer_extra_field.input_name,
@@ -75,6 +67,8 @@
         specific_answer_extra_field.possible_values,
         "",
         options|merge({
+            field_class: '',
+            mb: '',
             no_label: true,
             display_emptychoice: true,
             emptylabel: specific_answer_extra_field.empty_label,

--- a/templates/pages/admin/form/itil_config_fields/validation.html.twig
+++ b/templates/pages/admin/form/itil_config_fields/validation.html.twig
@@ -33,20 +33,11 @@
 
 {% import 'components/form/fields_macros.html.twig' as fields %}
 
-{{ fields.dropdownArrayField(
-    main_config_field.input_name,
-    main_config_field.value,
-    main_config_field.possible_values,
-    main_config_field.label,
-    options
-) }}
-
 <div
     {% if main_config_field.value != CONFIG_SPECIFIC_ACTORS %}
         class="d-none"
     {% endif %}
-    data-glpi-parent-dropdown="{{ main_config_field.input_name }}"
-    data-glpi-parent-dropdown-condition="{{ CONFIG_SPECIFIC_ACTORS }}"
+    data-glpi-itildestination-field-config-display-condition="{{ CONFIG_SPECIFIC_ACTORS }}"
 >
     {% set actors_dropdown = call('Glpi\\Form\\Dropdown\\FormActorsDropdown::show', [
         specific_values_extra_field.input_name,
@@ -63,8 +54,9 @@
         actors_dropdown,
         '',
         {
+            field_class: '',
+            mb: '',
             no_label: true,
-            mb: 'mb-2',
             wrapper_class: ''
         }
     ) }}
@@ -74,8 +66,7 @@
     {% if main_config_field.value != CONFIG_SPECIFIC_ANSWERS %}
         class="d-none"
     {% endif %}
-    data-glpi-parent-dropdown="{{ main_config_field.input_name }}"
-    data-glpi-parent-dropdown-condition="{{ CONFIG_SPECIFIC_ANSWERS }}"
+    data-glpi-itildestination-field-config-display-condition="{{ CONFIG_SPECIFIC_ANSWERS }}"
 >
     {{ fields.dropdownArrayField(
         specific_answers_extra_field.input_name,
@@ -83,6 +74,8 @@
         specific_answers_extra_field.possible_values,
         "",
         options|merge({
+            field_class: '',
+            mb: '',
             no_label: true,
             display_emptychoice: true,
             multiple: true,

--- a/tests/cypress/e2e/form/destination_config_fields/associated_items.cy.js
+++ b/tests/cypress/e2e/form/destination_config_fields/associated_items.cy.js
@@ -122,7 +122,7 @@ describe('Associated items configuration', () => {
         cy.findByRole('button', {'name': 'Update item'}).click();
         cy.checkAndCloseAlert('Item successfully updated');
         cy.get('@associated_items_dropdown').should('have.text', 'Specific items');
-        cy.get('@specific_associated_items_itemtype_dropdown').should('have.text', 'Computers');
+        cy.get('@config').getDropdownByLabelText('Select the itemtype of the item to associate...').eq(0).should('have.text', 'Computers');
         cy.get('@form_id').then((form_id) => {
             cy.get('@specific_associated_items_items_id_dropdown').should('have.text', `My computer - ${form_id}`);
         });
@@ -204,33 +204,31 @@ describe('Associated items configuration', () => {
         cy.get('@associated_items_dropdown').selectDropdownValue('Specific items');
 
         // Associate first computer
-        cy.get('@config').find('[data-glpi-specific-values-extra-field-item]').eq(0).getDropdownByLabelText('Select the itemtype of the item to associate...').as('specific_associated_items_itemtype_dropdown');
+        cy.get('@config').find('[data-glpi-associated-items-specific-values-extra-field-item]').eq(0).getDropdownByLabelText('Select the itemtype of the item to associate...').as('specific_associated_items_itemtype_dropdown');
         cy.get('@specific_associated_items_itemtype_dropdown').selectDropdownValue('Computers');
         cy.get('@form_id').then((form_id) => {
-            cy.get('@config').find('[data-glpi-specific-values-extra-field-item]').eq(0).getDropdownByLabelText('Select the item to associate...').as('specific_associated_items_items_id_dropdown');
+            cy.get('@config').find('[data-glpi-associated-items-specific-values-extra-field-item]').eq(0).getDropdownByLabelText('Select the item to associate...').as('specific_associated_items_items_id_dropdown');
             cy.get('@specific_associated_items_items_id_dropdown').selectDropdownValue(`My computer - ${form_id}`);
         });
 
         // Add second computer
-        cy.get('@config').findByRole('button', {'name': 'Add item'}).click();
-        cy.get('@config').find('[data-glpi-specific-values-extra-field-item]').eq(1).getDropdownByLabelText('Select the itemtype of the item to associate...').as('specific_associated_items_itemtype_dropdown');
+        cy.get('@config').find('[data-glpi-associated-items-specific-values-extra-field-item]').eq(1).getDropdownByLabelText('Select the itemtype of the item to associate...').as('specific_associated_items_itemtype_dropdown');
         cy.get('@specific_associated_items_itemtype_dropdown').selectDropdownValue('Computers');
         cy.get('@form_id').then((form_id) => {
-            cy.get('@config').find('[data-glpi-specific-values-extra-field-item]').eq(1).getDropdownByLabelText('Select the item to associate...').as('specific_associated_items_items_id_dropdown');
+            cy.get('@config').find('[data-glpi-associated-items-specific-values-extra-field-item]').eq(1).getDropdownByLabelText('Select the item to associate...').as('specific_associated_items_items_id_dropdown');
             cy.get('@specific_associated_items_items_id_dropdown').selectDropdownValue(`My second computer - ${form_id}`);
         });
 
         // Add monitor
-        cy.get('@config').findByRole('button', {'name': 'Add item'}).click();
-        cy.get('@config').find('[data-glpi-specific-values-extra-field-item]').eq(2).getDropdownByLabelText('Select the itemtype of the item to associate...').as('specific_associated_items_itemtype_dropdown');
+        cy.get('@config').find('[data-glpi-associated-items-specific-values-extra-field-item]').eq(2).getDropdownByLabelText('Select the itemtype of the item to associate...').as('specific_associated_items_itemtype_dropdown');
 
         cy.intercept('/ajax/dropdownAllItems.php').as('dropdownAllItems');
         cy.get('@specific_associated_items_itemtype_dropdown').selectDropdownValue('Monitors');
 
         cy.wait('@dropdownAllItems').then(() => {
             cy.get('@form_id').then((form_id) => {
-                cy.get('@config').find('[data-glpi-specific-values-extra-field-item]').eq(2).getDropdownByLabelText('Select the item to associate...').as('specific_associated_items_items_id_dropdown');
-                cy.get('@config').find('[data-glpi-specific-values-extra-field-item]').eq(2).getDropdownByLabelText('Select the item to associate...').selectDropdownValue(`My monitor - ${form_id}`);
+                cy.get('@config').find('[data-glpi-associated-items-specific-values-extra-field-item]').eq(2).getDropdownByLabelText('Select the item to associate...').as('specific_associated_items_items_id_dropdown');
+                cy.get('@config').find('[data-glpi-associated-items-specific-values-extra-field-item]').eq(2).getDropdownByLabelText('Select the item to associate...').selectDropdownValue(`My monitor - ${form_id}`);
             });
         });
 
@@ -239,24 +237,59 @@ describe('Associated items configuration', () => {
         cy.checkAndCloseAlert('Item successfully updated');
         cy.get('@associated_items_dropdown').should('have.text', 'Specific items');
         cy.get('@form_id').then((form_id) => {
-            cy.get('@config').find('[data-glpi-specific-values-extra-field-item]').eq(0)
+            cy.get('@config').find('[data-glpi-associated-items-specific-values-extra-field-item]').eq(0)
                 .getDropdownByLabelText('Select the itemtype of the item to associate...')
                 .should('have.text', 'Computers');
-            cy.get('@config').find('[data-glpi-specific-values-extra-field-item]').eq(0)
+            cy.get('@config').find('[data-glpi-associated-items-specific-values-extra-field-item]').eq(0)
                 .getDropdownByLabelText('Select the item to associate...')
                 .should('have.text', `My computer - ${form_id}`);
-            cy.get('@config').find('[data-glpi-specific-values-extra-field-item]').eq(1)
+            cy.get('@config').find('[data-glpi-associated-items-specific-values-extra-field-item]').eq(1)
                 .getDropdownByLabelText('Select the itemtype of the item to associate...')
                 .should('have.text', 'Computers');
-            cy.get('@config').find('[data-glpi-specific-values-extra-field-item]').eq(1)
+            cy.get('@config').find('[data-glpi-associated-items-specific-values-extra-field-item]').eq(1)
                 .getDropdownByLabelText('Select the item to associate...')
                 .should('have.text', `My second computer - ${form_id}`);
-            cy.get('@config').find('[data-glpi-specific-values-extra-field-item]').eq(2)
+            cy.get('@config').find('[data-glpi-associated-items-specific-values-extra-field-item]').eq(2)
                 .getDropdownByLabelText('Select the itemtype of the item to associate...')
                 .should('have.text', 'Monitors');
-            cy.get('@config').find('[data-glpi-specific-values-extra-field-item]').eq(2)
+            cy.get('@config').find('[data-glpi-associated-items-specific-values-extra-field-item]').eq(2)
                 .getDropdownByLabelText('Select the item to associate...')
                 .should('have.text', `My monitor - ${form_id}`);
+        });
+    });
+
+    it('can add a specifc item, add another strategy and add another specific item', () => {
+        // Go to destination tab
+        cy.findByRole('tab', {'name': "Items to create"}).click();
+        cy.findByRole('button', {'name': "Add ticket"}).click();
+        cy.checkAndCloseAlert('Item successfully added');
+
+        // Retrieve configuration section
+        cy.findByRole('region', {'name': "Associated items configuration"}).as("config");
+        cy.get('@config').getDropdownByLabelText('Associated items').as("associated_items_dropdown");
+
+        // Switch to "Specific items"
+        cy.get('@associated_items_dropdown').selectDropdownValue('Specific items');
+
+        // Associate computer
+        cy.get('@config').find('[data-glpi-associated-items-specific-values-extra-field-item]').eq(0).getDropdownByLabelText('Select the itemtype of the item to associate...').as('specific_associated_items_itemtype_dropdown');
+        cy.get('@specific_associated_items_itemtype_dropdown').selectDropdownValue('Computers');
+        cy.get('@form_id').then((form_id) => {
+            cy.get('@config').find('[data-glpi-associated-items-specific-values-extra-field-item]').eq(0).getDropdownByLabelText('Select the item to associate...').as('specific_associated_items_items_id_dropdown');
+            cy.get('@specific_associated_items_items_id_dropdown').selectDropdownValue(`My computer - ${form_id}`);
+        });
+
+        // Add strategy
+        cy.get('@config').findByRole('button', {'name': 'Add strategy'}).click();
+        cy.get('@config').find('[data-glpi-itildestination-field-config]').eq(1).getDropdownByLabelText('Select strategy...').as('specific_associated_items_strategy_dropdown');
+        cy.get('@specific_associated_items_strategy_dropdown').selectDropdownValue('Answer from specific questions');
+
+        // Associate monitor
+        cy.get('@config').find('[data-glpi-associated-items-specific-values-extra-field-item]').eq(1).getDropdownByLabelText('Select the itemtype of the item to associate...').as('specific_associated_items_itemtype_dropdown');
+        cy.get('@specific_associated_items_itemtype_dropdown').selectDropdownValue('Monitors');
+        cy.get('@form_id').then((form_id) => {
+            cy.get('@config').find('[data-glpi-associated-items-specific-values-extra-field-item]').eq(1).getDropdownByLabelText('Select the item to associate...').as('specific_associated_items_items_id_dropdown');
+            cy.get('@specific_associated_items_items_id_dropdown').selectDropdownValue(`My Assigned monitor - ${form_id}`);
         });
     });
 });

--- a/tests/cypress/e2e/form/destination_config_fields/associated_items.cy.js
+++ b/tests/cypress/e2e/form/destination_config_fields/associated_items.cy.js
@@ -280,7 +280,7 @@ describe('Associated items configuration', () => {
         });
 
         // Add strategy
-        cy.get('@config').findByRole('button', {'name': 'Add strategy'}).click();
+        cy.get('@config').findByRole('button', {'name': 'Combine with another option'}).click();
         cy.get('@config').find('[data-glpi-itildestination-field-config]').eq(1).getDropdownByLabelText('Select strategy...').as('specific_associated_items_strategy_dropdown');
         cy.get('@specific_associated_items_strategy_dropdown').selectDropdownValue('Answer from specific questions');
 

--- a/tests/cypress/e2e/form/form_destination.cy.js
+++ b/tests/cypress/e2e/form/form_destination.cy.js
@@ -144,4 +144,55 @@ describe('Form destination', () => {
         cy.findByLabelText("Title").awaitTinyMCE().as("title_field");
         cy.get('@title_field').contains('Form name: Test form for the destination form suite');
     });
+
+    it('can define multiple strategies for the same field', () => {
+        cy.findByRole('region', {name: 'Requesters configuration'}).as('requesters_config');
+        cy.get('@requesters_config').findByRole('button', {name: 'Add strategy'}).should('exist').as('add_strategy_button');
+        cy.getDropdownByLabelText('Requesters').as('first_strategy_dropdown');
+
+        // Define first strategy
+        cy.get('@first_strategy_dropdown').selectDropdownValue('From template');
+
+        // Add a second strategy
+        cy.get('@add_strategy_button').click();
+        cy.findByRole('combobox', {name: '-----'}).as('second_strategy_dropdown');
+        cy.get('@second_strategy_dropdown').selectDropdownValue('Specific actors');
+        cy.get('@requesters_config').getDropdownByLabelText('Select actors...').as('second_strategy_actors_dropdown');
+        cy.get('@second_strategy_actors_dropdown').selectDropdownValue('glpi');
+
+        // Add a third strategy
+        cy.get('@add_strategy_button').click();
+        cy.findByRole('combobox', {name: '-----'}).as('third_strategy_dropdown');
+        cy.get('@third_strategy_dropdown').selectDropdownValue('Answer to last "Requesters" question');
+
+        // Save changes
+        cy.findByRole('button', {name: 'Update item'}).click();
+
+        // Check if the strategies are saved
+        cy.checkAndCloseAlert('Item successfully updated');
+        cy.get('@requesters_config').within(() => {
+            cy.findByRole('combobox', {name: 'From template'}).should('exist');
+            cy.findByRole('combobox', {name: 'Specific actors'}).should('exist');
+            cy.findByRole('listitem', {name: 'glpi'}).should('exist');
+            cy.findByRole('combobox', {name: 'Answer to last "Requesters" question'}).should('exist');
+        });
+
+        // Add a fourth strategy
+        cy.get('@requesters_config').findByRole('button', {name: 'Add strategy'}).click();
+        cy.findByRole('combobox', {name: '-----'}).as('fourth_strategy_dropdown');
+        cy.get('@fourth_strategy_dropdown').selectDropdownValue('User who filled the form');
+
+        // Save changes
+        cy.findByRole('button', {name: 'Update item'}).click();
+
+        // Check if the strategies are saved
+        cy.checkAndCloseAlert('Item successfully updated');
+        cy.get('@requesters_config').within(() => {
+            cy.findByRole('combobox', {name: 'From template'}).should('exist');
+            cy.findByRole('combobox', {name: 'Specific actors'}).should('exist');
+            cy.findByRole('listitem', {name: 'glpi'}).should('exist');
+            cy.findByRole('combobox', {name: 'Answer to last "Requesters" question'}).should('exist');
+            cy.findByRole('combobox', {name: 'User who filled the form'}).should('exist');
+        });
+    });
 });

--- a/tests/cypress/e2e/form/form_destination.cy.js
+++ b/tests/cypress/e2e/form/form_destination.cy.js
@@ -147,7 +147,7 @@ describe('Form destination', () => {
 
     it('can define multiple strategies for the same field', () => {
         cy.findByRole('region', {name: 'Requesters configuration'}).as('requesters_config');
-        cy.get('@requesters_config').findByRole('button', {name: 'Add strategy'}).should('exist').as('add_strategy_button');
+        cy.get('@requesters_config').findByRole('button', {name: 'Combine with another option'}).should('exist').as('add_strategy_button');
         cy.getDropdownByLabelText('Requesters').as('first_strategy_dropdown');
 
         // Define first strategy
@@ -178,7 +178,7 @@ describe('Form destination', () => {
         });
 
         // Add a fourth strategy
-        cy.get('@requesters_config').findByRole('button', {name: 'Add strategy'}).click();
+        cy.get('@requesters_config').findByRole('button', {name: 'Combine with another option'}).click();
         cy.findByRole('combobox', {name: '-----'}).as('fourth_strategy_dropdown');
         cy.get('@fourth_strategy_dropdown').selectDropdownValue('User who filled the form');
 


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] This change requires a documentation update.

## Description

Added the possibility of combining several strategies for certain fields in form destinations.
Modification of the UI/UX of the “Associated Items” field:
- More compact interface in the form of a single component
- Removal of the “Add new item” button for an automatic new item system as soon as all previous fields have been completed.

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/fb741550-6773-4976-99a4-8cbf7cabd732)

