### PR TITLE
Drop temporary migration code

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -254,12 +254,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/install/migrations/update_10.0.x_to_11.0.0.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Loose comparison using \\=\\= between \'11\\.0\\.0\\-dev\' and \'11\\.0\\.0\\-dev\' will always evaluate to true\\.$#',
-	'identifier' => 'equal.alwaysTrue',
-	'count' => 1,
-	'path' => __DIR__ . '/install/migrations/update_10.0.x_to_11.0.0/form.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Empty array passed to foreach\\.$#',
 	'identifier' => 'foreach.emptyArray',
 	'count' => 1,


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.

## Description

This code was supposed to help developers work on different versions of the native forms feature without resetting their database too often.
In the end we still reset our databases all the time and this become more work to maintain when adding new feature so we should probably drop it now even if the database schema is not yet final for this feature.


