### PR TITLE
Remove the specific SQL error logger

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -2162,18 +2162,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Application/ErrorHandler.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Offset \'Code\' does not exist on string\\.$#',
-	'identifier' => 'offsetAccess.notFound',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Application/ErrorHandler.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Offset \'Message\' does not exist on string\\.$#',
-	'identifier' => 'offsetAccess.notFound',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Application/ErrorHandler.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Property Glpi\\\\Application\\\\ErrorHandler\\:\\:\\$exit_code is never read, only written\\.$#',
 	'identifier' => 'property.onlyWritten',
 	'count' => 1,

--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -1436,18 +1436,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/DBmysqlIterator.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Loose comparison using \\=\\= between null and true will always evaluate to false\\.$#',
-	'identifier' => 'equal.alwaysFalse',
-	'count' => 1,
-	'path' => __DIR__ . '/src/DBmysqlIterator.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Result of && is always false\\.$#',
-	'identifier' => 'booleanAnd.alwaysFalse',
-	'count' => 1,
-	'path' => __DIR__ . '/src/DBmysqlIterator.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Instanceof between static\\(DCRoom\\) and PDU will always evaluate to false\\.$#',
 	'identifier' => 'instanceof.alwaysFalse',
 	'count' => 1,
@@ -5488,12 +5476,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Comparison operation "\\>\\=" between 3 and 3 is always true\\.$#',
 	'identifier' => 'greaterOrEqual.alwaysTrue',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Toolbox.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Default value of the parameter \\#2 \\$level \\(string\\) of method Toolbox\\:\\:log\\(\\) is incompatible with type int\\.$#',
-	'identifier' => 'parameter.defaultValue',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Toolbox.php',
 ];

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -301,6 +301,7 @@ The present file will list all changes made to the project; according to the
 - `GLPI_USE_CSRF_CHECK`, `GLPI_USE_IDOR_CHECK`, `GLPI_CSRF_EXPIRES`, `GLPI_CSRF_MAX_TOKENS` and `GLPI_IDOR_EXPIRES` constants.
 - `GLPI_DEMO_MODE` constant.
 - `GLPI_DUMP_DIR` constant.
+- `GLPI_SQL_DEBUG` constant.
 - `$CFG_GLPI_PLUGINS` global variable.
 - `$DBCONNECTION_REQUIRED` and `$USEDBREPLICATE` global variables. Use `DBConnection::getReadConnection()` to get the most apporpriate connection for read only operations.
 - `$dont_check_maintenance_mode` and `$skip_db_check` global variables.
@@ -308,6 +309,7 @@ The present file will list all changes made to the project; according to the
 - `$LANG` global variable.
 - `$PLUGINS_EXCLUDED` and `$PLUGINS_INCLUDED` global variables.
 - `$SECURITY_STRATEGY` global variable.
+- `$SQLLOGGER` global variable
 - Usage of `$CFG_GLPI['itemdevices']` and `$CFG_GLPI['item_device_types']` configuration entries. Use `Item_Devices::getDeviceTypes()` to get the `Item_Devices` concrete class list.
 - Usage of `csrf_compliant` plugins hook.
 - Usage of `migratetypes` plugin hooks.
@@ -375,6 +377,7 @@ The present file will list all changes made to the project; according to the
 - `DbUtils::regenerateTreeCompleteName()`
 - `DBConnection::displayMySQLError()`
 - `DBmysql::error` property.
+- `DBmysql::getLastQueryWarnings()`
 - `Document::getImage()`
 - `Document::showUploadedFilesDropdown()`
 - `Document::uploadDocument()`
@@ -544,6 +547,9 @@ The present file will list all changes made to the project; according to the
 - `Toolbox::handleProfileChangeRedirect()`
 - `Toolbox::logError()`
 - `Toolbox::logNotice()`
