### PR TITLE
Fix direct access token being regenerated accidentally

### DIFF
--- a/templates/pages/admin/form/access_control/direct_access.html.twig
+++ b/templates/pages/admin/form/access_control/direct_access.html.twig
@@ -85,6 +85,6 @@
 
 <input
     type="hidden"
-    {{ access_control.getNormalizedInputName("_token") }}
+    name="{{ access_control.getNormalizedInputName("_token") }}"
     value="{{ config.getToken() }}"
 >

--- a/tests/cypress/e2e/form/access_policies/direct_access.cy.js
+++ b/tests/cypress/e2e/form/access_policies/direct_access.cy.js
@@ -47,6 +47,8 @@ describe('Form access policy', () => {
     });
 
     it('check if form direct access policy can be set', () => {
+        cy.changeProfile('Super-Admin');
+
         // Enable direct access policy
         cy.findByRole('region', {
             name: 'Allow direct access'
@@ -59,6 +61,7 @@ describe('Form access policy', () => {
 
         // Check if "allow unauthenticated users" checkbox isn't checked
         cy.findByRole('checkbox', { 'name': 'Allow unauthenticated users ?' }).should('not.be.checked');
+        cy.findByRole('textbox', { 'name': 'Direct access URL' }).should('exist').as('direct_access_url_before_save');
 
         // Save changes
         cy.findByRole('button', { 'name': 'Save changes' }).click();
@@ -66,8 +69,16 @@ describe('Form access policy', () => {
         // Retrieve the direct access URL
         cy.findByRole('textbox', { 'name': 'Direct access URL' }).should('exist').as('direct_access_url');
 
-        // Visit the direct access URL
+        // Make sure the url wasn't regenerated
+        cy.get('@direct_access_url_before_save').invoke('val').then((direct_access_url_before_save) => {
+            cy.get('@direct_access_url').invoke('val').then((direct_access_url) => {
+                expect(direct_access_url_before_save).to.equal(direct_access_url);
+            });
+        });
+
+        // Visit the direct access URL as non admin (to make sure the token is taken into account)
         cy.get('@direct_access_url').invoke('val').then((direct_access_url) => {
+            cy.changeProfile('Self-Service');
             cy.visit(direct_access_url);
 
             // Check if the form title is displayed
@@ -76,6 +87,8 @@ describe('Form access policy', () => {
     });
 
     it('check if form direct access policy can be set and direct access works with autenticated user', () => {
+        cy.changeProfile('Super-Admin');
+
         // Enable direct access policy
         cy.findByRole('region', {
             name: 'Allow direct access'
@@ -111,6 +124,8 @@ describe('Form access policy', () => {
     });
 
     it('check if form direct access policy can be set and direct access works with unauthenticated user', () => {
+        cy.changeProfile('Super-Admin');
+
         // Enable direct access policy
         cy.findByRole('region', {
             name: 'Allow direct access'
@@ -143,6 +158,8 @@ describe('Form access policy', () => {
     });
 
     it('check if form direct access policy can be set and direct access works with unauthenticated user and hide blacklisted questions', () => {
+        cy.changeProfile('Super-Admin');
+
         // Enable direct access policy
         cy.findByRole('region', {
             name: 'Allow direct access'


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

The configured token was lost each time the form was saved due to an input name property being incorrectly set.

## Screenshots

You can see the issue here, the token value change every time the form is saved:

![token](https://github.com/user-attachments/assets/8ae9e2a2-626f-47ea-a9b8-e2f125b0cdb1)

