### PR TITLE
Move MainAsset classes to their own directory

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -2804,43 +2804,37 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Inventory/Asset/InventoryAsset.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Property Glpi\\\\Inventory\\\\Asset\\\\InventoryAsset\\:\\:\\$main_asset \\(Glpi\\\\Inventory\\\\Asset\\\\MainAsset\\) does not accept Glpi\\\\Inventory\\\\Asset\\\\InventoryAsset\\.$#',
-	'identifier' => 'assign.propertyType',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Inventory/Asset/InventoryAsset.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Argument of an invalid type stdClass supplied for foreach, only iterables are supported\\.$#',
 	'identifier' => 'foreach.nonIterable',
 	'count' => 2,
-	'path' => __DIR__ . '/src/Glpi/Inventory/Asset/MainAsset.php',
+	'path' => __DIR__ . '/src/Glpi/Inventory/MainAsset/MainAsset.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Property Glpi\\\\Inventory\\\\Asset\\\\InventoryAsset\\:\\:\\$itemtype \\(string\\) does not accept null\\.$#',
 	'identifier' => 'assign.propertyType',
 	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Inventory/Asset/MainAsset.php',
+	'path' => __DIR__ . '/src/Glpi/Inventory/MainAsset/MainAsset.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Property Glpi\\\\Inventory\\\\Asset\\\\InventoryAsset\\:\\:\\$request_query \\(string\\) on left side of \\?\\? is not nullable\\.$#',
 	'identifier' => 'nullCoalesce.property',
 	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Inventory/Asset/MainAsset.php',
+	'path' => __DIR__ . '/src/Glpi/Inventory/MainAsset/MainAsset.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Property Glpi\\\\Inventory\\\\Asset\\\\MainAsset\\:\\:\\$states_id_default \\(int\\) on left side of \\?\\? is not nullable\\.$#',
+	'message' => '#^Property Glpi\\\\Inventory\\\\MainAsset\\\\MainAsset\\:\\:\\$states_id_default \\(int\\) on left side of \\?\\? is not nullable\\.$#',
 	'identifier' => 'nullCoalesce.property',
 	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Inventory/Asset/MainAsset.php',
+	'path' => __DIR__ . '/src/Glpi/Inventory/MainAsset/MainAsset.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Call to function method_exists\\(\\) with Glpi\\\\Inventory\\\\Asset\\\\MainAsset and \'isPartial\' will always evaluate to true\\.$#',
+	'message' => '#^Call to function method_exists\\(\\) with Glpi\\\\Inventory\\\\MainAsset\\\\MainAsset and \'isPartial\' will always evaluate to true\\.$#',
 	'identifier' => 'function.alreadyNarrowedType',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Glpi/Inventory/Asset/NetworkCard.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Property Glpi\\\\Inventory\\\\Asset\\\\InventoryAsset\\:\\:\\$main_asset \\(Glpi\\\\Inventory\\\\Asset\\\\MainAsset\\) in isset\\(\\) is not nullable\\.$#',
+	'message' => '#^Property Glpi\\\\Inventory\\\\Asset\\\\InventoryAsset\\:\\:\\$main_asset \\(Glpi\\\\Inventory\\\\MainAsset\\\\MainAsset\\) in isset\\(\\) is not nullable\\.$#',
 	'identifier' => 'isset.property',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Glpi/Inventory/Asset/NetworkCard.php',
