### PR TITLE
Use strict variables in Twig

### DIFF
--- a/src/Glpi/Application/View/TemplateRenderer.php
+++ b/src/Glpi/Application/View/TemplateRenderer.php
@@ -81,8 +81,9 @@ class TemplateRenderer
         }
 
         $env_params = [
-            'debug'       => $_SESSION['glpi_use_mode'] ?? null === Session::DEBUG_MODE,
-            'auto_reload' => GLPI_ENVIRONMENT_TYPE !== GLPI::ENV_PRODUCTION,
+            'debug'             => $_SESSION['glpi_use_mode'] ?? null === Session::DEBUG_MODE,
+            'auto_reload'       => GLPI_ENVIRONMENT_TYPE !== GLPI::ENV_PRODUCTION,
+            'strict_variables'  => true,
         ];
 
         $tpl_cachedir = $cachedir . '/templates';

--- a/src/Html.php
+++ b/src/Html.php
@@ -1144,10 +1144,6 @@ TWIG,
        // load log filters everywhere
         Html::requireJs('log_filters');
 
-        if (isset($_SESSION['glpihighcontrast_css']) && $_SESSION['glpihighcontrast_css']) {
-            $tpl_vars['high_contrast'] = true;
-        }
-
         $tpl_vars['css_files'][] = ['path' => 'lib/tabler.css'];
         $tpl_vars['css_files'][] = ['path' => 'css/glpi.scss'];
         $tpl_vars['css_files'][] = ['path' => 'css/core_palettes.scss'];

--- a/src/Planning.php
+++ b/src/Planning.php
@@ -807,20 +807,15 @@ TWIG, ['options' => $options]);
             $color = self::getPaletteColor('bg', $params['filter_color_index']);
         }
 
-        if ($filter_data['type'] !== 'event_filter') {
-            if ($caldav_item_url !== '' && $filter_data['type'] !== 'group_users' && $filter_data['type'] !== 'external') {
-                $url = parse_url($CFG_GLPI["url_base"]);
-                $url_port = 80;
-                if (isset($url['port'])) {
-                    $url_port = $url['port'];
-                } else if (isset($url['scheme']) && ($url["scheme"] === 'https')) {
-                    $url_port = 443;
-                }
-
-                $loginUser = new User();
-                $loginUser->getFromDB(Session::getLoginUserID(true));
-            }
+        $url = parse_url($CFG_GLPI["url_base"]);
+        if (!isset($url['port'])) {
+            $url['port'] = isset($url['scheme']) && ($url["scheme"] === 'https')
+                ? 443
+                : 80;
         }
+
+        $loginUser = new User();
+        $loginUser->getFromDB(Session::getLoginUserID(true));
 
         TemplateRenderer::getInstance()->display('pages/assistance/planning/single_filter.html.twig', [
             'filter_key'    => $filter_key,
@@ -831,9 +826,8 @@ TWIG, ['options' => $options]);
             'color'         => $color,
             'uID'           => $uID,
             'gID'           => $gID,
-            'login_user'    => $loginUser ?? null,
-            'url'           => $url ?? null,
-            'url_port'      => $url_port ?? null,
+            'login_user'    => $loginUser,
+            'url'           => $url,
             'caldav_url'    => $caldav_item_url !== null ? $CFG_GLPI['url_base'] . '/caldav.php/' . $caldav_item_url : null,
         ]);
     }

--- a/src/User.php
+++ b/src/User.php
@@ -1917,13 +1917,11 @@ class User extends CommonDBTM
             'usertitles_id'       => $this->fields['usertitles_id'],
             'usercategories_id'   => $this->fields['usercategories_id'],
             'registration_number' => $this->fields['registration_number'],
+            'groups_id'           => $this->fields["groups_id"],
         ];
 
         if (Session::haveRight('user', READ)) {
              $user_params['login'] = $this->fields['name'];
-        }
-        if (!empty($this->fields["groups_id"])) {
-            $user_params['groups_id'] = $this->fields["groups_id"];
         }
         return TemplateRenderer::getInstance()->render('components/user/info_card.html.twig', [
             'user'                 => $user_params,

--- a/templates/components/datatable.html.twig
+++ b/templates/components/datatable.html.twig
@@ -33,14 +33,19 @@
 
 {% import 'components/alerts_macros.html.twig' as alerts %}
 
-{% set datatable_id = datatable_id|default('datatable' ~ random()) %}
+{% set datatable_id      = datatable_id|default('datatable' ~ random()) %}
+{% set filters           = filters|default([]) %}
+{% set footers           = footers|default([]) %}
+{% set sort              = sort|default(null) %}
+{% set additional_params = additional_params|default('') %}
+
 {% if total_number < 1 and filters|length == 0 %}
     <table id="{{ datatable_id }}" class="table">
         <thead>
         {% if super_header is defined and super_header is not empty %}
             {% set super_header_label = super_header is array ? super_header['label'] : super_header %}
             {% if super_header_label is not empty %}
-                {% set super_header_raw = super_header is array ? super_header['is_raw'] : false %}
+                {% set super_header_raw = super_header is array ? super_header['is_raw']|default('false') : false %}
                 <tr>
                     <th colspan="1">
                         {{ super_header_raw ? super_header_label|raw : super_header_label }}
@@ -78,7 +83,7 @@
             <thead>
                 {% if super_header is defined and super_header is not empty %}
                     {% set super_header_label = super_header is array ? super_header['label'] : super_header %}
-                    {% set super_header_raw = super_header is array ? super_header['is_raw'] : false %}
+                    {% set super_header_raw = super_header is array ? super_header['is_raw']|default(false) : false %}
                     <tr>
                         {% if super_header_raw is not same as 'th_elements' %}<th colspan="{{ total_cols }}">{% endif %}
                             {{ super_header_raw ? super_header_label|raw : super_header_label }}
@@ -120,21 +125,13 @@
                             </th>
                         {% endfor %}
 
-                       {% if nofilter is not defined or csv_url|length %}
+                       {% if nofilter is not defined %}
                            <th>
                                <span class="float-end log-toolbar mb-0">
-                                   {% if nofilter is not defined %}
-                                       <button class="btn btn-sm show_filters {{ filters|length > 0 ? 'btn-secondary active' : 'btn-outline-secondary' }}">
-                                           <i class="fas fa-filter"></i>
-                                           <span class="d-none d-xl-block">{{ __('Filter') }}</span>
-                                       </button>
-                                   {% endif %}
-                                   {% if csv_url|length %}
-                                       <a href="{{ csv_url }}" class="btn btn-sm text-capitalize btn-outline-secondary">
-                                           <i class="fas fa-file-download"></i>
-                                           <span class="d-none d-xl-block">{{ __('Export') }}</span>
-                                       </a>
-                                   {% endif %}
+                                   <button class="btn btn-sm show_filters {{ filters|length > 0 ? 'btn-secondary active' : 'btn-outline-secondary' }}">
+                                       <i class="fas fa-filter"></i>
+                                       <span class="d-none d-xl-block">{{ __('Filter') }}</span>
+                                   </button>
                                </span>
                            </th>
                          {% endif %}
@@ -309,7 +306,7 @@
                     </tr>
                 {% endif %}
             </tbody>
-            {% if footers %}
+            {% if footers|length > 0 %}
                 <tfoot class="{{ footer_class|default('') }}">
                     {% for footer in footers %}
                         <tr>

--- a/templates/components/dropdown/limit.html.twig
+++ b/templates/components/dropdown/limit.html.twig
@@ -31,6 +31,9 @@
  # ---------------------------------------------------------------------
  #}
 
+{% set additional_attributes = additional_attributes|default([]) %}
+{% set no_onchange = no_onchange|default(false) %}
+
 {% if additional_params is not defined %}
    {% set additional_params = '' %}
 {% else %}

--- a/templates/components/form/basic_inputs_macros.html.twig
+++ b/templates/components/form/basic_inputs_macros.html.twig
@@ -41,16 +41,17 @@
         'disabled': false,
         'multiple': false,
         'required': false,
+        'maxlength': null,
         'is_disclosable': false,
         'is_copyable': false,
         'clearable': false,
     }|merge(options) %}
 
