### PR TITLE
Create HtmlExtension and make all Html calls from Twig more explicit

### DIFF
--- a/src/Glpi/Application/View/Extension/HtmlExtension.php
+++ b/src/Glpi/Application/View/Extension/HtmlExtension.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Application\View\Extension;
+
+use Html;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+class HtmlExtension extends AbstractExtension
+{
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('html_clean_id', Html::cleanId(...)),
+            new TwigFunction('html_display_title', Html::displayTitle(...)),
+            new TwigFunction('html_file', Html::file(...)),
+            new TwigFunction('html_init_editor_system', Html::initEditorSystem(...)),
+            new TwigFunction('html_js_ajax_dropdown', Html::jsAjaxDropdown(...)),
+            new TwigFunction('html_parse_attributes', Html::parseAttributes(...)),
+            new TwigFunction('html_print_ajax_pager', Html::printAjaxPager(...)),
+            new TwigFunction('html_progress', Html::progress(...)),
+
+            new TwigFunction('html_header', Html::header(...)),
+            new TwigFunction('html_help_header', Html::helpHeader(...)),
+            new TwigFunction('html_pop_header', Html::popHeader(...)),
+            new TwigFunction('html_simple_header', Html::simpleHeader(...)),
+            new TwigFunction('html_null_header', Html::nullHeader(...)),
+
+            new TwigFunction('html_footer', Html::footer(...)),
+            new TwigFunction('html_pop_footer', Html::popFooter(...)),
+
+            new TwigFunction('html_show_checkbox', Html::showCheckbox(...)),
+            new TwigFunction('html_show_date_time_field', Html::showDateTimeField(...)),
+            new TwigFunction('html_show_massive_action_checkbox', Html::showMassiveActionCheckBox(...)),
+            new TwigFunction('html_show_massive_actions', Html::showMassiveActions(...)),
+            new TwigFunction('html_show_simple_form', Html::showSimpleForm(...)),
+            new TwigFunction('html_show_tooltip', Html::showToolTip(...)),
+        ];
+    }
+}

--- a/src/Glpi/Application/View/TemplateRenderer.php
+++ b/src/Glpi/Application/View/TemplateRenderer.php
@@ -51,6 +51,7 @@ use Glpi\Application\View\Extension\SearchExtension;
 use Glpi\Application\View\Extension\SecurityExtension;
 use Glpi\Application\View\Extension\SessionExtension;
 use Glpi\Application\View\Extension\TeamExtension;
+use Glpi\Application\View\Extension\HtmlExtension;
 use Glpi\Debug\Profiler;
 use Plugin;
 use Session;
@@ -118,6 +119,7 @@ class TemplateRenderer
         $this->environment->addExtension(new SearchExtension());
         $this->environment->addExtension(new SessionExtension());
         $this->environment->addExtension(new TeamExtension());
+        $this->environment->addExtension(new HtmlExtension());
 
        // add superglobals
         $this->environment->addGlobal('_post', $_POST);

--- a/templates/components/checkbox_matrix.html.twig
+++ b/templates/components/checkbox_matrix.html.twig
@@ -44,14 +44,14 @@
          <tr>
             <th>{{ param['first_cell']|raw }}</th>
             {% for col_name, column in columns %}
-               {% set col_id = call('Html::cleanId', ['col_label_' ~ col_name ~ '_' ~ param['rand']]) %}
+               {% set col_id = html_clean_id('col_label_' ~ col_name ~ '_' ~ param['rand']) %}
                <th id="{{ col_id }}">
                   {% if column is not iterable %}
                      {{ column }}
                   {% else %}
                      {% if column['short'] is defined and column['long'] is defined %}
                         {{ column['short'] }}
-                        {% do call('Html::showToolTip', [column['long'], {'applyto': col_id}]) %}
+                        {% do html_show_tooltip(column['long'], {'applyto': col_id}) %}
                      {% else %}
                         {{ column['label'] }}
                      {% endif %}
@@ -60,7 +60,7 @@
             {% endfor %}
 
             {% if param['row_check_all'] %}
-               {% set col_id = call('Html::cleanId', ['col_of_table_' ~ param['rand']]) %}
+               {% set col_id = html_clean_id('col_of_table_' ~ param['rand']) %}
                <th id="{{ col_id }}">
                   {{ __('Select/unselect all') }}
                </th>
