### PR TITLE
Apply same container width for all helpdesk pages

### DIFF
--- a/css/includes/components/_utils.scss
+++ b/css/includes/components/_utils.scss
@@ -54,3 +54,8 @@
 .w-fit-content {
     width: fit-content !important;
 }
+
+.force-full-width {
+    width: 100vw;
+    margin-left: calc(50% - 50vw);
+}

--- a/templates/layout/parts/page_header.html.twig
+++ b/templates/layout/parts/page_header.html.twig
@@ -143,5 +143,5 @@
       {% endif %}
 
       <div class="page-wrapper mb-0">
-         <div class="page-body container-fluid">
+         <div class="page-body container-fluid {{ is_helpdesk ? 'container-xl' : '' }}">
             <main role="main" id="page" class="legacy">

--- a/templates/pages/helpdesk/index.html.twig
+++ b/templates/pages/helpdesk/index.html.twig
@@ -34,7 +34,10 @@
 {% extends "layout/page_skeleton.html.twig" %}
 
 {% block content %}
-    <div class="d-flex flex-column helpdesk-home-container">
+    {# We override the parent width using .force-full-width because we need our background images and colors to bleed
+       through and use all the available width. The content is still using the correct width by redefining manually the
+       container size for each sections of the page using container-xl/container-narrow classes#}
+    <div class="d-flex flex-column helpdesk-home-container force-full-width">
         <div class="search-banner">
             <div class="container-narrow">
                 <h1 class="text-dark text-center">


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works (no tests are needed for this change).

## Description

As a reminder, we changed the helpdesk UI a few month ago to force the "horizontal" layout and reduced the container for new pages like the home page or the service catalog:

![image](https://github.com/user-attachments/assets/a1092c55-ccf1-4fd0-b842-469db927f11b)

This PR apply the same container to all the others helpdesk pages, for example here is the setting page before and after:

![image](https://github.com/user-attachments/assets/7311eb4a-5fcd-4e79-8e05-b0d1c71d3293)

![image](https://github.com/user-attachments/assets/5cb4e9f6-1384-4bb7-8490-067c722d82c0)