-    {% if options.fields_template.isMandatoryField(name) %}
+    {% if options.fields_template.isMandatoryField(name)|default(false) %}
         {% set options = options|merge({'required': true}) %}
     {% endif %}
 
-    {% if options.fields_template.isReadonlyField(name) %}
+    {% if options.fields_template.isReadonlyField(name)|default(false) %}
         {% set options = options|merge({'readonly': true}) %}
     {% endif %}
 
@@ -118,6 +119,10 @@
 
 
 {% macro text(name, value, options = {}) %}
+    {% set options = {
+        'copyable': false,
+    }|merge(options) %}
+
     {% if options.copyable %}
         <div class="copy_to_clipboard_wrapper">
     {% endif %}
@@ -212,8 +217,10 @@
     {% set options = {
         'rand': random(),
         'enableTime': false,
-        'checkIsExpired ': false,
-        'clearable': false,
+        'checkIsExpired': false,
+        'clearable': options['maybeempty']|default(false),
+        'readonly': false,
+        'input_addclass': '',
     }|merge(options) %}
 
     {% set options = {
@@ -251,8 +258,7 @@
             <button type="button" class="btn btn-outline-secondary btn-sm" data-toggle title="{{ __('Show date picker') }}">
                 <i class="{{ calendar_icon }}"></i>
             </button>
-            {# maybeempty has no distinct purpose, but it was here first #}
-            {% if options.clearable or options.maybeempty %}
+            {% if options.clearable %}
                 <button type="button" class="btn btn-outline-secondary btn-sm" data-toggle title="{{ __('Clear') }}">
                     <i class="ti ti-circle-x" data-clear></i>
                 </button>
@@ -321,9 +327,10 @@
         'aria_label': "",
         'statusbar': true,
         'content_style': "",
+        'input_addclass': '',
     }|merge(options) %}
 
-    {% if options.fields_template.isMandatoryField(name) %}
+    {% if options.fields_template.isMandatoryField(name)|default(false) %}
         {% set options = {'required': true}|merge(options) %}
     {% endif %}
     {% set options = options|merge({
@@ -441,11 +448,13 @@
     {% set options = {
         locked: false,
         locked_value: null,
-        tpl_mark: null
+        tpl_mark: null,
+        helper: null,
+        required: false,
     }|merge(options) %}
 
     {% set required_mark = '' %}
-    {% if options.fields_template.isMandatoryField(options.name) or options.required %}
+    {% if options.name is defined and options.fields_template.isMandatoryField(options.name)|default(false) or options.required %}
         {% set required_mark = '<span class="required">*</span>' %}
     {% endif %}
 

--- a/templates/components/form/buttons.html.twig
+++ b/templates/components/form/buttons.html.twig
@@ -133,7 +133,7 @@
             <input type="hidden" name="id" value="{{ id }}" />
          {% endif %}
 
-         {% if canedit and params['addbuttons']|length > 0 %}
+         {% if canedit and params['addbuttons']|default('')|length > 0 %}
             {% for key, val in params['addbuttons'] %}
                 {% if val.add_attribs is not empty %}
                     {% set extra_attribs = call('Html::parseAttributes', {options: val.add_attribs}) %}

--- a/templates/components/form/fields_macros.html.twig
+++ b/templates/components/form/fields_macros.html.twig
@@ -78,7 +78,7 @@
 {% endmacro %}
 
 {% macro autoNameField(name, item, label = '', withtemplate, options = {}) %}
-   {% set tpl_value = option.value|length > 0 ? option.value : item.fields[name] %}
+   {% set tpl_value = options.value|default('')|length > 0 ? options.value : item.fields[name] %}
    {% if item.isTemplate() %} {# TODO exluded types #}
        {% set options = options|merge({
            tpl_mark: item.getAutofillMark(name, {'withtemplate': withtemplate}, tpl_value)
@@ -138,18 +138,22 @@
 
 
 {% macro sliderField(name, value, label = '', options = {}) %}
-   {% if options.fields_template.isMandatoryField(name) %}
-      {% set options = {
-         'required': true
-      }|merge(options) %}
-   {% endif %}
-   {% if options.fields_template.isReadonlyField(name) %}
-      {% set options = options|merge({'readonly': true}) %}
-   {% endif %}
    {% set options = {
       'no_value': 0,
       'yes_value': 1,
+      'readonly': false,
+      'required': false,
+      'disabled': false,
+      'label2': null,
+      'additional_attributes': [],
    }|merge(options) %}
+
+   {% if options.fields_template.isMandatoryField(name)|default(false) %}
+      {% set options = options|merge({'required': true}) %}
+   {% endif %}
+   {% if options.fields_template.isReadonlyField(name)|default(false) %}
+      {% set options = options|merge({'readonly': true}) %}
+   {% endif %}
 
    {% set field %}
       <label class="form-check form-switch mt-2">
@@ -187,7 +191,12 @@
 
 
 {% macro readOnlyField(name, value, label = '', options = {}) %}
+   {% set options = {
+      'input_addclass': '',
+   }|merge(options) %}
+
    {% set options = options|merge({'readonly': true}) %}
+
    {% set value %}
       <span class="form-control {{ options.input_addclass }}" readonly>
          {% if value|length == 0 %}
@@ -204,6 +213,7 @@
 {% macro textareaField(name, value, label = '', options = {}) %}
    {% set options = {
       'rand': random(),
+      'readonly': false,
       'enable_richtext': false,
       'enable_images': true,
       'enable_fileupload': false,
@@ -234,7 +244,7 @@
              'editor_id': options.id,
              'multiple': true,
              'uploads': options.uploads,
-             'required': options.fields_template.isMandatoryField('_documents_id')
+             'required': options.fields_template.isMandatoryField('_documents_id')|default(false)
          }]) %}
       {% endset %}
    {% elseif not options.readonly and not options.enable_fileupload and options.enable_richtext and options.enable_images %}
@@ -244,7 +254,7 @@
              'name': name,
              'only_uploaded_files': true,
              'uploads': options.uploads,
-             'required': options.fields_template.isMandatoryField('_documents_id')
+             'required': options.fields_template.isMandatoryField('_documents_id')|default(false)
          }]) %}
       {% endset %}
    {% endif %}
@@ -367,7 +377,7 @@
          {% endif %}
       </div>
    {% endset %}
-   {% if options.fields_template.isReadonlyField(name) %}
+   {% if options.fields_template.isReadonlyField(name)|default(false) %}
       {% set options = options|merge({'readonly': true}) %}
    {% endif %}
    {{ _self.field(name, field, label, options) }}
@@ -393,7 +403,7 @@
       }) }}
    {% endset %}
 
