### PR TITLE
Remove useless usages of `$_SERVER['PHP_SELF']`

### DIFF
--- a/front/documenttype.list.php
+++ b/front/documenttype.list.php
@@ -37,7 +37,6 @@ Html::popHeader(__('Setup'));
 
 $params = Search::manageParams('DocumentType', $_GET);
 
-$params['target'] = $_SERVER['PHP_SELF'];
 Search::showList('DocumentType', $params);
 
 Html::popFooter();

--- a/src/Infocom.php
+++ b/src/Infocom.php
@@ -1378,10 +1378,7 @@ JS;
             $dev_ID   = $item->getField('id');
             $ic       = new self();
 
-            if (
-                !strpos($_SERVER['PHP_SELF'], "infocoms-show")
-                && in_array($item->getType(), self::getExcludedTypes())
-            ) {
+            if (in_array($item->getType(), self::getExcludedTypes())) {
                 echo "<div class='firstbloc center'>" .
                   __('For this type of item, the financial and administrative information are only a model for the items which you should add.') .
                  "</div>";

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -1371,7 +1371,6 @@ TWIG, $twig_params);
         $params["start"]                     = "0";
         $params["knowbaseitemcategories_id"] = null;
         $params["contains"]                  = "";
-        $params["target"]                    = $_SERVER['PHP_SELF'];
 
         if (is_array($options) && count($options)) {
             foreach ($options as $key => $val) {


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

1. `target` param value seems to have no effect in the `Search::showList()` method.
2. `infocoms-show` is not referenced anywhere in the code, therefore the `!strpos($_SERVER['PHP_SELF'], "infocoms-show")` check is probably useless.
1. `target` param value seems to have no effect in the `KnowbaseItem::showList()` method.