### PR TITLE
Move QR code to 3rd column

### DIFF
--- a/templates/components/form/pictures.html.twig
+++ b/templates/components/form/pictures.html.twig
@@ -31,45 +31,67 @@
  # ---------------------------------------------------------------------
  #}
 
+{% import 'components/form/fields_macros.html.twig' as fields %}
+
 {% set model_itemtype = item.getModelClass() %}
 {% set gallery_type = gallery_type|default('') %}
 {% if model_itemtype is not null or item is usingtrait('Glpi\\Features\\AssetImage') %}
 
-   {% set picture_single = item.getItemtypeOrModelPicture('picture') %}
-   {% set picture_front = item.getItemtypeOrModelPicture('picture_front') %}
-   {% set picture_rear = item.getItemtypeOrModelPicture('picture_rear') %}
-   {% set pictures_misc = item.getItemtypeOrModelPicture('pictures') %}
+    {% set picture_single = item.getItemtypeOrModelPicture('picture') %}
+    {% set picture_front = item.getItemtypeOrModelPicture('picture_front') %}
+    {% set picture_rear = item.getItemtypeOrModelPicture('picture_rear') %}
+    {% set pictures_misc = item.getItemtypeOrModelPicture('pictures') %}
+    {% set has_pictures = picture_single is not empty or picture_front is not empty or picture_rear is not empty or pictures_misc is not empty %}
+    {% set has_qr = not item.isNewItem() and item.getType() in config("asset_types") %}
 
-   {% if picture_single is not empty or picture_front is not empty or picture_rear is not empty or pictures_misc is not empty %}
-      <div class="{{ gallery_type == 'horizontal' ? 'col-12 me-n2' : '' }} d-flex flex-column card">
-         <div class="card-body">
-            <h3 class="mb-3">
-               {{ _n('Picture', 'Pictures', get_plural_number()) }}
-            </h3>
+    {% if has_pictures or has_qr %}
+        <div class="{{ gallery_type == 'horizontal' ? 'col-12 me-n2' : '' }} d-flex flex-column card">
+            <div class="card-body">
+                {% if has_pictures %}
+                    <h3 class="mb-3">
+                        {{ _n('Picture', 'Pictures', get_plural_number()) }}
+                    </h3>
 
-            <div class="d-flex">
-               {% if picture_single is not empty %}
-                  {% set picture_single = picture_single|first %}
-                  {% set imgs = [picture_single|merge({'title': _n('Picture', 'Pictures', 1)})] %}
-               {% else %}
-                  {% if picture_front is not empty or picture_rear is not empty or pictures_misc is not empty %}
-                     {% set imgs = [] %}
-                     {% if picture_front|length >= 1 %}
-                        {% set picture_front = picture_front|first %}
-                        {% set imgs = imgs|merge([picture_front|merge({'title': __('Front picture')})]) %}
-                     {% endif %}
-                     {% if picture_rear|length >= 1 %}
-                        {% set picture_rear = picture_rear|first %}
-                        {% set imgs = imgs|merge([picture_rear|merge({'title': __('Rear picture')})]) %}
-                     {% endif %}
-                     {% if pictures_misc is not empty %}
-                        {% set imgs = imgs|merge(pictures_misc) %}
-                     {% endif %}
-                  {% endif %}
-               {% endif %}
-               {{ include('components/photoswipe.html.twig', {'imgs': imgs, 'gallery_type': gallery_type}) }}
+                    <div class="d-flex">
+                        {% if picture_single is not empty %}
+                            {% set picture_single = picture_single|first %}
+                            {% set imgs = [picture_single|merge({'title': _n('Picture', 'Pictures', 1)})] %}
+                        {% else %}
+                            {% if picture_front is not empty or picture_rear is not empty or pictures_misc is not empty %}
+                                {% set imgs = [] %}
+                                {% if picture_front|length >= 1 %}
+                                    {% set picture_front = picture_front|first %}
+                                    {% set imgs = imgs|merge([picture_front|merge({'title': __('Front picture')})]) %}
+                                {% endif %}
+                                {% if picture_rear|length >= 1 %}
+                                    {% set picture_rear = picture_rear|first %}
+                                    {% set imgs = imgs|merge([picture_rear|merge({'title': __('Rear picture')})]) %}
+                                {% endif %}
+                                {% if pictures_misc is not empty %}
+                                    {% set imgs = imgs|merge(pictures_misc) %}
+                                {% endif %}
+                            {% endif %}
+                        {% endif %}
+                        {{ include('components/photoswipe.html.twig', {'imgs': imgs, 'gallery_type': gallery_type}) }}
+                    </div>
+                {% endif %}
+                {% if has_qr %}
+                    {% set barcode %}
+                        {{ call('BarcodeManager::renderQRCode', [
+                            item
+                        ])|raw }}
+                    {% endset %}
+                    {{ fields.htmlField(
+                        'qrcode',
+                        barcode,
+                        __('Asset URL'),
+                        {
+                            'is_horizontal': false,
+                            'helper': __('Scan this QRCode to be redirected to the asset page from your mobile device'),
+                        }
+                    ) }}
+                {% endif %}
             </div>
