### PR TITLE
Remove unused appliance massive actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -320,6 +320,7 @@ The present file will list all changes made to the project; according to the
 - Handling of encoded/escaped value in `autoName()`.
 - `closeDBConnections`
 - `regenerateTreeCompleteName()`
+- `Appliance::getMassiveActionsForItemtype()`
 - `AuthLDAP::ldapChooseDirectory()`
 - `AuthLDAP::displayLdapFilter()`
 - `AuthLDAP::dropdownUserDeletedActions()`

--- a/src/Appliance.php
+++ b/src/Appliance.php
@@ -507,22 +507,6 @@ class Appliance extends CommonDBTM
         return $actions;
     }
 
-    public static function getMassiveActionsForItemtype(
-        array &$actions,
-        $itemtype,
-        $is_deleted = false,
-        ?CommonDBTM $checkitem = null
-    ) {
-        if (in_array($itemtype, self::getTypes())) {
-            if (self::canUpdate()) {
-                $action_prefix                    = 'Appliance_Item' . MassiveAction::CLASS_ACTION_SEPARATOR;
-                $actions[$action_prefix . 'add']    = "<i class='fa-fw fas fa-file-contract'></i>" .
-                                                _sx('button', 'Add to an appliance');
-                $actions[$action_prefix . 'remove'] = _sx('button', 'Remove from an appliance');
-            }
-        }
-    }
-
     public static function showMassiveActionsSubForm(MassiveAction $ma)
     {
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

These two actions are never added to any itemtypes because `Appliance::getMassiveActionsForItemtype` isn't called from anywhere. Instead, `CommonDBTM` already adds the "Associate to an appliance" action to the itemtypes that can be linked to an Appliance.


