### PR TITLE
Make sure only active forms can be answered + include token in form

### DIFF
--- a/src/Glpi/Controller/Form/RendererController.php
+++ b/src/Glpi/Controller/Form/RendererController.php
@@ -68,6 +68,10 @@ final class RendererController extends AbstractController
             'menu' => ['admin', Form::getType()],
             'form' => $form,
             'unauthenticated_user' => !Session::isAuthenticated(),
+
+            // Direct access token must be included in the form data as it will
+            // be checked in the submit answers controller.
+            'token' => $request->query->getString('token'),
         ]);
     }
 

--- a/src/Glpi/Controller/Form/SubmitAnswerController.php
+++ b/src/Glpi/Controller/Form/SubmitAnswerController.php
@@ -100,7 +100,7 @@ final class SubmitAnswerController extends AbstractController
             // Load current user session info and URL parameters.
             $parameters = new FormAccessParameters(
                 session_info: Session::getCurrentSessionInfo(),
-                url_parameters: $request->query->all(),
+                url_parameters: $request->request->all(),
             );
         }
 

--- a/src/Glpi/Form/AccessControl/FormAccessControlManager.php
+++ b/src/Glpi/Form/AccessControl/FormAccessControlManager.php
@@ -121,6 +121,10 @@ final class FormAccessControlManager
             return true;
         }
 
+        if (!$form->isActive()) {
+            return false;
+        }
+
         $access_controls_policies = $this->getActiveAccessControlsForForm($form);
         if (count($access_controls_policies) === 0) {
             // Refuse access if no access controls are configured.

--- a/templates/pages/form_renderer.html.twig
+++ b/templates/pages/form_renderer.html.twig
@@ -203,6 +203,11 @@
 
     <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}" />
 
+    {# Include direct access token if supplied #}
+    {% if token %}
+        <input type="hidden" name="token" value="{{ token }}" />
+    {% endif %}
+
     <script>
         import("{{ js_path('js/modules/Forms/RendererController.js') }}").then((m) => {
             new m.GlpiFormRendererController($('#forms_form_answers'));


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Two minor bugfixes for the forms feature.
1) Make sure only active forms can be answered.
2) The direct access token, which allow a form to be shared with a unique url like `http://localhost/Form/Render/526?token=xC4zlC6dOH6lCllLqjeMDMivmZNGPGx360AgIKWu`, needs to be included in the POSTed data when submitting answer as we obviously check it to make sure the user is allowed to answer the form.