-         </div>
-      </div>
-   {% endif %}
+        </div>
+    {% endif %}
 {% endif %}

--- a/templates/generic_show_form.html.twig
+++ b/templates/generic_show_form.html.twig
@@ -56,9 +56,10 @@
     {# Support custom fields for generic assets #}
     {% set custom_fields = custom_fields|default({}) %}
     {% set field_order = field_order|default(item.getFormFields()) %}
+    {% set has_third_col = item_has_pictures or (not item.isNewItem() and item_type in config("asset_types")) %}
 
    <div class="card-body d-flex flex-wrap">
-      <div class="col-12 col-xxl-{{ item_has_pictures ? '9' : '12' }} flex-column">
+      <div class="col-12 col-xxl-{{ has_third_col ? '9' : '12' }} flex-column">
          <div class="d-flex flex-row flex-wrap flex-xl-nowrap">
             <div class="row flex-row align-items-start flex-grow-1">
                <div class="row flex-row">
@@ -553,23 +554,6 @@
                           {% endif %}
                       {% endfor %}
 
-                     {% if item_type in config("asset_types") %}
-                        {% set barcode %}
-                           {{ call('BarcodeManager::renderQRCode', [
-                              item
-                           ])|raw }}
-                        {% endset %}
-
-                        {{ fields.htmlField(
-                           'qrcode',
-                           barcode,
-                           __('Asset URL'),
-                           {
-                              'helper': __('Scan this QRCode to be redirected to the asset page from your mobile device')
-                           }
-                        ) }}
-                     {% endif %}
-
                      {% block more_fields %}
                      {% endblock %}
                   {% endblock %}
@@ -577,13 +561,11 @@
             </div> {# .row #}
          </div> {# .flex-row #}
       </div>
-      {% if item_has_pictures %}
-         <div class="col-12 col-xxl-3 flex-column">
-            <div class="flex-row asset-pictures">
+       <div class="col-12 col-xxl-3 flex-column">
+           <div class="flex-row asset-pictures">
                {{ include('components/form/pictures.html.twig', {'gallery_type': ''}) }}
-            </div>
-         </div>
-      {% endif %}
+           </div>
+       </div>
    </div> {# .card-body #}
 
    {% if item_type == 'Contract' %}


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Moves the asset QR code into the sidebar where asset pictures are shown and no longer shows the QR code field when creating new items.

Replaces #18494
Fixes #18493
Fixes #18670

## Screenshots (if appropriate):

Asset with model pictures:
![Selection_392](https://github.com/user-attachments/assets/a6c24f50-361b-4d11-aff2-55e48c53d031)

Asset without model pictures:
![Selection_393](https://github.com/user-attachments/assets/eb610634-1fe4-41d6-977a-6e5288202e8b)

