### PR TITLE
Extract session entities force loading out its own listener

### DIFF
--- a/src/Glpi/Config/LegacyConfigurators/ConfigRest.php
+++ b/src/Glpi/Config/LegacyConfigurators/ConfigRest.php
@@ -60,35 +60,5 @@ final readonly class ConfigRest implements LegacyConfigProviderInterface
                 Session::checkCSRF($_POST);
             }
         }
-
-        // Manage profile change
-        if (isset($_REQUEST["force_profile"]) && ($_SESSION['glpiactiveprofile']['id'] ?? -1) != $_REQUEST["force_profile"]) {
-            if (isset($_SESSION['glpiprofiles'][$_REQUEST["force_profile"]])) {
-                Session::changeProfile($_REQUEST["force_profile"]);
-            }
-        }
-
-        // Manage entity change
-        if (isset($_REQUEST["force_entity"]) && ($_SESSION["glpiactive_entity"] ?? -1) != $_REQUEST["force_entity"]) {
-            Session::changeActiveEntities($_REQUEST["force_entity"], true);
-        } elseif (Session::shouldReloadActiveEntities()) {
-            Session::changeActiveEntities(
-                $_SESSION["glpiactive_entity"],
-                $_SESSION["glpiactive_entity_recursive"]
-            );
-        }
-
-        // The user's current groups are stored in his session
-        // If there was any change regarding groups membership and/or configuration, we
-        // need to reset the data stored in his session
-        if (
-            isset($_SESSION['glpigroups'])
-            && (
-                !isset($_SESSION['glpigroups_cache_date'])
-                || $_SESSION['glpigroups_cache_date'] < $GLPI_CACHE->get('last_group_change')
-            )
-        ) {
-            Session::loadGroups();
-        }
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

---

Note: when #18589 will be merged, this PR will have to remove "ConfigRest" too