### PR TITLE
feat(forms): Move the itemtype config field for QuestionTypeItem

### DIFF
--- a/ajax/dropdownAllItems.php
+++ b/ajax/dropdownAllItems.php
@@ -98,6 +98,9 @@ if ($_POST["idtable"] && class_exists($_POST["idtable"])) {
     if (isset($_POST['specific_tags_items_id_dropdown'])) {
         $p['specific_tags'] = $_POST['specific_tags_items_id_dropdown'];
     }
+    if (isset($_POST['aria_label'])) {
+        $p['aria_label'] = $_POST['aria_label'];
+    }
     $p['_idor_token'] = Session::getNewIDORToken($_POST["idtable"], $idor_params);
 
     echo  Html::jsAjaxDropdown(

--- a/js/modules/Forms/EditorController.js
+++ b/js/modules/Forms/EditorController.js
@@ -69,6 +69,12 @@ export class GlpiFormEditorController
     #options;
 
     /**
+     * Subtypes options for each question type
+     * @type {Object}
+     */
+    #question_subtypes_options;
+
+    /**
      * Create a new GlpiFormEditorController instance for the given target.
      * The target must be a valid form.
      *
@@ -83,6 +89,7 @@ export class GlpiFormEditorController
         this.#defaultQuestionType = defaultQuestionType;
         this.#templates           = templates;
         this.#options             = {};
+        this.#question_subtypes_options    = {};
 
         // Validate target
         if ($(this.#target).prop("tagName") != "FORM") {
@@ -229,6 +236,16 @@ export class GlpiFormEditorController
     }
 
     /**
+     * Register new subtypes options for the given question type.
+     *
+     * @param {string} type    Question type
+     * @param {Object} options Subtypes options for the question type
+     */
+    registerQuestionSubTypesOptions(type, options) {
+        this.#question_subtypes_options[type] = options;
+    }
+
+    /**
      * Handle backend response
      */
     #handleBackendUpdateResponse() {
@@ -311,6 +328,13 @@ export class GlpiFormEditorController
             // Change the type of the target question
             case "change-question-type":
                 this.#changeQuestionType(
+                    target.closest("[data-glpi-form-editor-question]"),
+                    target.val()
+                );
+                break;
+
+            case "change-question-sub-type":
+                this.#changeQuestionSubType(
                     target.closest("[data-glpi-form-editor-question]"),
                     target.val()
                 );
@@ -1208,7 +1232,61 @@ export class GlpiFormEditorController
             extracted_default_value
         );
 