@@ -2849,19 +2843,19 @@ $ignoreErrors[] = [
 	'message' => '#^Argument of an invalid type stdClass supplied for foreach, only iterables are supported\\.$#',
 	'identifier' => 'foreach.nonIterable',
 	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Inventory/Asset/NetworkEquipment.php',
+	'path' => __DIR__ . '/src/Glpi/Inventory/MainAsset/NetworkEquipment.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Call to function method_exists\\(\\) with \\$this\\(Glpi\\\\Inventory\\\\Asset\\\\NetworkEquipment\\) and \'getManagementPorts\' will always evaluate to true\\.$#',
+	'message' => '#^Call to function method_exists\\(\\) with \\$this\\(Glpi\\\\Inventory\\\\MainAsset\\\\NetworkEquipment\\) and \'getManagementPorts\' will always evaluate to true\\.$#',
 	'identifier' => 'function.alreadyNarrowedType',
 	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Inventory/Asset/NetworkEquipment.php',
+	'path' => __DIR__ . '/src/Glpi/Inventory/MainAsset/NetworkEquipment.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Expression on left side of \\?\\? is not nullable\\.$#',
 	'identifier' => 'nullCoalesce.expr',
 	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Inventory/Asset/NetworkEquipment.php',
+	'path' => __DIR__ . '/src/Glpi/Inventory/MainAsset/NetworkEquipment.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Call to function is_array\\(\\) with array will always evaluate to true\\.$#',
@@ -2876,7 +2870,7 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Inventory/Asset/NetworkPort.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Call to function method_exists\\(\\) with Glpi\\\\Inventory\\\\Asset\\\\MainAsset and \'isPartial\' will always evaluate to true\\.$#',
+	'message' => '#^Call to function method_exists\\(\\) with Glpi\\\\Inventory\\\\MainAsset\\\\MainAsset and \'isPartial\' will always evaluate to true\\.$#',
 	'identifier' => 'function.alreadyNarrowedType',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Glpi/Inventory/Asset/NetworkPort.php',
@@ -2942,7 +2936,7 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Inventory/Asset/NetworkPort.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Property Glpi\\\\Inventory\\\\Asset\\\\InventoryAsset\\:\\:\\$main_asset \\(Glpi\\\\Inventory\\\\Asset\\\\MainAsset\\) in isset\\(\\) is not nullable\\.$#',
+	'message' => '#^Property Glpi\\\\Inventory\\\\Asset\\\\InventoryAsset\\:\\:\\$main_asset \\(Glpi\\\\Inventory\\\\MainAsset\\\\MainAsset\\) in isset\\(\\) is not nullable\\.$#',
 	'identifier' => 'isset.property',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Glpi/Inventory/Asset/NetworkPort.php',
@@ -3002,7 +2996,7 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Inventory/Asset/Software.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Property Glpi\\\\Inventory\\\\Asset\\\\InventoryAsset\\:\\:\\$main_asset \\(Glpi\\\\Inventory\\\\Asset\\\\MainAsset\\) in isset\\(\\) is not nullable\\.$#',
+	'message' => '#^Property Glpi\\\\Inventory\\\\Asset\\\\InventoryAsset\\:\\:\\$main_asset \\(Glpi\\\\Inventory\\\\MainAsset\\\\MainAsset\\) in isset\\(\\) is not nullable\\.$#',
 	'identifier' => 'isset.property',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Glpi/Inventory/Asset/Software.php',
@@ -3011,28 +3005,28 @@ $ignoreErrors[] = [
 	'message' => '#^Argument of an invalid type stdClass supplied for foreach, only iterables are supported\\.$#',
 	'identifier' => 'foreach.nonIterable',
 	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Inventory/Asset/Unmanaged.php',
+	'path' => __DIR__ . '/src/Glpi/Inventory/MainAsset/Unmanaged.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#4 \\$ports_id \\(array\\) of method Glpi\\\\Inventory\\\\Asset\\\\Unmanaged\\:\\:rulepassed\\(\\) should be compatible with parameter \\$ports_id \\(int\\) of method Glpi\\\\Inventory\\\\Asset\\\\MainAsset\\:\\:rulepassed\\(\\)$#',
+	'message' => '#^Parameter \\#4 \\$ports_id \\(array\\) of method Glpi\\\\Inventory\\\\MainAsset\\\\Unmanaged\\:\\:rulepassed\\(\\) should be compatible with parameter \\$ports_id \\(int\\) of method Glpi\\\\Inventory\\\\MainAsset\\\\MainAsset\\:\\:rulepassed\\(\\)$#',
 	'identifier' => 'method.childParameterType',
 	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Inventory/Asset/Unmanaged.php',
+	'path' => __DIR__ . '/src/Glpi/Inventory/MainAsset/Unmanaged.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Property Glpi\\\\Inventory\\\\Asset\\\\InventoryAsset\\:\\:\\$request_query \\(string\\) on left side of \\?\\? is not nullable\\.$#',
 	'identifier' => 'nullCoalesce.property',
 	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Inventory/Asset/Unmanaged.php',
+	'path' => __DIR__ . '/src/Glpi/Inventory/MainAsset/Unmanaged.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Property Glpi\\\\Inventory\\\\Asset\\\\MainAsset\\:\\:\\$states_id_default \\(int\\) on left side of \\?\\? is not nullable\\.$#',
+	'message' => '#^Property Glpi\\\\Inventory\\\\MainAsset\\\\MainAsset\\:\\:\\$states_id_default \\(int\\) on left side of \\?\\? is not nullable\\.$#',
 	'identifier' => 'nullCoalesce.property',
 	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Inventory/Asset/Unmanaged.php',
+	'path' => __DIR__ . '/src/Glpi/Inventory/MainAsset/Unmanaged.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Call to function method_exists\\(\\) with Glpi\\\\Inventory\\\\Asset\\\\MainAsset and \'isPartial\' will always evaluate to true\\.$#',
+	'message' => '#^Call to function method_exists\\(\\) with Glpi\\\\Inventory\\\\MainAsset\\\\MainAsset and \'isPartial\' will always evaluate to true\\.$#',
 	'identifier' => 'function.alreadyNarrowedType',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Glpi/Inventory/Asset/VirtualMachine.php',
@@ -3050,7 +3044,7 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Inventory/Asset/VirtualMachine.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Property Glpi\\\\Inventory\\\\Asset\\\\InventoryAsset\\:\\:\\$main_asset \\(Glpi\\\\Inventory\\\\Asset\\\\MainAsset\\) in isset\\(\\) is not nullable\\.$#',
+	'message' => '#^Property Glpi\\\\Inventory\\\\Asset\\\\InventoryAsset\\:\\:\\$main_asset \\(Glpi\\\\Inventory\\\\MainAsset\\\\MainAsset\\) in isset\\(\\) is not nullable\\.$#',
 	'identifier' => 'isset.property',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Glpi/Inventory/Asset/VirtualMachine.php',
@@ -3128,7 +3122,7 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Inventory/Inventory.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Property Glpi\\\\Inventory\\\\Inventory\\:\\:\\$mainasset \\(Glpi\\\\Inventory\\\\Asset\\\\MainAsset\\) in isset\\(\\) is not nullable\\.$#',
+	'message' => '#^Property Glpi\\\\Inventory\\\\Inventory\\:\\:\\$mainasset \\(Glpi\\\\Inventory\\\\MainAsset\\\\MainAsset\\) in isset\\(\\) is not nullable\\.$#',
 	'identifier' => 'isset.property',
 	'count' => 2,
 	'path' => __DIR__ . '/src/Glpi/Inventory/Inventory.php',

--- a/phpunit/functional/Glpi/Inventory/Assets/ComputerTest.php
+++ b/phpunit/functional/Glpi/Inventory/Assets/ComputerTest.php
@@ -187,7 +187,7 @@ class ComputerTest extends AbstractInventoryAsset
         $json = json_decode($data);
 
         $computer = getItemByTypeName('Computer', '_test_pc01');
-        $main = new \Glpi\Inventory\Asset\Computer($computer, $json);
+        $main = new \Glpi\Inventory\MainAsset\Computer($computer, $json);
         $main->setExtraData((array)$json->content);
         $result = $main->prepare();
         $this->assertEquals(json_decode($asset), $result[0]);
@@ -590,7 +590,7 @@ class ComputerTest extends AbstractInventoryAsset
         $agent = new \Agent();
         $this->assertGreaterThan(0, $agent->handleAgent($inventory->extractMetadata()));
 
-        $main = new \Glpi\Inventory\Asset\Computer($computer, $json);
+        $main = new \Glpi\Inventory\MainAsset\Computer($computer, $json);
         $main->setAgent($agent)->setExtraData($data)->checkConf($conf);
         $result = $main->prepare();
         $this->assertCount(1, $result);

--- a/phpunit/functional/Glpi/Inventory/Assets/NetworkEquipmentTest.php
+++ b/phpunit/functional/Glpi/Inventory/Assets/NetworkEquipmentTest.php
@@ -172,7 +172,7 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
         $json = json_decode($data);
 
         $netequ = new \NetworkEquipment();
-        $main = new \Glpi\Inventory\Asset\NetworkEquipment($netequ, $json);
+        $main = new \Glpi\Inventory\MainAsset\NetworkEquipment($netequ, $json);
         $main->setExtraData((array)$json->content);
         $result = $main->prepare();
         $this->assertEquals(json_decode($asset), $result[0]);
@@ -193,7 +193,7 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
         $agent = new \Agent();
         $this->assertSame(0, $agent->handleAgent($inventory->extractMetadata()));
 
-        $main = new \Glpi\Inventory\Asset\NetworkEquipment($netequ, $json);
+        $main = new \Glpi\Inventory\MainAsset\NetworkEquipment($netequ, $json);
         $main->setAgent($agent)->setExtraData($data);
         $result = $main->prepare();
         $this->assertCount(1, $result);
@@ -213,7 +213,7 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
         $agent = new \Agent();
         $this->assertSame(0, $agent->handleAgent($inventory->extractMetadata()));
 
-        $main = new \Glpi\Inventory\Asset\NetworkEquipment($netequ, $json);
+        $main = new \Glpi\Inventory\MainAsset\NetworkEquipment($netequ, $json);
         $main->setAgent($agent)->setExtraData($data);
         $result = $main->prepare();
         $this->assertCount(5, $result);
@@ -423,7 +423,7 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
         $agent = new \Agent();
         $this->assertSame(0, $agent->handleAgent($inventory->extractMetadata()));
 
-        $main = new \Glpi\Inventory\Asset\NetworkEquipment($netequ, $json);
+        $main = new \Glpi\Inventory\MainAsset\NetworkEquipment($netequ, $json);
         $main->setAgent($agent)->setExtraData($data);
         $main->checkConf(new \Glpi\Inventory\Conf());
         $result = $main->prepare();

--- a/phpunit/functional/Glpi/Inventory/Assets/PrinterTest.php
+++ b/phpunit/functional/Glpi/Inventory/Assets/PrinterTest.php
@@ -69,7 +69,7 @@ class PrinterTest extends AbstractInventoryAsset
   <DEVICEID>glpixps.teclib.infra-2018-10-03-08-42-36</DEVICEID>
   <QUERY>INVENTORY</QUERY>
   </REQUEST>",
-                'expected'  => '{"driver": "HP Color LaserJet Pro MFP M476 PCL 6", "name": "HP Color LaserJet Pro MFP M476 PCL 6", "network": false, "printprocessor": "hpcpp155", "resolution": "600x600", "shared": false, "sharename": "HP Color LaserJet Pro MFP M476 PCL 6  (1)", "status": "Unknown", "have_usb": 0, "autoupdatesystems_id": "GLPI Native Inventory", "last_inventory_update": "DATE_NOW"}'
+                'expected'  => '{"driver": "HP Color LaserJet Pro MFP M476 PCL 6", "name": "HP Color LaserJet Pro MFP M476 PCL 6", "network": false, "printprocessor": "hpcpp155", "resolution": "600x600", "shared": false, "sharename": "HP Color LaserJet Pro MFP M476 PCL 6  (1)", "status": "Unknown", "have_usb": 0, "autoupdatesystems_id": "GLPI Native Inventory", "last_inventory_update": "DATE_NOW", "is_deleted": 0}'
             ]
         ];
     }
