### PR TITLE
Handle plugins errors

### DIFF
--- a/src/Glpi/Kernel/Listener/LoadPlugin.php
+++ b/src/Glpi/Kernel/Listener/LoadPlugin.php
@@ -1,0 +1,166 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+declare(strict_types=1);
+
+namespace Glpi\Kernel\Listener;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * LoadPlugin class Error handling.
+ * Exceptions are caught in Plugin::loadPluginSetupFile() and Plugin::load()
+ * Only fatal errors are caught here.
+ * There is currently a PR related to error handling. So this handler may be removed or used with the new error handling.
+ * -> PR https://github.com/glpi-project/glpi/pull/18696 #
+ */
+final readonly class LoadPlugin implements EventSubscriberInterface
+{
+    private LoggerInterface $logger;
+
+    public function __construct(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+    }
+
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::EXCEPTION => ['handlePluginExceptions', 2],
+//            ConsoleErrorEvent::class => ['handlePluginExceptionsConsole', 2], // @todo test behavior in console, maybe implement this
+        ];
+    }
+
+    public function handlePluginExceptions(ExceptionEvent $event): void
+    {
+//         return; // usefull to have stack track
+        $throwable = $event->getThrowable();
+
+        $plugin_key = $this->getPluginKeyFromFilePath($throwable->getFile());
+        if (is_null($plugin_key)) {
+            // not a plugin error since path is not related to a plugin
+            return;
+        }
+
+        $this->suspendPlugin($plugin_key);
+
+        // display error message using trigger_error
+        // setResponse to return a 500 error
+
+        // /!\ Do not trigger E_COMPILE_ERROR or an error that stop the current script
+        // E_USER_WARNING is probably the most appropriate
+        // @see https://www.php.net/manual/en/errorfunc.constants.php#constant.e-user-warning
+        trigger_error('Plugin error: ' . $throwable->getMessage(), E_USER_WARNING);
+        // @todo this error is not in the files/_log/php-errors.log, maybe because we are currently handling an exception...
+
+
+        $event->setResponse(new Response(
+            'Plugin "' . $plugin_key . '" Fatal error: ' . $throwable->getMessage(),
+            Response::HTTP_INTERNAL_SERVER_ERROR
+        ));
+
+        $message = sprintf(
+            __('Plugin %1$s has been suspended by system, it has fatal errors.'),
+            $plugin_key
+        );
+        $this->logger->critical($message, ['exception' => $throwable]);
+
+        \Session::addMessageAfterRedirect(
+            $message,
+            true,
+            ERROR
+        );
+
+        // maybe we could make a redirection here.
+        // but it's probably better to let the user see the error message
+        // In case, we do it we should do something to avoir risk of an infinite loop.
+
+        $event->stopPropagation();
+    }
+
+    /**
+     * Suspend plugin
+     *
+     * Being suspended, a plugin should not be loaded anymore.
+     * If it doesn't exist in database, it will be created,
+     * doing so it can be filtered to avoid loading it.
+     * Filtering happens in Plugin::loadPluginSetupFile() and Plugin::load()
+     * so the state used here must be the state used for filtering in these methods.
+     *
+     * @param string $plugin_key
+     * @return void
+     */
+    private function suspendPlugin(string $plugin_key): void
+    {
+        $plugin = new \Plugin();
+        $is_in_database = $plugin->getFromDBbyDir($plugin_key);
+        if (!$is_in_database) {
+            // @todo maybe we can get the name from xml, but it's probably better do display the directory to give useful information to the user/developer
+            $creation = $plugin->add(
+                [
+                    'directory' => $plugin_key,
+                    'name' => $plugin_key,
+                    'version' => '0.0.0', // stupid but mandatory
+                    'state' => \Plugin::SUSPENDED,
+                ]
+            );
+
+            if (!$creation) {
+                $this->logger->error(
+                    "Failed to create plugin $plugin_key in database for suspension."
+                );
+                throw new \RuntimeException("Failed to create plugin '$plugin_key' in database for suspension.");
+            }
+        }
+
+        $plugin->suspend();
+    }
+
+    private function getPluginKeyFromFilePath(string $path): ?string
+    {
+        // @todo maybe convert to lowercase, see Plugin::isXXX (activated, etc.)
+        foreach (PLUGINS_DIRECTORIES as $plugin_directory) {
+            if (preg_match('#' . preg_quote($plugin_directory, '#') . '/([^/]+)/#', $path, $matches)) {
+                return $matches[1];
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -84,7 +84,9 @@ class Plugin extends CommonDBTM
     const NOTACTIVATED   = 4;
 
     /**
-     * @var int Plugin was previously discovered, but the plugin directory is missing now. The DB needs cleaned.
+     * @var int Plugin has a problem
+     * Plugin was previously discovered but its directory is missing. The DB needs cleaned.
+     * The plugin has code error or throw Exception, should not be loaded.
      */
     const TOBECLEANED    = 5;
 
@@ -227,6 +229,28 @@ class Plugin extends CommonDBTM
         return false;
     }
 
+    private static function isPluginSuspended(string $plugin_key): bool
+    {
+        $plugin_keys = array_column(self::getSuspendedPlugins(), 'directory');
+
+        return in_array($plugin_key, $plugin_keys);
+    }
+
+    /**
+     * List of plugins with state SUSPENDED in database
+     *
+     * @return array<int, array{id: int, directory: string, name: string, version: string, state: int, author: string|null, homepage: string|null, licence: string|null}>
+     */
+    private static function getSuspendedPlugins(): array
+    {
+        $all_plugins = (new self())->getList();
+        $suspended_plugins = array_filter($all_plugins, function ($plugin) {
+            return $plugin['state'] == self::SUSPENDED;
+        });
+
+        return $suspended_plugins;
+    }
+
     public function prepareInputForAdd($input)
     {
         $input = $this->prepareInput($input);
@@ -324,8 +348,10 @@ class Plugin extends CommonDBTM
 
 
     /**
-     * Init a plugin including setup.php file
-     * launching plugin_init_NAME function  after checking compatibility
+     * Init a plugin by including its setup.php file
+     *
+     * Executes plugin_init_<plugin_key> function after checking compatibility.
+     * All plugins are loaded, except plugins that are suspended.
      *
      * @param string  $plugin_key        System name (Plugin directory)
      * @param boolean $withhook   Load hook functions (false by default)
@@ -346,9 +372,19 @@ class Plugin extends CommonDBTM
                 continue;
             }
 
+            /**
+             * @todo maybe we should only load activated (and other state?) plugins
+             * @see \Glpi\Kernel\Listener\LoadPlugin::suspendPlugin()
+             *  at the moment I choose to make the possible modification, so only suspended plugins are excluded
+             */
+            $suspended_plugins = self::getSuspendedPlugins();
+
             if ((new self())->loadPluginSetupFile($plugin_key)) {
                 $loaded = true;
-                if (!in_array($plugin_key, self::$loaded_plugins)) {
+                if (
+                    !in_array($plugin_key, self::$loaded_plugins)
+                    && !in_array($plugin_key, $suspended_plugins)
+                ) {
                     // Register PSR-4 autoloader
                     $psr4_dir = $plugin_directory . '/src/';
                     if (is_dir($psr4_dir)) {
@@ -658,6 +694,8 @@ class Plugin extends CommonDBTM
         }
 
         if (!$is_loadable) {
+            // @todo maybe we should not display this message for SUSPENDED plugins
+            // it creates an entry in log file php-errors, so maybe we should avoid it...
             trigger_error(
                 sprintf(
                     'Unable to load plugin "%s" information.',
@@ -1773,6 +1811,10 @@ class Plugin extends CommonDBTM
             return false;
         }
 
+        if (self::isPluginSuspended($plugin_key)) {
+            return false;
+        };
+
         foreach (PLUGINS_DIRECTORIES as $base_dir) {
             if (!is_dir($base_dir)) {
                 continue;
@@ -1784,11 +1826,30 @@ class Plugin extends CommonDBTM
                 // variables used in this function.
                 // For example, if the included files contains a $key variable, it will
                 // replace the $key variable used here.
-                $include_fct = function () use ($file_path) {
-                    include_once($file_path);
-                };
-                $include_fct();
-                return true;
+
+                // @todo we should catch Exceptions here, as in load()
+                // at the moment, at boottime, postBootEvent, the exceptions throw here are not catched anywhere.
+                try {
+                    $include_fct = function () use ($file_path) {
+                        include_once($file_path);
+                    };
+                    $include_fct();
+                    return true;
+                } catch (\Throwable $e) {
+                    trigger_error(
+                        sprintf('Error while loading plugin setup file `%s`: %s', $file_path, $e->getMessage()),
+                        E_USER_WARNING
+                    );
+
+                    // copied from loadPluginSetupFile()
+                    $plugin = new self();
+                    if ($plugin->isActivated($plugin_key)) {
+                        $plugin->getFromDBbyDir($plugin_key);
+                        $plugin->unactivate($plugin->getID());
+                    }
+
+                    return false;
+                }
             }
         }
         return false;


### PR DESCRIPTION
Error handler for plugins Errors.

This is a draft, some points needs review and discussion.

Try/catch bloc handle Exceptions, not fatal errors.
Not all php errors throw exceptions, Symfony handle this fatal errors and give us a chance to handle them.
So, the try/catch handle all exceptions and the Error handler is for other errors (eg parse errors, compilation errors).

Since another PR (https://github.com/glpi-project/glpi/pull/18696) is about the same problematic, this one is left as draft until it gets resolved.

<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does

## Screenshots (if appropriate):


