### PR TITLE
Fix Anonymization For Requesters / Observers

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -514,7 +514,11 @@ abstract class CommonITILObject extends CommonDBTM
        // load existing actors (from existing itilobject)
         if (isset($this->users[$actortype])) {
             foreach ($this->users[$actortype] as $user) {
-                $name = getUserName($user['users_id']);
+                $name = getUserName(
+                    $user['users_id'],
+                    0,
+                    in_array($actortype, [CommonITILActor::REQUESTER, CommonITILActor::OBSERVER])
+                );
                 $fn_add_actor('User', $user['users_id'], [
                     'id'                => $user['id'],
                     'text'              => $name,


### PR DESCRIPTION
- [X ] I have read the CONTRIBUTING document.
- [X ] I have performed a self-review of my code.


## Description

When you use Technician anonymization for helpdesk interface, the others requesters & observers are also anonymized. But in fact, the self-service user can add observers on his ticket, so he can see the others users.



