### PR TITLE
Fix invalid CSS selector

### DIFF
--- a/css/includes/_base.scss
+++ b/css/includes/_base.scss
@@ -338,6 +338,6 @@ body input {
     visibility: hidden !important;
 }
 
-&:-webkit-autofill {
+:-webkit-autofill {
    -webkit-text-fill-color: var(--tblr-body-color);
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

The `&` selector is not valid at root level. With `scssphp` v1.x, it is replaced by an empty value, making the resulting CSS valid, but with `scssphp` v2, it causes the following issue:

```
  [ScssPhp\ScssPhp\Exception\SimpleSassException]               
  Top-level selectors may not contain the parent selector "&".  
      ,                                                         
  402 | &:-webkit-autofill {                                    
      | ^                                                       
      '                                                         
    css/includes/_base.scss 402:1  root stylesheet        
```