@@ -73,7 +73,7 @@
                {% if row is not iterable %}
                   <td colspan="{{ number_columns }}">{{ row }}</td>
                {% else %}
-                  {% set row_id = call('Html::cleanId', ['row_label_' ~ row_name ~ '_' ~ param['rand']]) %}
+                  {% set row_id = html_clean_id('row_label_' ~ row_name ~ '_' ~ param['rand']) %}
                   <td class="{{ row['class'] }}" id="{{ row_id }}">
                      {{ row['label'] ?? '&nbsp;' }}
                   </td>
@@ -87,7 +87,7 @@
                            {% endif %}
                            {% set content = content|merge({
                               'name': row_name ~ '[' ~ col_name ~ ']',
-                              'id': call('Html::cleanId', ['cb_' ~ row_name ~ '_' ~ col_name ~ '_' ~ param['rand']])
+                              'id': html_clean_id('cb_' ~ row_name ~ '_' ~ col_name ~ '_' ~ param['rand'])
                            }) %}
                            {% set massive_tags = [] %}
                            {% if param['row_check_all'] %}
@@ -108,7 +108,7 @@
                            {% set content = content|merge({
                               'massive_tags': massive_tags
                            }) %}
-                           {% do call('Html::showCheckbox', [content]) %}
+                           {% do html_show_checkbox(content) %}
 
                         {% else %}
                            {% if content is not iterable %}
@@ -120,15 +120,15 @@
 
                   {% if param['row_check_all'] %}
                      <td>
-                        {% do call('Html::showCheckbox', [{
+                        {% do html_show_checkbox({
                            'title': __('Check/uncheck all'),
                            'criterion': {
                               'tag_for_massive': 'row_' ~ row_name ~ '_' ~ param['rand']
                            },
                            'massive_tags': 'table_' ~ param['rand'],
-                           'id': call('Html::cleanId', ['cb_checkall_row_' ~ row_name ~ '_' ~ param['rand']]),
+                           'id': html_clean_id('cb_checkall_row_' ~ row_name ~ '_' ~ param['rand']),
                            'checked': (nb_cb_per_row[row_name]['checked'] >= (nb_cb_per_row[row_name]['total'])),
-                        }]) %}
+                        }) %}
                      </td>
                   {% endif %}
                {% endif %}
@@ -141,29 +141,29 @@
                {% for col_name, column in columns %}
                   <td>
                      {% if nb_cb_per_col[col_name]['total'] >= 2 %}
-                        {% do call('Html::showCheckbox', [{
+                        {% do html_show_checkbox({
                            'title': __('Check/uncheck all'),
                            'criterion': {
                               'tag_for_massive': 'col_' ~ col_name ~ '_' ~ param['rand']
                            },
                            'massive_tags': 'table_' ~ param['rand'],
-                           'id': call('Html::cleanId', ['cb_checkall_col_' ~ col_name ~ param['rand']]),
+                           'id': html_clean_id('cb_checkall_col_' ~ col_name ~ param['rand']),
                            'checked': (nb_cb_per_col[col_name]['checked'] >= (nb_cb_per_col[col_name]['total'])),
-                        }]) %}
+                        }) %}
                      {% endif %}
                   </td>
                {% endfor %}
 
                {% if param['row_check_all'] %}
                   <td>
-                     {% do call('Html::showCheckbox', [{
+                     {% do html_show_checkbox({
                         'title': __('Check/uncheck all'),
                         'criterion': {
                            'tag_for_massive': 'table_' ~ param['rand']
                         },
                         'massive_tags': '',
-                        'id': call('Html::cleanId', ['cb_checkall_table_' ~ param['rand']]),
-                     }]) %}
+                        'id': html_clean_id('cb_checkall_table_' ~ param['rand']),
+                     }) %}
                   </td>
                {% endif %}
             </tr>

--- a/templates/components/datatable.html.twig
+++ b/templates/components/datatable.html.twig
@@ -67,7 +67,7 @@
     <div class="table-responsive" {% if showmassiveactions %} id="{{ massiveactionparams['container'] }}" {% endif %}>
         {% if showmassiveactions %}
             <div class="mb-2">
