### PR TITLE
Fix update controller

### DIFF
--- a/src/Glpi/Controller/NeedsUpdateController.php
+++ b/src/Glpi/Controller/NeedsUpdateController.php
@@ -37,6 +37,8 @@ namespace Glpi\Controller;
 use Config;
 use DBmysql;
 use Glpi\Application\View\TemplateRenderer;
+use Glpi\Http\Firewall;
+use Glpi\Security\Attribute\SecurityStrategy;
 use Glpi\System\Requirement\DatabaseTablesEngine;
 use Glpi\System\RequirementsManager;
 use Glpi\Toolbox\VersionParser;
@@ -48,7 +50,8 @@ use Toolbox;
 
 class NeedsUpdateController extends AbstractController
 {
-    public function __invoke(string $key): Response
+    #[SecurityStrategy(Firewall::STRATEGY_NO_CHECK)]
+    public function __invoke(): Response
     {
         return new StreamedResponse($this->display(...));
     }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

1. Do not check require the user to be connected during the update process. This check was resulting in an infinite redirection loop when an update was required.

2. Remove useless unresolvable parameter. It fixes the following error: 
```Could not resolve argument $key of "Glpi\Controller\NeedsUpdateController::__invoke()", maybe you forgot to register the controller as a service or missed tagging it with the "controller.service_arguments"?```