### PR TITLE
Enhance CSRF handling

### DIFF
--- a/js/modules/GlpiInstall.js
+++ b/js/modules/GlpiInstall.js
@@ -30,6 +30,8 @@
  * ---------------------------------------------------------------------
  */
 
+/* global getAjaxCsrfToken */
+
 import { ProgressBar } from './ProgressBar.js';
 
 export async function init_database(progress_key)
@@ -74,7 +76,15 @@ export async function init_database(progress_key)
     }, 1500);
 
     try {
-        await fetch(`${CFG_GLPI.root_doc}/install/init_database`, {method: 'POST'});
+        await fetch(`${CFG_GLPI.root_doc}/install/init_database`, {
+            method: 'POST',
+            headers: {
+                'Accept': 'application/json',
+                'Content-Type': 'application/x-www-form-urlencoded;',
+                'X-Requested-With': 'XMLHttpRequest',
+                'X-Glpi-Csrf-Token': getAjaxCsrfToken(),
+            },
+        });
     } catch {
         // DB installation is really long and can result in a `Proxy timeout` error.
         // It does not mean that the process is killed, it just mean that the proxy did not wait for the response

--- a/js/modules/ObjectLock.js
+++ b/js/modules/ObjectLock.js
@@ -162,7 +162,8 @@ class ObjectLock {
                         headers: {
                             'Accept': 'application/json',
                             'Content-Type': 'application/x-www-form-urlencoded;',
-                            'X-Glpi-Csrf-Token': getAjaxCsrfToken()
+                            'X-Requested-With': 'XMLHttpRequest',
+                            'X-Glpi-Csrf-Token': getAjaxCsrfToken(),
                         },
                         body: `unlock=1&id=${this.lock.id}`
                     }).catch(() => {

--- a/src/Glpi/Controller/ApiController.php
+++ b/src/Glpi/Controller/ApiController.php
@@ -41,6 +41,7 @@ use Glpi\Http\Firewall;
 use Glpi\Http\HeaderlessStreamedResponse;
 use Glpi\Http\JSONResponse;
 use Glpi\Http\Request;
+use Glpi\Security\Attribute\DisableCsrfChecks;
 use Glpi\Security\Attribute\SecurityStrategy;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
@@ -55,6 +56,7 @@ final class ApiController extends AbstractController
             'request_parameters' => '.*',
         ]
     )]
+    #[DisableCsrfChecks()]
     #[SecurityStrategy(Firewall::STRATEGY_NO_CHECK)]
     public function __invoke(SymfonyRequest $request): SymfonyResponse
     {

--- a/src/Glpi/Controller/ApiRestController.php
+++ b/src/Glpi/Controller/ApiRestController.php
@@ -38,6 +38,7 @@ use Glpi\Api\APIRest;
 use Glpi\Application\ErrorHandler;
 use Glpi\Http\Firewall;
 use Glpi\Http\HeaderlessStreamedResponse;
+use Glpi\Security\Attribute\DisableCsrfChecks;
 use Glpi\Security\Attribute\SecurityStrategy;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -52,6 +53,7 @@ final class ApiRestController extends AbstractController
             'request_parameters' => '.*',
         ]
     )]