@@ -111,7 +111,7 @@ class PrinterTest extends AbstractInventoryAsset
         $agent = new \Agent();
         $this->assertSame(0, $agent->handleAgent($inventory->extractMetadata()));
 
-        $main = new \Glpi\Inventory\Asset\Printer($printer, $json);
+        $main = new \Glpi\Inventory\MainAsset\Printer($printer, $json);
         $main->setAgent($agent)->setExtraData($data);
         $main->checkConf(new \Glpi\Inventory\Conf());
         $result = $main->prepare();
@@ -215,7 +215,7 @@ class PrinterTest extends AbstractInventoryAsset
         $agent = new \Agent();
         $this->assertSame(0, $agent->handleAgent($inventory->extractMetadata()));
 
-        $main = new \Glpi\Inventory\Asset\Printer($printer, $json);
+        $main = new \Glpi\Inventory\MainAsset\Printer($printer, $json);
         $main->setAgent($agent)->setExtraData($data);
         $main->checkConf(new \Glpi\Inventory\Conf());
         $result = $main->prepare();
@@ -301,7 +301,7 @@ class PrinterTest extends AbstractInventoryAsset
         $agent = new \Agent();
         $this->assertSame(0, $agent->handleAgent($inventory->extractMetadata()));
 
-        $main = new \Glpi\Inventory\Asset\Printer($printer, $json);
+        $main = new \Glpi\Inventory\MainAsset\Printer($printer, $json);
         $main->setAgent($agent)->setExtraData($data);
         $main->checkConf(new \Glpi\Inventory\Conf());
         $result = $main->prepare();
@@ -1492,7 +1492,7 @@ class PrinterTest extends AbstractInventoryAsset
         $agent = new \Agent();
         $this->assertSame(0, $agent->handleAgent($inventory->extractMetadata()));
 
-        $main = new \Glpi\Inventory\Asset\Printer($printer, $json);
+        $main = new \Glpi\Inventory\MainAsset\Printer($printer, $json);
         $main->setAgent($agent)->setExtraData($data);
         $main->checkConf(new \Glpi\Inventory\Conf());
         $main->setDiscovery(true);
@@ -1560,7 +1560,7 @@ class PrinterTest extends AbstractInventoryAsset
         $agent = new \Agent();
         $this->assertSame(0, $agent->handleAgent($inventory->extractMetadata()));
 
-        $main = new \Glpi\Inventory\Asset\Printer($printer, $json);
+        $main = new \Glpi\Inventory\MainAsset\Printer($printer, $json);
         $main->setAgent($agent)->setExtraData($data);
         $main->checkConf(new \Glpi\Inventory\Conf());
         $main->setDiscovery(true);
