### PR TITLE
Enhance legacy api client config

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -583,7 +583,9 @@ class Config extends CommonDBTM
             'legacy_doc_url' => $legacy_version['endpoint'],
             'legacy_api_url' => $legacy_version['endpoint'],
         ]);
-        TemplateRenderer::getInstance()->display('pages/setup/general/api_apiclients_section.html.twig');
+        if ($CFG_GLPI['enable_api']) {
+            TemplateRenderer::getInstance()->display('pages/setup/general/api_apiclients_section.html.twig');
+        }
     }
 
 

--- a/templates/pages/setup/general/api_apiclients_section.html.twig
+++ b/templates/pages/setup/general/api_apiclients_section.html.twig
@@ -33,7 +33,7 @@
 
 {% import 'components/form/fields_macros.html.twig' as fields %}
 
-{{ fields.largeTitle('APIClient'|itemtype_name(get_plural_number()), 'APIClient'|itemtype_icon) }}
+{{ fields.largeTitle(__('API clients (Legacy API)'), 'APIClient'|itemtype_icon) }}
 {% do call('Html::displayTitle', ['', '', '', {
    'apiclient.form.php': __('Add API client')
 }]) %}


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Hide the API Client config section in Setup > General > API tab if the legacy API is disabled and also change the section header to specify that these clients are for the legacy API only. Hopefully this helps reduce confusion with having two different APIs and different authentication methods.