+    #[DisableCsrfChecks()]
     #[SecurityStrategy(Firewall::STRATEGY_NO_CHECK)]
     public function __invoke(Request $request): Response
     {

--- a/src/Glpi/Controller/IndexController.php
+++ b/src/Glpi/Controller/IndexController.php
@@ -48,15 +48,10 @@ use Glpi\Plugin\Hooks;
 use Glpi\Security\Attribute\SecurityStrategy;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Routing\Attribute\Route;
 
 final class IndexController extends AbstractController
 {
-    public function __construct(private HttpKernelInterface $http_kernel)
-    {
-    }
-
     #[Route(
         [
             "base" => "/",
@@ -67,18 +62,6 @@ final class IndexController extends AbstractController
     #[SecurityStrategy(Firewall::STRATEGY_NO_CHECK)]
     public function __invoke(Request $request): Response
     {
-        if (
-            $request->isMethod('POST')
-            && !$request->request->has('totp_code')
-            && $request->getContent() !== ''
-        ) {
-            // POST request from the inventory agent, forward it to the inventory controller.
-            $sub_request = $request->duplicate(
-                attributes: ['_controller' => InventoryController::class . '::index']
-            );
-            return $this->http_kernel->handle($sub_request, HttpKernelInterface::SUB_REQUEST);
-        }
-
         return new HeaderlessStreamedResponse($this->call(...));
     }
 

--- a/src/Glpi/Controller/InventoryController.php
+++ b/src/Glpi/Controller/InventoryController.php
@@ -39,6 +39,7 @@ use Glpi\Exception\Http\HttpException;
 use Glpi\Http\Firewall;
 use Symfony\Component\HttpFoundation\Request;
 use Glpi\Inventory\Conf;
+use Glpi\Security\Attribute\DisableCsrfChecks;
 use Glpi\Security\Attribute\SecurityStrategy;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
@@ -47,6 +48,8 @@ use Symfony\Component\Routing\Attribute\Route;
 final class InventoryController extends AbstractController
 {
     public static bool $is_running = false;
+
+    #[DisableCsrfChecks()]
     #[SecurityStrategy(Firewall::STRATEGY_NO_CHECK)]
     #[Route("/Inventory", name: "glpi_inventory", methods: ['GET', 'POST'])]
     #[Route("/front/inventory.php", name: "glpi_inventory_legacy", methods: ['GET', 'POST'])]

--- a/src/Glpi/Kernel/ListenersPriority.php
+++ b/src/Glpi/Kernel/ListenersPriority.php
@@ -71,7 +71,8 @@ final class ListenersPriority
 
         HttpListener\CheckMaintenanceListener::class    => 430,
 
-        HttpListener\CheckCsrfListener::class           => 420,
+        // This listener will forward to the inventory controller any inventory agent requests made on the index endpoint.
+        HttpListener\CatchInventoryAgentRequestListener::class => 420,
 
         // Executes the legacy controller scripts (`/ajax/*.php` or `/front/*.php` scripts) whenever the
         // requested URI matches an existing file.

--- a/src/Glpi/Security/Attribute/DisableCsrfChecks.php
+++ b/src/Glpi/Security/Attribute/DisableCsrfChecks.php
@@ -32,36 +32,9 @@
  * ---------------------------------------------------------------------
  */
 
-namespace Glpi\Controller;
+namespace Glpi\Security\Attribute;
 
-use Glpi\Http\Firewall;
-use Glpi\Http\HeaderlessStreamedResponse;
-use Glpi\Security\Attribute\DisableCsrfChecks;
-use Glpi\Security\Attribute\SecurityStrategy;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Attribute\Route;
-
-final class CaldavController extends AbstractController
+#[\Attribute(\Attribute::TARGET_METHOD)]
+final readonly class DisableCsrfChecks
 {
-    #[Route(
-        "/caldav.php{request_parameters}",
-        name: "glpi_caldav",
-        requirements: [
-            'request_parameters' => '.*',
-        ]
-    )]
-    #[DisableCsrfChecks()]
-    #[SecurityStrategy(Firewall::STRATEGY_NO_CHECK)]
-    public function __invoke(Request $request): Response
-    {
-        return new HeaderlessStreamedResponse(function () {
-            /** @var array $CFG_GLPI */
-            global $CFG_GLPI;
-
-            $server = new \Glpi\CalDAV\Server();
-            $server->setBaseUri($CFG_GLPI['root_doc'] . '/caldav.php');
-            $server->start();
-        });
-    }
 }

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -428,14 +428,21 @@ Cypress.Commands.add('enableDebugMode', () => {
         return;
     }
 
-    cy.request({
-        method: 'POST',
-        url: '/ajax/switchdebug.php',
-        body: {
-            'debug': 'on',
-        },
-    }).then(() => {
-        cy.reload();
+    cy.getCsrfToken().then((csrf) => {
+        cy.request({
+            method: 'POST',
+            url: '/ajax/switchdebug.php',
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded',
+                'X-Requested-With': 'XMLHttpRequest',
+                'X-Glpi-Csrf-Token': csrf,
+            },
+            body: {
+                'debug': 'on',
+            },
+        }).then(() => {
+            cy.reload();
+        });
     });
 });
 
@@ -448,14 +455,22 @@ Cypress.Commands.add('disableDebugMode', () => {
     if (Cypress.$('#debug-toolbar-applet').length === 0) {
         return;
     }
-    cy.request({
-        method: 'POST',
-        url: '/ajax/switchdebug.php',
-        body: {
-            'debug': 'off',
-        },
-    }).then(() => {
-        cy.reload();
+
+    cy.getCsrfToken().then((csrf) => {
+        cy.request({
+            method: 'POST',
+            url: '/ajax/switchdebug.php',
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded',
+                'X-Requested-With': 'XMLHttpRequest',
+                'X-Glpi-Csrf-Token': csrf,
+            },
+            body: {
+                'debug': 'off',
+            },
+        }).then(() => {
+            cy.reload();
+        });
     });
 });
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

GLPI has currently a distinct CSRF check logic for AJAX endpoint. Indeed, for these specific endpoints, a CSRF token can be consumed multiple times, see 93750ead9b827637198d17deb6391a7841ed3232

The propose change permits to consider that a request is an AJAX request when the `X-Requested-With: XMLHttpRequest` is used (it is commonly used as a flag to mark AJAX requests by the popular JS frameworks), instead of checking tha the request is made on a `/ajax/xxx` path.

The idea is to permit to use any URL pattern for AJAX endpoints.