### PR TITLE
Allow central users to use the service catalog

### DIFF
--- a/phpunit/functional/HtmlTest.php
+++ b/phpunit/functional/HtmlTest.php
@@ -282,6 +282,7 @@ class HtmlTest extends \GLPITestCase
 
         $expected = [
             'Ticket',
+            'Glpi\Form\ServiceCatalog\ServiceCatalog',
             'Problem',
             'Change',
             'Planning',

--- a/src/Glpi/Controller/Form/RendererController.php
+++ b/src/Glpi/Controller/Form/RendererController.php
@@ -42,6 +42,7 @@ use Glpi\Exception\Http\NotFoundHttpException;
 use Glpi\Form\AccessControl\FormAccessControlManager;
 use Glpi\Form\AccessControl\FormAccessParameters;
 use Glpi\Form\Form;
+use Glpi\Form\ServiceCatalog\ServiceCatalog;
 use Glpi\Http\Firewall;
 use Glpi\Security\Attribute\SecurityStrategy;
 use Session;
@@ -65,7 +66,7 @@ final class RendererController extends AbstractController
 
         return $this->render('pages/form_renderer.html.twig', [
             'title' => $form->fields['name'],
-            'menu' => ['admin', Form::getType()],
+            'menu' => ['helpdesk', ServiceCatalog::getType()],
             'form' => $form,
             'unauthenticated_user' => !Session::isAuthenticated(),
 

--- a/src/Glpi/Controller/ServiceCatalog/IndexController.php
+++ b/src/Glpi/Controller/ServiceCatalog/IndexController.php
@@ -37,7 +37,7 @@ namespace Glpi\Controller\ServiceCatalog;
 use Glpi\Controller\AbstractController;
 use Glpi\Form\AccessControl\FormAccessParameters;
 use Glpi\Form\ServiceCatalog\ItemRequest;
-use Glpi\Form\ServiceCatalog\ServiceCatalogCompositeInterface;
+use Glpi\Form\ServiceCatalog\ServiceCatalog;
 use Glpi\Form\ServiceCatalog\ServiceCatalogManager;
 use Glpi\Http\Firewall;
 use Glpi\Security\Attribute\SecurityStrategy;
@@ -48,15 +48,17 @@ use Symfony\Component\Routing\Attribute\Route;
 
 final class IndexController extends AbstractController
 {
+    private string $interface;
     private ServiceCatalogManager $service_catalog_manager;
 
     public function __construct()
     {
         // TODO: replace by autowiring once dependency injection is fully implemented.
         $this->service_catalog_manager = new ServiceCatalogManager();
+        $this->interface = Session::getCurrentInterface();
     }
 
-    #[SecurityStrategy(Firewall::STRATEGY_HELPDESK_ACCESS)]
+    #[SecurityStrategy(Firewall::STRATEGY_AUTHENTICATED)]
     #[Route(
         "/ServiceCatalog",
         name: "glpi_service_catalog",
@@ -76,7 +78,10 @@ final class IndexController extends AbstractController
 
         return $this->render('pages/self-service/service_catalog.html.twig', [
             'title' => __("New ticket"),
-            'menu'  => ["create_ticket"],
+            'menu'  => $this->interface == "central"
+                ? ["helpdesk", ServiceCatalog::class]
+                : ["create_ticket"]
+            ,
             'items' => $items,
         ]);
     }

--- a/src/Glpi/Form/ServiceCatalog/ServiceCatalog.php
+++ b/src/Glpi/Form/ServiceCatalog/ServiceCatalog.php
@@ -39,6 +39,8 @@ use CommonGLPI;
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\Form\Form;
 use Override;
+use Session;
+use Ticket;
 
 final class ServiceCatalog extends CommonGLPI
 {
@@ -48,9 +50,10 @@ final class ServiceCatalog extends CommonGLPI
         return __("Service catalog");
     }
 
-    public static function getIcon()
+    // TODO: Should be #[Override] but getIcon() is defined by CommonDBTM instead of CommonGLPI.
+    public static function getIcon(): string
     {
-        return "ti ti-notes";
+        return "ti ti-library";
     }
 
     #[Override]
@@ -82,5 +85,20 @@ final class ServiceCatalog extends CommonGLPI
         ]);
 
         return true;
+    }
+
+    #[Override]
+    public static function getSearchURL($full = true): string
+    {
+        /** @var array $CFG_GLPI */
+        global $CFG_GLPI;
+
+        return $full ? $CFG_GLPI['root_doc'] . '/ServiceCatalog' : '/ServiceCatalog';
+    }
+
+    #[Override]
+    public static function canView(): bool
+    {
+        return Session::haveRight(Ticket::$rightname, CREATE);
     }
 }

--- a/src/Html.php
+++ b/src/Html.php
@@ -43,6 +43,7 @@ use Glpi\Exception\Http\AccessDeniedHttpException;
 use Glpi\Exception\Http\BadRequestHttpException;
 use Glpi\Exception\Http\NotFoundHttpException;
 use Glpi\Exception\RedirectException;
