### PR TITLE
Rename timeline items hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -224,6 +224,7 @@ The present file will list all changes made to the project; according to the
 - `Search::getOptions()` no longer returns a reference.
 - The `$target` parameter has been removed from the `AuthLDAP::showLdapGroups()` method.
 - The `$target` parameter has been removed from the `Rule::showRulePreviewCriteriasForm()`, `Rule::showRulePreviewResultsForm()`, `RuleCollection::showRulesEnginePreviewCriteriasForm()`, and `RuleCollection::showRulesEnginePreviewResultsForm()` methods signature.
+- `Hooks::SHOW_IN_TIMELINE`/`show_in_timeline` plugin hook has been renamed to `Hooks::TIMELINE_ITEMS`/`timeline_items`.
 
 #### Deprecated
 - Usage of the `/marketplace` path for plugins URLs. All plugins URLs should now start with `/plugins`.

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -7930,6 +7930,8 @@ abstract class CommonITILObject extends CommonDBTM
             ];
         }
 
+        // TODO: Remove SHOW_IN_TIMELINE hook in next major release after GLPI 11.0
+        Plugin::doHook(Hooks::SHOW_IN_TIMELINE, ['item' => $this, 'timeline' => &$timeline]);
         Plugin::doHook(Hooks::TIMELINE_ITEMS, ['item' => $this, 'timeline' => &$timeline]);
 
         //sort timeline items by date. If items have the same date, sort by id

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -7930,7 +7930,7 @@ abstract class CommonITILObject extends CommonDBTM
             ];
         }
 
-        Plugin::doHook(Hooks::SHOW_IN_TIMELINE, ['item' => $this, 'timeline' => &$timeline]);
+        Plugin::doHook(Hooks::TIMELINE_ITEMS, ['item' => $this, 'timeline' => &$timeline]);
 
         //sort timeline items by date. If items have the same date, sort by id
         $reverse = $params['sort_by_date_desc'];

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -7930,8 +7930,7 @@ abstract class CommonITILObject extends CommonDBTM
             ];
         }
 
-        // TODO: Remove SHOW_IN_TIMELINE hook in next major release after GLPI 11.0
-        Plugin::doHook(Hooks::SHOW_IN_TIMELINE, ['item' => $this, 'timeline' => &$timeline]);
+        Plugin::doHook(Hooks::SHOW_IN_TIMELINE, ['item' => $this, 'timeline' => &$timeline]); // @phpstan-ignore classConstant.deprecated
         Plugin::doHook(Hooks::TIMELINE_ITEMS, ['item' => $this, 'timeline' => &$timeline]);
 
         //sort timeline items by date. If items have the same date, sort by id

--- a/src/Glpi/Plugin/Hooks.php
+++ b/src/Glpi/Plugin/Hooks.php
@@ -125,6 +125,7 @@ class Hooks
     const PRE_ITEM_LIST           = 'pre_item_list';
     const TIMELINE_ACTIONS        = 'timeline_actions';  // (keys: item, rand)
     const TIMELINE_ANSWER_ACTIONS = 'timeline_answer_actions';  // (keys: item)
+    const SHOW_IN_TIMELINE        = 'timeline_items'; // Old constant of hook for BC. Replaced by TIMELINE_ITEMS in GLPI 11.0
     const TIMELINE_ITEMS          = 'timeline_items';  // (keys: item)
     const SET_ITEM_IMPACT_ICON    = 'set_item_impact_icon'; // (keys: itemtype, items_id)
 

--- a/src/Glpi/Plugin/Hooks.php
+++ b/src/Glpi/Plugin/Hooks.php
@@ -125,7 +125,7 @@ class Hooks
     const PRE_ITEM_LIST           = 'pre_item_list';
     const TIMELINE_ACTIONS        = 'timeline_actions';  // (keys: item, rand)
     const TIMELINE_ANSWER_ACTIONS = 'timeline_answer_actions';  // (keys: item)
-    const SHOW_IN_TIMELINE        = 'timeline_items'; // Old constant of hook for BC. Replaced by TIMELINE_ITEMS in GLPI 11.0
+    const SHOW_IN_TIMELINE        = 'show_in_timeline'; // Old constant of hook for BC. Replaced by TIMELINE_ITEMS in GLPI 11.0
     const TIMELINE_ITEMS          = 'timeline_items';  // (keys: item)
     const SET_ITEM_IMPACT_ICON    = 'set_item_impact_icon'; // (keys: itemtype, items_id)
 

--- a/src/Glpi/Plugin/Hooks.php
+++ b/src/Glpi/Plugin/Hooks.php
@@ -125,7 +125,7 @@ class Hooks
     const PRE_ITEM_LIST           = 'pre_item_list';
     const TIMELINE_ACTIONS        = 'timeline_actions';  // (keys: item, rand)
     const TIMELINE_ANSWER_ACTIONS = 'timeline_answer_actions';  // (keys: item)
-    const SHOW_IN_TIMELINE        = 'show_in_timeline';  // (keys: item)
+    const TIMELINE_ITEMS          = 'timeline_items';  // (keys: item)
     const SET_ITEM_IMPACT_ICON    = 'set_item_impact_icon'; // (keys: itemtype, items_id)
 
    // Security hooks (data to encypt)

--- a/src/Glpi/Plugin/Hooks.php
+++ b/src/Glpi/Plugin/Hooks.php
@@ -125,7 +125,10 @@ class Hooks
     const PRE_ITEM_LIST           = 'pre_item_list';
     const TIMELINE_ACTIONS        = 'timeline_actions';  // (keys: item, rand)
     const TIMELINE_ANSWER_ACTIONS = 'timeline_answer_actions';  // (keys: item)
-    const SHOW_IN_TIMELINE        = 'show_in_timeline'; // Old constant of hook for BC. Replaced by TIMELINE_ITEMS in GLPI 11.0
+    /**
+     * @deprecated 11.0.0 Use `TIMELINE_ITEMS` instead.
+     */
+    const SHOW_IN_TIMELINE        = 'show_in_timeline';
     const TIMELINE_ITEMS          = 'timeline_items';  // (keys: item)
     const SET_ITEM_IMPACT_ICON    = 'set_item_impact_icon'; // (keys: itemtype, items_id)
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -1537,6 +1537,10 @@ class Plugin extends CommonDBTM
                         continue;
                     }
 
+                    if ($name === Hooks::SHOW_IN_TIMELINE) { // @phpstan-ignore classConstant.deprecated
+                        Toolbox::deprecated('`show_in_timeline` hook is deprecated, use `timeline_items` instead.');
+                    }
+
                     if (isset($tab[$itemtype])) {
                         \Glpi\Debug\Profiler::getInstance()->start("{$plugin_key}:{$name}", \Glpi\Debug\Profiler::CATEGORY_PLUGINS);
                         self::includeHook($plugin_key);


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] This change requires a documentation update.

## Description

Fixes #18580.
Renames `show_in_timeline` plugin hook to `timeline_items` as this hook is not used to directly show anything in the timeline. Instead, it is used to modify the array of items in the timeline. The old hook name was causing confusion even among GLPI developers.