+- `Toolbox::logSqlDebug()`
+- `Toolbox::logSqlError()`
+- `Toolbox::logSqlWarning()`
 - `Toolbox::logWarning()`
 - `Toolbox::showMailServerConfig()`
 - `Toolbox::sodiumDecrypt()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -395,6 +395,7 @@ The present file will list all changes made to the project; according to the
 - `Glpi\Api\API::showDebug()`
 - `Glpi\Api\API::returnSanitizedContent()`
 - `Glpi\Application\ErrorHandler::handleSqlError()`
+- `Glpi\Application\ErrorHandler::handleSqlWarnings()`
 - `Glpi\Application\ErrorHandler::handleTwigError()`
 - `Glpi\Console\Command\ForceNoPluginsOptionCommandInterface` class
 - `Glpi\Dashboard\Filter::dates()`

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -48,7 +48,6 @@ parameters:
         - GLPI_RSS_DIR
         - GLPI_SERVERSIDE_URL_ALLOWLIST
         - GLPI_SESSION_DIR
-        - GLPI_SQL_DEBUG
         - GLPI_STRICT_DEPRECATED
         - GLPI_TELEMETRY_URI
         - GLPI_TEXT_MAXSIZE

--- a/phpunit/functional/DBTest.php
+++ b/phpunit/functional/DBTest.php
@@ -689,40 +689,15 @@ SQL,
         $DB->rollBack();
     }
 
-    public function testGetLastQueryWarnings()
+    public function testQueryWarningsAreLogged()
     {
         $db = new \DB();
 
         $db->doQuery('SELECT 1/0');
-        $this->assertEquals(
-            [
-                [
-                    'Level'   => 'Warning',
-                    'Code'    => 1365,
-                    'Message' => 'Division by 0',
-                ]
-            ],
-            $db->getLastQueryWarnings()
-        );
-        $this->hasSqlLogRecordThatContains('1365: Division by 0', LogLevel::WARNING);
+        $this->hasPhpLogRecordThatContains('1365: Division by 0', LogLevel::WARNING);
 
         $db->doQuery('SELECT CAST("1a" AS SIGNED), CAST("123b" AS SIGNED)');
-        $this->assertEquals(
-            [
-                [
-                    'Level'   => 'Warning',
-                    'Code'    => 1292,
-                    'Message' => 'Truncated incorrect INTEGER value: \'1a\'',
-                ],
-                [
-                    'Level'   => 'Warning',
-                    'Code'    => 1292,
-                    'Message' => 'Truncated incorrect INTEGER value: \'123b\'',
-                ]
-            ],
-            $db->getLastQueryWarnings()
-        );
-        $this->hasSqlLogRecordThatContains(
+        $this->hasPhpLogRecordThatContains(
             '1292: Truncated incorrect INTEGER value: \'1a\'' . "\n" . '1292: Truncated incorrect INTEGER value: \'123b\'',
             LogLevel::WARNING
         );

--- a/phpunit/functional/DBmysqlIteratorTest.php
+++ b/phpunit/functional/DBmysqlIteratorTest.php
@@ -116,20 +116,6 @@ class DBmysqlIteratorTest extends DbTestCase
         $this->it->execute(['FROM' => []]);
     }
 
-    public function testDebug()
-    {
-        //Defining the following constant should produce the same, but this is not testable.
-        //define('GLPI_SQL_DEBUG', true);
-
-        $id = mt_rand();
-        $this->it->execute(['FROM' => 'foo', 'FIELDS' => 'name', 'id = ' . $id], true);
-
-        $this->hasSqlLogRecordThatContains(
-            'Generated query: SELECT `name` FROM `foo` WHERE (id = ' . $id . ')',
-            LogLevel::DEBUG
-        );
-    }
-
     public function testFields()
     {
         $it = $this->it->execute(['FROM' => 'foo', 'FIELDS' => 'bar', 'DISTINCT' => true]);
@@ -1529,10 +1515,7 @@ class DBmysqlIteratorTest extends DbTestCase
         yield [
             'params'   => ['glpi_computers', ''],
             'expected' => [
-                'criteria' => [
-                    'FROM' => 'glpi_computers',
-                ],
-                'debug'    => false,
+                'FROM' => 'glpi_computers',
             ],
             'sql'      => 'SELECT * FROM `glpi_computers`',
         ];
@@ -1541,11 +1524,8 @@ class DBmysqlIteratorTest extends DbTestCase
         yield [
             'params'   => ['glpi_computers', 'is_deleted = 0'],
             'expected' => [
-                'criteria' => [
-                    'FROM'  => 'glpi_computers',
-                    'WHERE' => [new QueryExpression('is_deleted = 0')]
-                ],
-                'debug'    => false,
+                'FROM'  => 'glpi_computers',
+                'WHERE' => [new QueryExpression('is_deleted = 0')]
             ],
             'sql'      => 'SELECT * FROM `glpi_computers` WHERE is_deleted = 0',
         ];
@@ -1554,12 +1534,9 @@ class DBmysqlIteratorTest extends DbTestCase
         yield [
             'params'   => ['glpi_computers', ['WHERE' => ['is_deleted' => 0], 'ORDER' => 'id DESC']],
             'expected' => [
-                'criteria' => [
-                    'FROM'  => 'glpi_computers',
-                    'WHERE' => ['is_deleted' => 0],
-                    'ORDER' => 'id DESC'
-                ],
-                'debug'    => false,
+                'FROM'  => 'glpi_computers',
+                'WHERE' => ['is_deleted' => 0],
+                'ORDER' => 'id DESC'
             ],
             'sql'      => 'SELECT * FROM `glpi_computers` WHERE `is_deleted` = \'0\' ORDER BY `id` DESC',
         ];
@@ -1568,11 +1545,8 @@ class DBmysqlIteratorTest extends DbTestCase
         yield [
             'params'   => ['glpi_computers', ['is_deleted' => 1]],
             'expected' => [
-                'criteria' => [
-                    'FROM'  => 'glpi_computers',
-                    'is_deleted' => 1,
-                ],
-                'debug'    => false,
+                'FROM'  => 'glpi_computers',
+                'is_deleted' => 1,
             ],
             'sql'      => 'SELECT * FROM `glpi_computers` WHERE `is_deleted` = \'1\'',
         ];
@@ -1589,10 +1563,7 @@ class DBmysqlIteratorTest extends DbTestCase
         yield [
             'params'   => [$union, ''],
             'expected' => [
-                'criteria' => [
-                    'FROM'  => $union,
-                ],
-                'debug'    => false,
+                'FROM'  => $union,
             ],
             'sql'      => 'SELECT * FROM ((SELECT `serial` FROM `glpi_computers`) UNION ALL (SELECT `serial` FROM `glpi_printers`)) AS `testalias`',
         ];

--- a/phpunit/functional/SearchTest.php
+++ b/phpunit/functional/SearchTest.php
@@ -3580,8 +3580,8 @@ class SearchTest extends DbTestCase
             ];
             // log for both AND and AND NOT cases
             if ($is_mariadb) {
-                $this->hasSqlLogRecordThatContains("Truncated incorrect DECIMAL value: ''", LogLevel::WARNING);
-                $this->hasSqlLogRecordThatContains("Truncated incorrect DECIMAL value: ''", LogLevel::WARNING);
+                $this->hasPhpLogRecordThatContains("Truncated incorrect DECIMAL value: ''", LogLevel::WARNING);
+                $this->hasPhpLogRecordThatContains("Truncated incorrect DECIMAL value: ''", LogLevel::WARNING);
             }
 
             // datatype=number
@@ -3594,8 +3594,8 @@ class SearchTest extends DbTestCase
             ];
             // log for both AND and AND NOT cases
             if ($is_mariadb) {
-                $this->hasSqlLogRecordThatContains("Truncated incorrect DECIMAL value: ''", LogLevel::WARNING);
-                $this->hasSqlLogRecordThatContains("Truncated incorrect DECIMAL value: ''", LogLevel::WARNING);
+                $this->hasPhpLogRecordThatContains("Truncated incorrect DECIMAL value: ''", LogLevel::WARNING);
+                $this->hasPhpLogRecordThatContains("Truncated incorrect DECIMAL value: ''", LogLevel::WARNING);
             }
 
             // datatype=number (usehaving=true)
@@ -3616,8 +3616,8 @@ class SearchTest extends DbTestCase
                 'expected_and_not'  => "(`glpi_budgets`.`value` IS NOT NULL AND `glpi_budgets`.`value` <> '')",
             ];
             // log for both AND and AND NOT cases
-            $this->hasSqlLogRecordThatContains("Truncated incorrect DECIMAL value: ''", LogLevel::WARNING);
-            $this->hasSqlLogRecordThatContains("Truncated incorrect DECIMAL value: ''", LogLevel::WARNING);
+            $this->hasPhpLogRecordThatContains("Truncated incorrect DECIMAL value: ''", LogLevel::WARNING);
+            $this->hasPhpLogRecordThatContains("Truncated incorrect DECIMAL value: ''", LogLevel::WARNING);
 
             // datatype=decimal (usehaving=true)
             yield [
@@ -3638,8 +3638,8 @@ class SearchTest extends DbTestCase
             ];
             // log for both AND and AND NOT cases
             if ($is_mariadb) {
-                $this->hasSqlLogRecordThatContains("Truncated incorrect DECIMAL value: ''", LogLevel::WARNING);
-                $this->hasSqlLogRecordThatContains("Truncated incorrect DECIMAL value: ''", LogLevel::WARNING);
+                $this->hasPhpLogRecordThatContains("Truncated incorrect DECIMAL value: ''", LogLevel::WARNING);
+                $this->hasPhpLogRecordThatContains("Truncated incorrect DECIMAL value: ''", LogLevel::WARNING);
             }
 
             // datatype=mio (usehaving=true)
@@ -3670,8 +3670,8 @@ class SearchTest extends DbTestCase
             ];
             // log for both AND and AND NOT cases
             if ($is_mariadb) {
-                $this->hasSqlLogRecordThatContains("Truncated incorrect DECIMAL value: ''", LogLevel::WARNING);
-                $this->hasSqlLogRecordThatContains("Truncated incorrect DECIMAL value: ''", LogLevel::WARNING);
+                $this->hasPhpLogRecordThatContains("Truncated incorrect DECIMAL value: ''", LogLevel::WARNING);
+                $this->hasPhpLogRecordThatContains("Truncated incorrect DECIMAL value: ''", LogLevel::WARNING);
             }
 
             // datatype=timestamp (usehaving=true)

--- a/src/DBmysqlIterator.php
+++ b/src/DBmysqlIterator.php
@@ -108,15 +108,16 @@ class DBmysqlIterator implements SeekableIterator, Countable
      * Executes the query
      *
      * @param array   $criteria Query criteria
-     * @param boolean $debug    To log the request (default false)
      *
      * @return DBmysqlIterator
+     *
+     * @since 11.0.0 The `$debug` parameter has been removed.
      */
-    public function execute($criteria, $debug = false): self
+    public function execute($criteria): self
     {
-        ['criteria' => $criteria, 'debug' => $debug] = $this->convertOldRequestArgsToCriteria(func_get_args(), __METHOD__);
+        $criteria = $this->convertOldRequestArgsToCriteria(func_get_args(), __METHOD__);
 
-        $this->buildQuery($criteria, $debug);
+        $this->buildQuery($criteria);
         $this->res = $this->conn ? $this->conn->doQuery($this->sql) : false;
         $this->count = $this->res instanceof \mysqli_result ? $this->conn->numrows($this->res) : 0;
         $this->setPosition(0);
@@ -127,13 +128,14 @@ class DBmysqlIterator implements SeekableIterator, Countable
      * Builds the query
      *
      * @param array   $criteria Query criteria
-     * @param boolean $log      To log the request (default false)
      *
      * @return void
+     *
+     * @since 11.0.0 The `$log` parameter has been removed.
      */
-    public function buildQuery($criteria, $log = false): void
+    public function buildQuery($criteria): void
     {
-        ['criteria' => $criteria, 'debug' => $log] = $this->convertOldRequestArgsToCriteria(func_get_args(), __METHOD__);
+        $criteria = $this->convertOldRequestArgsToCriteria(func_get_args(), __METHOD__);
 
         $this->sql = null;
         $this->res = false;
@@ -328,11 +330,6 @@ class DBmysqlIterator implements SeekableIterator, Countable
 
         //LIMIT & OFFSET
         $this->sql .= $this->handleLimits($limit, $start);
-
-
-        if ($log == true || defined('GLPI_SQL_DEBUG') && GLPI_SQL_DEBUG == true) {
-            Toolbox::logSqlDebug("Generated query:", $this->getSql());
-        }
     }
 
     /**
@@ -889,7 +886,6 @@ class DBmysqlIterator implements SeekableIterator, Countable
         if (is_array($args[0])) {
             // The new signature ($criteria, $debug = false) is already used
             $criteria = $args[0];
-            $debug    = $args[1] ?? false;
         } else {
             // The old signature ($tableorsql, $crit = "", $debug = false) is still used
             Toolbox::deprecated(
@@ -901,13 +897,9 @@ class DBmysqlIterator implements SeekableIterator, Countable
                     ? ['WHERE' => [new QueryExpression($criteria)]]
                     : [];
             }
-            $debug    = $args[2] ?? false;
             $criteria['FROM'] = $args[0];
         }
 
-        return [
-            'criteria' => $criteria,
-            'debug'    => $debug,
-        ];
+        return $criteria;
     }
 }

--- a/src/GLPI.php
+++ b/src/GLPI.php
@@ -78,9 +78,8 @@ class GLPI
     {
         /**
          * @var \Psr\Log\LoggerInterface $PHPLOGGER
-         * @var \Psr\Log\LoggerInterface $SQLLOGGER
          */
-        global $PHPLOGGER, $SQLLOGGER;
+        global $PHPLOGGER;
 
         if (defined('GLPI_LOG_LVL')) {
             $log_level = GLPI_LOG_LVL;
@@ -104,24 +103,14 @@ class GLPI
             }
         }
 
-        foreach (['php', 'sql'] as $type) {
-            $logger = new Logger('glpi' . $type . 'log');
-            $handler = new StreamHandler(
-                GLPI_LOG_DIR . "/{$type}-errors.log",
-                $log_level
-            );
-            $formatter = new LineFormatter(null, 'Y-m-d H:i:s', true, true);
-            $handler->setFormatter($formatter);
-            $logger->pushHandler($handler);
-            switch ($type) {
-                case 'php':
-                    $PHPLOGGER = $logger;
-                    break;
-                case 'sql':
-                    $SQLLOGGER = $logger;
-                    break;
-            }
-        }
+        $PHPLOGGER = new Logger('glpiphplog');
+        $handler = new StreamHandler(
+            GLPI_LOG_DIR . "/php-errors.log",
+            $log_level
+        );
+        $formatter = new LineFormatter(null, 'Y-m-d H:i:s', true, true);
+        $handler->setFormatter($formatter);
+        $PHPLOGGER->pushHandler($handler);
     }
 
     /**

--- a/src/Glpi/Application/ErrorHandler.php
+++ b/src/Glpi/Application/ErrorHandler.php
@@ -39,7 +39,6 @@ use GLPI;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 use Symfony\Component\Console\Output\OutputInterface;
-use Twig\Error\Error;
 
 /**
  * @since 9.5.0
@@ -306,33 +305,6 @@ class ErrorHandler
         $this->outputDebugMessage($error_type, $error_description, $log_level);
 
         return $return;
-    }
-
-    /**
-     * SQL warnings handler.
-     *
-     * This handler is manually called by application when warnings are triggered by a SQL query.
-     *
-     * @param string[] $warnings
-     * @param string   $query
-     *
-     * @return void
-     */
-    public function handleSqlWarnings(array $warnings, string $query)
-    {
-        $message = "\n"
-            . implode(
-                "\n",
-                array_map(
-                    function ($warning) {
-                        return sprintf('%s: %s', $warning['Code'], $warning['Message']);
-                    },
-                    $warnings
-                )
-            )
-            . "\n"
-            . sprintf('in query "%s"', $query);
-        $this->outputDebugMessage('SQL Warnings', $message, self::ERROR_LEVEL_MAP[E_USER_WARNING]);
     }
 
     /**

--- a/stubs/glpi_constants.php
+++ b/stubs/glpi_constants.php
@@ -60,7 +60,6 @@ define('GLPI_VAR_DIR', null);
 // Optionnal constants
 define('GLPI_FORCE_MAIL', null);
 define('GLPI_LOG_LVL', null);
-define('GLPI_SQL_DEBUG', null);
 define('GLPI_STRICT_DEPRECATED', null);
 
 // Other constants

--- a/tests/GLPITestCase.php
+++ b/tests/GLPITestCase.php
@@ -47,12 +47,7 @@ class GLPITestCase extends atoum
     /**
      * @var TestHandler
      */
-    private $php_log_handler;
-
-    /**
-     * @var TestHandler
-     */
-    private $sql_log_handler;
+    private $log_handler;
 
     public function beforeTestMethod($method)
     {
@@ -66,13 +61,11 @@ class GLPITestCase extends atoum
         global $GLPI_CACHE;
         $GLPI_CACHE->clear();
 
-        // Init log handlers
-        global $PHPLOGGER, $SQLLOGGER;
+        // Init log handler
+        global $PHPLOGGER;
         /** @var \Monolog\Logger $PHPLOGGER */
-        $this->php_log_handler = new TestHandler(LogLevel::DEBUG);
-        $PHPLOGGER->setHandlers([$this->php_log_handler]);
-        $this->sql_log_handler = new TestHandler(LogLevel::DEBUG);
-        $SQLLOGGER->setHandlers([$this->sql_log_handler]);
+        $this->log_handler = new TestHandler(LogLevel::DEBUG);
+        $PHPLOGGER->setHandlers([$this->log_handler]);
     }
 
     public function afterTestMethod($method)
@@ -91,27 +84,25 @@ class GLPITestCase extends atoum
         }
 
         if (!$this->has_failed) {
-            foreach ([$this->php_log_handler, $this->sql_log_handler] as $log_handler) {
-                $this->array($log_handler->getRecords());
-                $clean_logs = array_map(
-                    static function (\Monolog\LogRecord $entry): array {
-                        return [
-                            'channel' => $entry->channel,
-                            'level'   => $entry->level->name,
-                            'message' => $entry->message,
-                        ];
-                    },
-                    $log_handler->getRecords()
-                );
-                $this->array($clean_logs)->isEmpty(
-                    sprintf(
-                        "Unexpected entries in log in %s::%s:\n%s",
-                        static::class,
-                        $method,
-                        print_r($clean_logs, true)
-                    )
-                );
-            }
+            $this->array($this->log_handler->getRecords());
+            $clean_logs = array_map(
+                static function (\Monolog\LogRecord $entry): array {
+                    return [
+                        'channel' => $entry->channel,
+                        'level'   => $entry->level->name,
+                        'message' => $entry->message,
+                    ];
+                },
+                $this->log_handler->getRecords()
+            );
+            $this->array($clean_logs)->isEmpty(
+                sprintf(
+                    "Unexpected entries in log in %s::%s:\n%s",
+                    static::class,
+                    $method,
+                    print_r($clean_logs, true)
+                )
+            );
         }
     }
 
@@ -236,32 +227,6 @@ class GLPITestCase extends atoum
      */
     protected function hasPhpLogRecordThatContains(string $message, string $level): void
     {
-        $this->hasLogRecordThatContains($this->php_log_handler, $message, $level);
-    }
-
-    /**
-     * Check in SQL log for a record that contains given message.
-     *
-     * @param string $message
-     * @param string $level
-     *
-     * @return void
-     */
-    protected function hasSqlLogRecordThatContains(string $message, string $level): void
-    {
-        $this->hasLogRecordThatContains($this->sql_log_handler, $message, $level);
-    }
-
-    /**
-     * Check given log handler for a record that contains given message.
-     *
-     * @param string $message
-     * @param string $level
-     *
-     * @return void
-     */
-    private function hasLogRecordThatContains(TestHandler $handler, string $message, string $level): void
-    {
         $this->has_failed = true;
 
         $records = array_map(
@@ -272,7 +237,7 @@ class GLPITestCase extends atoum
                     'message' => $record['message'],
                 ];
             },
-            $handler->getRecords()
+            $this->log_handler->getRecords()
         );
 
         $matching = null;
@@ -289,7 +254,7 @@ class GLPITestCase extends atoum
             sprintf("Message not found in log records\n- %s\n+ %s", $message, print_r($records, true))
         );
 
-        $handler->dropFromRecords($matching['message'], $matching['level']);
+        $this->log_handler->dropFromRecords($matching['message'], $matching['level']);
 
         $this->has_failed = false;
     }
@@ -304,36 +269,10 @@ class GLPITestCase extends atoum
      */
     protected function hasPhpLogRecordThatMatches(string $pattern, string $level): void
     {
-        $this->hasLogRecordThatMatches($this->php_log_handler, $pattern, $level);
-    }
-
-    /**
-     * Check in SQL log for a record that matches given pattern.
-     *
-     * @param string $message
-     * @param string $level
-     *
-     * @return void
-     */
-    protected function hasSqlLogRecordThatMatches(string $pattern, string $level): void
-    {
-        $this->hasLogRecordThatMatches($this->sql_log_handler, $pattern, $level);
-    }
-
-    /**
-     * Check given log handler for a record that matches given pattern.
-     *
-     * @param string $message
-     * @param string $level
-     *
-     * @return void
-     */
-    private function hasLogRecordThatMatches(TestHandler $handler, string $pattern, string $level): void
-    {
         $this->has_failed = true;
 
         $matching = null;
-        foreach ($handler->getRecords() as $record) {
+        foreach ($this->log_handler->getRecords() as $record) {
             if (
                 Level::fromValue($record['level']) === Level::fromName($level)
                 && preg_match($pattern, $record['message']) === 1
@@ -343,7 +282,7 @@ class GLPITestCase extends atoum
             }
         }
         $this->variable($matching)->isNotNull('No matching log found.');
-        $handler->dropFromRecords($matching['message'], $matching['level']);
+        $this->log_handler->dropFromRecords($matching['message'], $matching['level']);
 
         $this->has_failed = false;
     }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] This change requires a documentation update.

## Description

Since #18151, only SQL warnings and SQL debug information are logged in the `sql-errors.log`.

Having several handlers makes it more complicated to modify our error handling system to make it fully compliant with the Symfony error handling. Indeed, the Symfony system expects that only one error logger exists. It is still possible to have multiple log files, but this should be achieved using one logger with multiple handlers, instead of having multiple loggers with one handler for each, see https://symfony.com/doc/6.4/logging/channels_handlers.html.

I do not think it is really necessary to split our log files, so I propose to just trigger a PHP Warning when a query triggers SQL warnings, in order to make this error handled the same way as any other PHP error.

Also, I removed the `$debug` parameter from the `DBmysql::request()` method. I am not sure it is really used, and it is still possible to check the generated query using the xdebug debug mode.

