### PR TITLE
Fix(NetworkPort): Display minimal information in the absence of the instantiation type

### DIFF
--- a/src/NetworkPort.php
+++ b/src/NetworkPort.php
@@ -1452,6 +1452,15 @@ class NetworkPort extends CommonDBChild
             echo "<tr class='tab_bg_1'><th colspan='4'>" . $instantiation->getTypeName(1) . "</th></tr>\n";
             $instantiation->showInstantiationForm($this, $options, $recursiveItems);
             unset($instantiation);
+        } else {
+            // display minimal information if needed
+            if (!empty($this->fields['mac'])) {
+                echo "<tr class='tab_bg_1'><th colspan='4'>" . __('Port') . "</th></tr>\n";
+                echo "<tr class='tab_bg_1'>\n";
+                echo "<td>" . __('MAC') . "</td>\n<td>";
+                echo Html::input('mac', ['value' => $this->fields['mac']]);
+                echo "</td>\n";
+            }
         }
 
         if (!$options['several']) {


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes #!35886

When a `NetworkPort` is added to GLPI via dynamic inventory, the agent may sometimes fail to determine the port type (e.g., `NetworkPortEthernet`, `NetworkPortFiberChannel`, etc.). 

This specialization allows GLPI to display additional information based on the type.

Ex `NetworkPortEthernet`

![image](https://github.com/user-attachments/assets/127b0303-4b21-4317-afa2-a062527e4f19)


In such cases, GLPI does not display certain information, such as the `MAC address` of the port.

This Pull Request  addresses this issue by ensuring that the `MAC address` is displayed, if not empty, when the instantiation_type property is missing.

![image](https://github.com/user-attachments/assets/4200b5c2-4919-4f7f-a208-0f076173c9db)



## Screenshots (if appropriate):


