### PR TITLE
Add illustration picker for service catalog categories

### DIFF
--- a/src/Glpi/Form/Category.php
+++ b/src/Glpi/Form/Category.php
@@ -74,7 +74,7 @@ final class Category extends CommonTreeDropdown implements ServiceCatalogComposi
         $fields[] = [
             'name'  => 'illustration',
             'label' => __('Illustration'),
-            'type'  => 'text',
+            'type'  => 'illustration',
             'list'  => false,
         ];
 
@@ -96,7 +96,10 @@ final class Category extends CommonTreeDropdown implements ServiceCatalogComposi
     #[Override]
     public function getServiceCatalogItemIllustration(): string
     {
-        return $this->fields['illustration'];
+        /** @var array $CFG_GLPI */
+        global $CFG_GLPI;
+
+        return $this->fields['illustration'] ?: $CFG_GLPI['default_illustration'];
     }
 
     #[Override]

--- a/src/Glpi/Form/Category.php
+++ b/src/Glpi/Form/Category.php
@@ -97,9 +97,6 @@ final class Category extends CommonTreeDropdown implements ServiceCatalogComposi
     #[Override]
     public function getServiceCatalogItemIllustration(): string
     {
-        /** @var array $CFG_GLPI */
-        global $CFG_GLPI;
-
         return $this->fields['illustration'] ?: IllustrationManager::DEFAULT_ILLUSTRATION;
     }
 

--- a/src/Glpi/Form/Category.php
+++ b/src/Glpi/Form/Category.php
@@ -38,6 +38,7 @@ use CommonTreeDropdown;
 use Glpi\Form\ServiceCatalog\ItemRequest;
 use Glpi\Form\ServiceCatalog\ServiceCatalogCompositeInterface;
 use Glpi\Form\ServiceCatalog\ServiceCatalogItemInterface;
+use Glpi\UI\IllustrationManager;
 use Override;
 
 final class Category extends CommonTreeDropdown implements ServiceCatalogCompositeInterface
@@ -99,7 +100,7 @@ final class Category extends CommonTreeDropdown implements ServiceCatalogComposi
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        return $this->fields['illustration'] ?: $CFG_GLPI['default_illustration'];
+        return $this->fields['illustration'] ?: IllustrationManager::DEFAULT_ILLUSTRATION;
     }
 
     #[Override]

--- a/src/Glpi/Form/Form.php
+++ b/src/Glpi/Form/Form.php
@@ -48,6 +48,7 @@ use Glpi\DBAL\QuerySubQuery;
 use Glpi\Form\AccessControl\FormAccessControlManager;
 use Glpi\Form\QuestionType\QuestionTypesManager;
 use Glpi\Form\ServiceCatalog\ServiceCatalogLeafInterface;
+use Glpi\UI\IllustrationManager;
 use Html;
 use Log;
 use MassiveAction;
@@ -882,7 +883,7 @@ final class Form extends CommonDBTM implements ServiceCatalogLeafInterface
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        return $this->fields['illustration'] ?: $CFG_GLPI['default_illustration'];
+        return $this->fields['illustration'] ?: IllustrationManager::DEFAULT_ILLUSTRATION;
     }
 
     #[Override]

--- a/src/Glpi/Form/Form.php
+++ b/src/Glpi/Form/Form.php
@@ -880,9 +880,6 @@ final class Form extends CommonDBTM implements ServiceCatalogLeafInterface
     #[Override]
     public function getServiceCatalogItemIllustration(): string
     {
-        /** @var array $CFG_GLPI */
-        global $CFG_GLPI;
-
         return $this->fields['illustration'] ?: IllustrationManager::DEFAULT_ILLUSTRATION;
     }
 

--- a/src/Glpi/Form/Form.php
+++ b/src/Glpi/Form/Form.php
@@ -879,7 +879,10 @@ final class Form extends CommonDBTM implements ServiceCatalogLeafInterface
     #[Override]
     public function getServiceCatalogItemIllustration(): string
     {
-        return $this->fields['illustration'] ?: 'request-service';
+        /** @var array $CFG_GLPI */
+        global $CFG_GLPI;
+
+        return $this->fields['illustration'] ?: $CFG_GLPI['default_illustration'];
     }
 
     #[Override]

--- a/src/Glpi/UI/IllustrationManager.php
+++ b/src/Glpi/UI/IllustrationManager.php
@@ -42,6 +42,8 @@ final class IllustrationManager
     private string $icons_sprites_path;
     private ?array $icons_definitions = null;
 
+    public const DEFAULT_ILLUSTRATION = "request-service";
+
     public function __construct(
         ?string $icons_definition_file = null,
         ?string $icons_sprites_path = null,

--- a/src/autoload/CFG_GLPI.php
+++ b/src/autoload/CFG_GLPI.php
@@ -650,3 +650,4 @@ $CFG_GLPI['admin_types'] = [
 
 $CFG_GLPI['process_types'] = ['Computer'];
 $CFG_GLPI['environment_types'] = ['Computer'];
+$CFG_GLPI['default_illustration'] = 'request-service';

--- a/src/autoload/CFG_GLPI.php
+++ b/src/autoload/CFG_GLPI.php
@@ -650,4 +650,3 @@ $CFG_GLPI['admin_types'] = [
 
 $CFG_GLPI['process_types'] = ['Computer'];
 $CFG_GLPI['environment_types'] = ['Computer'];
-$CFG_GLPI['default_illustration'] = 'request-service';

--- a/templates/dropdown_form.html.twig
+++ b/templates/dropdown_form.html.twig
@@ -114,7 +114,7 @@
                         {{ fields.autoNameField(field['name'], item, field['label'], withtemplate, fields_params) }}
                     {% elseif type == 'textarea' %}
                         {{ fields.textareaField(field['name'], item.fields[field['name']], field['label'], fields_params) }}
-                     {% elseif type == 'richtext' %}
+                    {% elseif type == 'richtext' %}
                         {{ fields.textareaField(
                             field['name'],
                             item.fields[field['name']],
@@ -123,6 +123,12 @@
                                 'enable_richtext': true,
                                 'enable_images': false,
                             })
+                        ) }}
+                    {% elseif type == 'illustration' %}
+                        {{ fields.illustrationField(
+                            field['name'],
+                            item.fields[field['name']],
+                            field['label'],
                         ) }}
                     {% elseif type == 'integer' %}
                         {% set fields_params = {


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.

## Description

I forgot to apply the new `illustrationField` to the categories in #18565.
I've also added a new `$CFG_GLPI['default_illustration']` config entry to easily update the default illustration later on.