-                {% do call('Html::showMassiveActions', [massiveactionparams|default([])]) %}
+                {% do html_show_massive_actions(massiveactionparams|default([])) %}
             </div>
         {% endif %}
         <table id="{{ datatable_id }}" class="table {{ table_class_style|default('table-hover') }}">
@@ -159,21 +159,21 @@
                                             {% endfor %}
                                         </select>
                                     {% elseif formatter == "datetime" %}
-                                        {{ call("Html::showDateTimeField", [
+                                        {{ html_show_date_time_field(
                                             "filters[" ~ colkey ~ "]",
                                             {
                                                 'value': filters[colkey],
                                                 'display': false
                                             }
-                                        ])|raw }}
+                                        )|raw }}
                                     {% elseif formatter == "date" %}
-                                        {{ call("Html::showDateField", [
+                                        {{ html_show_date_time_field(
                                             "filters[" ~ colkey ~ "]",
                                             {
                                                 'value': filters[colkey],
                                                 'display': false
                                             }
-                                        ])|raw }}
+                                        )|raw }}
                                     {% elseif formatter starts with "progress" %}
                                         <input type="range" class="form-range"
                                             name="filters[{{ colkey }}]"
@@ -237,11 +237,11 @@
                                                 {{ entry[colkey] }}
                                             </span>
                                         {% elseif formatter starts with "progress" %}
-                                            {{ call("Html::progress", [100, entry[colkey]])|raw }}
+                                            {{ html_progress(100, entry[colkey])|raw }}
                                         {% elseif formatter == "date" %}
-                                            {{ call("Html::convDate", [entry[colkey]])|raw }}
+                                            {{ entry[colkey]|formatted_date|raw }}
                                         {% elseif formatter == "datetime" %}
-                                            {{ call("Html::convDateTime", [entry[colkey]])|raw }}
+                                            {{ entry[colkey]|formatted_datetime|raw }}
                                         {% elseif formatter == "duration" %}
                                             {{ entry[colkey]|formatted_duration }}
                                         {% elseif formatter == "bytesize" %}

--- a/templates/components/form/basic_inputs_macros.html.twig
+++ b/templates/components/form/basic_inputs_macros.html.twig
@@ -139,7 +139,7 @@
 
     {% if options.step != 'any' and options.step|round(0, 'floor') != options.step %}
         {# Only format number if not a whole number #}
-        {% set value = call('Html::formatNumber', [value, true]) %}
+        {% set value = value|formatted_number(true) %}
     {% endif %}
 
     {{ _self.input(name, value, options|merge({'type': 'number'})) }}
@@ -194,11 +194,7 @@
     {% if options.simple %}
         {{ _self.input(name, value, options|merge({'type': 'file'})) }}
     {% else %}
-        {% do call('Html::file', [
-            options|merge({
-                'name': name,
-            })
-        ]) %}
+        {% do html_file(options|merge({'name': name})) %}
     {% endif %}
 {% endmacro %}
 
@@ -338,7 +334,7 @@
             {{ options.required ? 'required' : '' }}>{{ options.enable_richtext ? value|safe_html|escape : value }}</textarea>
 
     {% if options.enable_richtext %}
-        {% do call('Html::initEditorSystem', [
+        {% do html_init_editor_system(
             options.id,
             options.rand,
             true,
@@ -352,7 +348,7 @@
             options.toolbar,
             options.statusbar,
             options.content_style,
-        ]) %}
+        ) %}
    {% endif %}
 
    {% if options.enable_form_tags %}

--- a/templates/components/form/buttons.html.twig
+++ b/templates/components/form/buttons.html.twig
@@ -136,7 +136,7 @@
          {% if canedit and params['addbuttons']|length > 0 %}
             {% for key, val in params['addbuttons'] %}
                 {% if val.add_attribs is not empty %}
-                    {% set extra_attribs = call('Html::parseAttributes', {options: val.add_attribs}) %}
+                    {% set extra_attribs = html_parse_attributes(val.add_attribs) %}
                 {% else %}
                     {% set extra_attribs = '' %}
                 {% endif %}

--- a/templates/components/form/fields_macros.html.twig
+++ b/templates/components/form/fields_macros.html.twig
@@ -226,22 +226,22 @@
    {% set add_html = '' %}
    {% if not options.readonly and options.enable_fileupload %}
       {% set add_html %}
-         {% do call('Html::file', [{
+         {% do html_file({
              'editor_id': options.id,
              'multiple': true,
              'uploads': options.uploads,
              'required': options.fields_template.isMandatoryField('_documents_id')
-         }]) %}
+         }) %}
       {% endset %}
    {% elseif not options.readonly and not options.enable_fileupload and options.enable_richtext and options.enable_images %}
       {% set add_html %}
-         {% do call('Html::file', [{
+         {% do html_file({
              'editor_id': options.id,
              'name': name,
              'only_uploaded_files': true,
              'uploads': options.uploads,
              'required': options.fields_template.isMandatoryField('_documents_id')
-         }]) %}
+         }) %}
       {% endset %}
    {% endif %}
 
@@ -348,9 +348,9 @@
          {% set url = options['url'] ?? null %}
          {% set options = options|filter((v, k) => k != 'url' and k != 'clearable') %}
          {% if url is not empty %}
-            <a href="{{ url }}" {{ call('Html::parseAttributes', [link_options])|raw }}>
+            <a href="{{ url }}" {{ html_parse_attributes(link_options)|raw }}>
          {% endif %}
-               <img src="{{ value }}" {{ call('Html::parseAttributes', [options])|raw }} />
+               <img src="{{ value }}" {{ html_parse_attributes(options)|raw }} />
          {% if url is not empty %}
             </a>
          {% endif %}
@@ -732,7 +732,7 @@
     }) %}
     {% set field %}
         {% set ajax_opts = options|filter((v, k) => k in ['templateResult', 'templateSelection', 'rand']) %}
