### PR TITLE
fix: PHPDoc for request()

### DIFF
--- a/src/DBmysql.php
+++ b/src/DBmysql.php
@@ -1093,7 +1093,7 @@ class DBmysql
      * Instanciate a Simple DBIterator
      *
      * @param string|array|QueryUnion   $tableorsql Table name, array of names or SQL query
-     * @param string|string[]           $crit       String or array of filed/values, ex array("id"=>1), if empty => all rows
+     * @param string|array              $crit       String or array of filed/values, ex array("id"=>1), if empty => all rows
      *                                              (default '')
      * @param boolean                   $debug      To log the request (default false)
      *

--- a/src/DBmysql.php
+++ b/src/DBmysql.php
@@ -1092,10 +1092,10 @@ class DBmysql
     /**
      * Instanciate a Simple DBIterator
      *
-     * @param string|string[] $tableorsql Table name, array of names or SQL query
-     * @param string|string[] $crit       String or array of filed/values, ex array("id"=>1), if empty => all rows
-     *                                    (default '')
-     * @param boolean         $debug      To log the request (default false)
+     * @param string|array|QueryUnion   $tableorsql Table name, array of names or SQL query
+     * @param string|string[]           $crit       String or array of filed/values, ex array("id"=>1), if empty => all rows
+     *                                              (default '')
+     * @param boolean                   $debug      To log the request (default false)
      *
      * @return DBmysqlIterator
      */


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Prevent this type of error with a PHPStan analysis at level 5 in plugins:

`Parameter #1 $tableorsql of method DBmysql::request() expects array<string>|QueryUnion|string, array<string, array<string, mixed>|string> given.`

## Screenshots (if appropriate):


