### PR TITLE
Remove `$_SERVER['PHP_SELF']` from `Html::header()` calls

### DIFF
--- a/front/auth.others.php
+++ b/front/auth.others.php
@@ -47,7 +47,7 @@ if (isset($_POST["update"])) {
     Html::redirect($CFG_GLPI["root_doc"] . "/front/auth.others.php");
 }
 
-Html::header(__('External authentication sources'), $_SERVER['PHP_SELF'], "config", "auth", "others");
+Html::header(__('External authentication sources'), '', "config", "auth", "others");
 
 Auth::showOtherAuthList();
 

--- a/front/auth.settings.php
+++ b/front/auth.settings.php
@@ -39,7 +39,7 @@ $config = new Config();
 
 Html::header(
     __('External authentication sources'),
-    $_SERVER['PHP_SELF'],
+    '',
     "config",
     "auth",
     "settings"

--- a/front/central.php
+++ b/front/central.php
@@ -50,7 +50,7 @@ if (isset($_GET["embed"]) && isset($_GET["dashboard"])) {
 
 Session::checkCentralAccess();
 
-Html::header(Central::getTypeName(1), $_SERVER['PHP_SELF'], 'central', 'central');
+Html::header(Central::getTypeName(1), '', 'central', 'central');
 
 // Redirect management
 if (isset($_GET["redirect"])) {

--- a/front/change.form.php
+++ b/front/change.form.php
@@ -200,7 +200,7 @@ if (isset($_POST["add"])) {
     }
 
     if (isset($_GET['showglobalkanban']) && $_GET['showglobalkanban']) {
-        Html::header(sprintf(__('%s Kanban'), Change::getTypeName(1)), $_SERVER['PHP_SELF'], "helpdesk", "change");
+        Html::header(sprintf(__('%s Kanban'), Change::getTypeName(1)), '', "helpdesk", "change");
         $change::showKanban(0);
     } else {
         $menus = ["helpdesk", "change"];

--- a/front/consumableitem.php
+++ b/front/consumableitem.php
@@ -35,7 +35,7 @@
 
 Session::checkRightsOr(Consumable::$rightname, [READ, READ_ASSIGNED, READ_OWNED]);
 
-Html::header(Consumable::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "assets", "consumableitem");
+Html::header(Consumable::getTypeName(Session::getPluralNumber()), '', "assets", "consumableitem");
 
 if (isset($_GET["synthese"])) {
     Consumable::showSummary();

--- a/front/dashboard_assets.php
+++ b/front/dashboard_assets.php
@@ -52,7 +52,7 @@ if (!$dashboard->canViewCurrent()) {
     throw new AccessDeniedHttpException();
 }
 
-Html::header(__('Assets Dashboard'), $_SERVER['PHP_SELF'], "assets", "dashboard");
+Html::header(__('Assets Dashboard'), '', "assets", "dashboard");
 
 $grid = new Glpi\Dashboard\Grid($default);
 $grid->showDefault();

--- a/front/dashboard_helpdesk.php
+++ b/front/dashboard_helpdesk.php
@@ -52,7 +52,7 @@ if (!$dashboard->canViewCurrent()) {
     throw new AccessDeniedHttpException();
 }
 
-Html::header(__('Helpdesk Dashboard'), $_SERVER['PHP_SELF'], "helpdesk", "dashboard");
+Html::header(__('Helpdesk Dashboard'), '', "helpdesk", "dashboard");
 
 $grid = new Glpi\Dashboard\Grid($default);
 $grid->showDefault();

--- a/front/devices.php
+++ b/front/devices.php
@@ -35,7 +35,7 @@
 
 Session::checkRight("device", READ);
 
-Html::header(_n('Component', 'Components', Session::getPluralNumber()), $_SERVER['PHP_SELF'], "config", "commondevice");
+Html::header(_n('Component', 'Components', Session::getPluralNumber()), '', "config", "commondevice");
 echo "<div class='text-center'>";
 
 $optgroup = Dropdown::getDeviceItemTypes();

--- a/front/dictionnary.php
+++ b/front/dictionnary.php
@@ -39,7 +39,7 @@ Session::checkSeveralRightsOr(['rule_dictionnary_dropdown' => READ,
     'rule_dictionnary_software' => READ
 ]);
 
-Html::header(_n('Dictionary', 'Dictionaries', Session::getPluralNumber()), $_SERVER['PHP_SELF'], "admin", "dictionnary", -1);
+Html::header(_n('Dictionary', 'Dictionaries', Session::getPluralNumber()), '', "admin", "dictionnary", -1);
 
 echo TemplateRenderer::getInstance()->render(
     'pages/admin/rules/collections_list.html.twig',

--- a/front/dropdown.php
+++ b/front/dropdown.php
@@ -35,7 +35,7 @@
 
 use Glpi\Exception\Http\AccessDeniedHttpException;
 
-Html::header(__('Setup'), $_SERVER['PHP_SELF'], "config", "commondropdown");
+Html::header(__('Setup'), '', "config", "commondropdown");
 
 echo "<div class='center'>";
 

--- a/front/group.form.php
+++ b/front/group.form.php
@@ -66,7 +66,7 @@ if (isset($_POST["add"])) {
     ) {
         Html::header(
             $group->getTypeName(1),
-            $_SERVER['PHP_SELF'],
+            '',
             "admin",
             "group"
         );

--- a/front/inventory.conf.php
+++ b/front/inventory.conf.php
@@ -37,7 +37,7 @@ use Glpi\Inventory\Conf;
 
 Session::checkRight(Conf::$rightname, Conf::IMPORTFROMFILE);
 
-Html::header(__('Inventory'), $_SERVER['PHP_SELF'], "admin", "glpi\inventory\inventory");
+Html::header(__('Inventory'), '', "admin", "glpi\inventory\inventory");
 
 $conf = new Conf();
 

--- a/front/item_device.php
+++ b/front/item_device.php
@@ -52,7 +52,7 @@ if (!$itemDevice->canView()) {
 }
 
 if (in_array($itemDevice->getType(), $CFG_GLPI['devices_in_menu'])) {
-    Html::header($itemDevice->getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "assets", strtolower($itemDevice->getType()));
+    Html::header($itemDevice->getTypeName(Session::getPluralNumber()), '', "assets", strtolower($itemDevice->getType()));
 } else {
     Html::header($itemDevice->getTypeName(Session::getPluralNumber()), '', "config", "commondevice", $itemDevice->getType());
 }

--- a/front/knowbaseitem.php
+++ b/front/knowbaseitem.php
@@ -46,7 +46,7 @@ if (isset($_GET["id"])) {
     Html::redirect(KnowbaseItem::getFormURLWithID($_GET["id"]));
 }
 
-Html::header(KnowbaseItem::getTypeName(1), $_SERVER['PHP_SELF'], "tools", "knowbaseitem");
+Html::header(KnowbaseItem::getTypeName(1), '', "tools", "knowbaseitem");
 
 // Search a solution
 if (

--- a/front/knowbaseitemtranslation.form.php
+++ b/front/knowbaseitemtranslation.form.php
@@ -76,7 +76,7 @@ if (isset($_POST['add'])) {
 
     if (Session::getLoginUserID()) {
         if (Session::getCurrentInterface() == "central") {
-            Html::header(KnowbaseItem::getTypeName(1), $_SERVER['PHP_SELF'], "tools", "knowbaseitemtranslation");
+            Html::header(KnowbaseItem::getTypeName(1), '', "tools", "knowbaseitemtranslation");
         } else {
             Html::helpHeader(__('FAQ'));
         }

--- a/front/ldap.group.import.php
+++ b/front/ldap.group.import.php
@@ -37,7 +37,7 @@ Session::checkRightsOr('group', [CREATE, UPDATE]);
 Session::checkRight('user', User::UPDATEAUTHENT);
 AuthLDAP::manageRequestValues(false);
 
-Html::header(__('LDAP directory link'), $_SERVER['PHP_SELF'], "admin", "group", "ldap");
+Html::header(__('LDAP directory link'), '', "admin", "group", "ldap");
 
 $authldap = new AuthLDAP();
 $authldap->getFromDB($_REQUEST['authldaps_id'] ?? 0);

--- a/front/ldap.group.php
+++ b/front/ldap.group.php
@@ -39,7 +39,7 @@ $group = new Group();
 $group->checkGlobal(UPDATE);
 Session::checkRight('user', User::UPDATEAUTHENT);
 
-Html::header(__('LDAP directory link'), $_SERVER['PHP_SELF'], "admin", "group", "ldap");
+Html::header(__('LDAP directory link'), '', "admin", "group", "ldap");
 
 echo TemplateRenderer::getInstance()->render(
     'pages/admin/ldap.groups.html.twig'

--- a/front/ldap.import.php
+++ b/front/ldap.import.php
@@ -41,7 +41,7 @@ if (isset($_REQUEST['_in_modal']) && $_REQUEST['_in_modal']) {
     $_REQUEST['_in_modal'] = 1;
 }
 
-Html::header(__('LDAP directory link'), $_SERVER['PHP_SELF'], "admin", "user", "ldap");
+Html::header(__('LDAP directory link'), '', "admin", "user", "ldap");
 
 if (($_REQUEST['action'] ?? 'show') === 'show') {
     $authldap = new AuthLDAP();

--- a/front/ldap.php
+++ b/front/ldap.php
@@ -37,7 +37,7 @@ use Glpi\Application\View\TemplateRenderer;
 
 Session::checkRight("user", User::IMPORTEXTAUTHUSERS);
 
-Html::header(__('LDAP directory link'), $_SERVER['PHP_SELF'], "admin", "user", "ldap");
+Html::header(__('LDAP directory link'), '', "admin", "user", "ldap");
 
 echo TemplateRenderer::getInstance()->render(
     'pages/admin/ldap.users.html.twig'

--- a/front/logs.php
+++ b/front/logs.php
@@ -39,7 +39,7 @@ Session::checkRight("logs", READ);
 
 Html::header(
     LogViewer::getTypeName(Session::getPluralNumber()),
-    $_SERVER['PHP_SELF'],
+    '',
     "admin",
     'glpi\system\log\logviewer'
 );

--- a/front/logviewer.php
+++ b/front/logviewer.php
@@ -68,7 +68,7 @@ if (($_GET['action'] ?? '') === 'download') {
 } else {
     Html::header(
         LogViewer::getTypeName(Session::getPluralNumber()),
-        $_SERVER['PHP_SELF'],
+        '',
         'admin',
         'glpi\system\log\logviewer',
         'logfile'

--- a/front/marketplace.php
+++ b/front/marketplace.php
@@ -44,7 +44,7 @@ if (!Glpi\Marketplace\Controller::isWebAllowed()) {
 $plugin = new Plugin();
 $plugin->checkStates(true);
 
-Html::header(__('Marketplace'), $_SERVER['PHP_SELF'], "config", "plugin", "marketplace");
+Html::header(__('Marketplace'), '', "config", "plugin", "marketplace");
 
 $market_view = new \Glpi\Marketplace\View();
 $market_view->display();

--- a/front/planning.php
+++ b/front/planning.php
@@ -145,7 +145,7 @@ if (isset($_GET['checkavailability'])) {
         }
     }
 } else {
-    Html::header(__('Planning'), $_SERVER['PHP_SELF'], "helpdesk", "planning");
+    Html::header(__('Planning'), '', "helpdesk", "planning");
 
     Session::checkRightsOr('planning', [Planning::READALL, Planning::READMY]);
 

--- a/front/plugin.php
+++ b/front/plugin.php
@@ -40,7 +40,7 @@ Session::checkRight("config", UPDATE);
 $plugin = new Plugin();
 $plugin->checkStates(true);
 
-Html::header(__('Setup'), $_SERVER['PHP_SELF'], "config", "plugin");
+Html::header(__('Setup'), '', "config", "plugin");
 
 \Glpi\Marketplace\View::showFeatureSwitchDialog();
 

--- a/front/preference.php
+++ b/front/preference.php
@@ -70,7 +70,7 @@ if (
     Html::back();
 } else {
     if (Session::getCurrentInterface() == "central") {
-        Html::header(Preference::getTypeName(1), $_SERVER['PHP_SELF'], 'preference');
+        Html::header(Preference::getTypeName(1), '', 'preference');
     } else {
         Html::helpHeader(Preference::getTypeName(1));
     }

--- a/front/problem.form.php
+++ b/front/problem.form.php
@@ -203,7 +203,7 @@ if (isset($_POST["add"])) {
     }
 
     if (isset($_GET['showglobalkanban']) && $_GET['showglobalkanban']) {
-        Html::header(sprintf(__('%s Kanban'), Problem::getTypeName(1)), $_SERVER['PHP_SELF'], "helpdesk", "problem");
+        Html::header(sprintf(__('%s Kanban'), Problem::getTypeName(1)), '', "helpdesk", "problem");
         $problem::showKanban(0);
         Html::footer();
     } else {

--- a/front/project.form.php
+++ b/front/project.form.php
@@ -123,7 +123,7 @@ if (isset($_POST["add"])) {
     Html::popFooter();
 } else {
     if (isset($_GET['showglobalkanban']) && $_GET['showglobalkanban']) {
-        Html::header(Project::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "tools", "project");
+        Html::header(Project::getTypeName(Session::getPluralNumber()), '', "tools", "project");
         $project->showKanban(0);
         Html::footer();
     } else {

--- a/front/report.contract.php
+++ b/front/report.contract.php
@@ -35,7 +35,7 @@
 
 Session::checkRight("reports", READ);
 
-Html::header(Report::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "tools", "report");
+Html::header(Report::getTypeName(Session::getPluralNumber()), '', "tools", "report");
 
 Report::title();
 Report::showContractAssetsReport($_GET['item_type'] ?? [], $_GET['year'] ?? []);

--- a/front/report.default.php
+++ b/front/report.default.php
@@ -35,7 +35,7 @@
 
 Session::checkRight("reports", READ);
 
-Html::header(Report::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "tools", "report");
+Html::header(Report::getTypeName(Session::getPluralNumber()), '', "tools", "report");
 
 Report::title();
 Report::showDefaultReport();

--- a/front/report.infocom.conso.php
+++ b/front/report.infocom.conso.php
@@ -35,7 +35,7 @@
 
 Session::checkRight("reports", READ);
 
-Html::header(Report::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "tools", "report");
+Html::header(Report::getTypeName(Session::getPluralNumber()), '', "tools", "report");
 
 Report::title();
 Report::showOtherInfocomReport($_GET['date1'] ?? null, $_GET['date2'] ?? null);

--- a/front/report.infocom.php
+++ b/front/report.infocom.php
@@ -36,7 +36,7 @@
 Session::checkRight(Report::$rightname, READ);
 Session::checkRight(Infocom::$rightname, READ);
 
-Html::header(Report::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "tools", "report");
+Html::header(Report::getTypeName(Session::getPluralNumber()), '', "tools", "report");
 
 Report::title();
 Report::showInfocomReport($_GET['date1'] ?? null, $_GET['date2'] ?? null);

--- a/front/report.networking.php
+++ b/front/report.networking.php
@@ -35,7 +35,7 @@
 
 Session::checkRight("reports", READ);
 
-Html::header(Report::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "tools", "report");
+Html::header(Report::getTypeName(Session::getPluralNumber()), '', "tools", "report");
 
 $itemtype = match (true) {
     isset($_GET['locations_id']) => Location::class,

--- a/front/report.php
+++ b/front/report.php
@@ -35,7 +35,7 @@
 
 Session::checkRight("reports", READ);
 
-Html::header(Report::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "tools", "report");
+Html::header(Report::getTypeName(Session::getPluralNumber()), '', "tools", "report");
 
 Report::title();
 Html::footer();

--- a/front/report.reservation.php
+++ b/front/report.reservation.php
@@ -35,7 +35,7 @@
 
 Session::checkRight("reports", READ);
 
-Html::header(Report::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "tools", "report");
+Html::header(Report::getTypeName(Session::getPluralNumber()), '', "tools", "report");
 
 if (!isset($_GET["id"])) {
     $_GET["id"] = 0;

--- a/front/report.state.php
+++ b/front/report.state.php
@@ -39,7 +39,7 @@
 
 Session::checkRight("reports", READ);
 
-Html::header(Report::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "tools", "report");
+Html::header(Report::getTypeName(Session::getPluralNumber()), '', "tools", "report");
 
 if (!isset($_GET["id"])) {
     $_GET["id"] = 0;

--- a/front/report.year.php
+++ b/front/report.year.php
@@ -35,7 +35,7 @@
 
 Session::checkRight("reports", READ);
 
-Html::header(Report::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "tools", "report");
+Html::header(Report::getTypeName(Session::getPluralNumber()), '', "tools", "report");
 
 Report::title();
 Report::showYearlyAssetsReport($_GET["item_type"] ?? [], $_GET["year"] ?? []);

--- a/front/reservation.form.php
+++ b/front/reservation.form.php
@@ -56,7 +56,7 @@ if (isset($_REQUEST['ajax'])) {
 } else if (Session::getCurrentInterface() == "helpdesk") {
     Html::helpHeader(__('Simplified interface'));
 } else {
-    Html::header(Reservation::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "tools", "reservationitem");
+    Html::header(Reservation::getTypeName(Session::getPluralNumber()), '', "tools", "reservationitem");
 }
 
 if (isset($_POST["update"])) {

--- a/front/reservation.php
+++ b/front/reservation.php
@@ -40,7 +40,7 @@ if (!isset($_GET["reservationitems_id"])) {
 if (Session::getCurrentInterface() == "helpdesk") {
     Html::helpHeader(__('Simplified interface'));
 } else {
-    Html::header(Reservation::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "tools", "reservationitem");
+    Html::header(Reservation::getTypeName(Session::getPluralNumber()), '', "tools", "reservationitem");
 }
 
 Reservation::showCalendar((int) $_GET["reservationitems_id"]);

--- a/front/reservationitem.form.php
+++ b/front/reservationitem.form.php
@@ -104,7 +104,7 @@ if (isset($_POST["add"])) {
     Html::back();
 } else {
     $ri->check($_GET["id"], READ);
-    Html::header(Reservation::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "tools", "reservationitem");
+    Html::header(Reservation::getTypeName(Session::getPluralNumber()), '', "tools", "reservationitem");
     $ri->showForm($_GET["id"]);
 }
 

--- a/front/reservationitem.php
+++ b/front/reservationitem.php
@@ -38,7 +38,7 @@ Session::checkRightsOr('reservation', [READ, ReservationItem::RESERVEANITEM]);
 if (Session::getCurrentInterface() == "helpdesk") {
     Html::helpHeader(__('Simplified interface'), 'reservation');
 } else {
-    Html::header(Reservation::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "tools", "reservationitem");
+    Html::header(Reservation::getTypeName(Session::getPluralNumber()), '', "tools", "reservationitem");
 }
 
 $res = new ReservationItem();

--- a/front/rule.backup.php
+++ b/front/rule.backup.php
@@ -50,7 +50,7 @@ $rulecollection = new RuleCollection();
 $rulecollection->checkGlobal(READ);
 
 if ($action !== "export") {
-    Html::header(Rule::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "admin", "rule", -1);
+    Html::header(Rule::getTypeName(Session::getPluralNumber()), '', "admin", "rule", -1);
 }
 
 switch ($action) {

--- a/front/rule.common.php
+++ b/front/rule.common.php
@@ -84,7 +84,7 @@ if (isset($_POST["action"])) {
 
     Html::header(
         Rule::getTypeName(Session::getPluralNumber()),
-        $_SERVER['PHP_SELF'],
+        '',
         "admin",
         $rulecollection->menu_type,
         $rulecollection->menu_option
@@ -148,7 +148,7 @@ if (isset($_POST["action"])) {
 
 Html::header(
     Rule::getTypeName(Session::getPluralNumber()),
-    $_SERVER['PHP_SELF'],
+    '',
     'admin',
     $rulecollection->menu_type,
     $rulecollection->menu_option

--- a/front/rule.php
+++ b/front/rule.php
@@ -37,7 +37,7 @@ use Glpi\Application\View\TemplateRenderer;
 
 Session::checkCentralAccess();
 
-Html::header(Rule::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], "admin", "rule", -1);
+Html::header(Rule::getTypeName(Session::getPluralNumber()), '', "admin", "rule", -1);
 
 RuleCollection::showCollectionsList();
 

--- a/front/savedsearch.php
+++ b/front/savedsearch.php
@@ -36,7 +36,7 @@
 if (Session::getCurrentInterface() == "helpdesk") {
     Html::helpHeader(SavedSearch::getTypeName(Session::getPluralNumber()));
 } else {
-    Html::header(SavedSearch::getTypeName(Session::getPluralNumber()), $_SERVER['PHP_SELF'], 'tools', 'savedsearch');
+    Html::header(SavedSearch::getTypeName(Session::getPluralNumber()), '', 'tools', 'savedsearch');
 }
 
 $savedsearch = new SavedSearch();

--- a/front/search.php
+++ b/front/search.php
@@ -39,7 +39,7 @@ use Glpi\Exception\Http\AccessDeniedHttpException;
 global $CFG_GLPI;
 
 Session::checkCentralAccess();
-Html::header(__('Search'), $_SERVER['PHP_SELF']);
+Html::header(__('Search'));
 
 if (!$CFG_GLPI['allow_search_global']) {
     throw new AccessDeniedHttpException();

--- a/front/setup.auth.php
+++ b/front/setup.auth.php
@@ -37,7 +37,7 @@ use Glpi\Application\View\TemplateRenderer;
 
 Session::checkRight("config", READ);
 
-Html::header(__('External authentication sources'), $_SERVER['PHP_SELF'], "config", "auth", -1);
+Html::header(__('External authentication sources'), '', "config", "auth", -1);
 
 echo TemplateRenderer::getInstance()->render(
     'pages/setup/authentication.html.twig',

--- a/front/setup.notification.php
+++ b/front/setup.notification.php
@@ -40,7 +40,7 @@ Session::checkSeveralRightsOr(['notification' => READ,
     'config'       => UPDATE
 ]);
 
-Html::header(_n('Notification', 'Notifications', Session::getPluralNumber()), $_SERVER['PHP_SELF'], "config", "notification");
+Html::header(_n('Notification', 'Notifications', Session::getPluralNumber()), '', "config", "notification");
 
 if (
     !Session::haveRight("config", READ)

--- a/front/setup.templates.php
+++ b/front/setup.templates.php
@@ -53,7 +53,7 @@ if (isset($_GET["itemtype"])) {
         }
     }
 
-    Html::header(__('Manage templates...'), $_SERVER['PHP_SELF'], $sector, $itemtype);
+    Html::header(__('Manage templates...'), '', $sector, $itemtype);
 
     CommonDBTM::listTemplates($itemtype, $link, $_GET["add"]);
 

--- a/front/stat.global.php
+++ b/front/stat.global.php
@@ -39,7 +39,7 @@ use Glpi\Stat\Data\Sglobal\StatDataSatisfaction;
 use Glpi\Stat\Data\Sglobal\StatDataTicketAverageTime;
 use Glpi\Stat\Data\Sglobal\StatDataTicketNumber;
 
-Html::header(__('Statistics'), $_SERVER['PHP_SELF'], "helpdesk", "stat");
+Html::header(__('Statistics'), '', "helpdesk", "stat");
 
 Session::checkRight("statistic", READ);
 

--- a/front/stat.graph.php
+++ b/front/stat.graph.php
@@ -45,7 +45,7 @@ use Glpi\Stat\Data\Graph\StatDataTicketNumber;
  */
 global $DB;
 
-Html::header(__('Statistics'), $_SERVER['PHP_SELF'], "helpdesk", "stat");
+Html::header(__('Statistics'), '', "helpdesk", "stat");
 
 Session::checkRight("statistic", READ);
 

--- a/front/updatepassword.php
+++ b/front/updatepassword.php
@@ -47,7 +47,7 @@ if (Session::getLoginUserID() === false) {
 
 switch (Session::getCurrentInterface()) {
     case 'central':
-        Html::header(__('Update password'), $_SERVER['PHP_SELF']);
+        Html::header(__('Update password'));
         break;
     case 'helpdesk':
         Html::helpHeader(__('Update password'));

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -6712,7 +6712,7 @@ TWIG, $twig_params);
         \Glpi\Debug\Profiler::getInstance()->start('Html::header');
         Html::header(
             $title,
-            $_SERVER['PHP_SELF'],
+            '',
             $menus[0] ?? 'none',
             $menus[1] ?? 'none',
             $menus[2] ?? '',


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

This parameter is not used anymore, see https://github.com/glpi-project/glpi/blob/d52b53dcee729ebb024f37ac08b513824b16d5c6/src/Html.php#L1616

Removing this parameter from the method signature would be a pain to handle in plugins. Anyway, we should review all `$_SERVER['PHP_SELF']` to see if we still require the thow following hacks, and removing these usages would be helpful.

 - https://github.com/glpi-project/glpi/blob/d52b53dcee729ebb024f37ac08b513824b16d5c6/src/Glpi/Config/LegacyConfigurators/CleanPHPSelfParam.php#L47-L51
 - https://github.com/glpi-project/glpi/blob/d52b53dcee729ebb024f37ac08b513824b16d5c6/src/Glpi/Http/Listener/LegacyRouterListener.php#L99-L105

