### PR TITLE
Unmanaged devices: Do not override device name if it's a managed device

### DIFF
--- a/src/Inventory/Asset/Unmanaged.php
+++ b/src/Inventory/Asset/Unmanaged.php
@@ -38,6 +38,7 @@ namespace Glpi\Inventory\Asset;
 use Glpi\Inventory\Conf;
 use Glpi\Inventory\Request;
 use Glpi\Toolbox\Sanitizer;
+use IPAddress;
 use NetworkPortInstantiation;
 use RefusedEquipment;
 use RuleMatchedLog;
@@ -193,9 +194,14 @@ class Unmanaged extends MainAsset
                         $this->item = $converted_object;
                         $items_id = $result['id'];
                         $itemtype = $result['itemtype'];
-                        //do not override device name if it's a managed device
                         if (property_exists($val, 'name')) {
-                            unset($val->name);
+                            $curname = new IPAddress($this->item->fields['name']);
+                            $newname = new IPAddress($val->name);
+                            //if new name is an IP address but current asset name isn't
+                            if ($newname->is_valid() && !$curname->is_valid()) {
+                                //do not override device name
+                                unset($val->name);
+                            }
                         }
                     } else {
                         $need_to_add = true;

--- a/src/Inventory/Asset/Unmanaged.php
+++ b/src/Inventory/Asset/Unmanaged.php
@@ -193,6 +193,8 @@ class Unmanaged extends MainAsset
                         $this->item = $converted_object;
                         $items_id = $result['id'];
                         $itemtype = $result['itemtype'];
+                        //do not override device name if it's a managed device
+                        unset($val->name);
                     } else {
                         $need_to_add = true;
                     }

--- a/src/Inventory/Asset/Unmanaged.php
+++ b/src/Inventory/Asset/Unmanaged.php
@@ -194,7 +194,9 @@ class Unmanaged extends MainAsset
                         $items_id = $result['id'];
                         $itemtype = $result['itemtype'];
                         //do not override device name if it's a managed device
-                        unset($val->name);
+                        if (property_exists($val, 'name')) {
+                            unset($val->name);
+                        }
                     } else {
                         $need_to_add = true;
                     }


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable): https://github.com/glpi-project/glpi-inventory-plugin/issues/530
- Here is a brief description of what this PR does:
(This is a continuation of https://github.com/glpi-project/glpi/pull/17506)
A MAC address should be unique. When running a NetDiscovery task, it may create a new Unmanaged asset with a MAC address that already exists on GLPI, which can lead to duplicate MAC addresses on NetworkPort DB table, so before assuming it's an Unmanaged device, check if there's any item on DB that matches this MAC address. It would be great if GLPI implements an option to cleanup orphans/unmanaged devices from time to time as seen in: https://github.com/glpi-project/glpi-inventory-plugin/blob/e8cd779e0449ab4d402774e39a22f84b69317f3b/hook.php#L357 

Here's the output of the affected 'Unmanaged device' asset import:

```
[20-Jan-2025 10:25:32 America/Sao_Paulo] stdClass Object
(
    [autoupdatesystems_id] => GLPI Native Inventory
    [last_inventory_update] => 2025-01-20 10:25:32
    [is_deleted] => 0
    [type] => Unmanaged
    [name] => 192.168.0.9
    [mac] => 20:47:47:ff:a2:72
    [ips] => Array
        (
            [0] => 192.168.0.9
        )

    [is_dynamic] => 1
    [entities_id] => 1
)
```

This fix simplies unset the ``[name]`` attribute of an unmanaged asset if it's already imported (aka. is a managed asset).

Here's the inventory files as requested by @stonebuzz:

[esxi01.json](https://github.com/user-attachments/files/18478358/esxi01.json)
[server02.json](https://github.com/user-attachments/files/18478359/server02.json)

## Screenshots (if appropriate):


