### PR TITLE
Do not catch Twig exceptions anymore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -392,6 +392,7 @@ The present file will list all changes made to the project; according to the
 - `Glpi\Api\API::showDebug()`
 - `Glpi\Api\API::returnSanitizedContent()`
 - `Glpi\Application\ErrorHandler::handleSqlError()`
+- `Glpi\Application\ErrorHandler::handleTwigError()`
 - `Glpi\Console\Command\ForceNoPluginsOptionCommandInterface` class
 - `Glpi\Dashboard\Filter::dates()`
 - `Glpi\Dashboard\Filter::dates_mod()`

--- a/src/Glpi/Application/ErrorHandler.php
+++ b/src/Glpi/Application/ErrorHandler.php
@@ -309,36 +309,6 @@ class ErrorHandler
     }
 
     /**
-     * Twig error handler.
-     *
-     * This handler is manually called by application when an error occurred during Twig template rendering.
-     *
-     * @param \Twig\Error\Error $error
-     *
-     * @return void
-     */
-    public function handleTwigError(Error $error): void
-    {
-        $context = $error->getSourceContext();
-
-        $error_type = sprintf(
-            'Twig Error (%s)',
-            get_class($error)
-        );
-        $error_description = sprintf(
-            '"%s" in %s at line %s',
-            $error->getRawMessage(),
-            $context !== null ? sprintf('template "%s"', $context->getPath()) : 'unknown template',
-            $error->getTemplateLine()
-        );
-        $error_trace = $this->getTraceAsString($error->getTrace());
-        $log_level = self::ERROR_LEVEL_MAP[E_ERROR];
-
-        $this->logErrorMessage($error_type, $error_description, $error_trace, $log_level);
-        $this->outputDebugMessage($error_type, $error_description, $log_level);
-    }
-
-    /**
      * SQL warnings handler.
      *
      * This handler is manually called by application when warnings are triggered by a SQL query.

--- a/src/Glpi/Application/View/TemplateRenderer.php
+++ b/src/Glpi/Application/View/TemplateRenderer.php
@@ -36,7 +36,6 @@
 namespace Glpi\Application\View;
 
 use GLPI;
-use Glpi\Application\ErrorHandler;
 use Glpi\Application\View\Extension\ConfigExtension;
 use Glpi\Application\View\Extension\DataHelpersExtension;
 use Glpi\Application\View\Extension\DocumentExtension;
@@ -164,12 +163,9 @@ class TemplateRenderer
         try {
             Profiler::getInstance()->start($template, Profiler::CATEGORY_TWIG);
             return $this->environment->load($template)->render($variables);
-        } catch (\Twig\Error\Error $e) {
-            ErrorHandler::getInstance()->handleTwigError($e);
         } finally {
             Profiler::getInstance()->stop($template);
         }
-        return '';
     }
 
     /**
@@ -185,8 +181,6 @@ class TemplateRenderer
         try {
             Profiler::getInstance()->start($template, Profiler::CATEGORY_TWIG);
             $this->environment->load($template)->display($variables);
-        } catch (\Twig\Error\Error $e) {
-            ErrorHandler::getInstance()->handleTwigError($e);
         } finally {
             Profiler::getInstance()->stop($template);
         }
@@ -205,11 +199,8 @@ class TemplateRenderer
         try {
             Profiler::getInstance()->start($template, Profiler::CATEGORY_TWIG);
             return $this->environment->createTemplate($template)->render($variables);
-        } catch (\Twig\Error\Error $e) {
-            ErrorHandler::getInstance()->handleTwigError($e);
         } finally {
             Profiler::getInstance()->stop($template);
         }
-        return '';
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Exception that are not specifically caught are now resulting in a clean error page. It s no longuer necessary to catch Twig exception to prevent having a "blank error page". Also, the rendering will be more appropriate when the error prevent the whole page to be rendered.

## Screenshots (if appropriate):

Before:
![image](https://github.com/user-attachments/assets/c85294ae-f5a3-4985-b62a-e3edb9b1c8a0)

After:
![image](https://github.com/user-attachments/assets/708318fa-2237-495e-b0fa-10766fdb7a79)