-        {{ call('Html::jsAjaxDropdown', [name, options.id, url, ajax_opts])|raw }}
+        {{ html_js_ajax_dropdown(name, options.id, url, ajax_opts)|raw }}
     {% endset %}
 
     {% if field|trim is not empty %}
@@ -834,7 +834,7 @@
    {% set class = class ~ ' ' ~ options.add_field_class %}
 
    {% if options.add_field_attribs is not empty %}
-      {% set extra_attribs = call('Html::parseAttributes', {options: options.add_field_attribs}) %}
+      {% set extra_attribs = html_parse_attributes(options.add_field_attribs) %}
    {% else %}
       {% set extra_attribs = '' %}
    {% endif %}
@@ -886,7 +886,7 @@
    {% endif %}
 
    {% if options.add_field_attribs is not empty %}
-      {% set extra_attribs = call('Html::parseAttributes', {options: options.add_field_attribs}) %}
+      {% set extra_attribs = html_parse_attributes(options.add_field_attribs) %}
    {% else %}
       {% set extra_attribs = '' %}
    {% endif %}
@@ -927,7 +927,7 @@
    {% endif %}
 
    {% if options.add_field_attribs is not empty %}
-      {% set extra_attribs = call('Html::parseAttributes', {options: options.add_field_attribs}) %}
+      {% set extra_attribs = html_parse_attributes(options.add_field_attribs) %}
    {% else %}
       {% set extra_attribs = '' %}
    {% endif %}

--- a/templates/components/form/item_itilobject_item_list.html.twig
+++ b/templates/components/form/item_itilobject_item_list.html.twig
@@ -32,7 +32,7 @@
 
 {% if linknewitil %}
     <div class='mb-3'>
-        {{ call('Html::showSimpleForm', [itemtype_1|itemtype_form_path, '_add_fromitem', __('New %s for this item')|format(itemtype_1|itemtype_name(1)), {'itemtype': item.getType(), 'items_id': item.getID()}]) }}
+        {{ html_show_simple_form(itemtype_1|itemtype_form_path, '_add_fromitem', __('New %s for this item')|format(itemtype_1|itemtype_name(1)), {'itemtype': item.getType(), 'items_id': item.getID()}) }}
     </div>
 {% endif %}
 <div class="mb-3">

--- a/templates/components/form/rulematchedlogs.html.twig
+++ b/templates/components/form/rulematchedlogs.html.twig
@@ -32,7 +32,7 @@
  #}
 
 {% block more_fields %}
-    {% do call('Html::printAjaxPager', ['RuleMatchedLog'|itemtype_name, start, count]) %}
+    {% do html_print_ajax_pager('RuleMatchedLog'|itemtype_name, start, count) %}
 
     <table class="tab_cadre_fixe">
         <tr>