-   {% if options.fields_template.isReadonlyField(name) %}
+   {% if options.fields_template.isReadonlyField(name)|default(false) %}
       {% set options = options|merge({'readonly': true}) %}
    {% endif %}
 
@@ -407,6 +417,10 @@
 {% endmacro %}
 
 {% macro hiddenField(name, value, label = '', options = {}) %}
+    {% set options = {
+        'no_label': false,
+    }|merge(options) %}
+
    {% if options.no_label %}
       {% set options = {
          mb: 'mb-0'
@@ -425,21 +439,21 @@
         'width': '100%',
     }|merge(options) %}
 
-   {% if options.fields_template.isReadonlyField(name) %}
+   {% if options.fields_template.isReadonlyField(name)|default(false) %}
       {% set options = options|merge({'readonly': true}) %}
    {% endif %}
 
    {% if options.disabled %}
       {% set options = options|merge({specific_tags: {'disabled': 'disabled'}}) %}
    {% endif %}
-   {% if options.fields_template.isMandatoryField(name) %}
+   {% if options.fields_template.isMandatoryField(name)|default(false) %}
       {% set options = {'specific_tags': {'required': true}}|merge(options) %}
    {% endif %}
 
    {% set field %}
       {% do call('Dropdown::showNumber', [name, {
          'value': value,
-         'rand': rand
+         'rand': options['rand']
       }|merge(options)]) %}
    {% endset %}
 
@@ -450,9 +464,10 @@
     {% set options = {
         'rand': random(),
         'width': '100%',
+        'disabled': false,
     }|merge(options) %}
 
-   {% if options.fields_template.isReadonlyField(name) %}
+   {% if options.fields_template.isReadonlyField(name)|default(false) %}
       {% set options = options|merge({'readonly': true}) %}
    {% endif %}
 
@@ -460,14 +475,14 @@
       {% set options = options|merge({specific_tags: {'disabled': 'disabled'}}) %}
    {% endif %}
 
-   {% if options.fields_template.isMandatoryField(name) %}
+   {% if options.fields_template.isMandatoryField(name)|default(false) %}
       {% set options = {'required': true}|merge(options) %}
    {% endif %}
 
    {% set field %}
       {% do call('Dropdown::showFromArray', [name, elements, {
          'value': value,
-         'rand': rand,
+         'rand': options['rand'],
       }|merge(options)]) %}
    {% endset %}
 
@@ -477,13 +492,14 @@
 {% macro dropdownTimestampField(name, value, label = '', options = {}) %}
     {% set options = {
         'rand': random(),
+        'disabled': false,
         'width': '100%',
     }|merge(options) %}
-   {% if options.fields_template.isMandatoryField(name) %}
+   {% if options.fields_template.isMandatoryField(name)|default(false) %}
       {% set options = {'required': true}|merge(options) %}
    {% endif %}
 
-   {% if options.fields_template.isReadonlyField(name) %}
+   {% if options.fields_template.isReadonlyField(name)|default(false) %}
       {% set options = options|merge({'readonly': true}) %}
    {% endif %}
 
@@ -494,7 +510,7 @@
    {% set field %}
       {% do call('Dropdown::showTimestamp', [name, {
          'value': value,
-         'rand': rand,
+         'rand': options['rand'],
       }|merge(options)]) %}
    {% endset %}
 
@@ -506,11 +522,11 @@
         'rand': random(),
         'width': '100%',
     }|merge(options) %}
-   {% if options.fields_template.isMandatoryField(name) %}
+   {% if options.fields_template.isMandatoryField(name)|default(false) %}
       {% set options = {'required': true}|merge(options) %}
    {% endif %}
 
-   {% if options.fields_template.isReadonlyField(name) %}
+   {% if options.fields_template.isReadonlyField(name)|default(false) %}
       {% set options = options|merge({'readonly': true}) %}
    {% endif %}
 
@@ -520,7 +536,7 @@
 
    {% set field %}
       {% do call('Dropdown::showYesNo', [name, value, -1, {
-         'rand': rand,
+         'rand': options['rand'],
       }|merge(options)]) %}
    {% endset %}
 
@@ -530,13 +546,14 @@
 {% macro dropdownItemTypes(name, value, label = '', options = {}) %}
     {% set options = {
         'rand': random(),
+        'disabled': false,
         'width': '100%',
     }|merge(options) %}
-   {% if options.fields_template.isMandatoryField(name) %}
+   {% if options.fields_template.isMandatoryField(name)|default(false) %}
       {% set options = {'required': true}|merge(options) %}
    {% endif %}
 
-   {% if options.fields_template.isReadonlyField(name) %}
+   {% if options.fields_template.isReadonlyField(name)|default(false) %}
       {% set options = options|merge({'readonly': true}) %}
    {% endif %}
 
@@ -548,7 +565,7 @@
 
    {% set field %}
       {% do call('Dropdown::showItemTypes', [name, types, {
-         'rand': rand,
+         'rand': options['rand'],
          'value': value
       }|merge(options)]) %}
    {% endset %}
@@ -561,7 +578,7 @@
       'rand': random()
    }|merge(options) %}
 
-   {% if options.fields_template.isReadonlyField(name) %}
+   {% if options.fields_template.isReadonlyField(name)|default(false) %}
       {% set options = options|merge({'readonly': true}) %}
    {% endif %}
 
@@ -576,11 +593,11 @@
         'rand': random(),
         'width': '100%',
     }|merge(options) %}
-   {% if options.fields_template.isMandatoryField(name) %}
+   {% if options.fields_template.isMandatoryField(name)|default(false) %}
       {% set options = {'required': true}|merge(options) %}
    {% endif %}
 
-   {% if options.fields_template.isReadonlyField(name) %}
+   {% if options.fields_template.isReadonlyField(name)|default(false) %}
       {% set options = options|merge({'readonly': true}) %}
    {% endif %}
 
