### PR TITLE
Clear Twig cache when Group_User is purged to avoid out-of-date displays

### DIFF
--- a/src/Cache/CacheManager.php
+++ b/src/Cache/CacheManager.php
@@ -310,22 +310,31 @@ class CacheManager
     }
 
     /**
-     * Reset all caches.
+     * Clears the cache for all known contexts.
      *
-     * @return bool
+     * @return bool Returns true if the cache was successfully cleared for all contexts, false otherwise.
      */
-    public function resetAllCaches(): bool
+    public function clearCacheContext(): bool
     {
-
         $success = true;
 
-       // Clear all cache contexts
         $known_contexts = $this->getKnownContexts();
         foreach ($known_contexts as $context) {
             $success = $this->getCacheInstance($context)->clear() && $success;
         }
 
-       // Clear compiled templates
+        return $success;
+    }
+
+    /**
+     * Clears the compiled template cache.
+     *
+     * @return bool True if all cache files and directories were successfully deleted, false otherwise.
+     */
+    public function clearCompiledCache(): bool
+    {
+        $success = true;
+
         $tpl_cache_dir = $this->cache_dir . '/templates';
         if (file_exists($tpl_cache_dir)) {
             $tpl_files = glob($tpl_cache_dir . '/**/*.php');
@@ -340,6 +349,16 @@ class CacheManager
         }
 
         return $success;
+    }
+
+    /**
+     * Reset all caches.
+     *
+     * @return bool
+     */
+    public function resetAllCaches(): bool
+    {
+        return $this->clearCacheContext() && $this->clearCompiledCache();
     }
 
     /**

--- a/src/Group_User.php
+++ b/src/Group_User.php
@@ -33,6 +33,8 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Cache\CacheManager;
+
 /**
  * Group_User Class
  *
@@ -958,13 +960,20 @@ class Group_User extends CommonDBRelation
         $user_inst = new User();
 
         // If user's default group is affected, remove it from user
-        if ($user_inst->getFromDB($users_id) && $user_inst->fields['groups_id'] == $groups_id) {
-            $user_inst->update(
-                [
-                    'id'        => $users_id,
-                    'groups_id' => 0,
-                ]
-            );
+        if ($user_inst->getFromDB($users_id)
+            && $user_inst->fields['groups_id'] == $groups_id
+        ) {
+            if (
+                $user_inst->update(
+                    [
+                        'id'        => $users_id,
+                        'groups_id' => 0,
+                    ]
+                )
+            ) {
+                // Clear twig cache to avoid wrong group in user tooltip
+                (new CacheManager())->clearCompiledCache();
+            }
         }
 
         // remove user from plannings

--- a/src/Group_User.php
+++ b/src/Group_User.php
@@ -960,7 +960,8 @@ class Group_User extends CommonDBRelation
         $user_inst = new User();
 
         // If user's default group is affected, remove it from user
-        if ($user_inst->getFromDB($users_id)
+        if (
+            $user_inst->getFromDB($users_id)
             && $user_inst->fields['groups_id'] == $groups_id
         ) {
             if (


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Linked PR https://github.com/glpi-project/glpi/pull/18573

- It fixes !35654
- Here is a brief description of what this PR does

After the PR fix mentioned above, the customer complained that he had to clear his twig cache to see the change. This PR fixes the problem with a minor reorganization of the `CacheManager` class.

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/29e5e8c7-fd05-4e53-86c1-d8612342d95e)
