### PR TITLE
Get enabled impact itemtypes from `$CFG_GLPI`

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -3064,6 +3064,10 @@ HTML;
             $CFG_GLPI['planning_work_days'] = importArrayFromDB($CFG_GLPI['planning_work_days']);
         }
 
+        if (isset($CFG_GLPI[Impact::CONF_ENABLED])) {
+            $CFG_GLPI[Impact::CONF_ENABLED] = importArrayFromDB($CFG_GLPI[Impact::CONF_ENABLED]);
+        }
+
         return true;
     }
 

--- a/src/Impact.php
+++ b/src/Impact.php
@@ -1759,16 +1759,13 @@ class Impact extends CommonGLPI
      */
     public static function getEnabledItemtypes(): array
     {
-       // Get configured values
-        $conf = Config::getConfigurationValues('core');
+        /** @var array $CFG_GLPI */
+        global $CFG_GLPI;
 
-        if (!isset($conf[self::CONF_ENABLED])) {
-            return [];
-        }
+        // Get configured values
+        $enabled = $CFG_GLPI[Impact::CONF_ENABLED] ?? [];
 
-        $enabled = importArrayFromDB($conf[self::CONF_ENABLED]);
-
-       // Remove any forbidden values
+        // Remove any forbidden values
         return array_filter($enabled, function ($itemtype) {
             /** @var array $CFG_GLPI */
             global $CFG_GLPI;


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

This change permits to save either 1 or 3 queries when displaying any item form :
 - 1 query, from `CommonGLPI::defineTabs() -> CommonGLPI::addImpactTab() -> Impact::isEnabled() -> Impact::getEnabledItemtypes()` (`src/CommonGLPI.php` line 392)
 - 1 query when impact tab is registered, from `Impact::getTabNameForItem() -> Impact::isEnabled() -> Impact::getEnabledItemtypes()` (`src/Impact.php` line 97)
 - 1 query when impact tab is registered, from `Impact::getTabNameForItem() -> Impact::getEnabledItemtypes()` (`src/Impact.php` line 129)

