### PR TITLE
Standardize loading spinners

### DIFF
--- a/css/includes/components/_utils.scss
+++ b/css/includes/components/_utils.scss
@@ -44,13 +44,6 @@
     transition: border-color 0.3s;
 }
 
-// Apply the same font-size and line-height as btn-text.
-// Useful when replacing a btn-text content by a loading icon.
-.btn-text-loading {
-    font-size: var(--tblr-btn-font-size) !important;
-    line-height: var(--tblr-btn-line-height) !important;
-}
-
 .w-fit-content {
     width: fit-content !important;
 }

--- a/js/modules/IllustrationPicker/Controller.js
+++ b/js/modules/IllustrationPicker/Controller.js
@@ -168,10 +168,10 @@ export class GlpiIllustrationPickerController
             .querySelector(`[data-glpi-icon-picker-go-to-page="${page}"]`)
         ;
         const button_text = button.querySelector(
-            '[data-glpi-icon-picker-pagination-text'
+            '[data-glpi-icon-picker-pagination-text]'
         );
         const button_loading_indicator = button.querySelector(
-            '[data-glpi-icon-picker-pagination-loading-icon'
+            '[data-glpi-icon-picker-pagination-loading-icon]'
         );
 
         button.classList.add('active');
@@ -225,13 +225,13 @@ export class GlpiIllustrationPickerController
 
     #getSearchDefaultIcon()
     {
-        return this.#container.querySelector('[data-glpi-icon-picker-filter-default-icon')
+        return this.#container.querySelector('[data-glpi-icon-picker-filter-default-icon]')
         ;
     }
 
     #getSearchLoadingIcon()
     {
-        return this.#container.querySelector('[data-glpi-icon-picker-filter-loading-icon');
+        return this.#container.querySelector('[data-glpi-icon-picker-filter-loading-icon]');
     }
 
     #getSearchResultsDiv()

--- a/js/modules/IllustrationPicker/Controller.js
+++ b/js/modules/IllustrationPicker/Controller.js
@@ -167,16 +167,9 @@ export class GlpiIllustrationPickerController
         const button = this.#container
             .querySelector(`[data-glpi-icon-picker-go-to-page="${page}"]`)
         ;
-        const button_text = button.querySelector(
-            '[data-glpi-icon-picker-pagination-text]'
-        );
-        const button_loading_indicator = button.querySelector(
-            '[data-glpi-icon-picker-pagination-loading-icon]'
-        );
 
         button.classList.add('active');
-        button_text.classList.add('d-none');
-        button_loading_indicator.classList.remove('d-none');
+        button.classList.add('btn-loading');
 
         // Apply loading indicator to the search results
         this.#getSearchResultsDiv().style.opacity = 0.7;

--- a/src/Ajax.php
+++ b/src/Ajax.php
@@ -428,7 +428,7 @@ HTML;
                 updateCurrentTab();
                 return;
             }