@@ -1703,7 +1703,7 @@ class PrinterTest extends AbstractInventoryAsset
         $agent = new \Agent();
         $this->assertSame(0, $agent->handleAgent($inventory->extractMetadata()));
 
-        $main = new \Glpi\Inventory\Asset\Printer($printer, $json);
+        $main = new \Glpi\Inventory\MainAsset\Printer($printer, $json);
         $main->setAgent($agent)->setExtraData($data);
         $main->checkConf(new \Glpi\Inventory\Conf());
         $result = $main->prepare();

--- a/src/Glpi/Inventory/Asset/InventoryAsset.php
+++ b/src/Glpi/Inventory/Asset/InventoryAsset.php
@@ -43,6 +43,7 @@ use CommonDropdown;
 use Dropdown;
 use Glpi\Asset\Asset_PeripheralAsset;
 use Glpi\Inventory\Conf;
+use Glpi\Inventory\MainAsset\MainAsset;
 use Glpi\Inventory\Request;
 use Lockedfield;
 use Manufacturer;
@@ -84,8 +85,6 @@ abstract class InventoryAsset
     protected array $known_links = [];
     /** @var array */
     protected array $raw_links = [];
-        /** @var array */
-    protected array $input_notmanaged = [];
 
     /**
      * Constructor
@@ -391,11 +390,11 @@ abstract class InventoryAsset
     /**
      * Set inventory item
      *
-     * @param InventoryAsset $mainasset Main inventory asset instance
+     * @param MainAsset $mainasset Main inventory asset instance
      *
      * @return InventoryAsset
      */
