### PR TITLE
Replace followup with notification in some labels

### DIFF
--- a/phpunit/functional/NotificationAjaxSettingTest.php
+++ b/phpunit/functional/NotificationAjaxSettingTest.php
@@ -48,8 +48,8 @@ class NotificationAjaxSettingTest extends DbTestCase
 
     public function testGetTypeName()
     {
-        $this->assertSame('Browser followups configuration', \NotificationAjaxSetting::getTypeName());
-        $this->assertSame('Browser followups configuration', \NotificationAjaxSetting::getTypeName(10));
+        $this->assertSame('Browser notifications configuration', \NotificationAjaxSetting::getTypeName());
+        $this->assertSame('Browser notifications configuration', \NotificationAjaxSetting::getTypeName(10));
     }
 
     public function testDefineTabs()
@@ -77,7 +77,7 @@ class NotificationAjaxSettingTest extends DbTestCase
     public function testGetEnableLabel()
     {
         $settings = new \NotificationAjaxSetting();
-        $this->assertSame('Enable followups from browser', $settings->getEnableLabel());
+        $this->assertSame('Enable browser notifications', $settings->getEnableLabel());
     }
 
     public function testGetMode()

--- a/phpunit/functional/NotificationMailingSettingTest.php
+++ b/phpunit/functional/NotificationMailingSettingTest.php
@@ -48,8 +48,8 @@ class NotificationMailingSettingTest extends DbTestCase
 
     public function testGetTypeName()
     {
-        $this->assertSame('Email followups configuration', \NotificationMailingSetting::getTypeName());
-        $this->assertSame('Email followups configuration', \NotificationMailingSetting::getTypeName(10));
+        $this->assertSame('Email notifications configuration', \NotificationMailingSetting::getTypeName());
+        $this->assertSame('Email notifications configuration', \NotificationMailingSetting::getTypeName(10));
     }
 
     public function testDefineTabs()
@@ -83,7 +83,7 @@ class NotificationMailingSettingTest extends DbTestCase
     public function testGetEnableLabel()
     {
         $settings = new \NotificationMailingSetting();
-        $this->assertSame('Enable followups via email', $settings->getEnableLabel());
+        $this->assertSame('Enable email notifications', $settings->getEnableLabel());
     }
 
     public function testGetMode()

--- a/phpunit/functional/NotificationSettingConfigTest.php
+++ b/phpunit/functional/NotificationSettingConfigTest.php
@@ -114,8 +114,8 @@ class NotificationSettingConfigTest extends DbTestCase
         $content = ob_get_clean();
         $this->assertStringContainsString('Notifications configuration', $content);
         $this->assertStringContainsString('Notification templates', $content);
-        $this->assertStringContainsString('Browser followups configuration', $content);
-        $this->assertStringNotContainsString('Email followups configuration', $content);
+        $this->assertStringContainsString('Browser notifications configuration', $content);
+        $this->assertStringNotContainsString('Email notifications configuration', $content);
 
         $CFG_GLPI['notifications_mailing'] = 1;
 
@@ -124,8 +124,8 @@ class NotificationSettingConfigTest extends DbTestCase
         $content = ob_get_clean();
         $this->assertStringContainsString('Notifications configuration', $content);
         $this->assertStringContainsString('Notification templates', $content);
-        $this->assertStringContainsString('Browser followups configuration', $content);
-        $this->assertStringContainsString('Email followups configuration', $content);
+        $this->assertStringContainsString('Browser notifications configuration', $content);
+        $this->assertStringContainsString('Email notifications configuration', $content);
 
         //reset
         $CFG_GLPI['use_notifications'] = 0;

--- a/src/NotificationAjaxSetting.php
+++ b/src/NotificationAjaxSetting.php
@@ -42,12 +42,12 @@ class NotificationAjaxSetting extends NotificationSetting
 {
     public static function getTypeName($nb = 0)
     {
-        return __('Browser followups configuration');
+        return __('Browser notifications configuration');
     }
 
     public function getEnableLabel()
     {
-        return __('Enable followups from browser');
+        return __('Enable browser notifications');
     }
 
     public static function getMode()

--- a/src/NotificationMailingSetting.php
+++ b/src/NotificationMailingSetting.php
@@ -43,13 +43,13 @@ class NotificationMailingSetting extends NotificationSetting
 {
     public static function getTypeName($nb = 0)
     {
-        return __('Email followups configuration');
+        return __('Email notifications configuration');
     }
 
 
     public function getEnableLabel()
     {
-        return __('Enable followups via email');
+        return __('Enable email notifications');
     }
 
 

--- a/templates/pages/setup/setup_notifications.html.twig
+++ b/templates/pages/setup/setup_notifications.html.twig
@@ -56,7 +56,7 @@
                               class="form-check-input" type="checkbox" value="1"
                               {{ use_notifications ? 'checked="checked"' : '' }} />
                         <label class="form-check-label" for="use_notifications">
-                           {{ __('Enable followup') }}
+                           {{ __('Enable notifications') }}
                         </label>
                      </div>
                   </li>
@@ -112,7 +112,7 @@
                   <div class="list-group-item">
                      <div class="alert alert-important alert-warning m-3">
                         <i class="fa-fw ti ti-alert-triangle me-2"></i>
-                        {{ __('Unable to configure notifications: please configure at least one followup type using the above configuration.') }}
+                        {{ __('Unable to configure notifications: please configure at least one notification type using the above configuration.') }}
                      </div>
                   </div>
                {% endif %}


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] This change requires a documentation update.

## Description

Replace "followup" with "notification" in the notification settings labels to make them more accurate since they are related to the sending of notifications and not related to Followups.

## Screenshots (if appropriate):

![Selection_398](https://github.com/user-attachments/assets/ec3eaae7-7240-4762-a0fd-e8db64787bb6)

![Selection_397](https://github.com/user-attachments/assets/d5146215-8625-4447-9841-bd03470480c9)
