### PR TITLE
Do not trigger warranty alerts on deleted items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ The present file will list all changes made to the project; according to the
 - `Group` and `Group in charge` fields for assets may now contain multiple groups.
 - "If software are no longer used" transfer option is now taken into account rather than always preserving.
 - Notifications can now specify exclusions for recipients.
+- Warranty expiration alerts no longer trigger for deleted items.
 
 ### Deprecated
 - Survey URL tags `TICKETCATEGORY_ID` and `TICKETCATEGORY_NAME` are deprecated and replaced by `ITILCATEGORY_ID` and `ITILCATEGORY_NAME` respectively.

--- a/phpunit/functional/InfocomTest.php
+++ b/phpunit/functional/InfocomTest.php
@@ -230,11 +230,23 @@ class InfocomTest extends \DBTestCase
             'entities_id' => $root_entity->getID(),
             'is_deleted' => 1,
         ]);
-        $deleted_infocom_id = $infocom->add([
+        $deleted_expired_infocom_id = $infocom->add([
             'itemtype' => 'Computer',
             'items_id' => $deleted_id,
             'warranty_date' => date('Y-m-d', strtotime('-1 year')),
             'warranty_duration' => 10, // 10 months
+        ]);
+
+        $deleted_id2 = $computer->add([
+            'name' => 'Deleted test',
+            'entities_id' => $root_entity->getID(),
+            'is_deleted' => 1,
+        ]);
+        $deleted_infocom_id = $infocom->add([
+            'itemtype' => 'Computer',
+            'items_id' => $deleted_id2,
+            'warranty_date' => date('Y-m-d', strtotime('-1 year')),
+            'warranty_duration' => 14, // 14 months
         ]);
 
         $not_deleted_id = $computer->add([
@@ -252,9 +264,11 @@ class InfocomTest extends \DBTestCase
         \Infocom::cronInfocom();
         $alerts = array_values(getAllDataFromTable(\Alert::getTable(), [
             'itemtype' => 'Infocom',
-            'items_id' => [$deleted_infocom_id, $not_deleted_infocom_id],
+            'items_id' => [$deleted_infocom_id, $deleted_expired_infocom_id, $not_deleted_infocom_id],
         ]));
-        $this->assertCount(1, $alerts);
+
+        $this->assertCount(2, $alerts);
         $this->assertSame($not_deleted_infocom_id, $alerts[0]['items_id']);
+        $this->assertSame($deleted_expired_infocom_id, $alerts[1]['items_id']);
     }
 }

--- a/phpunit/functional/InfocomTest.php
+++ b/phpunit/functional/InfocomTest.php
@@ -39,7 +39,7 @@ namespace tests\units;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 
-class InfocomTest extends \GLPITestCase
+class InfocomTest extends \DBTestCase
 {
     public static function dataLinearAmortise()
     {
@@ -203,5 +203,58 @@ class InfocomTest extends \GLPITestCase
         if (count($oldmft)) {
             $this->assertSame($oldmft, \Infocom::mapOldAmortiseFormat($amortise, false));
         }
+    }
+
+    /**
+     * Test that alerts are raised for non-deleted items that have warranties that are about to expire.
+     * @return void
+     */
+    public function testExpireCronAlerts()
+    {
+        /** @var array $CFG_GLPI */
+        global $CFG_GLPI;
+
+        $this->login();
+        $root_entity = $this->getTestRootEntity();
+        $computer = new \Computer();
+        $infocom = new \Infocom();
+
+        $this->assertTrue($root_entity->update([
+            'id' => $root_entity->getID(),
+            'use_infocoms_alert' => 1,
+            'send_infocoms_alert_before_delay' => 10, // 10 days
+        ]));
+
+        $deleted_id = $computer->add([
+            'name' => 'Deleted test',
+            'entities_id' => $root_entity->getID(),
+            'is_deleted' => 1,
+        ]);
+        $deleted_infocom_id = $infocom->add([
+            'itemtype' => 'Computer',
+            'items_id' => $deleted_id,
+            'warranty_date' => date('Y-m-d', strtotime('-1 year')),
+            'warranty_duration' => 10, // 10 months
+        ]);
+
+        $not_deleted_id = $computer->add([
+            'name' => 'Not deleted test',
+            'entities_id' => $root_entity->getID(),
+        ]);
+        $not_deleted_infocom_id = $infocom->add([
+            'itemtype' => 'Computer',
+            'items_id' => $not_deleted_id,
+            'warranty_date' => date('Y-m-d', strtotime('-1 year')),
+            'warranty_duration' => 10, // 10 months
+        ]);
+
+        $CFG_GLPI["use_notifications"] = true;
+        \Infocom::cronInfocom();
+        $alerts = array_values(getAllDataFromTable(\Alert::getTable(), [
+            'itemtype' => 'Infocom',
+            'items_id' => [$deleted_infocom_id, $not_deleted_infocom_id],
+        ]));
+        $this->assertCount(1, $alerts);
+        $this->assertSame($not_deleted_infocom_id, $alerts[0]['items_id']);
     }
 }

--- a/src/Infocom.php
+++ b/src/Infocom.php
@@ -719,6 +719,7 @@ class Infocom extends CommonDBChild
 
                           $data['warrantyexpiration']        = $warranty;
                           $data['item_name']                 = $item_infocom->getName();
+                          $data['is_deleted']                = $item_infocom->maybeDeleted() ? (int) $item_infocom->fields['is_deleted'] : 0;
                           $items_infos[$entity][$data['id']] = $data;
 
                         if (!isset($items_messages[$entity])) {
@@ -731,9 +732,14 @@ class Infocom extends CommonDBChild
         }
 
         foreach ($items_infos as $entity => $items) {
+            // We will ignore items that have been deleted, but we won't add an alert to the DB in case they are restored before the warranty expires
+            $not_deleted_items = array_filter($items, static function ($item) {
+                return $item['is_deleted'] === 0;
+            });
             if (
-                NotificationEvent::raiseEvent("alert", new self(), ['entities_id' => $entity,
-                    'items'       => $items
+                NotificationEvent::raiseEvent("alert", new self(), [
+                    'entities_id' => $entity,
+                    'items'       => $not_deleted_items
                 ])
             ) {
                 $message     = $items_messages[$entity];
@@ -757,9 +763,11 @@ class Infocom extends CommonDBChild
                 }
 
                 $alert             = new Alert();
-                $input["itemtype"] = 'Infocom';
-                $input["type"]     = Alert::END;
-                foreach ($items as $id => $item) {
+                $input = [
+                    'itemtype' => 'Infocom',
+                    'type'     => Alert::END
+                ];
+                foreach ($not_deleted_items as $id => $item) {
                     $input["items_id"] = $id;
                     $alert->add($input);
                     unset($alert->fields['id']);


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] This change requires a documentation update.

## Description

Fixes #17408
If an item is deleted when the warranty expiration automatic action is run, there will not be a notification triggered for it. There will also not be an Alert created for it (unless the warranty has reached its expiration) so that if the item is restored, warranty alerts can be triggered.