### PR TITLE
Fix CAS server status check

### DIFF
--- a/inc/based_config.php
+++ b/inc/based_config.php
@@ -85,7 +85,23 @@ include_once(GLPI_ROOT . "/inc/autoload.function.php");
         'GLPI_SERVERSIDE_URL_ALLOWLIST'  => [
             // allowlist (regex format) of URL that can be fetched from server side (used for RSS feeds and external calendars, among others)
             // URL will be considered as safe as long as it matches at least one entry of the allowlist
-            '/^(https?|feed):\/\/[^@:]+(\/.*)?$/', // only accept http/https/feed protocols, and reject presence of @ (username) and : (protocol) in host part of URL
+
+            // `http://` URLs
+            // - without presence of @ (username) and : (protocol) in host part of URL
+            // - with optional `:80` default port
+            // - with optional path
+            '#^http://[^@:]+(:80)?(/.*)?$#',
+
+            // `https://` URLs
+            // - without presence of @ (username) and : (protocol) in host part of URL
+            // - with optional `:443` default port
+            // - with optional path
+            '#^https://[^@:]+(:443)?(/.*)?$#',
+
+            // `feed://` URLs
+            // - without presence of @ (username) and : (protocol) in host part of URL
+            // - with optional path
+            '#^feed://[^@:]+(/.*)?$#',
         ],
 
       // Constants related to GLPI Project / GLPI Network external services

--- a/phpunit/bootstrap.php
+++ b/phpunit/bootstrap.php
@@ -60,8 +60,13 @@ define(
 define(
     'GLPI_SERVERSIDE_URL_ALLOWLIST',
     [
-        '/^(https?|feed):\/\/[^@:]+(\/.*)?$/', // default allowlist entry
-        '/^file:\/\/.*\.ics$/', // calendar mockups
+        // default allowlist entries
+        '#^http://[^@:]+(:80)?(/.*)?$#',
+        '#^https://[^@:]+(:443)?(/.*)?$#',
+        '#^feed://[^@:]+(/.*)?$#',
+
+        // calendar mockups
+        '/^file:\/\/.*\.ics$/',
     ]
 );
 

--- a/phpunit/functional/ToolboxTest.php
+++ b/phpunit/functional/ToolboxTest.php
@@ -1633,11 +1633,15 @@ HTML;
             'expected' => false,
         ];
 
-        // http, https and feed URLs are accepted, unless they contains a user or port information
-        foreach (['http', 'https', 'feed'] as $scheme) {
-            foreach (['', '/', '/path/to/feed.php'] as $path) {
+        // http, https and feed URLs are accepted, unless they contains a user or non default port information
+        foreach (['http' => ':80', 'https' => ':443', 'feed' => ''] as $scheme => $default_port) {
+            foreach (['', '/', '/path/to/resource.php'] as $path) {
                 yield [
                     'url'      => sprintf('%s://localhost%s', $scheme, $path),
+                    'expected' => true,
+                ];
+                yield [
+                    'url'      => sprintf('%s://localhost%s%s', $scheme, $default_port, $path),
                     'expected' => true,
                 ];
                 yield [
@@ -1649,7 +1653,15 @@ HTML;
                     'expected' => false,
                 ];
                 yield [
+                    'url'      => sprintf('%s://test@localhost%s%s', $scheme, $default_port, $path),
+                    'expected' => false,
+                ];
+                yield [
                     'url'      => sprintf('%s://test:pass@localhost%s', $scheme, $path),
+                    'expected' => false,
+                ];
+                yield [
+                    'url'      => sprintf('%s://test:pass@localhost%s%s', $scheme, $default_port, $path),
                     'expected' => false,
                 ];
             }

--- a/src/System/Status/StatusChecker.php
+++ b/src/System/Status/StatusChecker.php
@@ -389,11 +389,14 @@ final class StatusChecker
         if ($status === null) {
             $status['status'] = self::STATUS_NO_DATA;
             if (!empty($CFG_GLPI['cas_host'])) {
-                $url = $CFG_GLPI['cas_host'];
+                // Rebuild CAS URL
+                // see `CAS_Client::_getServerBaseURL()`
+                $url = 'https://' . $CFG_GLPI['cas_host'];
                 if (!empty($CFG_GLPI['cas_port'])) {
                     $url .= ':' . (int)$CFG_GLPI['cas_port'];
                 }
                 $url .= '/' . $CFG_GLPI['cas_uri'];
+
                 if (Toolbox::isUrlSafe($url)) {
                     $data = Toolbox::getURLContent($url);
                     if (!empty($data)) {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -58,8 +58,13 @@ define(
 define(
     'GLPI_SERVERSIDE_URL_ALLOWLIST',
     [
-        '/^(https?|feed):\/\/[^@:]+(\/.*)?$/', // default allowlist entry
-        '/^file:\/\/.*\.ics$/', // calendar mockups
+        // default allowlist entries
+        '#^http://[^@:]+(:80)?(/.*)?$#',
+        '#^https://[^@:]+(:443)?(/.*)?$#',
+        '#^feed://[^@:]+(/.*)?$#',
+
+        // calendar mockups
+        '/^file:\/\/.*\.ics$/',
     ]
 );
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

The `cas_host` configuration corresponds to the CAS server hostname. It must be prefixed by `https://` to build a valid URL.
It fixes #18346.

I cannot test against a real CAS server, so I cannot validate the rest of the status checking logic.