### PR TITLE
Remove unused second argument when calling Html::popHeader

### DIFF
--- a/front/change_supplier.form.php
+++ b/front/change_supplier.form.php
@@ -42,7 +42,7 @@ use Glpi\Exception\Http\BadRequestHttpException;
 
 $link = new Change_Supplier();
 
-Html::popHeader(__('Email followup'), $_SERVER['PHP_SELF']);
+Html::popHeader(__('Email followup'));
 
 if (isset($_POST["update"])) {
     $link->check($_POST["id"], UPDATE);

--- a/front/change_user.form.php
+++ b/front/change_user.form.php
@@ -46,7 +46,7 @@ global $CFG_GLPI;
 $link = new Change_User();
 $item = new Change();
 
-Html::popHeader(__('Email followup'), $_SERVER['PHP_SELF']);
+Html::popHeader(__('Email followup'));
 
 if (isset($_POST["update"])) {
     $link->check($_POST["id"], UPDATE);

--- a/front/displaypreference.form.php
+++ b/front/displaypreference.form.php
@@ -39,7 +39,7 @@ Session::checkRightsOr('search_config', [DisplayPreference::PERSONAL,
 
 $setupdisplay = new DisplayPreference();
 
-Html::popHeader(__('Setup'), $_SERVER['PHP_SELF'], true);
+Html::popHeader(__('Setup'), in_modal: true);
 // Datas may come from GET or POST : use REQUEST
 if (isset($_REQUEST["itemtype"])) {
     $setupdisplay->display([

--- a/front/documenttype.list.php
+++ b/front/documenttype.list.php
@@ -33,7 +33,7 @@
  * ---------------------------------------------------------------------
  */
 
-Html::popHeader(__('Setup'), $_SERVER['PHP_SELF']);
+Html::popHeader(__('Setup'));
 
 $params = Search::manageParams('DocumentType', $_GET);
 

--- a/front/domainrecord.form.php
+++ b/front/domainrecord.form.php
@@ -68,7 +68,7 @@ if (isset($_POST["add"])) {
     $record->update($_POST);
     Html::back();
 } else if (isset($_GET['_in_modal'])) {
-    Html::popHeader(DomainRecord::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], true);
+    Html::popHeader(DomainRecord::getTypeName(Session::getPluralNumber()), in_modal: true);
     $record->showForm($_GET["id"], ['domains_id' => $_GET['domains_id'] ?? null]);
     Html::popFooter();
 } else {

--- a/front/group.form.php
+++ b/front/group.form.php
@@ -98,7 +98,7 @@ if (isset($_POST["add"])) {
     );
     Html::back();
 } else if (isset($_GET['_in_modal'])) {
-    Html::popHeader(Group::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], true);
+    Html::popHeader(Group::getTypeName(Session::getPluralNumber()), in_modal: true);
     $group->showForm($_GET["id"]);
     Html::popFooter();
 } else if (isset($_POST["replace"])) {

--- a/front/knowbaseitem.form.php
+++ b/front/knowbaseitem.form.php
@@ -170,7 +170,7 @@ if (isset($_POST["add"])) {
     }
 
     if (isset($_GET["_in_modal"])) {
-        Html::popHeader(__('Knowledge base'), $_SERVER['PHP_SELF']);
+        Html::popHeader(__('Knowledge base'));
         if ($_GET['id']) {
             $kb->check($_GET["id"], READ);
             $kb->showFull();

--- a/front/massiveaction.php
+++ b/front/massiveaction.php
@@ -42,7 +42,7 @@ Html::header_nocache();
 try {
     $ma = new MassiveAction($_POST, $_GET, 'process');
 } catch (\Throwable $e) {
-    Html::popHeader(__('Bulk modification error'), $_SERVER['PHP_SELF']);
+    Html::popHeader(__('Bulk modification error'));
 
     echo "<div class='center'><img src='" . $CFG_GLPI["root_doc"] . "/pics/warning.png' alt='" .
       __s('Warning') . "'><br><br>";
@@ -53,7 +53,7 @@ try {
     Html::popFooter();
     return;
 }
-Html::popHeader(__('Bulk modification'), $_SERVER['PHP_SELF']);
+Html::popHeader(__('Bulk modification'));
 
 $results   = $ma->process();
 

--- a/front/networkalias.form.php
+++ b/front/networkalias.form.php
@@ -96,7 +96,7 @@ if (isset($_POST["add"])) {
 }
 
 if (isset($_GET['_in_modal'])) {
-    Html::popHeader(NetworkAlias::getTypeName(1), $_SERVER['PHP_SELF']);
+    Html::popHeader(NetworkAlias::getTypeName(1));
     $alias->showForm($_GET["id"], $_GET);
     Html::popFooter();
 } else {

--- a/front/notification.tags.php
+++ b/front/notification.tags.php
@@ -35,7 +35,7 @@
 
 use Glpi\Exception\Http\BadRequestHttpException;
 
-Html::popHeader(__('List of available tags'), $_SERVER['PHP_SELF']);
+Html::popHeader(__('List of available tags'));
 
 if (isset($_GET["sub_type"])) {
     Session::checkCentralAccess();

--- a/front/problem_supplier.form.php
+++ b/front/problem_supplier.form.php
@@ -42,7 +42,7 @@ use Glpi\Exception\Http\BadRequestHttpException;
 
 $link = new Problem_Supplier();
 
-Html::popHeader(__('Email followup'), $_SERVER['PHP_SELF']);
+Html::popHeader(__('Email followup'));
 
 if (isset($_POST["update"])) {
     $link->check($_POST["id"], UPDATE);

--- a/front/problem_user.form.php
+++ b/front/problem_user.form.php
@@ -46,7 +46,7 @@ global $CFG_GLPI;
 $link = new Problem_User();
 $item = new Problem();
 
-Html::popHeader(__('Email followup'), $_SERVER['PHP_SELF']);
+Html::popHeader(__('Email followup'));
 
 if (isset($_POST["update"])) {
     $link->check($_POST["id"], UPDATE);

--- a/front/project.form.php
+++ b/front/project.form.php
@@ -118,7 +118,7 @@ if (isset($_POST["add"])) {
 
     Html::back();
 } else if (isset($_GET['_in_modal'])) {
-    Html::popHeader(Budget::getTypeName(1), $_SERVER['PHP_SELF'], true);
+    Html::popHeader(Budget::getTypeName(1), in_modal: true);
     $project->showForm($_GET["id"], ['withtemplate' => $_GET["withtemplate"]]);
     Html::popFooter();
 } else {

--- a/front/projecttask.form.php
+++ b/front/projecttask.form.php
@@ -122,7 +122,7 @@ if (isset($_POST["add"])) {
     );
     Html::back();
 } else if (isset($_GET['_in_modal'])) {
-    Html::popHeader(ProjectTask::getTypeName(1), $_SERVER['PHP_SELF'], true);
+    Html::popHeader(ProjectTask::getTypeName(1), in_modal: true);
     $task->showForm($_GET["id"], ['withtemplate' => $_GET["withtemplate"]]);
     Html::popFooter();
 } else {

--- a/front/rule.test.php
+++ b/front/rule.test.php
@@ -59,7 +59,7 @@ if (!$rule = getItemForItemtype($sub_type)) {
 }
 $rule->checkGlobal(READ);
 
-Html::popHeader(__('Setup'), $_SERVER['PHP_SELF']);
+Html::popHeader(__('Setup'));
 
 $rule->showRulePreviewCriteriasForm($_SERVER['PHP_SELF'], $rules_id);
 

--- a/front/rulesengine.test.php
+++ b/front/rulesengine.test.php
@@ -61,7 +61,7 @@ if ($rulecollection->isRuleRecursive()) {
 }
 $rulecollection->checkGlobal(READ);
 
-Html::popHeader(__('Setup'), $_SERVER['PHP_SELF']);
+Html::popHeader(__('Setup'));
 
 $rulecollection->showRulesEnginePreviewCriteriasForm($_SERVER['PHP_SELF'], $_POST, $condition);
 

--- a/front/supplier_ticket.form.php
+++ b/front/supplier_ticket.form.php
@@ -42,7 +42,7 @@ use Glpi\Exception\Http\BadRequestHttpException;
 
 $link = new Supplier_Ticket();
 
-Html::popHeader(__('Email followup'), $_SERVER['PHP_SELF']);
+Html::popHeader(__('Email followup'));
 
 if (isset($_POST["update"])) {
     $link->check($_POST["id"], UPDATE);

--- a/front/ticket_user.form.php
+++ b/front/ticket_user.form.php
@@ -42,7 +42,7 @@ global $CFG_GLPI;
 $link = new Ticket_User();
 $item = new Ticket();
 
-Html::popHeader(__('Email followup'), $_SERVER['PHP_SELF']);
+Html::popHeader(__('Email followup'));
 
 if (isset($_POST["update"])) {
     $link->check($_POST["id"], UPDATE);

--- a/src/Html.php
+++ b/src/Html.php
@@ -1635,7 +1635,7 @@ TWIG,
 
         // If in modal : display popHeader
         if (isset($_REQUEST['_in_modal']) && $_REQUEST['_in_modal']) {
-            return self::popHeader($title, $url, false, $sector, $item, $option);
+            return self::popHeader($title, '', false, $sector, $item, $option);
         }
         // Print a nice HTML-head for every page
         if ($HEADER_LOADED) {


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

`Html::popHeader()`'s second argument `$url` is not used, but it was still receiving `$_SERVER['PHP_SELF']` in many places.