### PR TITLE
Allow assigning users while creating a closed ticket

### DIFF
--- a/phpunit/functional/TicketTest.php
+++ b/phpunit/functional/TicketTest.php
@@ -7654,4 +7654,104 @@ HTML
 
         $this->assertEquals(\CommonITILValidation::REFUSED, TicketValidation::computeValidationStatus($ticket));
     }
+
+    public function testCanAssign()
+    {
+        $this->login();
+
+        $ticket = new \Ticket();
+        $tickets_id = $ticket->add([
+            'name' => __FUNCTION__,
+            'content' => __FUNCTION__,
+            '_skip_auto_assign' => true,
+            '_actors' => [
+                'assign' => [
+                    [
+                        'itemtype'  => 'User',
+                        'items_id'  => getItemByTypeName('User', 'tech', true),
+                        'use_notification' => 0,
+                        'alternative_email' => '',
+                    ]
+                ]
+            ]
+        ]);
+        $this->assertGreaterThan(0, $tickets_id);
+        $ticket->loadActors();
+        $this->assertEquals(1, $ticket->countUsers(\CommonITILActor::ASSIGN));
+
+        // Assigning technician during creation of closed ticket should work
+        $tickets_id = $ticket->add([
+            'name' => __FUNCTION__,
+            'content' => __FUNCTION__,
+            'status' => \CommonITILObject::CLOSED,
+            '_actors' => [
+                'assign' => [
+                    [
+                        'itemtype'  => 'User',
+                        'items_id'  => getItemByTypeName('User', 'tech', true),
+                        'use_notification' => 0,
+                        'alternative_email' => '',
+                    ]
+                ]
+            ],
+            '_skip_auto_assign' => true,
+        ]);
+        $this->assertGreaterThan(0, $tickets_id);
+        $ticket->loadActors();
+        $this->assertEquals(1, $ticket->countUsers(\CommonITILActor::ASSIGN));
+        $this->assertEquals(\CommonITILObject::CLOSED, $ticket->fields['status']);
+
+        // Assigning technician in same update as closing should work
+        $tickets_id = $ticket->add([
+            'name' => __FUNCTION__,
+            'content' => __FUNCTION__,
+            '_skip_auto_assign' => true,
+        ]);
+        $this->assertGreaterThan(0, $tickets_id);
+        $ticket->loadActors();
+        $this->assertEquals(0, $ticket->countUsers(\CommonITILActor::ASSIGN));
+        $ticket->update([
+            'id' => $tickets_id,
+            'status' => \CommonITILObject::CLOSED,
+            '_actors' => [
+                'assign' => [
+                    [
+                        'itemtype'  => 'User',
+                        'items_id'  => getItemByTypeName('User', 'tech', true),
+                        'use_notification' => 0,
+                        'alternative_email' => '',
+                    ]
+                ]
+            ]
+        ]);
+        $ticket->loadActors();
+        $this->assertEquals(1, $ticket->countUsers(\CommonITILActor::ASSIGN));
+        $this->assertEquals(\CommonITILObject::CLOSED, $ticket->fields['status']);
+
+        // Assigning technician after ticket is already closed should be blocked
+        $tickets_id = $ticket->add([
+            'name' => __FUNCTION__,
+            'content' => __FUNCTION__,
+            'status' => \CommonITILObject::CLOSED,
+            '_skip_auto_assign' => true,
+        ]);
+        $this->assertGreaterThan(0, $tickets_id);
+        $ticket->loadActors();
+        $this->assertEquals(0, $ticket->countUsers(\CommonITILActor::ASSIGN));
+        $this->assertFalse($ticket->update([
+            'id' => $tickets_id,
+            '_actors' => [
+                'assign' => [
+                    [
+                        'itemtype'  => 'User',
+                        'items_id'  => getItemByTypeName('User', 'tech', true),
+                        'use_notification' => 0,
+                        'alternative_email' => '',
+                    ]
+                ]
+            ]
+        ]));
+        $ticket->loadActors();
+        $this->assertEquals(0, $ticket->countUsers(\CommonITILActor::ASSIGN));
+    }
 }

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -906,12 +906,10 @@ abstract class CommonITILObject extends CommonDBTM
      */
     public function canAssign()
     {
-        if (
-            isset($this->fields['is_deleted']) && ($this->fields['is_deleted'] == 1)
-            || isset($this->fields['status']) && in_array($this->fields['status'], $this->getClosedStatusArray())
-        ) {
+        if ($this->isDeleted() || (!$this->isNewItem() && $this->isClosed())) {
             return false;
         }
+
         return Session::haveRight(static::$rightname, UPDATE);
     }
 
@@ -3588,7 +3586,7 @@ abstract class CommonITILObject extends CommonDBTM
         }
 
         return in_array(
-            $this->fields['status'],
+            $this->fields['status'] ?? null,
             $status
         );
     }
@@ -3603,7 +3601,7 @@ abstract class CommonITILObject extends CommonDBTM
     public function isClosed()
     {
         return in_array(
-            $this->fields['status'],
+            $this->fields['status'] ?? null,
             $this->getClosedStatusArray()
         );
     }

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -185,10 +185,7 @@ class Ticket extends CommonITILObject
 
     public function canAssign()
     {
-        if (
-            isset($this->fields['is_deleted']) && ($this->fields['is_deleted'] == 1)
-            || isset($this->fields['status']) && in_array($this->fields['status'], $this->getClosedStatusArray())
-        ) {
+        if ($this->isDeleted() || (!$this->isNewItem() && $this->isClosed())) {
             return false;
         }
         return Session::haveRight(static::$rightname, self::ASSIGN);


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

Fixes #18016

When creating a ticket, the status field gets populated before actors are handled. Because of that, the `canAssign` check will fail because you aren't supposed to be able to assign technicians **after** the ticket is closed. The check now ignores the status if it is a new Ticket.