### PR TITLE
Force allDay planning flag when start at midnight and last entire day(s)

### DIFF
--- a/phpunit/functional/PlanningTest.php
+++ b/phpunit/functional/PlanningTest.php
@@ -278,4 +278,48 @@ class PlanningTest extends \DbTestCase
             'end'      => '2020-01-02 01:00:00'
         ]));
     }
+
+    public function testAllDayEvents()
+    {
+        $this->login();
+
+        $event = new \PlanningExternalEvent();
+        $event->add([
+            'name'  => __FUNCTION__,
+            'text'  => __FUNCTION__,
+            'plan' => [
+                'begin' => '2020-01-01 00:00:00',
+                'end'   => '2020-01-02 00:00:00',
+            ]
+        ]);
+        $event->add([
+            'name'  => __FUNCTION__ . '_recurring',
+            'text'  => __FUNCTION__ . '_recurring',
+            'plan' => [
+                'begin' => '2020-01-01 00:00:00',
+                'end'   => '2020-01-02 00:00:00',
+            ],
+            'rrule' => '{"freq":"weekly","interval":"3","until":""}'
+        ]);
+        $event->add([
+            'name'  => __FUNCTION__ . '_not_allday',
+            'text'  => __FUNCTION__ . '_not_allday',
+            'plan' => [
+                'begin' => '2020-01-01 01:00:00',
+                'end'   => '2020-01-02 01:00:00',
+            ]
+        ]);
+
+        $events = \Planning::constructEventsArray([
+            'start' => '2020-01-01 00:00:00',
+            'end'   => '2020-01-30 00:00:00',
+        ]);
+        $this->assertCount(3, $events);
+        $this->assertEquals(__FUNCTION__, $events[0]['title']);
+        $this->assertTrue($events[0]['allDay'] ?? false);
+        $this->assertEquals(__FUNCTION__ . '_recurring', $events[1]['title']);
+        $this->assertTrue($events[1]['allDay'] ?? false);
+        $this->assertEquals(__FUNCTION__ . '_not_allday', $events[2]['title']);
+        $this->assertFalse($events[2]['allDay'] ?? false);
+    }
 }

--- a/phpunit/functional/PlanningTest.php
+++ b/phpunit/functional/PlanningTest.php
@@ -282,6 +282,8 @@ class PlanningTest extends \DbTestCase
     public function testAllDayEvents()
     {
         $this->login();
+        \Planning::initSessionForCurrentUser();
+
 
         $event = new \PlanningExternalEvent();
         $event->add([
@@ -313,6 +315,8 @@ class PlanningTest extends \DbTestCase
         $events = \Planning::constructEventsArray([
             'start' => '2020-01-01 00:00:00',
             'end'   => '2020-01-30 00:00:00',
+            'view_name' => 'listFull',
+            'force_all_events' => true
         ]);
         $this->assertCount(3, $events);
         $this->assertEquals(__FUNCTION__, $events[0]['title']);

--- a/src/Planning.php
+++ b/src/Planning.php
@@ -2132,6 +2132,11 @@ JAVASCRIPT;
                 'state'       => $event['state'] ?? "",
             ];
 
+            // if duration is full day and start is midnight, force allDay to true
+            if (date('H:i:s', strtotime($begin)) === '00:00:00' && (int) $ms_duration % (DAY_TIMESTAMP * 1000) === 0) {
+                $new_event['allDay'] = true;
+            }
+
            // if we can't update the event, pass the editable key
             if (!$event['editable']) {
                 $new_event['editable'] = false;


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

Fixes #17385

I think this is mostly an issue with the Full Calendar library, but this PR will force the `allDay` flag to be true when an event starts at midnight and the duration is an entire day(s). Events that last all day (recurring or not) will now show up in the All Day section when appropriate.

