### PR TITLE
fix broken tooltip when loading a ticket preview (ticket listing)

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -3383,7 +3383,7 @@ JS;
         if (!is_null($param['url'])) {
             $js .= "
                 ajax: {
-                    url: '" . htmlescape($CFG_GLPI['root_doc'] . $param['url']) . "',
+                    url: '" . URL::sanitizeURL($CFG_GLPI['root_doc'] . $param['url'])  . "',
                     type: 'GET',
                     data: {},
                 },

--- a/src/Html.php
+++ b/src/Html.php
@@ -3383,7 +3383,7 @@ JS;
         if (!is_null($param['url'])) {
             $js .= "
                 ajax: {
-                    url: '" . URL::sanitizeURL($CFG_GLPI['root_doc'] . $param['url'])  . "',
+                    url: " . json_encode($CFG_GLPI['root_doc'] . $param['url'])  . ",
                     type: 'GET',
                     data: {},
                 },


### PR DESCRIPTION
htmlescape() which breaks urls, The '&' were replaced with html entities which breaks url parameters

<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes #18680


