### PR TITLE
Remove more `$_SERVER['PHP_SELF']` usages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -220,6 +220,7 @@ The present file will list all changes made to the project; according to the
 - `Contract::getExpiredCriteria()` renamed to `Contract::getNotExpiredCriteria()` to match the actual behavior.
 - `Migration::updateRight()` renamed to `Migration::replaceRight()`.
 - `Search::getOptions()` no longer returns a reference.
+- The `$target` parameter has been removed from the `AuthLDAP::showLdapGroups()` method.
 
 #### Deprecated
 - Usage of the `/marketplace` path for plugins URLs. All plugins URLs should now start with `/plugins`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -221,6 +221,7 @@ The present file will list all changes made to the project; according to the
 - `Migration::updateRight()` renamed to `Migration::replaceRight()`.
 - `Search::getOptions()` no longer returns a reference.
 - The `$target` parameter has been removed from the `AuthLDAP::showLdapGroups()` method.
+- The `$target` parameter has been removed from the `Rule::showRulePreviewCriteriasForm()`, `Rule::showRulePreviewResultsForm()`, `RuleCollection::showRulesEnginePreviewCriteriasForm()`, and `RuleCollection::showRulesEnginePreviewResultsForm()` methods signature.
 
 #### Deprecated
 - Usage of the `/marketplace` path for plugins URLs. All plugins URLs should now start with `/plugins`.

--- a/front/group.form.php
+++ b/front/group.form.php
@@ -71,7 +71,7 @@ if (isset($_POST["add"])) {
             "group"
         );
 