@@ -96,5 +96,5 @@
         {% endfor %}
     </table>
 
-    {% do call('Html::printAjaxPager', ['RuleMatchedLog'|itemtype_name, start, count]) %}
+    {% do html_print_ajax_pager('RuleMatchedLog'|itemtype_name, start, count) %}
 {% endblock %}

--- a/templates/components/itilobject/timeline/pending_reasons_messages.html.twig
+++ b/templates/components/itilobject/timeline/pending_reasons_messages.html.twig
@@ -53,13 +53,13 @@
          {% set next_bump = pending_reason_item_parent.getNextFollowupDate() %}
          {% if next_bump %}
 
-            <i class="fas fa-clock ms-2" title="{{ __("Next automatic follow-up scheduled on %s")|format(call("Html::convDate", [next_bump])) }}"
+            <i class="fas fa-clock ms-2" title="{{ __("Next automatic follow-up scheduled on %s")|format(next_bump|formatted_date) }}"
                data-bs-toggle="tooltip"></i>
          {% endif %}
 
          {% set resolve = pending_reason_item_parent.getAutoResolvedate() %}
          {% if resolve %}
-            <i class="fas fa-stop ms-2" title="{{ __("Automatic resolution scheduled on %s")|format(call("Html::convDate", [resolve])) }}"
+            <i class="fas fa-stop ms-2" title="{{ __("Automatic resolution scheduled on %s")|format(resolve|formatted_date) }}"
                data-bs-toggle="tooltip"></i>
          {% endif %}
       {% endif %}

--- a/templates/components/itilobject/timeline/timeline.html.twig
+++ b/templates/components/itilobject/timeline/timeline.html.twig
@@ -148,14 +148,14 @@
                      }, with_context = false) }}
                   </span>
                   {% if not anonym_user and entry_user.canView() %}
-                     {% do call('Html::showToolTip', [
+                     {% do html_show_tooltip(
                         include('components/user/info_card.html.twig', {
                            'user': user_fields,
                            'user_object': entry_user,
                            'enable_anonymization': false,
                         }, with_context = false), {
                            'applyto': 'timeline-avatar' ~ avatar_rand
-                        }]) %}
+                        }) %}
                   {% endif %}
                {% else %}
                   <span id="timeline-avatar{{ avatar_rand }}"><span class="avatar avatar-md rounded"></span></span>

--- a/templates/components/rss_feed.html.twig
+++ b/templates/components/rss_feed.html.twig
@@ -56,10 +56,10 @@
                {% set preview = rss_item.content|html_to_text %}
                {% set preview = preview|length > 1000 ? preview|slice(0, 1000) ~ ' (...)' : preview %}
                <span id="rssitem{{ rand }}" class="pointer">{{ preview }}</span>
-               {% do call('Html::showToolTip', [rss_item.content, {
+               {% do html_show_tooltip(rss_item.content, {
                   'applyto': 'rssitem' ~ rand,
                   'display': true
-               }]) %}
+               }) %}
             </td>
          </tr>
       {% endfor %}

--- a/templates/components/search/controls.html.twig
+++ b/templates/components/search/controls.html.twig
@@ -33,7 +33,7 @@
 
 {% if showmassiveactions and count > 0 %}
     <div class="massiveactions-control card-header search-header ps-3 animate__animated animate__faster d-none">
-        {% do call('Html::showMassiveActions', [massiveactionparams]) %}
+        {% do html_show_massive_actions(massiveactionparams) %}
     </div>
 {% endif %}
 

--- a/templates/components/search/displaypreference_list.html.twig
+++ b/templates/components/search/displaypreference_list.html.twig
@@ -38,7 +38,7 @@
         {% if massiveactionparams['specific_actions']|length > 0 %}
         <form id="massDisplayPreference{{ rand }}" method="get" action="{{ path('front/massiveaction.php') }}"
               data-search-itemtype="DisplayPreference" data-submit-once>