-    public function setMainAsset(InventoryAsset $mainasset): self
+    public function setMainAsset(MainAsset $mainasset): self
     {
         $this->main_asset = $mainasset;
         return $this;
@@ -404,16 +403,16 @@ abstract class InventoryAsset
     /**
      * Get main inventory asset
      *
-     * @return InventoryAsset
+     * @return MainAsset
      */
-    public function getMainAsset(): InventoryAsset
+    public function getMainAsset(): MainAsset
     {
         return $this->main_asset;
     }
 
     /**
      * Add or move a peripheral asset.
-     * If the peripheral asset is already linked to another maina sset, existing link will be replaced by new link.
+     * If the peripheral asset is already linked to another main asset, existing link will be replaced by new link.
      *
      * @param array $input
      *
@@ -440,7 +439,7 @@ abstract class InventoryAsset
         }
 
         $relation = new Asset_PeripheralAsset();
-        $relation->add($input, [], !$this->item->isNewItem()); //log only if mainitem is not new
+        $relation->add($input, [], !$this->item->isNewItem()); //log only if main item is not new
     }
 
     protected function setNew(): self

--- a/src/Glpi/Inventory/Asset/InventoryNetworkPort.php
+++ b/src/Glpi/Inventory/Asset/InventoryNetworkPort.php
@@ -38,6 +38,7 @@ namespace Glpi\Inventory\Asset;
 
 use DBmysqlIterator;
 use Glpi\Inventory\Conf;
+use Glpi\Inventory\MainAsset\MainAsset;
 use IPAddress;
 use IPNetwork;
 use Item_DeviceNetworkCard;

--- a/src/Glpi/Inventory/Asset/NetworkPort.php
+++ b/src/Glpi/Inventory/Asset/NetworkPort.php
@@ -68,7 +68,7 @@ class NetworkPort extends InventoryAsset
         $this->aggregates = [];
         $this->vlans = [];
 
-        $this->extra_data['\Glpi\Inventory\Asset\\' . $this->item->getType()] = null;
+        $this->extra_data['\Glpi\Inventory\MainAsset\\' . $this->item->getType()] = null;
         $mapping = [
             'ifname'       => 'name',
             'ifnumber'     => 'logical_number',
@@ -624,7 +624,7 @@ class NetworkPort extends InventoryAsset
 
     public function handle()
     {
-        $this->ports += $this->extra_data['\Glpi\Inventory\Asset\\' . $this->item->getType()]->getManagementPorts();
+        $this->ports += $this->extra_data['\Glpi\Inventory\MainAsset\\' . $this->item->getType()]->getManagementPorts();
         $this->handlePorts();
     }
 
@@ -788,12 +788,12 @@ class NetworkPort extends InventoryAsset
 
     public function handlePorts($itemtype = null, $items_id = null)
     {
-        $mainasset = $this->extra_data['\Glpi\Inventory\Asset\\' . $this->item->getType()];
+        $mainasset = $this->extra_data['\Glpi\Inventory\MainAsset\\' . $this->item->getType()];
 
         //remove management port for Printer on netinventory
         //to prevent twice IP (NetworkPortAggregate / NetworkPortEthernet)
         if ($mainasset instanceof Printer && !$this->item->isNewItem()) {
-            if (empty($this->extra_data['\Glpi\Inventory\Asset\\' . $this->item->getType()]->getManagementPorts())) {
+            if (empty($this->extra_data['\Glpi\Inventory\MainAsset\\' . $this->item->getType()]->getManagementPorts())) {
                 //remove all port management ports
                 $networkport = new GlobalNetworkPort();
                 $networkport->deleteByCriteria([

--- a/src/Glpi/Inventory/Asset/Printer.php
+++ b/src/Glpi/Inventory/Asset/Printer.php
@@ -9,7 +9,6 @@
  *
  * @copyright 2015-2024 Teclib' and contributors.
  * @copyright 2003-2014 by the INDEPNET Development Team.
- * @copyright 2010-2022 by the FusionInventory Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -36,75 +35,25 @@
 
 namespace Glpi\Inventory\Asset;
 
-use Blacklist;
-use CommonDBTM;
+use AutoUpdateSystem;
 use Glpi\Asset\Asset_PeripheralAsset;
 use Glpi\Inventory\Conf;
-use IPAddress;
-use Printer as GPrinter;
-use PrinterLog;
-use PrinterModel;
-use PrinterType;
 use RuleDictionnaryPrinterCollection;
+use Printer as GPrinter;
 use RuleImportAssetCollection;
 
-class Printer extends NetworkEquipment
+class Printer extends InventoryAsset
 {
-    private $counters;
-
-    public function __construct(CommonDBTM $item, $data)
-    {
-        $this->extra_data['pagecounters'] = null;
-        parent::__construct($item, $data);
-    }
-
-    protected function getModelsFieldName(): string
-    {
-        return PrinterModel::getForeignKeyField();
-    }
-
-    protected function getTypesFieldName(): string
-    {
-        return PrinterType::getForeignKeyField();
-    }
-
     public function prepare(): array
     {
-        if ($this->item->getType() != GPrinter::getType() && $this->conf->import_printer == 0) {
-            return [];
-        }
-
-        parent::prepare();
-
-        if (!property_exists($this->raw_data->content ?? new \stdClass(), 'network_device')) {
-            $autoupdatesystems_id = $this->data[0]->autoupdatesystems_id;
-            $this->data = [];
-            foreach ($this->raw_data as $val) {
-                $val->autoupdatesystems_id = $autoupdatesystems_id;
-                $val->last_inventory_update = $_SESSION['glpi_currenttime'];
-                $this->data[] = $val;
-            }
-        }
-
         $rulecollection = new RuleDictionnaryPrinterCollection();
 
-        $mapping_pcounter = [
-            'total'        => 'total_pages',
-            'black'        => 'bw_pages',
-            'color'        => 'color_pages',
-            'duplex'       => 'rv_pages', //keep first, rectoverso is the standard and should be used if present
-            'rectoverso'   => 'rv_pages',
-            'scanned'      => 'scanned',
-            'printtotal'   => 'prints',
-            'printblack'   => 'bw_prints',
-            'printcolor'   => 'color_prints',
-            'copytotal'    => 'copies',
-            'copyblack'    => 'bw_copies',
-            'copycolor'    => 'color_copies',
-            'faxtotal'     => 'faxed',
-        ];
-
         foreach ($this->data as $k => &$val) {
+            //set update system
+            $val->autoupdatesystems_id = AutoUpdateSystem::NATIVE_INVENTORY;
+            $val->last_inventory_update = $_SESSION["glpi_currenttime"];
+            $val->is_deleted = 0;
+
             if (property_exists($val, 'port') && strstr($val->port, "USB")) {
                 $val->have_usb = 1;
             } else {
@@ -112,27 +61,12 @@ class Printer extends NetworkEquipment
             }
             unset($val->port);
 
-           //inventoried printers certainly have ethernet
-            if (property_exists($this->raw_data->content ?? new \stdClass(), 'network_device')) {
-                $val->have_ethernet = 1;
-            }
-
-           // Hack for USB Printer serial
+            // Hack for USB Printer serial
             if (
                 property_exists($val, 'serial')
                 && preg_match('/\/$/', $val->serial)
             ) {
                 $val->serial = preg_replace('/\/$/', '', $val->serial);
-            }
-
-            if (property_exists($val, 'ram')) {
-                $val->memory_size = $val->ram;
-                unset($val->ram);
-            }
-
-            if (property_exists($val, 'credentials')) {
-                $val->snmpcredentials_id = $val->credentials;
-                unset($val->credentials);
             }
 
             $res_rule = $rulecollection->processAllRules(['name' => $val->name]);
@@ -148,78 +82,18 @@ class Printer extends NetworkEquipment
                     $known_key = md5('manufacturers_id' . $res_rule['manufacturer']);
                     $this->known_links[$known_key] = $res_rule['manufacturer'];
                 }
-
-                if (isset($this->extra_data['pagecounters'])) {
-                    $pcounter = (object)$this->extra_data['pagecounters'];
-                    foreach ($mapping_pcounter as $origin => $dest) {
-                        if (property_exists($pcounter, $origin)) {
-                             $pcounter->$dest = $pcounter->$origin;
-                        }
-
-                        if (property_exists($pcounter, 'total_pages')) {
-                            $val->last_pages_counter = $pcounter->total_pages;
-                        }
-                        $this->counters = $pcounter;
-                    }
-                }
             } else {
                 unset($this->data[$k]);
             }
         }
-
-        //try to know if management port IP is already known as IP port
-        //if yes remove it from management port
-        $known_ports = $port_managment = $this->getManagementPorts();
-        if (isset($known_ports['management']) && property_exists($known_ports['management'], 'ipaddress')) {
-            foreach ($known_ports['management']->ipaddress as $pa_ip_key => $pa_ip_val) {
-                if (property_exists($this->raw_data->content, 'network_ports')) {
-                    foreach ($this->raw_data->content->network_ports as $port_obj) {
-                        if (property_exists($port_obj, 'ips')) {
-                            foreach ($port_obj->ips as $port_ip) {
-                                if ($pa_ip_val == $port_ip) {
-                                    unset($port_managment['management']->ipaddress[$pa_ip_key]);
-                                    if (empty($port_managment['management']->ipaddress)) {
-                                        unset($port_managment['management']);
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        $this->setManagementPorts($port_managment);
 
         return $this->data;
     }
 
     public function handle()
     {
-        if ($this->item->getType() != GPrinter::getType()) {
-            if ($this->conf->import_printer == 1) {
-                $this->handleConnectedPrinter();
-            }
-            return;
-        }
-
-        parent::handle();
-        $this->handleMetrics();
-    }
-
-    /**
-     * Handle a printer connecter to a computer
-     *
-     * @return void
-     */
-    protected function handleConnectedPrinter()
-    {
         /** @var \DBmysql $DB */
         global $DB;
-
-        if (!$this->checkPrinterConf($this->conf)) {
-            return;
-        }
 
         $rule = new RuleImportAssetCollection();
         $printer = new GPrinter();
@@ -249,7 +123,7 @@ class Printer extends NetworkEquipment
                 $items_id = null;
                 $itemtype = \Printer::class;
                 if ($data['found_inventories'][0] == 0) {
-                   // add printer
+                    // add printer
                     $val->entities_id = $entities_id;
                     $val->is_recursive = $this->is_recursive;
                     $val->is_dynamic = 1;
@@ -308,7 +182,7 @@ class Printer extends NetworkEquipment
             $db_printers[$idtmp] = $data['id'];
         }
         if (count($db_printers)) {
-           // Check all fields from source:
+            // Check all fields from source:
             foreach ($printers as $key => $printers_id) {
                 foreach ($db_printers as $keydb => $prints_id) {
                     if ($printers_id == $prints_id) {
@@ -319,7 +193,7 @@ class Printer extends NetworkEquipment
                 }
             }
 
-           // Delete printers links in DB
+            // Delete printers links in DB
             foreach ($db_printers as $idtmp => $data) {
                 (new $lclass())->delete(['id' => $idtmp], true);
             }
@@ -338,81 +212,15 @@ class Printer extends NetworkEquipment
         }
     }
 
-    /**
-     * Get printer counters
-     *
-     * @return \stdClass
-     */
-    public function getCounters(): \stdClass
+    public function checkConf(Conf $conf): bool
     {
-        return $this->counters;
-    }
-
-    /**
-     * Handle printer metrics
-     *
-     * @return void
-     */
-    public function handleMetrics()
-    {
-        if ($this->counters === null) {
-            return;
-        }
-
-        $unicity_input = [
-            'printers_id' => $this->item->fields['id'],
-            'date'        => date('Y-m-d', strtotime($_SESSION['glpi_currenttime'])),
-        ];
-        $input = array_merge((array)$this->counters, $unicity_input);
-
-        $metrics = new PrinterLog();
-        if ($metrics->getFromDBByCrit($unicity_input)) {
-            $input['id'] = $metrics->fields['id'];
-            $metrics->update($input, false);
-        } else {
-            $metrics->add($input, [], false);
-        }
-    }
-
-    /**
-     * Try to know if printer need to be updated from discovery
-     * Only if IP has changed
-     * @return boolean
-     */
-    public static function needToBeUpdatedFromDiscovery(CommonDBTM $item, $val)
-    {
-        if (property_exists($val, 'ips')) {
-            foreach ($val->ips as $ip) {
-                $blacklist = new Blacklist();
-                //exclude IP if needed
-                if ('' != $blacklist->process(Blacklist::IP, $ip)) {
-                    //try to find IP (get from discovery) from known IP of Printer
-                    //if found refuse update
-                    //if no, printer IP have changed so  we allow the update from discovery
-                    $ipaddress = new IPAddress($ip);
-                    $tmp['mainitems_id'] = $item->fields['id'];
-                    $tmp['mainitemtype'] = $item::getType();
-                    $tmp['is_dynamic']   = 1;
-                    $tmp['name']         = $ipaddress->getTextual();
-                    if ($ipaddress->getFromDBByCrit($tmp)) {
-                        return false;
-                    }
-                    return true;
-                }
-            }
-        }
-        return false;
+        /** @var array $CFG_GLPI */
+        global $CFG_GLPI;
+        return $conf->import_printer == 1 && in_array($this->item::class, $CFG_GLPI['peripheralhost_types']);
     }
 
     public function getItemtype(): string
     {
         return \Printer::class;
-    }
-
-    public function checkPrinterConf(Conf $conf): bool
-    {
-        /** @var array $CFG_GLPI */
-        global $CFG_GLPI;
-        return $conf->import_printer == 1 && in_array($this->item::class, $CFG_GLPI['peripheralhost_types']);
     }
 }

--- a/src/Glpi/Inventory/Inventory.php
+++ b/src/Glpi/Inventory/Inventory.php
@@ -40,7 +40,7 @@ use CommonDBTM;
 use Glpi\Asset\AssetDefinitionManager;
 use Glpi\Asset\Capacity\IsInventoriableCapacity;
 use Glpi\Inventory\Asset\InventoryAsset;
-use Glpi\Inventory\Asset\MainAsset;
+use Glpi\Inventory\MainAsset\MainAsset;
 use Lockedfield;
 use RefusedEquipment;
 use Session;
@@ -568,7 +568,7 @@ class Inventory
     public function getMainClass()
     {
         $agent = $this->getAgent();
-        $class_ns = '\Glpi\Inventory\Asset\\';
+        $class_ns = '\Glpi\Inventory\MainAsset\\';
         $main_class = $class_ns . $agent->fields['itemtype'];
         if (class_exists($main_class)) {
             return $main_class;

--- a/src/Glpi/Inventory/MainAsset/Computer.php
+++ b/src/Glpi/Inventory/MainAsset/Computer.php
@@ -33,20 +33,20 @@
  * ---------------------------------------------------------------------
  */
 
-namespace Glpi\Inventory\Asset;
+namespace Glpi\Inventory\MainAsset;
 
-use PhoneModel;
-use PhoneType;
+use ComputerModel;
+use ComputerType;
 
-class Phone extends MainAsset
+class Computer extends MainAsset
 {
     protected function getModelsFieldName(): string
     {
-        return PhoneModel::getForeignKeyField();
+        return ComputerModel::getForeignKeyField();
     }
 
     protected function getTypesFieldName(): string
     {
-        return PhoneType::getForeignKeyField();
+        return ComputerType::getForeignKeyField();
     }
 }

--- a/src/Glpi/Inventory/MainAsset/GenericAsset.php
+++ b/src/Glpi/Inventory/MainAsset/GenericAsset.php
@@ -33,20 +33,25 @@
  * ---------------------------------------------------------------------
  */
 
-namespace Glpi\Inventory\Asset;
+namespace Glpi\Inventory\MainAsset;
 
-use ComputerModel;
-use ComputerType;
-
-class Computer extends MainAsset
+class GenericAsset extends MainAsset
 {
     protected function getModelsFieldName(): string
     {
-        return ComputerModel::getForeignKeyField();
+        /** @var \Glpi\Asset\Asset $item */
+        $item = $this->item;
+        $model_classname = $item->getDefinition()->getAssetModelClassName();
+
+        return getForeignKeyFieldForItemType($model_classname);
     }
 
     protected function getTypesFieldName(): string
     {
-        return ComputerType::getForeignKeyField();
+        /** @var \Glpi\Asset\Asset $item */
+        $item = $this->item;
+        $type_classname = $item->getDefinition()->getAssetTypeClassName();
+
+        return getForeignKeyFieldForItemType($type_classname);
     }
 }

--- a/src/Glpi/Inventory/MainAsset/MainAsset.php
+++ b/src/Glpi/Inventory/MainAsset/MainAsset.php
@@ -34,14 +34,17 @@
  * ---------------------------------------------------------------------
  */
 
-namespace Glpi\Inventory\Asset;
+namespace Glpi\Inventory\MainAsset;
 
 use Auth;
 use AutoUpdateSystem;
 use Blacklist;
 use CommonDBTM;
 use Dropdown;
-use Glpi\Inventory\Asset\Printer as AssetPrinter;
+use Glpi\Inventory\Asset\Firmware;
+use Glpi\Inventory\Asset\InventoryAsset;
+use Glpi\Inventory\Asset\InventoryNetworkPort;
+use Glpi\Inventory\MainAsset\Printer as MainAssetPrinter;
 use Glpi\Inventory\Conf;
 use Glpi\Inventory\Request;
 use NetworkEquipment;
@@ -858,7 +861,7 @@ abstract class MainAsset extends InventoryAsset
                 ||
                 (
                 $itemtype == Printer::getType()
-                && !AssetPrinter::needToBeUpdatedFromDiscovery($this->item, $val)
+                && !MainAssetPrinter::needToBeUpdatedFromDiscovery($this->item, $val)
                 )
             ) {
                 //only update autoupdatesystems_id, last_inventory_update, snmpcredentials_id

--- a/src/Glpi/Inventory/MainAsset/NetworkEquipment.php
+++ b/src/Glpi/Inventory/MainAsset/NetworkEquipment.php
@@ -34,9 +34,10 @@
  * ---------------------------------------------------------------------
  */
 
-namespace Glpi\Inventory\Asset;
+namespace Glpi\Inventory\MainAsset;
 
 use Blacklist;
+use Glpi\Inventory\Asset\NetworkPort;
 use NetworkEquipmentModel;
 use NetworkEquipmentType;
 use NetworkName;

--- a/src/Glpi/Inventory/MainAsset/Phone.php
+++ b/src/Glpi/Inventory/MainAsset/Phone.php
@@ -33,28 +33,20 @@
  * ---------------------------------------------------------------------
  */
 
-namespace Glpi\Inventory\Asset;
+namespace Glpi\Inventory\MainAsset;
 
 use PhoneModel;
 use PhoneType;
 
-class GenericAsset extends MainAsset
+class Phone extends MainAsset
 {
     protected function getModelsFieldName(): string
     {
-        /** @var \Glpi\Asset\Asset $item */
-        $item = $this->item;
-        $model_classname = $item->getDefinition()->getAssetModelClassName();
-
-        return getForeignKeyFieldForItemType($model_classname);
+        return PhoneModel::getForeignKeyField();
     }
 
     protected function getTypesFieldName(): string
     {
-        /** @var \Glpi\Asset\Asset $item */
-        $item = $this->item;
-        $type_classname = $item->getDefinition()->getAssetTypeClassName();
-
-        return getForeignKeyFieldForItemType($type_classname);
+        return PhoneType::getForeignKeyField();
     }
 }

--- a/src/Glpi/Inventory/MainAsset/Printer.php
+++ b/src/Glpi/Inventory/MainAsset/Printer.php
@@ -1,0 +1,257 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2024 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @copyright 2010-2022 by the FusionInventory Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Inventory\MainAsset;
+
+use Blacklist;
+use CommonDBTM;
+use Glpi\Asset\Asset_PeripheralAsset;
+use Glpi\Inventory\Conf;
+use IPAddress;
+use Printer as GPrinter;
+use PrinterLog;
+use PrinterModel;
+use PrinterType;
+use RuleDictionnaryPrinterCollection;
+use RuleImportAssetCollection;
+
+class Printer extends NetworkEquipment
+{
+    private $counters;
+
+    public function __construct(CommonDBTM $item, $data)
+    {
+        $this->extra_data['pagecounters'] = null;
+        parent::__construct($item, $data);
+    }
+
+    protected function getModelsFieldName(): string
+    {
+        return PrinterModel::getForeignKeyField();
+    }
+
+    protected function getTypesFieldName(): string
+    {
+        return PrinterType::getForeignKeyField();
+    }
+
+    public function prepare(): array
+    {
+        parent::prepare();
+
+        if (!property_exists($this->raw_data->content ?? new \stdClass(), 'network_device')) {
+            $autoupdatesystems_id = $this->data[0]->autoupdatesystems_id;
+            $this->data = [];
+            foreach ($this->raw_data as $val) {
+                $val->autoupdatesystems_id = $autoupdatesystems_id;
+                $val->last_inventory_update = $_SESSION['glpi_currenttime'];
+                $this->data[] = $val;
+            }
+        }
+
+        $rulecollection = new RuleDictionnaryPrinterCollection();
+
+        $mapping_pcounter = [
+            'total'        => 'total_pages',
+            'black'        => 'bw_pages',
+            'color'        => 'color_pages',
+            'duplex'       => 'rv_pages', //keep first, rectoverso is the standard and should be used if present
+            'rectoverso'   => 'rv_pages',
+            'scanned'      => 'scanned',
+            'printtotal'   => 'prints',
+            'printblack'   => 'bw_prints',
+            'printcolor'   => 'color_prints',
+            'copytotal'    => 'copies',
+            'copyblack'    => 'bw_copies',
+            'copycolor'    => 'color_copies',
+            'faxtotal'     => 'faxed',
+        ];
+
+        foreach ($this->data as $k => &$val) {
+            //no way to know if printer has a USB port but...
+            $val->have_usb = 0;
+            //inventoried printers certainly have ethernet
+            $val->have_ethernet = 1;
+
+            // Hack for USB Printer serial
+            if (
+                property_exists($val, 'serial')
+                && preg_match('/\/$/', $val->serial)
+            ) {
+                $val->serial = preg_replace('/\/$/', '', $val->serial);
+            }
+
+            if (property_exists($val, 'ram')) {
+                $val->memory_size = $val->ram;
+                unset($val->ram);
+            }
+
+            if (property_exists($val, 'credentials')) {
+                $val->snmpcredentials_id = $val->credentials;
+                unset($val->credentials);
+            }
+
+            $res_rule = $rulecollection->processAllRules(['name' => $val->name]);
+            if (
+                (!isset($res_rule['_ignore_ocs_import']) || $res_rule['_ignore_ocs_import'] != "1")
+                && (!isset($res_rule['_ignore_import']) || $res_rule['_ignore_import'] != "1")
+            ) {
+                if (isset($res_rule['name'])) {
+                    $val->name = $res_rule['name'];
+                }
+                if (isset($res_rule['manufacturer'])) {
+                    $val->manufacturers_id = $res_rule['manufacturer'];
+                    $known_key = md5('manufacturers_id' . $res_rule['manufacturer']);
+                    $this->known_links[$known_key] = $res_rule['manufacturer'];
+                }
+
+                if (isset($this->extra_data['pagecounters'])) {
+                    $pcounter = (object)$this->extra_data['pagecounters'];
+                    foreach ($mapping_pcounter as $origin => $dest) {
+                        if (property_exists($pcounter, $origin)) {
+                             $pcounter->$dest = $pcounter->$origin;
+                        }
+
+                        if (property_exists($pcounter, 'total_pages')) {
+                            $val->last_pages_counter = $pcounter->total_pages;
+                        }
+                        $this->counters = $pcounter;
+                    }
+                }
+            } else {
+                unset($this->data[$k]);
+            }
+        }
+
+        //try to know if management port IP is already known as IP port
+        //if yes remove it from management port
+        $known_ports = $port_managment = $this->getManagementPorts();
+        if (isset($known_ports['management']) && property_exists($known_ports['management'], 'ipaddress')) {
+            foreach ($known_ports['management']->ipaddress as $pa_ip_key => $pa_ip_val) {
+                if (property_exists($this->raw_data->content, 'network_ports')) {
+                    foreach ($this->raw_data->content->network_ports as $port_obj) {
+                        if (property_exists($port_obj, 'ips')) {
+                            foreach ($port_obj->ips as $port_ip) {
+                                if ($pa_ip_val == $port_ip) {
+                                    unset($port_managment['management']->ipaddress[$pa_ip_key]);
+                                    if (empty($port_managment['management']->ipaddress)) {
+                                        unset($port_managment['management']);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        $this->setManagementPorts($port_managment);
+
+        return $this->data;
+    }
+
+    public function handle()
+    {
+        parent::handle();
+        $this->handleMetrics();
+    }
+
+    /**
+     * Get printer counters
+     *
+     * @return \stdClass
+     */
+    public function getCounters(): \stdClass
+    {
+        return $this->counters;
+    }
+
+    /**
+     * Handle printer metrics
+     *
+     * @return void
+     */
+    public function handleMetrics()
+    {
+        if ($this->counters === null) {
+            return;
+        }
+
+        $unicity_input = [
+            'printers_id' => $this->item->fields['id'],
+            'date'        => date('Y-m-d', strtotime($_SESSION['glpi_currenttime'])),
+        ];
+        $input = array_merge((array)$this->counters, $unicity_input);
+
+        $metrics = new PrinterLog();
+        if ($metrics->getFromDBByCrit($unicity_input)) {
+            $input['id'] = $metrics->fields['id'];
+            $metrics->update($input, false);
+        } else {
+            $metrics->add($input, [], false);
+        }
+    }
+
+    /**
+     * Try to know if printer need to be updated from discovery
+     * Only if IP has changed
+     * @return boolean
+     */
+    public static function needToBeUpdatedFromDiscovery(CommonDBTM $item, $val)
+    {
+        if (property_exists($val, 'ips')) {
+            foreach ($val->ips as $ip) {
+                $blacklist = new Blacklist();
+                //exclude IP if needed
+                if ('' != $blacklist->process(Blacklist::IP, $ip)) {
+                    //try to find IP (get from discovery) from known IP of Printer
+                    //if found refuse update
+                    //if no, printer IP have changed so  we allow the update from discovery
+                    $ipaddress = new IPAddress($ip);
+                    $tmp['mainitems_id'] = $item->fields['id'];
+                    $tmp['mainitemtype'] = $item::getType();
+                    $tmp['is_dynamic']   = 1;
+                    $tmp['name']         = $ipaddress->getTextual();
+                    if ($ipaddress->getFromDBByCrit($tmp)) {
+                        return false;
+                    }
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/src/Glpi/Inventory/MainAsset/Unmanaged.php
+++ b/src/Glpi/Inventory/MainAsset/Unmanaged.php
@@ -33,7 +33,7 @@
  * ---------------------------------------------------------------------
  */
 
-namespace Glpi\Inventory\Asset;
+namespace Glpi\Inventory\MainAsset;
 
 use Glpi\Inventory\Conf;
 use Glpi\Inventory\Request;

--- a/src/RuleImportAsset.php
+++ b/src/RuleImportAsset.php
@@ -943,7 +943,7 @@ class RuleImportAsset extends Rule
                     }
 
                     $back_class = Unmanaged::class;
-                    if (is_a($class, \Glpi\Inventory\Asset\MainAsset::class)) {
+                    if (is_a($class, \Glpi\Inventory\MainAsset\MainAsset::class)) {
                         $back_class = $class->getItemtype();
                     }
                     if ($class && !isset($params['return'])) {
@@ -991,7 +991,7 @@ class RuleImportAsset extends Rule
                         }
 
                         $back_class = Unmanaged::class;
-                        if (is_a($class, \Glpi\Inventory\Asset\MainAsset::class)) {
+                        if (is_a($class, \Glpi\Inventory\MainAsset\MainAsset::class)) {
                             $back_class = $class->getItemtype();
                         }
 

--- a/src/RuleImportAssetCollection.php
+++ b/src/RuleImportAssetCollection.php
@@ -148,7 +148,6 @@ class RuleImportAssetCollection extends RuleCollection
                 ->handleRequest($contents);
 
             $inventory = $inventory_request->getInventory();
-            $item = $inventory->getItem();
             $invitem = $inventory->getMainAsset();
 
             // sanitize input


### PR DESCRIPTION
Main idea is to make distinction between simple asset and main assets (inventoriable ones).

Printer was a specific case because it can be either a MainAsset or a simple Asset. This is now handled from two distinct classes.