@@ -590,7 +607,7 @@
 
    {% set field %}
       {% do call('Dropdown::dropdownIcons', [name, value, constant('GLPI_ROOT') ~ '/pics/icones', {
-         'rand': rand,
+         'rand': options['rand'],
       }|merge(options)]) %}
    {% endset %}
 
@@ -621,11 +638,11 @@
         'rand': random(),
         'width': '100%',
     }|merge(options) %}
-   {% if options.fields_template.isMandatoryField(name) %}
+   {% if options.fields_template.isMandatoryField(name)|default(false) %}
       {% set options = {'required': true}|merge(options) %}
    {% endif %}
 
-   {% if options.fields_template.isReadonlyField(name) %}
+   {% if options.fields_template.isReadonlyField(name)|default(false) %}
       {% set options = options|merge({'readonly': true}) %}
    {% endif %}
 
@@ -635,7 +652,7 @@
 
    {% set field %}
       {% do call('Dropdown::showHours', [name, {
-         'rand': rand,
+         'rand': options['rand'],
          'value': value
       }|merge(options)]) %}
    {% endset %}
@@ -645,11 +662,11 @@
 
 {% macro dropdownFrequency(name, value, label = '', options = {}) %}
    {% set options = {'rand': random()}|merge(options) %}
-   {% if options.fields_template.isMandatoryField(name) %}
+   {% if options.fields_template.isMandatoryField(name)|default(false) %}
       {% set options = {'required': true}|merge(options) %}
    {% endif %}
 
-   {% if options.fields_template.isReadonlyField(name) %}
+   {% if options.fields_template.isReadonlyField(name)|default(false) %}
       {% set options = options|merge({'readonly': true}) %}
    {% endif %}
 
@@ -659,7 +676,7 @@
 
    {% set field %}
       {% do call('Dropdown::showFrequency', [name, value, {
-         'rand': rand,
+         'rand': options['rand'],
          'width': '100%',
          'value': value
       }|merge(options)]) %}
@@ -669,6 +686,24 @@
 {% endmacro %}
 
 {% macro dropdownField(itemtype, name, value, label = '', options = {}) %}
+    {% set options = {
+        'rand': random(),
+        'disabled': false,
+        'multiple': false,
+        'width': '100%',
+    }|merge(options) %}
+   {% if options.fields_template.isMandatoryField(name)|default(false) %}
+      {% set options = {'specific_tags': {'required': true}}|merge(options) %}
+   {% endif %}
+
+   {% if options.fields_template.isReadonlyField(name)|default(false) %}
+      {% set options = options|merge({'readonly': true}) %}
+   {% endif %}
+
+   {% if options.disabled %}
+      {% set options = options|merge({'specific_tags': {'disabled': 'disabled'}}) %}
+   {% endif %}
+
    {% if options.multiple %}
       {# Needed for empty value as the input wont be sent in this case... we need something to know the input was displayed AND empty #}
       {% set defined_input_name = "_#{name}_defined" %}
@@ -677,27 +712,12 @@
       {# Multiple values will be set, input need to be an array #}
       {% set name = "#{name}[]" %}
    {% endif %}
-    {% set options = {
-        'rand': random(),
-        'width': '100%',
-    }|merge(options) %}
-   {% if options.fields_template.isMandatoryField(name) %}
-      {% set options = {'specific_tags': {'required': true}}|merge(options) %}
-   {% endif %}
-
-   {% if options.fields_template.isReadonlyField(name) %}
-      {% set options = options|merge({'readonly': true}) %}
-   {% endif %}
-
-   {% if options.disabled %}
-      {% set options = options|merge({'specific_tags': {'disabled': 'disabled'}}) %}
-   {% endif %}
 
    {% set field %}
       {{ itemtype|itemtype_dropdown({
          'name': name,
          'value': value,
-         'rand': rand,
+         'rand': options['rand'],
       }|merge(options)) }}
    {% endset %}
 
@@ -719,11 +739,11 @@
         'rand': random(),
         'width': '100%',
     }|merge(options) %}
-    {% if options.fields_template.isMandatoryField(name) %}
+    {% if options.fields_template.isMandatoryField(name)|default(false) %}
         {% set options = {'specific_tags': {'required': true}}|merge(options) %}
     {% endif %}
 
-    {% if options.fields_template.isReadonlyField(name) %}
+    {% if options.fields_template.isReadonlyField(name)|default(false) %}
         {% set options = options|merge({'readonly': true}) %}
     {% endif %}
 
@@ -752,7 +772,7 @@
       wrapper_class: 'form-control-plaintext'
    }|merge(options) %}
 
-   {% if options.fields_template.isReadonlyField(name) %}
+   {% if options.fields_template.isReadonlyField(name)|default(false) %}
       {% set options = options|merge({'readonly': true}) %}
    {% endif %}
 
@@ -764,9 +784,11 @@
 
 {% macro field(name, field, label = '', options = {}) %}
    {% set options = {
+      'id': null,
       'rand': random(),
       'is_horizontal': true,
       'include_field': true,
+      'no_label': false,
       'add_field_html': '',
       'locked': false,
       'locked_fields': [],
@@ -778,7 +800,7 @@
       {% set options = options|merge({'locked': true}) %}
    {% endif %}
 
-   {% if options.fields_template.isReadonlyField(name) %}
+   {% if options.fields_template.isReadonlyField(name)|default(false) %}
       {% set options = options|merge({'readonly': true}) %}
    {% endif %}
 
@@ -864,6 +886,7 @@
       'center': false,
       'label_align': 'end',
       'inline_add_field_html': false,
+      'icon_label': false,
    }|merge(options) %}
 
    {% if options.icon_label %}
@@ -920,6 +943,8 @@
       'full_width': false,
       'mb': 'mb-2',
       'field_class': 'col-12 col-sm-6',
+      'label_class': '',
+      'input_class': '',
       'add_field_class': '',
       'add_field_attribs': {},
       'insert_content_after_label': '',

--- a/templates/components/form/header.html.twig
+++ b/templates/components/form/header.html.twig
@@ -73,7 +73,6 @@
 
       {{ call_plugin_hook(constant('Glpi\\Plugin\\Hooks::PRE_ITEM_FORM'), {'item': item, 'options': params}) }}
 
