### PR TITLE
include gridstack extra css

### DIFF
--- a/lib/bundles/gridstack.js
+++ b/lib/bundles/gridstack.js
@@ -35,3 +35,4 @@
 import { GridStack } from 'gridstack';
 window.GridStack = GridStack;
 require('gridstack/dist/gridstack.min.css');
+require('gridstack/dist/gridstack-extra.min.css');

--- a/src/Html.php
+++ b/src/Html.php
@@ -1130,6 +1130,7 @@ TWIG,
 
             if (in_array('gridstack', $jslibs)) {
                 $tpl_vars['css_files'][] = ['path' => 'lib/gridstack.css'];
+                $tpl_vars['css_files'][] = ['path' => 'lib/gridstack-extra.css'];
                 Html::requireJs('gridstack');
             }
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Reported by @Otijom 

It fixes
![image](https://github.com/user-attachments/assets/313da490-da03-4532-9ee6-f04a0aa53c22)

In main only, probably since the migration on [gridstack v8](https://github.com/gridstack/gridstack.js/blob/master/README.md#migrating-to-v8) (we are on v11 currently)

> CSS rules removed .grid-stack prefix for anything already gs based, 12 column (default) now uses .gs-12, extra.css is less than 1/4th it original size!, gs-min|max_w|h attribute no longer written (but read)


