### PR TITLE
Fix wrongly initiliazed destination config fields

### DIFF
--- a/phpunit/functional/Glpi/Helpdesk/DefaultDataManagerTest.php
+++ b/phpunit/functional/Glpi/Helpdesk/DefaultDataManagerTest.php
@@ -209,6 +209,9 @@ final class DefaultDataManagerTest extends DbTestCase
             [$computer->getID()],
             array_values($ticket->getLinkedItems()[Computer::class])
         );
+        $actors = $ticket->getActorsForType(CommonITILActor::REQUESTER);
+        $actor = current($actors);
+        $this->assertEquals(TU_USER, $actor['title']);
     }
 
     public function testRequestFormQuestions(): void
@@ -301,6 +304,9 @@ final class DefaultDataManagerTest extends DbTestCase
             [$computer->getID()],
             array_values($ticket->getLinkedItems()[Computer::class])
         );
+        $actors = $ticket->getActorsForType(CommonITILActor::REQUESTER);
+        $actor = current($actors);
+        $this->assertEquals(TU_USER, $actor['title']);
     }
 
     public function testIncidentFormShouldBeAccessibleBySelfServiceUsers(): void

--- a/src/Glpi/Form/Destination/CommonITILField/AssociatedItemsField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/AssociatedItemsField.php
@@ -206,6 +206,10 @@ class AssociatedItemsField extends AbstractConfigField
     {
         $input = parent::prepareInput($input);
 
+        if (!isset($input[$this->getKey()][AssociatedItemsFieldConfig::STRATEGY])) {
+            return $input;
+        }
+
         // Ensure that question_ids is an array
         if (!is_array($input[$this->getKey()][AssociatedItemsFieldConfig::SPECIFIC_QUESTION_IDS] ?? null)) {
             $input[$this->getKey()][AssociatedItemsFieldConfig::SPECIFIC_QUESTION_IDS] = null;

--- a/src/Glpi/Form/Destination/CommonITILField/ITILActorField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ITILActorField.php
@@ -140,6 +140,10 @@ abstract class ITILActorField extends AbstractConfigField
     {
         $input = parent::prepareInput($input);
 
+        if (!isset($input[$this->getKey()][ITILActorFieldConfig::STRATEGY])) {
+            return $input;
+        }
+
         // Ensure that itilactors_ids is an array
         if (!is_array($input[$this->getKey()][ITILActorFieldConfig::SPECIFIC_ITILACTORS_IDS] ?? null)) {
             $input[$this->getKey()][ITILActorFieldConfig::SPECIFIC_ITILACTORS_IDS] = null;

--- a/src/Glpi/Form/Destination/CommonITILField/ValidationField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ValidationField.php
@@ -199,6 +199,10 @@ class ValidationField extends AbstractConfigField
     {
         $input = parent::prepareInput($input);
 
+        if (!isset($input[$this->getKey()][ValidationFieldConfig::STRATEGY])) {
+            return $input;
+        }
+
         // Ensure that question_ids is an array
         if (!is_array($input[$this->getKey()][ValidationFieldConfig::SPECIFIC_QUESTION_IDS] ?? null)) {
             $input[$this->getKey()][ValidationFieldConfig::SPECIFIC_QUESTION_IDS] = null;


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Some config fields were wrongly initialized, which prevented their default values from being applied properly.
This prevented some fields like the requester from being correctly set when using the default forms.


