### PR TITLE
Remove useless `$_SERVER['PHP_SELF']` related condition on ajax files

### DIFF
--- a/ajax/actorinformation.php
+++ b/ajax/actorinformation.php
@@ -33,13 +33,10 @@
  * ---------------------------------------------------------------------
  */
 
-// Direct access to file
-if (strpos($_SERVER['PHP_SELF'], "actorinformation.php")) {
-    /** @var \Glpi\Controller\LegacyFileLoadController $this */
-    $this->setAjax();
-    header("Content-Type: text/html; charset=UTF-8");
-    Html::header_nocache();
-}
+/** @var \Glpi\Controller\LegacyFileLoadController $this */
+$this->setAjax();
+header("Content-Type: text/html; charset=UTF-8");
+Html::header_nocache();
 
 // save value and force boolval for security of $_REQUEST['only_number]
 $only_number = boolval($_REQUEST['only_number'] ?? false);

--- a/ajax/dropdownConnect.php
+++ b/ajax/dropdownConnect.php
@@ -35,10 +35,8 @@
 
 use Glpi\Asset\Asset_PeripheralAsset;
 
-if (strpos($_SERVER['PHP_SELF'], "dropdownConnect.php")) {
-    header("Content-Type: text/html; charset=UTF-8");
-    Html::header_nocache();
-}
+header("Content-Type: text/html; charset=UTF-8");
+Html::header_nocache();
 
 if (!isset($_POST['fromtype']) || !($fromitem = getItemForItemtype($_POST['fromtype']))) {
     return;

--- a/ajax/dropdownFieldsBlacklist.php
+++ b/ajax/dropdownFieldsBlacklist.php
@@ -33,10 +33,8 @@
  * ---------------------------------------------------------------------
  */
 
-if (strpos($_SERVER['PHP_SELF'], "dropdownFieldsBlacklist.php")) {
-    header("Content-Type: text/html; charset=UTF-8");
-    Html::header_nocache();
-}
+header("Content-Type: text/html; charset=UTF-8");
+Html::header_nocache();
 
 Session::checkRight("config", UPDATE);
 

--- a/ajax/dropdownInstallVersion.php
+++ b/ajax/dropdownInstallVersion.php
@@ -38,13 +38,11 @@
  */
 global $DB;
 
-if (strpos($_SERVER['PHP_SELF'], "dropdownInstallVersion.php")) {
-    /** @var \Glpi\Controller\LegacyFileLoadController $this */
-    $this->setAjax();
+/** @var \Glpi\Controller\LegacyFileLoadController $this */
+$this->setAjax();
 
-    header("Content-Type: text/html; charset=UTF-8");
-    Html::header_nocache();
-}
+header("Content-Type: text/html; charset=UTF-8");
+Html::header_nocache();
 
 Session::checkRight("software", UPDATE);
 

--- a/ajax/dropdownNotificationEvent.php
+++ b/ajax/dropdownNotificationEvent.php
@@ -33,10 +33,8 @@
  * ---------------------------------------------------------------------
  */
 
-if (strpos($_SERVER['PHP_SELF'], "dropdownNotificationEvent.php")) {
-    header("Content-Type: text/html; charset=UTF-8");
-    Html::header_nocache();
-}
+header("Content-Type: text/html; charset=UTF-8");
+Html::header_nocache();
 
 Session::checkRightsOr("notification", [CREATE, UPDATE]);
 

--- a/ajax/dropdownNotificationTemplate.php
+++ b/ajax/dropdownNotificationTemplate.php
@@ -33,10 +33,8 @@
  * ---------------------------------------------------------------------
  */
 
-if (strpos($_SERVER['PHP_SELF'], "dropdownNotificationTemplate.php")) {
-    header("Content-Type: text/html; charset=UTF-8");
-    Html::header_nocache();
-}
+header("Content-Type: text/html; charset=UTF-8");
+Html::header_nocache();
 
 Session::checkRight("notification", UPDATE);
 

--- a/ajax/dropdownRubDocument.php
+++ b/ajax/dropdownRubDocument.php
@@ -38,13 +38,11 @@
  */
 global $DB;
 
-if (strpos($_SERVER['PHP_SELF'], "dropdownRubDocument.php")) {
-    /** @var \Glpi\Controller\LegacyFileLoadController $this */
-    $this->setAjax();
+/** @var \Glpi\Controller\LegacyFileLoadController $this */
+$this->setAjax();
 
-    header("Content-Type: text/html; charset=UTF-8");
-    Html::header_nocache();
-}
+header("Content-Type: text/html; charset=UTF-8");
+Html::header_nocache();
 
 Session::checkCentralAccess();
 

--- a/ajax/dropdownSoftwareLicense.php
+++ b/ajax/dropdownSoftwareLicense.php
@@ -38,13 +38,11 @@
  */
 global $DB;
 
-if (strpos($_SERVER['PHP_SELF'], "dropdownSoftwareLicense.php")) {
-    /** @var \Glpi\Controller\LegacyFileLoadController $this */
-    $this->setAjax();
+/** @var \Glpi\Controller\LegacyFileLoadController $this */
+$this->setAjax();
 
-    header("Content-Type: text/html; charset=UTF-8");
-    Html::header_nocache();
-}
+header("Content-Type: text/html; charset=UTF-8");
+Html::header_nocache();
 
 Session::checkRight("software", UPDATE);
 

--- a/ajax/dropdownTicketCategories.php
+++ b/ajax/dropdownTicketCategories.php
@@ -33,10 +33,8 @@
  * ---------------------------------------------------------------------
  */
 
-if (strpos($_SERVER['PHP_SELF'], "dropdownTicketCategories.php")) {
-    header("Content-Type: text/html; charset=UTF-8");
-    Html::header_nocache();
-}
+header("Content-Type: text/html; charset=UTF-8");
+Html::header_nocache();
 
 $opt = ['entity' => Session::getMatchingActiveEntities($_POST['entity_restrict'])];
 $condition  = [];

--- a/ajax/dropdownUnicityFields.php
+++ b/ajax/dropdownUnicityFields.php
@@ -33,10 +33,8 @@
  * ---------------------------------------------------------------------
  */
 
-if (strpos($_SERVER['PHP_SELF'], "dropdownUnicityFields.php")) {
-    header("Content-Type: text/html; charset=UTF-8");
-    Html::header_nocache();
-}
+header("Content-Type: text/html; charset=UTF-8");
+Html::header_nocache();
 
 Session::checkRight("config", UPDATE);
 

--- a/ajax/dropdownValuesBlacklist.php
+++ b/ajax/dropdownValuesBlacklist.php
@@ -33,10 +33,8 @@
  * ---------------------------------------------------------------------
  */
 
-if (strpos($_SERVER['PHP_SELF'], "dropdownValuesBlacklist.php")) {
-    header("Content-Type: text/html; charset=UTF-8");
-    Html::header_nocache();
-}
+header("Content-Type: text/html; charset=UTF-8");
+Html::header_nocache();
 
 Session::checkRight("config", UPDATE);
 if (

--- a/ajax/getDropdownConnect.php
+++ b/ajax/getDropdownConnect.php
@@ -37,9 +37,7 @@
  * @since 0.85
  */
 
-if (strpos($_SERVER['PHP_SELF'], "getDropdownConnect.php")) {
-    header("Content-Type: application/json; charset=UTF-8");
-    Html::header_nocache();
-}
+header("Content-Type: application/json; charset=UTF-8");
+Html::header_nocache();
 
 echo Dropdown::getDropdownConnect($_POST);

--- a/ajax/getDropdownNumber.php
+++ b/ajax/getDropdownNumber.php
@@ -37,10 +37,7 @@
  * @since 0.85
  */
 
-// Direct access to file
-if (strpos($_SERVER['PHP_SELF'], "getDropdownNumber.php")) {
-    header("Content-Type: application/json; charset=UTF-8");
-    Html::header_nocache();
-}
+header("Content-Type: application/json; charset=UTF-8");
+Html::header_nocache();
 
 echo Dropdown::getDropdownNumber($_POST);

--- a/ajax/getDropdownUsers.php
+++ b/ajax/getDropdownUsers.php
@@ -37,13 +37,10 @@
  * @since 0.85
  */
 
-// Direct access to file
-if (strpos($_SERVER['PHP_SELF'], "getDropdownUsers.php")) {
-    /** @var \Glpi\Controller\LegacyFileLoadController $this */
-    $this->setAjax();
+/** @var \Glpi\Controller\LegacyFileLoadController $this */
+$this->setAjax();
 
-    header("Content-Type: application/json; charset=UTF-8");
-    Html::header_nocache();
-}
+header("Content-Type: application/json; charset=UTF-8");
+Html::header_nocache();
 
 echo Dropdown::getDropdownUsers($_POST);

--- a/ajax/getDropdownValue.php
+++ b/ajax/getDropdownValue.php
@@ -37,10 +37,7 @@
  * @since 0.85
  */
 
-// Direct access to file
-if (strpos($_SERVER['PHP_SELF'], "getDropdownValue.php")) {
-    header("Content-Type: application/json; charset=UTF-8");
-    Html::header_nocache();
-}
+header("Content-Type: application/json; charset=UTF-8");
+Html::header_nocache();
 
 echo Dropdown::getDropdownValue($_POST);

--- a/ajax/ruleaction.php
+++ b/ajax/ruleaction.php
@@ -36,11 +36,8 @@
 /** @var array $CFG_GLPI */
 global $CFG_GLPI;
 
-// Direct access to file
-if (strpos($_SERVER['PHP_SELF'], "ruleaction.php")) {
-    header("Content-Type: text/html; charset=UTF-8");
-    Html::header_nocache();
-}
+header("Content-Type: text/html; charset=UTF-8");
+Html::header_nocache();
 
 // Non define case
 if (isset($_POST["sub_type"]) && class_exists($_POST["sub_type"])) {

--- a/ajax/ruleactionvalue.php
+++ b/ajax/ruleactionvalue.php
@@ -33,11 +33,8 @@
  * ---------------------------------------------------------------------
  */
 
-// Direct access to file
-if (strpos($_SERVER['PHP_SELF'], "ruleactionvalue.php")) {
-    header("Content-Type: text/html; charset=UTF-8");
-    Html::header_nocache();
-}
+header("Content-Type: text/html; charset=UTF-8");
+Html::header_nocache();
 
 $ra = new RuleAction();
 

--- a/ajax/rulecriteria.php
+++ b/ajax/rulecriteria.php
@@ -36,11 +36,8 @@
 /** @var array $CFG_GLPI */
 global $CFG_GLPI;
 
-// Direct access to file
-if (strpos($_SERVER['PHP_SELF'], "rulecriteria.php")) {
-    header("Content-Type: text/html; charset=UTF-8");
-    Html::header_nocache();
-}
+header("Content-Type: text/html; charset=UTF-8");
+Html::header_nocache();
 
 /** @var Rule $rule */
 if (isset($_POST["sub_type"]) && ($rule = getItemForItemtype($_POST["sub_type"]))) {

--- a/ajax/rulecriteriavalue.php
+++ b/ajax/rulecriteriavalue.php
@@ -33,11 +33,8 @@
  * ---------------------------------------------------------------------
  */
 
-// Direct access to file
-if (strstr($_SERVER['PHP_SELF'], "rulecriteriavalue.php")) {
-    header("Content-Type: text/html; charset=UTF-8");
-    Html::header_nocache();
-}
+header("Content-Type: text/html; charset=UTF-8");
+Html::header_nocache();
 
 // Non define case
 /** @var Rule $rule */

--- a/ajax/subvisibility.php
+++ b/ajax/subvisibility.php
@@ -33,14 +33,11 @@
  * ---------------------------------------------------------------------
  */
 
-// Direct access to file
-if (strpos($_SERVER['PHP_SELF'], "subvisibility.php")) {
-    /** @var \Glpi\Controller\LegacyFileLoadController $this */
-    $this->setAjax();
+/** @var \Glpi\Controller\LegacyFileLoadController $this */
+$this->setAjax();
 
-    header("Content-Type: text/html; charset=UTF-8");
-    Html::header_nocache();
-}
+header("Content-Type: text/html; charset=UTF-8");
+Html::header_nocache();
 
 if (!empty($_POST['type']) && isset($_POST['items_id']) && ($_POST['items_id'] > 0)) {
     $prefix = '';

--- a/ajax/ticketiteminformation.php
+++ b/ajax/ticketiteminformation.php
@@ -33,14 +33,11 @@
  * ---------------------------------------------------------------------
  */
 
-// Direct access to file
-if (strpos($_SERVER['PHP_SELF'], "ticketiteminformation.php")) {
-    /** @var \Glpi\Controller\LegacyFileLoadController $this */
-    $this->setAjax();
+/** @var \Glpi\Controller\LegacyFileLoadController $this */
+$this->setAjax();
 
-    header("Content-Type: text/html; charset=UTF-8");
-    Html::header_nocache();
-}
+header("Content-Type: text/html; charset=UTF-8");
+Html::header_nocache();
 
 if (isset($_POST["my_items"]) && !empty($_POST["my_items"])) {
     $splitter = explode("_", $_POST["my_items"]);

--- a/ajax/uemailUpdate.php
+++ b/ajax/uemailUpdate.php
@@ -38,10 +38,8 @@ use Glpi\Application\View\TemplateRenderer;
 /** @var \Glpi\Controller\LegacyFileLoadController $this */
 $this->setAjax();
 
-if (strpos($_SERVER['PHP_SELF'], "uemailUpdate.php")) {
-    header("Content-Type: text/html; charset=UTF-8");
-    Html::header_nocache();
-}
+header("Content-Type: text/html; charset=UTF-8");
+Html::header_nocache();
 
 if (
     (isset($_POST['field']) && ($_POST["value"] > 0))

--- a/ajax/visibility.php
+++ b/ajax/visibility.php
@@ -38,14 +38,11 @@
  */
 global $CFG_GLPI;
 
-// Direct access to file
-if (strpos($_SERVER['PHP_SELF'], "visibility.php")) {
-    /** @var \Glpi\Controller\LegacyFileLoadController $this */
-    $this->setAjax();
+/** @var \Glpi\Controller\LegacyFileLoadController $this */
+$this->setAjax();
 
-    header("Content-Type: text/html; charset=UTF-8");
-    Html::header_nocache();
-}
+header("Content-Type: text/html; charset=UTF-8");
+Html::header_nocache();
 
 Session::checkCentralAccess();
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

The `if (strpos($_SERVER['PHP_SELF'], "xxx.php")) {` condition on many ajax files is supposed to prevent the execution of the related code when the file is included from another file. None of these files are included from another GLPI file, so this condition is useless. I guess this condition is inherited from some copy/paste operations.