### PR TITLE
Fix custom asset system name pattern

### DIFF
--- a/src/Glpi/CustomObject/AbstractDefinition.php
+++ b/src/Glpi/CustomObject/AbstractDefinition.php
@@ -434,7 +434,7 @@ abstract class AbstractDefinition extends CommonDBTM
         $has_errors = false;
 
         if (array_key_exists('system_name', $input)) {
-            if (!is_string($input['system_name']) || preg_match('/^[A-Za-z]+$/i', $input['system_name']) !== 1) {
+            if (!is_string($input['system_name']) || preg_match('/^[a-z]+$/i', $input['system_name']) !== 1) {
                 Session::addMessageAfterRedirect(
                     htmlescape(sprintf(
                         __('The following field has an incorrect value: "%s".'),

--- a/templates/pages/admin/customobjects/main.html.twig
+++ b/templates/pages/admin/customobjects/main.html.twig
@@ -141,9 +141,9 @@
             }
             const reserved_names = {{ reserved_system_names|json_encode()|raw }}.map((n) => n.toLowerCase());
             const existing_names = {{ existing_system_names|json_encode()|raw }}.map((n) => n.toLowerCase());
-            // label is made lowercase and spaces are replaced with underscores. All other characters are removed
-            $('#mainformtable input[name="system_name"]')
-                .val($('#mainformtable input[name="label"]').val().normalize('NFD').replace(/ /g, '_').replace(/[^a-z_]/gi, ''));
+            $('#mainformtable input[name="system_name"]').val(
+                $('#mainformtable input[name="label"]').val().normalize('NFD').replace(/[^a-z]/gi, '')
+            );
             const system_name = $('#mainformtable input[name="system_name"]').val().toLowerCase();
             if (reserved_names.includes(system_name) || system_name.endsWith('type') || system_name.endsWith('model')) {
                 $('#mainformtable input[name="system_name"]').get(0).setCustomValidity(__('The system name is a reserved name. Please enter a different label or manually change the system name.'));


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Extracted from #18481.

1. The custom assets system name pattern does not accept underscores.
2. The regex was using `[A-Za-z]` ranges with the insensitive (`i`) flag, therefore, the `A-Z` uppercase range was useless.

