### PR TITLE
Fix "Number of" search options for ITIL Categories

### DIFF
--- a/phpunit/functional/SearchTest.php
+++ b/phpunit/functional/SearchTest.php
@@ -898,6 +898,11 @@ class SearchTest extends DbTestCase
                     in_array($so['datatype'], $valid_datatypes),
                     sprintf('Unexpected `%s` search option datatype.', $so['datatype'])
                 );
+
+                if ($so['datatype'] === 'count') {
+                    // Must have `usehaving` = true because an aggregate function will be used
+                    $this->assertTrue($so['usehaving'] ?? false);
+                }
             }
         }
     }

--- a/src/ITILCategory.php
+++ b/src/ITILCategory.php
@@ -253,6 +253,7 @@ class ITILCategory extends CommonTreeDropdown
             'name'               => _x('quantity', 'Number of tickets'),
             'datatype'           => 'count',
             'forcegroupby'       => true,
+            'usehaving'          => true,
             'massiveaction'      => false,
             'joinparams'         => [
                 'jointype'           => 'child'
@@ -266,6 +267,7 @@ class ITILCategory extends CommonTreeDropdown
             'name'               => _x('quantity', 'Number of problems'),
             'datatype'           => 'count',
             'forcegroupby'       => true,
+            'usehaving'          => true,
             'massiveaction'      => false,
             'joinparams'         => [
                 'jointype'           => 'child'
@@ -279,6 +281,7 @@ class ITILCategory extends CommonTreeDropdown
             'name'               => _x('quantity', 'Number of changes'),
             'datatype'           => 'count',
             'forcegroupby'       => true,
+            'usehaving'          => true,
             'massiveaction'      => false,
             'joinparams'         => [
                 'jointype'           => 'child'


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

Fixes #18333

These options use `count` datatype which results in an aggregate COUNT function being used so the criteria must use `HAVING`.