### PR TITLE
fix(knowbase): Usage of $link parameter is deprecated

### DIFF
--- a/templates/pages/tools/kb/knowbaseitem.html.twig
+++ b/templates/pages/tools/kb/knowbaseitem.html.twig
@@ -62,7 +62,7 @@
         {% endset %}
     {% endif %}
     {% if item.fields['users_id'] %}
-        {% set user_field = call('getUserName', [item.fields['users_id'], has_profile_right('user', constant('READ')) ? 1 : 0]) %}
+        {% set user_field = call('getUserLink', [item.fields['users_id']]) %}
         {{ fields.htmlField('', user_field, __('Writer')) }}
     {% else %}
         {{ fields.nullField() }}


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Prevent error message:

```
glpiphplog.INFO:   *** PHP User deprecated function (16384): Usage of `$link` parameter is deprecated. See `DbUtils::getUserName()`. in .../src/Toolbox.php at line 411
  Backtrace :
  src/Toolbox.php:411                                trigger_error()
  src/autoload/dbutils-aliases.php:477               Toolbox::deprecated()
  :                                                  getUserName()
  .../Application/View/Extension/PhpExtension.php:91 call_user_func_array()
  ...tes/c7/c72b5b27661bd718f1e6bba6e8d1e266.php:135 Glpi\Application\View\Extension\PhpExtension->call()
  vendor/twig/twig/src/Template.php:431              __TwigTemplate_3ff457c41796e09aa1e3b83ed2b25246->block_form_fields()
  ...tes/c0/c09802a815195ad87a29b227a97dc252.php:119 Twig\Template->yieldBlock()
  vendor/twig/twig/src/Template.php:387              __TwigTemplate_8907afca8f67fdf5154c467403b4faba->doDisplay()
  ...ates/c7/c72b5b27661bd718f1e6bba6e8d1e266.php:52 Twig\Template->yield()
  vendor/twig/twig/src/Template.php:387              __TwigTemplate_3ff457c41796e09aa1e3b83ed2b25246->doDisplay()
  vendor/twig/twig/src/Template.php:343              Twig\Template->yield()
  vendor/twig/twig/src/TemplateWrapper.php:58        Twig\Template->display()
  src/Glpi/Application/View/TemplateRenderer.php:183 Twig\TemplateWrapper->display()
  src/KnowbaseItem.php:844                           Glpi\Application\View\TemplateRenderer->display()
  src/KnowbaseItem.php:271                           KnowbaseItem->showForm()
  src/CommonGLPI.php:681                             KnowbaseItem::displayTabContentForItem()
  ajax/common.tabs.php:112                           CommonGLPI::displayStandardTab()
  ...Glpi/Controller/LegacyFileLoadController.php:59 require()
  vendor/symfony/http-kernel/HttpKernel.php:101      Glpi\Controller\LegacyFileLoadController->Glpi\Controller\{closure}()
  ...ymfony/http-foundation/StreamedResponse.php:106 Symfony\Component\HttpKernel\HttpKernel::Symfony\Component\HttpKernel\{closure}()
  vendor/symfony/http-foundation/Response.php:423    Symfony\Component\HttpFoundation\StreamedResponse->sendContent()
  src/Glpi/Kernel/Kernel.php:235                     Symfony\Component\HttpFoundation\Response->send()
  public/index.php:58                                Glpi\Kernel\Kernel->sendResponse()
  
glpiphplog.INFO:   *** PHP User deprecated function (16384): Usage of `$link` parameter is deprecated. Use `getUserLink()` instead. in .../src/Toolbox.php at line 411
  Backtrace :
  src/Toolbox.php:411                                trigger_error()
  src/DbUtils.php:1781                               Toolbox::deprecated()
  src/autoload/dbutils-aliases.php:480               DbUtils->getUserName()
  :                                                  getUserName()
  .../Application/View/Extension/PhpExtension.php:91 call_user_func_array()
  ...tes/c7/c72b5b27661bd718f1e6bba6e8d1e266.php:135 Glpi\Application\View\Extension\PhpExtension->call()
  vendor/twig/twig/src/Template.php:431              __TwigTemplate_3ff457c41796e09aa1e3b83ed2b25246->block_form_fields()
  ...tes/c0/c09802a815195ad87a29b227a97dc252.php:119 Twig\Template->yieldBlock()
  vendor/twig/twig/src/Template.php:387              __TwigTemplate_8907afca8f67fdf5154c467403b4faba->doDisplay()
  ...ates/c7/c72b5b27661bd718f1e6bba6e8d1e266.php:52 Twig\Template->yield()
  vendor/twig/twig/src/Template.php:387              __TwigTemplate_3ff457c41796e09aa1e3b83ed2b25246->doDisplay()
  vendor/twig/twig/src/Template.php:343              Twig\Template->yield()
  vendor/twig/twig/src/TemplateWrapper.php:58        Twig\Template->display()
  src/Glpi/Application/View/TemplateRenderer.php:183 Twig\TemplateWrapper->display()
  src/KnowbaseItem.php:844                           Glpi\Application\View\TemplateRenderer->display()
  src/KnowbaseItem.php:271                           KnowbaseItem->showForm()
  src/CommonGLPI.php:681                             KnowbaseItem::displayTabContentForItem()
  ajax/common.tabs.php:112                           CommonGLPI::displayStandardTab()
  ...Glpi/Controller/LegacyFileLoadController.php:59 require()
  vendor/symfony/http-kernel/HttpKernel.php:101      Glpi\Controller\LegacyFileLoadController->Glpi\Controller\{closure}()
  ...ymfony/http-foundation/StreamedResponse.php:106 Symfony\Component\HttpKernel\HttpKernel::Symfony\Component\HttpKernel\{closure}()
  vendor/symfony/http-foundation/Response.php:423    Symfony\Component\HttpFoundation\StreamedResponse->sendContent()
  src/Glpi/Kernel/Kernel.php:235                     Symfony\Component\HttpFoundation\Response->send()
  public/index.php:58                                Glpi\Kernel\Kernel->sendResponse()
  
```

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/34633f10-b9ca-48f6-8783-3c3d7d1cef07)