-      {# todo modal message #}
-      {% if app.request.request('in_modal') == true %}
+      {% if _request['_in_modal'] is defined and _request['_in_modal'] == "1" %}
       <input type="hidden" name="_no_message_link" value="1" />
       {% endif %}

--- a/templates/components/form/header_content.html.twig
+++ b/templates/components/form/header_content.html.twig
@@ -31,13 +31,14 @@
  # ---------------------------------------------------------------------
  #}
 
-{% set canedit      = params['canedit'] ?? true %}
-{% set withtemplate = params['withtemplate'] ?? '' %}
-{% set rand         = rand|default(random()) %}
-{% set nametype     = params['formtitle'] ?? item.getTypeName(1) %}
-{% set friendlyname = params['friendlyname'] ?? item.getHeaderName() %}
-{% set id           = item.fields['id'] ?? -1 %}
-{% set in_navheader = in_navheader|default(false) %}
+{% set canedit        = params['canedit'] ?? true %}
+{% set withtemplate   = params['withtemplate'] ?? '' %}
+{% set rand           = rand|default(random()) %}
+{% set nametype       = params['formtitle'] ?? item.getTypeName(1) %}
+{% set friendlyname   = params['friendlyname'] ?? item.getHeaderName() %}
+{% set id             = item.fields['id'] ?? -1 %}
+{% set in_navheader   = in_navheader|default(false) %}
+{% set header_toolbar = header_toolbar|default(false) %}
 
 {% set entity_name = entity_name|default('') %}
 {% if entity_id is not defined %}
@@ -53,7 +54,7 @@
     {% endif %}
 {% endif %}
 
-{% set template_name = item.fields['template_name'] %}
+{% set template_name = item.fields['template_name']|default(null) %}
 {% if withtemplate == 2 and not item.isNewItem() %}
    <input type="hidden" name="template_name" value="{{ template_name }}" />
    {% set nametype = __('Created from the template %s')|format(template_name) %}

--- a/templates/components/form/item_itilobject_item_list.html.twig
+++ b/templates/components/form/item_itilobject_item_list.html.twig
@@ -60,8 +60,8 @@
     {% set entries = call(itemtype_1 ~ '::getDatatableEntries', [values]) %}
     {% set datatable_params = {
         'super_header': {
-            'label': superheader,
-            'is_raw': superheader_raw,
+            'label': superheader|default(''),
+            'is_raw': superheader_raw|default(false),
         },
         'is_tab': true,
         'nopager': true,
@@ -69,7 +69,7 @@
         'nosort': true,
         'entries': entries,
         'total_number': entries|length,
-        'showmassiveactions': canedit,
+        'showmassiveactions': canedit|default(false),
     } %}
     {% set merged_params = datatable_params|merge(common_columns) %}
 

--- a/templates/components/infocom.html.twig
+++ b/templates/components/infocom.html.twig
@@ -235,7 +235,7 @@
                         {'disabled': disabled, 'step': 'any'}
                      ) }}
 
