### PR TITLE
Add missing inputs for rules using ticket validation criteria

### DIFF
--- a/src/CommonITILValidation.php
+++ b/src/CommonITILValidation.php
@@ -453,8 +453,7 @@ abstract class CommonITILValidation extends CommonDBChild
                     'id'                    => $this->fields[static::$items_id],
                     'global_validation'     => self::computeValidationStatus($item),
                     '_from_itilvalidation'  => true,
-                    'itemtype'              => static::$itemtype
-                ];
+                ] + $item->fields;
                 $item->update($input);
             }
         }

--- a/src/CommonITILValidation.php
+++ b/src/CommonITILValidation.php
@@ -453,6 +453,7 @@ abstract class CommonITILValidation extends CommonDBChild
                     'id'                    => $this->fields[static::$items_id],
                     'global_validation'     => self::computeValidationStatus($item),
                     '_from_itilvalidation'  => true,
+                    'itemtype'              => static::$itemtype
                 ];
                 $item->update($input);
             }

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -1716,7 +1716,13 @@ class Rule extends CommonDBTM
         $partial_regex_result = [];
        // Undefine criteria field : set to blank
         if (!isset($input[$criteria->fields["criteria"]])) {
-            $input[$criteria->fields["criteria"]] = '';
+            if (isset($input['itemtype'])) {
+                $itemtype = new $input['itemtype']();
+                $item = $itemtype->getById($input['id']);
+                $input[$criteria->fields["criteria"]] = $item->fields[$criteria->fields["criteria"]];
+            } else {
+                $input[$criteria->fields["criteria"]] = '';
+            }
         }
 
        //If the value is not an array

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -1716,13 +1716,7 @@ class Rule extends CommonDBTM
         $partial_regex_result = [];
        // Undefine criteria field : set to blank
         if (!isset($input[$criteria->fields["criteria"]])) {
-            if (isset($input['itemtype'])) {
-                $itemtype = new $input['itemtype']();
-                $item = $itemtype->getById($input['id']);
-                $input[$criteria->fields["criteria"]] = $item->fields[$criteria->fields["criteria"]];
-            } else {
-                $input[$criteria->fields["criteria"]] = '';
-            }
+            $input[$criteria->fields["criteria"]] = '';
         }
 
        //If the value is not an array


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !35677
- Here is a brief description of what this PR does

We create business rules for tickets, if we create a rule using only one criterion which is 'validation' it works, otherwise if we add another criterion in addition to 'validation' the rule never passes.

The problem comes from the fact that when the rule engine is run, the main item is CommonITILValidation, so the inputs to be processed come from this object, which does not contain the ticket fields. So you have to go and find the missing fields you need 

## Screenshots (if appropriate):

Work : 
![image](https://github.com/user-attachments/assets/0d6c591a-23b0-4f83-936f-076186164a20)

Dont work : 
![image](https://github.com/user-attachments/assets/e172f95d-fcd3-4b7a-8c76-0646fe4a720d)