-            $(target).html('<i class=\"fas fa-3x fa-spinner fa-pulse position-absolute m-5 start-50\"></i>');
+            $(target).html(`<span class="spinner-border spinner-border position-absolute m-5 start-50" role="status" aria-hidden="true"></span>`);
 
             $.get(url, function(data) {
                $(target).html(data);

--- a/src/Glpi/Dashboard/Grid.php
+++ b/src/Glpi/Dashboard/Grid.php
@@ -153,7 +153,7 @@ class Grid
 
             $card_html    = <<<HTML
             <div class="loading-card">
-               <i class="fas fa-spinner fa-spin fa-3x"></i>
+               <span class="spinner-border spinner-border" role="status" aria-hidden="true"></span>
             </div>
 HTML;
             $this->addGridItem(

--- a/src/Impact.php
+++ b/src/Impact.php
@@ -1064,7 +1064,7 @@ JS);
         echo '</div>'; // <div class="impact-side-search-no-results">
 
         echo '<div class="impact-side-search-spinner">';
-        echo '<i class="fas fa-spinner fa-2x fa-spin"></i>';
+        echo '<span class="spinner-border spinner-border m-3" role="status" aria-hidden="true"></span>';
         echo '</div>'; // <div class="impact-side-search-spinner">
 
         echo '</div>'; // <div class="impact-side-search-panel">

--- a/templates/central/widget_tab.html.twig
+++ b/templates/central/widget_tab.html.twig
@@ -67,7 +67,7 @@
             'widget': this_obj.data('widget'),
             'params': this_obj.data('params')
          };
-         this_obj.html('<i class="fas fa-3x fa-spinner fa-spin ms-auto"></i>')
+         this_obj.html('<span class="spinner-border ms-auto" role="status" aria-hidden="true"></span>')
             .load('{{ path('/ajax/central.php') }}', params, function(response, status, xhr) {
                const parent = this_obj.closest('.grid-item').parent();
 

--- a/templates/components/form/inventory_info.html.twig
+++ b/templates/components/form/inventory_info.html.twig
@@ -100,7 +100,7 @@
          <div class="mb-3 col-12 col-sm-4">
             <label class="form-label" >
                {{ __('Agent status') }}
-               <i id="update-status" class="fas fa-sync" role="button" title="{{ __('Ask agent about its current status') }}"></i>
+               <i id="update-status" class="ti ti-refresh d-inline-block" role="button" title="{{ __('Ask agent about its current status') }}"></i>
             </label>
             <span id='agent_status'>{{ __('Unknown') }}</span>
          </div>
@@ -108,7 +108,7 @@
          <div class="mb-3 col-12 col-sm-4">
             <label class="form-label" >
                {{ __('Request inventory') }}
-               <i id="update-inventory" class="fas fa-sync" role="button" title="{{ __('Request agent to proceed an new inventory') }}"></i>
+               <i id="update-inventory" class="ti ti-refresh d-inline-block" role="button" title="{{ __('Request agent to proceed an new inventory') }}"></i>
             </label>
             <span id='inventory_status'>{{ __('Unknown') }}</span>
          </div>
@@ -118,7 +118,7 @@
       $(function () {
          $('#update-status').on('click', function() {
             var icon = $(this);
-            icon.addClass('fa-spin');
+            icon.addClass('icon-rotate');
             $.ajax({
                type: 'POST',
                url: '{{ path('/ajax/agent.php') }}',
@@ -132,14 +132,14 @@
                   $('#agent_status').text(json.answer);
                },
                complete: function() {
-                  icon.removeClass('fa-spin');
+                  icon.removeClass('icon-rotate');
                }
             });
          });
 
          $('#update-inventory').on('click', function() {
             var icon = $(this);
-            icon.addClass("fa-spin");
+            icon.addClass('icon-rotate');
             $.ajax({
                type: 'POST',
                url: '{{ path('/ajax/agent.php') }}',
@@ -153,7 +153,7 @@
                   $('#inventory_status').text(json.answer);
                },
                complete: function() {
-                  icon.removeClass('fa-spin');
+                  icon.removeClass('icon-rotate');
                }
             });
          });

--- a/templates/components/illustration/icon_picker_modal.html.twig
+++ b/templates/components/illustration/icon_picker_modal.html.twig
@@ -53,10 +53,7 @@
                             class="ti ti-search"
                             data-glpi-icon-picker-filter-default-icon
                         ></i>
-                        <i
-                            class="ti ti-loader-2 fa-spin d-none"
-                            data-glpi-icon-picker-filter-loading-icon
-                        ></i>
+                        <span class="spinner-border spinner-border d-none" role="status" aria-hidden="true" data-glpi-icon-picker-filter-loading-icon></span>
                     </span>
                     <input
                         type="text"

--- a/templates/components/illustration/icon_picker_search_results.html.twig
+++ b/templates/components/illustration/icon_picker_search_results.html.twig
@@ -71,13 +71,7 @@
                             aria-label="{{ __('Go to page %s')|format(i) }}"
                             data-glpi-icon-picker-go-to-page="{{ i }}"
                         >
-                            <span
-                                class="btn-text"
-                                data-glpi-icon-picker-pagination-text
-                            >{{ i }}</span>
-                            <span class="spinner-border spinner-border-sm d-none" role="status"
-                                  aria-hidden="true" data-glpi-icon-picker-pagination-loading-icon
-                            ></span>
+                            <span class="btn-text" data-glpi-icon-picker-pagination-text>{{ i }}</span>
                         </button>
                     {% endif %}
                 {% endfor %}

--- a/templates/components/illustration/icon_picker_search_results.html.twig
+++ b/templates/components/illustration/icon_picker_search_results.html.twig
@@ -75,10 +75,9 @@
                                 class="btn-text"
                                 data-glpi-icon-picker-pagination-text
                             >{{ i }}</span>
-                            <i
-                                class="btn-text-loading ti ti-loader-2 fa-spin d-none"
-                                data-glpi-icon-picker-pagination-loading-icon
-                            ></i>
+                            <span class="spinner-border spinner-border-sm d-none" role="status"
+                                  aria-hidden="true" data-glpi-icon-picker-pagination-loading-icon
+                            ></span>
                         </button>
                     {% endif %}
                 {% endfor %}

--- a/templates/components/itilobject/actors/field.html.twig
+++ b/templates/components/itilobject/actors/field.html.twig
@@ -191,13 +191,13 @@
                 } else if ("{{ actortype }}" == "requester") {
                     label = "{{ __('Number of tickets as requester') }}";
                 }
-                const existing_element = $(
-                    `<span class="assign_infos ms-1" title="${label}"
-                     data-bs-toggle="tooltip" data-bs-placement="top"
-                     data-id="${items_id}" data-fk="${fk}">
-                  <i class="fas fa-spinner fa-spin"></i>
-               </span>`
-                );
+                const existing_element = $(`
+                    <span class="assign_infos ms-1" title="${label}"
+                        data-bs-toggle="tooltip" data-bs-placement="top"
+                        data-id="${items_id}" data-fk="${fk}">
+                        <span class="spinner-border" role="status" aria-hidden="true"></span>
+                    </span>
+                `);
                 option_element.append(existing_element);
 
                 $.get("{{ path('/ajax/actorinformation.php') }}", {

--- a/templates/components/itilobject/timeline/timeline.html.twig
+++ b/templates/components/itilobject/timeline/timeline.html.twig
@@ -237,7 +237,7 @@ $(function() {
       content_block.find(".read-only-content").hide();
       content_block.find(".edit-content").show()
          .find(".ajax-content")
-         .html('<i class="fas fa-3x fa-spinner fa-spin ms-auto"></i>')
+         .html('<span class="spinner-border ms-auto" role="status" aria-hidden="true"></span>')
          .load("{{ path('/ajax/timeline.php') }}", {
             'action'     : 'viewsubitem',
             'type'       : itemtype,

--- a/templates/components/search/criteria_filter_actions.html.twig
+++ b/templates/components/search/criteria_filter_actions.html.twig
@@ -31,116 +31,118 @@
  # ---------------------------------------------------------------------
  #}
 
-{% set rand = random() %}
-{% set save_action_id = "save_filters_" ~ rand %}
-{% set save_action_icon_id = "save_filters_icon" ~ rand %}
-{% set delete_action_id = "delete_filters_" ~ rand %}
+<div>
+    <button
+        class="btn btn-sm btn-primary me-1 {{ show_save ? "" : "d-none" }}"
+        type="submit"
+        name="save_filters"
+    >
+        <i class="ti ti-device-floppy"></i>
+        <span class="spinner-border spinner-border-sm d-none" role="status" aria-hidden="true"></span>
+        <span class="d-none d-sm-block">{{ __("Save") }}</span>
+    </button>
 
-<button
-    id="{{ save_action_id }}"
-    class="btn btn-sm btn-primary me-1 {{ show_save ? "" : "d-none" }}"
-    type="submit"
-    name="save_filters"
->
-    <i id="{{ save_action_icon_id }}" class="ti ti-device-floppy"></i>
-    <span class="d-none d-sm-block">{{ __("Save") }}</span>
-</button>
+    <button
+        class="btn btn-sm btn-outline-danger me-1 {{ show_delete ? "" : "d-none" }}"
+        name="delete_filters"
+    >
+        <i class="ti ti-trash"></i>
+        <span class="spinner-border spinner-border-sm d-none" role="status" aria-hidden="true"></span>
+        <span class="d-none d-sm-block">{{ __("Delete") }}</span>
+    </button>
+</div>
 
-<button
-    id="{{ delete_action_id }}"
-    class="btn btn-sm btn-outline-danger me-1 {{ show_delete ? "" : "d-none" }}"
-    name="delete_filters"
->
-    <i id="{{ save_action_icon_id }}" class="ti ti-trash"></i>
-    <span class="d-none d-sm-block">{{ __("Delete") }}</span>
-</button>
+<script type="module">
+    function showLoading(btn) {
+        btn.find('i').addClass('d-none');
+        btn.find('.spinner-border').removeClass('d-none');
+        // Disable this and sibling buttons
+        btn.prop('disabled', true);
+        btn.siblings('button').prop('disabled', true);
+    }
 
-<script>
-    (function () {
-        // Save action
-        $("#{{ save_action_id }}").on("click", function(e) {
-            // Prevent form submit
-            e.preventDefault();
+    function hideLoading(btn) {
+        btn.find('i').removeClass('d-none');
+        btn.find('.spinner-border').addClass('d-none');
+        // Enable this and sibling buttons
+        btn.prop('disabled', false);
+        btn.siblings('button').prop('disabled', false);
+    }
 
-            // Find form
-            const form = $("#{{ save_action_id }}").closest('form');
+    // Save action
+    $("button[name='save_filters']").on("click", (e) => {
+        // Prevent form submit
+        e.preventDefault();
 
-            // Set loading icon and disable buttons
-            $("#{{ save_action_icon_id }}").removeClass('ti ti-device-floppy');
-            $("#{{ save_action_icon_id }}").addClass('fa-solid fa-spinner fa-spin');
-            $("#{{ save_action_id }}").prop('disabled', true);
-            $("#{{ delete_action_id }}").prop('disabled', true);
+        const btn = $(e.currentTarget);
 
-            // Save results
-            const form_data = new FormData(form[0]);
+        // Find form
+        const form = btn.closest('form');
 
-            // Add references to parent item, must be prefixed by "item_" because
-            // "itemtype" will already be set by the search's form
-            form_data.append('item_itemtype', "{{ itemtype }}");
-            form_data.append('item_items_id', {{ items_id }});
+        showLoading(btn);
 
-            // Endpoint
-            form_data.append('action', "save_filter");
+        // Save results
+        const form_data = new FormData(form[0]);
 
-            // Send data to backend
-            $.ajax({
-                type: "POST",
-                url: CFG_GLPI.root_doc + "/ajax/criteria_filter.php",
-                data: form_data,
-                processData: false, // Needed when using FormData object
-                contentType: false, // Needed when using FormData object
-            }).done(function() {
-                glpi_toast_info("{{ __("Filter saved") }}");
+        // Add references to parent item, must be prefixed by "item_" because
+        // "itemtype" will already be set by the search's form
+        form_data.append('item_itemtype', "{{ itemtype }}");
+        form_data.append('item_items_id', {{ items_id }});
 
-                // Show delete button if it wasn't already enabled
-                $("#{{ delete_action_id }}").removeClass('d-none');
+        // Endpoint
+        form_data.append('action', "save_filter");
 
-                // Add badge to menu to hint that a filter have been set
-                const tab = $("a.nav-link[href*='CriteriaFilter']");
-                if (tab.find('span.badge').length == 0) {
-                    tab.append('<span class="badge">1</span>');
-                }
-            }).fail(function() {
-                glpi_toast_error("{{ __("Unable to save filter") }}");
-            }).always(function() {
-                // Restore original icon and button
-                $("#{{ save_action_icon_id }}").addClass('ti ti-device-floppy');
-                $("#{{ save_action_icon_id }}").removeClass('fa-solid fa-spinner fa-spin');
-                $("#{{ save_action_id }}").prop('disabled', false);
-                $("#{{ delete_action_id }}").prop('disabled', false);
-            });
+        // Send data to backend
+        $.ajax({
+            type: "POST",
+            url: CFG_GLPI.root_doc + "/ajax/criteria_filter.php",
+            data: form_data,
+            processData: false, // Needed when using FormData object
+            contentType: false, // Needed when using FormData object
+        }).done(function() {
+            glpi_toast_info("{{ __("Filter saved") }}");
 
-            // Hide preview since its content may not match the saved value
-            $("#criteria_filter_preview").addClass("d-none");
+            // Show delete button if it wasn't already enabled
+            $("#{{ delete_action_id }}").removeClass('d-none');
+
+            // Add badge to menu to hint that a filter have been set
+            const tab = $("a.nav-link[href*='CriteriaFilter']");
+            if (tab.find('span.badge').length == 0) {
+                tab.append('<span class="badge">1</span>');
+            }
+        }).fail(function() {
+            glpi_toast_error("{{ __("Unable to save filter") }}");
+        }).always(function() {
+            hideLoading(btn);
         });
 
-        // Delete action
-        $("#{{ delete_action_id }}").on("click", function(e) {
-            // Prevent form submit
-            e.preventDefault();
+        // Hide preview since its content may not match the saved value
+        $("#criteria_filter_preview").addClass("d-none");
+    });
 
-            // Disable actions
-            $("#{{ save_action_id }}").prop('disabled', true);
-            $("#{{ delete_action_id }}").prop('disabled', true);
+    // Delete action
+    $("button[name='delete_filters']").on("click", (e) => {
+        // Prevent form submit
+        e.preventDefault();
 
-            $.ajax({
-                type: "POST",
-                url: CFG_GLPI.root_doc + "/ajax/criteria_filter.php",
-                data: {
-                    'action': 'delete_filter',
-                    'itemtype': '{{ itemtype }}',
-                    'items_id': {{ items_id }},
-                },
-            }).done(function() {
-                // Reload page, easiest way to clear search UI
-                location.reload();
-            }).fail(function() {
-                // Restore actions
-                $("#{{ save_action_id }}").prop('disabled', false);
-                $("#{{ delete_action_id }}").prop('disabled', false);
+        const btn = $(e.currentTarget);
+        showLoading(btn);
 
-                glpi_toast_error("{{ __("Failed to delete filter") }}");
-            });
+        $.ajax({
+            type: "POST",
+            url: CFG_GLPI.root_doc + "/ajax/criteria_filter.php",
+            data: {
+                'action': 'delete_filter',
+                'itemtype': '{{ itemtype }}',
+                'items_id': {{ items_id }},
+            },
+        }).done(function() {
+            // Reload page, easiest way to clear search UI
+            location.reload();
+        }).fail(function() {
+            hideLoading(btn);
+
+            glpi_toast_error("{{ __("Failed to delete filter") }}");
         });
-    })();
+    });
 </script>

--- a/templates/layout/parts/saved_searches.html.twig
+++ b/templates/layout/parts/saved_searches.html.twig
@@ -80,11 +80,11 @@
       </ul>
       <div class="saved-searches-panel-content tab-content">
          <div class="list-group list-group-flush list-group-hoverable saved-searches-panel-lists tab-pane show active" id="itemtype-filtered">
-            <i class="fas fa-spinner fa-spin m-3"></i>
+             <span class="spinner-border m-3" role="status" aria-hidden="true"></span>
          </div>
 
          <div class="list-group list-group-flush list-group-hoverable saved-searches-panel-lists tab-pane" id="all-savedsearches">
-            <i class="fas fa-spinner fa-spin m-3"></i>
+             <span class="spinner-border m-3" role="status" aria-hidden="true"></span>
          </div>
       </div>
    </div>


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Remove uses of `fa-spin` and any FA icons used for spinning loading indicators with Tabler style loaders.
In general spinners are now spans with `spinner-border` classes. The only exception is in the inventory information section of an asset since they were rotating sync/refresh icons. For those, `fa-spin` was replaced with `icon-rotate` from Tabler.