+use Glpi\Form\ServiceCatalog\ServiceCatalog;
 use Glpi\Plugin\Hooks;
 use Glpi\Toolbox\FrontEnd;
 use Glpi\Toolbox\URL;
@@ -1298,7 +1299,7 @@ TWIG,
             'helpdesk' => [
                 'title' => __('Assistance'),
                 'types' => [
-                    'Ticket', 'Problem', 'Change',
+                    'Ticket', ServiceCatalog::class, 'Problem', 'Change',
                     'Planning', 'Stat', 'TicketRecurrent', 'RecurrentChange'
                 ],
                 'icon'    => 'ti ti-headset'
@@ -1502,7 +1503,7 @@ TWIG,
 
         if (Session::haveRight("ticket", CREATE)) {
             $menu['create_ticket'] = [
-                'default' => '/ServiceCatalog',
+                'default' => ServiceCatalog::getSearchURL(false),
                 'title'   => __('Create a ticket'),
                 'icon'    => 'ti ti-plus',
             ];
@@ -1527,7 +1528,7 @@ TWIG,
             ];
 
             if (Session::haveRight("ticket", CREATE)) {
-                $menu['tickets']['content']['ticket']['links']['add'] = '/ServiceCatalog';
+                $menu['tickets']['content']['ticket']['links']['add'] = ServiceCatalog::getSearchURL(false);
             }
         }
 

--- a/tests/cypress/e2e/form/service_catalog/service_catalog_page.cy.js
+++ b/tests/cypress/e2e/form/service_catalog/service_catalog_page.cy.js
@@ -141,4 +141,38 @@ describe('Service catalog page', () => {
         cy.get('@child_category').click();
         cy.findByRole('region', {'name': form_name}).should('exist');
     });
+
+    it('can use the service catalog on the central interface', () => {
+        cy.changeProfile('Super-Admin');
+
+        // Create a simple form
+        const form_name = `Test form for service_catalog_page.cy.js ${(new Date()).getTime()}`;
+        createActiveForm(form_name);
+        cy.get('@form_id').visitFormTab('Form');
+        cy.findByRole('button', {'name': 'Add a new question'}).click();
+        cy.focused().type('Question 1');
+        cy.findByRole('button', {'name': 'Save'}).click();
+        cy.findByRole('alert')
+            .should('contain.text', 'Item successfully updated')
+        ;
+
+        // Go to service catalog
+        cy.visit('/ServiceCatalog');
+        cy.validateBreadcrumbs(['Home', 'Assistance', 'Service catalog']);
+        cy.validateMenuIsActive('Service catalog');
+
+        // Go to our form
+        cy.findByRole('region', {'name': form_name}).as('form');
+        cy.get('@form').click();
+        cy.url().should('include', '/Form/Render');
+        cy.validateBreadcrumbs(['Home', 'Assistance', 'Service catalog']);
+        cy.validateMenuIsActive('Service catalog');
+
+        // Submit the form
+        cy.findByRole('textbox', {'name': 'Question 1'}).type('Answer 1');
+        cy.findByRole('button', {'name': 'Send form'}).click();
+        cy.findByRole('alert')
+            .should('contain.text', 'Item successfully created')
+        ;
+    });
 });

--- a/tests/cypress/support/commands.d.ts
+++ b/tests/cypress/support/commands.d.ts
@@ -39,5 +39,7 @@ declare namespace Cypress {
         checkAndCloseAlert(text: string): Chainable<any>
         getCsrfToken(): Chainable<any>
         changeEntity(entity: string|number, is_recursive: boolean): Chainable<any>
+        validateBreadcrumbs(breadcrumbs: array): Chainable<any>
+        validateMenuIsActive(name: string): Chainable<any>
     }
 }

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -481,3 +481,21 @@ Cypress.Commands.add('checkAndCloseAlert', (text) => {
     cy.get('@alert').should('contain.text', text);
     cy.get('@alert').findByRole('button', {name: 'Close'}).click();
 });
+
+Cypress.Commands.add('validateBreadcrumbs', (breadcrumbs) => {
+    cy.findByRole('banner').findAllByRole('list').eq(0).as('breadcrumbs');
+    breadcrumbs.forEach((expected_breadcrumb, i) => {
+        cy.get('@breadcrumbs')
+            .findAllByRole('link')
+            .eq(i)
+            .should('contains.text', expected_breadcrumb)
+        ;
+    });
+});
+
+Cypress.Commands.add('validateMenuIsActive', (name) => {
+    cy.findByRole('complementary')
+        .findByRole('link', {'name': name})
+        .should('have.class', 'active')
+    ;
+});


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Add a menu entry for the service catalog on the central interface and update the various controllers to make sure central user are allowed to use this page.

![image](https://github.com/user-attachments/assets/9f5eb9bb-4c12-45da-ac21-023151b18e3d)


