### PR TITLE
feat(forms): Add 'Active entity of the form filler' strategy for EntityField

### DIFF
--- a/phpunit/functional/Glpi/Form/Destination/CommonITILField/EntityFieldTest.php
+++ b/phpunit/functional/Glpi/Form/Destination/CommonITILField/EntityFieldTest.php
@@ -82,6 +82,30 @@ final class EntityFieldTest extends DbTestCase
         ];
     }
 
+    public function testEntityFormFiller()
+    {
+        $form = $this->createAndGetFormWithMultipleEntityAndRequesterQuestions();
+        $answers = $this->getAnswers();
+        $this->sendFormAndAssertTicketEntity(
+            form: $form,
+            config: new EntityFieldConfig(
+                EntityFieldStrategy::FORM_FILLER
+            ),
+            answers: $answers['answers'],
+            expected_entity_id: $this->getTestRootEntity(true)
+        );
+
+        $this->setEntity($answers['entities'][0]->getName(), false);
+        $this->sendFormAndAssertTicketEntity(
+            form: $form,
+            config: new EntityFieldConfig(
+                EntityFieldStrategy::FORM_FILLER
+            ),
+            answers: $answers['answers'],
+            expected_entity_id: $answers['entities'][0]->getId()
+        );
+    }
+
     public function testEntityFromForm()
     {
         $form = $this->createAndGetFormWithMultipleEntityAndRequesterQuestions();

--- a/src/Glpi/Form/Destination/CommonITILField/EntityField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/EntityField.php
@@ -130,7 +130,7 @@ class EntityField extends AbstractConfigField
     #[Override]
     public function getDefaultConfig(Form $form): EntityFieldConfig
     {
-        // Returne last valid answer by default and fallback
+        // Return last valid answer by default and fallback
         // to form entity if no valid answer was found
         $valid_answers = array_filter(
             $form->getQuestionsByType(
@@ -141,7 +141,7 @@ class EntityField extends AbstractConfigField
 
         if (count($valid_answers) == 0) {
             return new EntityFieldConfig(
-                EntityFieldStrategy::FROM_FORM
+                EntityFieldStrategy::FORM_FILLER
             );
         }
 

--- a/src/Glpi/Form/Destination/CommonITILField/EntityFieldStrategy.php
+++ b/src/Glpi/Form/Destination/CommonITILField/EntityFieldStrategy.php
@@ -38,9 +38,11 @@ namespace Glpi\Form\Destination\CommonITILField;
 use Entity;
 use Glpi\Form\AnswersSet;
 use Glpi\Form\QuestionType\QuestionTypeItem;
+use Session;
 
 enum EntityFieldStrategy: string
 {
+    case FORM_FILLER          = 'form_filler';
     case FROM_FORM            = 'from_form';
     case SPECIFIC_VALUE       = 'specific_value';
     case SPECIFIC_ANSWER      = 'specific_answer';
@@ -49,6 +51,7 @@ enum EntityFieldStrategy: string
     public function getLabel(): string
     {
         return match ($this) {
+            self::FORM_FILLER          => __("Active entity of the form filler"),
             self::FROM_FORM            => __("From form"),
             self::SPECIFIC_VALUE       => __("Specific entity"),
             self::SPECIFIC_ANSWER      => __("Answer from a specific question"),
@@ -61,6 +64,7 @@ enum EntityFieldStrategy: string
         AnswersSet $answers_set,
     ): ?int {
         return match ($this) {
+            self::FORM_FILLER          => $this->getFormFillerEntityID(),
             self::FROM_FORM            => $answers_set->getItem()->fields['entities_id'],
             self::SPECIFIC_VALUE       => $config->getSpecificEntityId(),
             self::SPECIFIC_ANSWER      => $this->getEntityIDForSpecificAnswer(
@@ -69,6 +73,11 @@ enum EntityFieldStrategy: string
             ),
             self::LAST_VALID_ANSWER => $this->getEntityIDForLastValidAnswer($answers_set),
         };
+    }
+
+    private function getFormFillerEntityID(): int
+    {
+        return Session::getActiveEntity();
     }
 
     private function getEntityIDForSpecificAnswer(

--- a/tests/cypress/e2e/form/destination_config_fields/entity.cy.js
+++ b/tests/cypress/e2e/form/destination_config_fields/entity.cy.js
@@ -68,6 +68,12 @@ describe('Entity configuration', () => {
         cy.get('@config').getDropdownByLabelText('Select an entity...').should('not.exist');
         cy.get('@config').getDropdownByLabelText('Select a question...').should('not.exist');
 
+        // Switch to "Form filler"
+        cy.get('@entity_dropdown').selectDropdownValue('Active entity of the form filler');
+        cy.findByRole('button', { 'name': 'Update item' }).click();
+        cy.checkAndCloseAlert('Item successfully updated');
+        cy.get('@entity_dropdown').should('have.text', 'Active entity of the form filler');
+
         // Switch to "From form"
         cy.get('@entity_dropdown').selectDropdownValue('From form');
         cy.findByRole('button', { 'name': 'Update item' }).click();


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Added a new strategy `Active entity of the form filler` for `EntityField` form destination config.
This strategy retrieves the active entity of the user who filled in the form and applies it to the destination created.

![image](https://github.com/user-attachments/assets/e408dbf4-5619-4b9d-ab4e-819b3da08b2c)
