### PR TITLE
fix solution approval border

### DIFF
--- a/css/includes/components/itilobject/_timeline.scss
+++ b/css/includes/components/itilobject/_timeline.scss
@@ -93,7 +93,6 @@
         max-width: 820px;
         min-width: 100%;
         word-break: break-word;
-        border: 1px solid transparent;
 
         @include media-breakpoint-up(sm) {
             &::before {


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Fixes #18739

Reverts change made in c7cc636176beec945af804dbbdb21f7d0dadabe3 as part of #13019. I didn't see where this transparent border was meant to be for.

