### PR TITLE
Add action to reapply Authorization Assignment Rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The present file will list all changes made to the project; according to the
 - CLI commands for creating local GLPI users, enabling/disabling/deleting users, resetting local GLPI user passwords and granting profile assignments.
 - Cloning templates (such as computer templates)
 - Creating a template from an existing item (such as a computer). This action is only available from the Actions menu within the item form (bulk action not allowed).
+- Massive action for users to reapply authorization assignment rules.
 
 ### Changed
 - ITIL Objects can now be linked to any other ITIL Objects similar to the previous Ticket/Ticket links.

--- a/phpunit/functional/UserTest.php
+++ b/phpunit/functional/UserTest.php
@@ -2057,7 +2057,8 @@ class UserTest extends \DbTestCase
         $this->assertEquals(['name' => 'test'], $fields);
     }
 
-    public function testReapplyRightRules() {
+    public function testReapplyRightRules()
+    {
         $this->login();
         $entities_id = $this->getTestRootEntity(true);
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] This change requires a documentation update.

## Description

Add a massive action which allows re-processing authorization assignment rules for users.
While these rules run when the user logs in, there are cases where you may want any changes to take effect immediately or cases where the user isn't allowed to log in at all (See Deny Login rule action).

I've seen people perform a workaround by messing with the user's authentication source/forcing a synchronization. Having a dedicated action would be safer and more intuitive.
