### PR TITLE
Display some actions after a form is submitted

### DIFF
--- a/js/modules/Forms/RendererController.js
+++ b/js/modules/Forms/RendererController.js
@@ -31,7 +31,7 @@
  * ---------------------------------------------------------------------
  */
 
-/* global glpi_toast_info, tinymce */
+/* global glpi_toast_info, tinymce, glpi_toast_error */
 
 /**
  * Client code to handle users actions on the form_renderer template
@@ -148,7 +148,9 @@ export class GlpiFormRendererController
                 .addClass("d-none");
 
         } catch {
-            // Failure (TODO)
+            glpi_toast_error(
+                __("Failed to submit form, please contact your administrator.")
+            );
         }
     }
 

--- a/templates/pages/form_renderer.html.twig
+++ b/templates/pages/form_renderer.html.twig
@@ -196,6 +196,14 @@
                 <p class="empty-subtitle text-secondary">
                     {{ __("Your form has been submitted successfully.") }}
                 </p>
+                <div class="mt-3 d-flex">
+                    <a class="btn btn-outline-secondary me-2" href="{{ path('/ServiceCatalog') }}">
+                        {{ __("Go back to service catalog") }}
+                    </a>
+                    <a class="btn btn-outline-secondary" href="{{ path('/front/ticket.php?' ~ my_tickets_url_param) }}">
+                        {{ __("See my tickets") }}
+                    </a>
+                </div>
             </div>
         </div>
     </div>

--- a/templates/pages/form_renderer.html.twig
+++ b/templates/pages/form_renderer.html.twig
@@ -197,11 +197,13 @@
                     {{ __("Your form has been submitted successfully.") }}
                 </p>
                 <div class="mt-3 d-flex">
-                    <a class="btn btn-outline-secondary me-2" href="{{ path('/ServiceCatalog') }}">
-                        {{ __("Go back to service catalog") }}
+                    <a class="btn btn-outline-secondary me-2" href="{{ path('/Helpdesk') }}">
+                        <i class="ti ti-home me-1"></i>
+                        <span>{{ __("Go home") }}</span>
                     </a>
-                    <a class="btn btn-outline-secondary" href="{{ path('/front/ticket.php?' ~ my_tickets_url_param) }}">
-                        {{ __("See my tickets") }}
+                    <a class="btn btn-primary" href="{{ path('/front/ticket.php?' ~ my_tickets_url_param) }}">
+                        <i class="ti ti-article me-1"></i>
+                        <span>{{ __("See my tickets") }}</span>
                     </a>
                 </div>
             </div>


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.

## Description

Add two possible actions after a form is successfully submitted:
* Go back to service catalog
* See my tickets

An other alternative would be to replace "See my tickets" by a direct link to the created ticket (and remove the success toast that currently serve that purpose).
We would have to think about the cases where multiple tickets might be created tho, in this case maybe a link to a search request that returns all the newly created ticket (id=x or id=y or ...) ?

What do you think @orthagh ?

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/6052f69b-9cab-4e3a-a83e-e8cdd884a695)

