### PR TITLE
fix(forms): Cannot remove a horizontal layout

### DIFF
--- a/src/Glpi/Form/Question.php
+++ b/src/Glpi/Form/Question.php
@@ -183,6 +183,11 @@ final class Question extends CommonDBChild implements BlockInterface, Conditionn
             $input['forms_sections_uuid'] = $section->fields['uuid'];
         }
 
+        // Set horizontal rank to null if not set
+        if (!isset($input['horizontal_rank'])) {
+            $input['horizontal_rank'] = 'NULL';
+        }
+
         // If the question is being imported, we don't need to format the input
         // because it is already formatted. So we skip this step.
         if ($input['_from_import'] ?? false) {

--- a/tests/cypress/e2e/form/form_editor_horizontal_layout.cy.js
+++ b/tests/cypress/e2e/form/form_editor_horizontal_layout.cy.js
@@ -166,4 +166,47 @@ describe ('Form editor', () => {
             });
         });
     });
+
+    it('can remove a horizontal block and verify the questions are still displayed', () => {
+        cy.findByRole('button', {'name': 'Add a horizontal layout'}).click();
+        cy.findByRole('region', {'name': 'Horizontal blocks layout'}).within(() => {
+            // Focus the first placeholder
+            cy.findAllByRole('option', {'name': 'Form horizontal block placeholder'}).eq(0).click();
+
+            // Add a new question
+            cy.findAllByRole('option', {'name': 'Form horizontal block placeholder'}).eq(0)
+                .findByRole('button', {'name': 'Add a new question'}).click();
+            cy.findByRole('region', {'name': 'Question details'}).within(() => {
+                cy.findByRole('textbox', {'name': 'Question name'}).type('First question');
+            });
+
+            // Focus the second placeholder
+            cy.findAllByRole('option', {'name': 'Form horizontal block placeholder'}).eq(0).click();
+
+            // Add a new question
+            cy.findAllByRole('option', {'name': 'Form horizontal block placeholder'}).eq(0)
+                .findByRole('button', {'name': 'Add a new question'}).click();
+            cy.findAllByRole('region', {'name': 'Question details'}).eq(1).within(() => {
+                cy.findByRole('textbox', {'name': 'Question name'}).type('Second question');
+            });
+        });
+
+        // Save and reload
+        cy.saveFormEditorAndReload();
+
+        // Remove the horizontal block
+        cy.findByRole('button', {'name': 'Remove horizontal layout'}).click();
+
+        // Save and reload
+        cy.saveFormEditorAndReload();
+
+        // Check that the questions are displayed and not in a horizontal block
+        cy.findAllByRole('region', {'name': 'Horizontal blocks layout'}).should('not.exist');
+        cy.findAllByRole('region', {'name': 'Question details'}).eq(0).within(() => {
+            cy.findByRole('textbox', {'name': 'Question name'}).should('have.value', 'First question');
+        });
+        cy.findAllByRole('region', {'name': 'Question details'}).eq(1).within(() => {
+            cy.findByRole('textbox', {'name': 'Question name'}).should('have.value', 'Second question');
+        });
+    });
 });

--- a/tests/cypress/support/commands/form.js
+++ b/tests/cypress/support/commands/form.js
@@ -62,6 +62,9 @@ Cypress.Commands.add('saveFormEditorAndReload', () => {
         .should('contain.text', 'Item successfully updated')
     ;
     cy.reload();
+
+    // Wait for the form to be reloaded
+    cy.findByRole('button', { 'name': 'Save' }).should('exist');
 });
 
 Cypress.Commands.add('addQuestion', (name) => {


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Fixed a bug that prevented you from effectively deleting a horizontal layout.
Currently, if you have a form with questions in a horizontal layout container, and you delete this layout then save and reload the form, you get this rendering:

![image](https://github.com/user-attachments/assets/df0cca5d-b79c-42ad-81e1-5062206e5675)
