### PR TITLE
Extract URL checks from Toolbox::manageRedirect() to a new method

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -5522,12 +5522,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Toolbox.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Offset 0 on non\\-empty\\-list\\<string\\> in empty\\(\\) always exists and is not falsy\\.$#',
-	'identifier' => 'empty.offset',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Toolbox.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^PHPDoc tag @phpstan\\-return has invalid value \\(\\$return_response \\? Response \\: void\\)\\: Unexpected token "\\$return_response", expected type at offset 498 on line 12$#',
 	'identifier' => 'phpDoc.parseError',
 	'count' => 1,

--- a/phpunit/functional/ToolboxTest.php
+++ b/phpunit/functional/ToolboxTest.php
@@ -1566,4 +1566,63 @@ HTML;
         }
         $this->assertSame($expected, call_user_func_array('Toolbox::isUrlSafe', $params));
     }
+
+
+    public static function redirectProvider(): iterable
+    {
+        foreach (['helpdesk', 'central'] as $interface) {
+            // Redirect to absolute URLs.
+            yield [
+                'interface' => $interface,
+                'where'     => 'http://notglpi/',
+                'result'    => null,
+            ];
+            yield [
+                'interface' => $interface,
+                'where'     => 'http://localhost:80/',
+                'result'    => 'http://localhost:80/',
+            ];
+            yield [
+                'interface' => $interface,
+                'where'     => 'http://localhost:80/front/computer.php?id=15',
+                'result'    => 'http://localhost:80/front/computer.php?id=15',
+            ];
+
+            // Redirect to relative URLs.
+            yield [
+                'interface' => $interface,
+                'where'     => '/',
+                'result'    => '/glpi/',
+            ];
+            yield [
+                'interface' => $interface,
+                'where'     => '/front/computer.php?id=15',
+                'result'    => '/glpi/front/computer.php?id=15',
+            ];
+
+            // Redirect to a ticket.
+            yield [
+                'interface' => $interface,
+                'where'     => 'ticket_35341',
+                'result'    => '/glpi/front/ticket.form.php?id=35341&',
+            ];
+
+            // Redirect to a ticket tab.
+            yield [
+                'interface' => $interface,
+                'where'     => 'ticket_12345_Ticket$main#TicketValidation_1',
+                'result'    => '/glpi/front/ticket.form.php?id=12345&forcetab=Ticket$main#TicketValidation_1',
+            ];
+        }
+    }
+
+    #[DataProvider('redirectProvider')]
+    public function testComputeRedirect(string $interface, string $where, ?string $result): void
+    {
+        $_SESSION['glpiactiveprofile']['interface'] = $interface;
+
+        $instance = new \Toolbox();
+
+        $this->assertSame($result, $instance->computeRedirect($where));
+    }
 }

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -1506,7 +1506,7 @@ class Toolbox
         if ($redirect === null) {
             Session::addMessageAfterRedirect(__s('Redirection failed'));
             if (Session::getCurrentInterface() === "helpdesk") {
-                Html::redirect($CFG_GLPI["root_doc"] . "/front/helpdesk.public.php");
+                Html::redirect($CFG_GLPI["root_doc"] . "/Helpdesk");
             } else {
                 Html::redirect($CFG_GLPI["root_doc"] . "/front/central.php");
             }

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -1482,7 +1482,6 @@ class Toolbox
         }
     }
 
