### PR TITLE
Use `trigger_error()` instead of a direct call to the error handler

### DIFF
--- a/src/Glpi/Agent/Communication/AbstractRequest.php
+++ b/src/Glpi/Agent/Communication/AbstractRequest.php
@@ -348,13 +348,15 @@ abstract class AbstractRequest
         $xml = simplexml_load_string($data, 'SimpleXMLElement', LIBXML_NOCDATA);
         if (!$xml) {
             $xml_errors = libxml_get_errors();
-           /* @var \LibXMLError $xml_error */
+            /* @var \LibXMLError $xml_error */
             foreach ($xml_errors as $xml_error) {
-                ErrorHandler::getInstance()->handleError(
-                    E_USER_WARNING,
-                    $xml_error->message,
-                    $xml_error->file,
-                    $xml_error->line
+                \trigger_error(
+                    \sprintf(
+                        'XML error `%s` at line %d.',
+                        $xml_error->message,
+                        $xml_error->line
+                    ),
+                    E_USER_WARNING
                 );
             }
             $this->addError('XML not well formed!', 400);


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

The  `ErrorHandler::handleError()` is not supposed to be called manually. It cannot be made `private` because it is used as a callback by `set_error_handler`.