### PR TITLE
Add an information message when the service catalog has no forms

### DIFF
--- a/src/Glpi/Controller/ServiceCatalog/ItemsController.php
+++ b/src/Glpi/Controller/ServiceCatalog/ItemsController.php
@@ -94,7 +94,10 @@ final class ItemsController extends AbstractController
 
         return $this->render(
             'components/helpdesk_forms/service_catalog_items.html.twig',
-            ['items' => $items]
+            [
+                'items' => $items,
+                'is_default_search' => false,
+            ]
         );
     }
 }

--- a/templates/components/helpdesk_forms/service_catalog_items.html.twig
+++ b/templates/components/helpdesk_forms/service_catalog_items.html.twig
@@ -70,4 +70,20 @@
             </section>
         </div>
     {% endif %}
+{% else %}
+    {% if is_default_search %}
+        {# The user is not allowed to see any forms at this time #}
+        {% set empty_title = __("There are no forms available") %}
+        {% set empty_subtitle = __("Please try again later.") %}
+    {% else %}
+        {# The current search filter did not match any forms #}
+        {% set empty_title = __("No forms found") %}
+        {% set empty_subtitle = __("Try different keywords or filters.") %}
+    {% endif %}
+    <div class="empty">
+        <p class="empty-title">{{ empty_title }}</p>
+        <p class="empty-subtitle text-secondary">
+            {{ empty_subtitle }}
+        </p>
+    </div>
 {% endfor %}

--- a/templates/pages/self-service/service_catalog.html.twig
+++ b/templates/pages/self-service/service_catalog.html.twig
@@ -59,7 +59,10 @@
     >
         {{ include(
             'components/helpdesk_forms/service_catalog_items.html.twig',
-            {items: items},
+            {
+                items: items,
+                is_default_search: true,
+            },
             with_context = false
         ) }}
     </section>

--- a/tests/cypress/e2e/form/service_catalog/service_catalog_page.cy.js
+++ b/tests/cypress/e2e/form/service_catalog/service_catalog_page.cy.js
@@ -94,6 +94,11 @@ describe('Service catalog page', () => {
         cy.get('@filter_input').clear();
         cy.get('@filter_input').type(form_name);
         cy.get('@forms').findByText(form_name).should('exist');
+
+        // Check that an information message is displayed when there are no results
+        cy.get('@filter_input').clear();
+        cy.get('@filter_input').type("aaaaaaaaaaaaaaaaaaaaa");
+        cy.findByText('No forms found').should('be.visible');
     });
 
     it('can pick a category in the service catalog', () => {


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Show a message when a search do not return any results in the service catalog.

![image](https://github.com/user-attachments/assets/4cbed7f3-912e-4237-9dc6-5ee81042bba8)