-            {% do call('Html::showMassiveActions', [massiveactionparams]) %}
+            {% do html_show_massive_actions(massiveactionparams) %}
             {% endif %}
             {{ inputs.hidden('users_id', users_id, {
                 'data-glpicore-ma-tags': 'common'
@@ -49,7 +49,7 @@
                     <li class="list-group-item">
                         {% if massiveactionparams['specific_actions']|length > 0 %}
                             <span class="me-2">
-                        {% do call('Html::showMassiveActionCheckBox', ['DisplayPreference', pref['itemtype']]) %}
+                        {% do html_show_massive_action_checkbox('DisplayPreference', pref['itemtype']) %}
                      </span>
                         {% endif %}
                         <button type="button" class="btn btn-link p-0 btn-itemtype-pref" data-itemtype="{{ pref['itemtype'] }}">{{ name }}</button>
@@ -57,9 +57,9 @@
                 {% endfor %}
             </ul>
             {% if massiveactionparams['specific_actions']|length > 0 %}
-            {% do call('Html::showMassiveActions', [massiveactionparams|merge({
+            {% do html_show_massive_actions(massiveactionparams|merge({
                 'ontop': false
-            })]) %}
+            })) %}
         </form>
         {% endif %}
     </div>

--- a/templates/components/search/query_builder/metacriteria.html.twig
+++ b/templates/components/search/query_builder/metacriteria.html.twig
@@ -65,7 +65,7 @@
          }) }}
       </div>
       <input type="hidden" name="criteria{{ prefix ~ "[" ~ num ~ "][meta]" }}" value="true">
