### PR TITLE
Allow validating only unsolved ITIL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ The present file will list all changes made to the project; according to the
 - Notifications can now specify exclusions for recipients.
 - Warranty expiration alerts no longer trigger for deleted items.
 - New UI for searching for Ticket/Change/Problem solutions from the Knowledgebase.
+- Validations are only allowed on Tickets and Changes that are not solved or closed.
 
 ### Deprecated
 - Survey URL tags `TICKETCATEGORY_ID` and `TICKETCATEGORY_NAME` are deprecated and replaced by `ITILCATEGORY_ID` and `ITILCATEGORY_NAME` respectively.

--- a/phpunit/functional/TicketValidationTest.php
+++ b/phpunit/functional/TicketValidationTest.php
@@ -342,7 +342,16 @@ class TicketValidationTest extends CommonITILValidation
                     'name'      => 'Ticket_Closed_With_Validation_Request',
                     'content'   => 'Ticket_Closed_With_Validation_Request',
                 ],
-                'expected'  => 1,
+                'expected'  => true,
+                'user_id'   => getItemByTypeName('User', 'glpi', true)
+            ],
+            [
+                'input'     => [
+                    'name' => 'Ticket_With_Validation_Request',
+                    'content' => 'Ticket_With_Validation_Request',
+                    'status' =>  CommonITILObject::SOLVED
+                ],
+                'expected'  => false,
                 'user_id'   => getItemByTypeName('User', 'glpi', true)
             ],
             [
@@ -351,7 +360,7 @@ class TicketValidationTest extends CommonITILValidation
                     'content' => 'Ticket_With_Validation_Request',
                     'status' =>  CommonITILObject::CLOSED
                 ],
-                'expected'  => 0,
+                'expected'  => false,
                 'user_id'   => getItemByTypeName('User', 'glpi', true)
             ],
         ];
@@ -360,10 +369,12 @@ class TicketValidationTest extends CommonITILValidation
     #[DataProvider('testgetNumberToValidateProvider')]
     public function testgetNumberToValidate(
         array $input,
-        int $expected,
+        bool $expected,
         int $user_id
     ): void {
         $this->login();
+
+        $initial_count = \TicketValidation::getNumberToValidate($user_id);
 
         /** Create a ticket, approval requested */
         $ticket = $this->createItem('Ticket', $input);
@@ -374,6 +385,6 @@ class TicketValidationTest extends CommonITILValidation
             'items_id_target' => $user_id,
         ]);
 
-        $this->assertEquals($expected, \TicketValidation::getNumberToValidate($user_id));
+        $this->assertEquals($expected ? ($initial_count + 1) : $initial_count, \TicketValidation::getNumberToValidate($user_id));
     }
 }

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -7737,7 +7737,7 @@ abstract class CommonITILObject extends CommonDBTM
                 $canedit = $validation_obj->can($validations_id, UPDATE);
                 $cananswer = $validation_obj->canValidate($this->getID())
                     && $validation_row['status'] == CommonITILValidation::WAITING
-                    && !in_array($this->fields['status'], $this->getClosedStatusArray());
+                    && !$this->isSolved(true);
                 $user = new User();
                 $user->getFromDB($validation_row['users_id_validate']);
 

--- a/src/CommonITILValidation.php
+++ b/src/CommonITILValidation.php
@@ -711,7 +711,7 @@ abstract class CommonITILValidation extends CommonDBChild
         /** @var \DBmysql $DB */
         global $DB;
 
-        $row = $DB->request([
+        $it = $DB->request([
             'FROM'   => static::$itemtype::getTable(),
             'COUNT'  => 'cpt',
             'WHERE'  => [
@@ -726,12 +726,12 @@ abstract class CommonITILValidation extends CommonDBChild
                     ])
                 ],
                 'NOT' => [
-                    'status' => static::$itemtype::getClosedStatusArray(),
+                    'status' => [...static::$itemtype::getSolvedStatusArray(), ...static::$itemtype::getClosedStatusArray()],
                 ],
             ]
-        ])->current();
+        ]);
 
-        return $row['cpt'];
+        return $it->current()['cpt'];
     }
 
     /**

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -4207,8 +4207,8 @@ JAVASCRIPT;
 
                         $options['criteria'][2]['field']      = 12; // validation aprobator
                         $options['criteria'][2]['searchtype'] = 'equals';
-                        $options['criteria'][2]['value']      = 'old';
-                        $options['criteria'][2]['link']       = 'AND NOT';
+                        $options['criteria'][2]['value']      = 'notold';
+                        $options['criteria'][2]['link']       = 'AND';
 
                         $options['criteria'][3]['field']      = 52; // global validation status
                         $options['criteria'][3]['searchtype'] = 'equals';
@@ -4658,8 +4658,8 @@ JAVASCRIPT;
 
             $opt['criteria'][2]['field']      = 12; // ticket status
             $opt['criteria'][2]['searchtype'] = 'equals';
-            $opt['criteria'][2]['value']      = Ticket::CLOSED;
-            $opt['criteria'][2]['link']       = 'AND NOT';
+            $opt['criteria'][2]['value']      = 'notold';
+            $opt['criteria'][2]['link']       = 'AND';
 
             $twig_params['items'][] = [
                 'link'    => self::getSearchURL() . "?" . Toolbox::append_params($opt),


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

While working on #17215, I noticed one place where the search result link for tickets waiting for approval filtered to unsolved tickets only. Some of the issue reported in the bug report was fixed in #18380 but there was still an inconsistency. Instead of hiding the ability to validate closed tickets only, it seems like it makes sense to also block validating solved tickets and changes. Once something is solved, all actions should be considered finished so approvals are expected to happen before that. Once solved, it is just waiting for user validation that the fix worked or validation from technicians in the case of an Observed change.
