### PR TITLE
Custom asset field editor ux redesign

### DIFF
--- a/ajax/asset/assetdefinition.php
+++ b/ajax/asset/assetdefinition.php
@@ -63,40 +63,6 @@ if ($_REQUEST['action'] === 'get_all_fields') {
         'count' => count($all_fields)
     ], JSON_THROW_ON_ERROR);
     return;
-} else if ($_REQUEST['action'] === 'get_field_placeholder' && isset($_POST['fields']) && is_array($_POST['fields'])) {
-    header("Content-Type: application/json; charset=UTF-8");
-    $custom_field = new CustomFieldDefinition();
-    $results = [];
-    foreach ($_POST['fields'] as $field) {
-        if ($field['customfields_id'] > 0) {
-            if (!$custom_field->getFromDB($field['customfields_id'])) {
-                throw new NotFoundHttpException();
-            }
-        } else {
-            $custom_field->fields['system_name'] = '';
-            $custom_field->fields['label'] = $field['label'];
-            $custom_field->fields['type'] = $field['type'];
-            $custom_field->fields['itemtype'] = 'Computer'; // Doesn't matter what it is as long as it's not empty
-            $custom_field->fields['default_value'] = '';
-
-            $asset_definition = new AssetDefinition();
-            if (!$asset_definition->getFromDB($field['assetdefinitions_id'])) {
-                throw new NotFoundHttpException();
-            }
-            $fields_display = $asset_definition->getDecodedFieldsField();
-            foreach ($fields_display as $field_display) {
-                if ($field_display['key'] === $field['key']) {
-                    $custom_field->fields['field_options'] = $field_display['field_options'] ?? [];
-                    break;
-                }
-            }
-        }
-        $custom_field->fields['field_options'] = array_merge($custom_field->fields['field_options'] ?? [], $field['field_options'] ?? []);
-        $custom_field->fields['field_options']['disabled'] = true;
-        $results[$field['key']] = $custom_field->getFieldType()->getFormInput('', null);
-    }
-    echo json_encode($results, JSON_THROW_ON_ERROR);
-    return;
 } else if ($_REQUEST['action'] === 'get_core_field_editor') {
     header("Content-Type: text/html; charset=UTF-8");
     $asset_definition = new AssetDefinition();

--- a/ajax/asset/customfield.php
+++ b/ajax/asset/customfield.php
@@ -53,6 +53,9 @@ if (isset($_POST['action'])) {
         foreach ($field_options as $option) {
             echo $option->getFormInput();
         }
+    } else if ($_POST['action'] === 'purge_field') {
+        $field->check($_POST['customfielddefinitions_id'], PURGE);
+        $field->delete(['id' => $_POST['customfielddefinitions_id']]);
     } else {
         throw new BadRequestHttpException();
     }

--- a/js/src/vue/CustomObject/FieldPreview/Field.vue
+++ b/js/src/vue/CustomObject/FieldPreview/Field.vue
@@ -1,44 +1,32 @@
 <script setup>
-    import {computed} from 'vue';
-
     const props = defineProps({
         field_key: String,
         customfields_id: {
             type: Number,
             default: -1,
         },
-        label_classes: {
-            type: String,
-            default: 'col-form-label cursor-grab col-xxl-5 text-xxl-end',
+        field_options: {
+            type: Object,
+            default: () => ({}),
         },
-        field_classes: {
-            type: String,
-            default: 'col-xxl-7 field-container btn-group shadow-none',
+        is_active: {
+            type: Boolean,
+            default: true,
         },
-        wrapper_classes: {
-            type: String,
-            default: 'form-field row flex-grow-1',
-        },
-    });
-
-    const sortable_classes = computed(() => {
-        return props.wrapper_classes.split(' ').filter((cls) => cls.startsWith('col-')).join(' ');
     });
 </script>
 
 <template>
-    <div :class="`sortable-field align-items-center p-1 ${(!!$slots.field_preview) ? sortable_classes : 'col-12 col-sm-6'}`"
-         :data-key="field_key" :data-customfield-id="customfields_id" :style="`display: ${(!!$slots.field_preview) ? 'flex' : 'none'};`">
-        <input type="hidden" name="fields_display[]" :value="field_key" />
+    <div :class="`sortable-field align-items-center ${parseInt(field_options.full_width ?? 0) === 1 ? 'col-12' : 'col-12 col-sm-6'} cursor-grab`"
+         :data-key="field_key" :data-customfield-id="customfields_id">
+        <input type="hidden" name="fields_display[]" :value="field_key" :disabled="!is_active" />
         <slot name="field_options"></slot>
-        <div :class="wrapper_classes">
-            <label :class="label_classes">
+        <div :class="`form-field row flex-grow-1 ${is_active ? 'm-1' : 'mx-0 my-1'}`">
+            <div class="col py-2">
                 <slot name="field_label"></slot>
                 <slot name="field_markers"></slot>
-                <i class="ti ti-grip-vertical sort-handle align-middle"></i>
-            </label>
-            <div :class="field_classes">
-                <slot name="field_preview"></slot>
+            </div>
+            <div v-if="is_active" class="col-auto btn-group shadow-none field-actions">
                 <button type="button" class="btn btn-ghost-secondary btn-sm edit-field" :title="__('Edit')">
                     <i class="ti ti-pencil"></i>
                 </button>
@@ -46,13 +34,36 @@
                     <i class="ti ti-eye-off"></i>
                 </button>
             </div>
+            <div v-if="!is_active && customfields_id > 0" class="col-auto btn-group shadow-none field-actions">
+                <button type="button" class="btn btn-ghost-danger btn-sm purge-field" :title="_x('button', 'Delete permanently')">
+                    <i class="ti ti-trash"></i>
+                </button>
+            </div>
         </div>
     </div>
 </template>
 
 <style scoped>
-    .sortable-field .btn-group .select2-container {
-        flex-basis: auto;
-        width: 100% !important;
+    [data-glpi-theme-dark="1"] .form-field {
+        border: var(--tblr-border-width) solid var(--tblr-border-color);
+    }
+    .form-field {
+        border-radius: var(--tblr-border-radius);
+        border: var(--tblr-border-width) solid transparent;
+        background-color: var(--tblr-gray-200);
+
+        & > .col {
+            border-left: 1px solid var(--tblr-border-color);
+        }
+
+        @media (pointer: fine) {
+            & > .field-actions {
+                visibility: hidden;
+            }
+
+            &:hover > .field-actions {
+                visibility: visible;
+            }
+        }
     }
 </style>

--- a/js/src/vue/CustomObject/FieldPreview/FieldDisplay.vue
+++ b/js/src/vue/CustomObject/FieldPreview/FieldDisplay.vue
@@ -1,6 +1,7 @@
 <script setup>
-    import {onMounted, ref, computed, reactive, watch} from 'vue';
+    import {onMounted, computed, ref, reactive, watch, useTemplateRef, nextTick} from 'vue';
     import Field from "./Field.vue";
+    import Sidebar from "./Sidebar.vue";
 
     const props = defineProps({
         items_id: Number,
@@ -8,13 +9,12 @@
         all_fields: Object,
         fields_display: Array,
         add_edit_fn: String,
+        can_create_fields: Boolean,
     });
 
-    const initial_all_fields = props.all_fields;
+    const initial_fields = ref(props.all_fields);
     const fields_display = props.fields_display;
-    const toolbar_el = $(props.toolbar_el);
-    //TODO Vue 3.5: useTemplateRef('component_root')
-    const component_root = ref(null);
+    const component_root = useTemplateRef('component_root');
     const sortable_fields_container = computed(() => {
         return $(component_root.value).parent();
     });
@@ -26,75 +26,20 @@
      */
     const sortable_fields = reactive(new Map());
 
-    function getSelectedField(key) {
-        let selected_field = initial_all_fields[key];
-        if (selected_field === undefined) {
-            const opt = $(`select[name="new_field"] option[value="${key}"]`);
-            if (opt.length > 0) {
-                selected_field = {
-                    text: opt.text(),
-                    customfields_id: opt.attr('data-customfield-id') ?? -1,
-                };
-            }
-        }
-        return selected_field;
-    }
-
-    /**
-     * Fetch the field preview for the given fields and update the fields in the sortable list
-     * @param {{key: string, selected_field: {}}[]} fields
-     */
-    function appendFieldPreview(fields) {
-        const payload = {
-            action: 'get_field_placeholder',
-            assetdefinitions_id: props.items_id,
-            fields: []
-        };
-
-        fields.forEach(({key, selected_field}) => {
-            if (!sortable_fields.has(key)) {
-                sortable_fields.set(key, {
-                    key: key,
-                    label: selected_field.text ?? selected_field,
-                    field_options: fields_display.find((field) => field.key === key)?.field_options ?? {},
-                    customfields_id: selected_field.customfields_id ?? -1,
-                });
-            }
-
-            const field_options = {};
-            for (const [name, value] of Object.entries(sortable_fields.get(key).field_options)) {
-                field_options[name] = value;
-            }
-            payload.fields.push({
-                assetdefinitions_id: props.items_id,
-                customfields_id: selected_field.customfields_id ?? -1,
-                key: key,
-                label: sortable_fields.get(key).label,
-                type: selected_field.type ?? '',
-                field_options: field_options,
+    function refreshSortables() {
+        nextTick(() => {
+            // Need to wait for the DOM changes to be applied
+            window.sortable('#sortable-fields', {
+                items: '.sortable-field',
+                forcePlaceholderSize: false,
+                acceptFrom: '.fields-sidebar, #sortable-fields',
+            });
+            window.sortable('.fields-sidebar', {
+                items: '.sortable-field',
+                forcePlaceholderSize: false,
+                acceptFrom: false,
             });
         });
-        $.ajax({
-            method: 'POST',
-            url: `${CFG_GLPI.root_doc}/ajax/asset/assetdefinition.php`,
-            data: payload
-        }).then((data) => {
-            if (typeof data !== 'object') {
-                return;
-            }
-            fields.forEach(({key}) => {
-                updateFieldPreview(key, data[key]);
-            });
-        });
-    }
-
-    function updateFieldPreview(key, data) {
-        const placeholder_el = $(`<div>${data}</div>`);
-        const sortable_field = sortable_fields.get(key);
-        sortable_field.preview_html = placeholder_el.find('.field-container').html();
-        sortable_field.label_classes = `${placeholder_el.find('label').attr('class')} cursor-grab`;
-        sortable_field.field_classes = `${placeholder_el.find('.field-container').attr('class')} btn-group shadow-none`;
-        sortable_field.wrapper_classes = `${placeholder_el.find('.form-field').attr('class')} flex-grow-1`;
     }
 
     /**
@@ -109,45 +54,90 @@
             if (selected_fields_data !== undefined && selected_fields_data[key] !== undefined) {
                 selected_field = selected_fields_data[key];
             } else {
-                toolbar_el.find('select[name="new_field"]').val(key).trigger('change');
-                selected_field = getSelectedField(key);
+                selected_field = initial_fields.value[key];
             }
             if (selected_field === undefined) {
                 return;
             }
             preview_data.push({key: key, selected_field: selected_field});
         });
-        appendFieldPreview(preview_data);
-        // Clear the select2 value
-        toolbar_el.find('select[name="new_field"]').val('').trigger('change');
+        preview_data.forEach(({key, selected_field}) => {
+            if (!sortable_fields.has(key)) {
+                const next_order_position = sortable_fields.size;
+                sortable_fields.set(key, {
+                    key: key,
+                    label: selected_field.text ?? selected_field,
+                    field_options: fields_display.find((field) => field.key === key)?.field_options ?? {},
+                    customfields_id: selected_field.customfields_id ?? -1,
+                    is_active: selected_field.is_active ?? true,
+                    order: fields_display.find((field) => field.key === key)?.order ?? next_order_position,
+                });
+            }
+        });
+        refreshSortables();
     }
 
     function removeField(key) {
         // remove the field from sortable list
-        sortable_fields.delete(key);
+        sortable_fields.get(key).is_active = false;
+        refreshSortables();
+    }
+
+    /**
+     * Refresh the data in the all_fields object
+     */
+    function refreshAllFields() {
+        const url = `${CFG_GLPI.root_doc}/ajax/asset/assetdefinition.php?action=get_all_fields&assetdefinitions_id=${props.items_id}`;
+        $.get(url, (data) => {
+            const new_fields = {};
+            $.each(data['results'], (key, field) => {
+                new_fields[field.id] = field;
+            });
+            appendField(Object.keys(new_fields), new_fields)
+            refreshSortables();
+        });
     }
 
     onMounted(() => {
-        //for each field in fields_display, add it to the list using the template and slot
-        appendField(fields_display.map((field) => field.key));
+        $.each(initial_fields.value, (key, field) => {
+            const field_data = field;
+            field_data.is_active = fields_display.find((field) => field.key === key) !== undefined;
+            appendField([key], {[key]: field_data});
+        });
 
         const sortable_container = $('#sortable-fields');
-        const new_field_dropdown = toolbar_el.find('select[name="new_field"]');
 
         sortable_container.on('dragenter', () => {
             const sort_el = $('.sortable-field.sortable-dragging');
             const classes_to_copy = sort_el.attr('class').split(' ')
                 .filter((cls) => !['sortable-dragging'].includes(cls))
                 .join(' ');
-            sortable_container.find('.sortable-placeholder').attr('class', `sortable-placeholder ${classes_to_copy}`);
+            sortable_container.find('.sortable-placeholder').attr('class', `sortable-placeholder ${classes_to_copy} px-2`);
+            if (sortable_container.find('.sortable-placeholder .sortable-placeholder-inner').length === 0) {
+                sortable_container.find('.sortable-placeholder').append(`<div class="sortable-placeholder-inner"></div>`);
+            }
         });
 
-        // add field action
-        $('#add-field').on('click', () => {
-            //get select2 value
-            const field_key = new_field_dropdown.val();
-            if (field_key && field_key !== 0 ) {
-                appendField([field_key]);
+        // Change is_active property of the field when done dragging
+        sortable_container.on('sortupdate', (e) => {
+            const origin_container = e.originalEvent.detail.origin.container;
+            const destination_container = e.originalEvent.detail.destination.container;
+            // Do nothing here if the origin and destination are the same
+            if (origin_container === destination_container) {
+                return;
+            }
+            const moved_field = $(e.originalEvent.detail.item);
+            const moved_to_displayed = $(destination_container).attr('id') === 'sortable-fields';
+
+            if (moved_to_displayed) {
+                const sortable_field = sortable_fields.get(moved_field.attr('data-key'));
+                sortable_field.is_active = true;
+                // Recalculate the order of the fields to match the index in the displayed list
+                sortable_fields.forEach((field) => {
+                    field.order = $(component_root.value).find('.sortable-field').index($(`.sortable-field[data-key="${field.key}"]`));
+                });
+            } else {
+                removeField(moved_field.attr('data-key'));
             }
         });
 
@@ -170,26 +160,49 @@
                     id: 'core_field_options_editor',
                     modalclass: 'modal-lg',
                     appendTo: `#${$(sortable_fields_container.value).attr('id')}`,
-                    title: field_el.find('label').text(),
+                    title: field_el.text(),
                     url: url,
                     buttons: [
+                        {
+                            id: 'cancel_core_field_options',
+                            label: __('Cancel'),
+                            class: 'btn-ghost-secondary',
+                        },
                         {
                             id: 'save_core_field_options',
                             label: _x('button', 'Save'),
                             class: 'btn-primary',
                         },
-                        {
-                            id: 'cancel_core_field_options',
-                            label: __('Cancel'),
-                        }
                     ]
                 });
             } else {
                 window[props.add_edit_fn](field_id);
+                $('#customfield_form_container_modal .modal-title').text(field_el.text());
             }
         }).on('click', '.hide-field', (e) => {
             const field_key = $(e.target).closest('.sortable-field').attr('data-key');
             removeField(field_key);
+        }).on('click', '.purge-field', (e) => {
+            // Only custom fields can be purged
+            const field_key = $(e.target).closest('.sortable-field').attr('data-key');
+            const custom_fields_id = $(e.target).closest('.sortable-field').attr('data-customfield-id');
+
+            // Submit a form via AJAX to delete the field
+            $.ajax({
+                url: `${CFG_GLPI.root_doc}/ajax/asset/customfield.php`,
+                type: 'POST',
+                data: {
+                    customfielddefinitions_id: custom_fields_id,
+                    action: 'purge_field'
+                },
+                success: () => {
+                    sortable_fields.delete(field_key);
+                    refreshSortables();
+                },
+                complete: () => {
+                    displayAjaxMessageAfterRedirect();
+                }
+            });
         });
 
         sortable_fields_container.value.on('click', '#save_core_field_options', () => {
@@ -219,28 +232,41 @@
             const form_data = new FormData(e.target);
             const field_key = `custom_${form_data.get('system_name')}`;
 
-            if (btn_submit.attr('name') === 'add') {
-                new_field_dropdown.data('select2').dataAdapter.query('', (data) => {
-                    data.results.forEach((result) => {
-                        if (result.id === field_key) {
-                            appendField([field_key], {[field_key]: result});
-                        }
-                    });
+            refreshAllFields();
+            if (btn_submit.attr('name') === 'add' || btn_submit.attr('name') === 'update') {
+                appendField([field_key], {[field_key]: {
+                    text: form_data.get('label'),
+                }});
+                const sortable_field = sortable_fields.get(field_key);
+
+                sortable_field.field_options = {};
+                form_data.entries().forEach(([name, value]) => {
+                    if (name.startsWith('field_options[')) {
+                        const option_name = name.replace('field_options[', '').slice(0, -1);
+                        sortable_field.field_options[option_name] = value;
+                    }
                 });
-            } else if (btn_submit.attr('name') === 'update') {
-                // Reload preview
-                appendField([field_key], {[field_key]: sortable_fields.get(field_key)});
             } else if (btn_submit.attr('name') === 'purge') {
                 removeField(field_key);
             }
         });
     });
 
-    watch(sortable_fields, () => {
-        window.sortable('#sortable-fields', {
-            items: '.sortable-field',
-            forcePlaceholderSize: false,
-        });
+    const active_fields = computed(() => {
+        const ordered_active_fields = [];
+        [...sortable_fields].filter(([key, field]) => field.is_active)
+            .sort((a, b) => a[1].order - b[1].order)
+            .forEach(([key, field]) => {
+                ordered_active_fields.push({...field, key: key});
+            });
+        return ordered_active_fields;
+    });
+
+    const inactive_fields = computed(() => {
+        return new Map([...sortable_fields].filter(([key, field]) => !field.is_active));
+    });
+
+    watch(active_fields, () => {
         // If only one field remains, disable the remove button
         $(component_root.value).find('.hide-field')
             .prop('disabled', sortable_fields.size === 1)
@@ -250,30 +276,31 @@
 </script>
 
 <template>
-    <div class="col-12 col-xxl-12 flex-column" ref="component_root">
+    <div class="col-12 col-xxl-12 flex-column px-n3" ref="component_root">
         <input type="hidden" name="_update_fields_display" value="1" />
         <input type="hidden" name="fields_display" value="" />
+
         <div class="d-flex flex-row flex-wrap flex-xl-nowrap">
-            <div class="row flex-row align-items-start flex-grow-1">
-                <div class="user-select-none row flex-row" id="sortable-fields">
-                    <Field v-for="[field_key, sortable_field] of sortable_fields" :key="field_key"
-                           :field_key="field_key" :customfields_id="sortable_field.customfields_id" :label_classes="sortable_field.label_classes"
-                           :field_classes="sortable_field.field_classes" :wrapper_classes="sortable_field.wrapper_classes">
-                        <template v-slot:field_label>{{ sortable_field.label }}</template>
-                        <template v-slot:field_markers>
-                            <span v-if="(sortable_field.field_options.required ?? '0').toString() === '1'" class="required">*</span>
-                            <i v-if="(sortable_field.field_options.readonly ?? '0').toString() === '1'" class="ti ti-pencil-off ms-2" :title="__('Readonly')"></i>
-                        </template>
-                        <template v-slot:field_options>
-                            <template v-for="(field_option_value, field_option_name) in sortable_field.field_options" :key="field_option_name">
-                                <input type="hidden" :name="`field_options[${field_key}][${field_option_name}]`" :value="field_option_value" />
+            <div class="row flex-row align-items-start flex-grow-1 d-flex">
+                <div class="col">
+                    <div class="user-select-none row flex-row p-2" id="sortable-fields" style="min-height: 50px">
+                        <Field v-for="sortable_field of active_fields" :key="sortable_field.key"
+                               :field_key="sortable_field.key" :customfields_id="sortable_field.customfields_id" :field_options="sortable_field.field_options"
+                               :is_active="sortable_field.is_active">
+                            <template v-slot:field_label>{{ sortable_field.label }}</template>
+                            <template v-slot:field_markers>
+                                <span v-if="parseInt(sortable_field.field_options.required ?? 0) === 1" class="required">*</span>
+                                <i v-if="parseInt(sortable_field.field_options.readonly ?? 0) === 1" class="ti ti-pencil-off ms-2" :title="__('Readonly')"></i>
                             </template>
-                        </template>
-                        <template v-slot:field_preview v-if="sortable_field.preview_html">
-                            <div v-html="sortable_field.preview_html" style="display: contents"></div>
-                        </template>
-                    </Field>
+                            <template v-slot:field_options>
+                                <template v-for="(field_option_value, field_option_name) in sortable_field.field_options" :key="field_option_name">
+                                    <input type="hidden" :name="`field_options[${sortable_field.key}][${field_option_name}]`" :value="field_option_value" />
+                                </template>
+                            </template>
+                        </Field>
+                    </div>
                 </div>
+                <Sidebar :inactive_fields="inactive_fields" :add_edit_fn="add_edit_fn"></Sidebar>
             </div>
         </div>
     </div>
@@ -282,5 +309,15 @@
 <style scoped>
     :deep(.sortable-field .btn.hide-field:disabled) {
         pointer-events: auto;
+    }
+    :deep(.sortable-placeholder) {
+        background: unset;
+        border: unset;
+        height: 38px;
+        .sortable-placeholder-inner {
+            border: 2px dashed #dad55e;
+            background: #fff99038;
+            height: 100%;
+        }
     }
 </style>

--- a/js/src/vue/CustomObject/FieldPreview/Sidebar.vue
+++ b/js/src/vue/CustomObject/FieldPreview/Sidebar.vue
@@ -1,0 +1,77 @@
+<script setup>
+    import Field from "./Field.vue";
+    import {computed, ref, onMounted} from "vue";
+
+    const props = defineProps({
+        inactive_fields: Map,
+        add_edit_fn: String,
+    });
+
+    const search = ref('');
+
+    const unused_native_fields = computed(() => {
+        return new Map([...props.inactive_fields].filter(([key, field]) => (field.customfields_id ?? -1) < 0));
+    });
+    const unused_custom_fields = computed(() => {
+        return new Map([...props.inactive_fields].filter(([key, field]) => (field.customfields_id ?? -1) >= 0));
+    });
+
+    function getMatched(fields) {
+        if (search.value === '') {
+            return fields;
+        }
+        const results = new Map();
+        for (const [key, field] of fields) {
+            if (field.label.toLowerCase().includes(search.value.toLowerCase())) {
+                results.set(key, field);
+            }
+        }
+        return results;
+    }
+
+    onMounted(() => {
+        $('.fields-sidebar .new-custom-field').on('click', () => {
+            window[props.add_edit_fn](-1);
+        });
+    });
+
+</script>
+
+<template>
+    <div class="h-100 d-flex col-auto flex-column p-2 px-3 fields-sidebar">
+        <span class="fs-2">{{ __('Add more fields') }}</span>
+        <input type="text" class="form-control mb-3" name="search" :placeholder="__('Search')" v-model="search" />
+        <span v-if="unused_native_fields.size > 0" class="fs-3">{{ __('Native fields') }}</span>
+        <Field v-for="[field_key, unused_field] of getMatched(unused_native_fields)" :key="field_key" :field_key="field_key"
+               :is_active="false">
+            <template v-slot:field_label>{{ unused_field.label }}</template>
+        </Field>
+        <span class="fs-3 mt-3">{{ __('Custom fields') }}</span>
+        <Field v-for="[field_key, unused_field] of getMatched(unused_custom_fields)" :key="field_key" :field_key="field_key"
+               :is_active="false" :customfields_id="unused_field.customfields_id">
+            <template v-slot:field_label>{{ unused_field.label }}</template>
+        </Field>
+        <div class="align-items-center col-12">
+            <div class="form-field row flex-grow-1 mx-0 my-1 new-custom-field cursor-pointer btn btn-sm btn-ghost-secondary w-100" role="button">
+                <div class="col py-2 text-center">
+                    <i class="ti ti-plus"></i>
+                    {{ __('New field') }}
+                </div>
+            </div>
+        </div>
+    </div>
+</template>
+
+<style scoped>
+    .fields-sidebar {
+        border-left: 1px solid var(--tblr-border-color);
+        width: 300px;
+        .sortable-field.col-sm-6 {
+            width: 100%;
+        }
+        .form-field.new-custom-field {
+            border: var(--tblr-border-width) dashed var(--tblr-border-color);
+            border-radius: var(--tblr-border-radius);
+        }
+    }
+</style>

--- a/src/Glpi/Asset/AssetDefinition.php
+++ b/src/Glpi/Asset/AssetDefinition.php
@@ -190,8 +190,6 @@ final class AssetDefinition extends AbstractDefinition
     private function showFieldsForm(): void
     {
         $fields_display = $this->getDecodedFieldsField();
-        $used = array_column($fields_display, 'key');
-        $used = array_combine($used, $used);
 
         TemplateRenderer::getInstance()->display(
             'pages/admin/assetdefinition/fields_display.html.twig',
@@ -199,13 +197,12 @@ final class AssetDefinition extends AbstractDefinition
                 'item'           => $this,
                 'all_fields'     => $this->getAllFields(),
                 'fields_display' => $fields_display,
+                'can_create_fields' => CustomFieldDefinition::canCreate(),
                 'custom_field_form_params' => [
-                    'cancreate' => CustomFieldDefinition::canCreate(),
                     'id' => $this->fields['id'],
                     'type' => CustomFieldDefinition::class,
                     'parenttype' => CustomFieldDefinition::$itemtype,
                     'items_id' => CustomFieldDefinition::$items_id,
-                    'add_new_label' => __('Create new field'),
                     'subitem_container_id' => 'customfield_form_container',
                     'as_modal' => true,
                     'ajax_form_submit' => true,

--- a/templates/pages/admin/assetdefinition/fields_display.html.twig
+++ b/templates/pages/admin/assetdefinition/fields_display.html.twig
@@ -30,9 +30,6 @@
  # ---------------------------------------------------------------------
  #}
 
-{% extends "generic_show_form.html.twig" %}
-{% import 'components/form/fields_macros.html.twig' as fields %}
-
 {% set all_fields = all_fields ?? {} %}
 
 {% set params = {} %}
@@ -42,55 +39,36 @@
 {% set params = params|merge({'formfooter': false}) %}
 {% set rand = rand|default(random()) %}
 
-{% block form_fields %}
-    <div id="sortable-fields-toolbar" class="row mt-3">
-        <div class="col-12">
-            {% set btns %}
-                <button type="button" class="btn btn-outline-secondary ms-3" id="add-field">
-                    {{ __("Add") }}
-                </button>
-                {{ include('components/form/viewsubitem.html.twig', custom_field_form_params|merge({
-                    add_new_btn_class: 'btn-outline-secondary ms-2',
-                    add_new_inline: true,
-                    rand: rand,
-                }), with_context = false) }}
-            {% endset %}
-            <script>
-                function formatAllFields(field) {
-                    if ($(`.sortable-field[data-key="${field.id}"]`).length) {
-                        return null
-                    }
-                    $(field.element).attr('data-customfield-id', field.customfields_id);
-                    return $(`<span data-customfield-id="${field.customfields_id}">${field.text}</span>`);
-                }
-            </script>
-            {% set get_fields_url = path('ajax/asset/assetdefinition.php?action=get_all_fields&assetdefinitions_id=' ~ item.getID()) %}
-            {{ fields.dropdownAjaxField(get_fields_url, 'new_field', '', _n('Field', 'Fields', 1), {
-                rand: rand,
-                templateSelection: 'formatAllFields',
-                templateResult: 'formatAllFields',
-                add_field_html: btns,
-                inline_add_field_html: true,
-                full_width: true,
-                flex_class: 'd-flex'
-            }) }}
+<div class="card-body d-flex flex-wrap p-0 m-n2 mb-n5">
+    <div class="col-12 col-xxl-12 flex-column">
+        <div class="d-flex flex-row flex-wrap flex-xl-nowrap">
+            <div class="row flex-row align-items-start flex-grow-1">
+                <div class="row flex-row">
+                    <form id="main-form" name="asset_form" method="post" action="{{ 'Glpi\\Asset\\AssetDefinition'|itemtype_form_path }}" enctype="multipart/form-data" data-submit-once="">
+                        {{ include('components/form/viewsubitem.html.twig', custom_field_form_params|merge({
+                            cancreate: false,
+                            rand: rand,
+                            modal_title: __('New field'),
+                        }), with_context = false) }}
+                        <div id="sortable-fields-container" class="card-body d-flex flex-wrap p-0"></div>
+                        <script>
+                            window.Vue.createApp(window.Vue.components['CustomObject/FieldPreview/FieldDisplay'].component, {
+                                items_id: {{ item.getID() }},
+                                toolbar_el: '#sortable-fields-toolbar',
+                                all_fields: {{ all_fields|json_encode()|raw }},
+                                fields_display: {{ fields_display|default({})|json_encode()|raw }},
+                                add_edit_fn: 'viewAddEditSubItem{{ rand }}',
+                                can_create_fields: {{ can_create_fields|default(false) ? 'true' : 'false' }},
+                            }).mount('#sortable-fields-container');
+                        </script>
+                        <div class="w-100 px-2">
+                            {% if no_form_buttons is not defined or no_form_buttons == false %}
+                                {{ include('components/form/buttons.html.twig') }}
+                            {% endif %}
+                        </div>
+                    </form>
+                </div>
+            </div>
         </div>
     </div>
-    <div id="sortable-fields-container" class="card-body d-flex flex-wrap"></div>
-
-    <style>
-        .sortable-field .btn-group .select2-container {
-            flex-basis: auto;
-            width: 100% !important;
-        }
-    </style>
-    <script>
-        window.Vue.createApp(window.Vue.components['CustomObject/FieldPreview/FieldDisplay'].component, {
-            items_id: {{ item.getID() }},
-            toolbar_el: '#sortable-fields-toolbar',
-            all_fields: {{ all_fields|json_encode()|raw }},
-            fields_display: {{ fields_display|default({})|json_encode()|raw }},
-            add_edit_fn: 'viewAddEditSubItem{{ rand }}'
-        }).mount('#sortable-fields-container');
-    </script>
-{% endblock %}
+</div>

--- a/templates/pages/assets/customfield.html.twig
+++ b/templates/pages/assets/customfield.html.twig
@@ -43,6 +43,7 @@
     {% endset %}
     {{ fields.textField('system_name', item.fields['system_name'], __('System name'), {
         readonly: not item.isNewItem(),
+        required: true,
         helper: helper
     }) }}
     {{ fields.dropdownArrayField('type', item.fields['type']|default('Glpi\\Asset\\CustomFieldType\\StringType'), field_types, _n('Type', 'Types', 1), {

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -43,7 +43,12 @@ let api_token = null;
  */
 Cypress.Commands.add('login', (username = 'e2e_tests', password = 'glpi') => {
     cy.clearAllCookies();
-    cy.request('index.php').its('body').then((body) => {
+    cy.request('/').its('body').then((body) => {
+        // Click the "Log in again" button if it exists
+        const login_again = Cypress.$(body).find('a[href*="/front/logout.php"]');
+        if (login_again.length > 0) {
+            cy.request(login_again.attr('href'));
+        }
         const $html = Cypress.$(body);
 
         // Parse page


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.

## Description

Fixes #18406
- [x] fields now include their label inside -> reduce width usage in the viewport
- [x] we remove the preview of the field nature (input/dropdown)
- [x] we keep preview of some attributes (mandatory, full width)
- [x] a side panel helps retrieve all fields and drop them into the viewport
- [x] a separate section permits the creation of custom fields
- [x] native and custom fields are clearly identified
- [x] A search input filters available fields
- [x] We have 2 states for a field in the viewport: default and selected
- [x] We show the controls for editing or hiding the fields only for selected state
- [x] grip for drag&drop is always shown (to be discussed, we may have the selected state also)