-                     {% if item.getType() not in infocom.getExcludedTypes()|merge(['Cartridge', 'Consumable', 'SoftwareLicense'])  %}
+                     {% if item.fields['ticket_tco'] is defined %}
                         {% set ticket_tco_value = infocom.showTco(item.fields['ticket_tco'], infocom.fields['value']) %}
                         {{ fields.readOnlyField(
                            'ticket_tco',

--- a/templates/components/itilobject/layout.html.twig
+++ b/templates/components/itilobject/layout.html.twig
@@ -37,8 +37,8 @@
 {% set show_extra_fields = not is_helpdesk or show_tickets_properties_on_helpdesk %}
 
 {% set itil_layout = user_pref('itil_layout', true) %}
-{% set is_collapsed = itil_layout['collapsed'] == "true" %}
-{% set is_expanded  = itil_layout['expanded'] == "true" %}
+{% set is_collapsed = itil_layout['collapsed']|default(false) == "true" %}
+{% set is_expanded  = itil_layout['expanded']|default(false) == "true" %}
 {% set collapsed_cls = (is_collapsed ? "right-collapsed" : "") %}
 {% set expanded_cls  = (is_expanded == "true" ? "right-expanded" : "") %}
 

--- a/templates/components/itilobject/timeline/form_followup.html.twig
+++ b/templates/components/itilobject/timeline/form_followup.html.twig
@@ -39,7 +39,7 @@
 {% set candedit = item.maySolve() %}
 {% set can_read_kb = has_profile_right('knowbase', constant('READ')) or has_profile_right('knowbase', constant('KnowbaseItem::READFAQ')) %}
 {% set can_update_kb = has_profile_right('knowbase', constant('UPDATE')) %}
-{% set nokb = params['nokb'] is defined or params['nokb'] == true %}
+{% set nokb = params['nokb']|default(false) %}
 {% set rand = random() %}
 {% set is_default_pending = call('PendingReason::isDefaultPending') %}
 
@@ -136,7 +136,7 @@
                         {{ fields.dropdownField(
                            'ITILFollowupTemplate',
                            'itilfollowuptemplates_id',
-                           subitem.fields['itilfollowuptemplates_id'],
+                           null,
                            fup_template_lbl,
                            {
                               'full_width': true,

--- a/templates/components/itilobject/timeline/form_solution.html.twig
+++ b/templates/components/itilobject/timeline/form_solution.html.twig
@@ -39,8 +39,8 @@
 {% set candedit = item.maySolve() %}
 {% set can_read_kb = has_profile_right('knowbase', constant('READ')) or has_profile_right('knowbase', constant('KnowbaseItem::READFAQ')) %}
 {% set can_update_kb = has_profile_right('knowbase', constant('UPDATE')) %}
-{% set nokb = params['nokb'] is defined or params['nokb'] == true %}
-{% set noform = params['noform'] is defined or params['noform'] == true %}
+{% set nokb = params['nokb']|default(false) %}
+{% set noform = params['noform']|default(false) %}
 {% set disabled = (candedit == false) %}
 
 {% set content_field_id = 'solution_content_' ~ rand %}

--- a/templates/components/itilobject/timeline/form_task.html.twig
+++ b/templates/components/itilobject/timeline/form_task.html.twig
@@ -38,7 +38,7 @@
 {% set candedit = item.maySolve() %}
 {% set can_read_kb = has_profile_right('knowbase', constant('READ')) or has_profile_right('knowbase', constant('KnowbaseItem::READFAQ')) %}
 {% set can_update_kb = has_profile_right('knowbase', constant('UPDATE')) %}
-{% set nokb = params['nokb'] is defined or params['nokb'] == true %}
+{% set nokb = params['nokb']|default(false) %}
 {% set rand = random() %}
 {% set formoptions  = params['formoptions'] ?? '' %}
 

--- a/templates/components/itilobject/timeline/form_task_main_form.html.twig
+++ b/templates/components/itilobject/timeline/form_task_main_form.html.twig
@@ -39,7 +39,7 @@
     has_profile_right('knowbase', constant('READ')) or has_profile_right('knowbase', constant('KnowbaseItem::READFAQ'))
 ) %}
 {% set can_update_kb = can_update_kb|default(has_profile_right('knowbase', constant('UPDATE'))) %}
-{% set nokb = nokb|default(params['nokb'] is defined or params['nokb'] == true) %}
+{% set nokb = params['nokb']|default(false) %}
 {% set rand = rand|default(random()) %}
 {% set formoptions = formoptions|default(params['formoptions'] ?? '') %}
 

--- a/templates/components/itilobject/timeline/main_description.html.twig
+++ b/templates/components/itilobject/timeline/main_description.html.twig
@@ -33,6 +33,7 @@
 
 {% set users_id = (item.fields['users_id_recipient'] > 0 ? item.fields['users_id_recipient'] : 0) %}
 {% set entry_rand = random() %}
+{% set anonym_user = (get_current_interface() == 'helpdesk' and users_id != session('glpiID') and entity_config('anonymize_support_agents', session('glpiactive_entity')) != constant('Entity::ANONYMIZE_DISABLED')) %}
 
 <div class="timeline-item mb-3 ITILContent"
      data-itemtype="{{ item.getType() }}" data-items-id="{{ item.fields['id'] }}">
@@ -50,6 +51,7 @@
                         'date_creation': item.fields['date_creation'],
                         'date_mod': item.fields['date_mod'],
                         'users_id_editor': item.fields['users_id_lastupdater'],
+                        'anchor': get_class(item) ~ '_' ~ item.getID(),
                         'anonym_user': anonym_user,
                      }, with_context = false) }}
                   </div>

--- a/templates/components/itilobject/timeline/pending_reasons.html.twig
+++ b/templates/components/itilobject/timeline/pending_reasons.html.twig
@@ -120,7 +120,7 @@
             <div class="col-12 col-sm-6" title="{{ __('Automatic follow-up') }}"
                   data-bs-toggle="tooltip" data-bs-placement="top">
                {% set pendingreasons_frequency_field = call('PendingReason::displayFollowupFrequencyfield', [
-                  pending_item ? pending_item.fields['followup_frequency'] : pending_item_parent.fields['followup_frequency'],
+                  pending_item.fields['followup_frequency'] ?? pending_item_parent.fields['followup_frequency'] ?? null,
                   "",
                   {
                      'rand': rand
@@ -146,7 +146,7 @@
             <div class="col-12 col-sm-6" title="{{ __('Automatic resolution') }}"
                  data-bs-toggle="tooltip" data-bs-placement="top">
                {% set pendingreasons_resolution_field = call('PendingReason::displayFollowupsNumberBeforeResolutionField', [
-                     pending_item ? pending_item.fields['followups_before_resolution'] : pending_item_parent.fields['followups_before_resolution'],
+                      pending_item.fields['followups_before_resolution'] ?? pending_item_parent.fields['followups_before_resolution'] ?? null,
                      "",
                      {
                         'rand': rand

--- a/templates/components/itilobject/timeline/pending_reasons_messages.html.twig
+++ b/templates/components/itilobject/timeline/pending_reasons_messages.html.twig
@@ -31,6 +31,8 @@
  # ---------------------------------------------------------------------
  #}
 
+{% set display_for_parent = display_for_parent|default(false) %}
+
 {% set pending_reason_item_parent = call("PendingReason_Item::getForItem", [item]) %}
 
 {% if display_for_parent %}

--- a/templates/components/itilobject/timeline/timeline.html.twig
+++ b/templates/components/itilobject/timeline/timeline.html.twig
@@ -53,7 +53,7 @@
       {% set users_id = entry_i['users_id'] %}
       {% set is_private = entry_i['is_private'] ?? false %}
       {% set date_creation = entry_i['date_creation'] ?? entry_i['date'] %}
-      {% set date_mod = entry_i['date_mod'] %}
+      {% set date_mod = entry_i['date_mod'] ?? entry_i['date'] %}
       {% set entry_rand = random() %}
       {% set is_current_user = users_id == session('glpiID') %}
       {% set anonym_user = (get_current_interface() == 'helpdesk' and not is_current_user and entity_config('anonymize_support_agents', session('glpiactive_entity')) != constant('Entity::ANONYMIZE_DISABLED')) %}
@@ -77,13 +77,13 @@
       {% set itiltype = entry['itiltype'] is defined ? 'ITIL' ~ entry['itiltype'] : entry['type'] %}
 
       {% set state_class = '' %}
-      {% if entry_i['state'] is constant('Planning::INFO') %}
+      {% if entry_i['state']|default(null) is constant('Planning::INFO') %}
          {% set state_class = 'info' %}
       {% endif %}
-      {% if entry_i['state'] is constant('Planning::TODO') %}
+      {% if entry_i['state']|default(null) is constant('Planning::TODO') %}
          {% set state_class = 'todo' %}
       {% endif %}
-      {% if entry_i['state'] is constant('Planning::DONE') %}
+      {% if entry_i['state']|default(null) is constant('Planning::DONE') %}
          {% set state_class = 'done' %}
       {% endif %}
 
@@ -108,7 +108,7 @@
       {% set user_cache = user_cache|merge({("_" ~ users_id): entry_user}) %}
 
       {% set anchor = entry['type'] ~ '_' ~ entry_i['id'] %}
-      <div id="{{ anchor }}" class="timeline-item mb-3 {{ is_private_class }} {{ itiltype }} {{ state_class }} {{ entry['class'] }} {{ 'right' in item_position ? 'ms-auto' : '' }}"
+      <div id="{{ anchor }}" class="timeline-item mb-3 {{ is_private_class }} {{ itiltype }} {{ state_class }} {{ entry['class']|default('') }} {{ 'right' in item_position ? 'ms-auto' : '' }}"
             data-itemtype="{{ entry['type'] }}" data-items-id="{{ entry_i['id'] }}"
             {% if entry['item_action'] is defined %}data-item-action="{{ entry['item_action'] }}"{% endif %}>
 
@@ -116,13 +116,13 @@
 
          <div class="row">
             <div class="col-auto todo-list-state {{ 'left' in item_position ? 'ms-auto order-sm-last' : '' }}">
-               {% if entry_i['state'] is constant('Planning::TODO') %}
+               {% if entry_i['state']|default(null) is constant('Planning::TODO') %}
                   {% if can_edit_i %}
                      <span class="state state_1" onclick="change_task_state({{ entry_i['id'] }}, this)" title="{{ __('To do') }}"></span>
                   {% else %}
                      <span class="state state_1" title="{{ __('To do') }}" style="cursor: not-allowed;"></span>
                   {% endif %}
-               {% elseif entry_i['state'] is constant('Planning::DONE') %}
+               {% elseif entry_i['state']|default(null) is constant('Planning::DONE') %}
                   {% if can_edit_i %}
                      <span class="state state_2" onclick="change_task_state({{ entry_i['id'] }}, this)" title="{{ __('Done') }}"></span>
                   {% else %}

--- a/templates/components/itilobject/timeline/timeline_item_header.html.twig
+++ b/templates/components/itilobject/timeline/timeline_item_header.html.twig
@@ -38,7 +38,7 @@
          'user_object': user_object,
          'date_creation': date_creation,
          'date_mod': date_mod,
-         'users_id_editor': entry_i['users_id_editor'],
+         'users_id_editor': entry_i['users_id_editor']|default(null),
          'anchor': entry['type'] ~ '_' ~ entry_i['id'],
          'anonym_user': anonym_user,
          'entry': entry,
@@ -59,7 +59,7 @@
          {% set actions = actions|merge({edit_btn}) %}
       {% endif %}
 
-      {% if entry_i['can_promote'] %}
+      {% if entry_i['can_promote']|default(false) %}
          {% if entry_i['sourceof_items_id'] > 0 %}
             {% set promoted_btn %}
                <li>

--- a/templates/components/itilobject/timeline/timeline_item_header_badges.html.twig
+++ b/templates/components/itilobject/timeline/timeline_item_header_badges.html.twig
@@ -71,14 +71,14 @@
       {% endset %}
 
       {{ __('Created: %1$s by %2$s for the group %3$s')|format(date_span, creator_span, group_span)|raw }}
-   {% elseif entry['type'] == 'ITILReminder' %}
+   {% elseif entry is defined and entry['type'] == 'ITILReminder' %}
       {{ date_span|raw }}
    {% else %}
       {% if users_id > 0 %}
          {% set creator_span %}
             {{ include('components/user/link_with_tooltip.html.twig', {
                'users_id': users_id,
-               'enable_anonymization': anonym_user
+               'enable_anonymization': anonym_user|default(false)
             }, with_context = false) }}
          {% endset %}
 
@@ -112,7 +112,7 @@
       {% set editor_span %}
          {{ include('components/user/link_with_tooltip.html.twig', {
             'users_id': users_id_editor,
-            'user_object': users_id == users_id_editor ? user_object : null,
+            'user_object': users_id == users_id_editor ? user_object|default(null) : null,
             'enable_anonymization': anonym_editor
          }, with_context = false) }}
       {% endset %}

--- a/templates/components/notepad/form.html.twig
+++ b/templates/components/notepad/form.html.twig
@@ -120,6 +120,7 @@
                                     'date_creation': note['date_creation'],
                                     'date_mod': note['date_mod'],
                                     'users_id_editor': note['users_id_lastupdater'],
+                                    'anchor': 'Notepad' ~ '_' ~ note['id'],
                                 }, with_context = false) }}
                             </span>
 

--- a/templates/components/pager.html.twig
+++ b/templates/components/pager.html.twig
@@ -57,7 +57,7 @@
 {% endif %}
 
 {% set back = start - limit %}
-{% if current_start - list_limit <= 0 %}
+{% if current_start - limit <= 0 %}
    {% set back = 0 %}
 {% endif %}
 

--- a/templates/components/search/controls.html.twig
+++ b/templates/components/search/controls.html.twig
@@ -38,15 +38,15 @@
 {% endif %}
 
 <div class="card-header search-header px-1 px-xl-3">
-    {% if not original_params.hide_controls %}
+    {% if not original_params.hide_controls|default(false) %}
         <div class="search-controls d-flex justify-content-between align-items-center">
 
             {% set mainform = mainform ?? true %}
             {% set showaction = showaction ?? true %}
             {% if mainform and showaction %}
-                <form name="searchform{{ normalized_itemtype }}" class="search-form-container needs-validation" novalidate method="get" action="{{ p['target'] }}">
+                <form name="searchform{{ normalized_itemtype }}" class="search-form-container needs-validation" novalidate method="get" action="{{ href }}">
             {% endif %}
-            {% if not original_params.hide_criteria %}
+            {% if not original_params.hide_criteria|default(false) %}
                 <div class="primary-controls">
                 <div class="btn-group me-1 me-xl-2">
                     {% set is_filter_active = false %}

--- a/templates/components/search/display_data.html.twig
+++ b/templates/components/search/display_data.html.twig
@@ -38,7 +38,7 @@
    <div class="ajax-container search-display-data">
 {% endif %}
 {% set push_history = push_history is defined and push_history %}
-{% set hide_controls = data['search']['hide_controls'] or (hide_controls is defined and hide_controls) %}
+{% set hide_controls = data['search']['hide_controls'] ?? hide_controls ?? false %}
 
 {# Remove namespace separators for use in HTML attributes #}
 {% set normalized_itemtype = itemtype|replace({'\\': ''}) %}

--- a/templates/components/search/query_builder/criteria.html.twig
+++ b/templates/components/search/query_builder/criteria.html.twig
@@ -34,6 +34,8 @@
 {% import 'components/form/fields_macros.html.twig' as fields %}
 
 {% set add_padding = from_meta ? 'p-0' : 'p-2' %}
+{% set add_class = add_class|default('') %}
+{% set normalized_itemtype = itemtype|replace({'\\': ''}) %}
 
 {% if meta and not from_meta %}
    {{ call("Glpi\\Search\\Input\\QueryBuilder::displayMetaCriteria", [{

--- a/templates/components/search/query_builder/search_option.html.twig
+++ b/templates/components/search/query_builder/search_option.html.twig
@@ -56,7 +56,6 @@
       itemtype: itemtype,
       _idor_token: idor_token(itemtype),
       from_meta: from_meta is defined ? from_meta : false,
-      field: field,
       prefix: prefix,
       p: p,
    } %}

--- a/templates/components/user/info_card.html.twig
+++ b/templates/components/user/info_card.html.twig
@@ -31,7 +31,8 @@
  # ---------------------------------------------------------------------
  #}
 
-{% set enable_anonymization = enable_anonymization ?? false %}
+{% set enable_anonymization = enable_anonymization|default(false) %}
+{% set can_edit = can_edit|default(false) %}
 
 <div class="p-0 user-info-card">
    <div class="row">
@@ -39,7 +40,7 @@
          {% if user['id'] %}
             {{ include('components/user/picture.html.twig', {
                'users_id': user['id'],
-               'user_object': user_object,
+               'user_object': user_object|default(null),
                'enable_anonymization': enable_anonymization
             }) }}
          {% endif %}

--- a/templates/components/user/picture.html.twig
+++ b/templates/components/user/picture.html.twig
@@ -36,6 +36,9 @@
 {% set anonymized = enable_anonymization and entity_config('anonymize_support_agents', session('glpiactive_entity')) != constant('Entity::ANONYMIZE_DISABLED') %}
 {% set user = user_object ?? get_item('User', users_id) %}
 {% set with_link = with_link ?? true %}
+{% set force_initials = force_initials|default(false) %}
+{% set display_login = display_login|default(false) %}
+
 {% if not force_initials %}
     {% set user_thumbnail = user.getThumbnailPicturePath(enable_anonymization) %}
     {% if user_thumbnail == null and not entity_config('display_users_initials', session('glpiactive_entity')) %}

--- a/templates/generic_show_form.html.twig
+++ b/templates/generic_show_form.html.twig
@@ -125,7 +125,7 @@
                                   {% set conditions_met = conditions_met + 1 %}
                               {% endif %}
 
-                              {% if cluster is not null %}
+                              {% if cluster is defined and cluster is not null %}
                                   {{ fields.htmlField(
                                       '',
                                       cluster.getLink(),
@@ -579,7 +579,7 @@
       {{ include('components/form/inventory_info.html.twig') }}
    {% endif %}
 
-   {% if params['formfooter'] is null or params['formfooter'] == true %}
+   {% if params['formfooter']|default(true) %}
       <div class="card-footer mx-n2 mb-n2">
          {{ include('components/form/dates.html.twig') }}
       </div>

--- a/templates/layout/parts/context_links.html.twig
+++ b/templates/layout/parts/context_links.html.twig
@@ -32,7 +32,7 @@
  #}
 
 {% set links = menu[sector]['content'][item]['options'][option]['links'] ?? menu[sector]['content'][item]['links'] %}
-{% set lists_itemtype = menu[sector]['content'][item]['options'][option]['lists_itemtype'] ?? menu[sector]['content'][item]['lists_itemtype'] %}
+{% set lists_itemtype = menu[sector]['content'][item]['options'][option]['lists_itemtype'] ?? menu[sector]['content'][item]['lists_itemtype'] ?? null %}
 {% if lists_itemtype is empty %}
     {% set lists_itemtype = item %}
 {% endif %}

--- a/templates/layout/parts/head.html.twig
+++ b/templates/layout/parts/head.html.twig
@@ -33,7 +33,7 @@
 
 <!DOCTYPE html>
 <html lang="{{ lang }}"
-    {% if high_contrast %}
+    {% if session('glpihighcontrast_css') %}
         data-high-contrast="1"
     {% endif %}
     {% if theme is defined %}

--- a/templates/layout/parts/menu.html.twig
+++ b/templates/layout/parts/menu.html.twig
@@ -38,8 +38,8 @@
 
 <ul class="navbar-nav" id="menu_{{ rand }}">
 {% for firstlevel in menu %}
-   {% set firstlevel_active = menu[sector]['title'] == firstlevel['title'] %}
-   {% set firstlevel_shown = (menu[sector]['title'] == firstlevel['title'] and is_vertical and is_menu_folded == false) %}
+   {% set firstlevel_active = menu[sector]['title']|default('') == firstlevel['title'] %}
+   {% set firstlevel_shown = firstlevel_active and is_vertical and is_menu_folded == false %}
    {% set has_subitems = false %}
    {% if firstlevel['content'] is defined %}
       {# Are there any items under contents with a page property? #}

--- a/templates/pages/assistance/planning/single_filter.html.twig
+++ b/templates/pages/assistance/planning/single_filter.html.twig
@@ -64,7 +64,7 @@
                             <a target="_blank" href="#" onclick="GLPIPlanning.deletePlanning(this)" value="{{ filter_key }}">{{ __('Delete') }}</a>
                         </li>
                     {% endif %}
-                    {% if caldav_url != null and filter_data.type != 'group_users' and filter_data.type != 'external' %}
+                    {% if filter_data.type != 'group_users' and filter_data.type != 'external' %}
                         <li class="dropdown-item">
                             {% set export_url = path(
                                 'front/planning.php?genical=1&uID=' ~ uID ~ '&gID=' ~ gID ~ '&entities_id=' ~ session('glpiactive_entity') ~ '&is_recursive=' ~ session('glpiactive_entity_recursive') ~ '&token=' ~ login_user.getAuthToken()
@@ -74,7 +74,7 @@
                             </a>
                         </li>
                         <li class="dropdown-item">
-                            <a target="_blank" href="webcal://{{ url.host }}:{{ url.port }}{{ url.path }}{{ export_url }}">
+                            <a target="_blank" href="webcal://{{ url.host }}:{{ url.port }}{{ url.path|default('') }}{{ export_url }}">
                                 {{ _x('button', 'Export') }} - {{ __('Webcal') }}
                             </a>
                         </li>
@@ -83,17 +83,19 @@
                                 {{ _x('button', 'Export') }} - {{ __('CSV') }}
                             </a>
                         </li>
+                        {% if caldav_url is not null %}
                         <li class="dropdown-item">
                             <a target="_blank" href="#" onclick="copyTextToClipboard('{{ caldav_url|e('js') }}'); alert('{{ __('CalDAV URL has been copied to clipboard')|e('js') }}'); return false;">
                                 {{ __('Copy CalDAV URL to clipboard') }}
                             </a>
                         </li>
+                        {% endif %}
                     {% endif %}
                 </ul>
             </div>
         {% endif %}
     </span>
-    {% if caldav_item_url is not empty and filter_data.type == 'group_users' %}
+    {% if caldav_url is not null and filter_data.type == 'group_users' %}
         <ul class="group_listofusers filters">
             {% for user_key, user_data in filter_data.users %}
                 {% do call('Planning::showSingleLinePlanningFilter', [user_key, user_data, {

--- a/templates/pages/management/document_item.html.twig
+++ b/templates/pages/management/document_item.html.twig
@@ -38,7 +38,7 @@
     <form method="post" action="{{ 'Document'|itemtype_form_path }}" enctype="multipart/form-data" data-submit-once>
 
         <div class="d-flex">
-            {{ fields.dropdownField('DocumentCategory', 'documentcategories_id', item.fields['documentcategories_id'], 'DocumentCategory'|itemtype_name, {
+            {{ fields.dropdownField('DocumentCategory', 'documentcategories_id', null, 'DocumentCategory'|itemtype_name, {
                 field_class: 'col-12 col-sm-5 pe-2',
                 entity: entities
             }) }}

--- a/templates/pages/tools/item_project.html.twig
+++ b/templates/pages/tools/item_project.html.twig
@@ -38,7 +38,7 @@
     {{ inputs.hidden('itemtype', get_class(item)) }}
     <div class="d-flex">
         {{ 'Project'|itemtype_dropdown({
-            'entity': item.getEntity(),
+            'entity': item.getEntityID(),
             'used': used,
         }) }}
     </div>

--- a/templates/pages/tools/kb/knowbaseitem_item.html.twig
+++ b/templates/pages/tools/kb/knowbaseitem_item.html.twig
@@ -51,7 +51,7 @@
             {{ fields.htmlField('', dropdown, __('Add a linked item')) }}
         {% else %}
             {{ 'KnowbaseItem'|itemtype_dropdown({
-                'entity': item.getEntity(),
+                'entity': item.getEntityID(),
                 'used': used_knowbase_items,
                 'condition': visibility_condition
             }) }}


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] This change requires a documentation update.

## Description

With the default Twig configuration, accessing an unexisting variable, object property or object method will just be evaluated to `true`, without triggering any error. IMHO, it is a mistake to not use the `strict_variables=true` option and we should have done it when we started to use Twig templates.

I propose to enable strict variables in GLPI 11.0, as it is a major version. Indeed, it will be considered as a breaking change by plugins developers. If we validate this change, we should add a note about this in our migration guide.

I guess we will have to fix many of our templates. For now, I just changed the option value to see how many errors our test suite will detect.