-        $group->showDeleteConfirmForm($_SERVER['PHP_SELF']);
+        $group->showDeleteConfirmForm();
         Html::footer();
     } else {
         $group->delete($_POST, 1);

--- a/front/ldap.group.import.php
+++ b/front/ldap.group.import.php
@@ -48,7 +48,6 @@ if (
     && (isset($_REQUEST['search']) || isset($_REQUEST['start']) || isset($_REQUEST['glpilist_limit']))
 ) {
     AuthLDAP::showLdapGroups(
-        $_SERVER['PHP_SELF'],
         $_REQUEST['start'] ?? 0,
         0,
         $_REQUEST["ldap_group_filter"] ?? '',

--- a/front/reservation.form.php
+++ b/front/reservation.form.php
@@ -65,7 +65,6 @@ if (isset($_POST["update"])) {
         Session::haveRight("reservation", UPDATE)
         || (Session::getLoginUserID() == $_POST["users_id"])
     ) {
-        $_POST['_target'] = $_SERVER['PHP_SELF'];
         $_POST['_item']   = key($_POST["items"]);
         $_POST['begin']   = $_POST['resa']["begin"];
         $_POST['end']     = $_POST['resa']["end"];

--- a/front/rule.common.php
+++ b/front/rule.common.php
@@ -92,7 +92,7 @@ if (isset($_POST["action"])) {
 
     if (
         !(isset($_POST['replay_confirm']) || isset($_GET['offset']))
-        && $rulecollection->warningBeforeReplayRulesOnExistingDB($_SERVER['PHP_SELF'])
+        && $rulecollection->warningBeforeReplayRulesOnExistingDB()
     ) {
         Html::footer();
         return;
@@ -128,6 +128,8 @@ if (isset($_POST["action"])) {
         $start = $_GET["start"];
     }
 
+    $rule_class = $rulecollection->getRuleClassName();
+
     if ($offset < 0) {
        // Work ended
         $duree = round(microtime(true) - $start);
@@ -135,10 +137,10 @@ if (isset($_POST["action"])) {
             __('Task completed in %s'),
             Html::timestampToString($duree)
         ));
-        echo "<a href='" . $_SERVER['PHP_SELF'] . "'>" . __s('Back') . "</a>";
+        echo "<a href='" . htmlescape($rule_class::getSearchURL()) . "'>" . __s('Back') . "</a>";
     } else {
        // Need more work
-        Html::redirect($_SERVER['PHP_SELF'] . "?start=$start&replay_rule=1&offset=$offset&manufacturer=" .
+        Html::redirect($rule_class::getSearchURL() . "?start=$start&replay_rule=1&offset=$offset&manufacturer=" .
                      "$manufacturer");
     }
 

--- a/front/rule.test.php
+++ b/front/rule.test.php
@@ -61,7 +61,7 @@ $rule->checkGlobal(READ);
 
 Html::popHeader(__('Setup'));
 
-$rule->showRulePreviewCriteriasForm($_SERVER['PHP_SELF'], $rules_id);
+$rule->showRulePreviewCriteriasForm($rules_id);
 
 if (isset($_POST["test_rule"])) {
     $params = [];
@@ -75,7 +75,7 @@ if (isset($_POST["test_rule"])) {
     $input = $rule->prepareAllInputDataForProcess($_POST, $params);
    //$rule->regex_results = array();
     echo "<br>";
-    $rule->showRulePreviewResultsForm($_SERVER['PHP_SELF'], $input, $params);
+    $rule->showRulePreviewResultsForm($input, $params);
 }
 
 Html::popFooter();

--- a/front/rulesengine.test.php
+++ b/front/rulesengine.test.php
@@ -63,14 +63,14 @@ $rulecollection->checkGlobal(READ);
 
 Html::popHeader(__('Setup'));
 
-$rulecollection->showRulesEnginePreviewCriteriasForm($_SERVER['PHP_SELF'], $_POST, $condition);
+$rulecollection->showRulesEnginePreviewCriteriasForm($_POST, $condition);
 
 if (isset($_POST["test_all_rules"])) {
    //Unset values that must not be processed by the rule
     unset($_POST["sub_type"], $_POST["test_all_rules"]);
 
     echo "<br>";
-    $rulecollection->showRulesEnginePreviewResultsForm($_SERVER['PHP_SELF'], $_POST, $condition);
+    $rulecollection->showRulesEnginePreviewResultsForm($_POST, $condition);
 }
 
 Html::popFooter();

--- a/front/stat.graph.php
+++ b/front/stat.graph.php
@@ -71,8 +71,8 @@ if (
     $_GET["date2"] = $tmp;
 }
 
-$cleantarget = preg_replace("/&date[12]=[0-9-]*/", "", $_SERVER['QUERY_STRING']);
-$cleantarget = preg_replace("/&*id=(\d+&?)/", "", $cleantarget);
+$target_params = preg_replace("/&date[12]=[0-9-]*/", "", $_SERVER['QUERY_STRING']);
+$target_params = preg_replace("/&*id=(\d+&?)/", "", $target_params);
 
 $next    = 0;
 $prev    = 0;
@@ -340,11 +340,11 @@ if ($foundkey >= 0) {
 $stat = new Stat();
 
 TemplateRenderer::getInstance()->display('pages/assistance/stats/single_item_pager.html.twig', [
-    'php_self' => $_SERVER['PHP_SELF'],
-    'cleantarget' => $cleantarget,
-    'prev' => $prev,
-    'next' => $next,
-    'title' => $title,
+    'target'        => 'stat.graph.php',
+    'target_params' => $target_params,
+    'prev'          => $prev,
+    'next'          => $next,
+    'title'         => $title,
 ]);
 
 TemplateRenderer::getInstance()->display('pages/assistance/stats/form.html.twig', [

--- a/front/stat.item.php
+++ b/front/stat.item.php
@@ -75,6 +75,6 @@ TemplateRenderer::getInstance()->display('pages/assistance/stats/form.html.twig'
     'date2'     => $_POST["date2"],
 ]);
 
-Stat::showItems($_SERVER['PHP_SELF'], $_POST["date1"], $_POST["date2"], $_GET['start'], $_GET["itemtype"] ?? 'Ticket');
+Stat::showItems('stat.item.php', $_POST["date1"], $_POST["date2"], $_GET['start'], $_GET["itemtype"] ?? 'Ticket');
 
 Html::footer();

--- a/phpunit/functional/RuleLocationTest.php
+++ b/phpunit/functional/RuleLocationTest.php
@@ -400,7 +400,7 @@ class RuleLocationTest extends DbTestCase
         // intercepts the output of echo functions
         // as showRulePreviewResultsForm is also in charge of displaying the result (in addition to testing the rule)
         ob_start();
-        $rule->showRulePreviewResultsForm($_SERVER['PHP_SELF'], $input, $params);
+        $rule->showRulePreviewResultsForm($input, $params);
         ob_end_clean();
 
         // check that location was not created

--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -2085,7 +2085,6 @@ TWIG, $twig_params);
     /**
      * Show LDAP groups to add or synchronize in an entity
      *
-     * @param string  $target  target page for the form
      * @param integer $start   where to start the list
      * @param integer $sync    synchronize or add? (default 0)
      * @param string  $filter  ldap filter to use (default '')
@@ -2094,10 +2093,9 @@ TWIG, $twig_params);
      *
      * @return void
      *
-     * @since 11.0.0 $order parameter has been removed.
+     * @since 11.0.0 The `$target` and the `$order` parameters have been removed.
      */
     public static function showLdapGroups(
-        $target,
         $start,
         $sync = 0,
         $filter = '',

--- a/src/CommonDropdown.php
+++ b/src/CommonDropdown.php
@@ -605,9 +605,9 @@ abstract class CommonDropdown extends CommonDBTM
      * Show a dialog to Confirm delete action
      * And propose a value to replace
      *
-     * @param $target string URL
-     **/
-    public function showDeleteConfirmForm($target)
+     * since 11.0.0 The `$target` parameter has been removed and its value is automatically computed.
+     */
+    public function showDeleteConfirmForm()
     {
 
         if ($this->haveChildren()) {
@@ -617,7 +617,8 @@ abstract class CommonDropdown extends CommonDBTM
         }
 
         $ID = (int)$this->fields['id'];
-        $target = htmlescape($target);
+
+        $target = htmlescape(static::getFormURL());
 
         echo "<div class='center'><p class='red'>";
         echo __s("Caution: you're about to remove a heading used for one or more items.");

--- a/src/Glpi/Controller/DropdownFormController.php
+++ b/src/Glpi/Controller/DropdownFormController.php
@@ -125,7 +125,7 @@ final class DropdownFormController extends AbstractController
                 Html::header(
                     ...$dropdown->getHeaderParameters()
                 );
-                $dropdown->showDeleteConfirmForm($request->getPathInfo());
+                $dropdown->showDeleteConfirmForm();
                 Html::footer();
             } else {
                 $dropdown->delete($input, 1);

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -2081,11 +2081,12 @@ JS
     /**
      * Show preview result of a rule
      *
-     * @param string $target    Not used
      * @param array $input     input data array
      * @param array $params    params used (see addSpecificParamsForPreview)
-     **/
-    public function showRulePreviewResultsForm($target, $input, $params)
+     *
+     * @since 11.0.0 The `$target` parameter has been removed.
+     */
+    public function showRulePreviewResultsForm($input, $params)
     {
         $actions       = $this->getAllActions();
         $check_results = [];
@@ -2697,10 +2698,11 @@ JS
     /**
      * Criteria form used to preview rule
      *
-     * @param string  $target   target of the form
      * @param integer $rules_id ID of the rule
-     **/
-    public function showRulePreviewCriteriasForm($target, $rules_id)
+     *
+     * @since 11.0.0 The `$target` parameter has been removed.
+     */
+    public function showRulePreviewCriteriasForm($rules_id)
     {
         $criteria = $this->getAllCriteria();
         if (!$this->getRuleWithCriteriasAndActions($rules_id, 1, 0)) {
@@ -2718,6 +2720,12 @@ JS
                 $already_added_criterias[] = $criterion->fields["criteria"];
             }
         }
+
+        $target = '/front/rule.test.php';
+        if ($plugin = isPluginItemType(static::class)) {
+            $target = '/plugins/' . $plugin['plugin'] . $target;
+        }
+
         TemplateRenderer::getInstance()->display('pages/admin/rules/preview_criteria.html.twig', [
             'criterias' => $unique_criterias,
             'criteria_names' => $criteria_names,

--- a/src/RuleCollection.php
+++ b/src/RuleCollection.php
@@ -324,11 +324,11 @@ class RuleCollection extends CommonDBTM
      * Is a confirmation needed before replay on DB ?
      * If needed need to send 'replay_confirm' in POST
      *
-     * @param string $target filename : where to go when done
-     *
      * @return boolean true if confirmation is needed, else false
-     **/
-    public function warningBeforeReplayRulesOnExistingDB($target)
+     *
+     * since 11.0.0 The `$target` parameter has been removed and its value is automatically computed.
+     */
+    public function warningBeforeReplayRulesOnExistingDB()
     {
         return false;
     }
@@ -1478,13 +1478,14 @@ TWIG, $twig_params);
     /**
      * Show form displaying results for rule collection preview
      *
-     * @param string  $target    where to go
      * @param array   $values    array of data
      * @param integer $condition condition to limit rules (default 0)
      *
      * @return array
-     **/
-    public function showRulesEnginePreviewCriteriasForm($target, array $values, $condition = 0)
+     *
+     * @since 11.0.0 The `$target` parameter has been removed.
+     */
+    public function showRulesEnginePreviewCriteriasForm(array $values, $condition = 0)
     {
         $input = $this->prepareInputDataForTestProcess($condition);
         $rule      = $this->getRuleClass();
@@ -1503,6 +1504,12 @@ TWIG, $twig_params);
                 ];
             }
         }
+
+        $target = '/front/rulesengine.test.php';
+        if ($plugin = isPluginItemType(static::class)) {
+            $target = '/plugins/' . $plugin['plugin'] . $target;
+        }
+
         TemplateRenderer::getInstance()->display('pages/admin/rules/engine_preview_criteria.html.twig', [
             'rule' => $rule,
             'input' => $input,
@@ -1669,13 +1676,14 @@ TWIG, $twig_params);
     /**
      * Show form displaying results for rule engine preview
      *
-     * @param string  $target    where to go
      * @param array   $input     array of data
      * @param integer $condition condition to limit rules (DEFAULT 0)
      *
      * @return void
-     **/
-    public function showRulesEnginePreviewResultsForm($target, array $input, $condition = 0)
+     *
+     * @since 11.0.0 The `$target` parameter has been removed.
+     */
+    public function showRulesEnginePreviewResultsForm(array $input, $condition = 0)
     {
         /** @var \DBmysql $DB */
         global $DB;

--- a/src/RuleDictionnarySoftwareCollection.php
+++ b/src/RuleDictionnarySoftwareCollection.php
@@ -63,14 +63,16 @@ class RuleDictionnarySoftwareCollection extends RuleCollection
         return $output;
     }
 
-    public function warningBeforeReplayRulesOnExistingDB($target)
+    public function warningBeforeReplayRulesOnExistingDB()
     {
+        $rule_class = $this->getRuleClassName();
+
         $twig_params = [
             'warning_title' => __('Warning before running rename based on the dictionary rules'),
             'warning_message' => __('Warning! This operation can put merged software in the trashbin. Ensure to notify your users.'),
             'manufacturer_label' => __('Replay dictionary rules for manufacturers'),
             'btn_label' => _sx('button', 'Post'),
-            'target' => $target,
+            'target' => $rule_class::getSearchURL(),
             'emptylabel' => __('All'),
         ];
 

--- a/templates/pages/assistance/stats/single_item_pager.html.twig
+++ b/templates/pages/assistance/stats/single_item_pager.html.twig
@@ -34,7 +34,7 @@
 <div class="text-center mx-auto p-1 mb-2" style="background-color: var(--tblr-bg-surface); width: fit-content">
     {% if prev > 0 %}
         <div class="d-inline-block">
-            <a href="{{ php_self }}?{{ cleantarget }}&amp;date1={{ _request['date1'] }}&amp;date2={{ _request['date2'] }}&amp;id={{ prev }}" title="{{ __('Previous') }}">
+            <a href="{{ target }}?{{ target_params }}&amp;date1={{ _request['date1'] }}&amp;date2={{ _request['date2'] }}&amp;id={{ prev }}" title="{{ __('Previous') }}">
                 <i class="ti ti-chevron-left"></i>
             </a>
         </div>
@@ -42,7 +42,7 @@
     <div class="d-inline-block" style="width: 400px">{{ title|raw }}</div>
     {% if next > 0 %}
         <div class="d-inline-block">
-            <a href="{{ php_self }}?{{ cleantarget }}&amp;date1={{ _request['date1'] }}&amp;date2={{ _request['date2'] }}&amp;id={{ next }}" title="{{ __('Next') }}">
+            <a href="{{ target }}?{{ target_params }}&amp;date1={{ _request['date1'] }}&amp;date2={{ _request['date2'] }}&amp;id={{ next }}" title="{{ __('Next') }}">
                 <i class="ti ti-chevron-right"></i>
             </a>
         </div>


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

I remove the `$_SERVER['PHP_SELF']` usages that were not necessary. To be reviewed commit per commit.

There are still some usages of this global variable, but their replacement is more complex.