+        // Update sub question types
+        if (this.#question_subtypes_options[type] !== undefined) {
+            const sub_types_select = question.find("[data-glpi-form-editor-question-sub-type-selector]");
+
+            // Show sub question type selector
+            sub_types_select.closest("div").removeClass("d-none");
+            sub_types_select.attr('disabled', false);
+
+            // Remove current sub types options
+            sub_types_select.find('optgroup, option').remove();
+
+            // Find sub types available for the new type
+            const new_sub_types = this.#question_subtypes_options[type].subtypes;
+
+            // Copy the new sub types options into the dropdown
+            for (const category in new_sub_types) {
+                const optgroup = $(`<optgroup label="${category}"></optgroup>`);
+                for (const [sub_type, label] of Object.entries(new_sub_types[category])) {
+                    const option = $(`<option value="${sub_type}">${label}</option>`);
+                    optgroup.append(option);
+                }
+                sub_types_select.append(optgroup);
+            }
+
+            // Set the default sub type
+            if (this.#question_subtypes_options[type].default_value) {
+                sub_types_select.val(this.#question_subtypes_options[type].default_value);
+            }
+
+            // Update the field name and aria-label
+            sub_types_select.attr("name", this.#question_subtypes_options[type].field_name);
+            sub_types_select.attr("aria-label", this.#question_subtypes_options[type].field_aria_label);
+
+            // Remove the "original-name" data attribute to avoid conflicts
+            sub_types_select.removeAttr("data-glpi-form-editor-original-name");
+
+            // Trigger sub type change
+            sub_types_select.trigger("change");
+        } else {
+            // Hide sub question type selector
+            question.find("[data-glpi-form-editor-question-sub-type-selector]")
+                .attr('disabled', true)
+                .closest("div").addClass("d-none");
+        }
+
         $(document).trigger('glpi-form-editor-question-type-changed', [question, type]);
+    }
+
+    /**
+     * Handle the change of the sub type of the given question.
+     * @param {jQuery} question Question to update
+     * @param {string} sub_type New sub type
+     */
+    #changeQuestionSubType(question, sub_type) {
+        $(document).trigger('glpi-form-editor-question-sub-type-changed', [question, sub_type]);
     }
 
     /**

--- a/js/modules/Forms/QuestionItem.js
+++ b/js/modules/Forms/QuestionItem.js
@@ -55,6 +55,30 @@ export class GlpiFormQuestionTypeItem {
                 this.#updateItemsIdDropdownID(question_details);
             }
         });
+
+        $(document).on('glpi-form-editor-question-sub-type-changed', (event, question, sub_type) => {
+            if (question.find('[name="type"], [data-glpi-form-editor-original-name="type"]').val() !== this.#question_type) {
+                return;
+            }
+
+            const select = question.find('[data-glpi-form-editor-question-type-specific] select');
+            const container = select.parent();
+
+            // Add a flag to all children to mark them as to be removed
+            container.children().attr('data-to-remove', 'true');
+
+            // Load the new dropdown
+            container.load(
+                `${CFG_GLPI.root_doc}/ajax/dropdownAllItems.php`,
+                {
+                    'idtable'   : sub_type,
+                    'width'     : '100%',
+                    'name'      : select.data('glpi-form-editor-original-name') || select.attr('name'),
+                    'aria_label': select.attr('aria-label'),
+                },
+                () => container.find('[data-to-remove]').remove()
+            );
+        });
     }
 
     #updateItemsIdDropdownID(question_details) {

--- a/src/Glpi/Form/QuestionType/AbstractQuestionType.php
+++ b/src/Glpi/Form/QuestionType/AbstractQuestionType.php
@@ -169,4 +169,28 @@ abstract class AbstractQuestionType implements QuestionTypeInterface
 
         return $config_class::jsonDeserialize($serialized_data);
     }
+
+    #[Override]
+    public function getSubTypes(): array
+    {
+        return [];
+    }
+
+    #[Override]
+    public function getSubTypeFieldName(): string
+    {
+        return 'sub_type';
+    }
+
+    #[Override]
+    public function getSubTypeFieldAriaLabel(): string
+    {
+        return __('Question sub type');
+    }
+
+    #[Override]
+    public function getSubTypeDefaultValue(?Question $question): ?string
+    {
+        return '';
+    }
 }

--- a/src/Glpi/Form/QuestionType/QuestionTypeInterface.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeInterface.php
@@ -212,4 +212,33 @@ interface QuestionTypeInterface
      * @return ?JsonFieldInterface
      */
     public function getDefaultValueConfig(array $serialized_data): ?JsonFieldInterface;
+
+    /**
+     * Retrieve the allowed sub-types for the question type
+     *
+     * @return array
+     */
+    public function getSubTypes(): array;
+
+    /**
+     * Retrieve the sub-type field name for the question type
+     *
+     * @return string
+     */
+    public function getSubTypeFieldName(): string;
+
+    /**
+     * Retrieve the sub-type field label for the question type
+     *
+     * @return string
+     */
+    public function getSubTypeFieldAriaLabel(): string;
+
+    /**
+     * Retrieve the default value for the sub-type field
+     *
+     * @param Question|null $question The question to get the default value for
+     * @return null|string
+     */
+    public function getSubTypeDefaultValue(?Question $question): ?string;
 }

--- a/src/Glpi/Form/QuestionType/QuestionTypeItem.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeItem.php
@@ -37,9 +37,9 @@ namespace Glpi\Form\QuestionType;
 
 use CartridgeItem;
 use ConsumableItem;
+use Dropdown;
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\Form\Question;
-use Group;
 use Line;
 use Override;
 use PassiveDCEquipment;
@@ -168,6 +168,30 @@ class QuestionTypeItem extends AbstractQuestionType
     }
 
     #[Override]