-
     /**
      * Manage login redirection
      *
@@ -1492,153 +1491,152 @@ class Toolbox
      **/
     public static function manageRedirect($where)
     {
+        if (!$where || !($url = self::getManagedRedirectUrl($where))) {
+            return;
+        }
+
+        Html::redirect($url);
+    }
+
+    public static function getManagedRedirectUrl(string $url): ?string
+    {
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        if (!empty($where)) {
-            if (Session::getCurrentInterface()) {
-                // redirect to URL : URL must be rawurlencoded
-                $decoded_where = rawurldecode($where);
-                $matches = [];
-
-                // redirect to full url -> check if it's based on glpi url
-                if (preg_match('@(([^:/].+:)?//[^/]+)(/.+)?@', $decoded_where, $matches)) {
-                    if ($matches[1] !== $CFG_GLPI['url_base']) {
-                        Session::addMessageAfterRedirect(__s('Redirection failed'));
-                        if (Session::getCurrentInterface() === "helpdesk") {
-                            Html::redirect($CFG_GLPI["root_doc"] . "/Helpdesk");
-                        } else {
-                            Html::redirect($CFG_GLPI["root_doc"] . "/front/central.php");
-                        }
-                    } else {
-                        Html::redirect($decoded_where);
-                    }
-                }
-
-                // Redirect to relative url
-                if ($decoded_where[0] == '/') {
-                    // prevent exploit (//example.com) and force a redirect from glpi root
-                    $redirect_to = $CFG_GLPI["root_doc"] . "/" . ltrim($decoded_where, '/');
-                    Html::redirect($redirect_to);
-                }
-
-                // explode with limit 3 to preserve the last part of the url
-                // /index.php?redirect=ticket_2_Ticket$main#TicketValidation_1 (preserve anchor)
-                $data = explode("_", $where, 3);
-                $forcetab = '';
-                // forcetab for simple items
-                if (isset($data[2])) {
-                    $forcetab = 'forcetab=' . $data[2];
-                }
-
-                switch (Session::getCurrentInterface()) {
-                    case "helpdesk":
-                        switch (strtolower($data[0])) {
-                              // Use for compatibility with old name
-                            case "tracking":
-                            case "ticket":
-                                $data[0] = 'Ticket';
-                             // redirect to item
-                                if (
-                                    isset($data[1])
-                                    && is_numeric($data[1])
-                                    && ($data[1] > 0)
-                                ) {
-                                    // Check entity
-                                    if (
-                                        ($item = getItemForItemtype($data[0]))
-                                        && $item->isEntityAssign()
-                                    ) {
-                                        if ($item->getFromDB($data[1])) {
-                                            if (!Session::haveAccessToEntity($item->getEntityID())) {
-                                                Session::changeActiveEntities($item->getEntityID(), 1);
-                                            }
-                                        }
-                                    }
-                                  // force redirect to timeline when timeline is enabled and viewing
-                                  // Tasks or Followups
-                                    $forcetab = str_replace('TicketFollowup$1', 'Ticket$1', $forcetab);
-                                    $forcetab = str_replace('TicketTask$1', 'Ticket$1', $forcetab);
-                                    $forcetab = str_replace('ITILFollowup$1', 'Ticket$1', $forcetab);
-                                    Html::redirect(Ticket::getFormURLWithID($data[1]) . "&$forcetab");
-                                } else if (!empty($data[0])) { // redirect to list
-                                    if ($item = getItemForItemtype($data[0])) {
-                                        $searchUrl = $item->getSearchURL();
-                                        $searchUrl .= strpos($searchUrl, '?') === false ? '?' : '&';
-                                        $searchUrl .= $forcetab;
-                                        Html::redirect($searchUrl);
-                                    }
-                                }
-
-                                Html::redirect($CFG_GLPI["root_doc"] . "/Helpdesk");
-                                // phpcs doesn't understand that the script stops in Html::redirect() so we need a comment to avoid the fallthrough warning
-
-                            case "preference":
-                                Html::redirect($CFG_GLPI["root_doc"] . "/front/preference.php?$forcetab");
-                                // phpcs doesn't understand that the script stops in Html::redirect() so we need a comment to avoid the fallthrough warning
-
-                            case "reservation":
-                                Html::redirect(Reservation::getFormURLWithID($data[1]) . "&$forcetab");
-                                // phpcs doesn't understand that the script stops in Html::redirect() so we need a comment to avoid the fallthrough warning
-
-                            default:
-                                Html::redirect($CFG_GLPI["root_doc"] . "/Helpdesk");
-                        }
-                        // @phpstan-ignore deadCode.unreachable (defensive programming)
-                        break;
-
-                    case "central":
-                        switch (strtolower($data[0])) {
-                            case "preference":
-                                Html::redirect($CFG_GLPI["root_doc"] . "/front/preference.php?$forcetab");
-
-                           // Use for compatibility with old name
-                           // no break
-                            case "tracking":
-                                $data[0] = "Ticket";
-                             //var defined, use default case
-
-                            default:
-                             // redirect to item
-                                if (
-                                    !empty($data[0])
-                                    && isset($data[1])
-                                    && is_numeric($data[1])
-                                    && ($data[1] > 0)
-                                ) {
-                                    // Check entity
-                                    if ($item = getItemForItemtype($data[0])) {
-                                        if ($item->isEntityAssign()) {
-                                            if ($item->getFromDB($data[1])) {
-                                                if (!Session::haveAccessToEntity($item->getEntityID())) {
-                                                    Session::changeActiveEntities($item->getEntityID(), 1);
-                                                }
-                                            }
-                                        }
-                                    // force redirect to timeline when timeline is enabled
-                                        $forcetab = str_replace('TicketFollowup$1', 'Ticket$1', $forcetab);
-                                        $forcetab = str_replace('TicketTask$1', 'Ticket$1', $forcetab);
-                                        $forcetab = str_replace('ITILFollowup$1', 'Ticket$1', $forcetab);
-                                        Html::redirect($item->getFormURLWithID($data[1]) . "&$forcetab");
-                                    }
-                                } else if (!empty($data[0])) { // redirect to list
-                                    if ($item = getItemForItemtype($data[0])) {
-                                        $searchUrl = $item->getSearchURL();
-                                        $searchUrl .= strpos($searchUrl, '?') === false ? '?' : '&';
-                                        $searchUrl .= $forcetab;
-                                        Html::redirect($searchUrl);
-                                    }
-                                }
-
-                                Html::redirect($CFG_GLPI["root_doc"] . "/front/central.php");
-                        }
-                        // @phpstan-ignore deadCode.unreachable (defensive programming)
-                        break;
-                }
-            }
+        if (!Session::getCurrentInterface()) {
+            return null;
         }
-    }
 
+        // redirect to URL : URL must be rawurlencoded
+        $decoded_where = rawurldecode($url);
+        $matches = [];
+
+        // redirect to full url -> check if it's based on glpi url
+        if (preg_match('@(([^:/].+:)?//[^/]+)(/.+)?@', $decoded_where, $matches)) {
+            if ($matches[1] !== $CFG_GLPI['url_base']) {
+                Session::addMessageAfterRedirect(__s('Redirection failed'));
+
+                if (Session::getCurrentInterface() === "helpdesk") {
+                    return $CFG_GLPI["root_doc"] . "/Helpdesk";
+                }
+
+                return $CFG_GLPI["root_doc"] . "/front/central.php";
+            }
+
+            return $decoded_where;
+        }
+
+        // Redirect to relative url
+        if ($decoded_where[0] === '/') {
+            // prevent exploit (//example.com) and force a redirect from glpi root
+            return $CFG_GLPI["root_doc"] . "/" . ltrim($decoded_where, '/');
+        }
+
+        // explode with limit 3 to preserve the last part of the url
+        // /index.php?redirect=ticket_2_Ticket$main#TicketValidation_1 (preserve anchor)
+        $data = explode("_", $url, 3);
+        $forcetab = '';
+        // forcetab for simple items
+        if (isset($data[2])) {
+            $forcetab = 'forcetab=' . $data[2];
+        }
+
+        switch (Session::getCurrentInterface()) {
+            case "helpdesk":
+                switch (strtolower($data[0])) {
+                    // Use for compatibility with old name
+                    case "tracking":
+                    case "ticket":
+                        $data[0] = 'Ticket';
+                        // redirect to item
+                        if (
+                            isset($data[1])
+                            && is_numeric($data[1])
+                            && ($data[1] > 0)
+                        ) {
+                            // Check entity
+                            if (
+                                ($item = getItemForItemtype($data[0]))
+                                && $item->isEntityAssign()
+                                && $item->getFromDB($data[1])
+                                && !Session::haveAccessToEntity($item->getEntityID())
+                            ) {
+                                Session::changeActiveEntities($item->getEntityID(), 1);
+                            }
+                            // force redirect to timeline when timeline is enabled and viewing
+                            // Tasks or Followups
+                            $forcetab = str_replace(['TicketFollowup$1', 'TicketTask$1', 'ITILFollowup$1'], 'Ticket$1', $forcetab);
+
+                            return Ticket::getFormURLWithID($data[1]) . "&$forcetab";
+                        }
+
+                        if ($item = getItemForItemtype($data[0])) {
+                            $searchUrl = $item::getSearchURL();
+                            $searchUrl .= !str_contains($searchUrl, '?') ? '?' : '&';
+                            $searchUrl .= $forcetab;
+                            return $searchUrl;
+                        }
+
+                        return $CFG_GLPI["root_doc"] . "/Helpdesk";
+
+                    case "preference":
+                        return $CFG_GLPI["root_doc"] . "/front/preference.php?$forcetab";
+
+                    case "reservation":
+                        return Reservation::getFormURLWithID($data[1]) . "&$forcetab";
+
+                    default:
+                        return $CFG_GLPI["root_doc"] . "/Helpdesk";
+                }
+
+            case "central":
+                switch (strtolower($data[0])) {
+                    case "preference":
+                        return $CFG_GLPI["root_doc"] . "/front/preference.php?$forcetab";
+
+                    case "tracking":
+                        $data[0] = "Ticket";
+                        //
+
+                    default:
+                        // redirect to item
+                        if (
+                            !empty($data[0])
+                            && isset($data[1])
+                            && is_numeric($data[1])
+                            && ($data[1] > 0)
+                        ) {
+                            // Check entity
+                            if ($item = getItemForItemtype($data[0])) {
+                                if (
+                                    $item->isEntityAssign()
+                                    && $item->getFromDB($data[1])
+                                    && !Session::haveAccessToEntity($item->getEntityID())
+                                ) {
+                                    Session::changeActiveEntities($item->getEntityID(), 1);
+                                }
+                                // force redirect to timeline when timeline is enabled
+                                $forcetab = str_replace(['TicketFollowup$1', 'TicketTask$1', 'ITILFollowup$1'], 'Ticket$1', $forcetab);
+
+                                return $item::getFormURLWithID($data[1]) . "&$forcetab";
+                            }
+                        } else if (
+                            !empty($data[0])
+                            && $item = getItemForItemtype($data[0])
+                        ) {
+                            // redirect to list
+                            $searchUrl = $item::getSearchURL();
+                            $searchUrl .= !str_contains($searchUrl, '?') ? '?' : '&';
+                            $searchUrl .= $forcetab;
+                            return $searchUrl;
+                        }
+
+                        return $CFG_GLPI["root_doc"] . "/front/central.php";
+                }
+        }
+
+        return null;
+    }
 
     /**
      * Convert a value in byte, kbyte, megabyte etc...

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -1598,6 +1598,8 @@ class Toolbox
                         return Reservation::getFormURLWithID($data[1]) . "&$forcetab";
                 }
 
+                break;
+
             case "central":
                 switch (strtolower($data[0])) {
                     case "preference":
@@ -1644,6 +1646,9 @@ class Toolbox
 
                         return null;
                 }
+
+                // @phpstan-ignore deadCode.unreachable (defensive programming)
+                break;
         }
 
         return null;

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -1556,6 +1556,8 @@ class Toolbox
             case "helpdesk":
                 switch (strtolower($data[0])) {
                     case "tracking": // Used for compatibility with old name
+                        // similar to "ticket" case
+
                     case "ticket":
                         $data[0] = 'Ticket';
                         // redirect to item


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

The logic stays the same, code is just a bit cleaned up (early returns, merging `if` cascades, etc.).

The goal of this is to clean up all the calls to `Toolbox::manageRedirect()` (there are only 4 calls in the project itself, I don't know about plugins though) so that it no longer needs to throw an exception and instead just allows retrieving the URL to return a RedirectResponse.