-      {% set clean_id_prefix = call('Html::cleanId', [prefix]) %}
+      {% set clean_id_prefix = html_clean_id(prefix) %}
       {% set field_id = "dropdown_criteria" ~ clean_id_prefix ~ "[" ~ num ~ "][itemtype]" ~ rand %}
       {% set span_id = "show_" ~ normalized_itemtype ~ "_" ~ clean_id_prefix ~ num ~ "_" ~ rand %}
       {% set params = {

--- a/templates/components/user/link_with_tooltip.html.twig
+++ b/templates/components/user/link_with_tooltip.html.twig
@@ -47,21 +47,18 @@
         {% if has_profile_right('user', constant('READ')) %}
             {% set user_fields = user_fields|merge({login: user.fields['name']}) %}
         {% endif %}
-        {% do call(
-            'Html::showToolTip',
-            [
-                include(
-                    'components/user/info_card.html.twig',
-                    {
-                        'user': user_fields,
-                        'user_object': user,
-                    },
-                    with_context = false
-                ),
+        {% do html_show_tooltip(
+            include(
+                'components/user/info_card.html.twig',
                 {
-                    'applyto': "user_" ~ rand
-                }
-            ]
+                    'user': user_fields,
+                    'user_object': user,
+                },
+                with_context = false
+            ),
+            {
+                'applyto': "user_" ~ rand
+            }
         ) %}
     {% endif %}
 {% endif %}

--- a/templates/error_page.html.twig
+++ b/templates/error_page.html.twig
@@ -30,7 +30,15 @@
  # ---------------------------------------------------------------------
  #}
 
-{% do call(['Html', header_method], [page_title]) %}
+{% if header_method == 'simpleHeader' %}
+    {% do html_simple_header(page_title) %}
+{% elseif header_method == 'nullHeader' %}
+    {% do html_null_header(page_title) %}
+{% elseif header_method == 'header' %}
+    {% do html_header(page_title) %}
+{% elseif header_method == 'helpHeader' %}
+    {% do html_help_header(page_title) %}
+{% endif %}
 
 {{ include('error_block.html.twig', {
     message: message,
@@ -39,4 +47,4 @@
     link_text: link_text,
 }, with_context = false) }}
 
-{% do call(['Html', 'footer']) %}
+{% do html_footer() %}

--- a/templates/layout/page_skeleton.html.twig
+++ b/templates/layout/page_skeleton.html.twig
@@ -33,14 +33,21 @@
 {% set interface = get_current_interface() %}
 {% set header_method = interface == 'central' ? 'header' : 'helpHeader' %}
 
-{% do call(['Html', header_method], {
+{% set header_params = {
     title: title,
+    url: '',
     sector: menu[0] ?? 'none',
-    item  : menu[1] ?? 'none',
+    item: menu[1] ?? 'none',
     option: menu[2] ?? '',
-}) %}
+} %}
+
+{% if interface == 'central' %}
+    {% do html_header(...params) %}
+{% else %}
+    {% do html_help_header(...params) %}
+{% endif %}
 
 {% block content %}
 {% endblock content %}
 
-{% do call(['Html', 'footer']) %}
+{% do html_footer() %}

--- a/templates/pages/admin/inventory/agent.html.twig
+++ b/templates/pages/admin/inventory/agent.html.twig
@@ -152,7 +152,7 @@
 
                         {{ fields.htmlField(
                             'last_contact',
-                            call("Html::convDateTime", [item.fields['last_contact']]),
+                            item.fields['last_contact']|formatted_date,
                             __('Last contact'),
                             field_options
                         ) }}

--- a/templates/pages/generic_in_modal.html.twig
+++ b/templates/pages/generic_in_modal.html.twig
@@ -30,13 +30,10 @@
  # ---------------------------------------------------------------------
  #}
 
-{{ call(
-    'Html::popHeader',
-    [
-        call(object.getTypeName(), [1]),
-        '',
-        true,
-    ]
+{{ html_pop_header(
+    call(object.getTypeName(), [1]),
+    '',
+    true,
 ) }}
 
 {{ object.showForm(
@@ -44,4 +41,4 @@
     form_options
 ) }}
 
-{{ call('Html::popFooter') }}
+{{ html_pop_footer() }}

--- a/templates/pages/generic_list.html.twig
+++ b/templates/pages/generic_list.html.twig
@@ -32,8 +32,8 @@
 
 {% set header_params = call(class ~ '::getHeaderParameters') %}
 
-{{ call('Html::header', header_params) }}
+{{ html_header(...header_params) }}
 
 {{ call('Glpi\\Search\\SearchEngine::show', [class]) }}
 
-{{ call('Html::footer') }}
+{{ html_footer() }}

--- a/templates/pages/setup/general/api_apiclients_section.html.twig
+++ b/templates/pages/setup/general/api_apiclients_section.html.twig
@@ -34,7 +34,5 @@
 {% import 'components/form/fields_macros.html.twig' as fields %}
 
 {{ fields.largeTitle('APIClient'|itemtype_name(get_plural_number()), 'APIClient'|itemtype_icon) }}
-{% do call('Html::displayTitle', ['', '', '', {
-   'apiclient.form.php': __('Add API client')
-}]) %}
+{% do html_display_title('', '', '', { 'apiclient.form.php': __('Add API client') }) %}
 {% do call('Search::show', ['APIClient']) %}

--- a/templates/pages/setup/general/dbreplica_setup.html.twig
+++ b/templates/pages/setup/general/dbreplica_setup.html.twig
@@ -199,9 +199,9 @@
                                 {% else %}
                                     <span class="badge bg-red-lt">{{ __('Undefined') }}</span>
                                 {% endif %}
-                                {% do call('Html::showToolTip', [
+                                {% do html_show_tooltip(
                                     __('This indicates the delay between the primary and the replica for GLPI history (table: glpi_logs, column: date_mod).')
-                                ]) %}
+                                ) %}
                             </li>
                             <li>
                                 <span class="text-secondary">{{ __('Binary log GTID:') }}</span>

--- a/templates/pages/tools/reminder_planning.html.twig
+++ b/templates/pages/tools/reminder_planning.html.twig
@@ -61,9 +61,9 @@
         {{ text|raw }}
         {{ recall|raw }}
     {% endset %}
-    {% do call('Html::showToolTip', [tooltip_content, {
+    {% do html_show_tooltip(tooltip_content, {
         'applyto' : 'reminder_' ~ val['reminders_id'] ~ rand,
-    }]) %}
+    }) %}
 {% endif %}
 
 {{ parent_link|raw }}


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

The goal is to stop using the `call` wrapper from Twig and directly call the `Html::...` functions.

I also cleaned up a few missing calls to some functions from the `DataHelpersExtension`, which don't change the logic

It is a bit faster because PHP does not need to resolve the actual callable, neither has to wrap the call in `call_user_func_array`, and will just call it directly.

<details>
<summary>
Example for `components/datatable.html.twig`:
</summary>

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/dfa7a096-7042-4d93-8e70-c0fec9fbdc65) | ![image](https://github.com/user-attachments/assets/10c6c0d5-1fd3-4978-91b9-025801da55ec) |

</details>