### PR TITLE
Fix: Plugin not save in $_SESSION

### DIFF
--- a/src/Session.php
+++ b/src/Session.php
@@ -91,7 +91,7 @@ class Session
 
         if ($auth->auth_succeded) {
            // Restart GLPI session : complete destroy to prevent lost datas
-            $tosave = ['glpi_plugins', 'glpicookietest', 'phpCAS', 'glpicsrftokens',
+            $tosave = ['glpi_plugins', 'plugins', 'glpicookietest', 'phpCAS', 'glpicsrftokens',
                 'glpiskipMaintenance'
             ];
             $save   = [];


### PR DESCRIPTION

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !35797
- The plugins were not saved in the $_SESSION when the user performs an action outside of the GLPI interface. 