+    public function getSubTypes(): array
+    {
+        return Dropdown::buildItemtypesDropdownOptions($this->getAllowedItemtypes());
+    }
+
+    #[Override]
+    public function getSubTypeFieldName(): string
+    {
+        return 'itemtype';
+    }
+
+    #[Override]
+    public function getSubTypeFieldAriaLabel(): string
+    {
+        return $this->itemtype_aria_label;
+    }
+
+    #[Override]
+    public function getSubTypeDefaultValue(?Question $question): ?string
+    {
+        return $this->getDefaultValueItemtype($question);
+    }
+
+    #[Override]
     public function renderAdministrationTemplate(?Question $question): string
     {
         $template = <<<TWIG
@@ -175,29 +199,21 @@ class QuestionTypeItem extends AbstractQuestionType
 
             {% set rand = random() %}
 
-            {{ fields.dropdownItemsFromItemtypes(
+            {{ fields.dropdownField(
+                default_itemtype|default(itemtypes|first|first),
                 'default_value',
+                default_items_id,
                 '',
                 {
-                    'init'                           : init,
-                    'itemtypes'                      : itemtypes,
-                    'no_label'                       : true,
-                    'display_emptychoice'            : true,
-                    'default_itemtype'               : default_itemtype,
-                    'default_items_id'               : default_items_id,
-                    'itemtype_name'                  : 'itemtype',
-                    'items_id_name'                  : 'default_value',
-                    'width'                          : '100%',
-                    'container_css_class'            : 'mt-2',
-                    'no_sort'                        : true,
-                    'aria_label'                     : itemtype_aria_label,
-                    'specific_tags_items_id_dropdown': {
-                        'aria-label': items_id_aria_label,
-                    },
-                    'add_data_attributes_itemtype_dropdown' : {
-                        'glpi-form-editor-specific-question-extra-data': '',
-                    },
-                    'mb'                            : '',
+                    'init'               : init,
+                    'no_label'           : true,
+                    'display_emptychoice': true,
+                    'width'              : '100%',
+                    'container_css_class': 'mt-2',
+                    'mb'                 : '',
+                    'comments'           : false,
+                    'addicon'            : false,
+                    'aria_label'         : aria_label,
                 }
             ) }}
 
@@ -212,14 +228,13 @@ TWIG;
 
         $twig = TemplateRenderer::getInstance();
         return $twig->renderFromStringTemplate($template, [
-            'init'                => $question != null,
-            'question'            => $question,
-            'question_type'       => $this::class,
-            'default_itemtype'    => $this->getDefaultValueItemtype($question) ?? '0',
-            'default_items_id'    => $this->getDefaultValueItemId($question),
-            'itemtypes'           => $this->getAllowedItemtypes(),
-            'itemtype_aria_label' => $this->itemtype_aria_label,
-            'items_id_aria_label' => $this->items_id_aria_label,
+            'init'             => $question != null,
+            'question'         => $question,
+            'question_type'    => $this::class,
+            'default_itemtype' => $this->getDefaultValueItemtype($question),
+            'default_items_id' => $this->getDefaultValueItemId($question),
+            'itemtypes'        => $this->getAllowedItemtypes(),
+            'aria_label'       => $this->items_id_aria_label,
         ]);
     }
 
@@ -257,11 +272,11 @@ TWIG;
 
         $twig = TemplateRenderer::getInstance();
         return $twig->renderFromStringTemplate($template, [
-            'question'            => $question,
-            'itemtype'            => $this->getDefaultValueItemtype($question) ?? '0',
-            'default_items_id'    => $this->getDefaultValueItemId($question),
-            'aria_label'          => $this->items_id_aria_label,
-            'items_id_aria_label' => $this->items_id_aria_label,
+            'question'         => $question,
+            'itemtype'         => $this->getDefaultValueItemtype($question) ?? '0',
+            'default_items_id' => $this->getDefaultValueItemId($question),
+            'aria_label'       => $this->items_id_aria_label,
+            'sub_types'        => $this->getSubTypes(),
         ]);
     }
 

--- a/templates/pages/admin/form/form_editor.html.twig
+++ b/templates/pages/admin/form/form_editor.html.twig
@@ -389,6 +389,18 @@
             '{{ get_class(question_type)|e('js') }}',
             {{ question_type.getFormEditorJsOptions()|raw }}
         );
+
+        {% if question_type.getSubTypes() is not empty %}
+            controller.registerQuestionSubTypesOptions(
+                '{{ get_class(question_type)|e('js') }}',
+                {
+                    'subtypes'        : {{ question_type.getSubTypes()|json_encode|raw }},
+                    'default_value'   : '{{ question_type.getSubTypeDefaultValue(null) }}',
+                    'field_name'      : '{{ question_type.getSubTypeFieldName() }}',
+                    'field_aria_label': '{{ question_type.getSubTypeFieldAriaLabel() }}',
+                }
+            )
+        {% endif %}
     {% endfor %}
 
     $(container_selector).data('controller', controller);

--- a/templates/pages/admin/form/form_editor.html.twig
+++ b/templates/pages/admin/form/form_editor.html.twig
@@ -395,9 +395,9 @@
                 '{{ get_class(question_type)|e('js') }}',
                 {
                     'subtypes'        : {{ question_type.getSubTypes()|json_encode|raw }},
-                    'default_value'   : '{{ question_type.getSubTypeDefaultValue(null) }}',
-                    'field_name'      : '{{ question_type.getSubTypeFieldName() }}',
-                    'field_aria_label': '{{ question_type.getSubTypeFieldAriaLabel() }}',
+                    'default_value'   : '{{ question_type.getSubTypeDefaultValue(null)|e('js') }}',
+                    'field_name'      : '{{ question_type.getSubTypeFieldName()|e('js') }}',
+                    'field_aria_label': '{{ question_type.getSubTypeFieldAriaLabel()|e('js') }}',
                 }
             )
         {% endif %}

