### PR TITLE
Fix failing tests

### DIFF
--- a/js/modules/Forms/RendererController.js
+++ b/js/modules/Forms/RendererController.js
@@ -114,9 +114,11 @@ export class GlpiFormRendererController
         // Form will be sumitted using an AJAX request instead
         try {
             // Update tinymce values
-            tinymce.get().forEach(editor => {
-                editor.save();
-            });
+            if (window.tinymce !== undefined) {
+                tinymce.get().forEach(editor => {
+                    editor.save();
+                });
+            }
 
             // Submit form using AJAX
             const response = await $.post({
@@ -147,7 +149,8 @@ export class GlpiFormRendererController
                 `)
                 .addClass("d-none");
 
-        } catch {
+        } catch (e) {
+            console.error(e);
             glpi_toast_error(
                 __("Failed to submit form, please contact your administrator.")
             );


### PR DESCRIPTION
## Description

Tests on main seems to be failing (we merged a lot of things at once recently, probably some unseen conflict).
It seems to come from the fact that the `tinymce` variable is now only defined if there is at least one editor on a page, unsure why.
