### PR TITLE
fix: Ticket rules are not correctly executed with MA

### DIFF
--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -1284,8 +1284,8 @@ class Ticket extends CommonITILObject
             }
 
             $input = $rules->processAllRules(
-                $input,
-                $input,
+                $input + $this->fields,
+                $input + $this->fields,
                 ['recursive'   => true,
                     'entities_id' => $entid
                 ],


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !35358
- The data passed to the ticket rules engine when using bulk actions contains only the modified data, which prevents the correct execution of the rules.

## Screenshots (if appropriate):