--- a/templates/pages/admin/form/form_question.html.twig
+++ b/templates/pages/admin/form/form_question.html.twig
@@ -201,6 +201,29 @@
                     }
                 ) }}
 
+                {% set sub_types = question_type.getSubTypes() %}
+                {{ fields.dropdownArrayField(
+                    question_type.getSubTypeFieldName(),
+                    question_type.getSubTypeDefaultValue(question),
+                    question_type.getSubTypes(),
+                    '',
+                    {
+                        'init'                 : question is not null,
+                        'no_label'             : true,
+                        'mb'                   : '',
+                        'field_class'          : 'me-2' ~ (sub_types is empty ? ' d-none' : ''),
+                        'class'                : 'form-select form-select-sm',
+                        'width'                : 'auto',
+                        'disabled'             : sub_types is empty,
+                        'aria_label'           : question_type.getSubTypeFieldAriaLabel(),
+                        'add_data_attributes'  : {
+                            'glpi-form-editor-on-change'                   : 'change-question-sub-type',
+                            'glpi-form-editor-question-sub-type-selector'  : '',
+                            'glpi-form-editor-specific-question-extra-data': ''
+                        }
+                    }
+                ) }}
+
                 {# Render the specific question options #}
                 <div class="ms-2" data-glpi-form-editor-specific-question-options data-glpi-form-editor-question-extra-details>
                     {{ question_type.renderAdministrationOptionsTemplate(question)|raw }}

--- a/tests/cypress/e2e/form/destination_config_fields/itilcategory.cy.js
+++ b/tests/cypress/e2e/form/destination_config_fields/itilcategory.cy.js
@@ -55,6 +55,13 @@ describe('ITILCategory configuration', () => {
         cy.getDropdownByLabelText("Select a dropdown type").selectDropdownValue('ITIL categories');
         cy.get('@form_id').then((form_id) => {
             const itilcategory_name = `Test ITIL Category for the ITILCategory configuration suite - ${form_id}`;
+
+            // Wait for the items_id dropdown to be loaded
+            cy.intercept('/ajax/dropdownAllItems.php').as('dropdownAllItems');
+
+            // eslint-disable-next-line cypress/no-unnecessary-waiting
+            cy.wait(200);
+
             cy.getDropdownByLabelText("Select a dropdown item").selectDropdownValue(`»${itilcategory_name}`);
         });
         cy.findByRole('button', {'name': 'Save'}).click();

--- a/tests/cypress/e2e/form/question_types/item.cy.js
+++ b/tests/cypress/e2e/form/question_types/item.cy.js
@@ -70,6 +70,9 @@ describe('Item form question type', () => {
         // Select the ticket itemtype
         cy.findByRole("option", { name: "Tickets" }).should('exist').click();
 
+        // Wait for the items_id dropdown to be loaded
+        cy.intercept('/ajax/dropdownAllItems.php').as('dropdownAllItems');
+
         // Click on the items_id dropdown
         cy.getDropdownByLabelText("Select an item").click();
 
@@ -104,6 +107,9 @@ describe('Item form question type', () => {
 
         // Select the ITIL category itemtype
         cy.findByRole("option", { name: "ITIL categories" }).should('exist').click();
+
+        // Wait for the items_id dropdown to be loaded
+        cy.intercept('/ajax/dropdownAllItems.php').as('dropdownAllItems');
 
         // Click on the items_id dropdown
         cy.getDropdownByLabelText("Select a dropdown item").click();


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

The itemtype selection field for Item questions (Glpi Objects and Dropdowns) has been moved to the question type selection field, so that only the object selection field is in the default value area.

This arrangement is all the more logical as it is not possible to define an item type question without defining an itemtype; it will not be displayed in the final form. This new interface approach forces the user to select an itemtype by default.

PR #18354 introduces some interface modifications to the question type selection fields, notably by grouping them together. It will be important to do the same with this new field once the PR has been merged.

## Screenshots (if appropriate):

#### Before : 
![image](https://github.com/user-attachments/assets/a79f1f98-ce0d-41aa-8ff5-e3ca41a85edf)

#### Now : 
![image](https://github.com/user-attachments/assets/edecc651-2f7c-4e5c-901c-fc6d304ee97d)