### PR TITLE
Fix parent status overhide with rule using followup template action and status

### DIFF
--- a/phpunit/functional/RuleTicketTest.php
+++ b/phpunit/functional/RuleTicketTest.php
@@ -3665,6 +3665,7 @@ class RuleTicketTest extends DbTestCase
         ]);
         $this->checkInput($followuptemplate, $templateid, $templateinput);
 
+        // Create the rule to change status and add a followup template
         $ruleticket = new \RuleTicket();
         $rulecrit   = new \RuleCriteria();
         $ruleaction = new \RuleAction();
@@ -3712,7 +3713,7 @@ class RuleTicketTest extends DbTestCase
         $this->assertGreaterThan(0, $user2->getID());
 
         $ticket = new \Ticket();
-        // Assigning technician after ticket is already closed should be blocked
+        // Create ticket with two actors (requester and technician)
         $tickets_id = $ticket->add([
             'name' => 'test ticket ' . __FUNCTION__,
             'content' => __FUNCTION__,
@@ -3738,6 +3739,7 @@ class RuleTicketTest extends DbTestCase
 
         $this->assertEquals(\CommonITILObject::WAITING, $ticket->fields['status']);
 
+        // Create followup without _do_not_compute_status
         $this->createItem('ITILFollowup', [
             'itemtype'               => $ticket::getType(),
             'items_id'               => $tickets_id,

--- a/phpunit/functional/RuleTicketTest.php
+++ b/phpunit/functional/RuleTicketTest.php
@@ -35,6 +35,7 @@
 
 namespace tests\units;
 
+use CommonITILObject;
 use CommonITILValidation;
 use Contract;
 use ContractType;
@@ -3651,5 +3652,102 @@ class RuleTicketTest extends DbTestCase
         $this->checkInput($ticket, $tickets_id, $ticket_input);
         $this->assertEquals($user_id, (int)$ticket->getField('users_id_recipient'));
         $this->assertEquals($requesttypes_id, (int)$ticket->getField('requesttypes_id'));
+    }
+
+    public function testDoNotComputeStatusFollowupWithRule()
+    {
+        $this->login('glpi', 'glpi');
+
+        $followuptemplate = new \ITILFollowupTemplate();
+        $templateid = $followuptemplate->add($templateinput = [
+            'name' => 'followuptemplate_' . __FUNCTION__,
+            'content' => 'Test',
+        ]);
+        $this->checkInput($followuptemplate, $templateid, $templateinput);
+
+        $ruleticket = new \RuleTicket();
+        $rulecrit   = new \RuleCriteria();
+        $ruleaction = new \RuleAction();
+
+        $ruletid = $ruleticket->add($ruletinput = [
+            'name'         => 'test do not compute status followup',
+            'match'        => 'AND',
+            'is_active'    => 1,
+            'sub_type'     => 'RuleTicket',
+            'condition'    => \RuleTicket::ONADD,
+            'is_recursive' => 1,
+        ]);
+        $this->checkInput($ruleticket, $ruletid, $ruletinput);
+
+        $crit_id = $rulecrit->add($crit_input = [
+            'rules_id'  => $ruletid,
+            'criteria'  => 'name',
+            'condition' => \Rule::PATTERN_CONTAIN,
+            'pattern'   => 'test',
+        ]);
+        $this->checkInput($rulecrit, $crit_id, $crit_input);
+
+        $act_id = $ruleaction->add($act_input = [
+            'rules_id'    => $ruletid,
+            'action_type' => 'assign',
+            'field'       => 'status',
+            'value'       => CommonITILObject::WAITING,
+        ]);
+        $this->checkInput($ruleaction, $act_id, $act_input);
+
+        $act2_id = $ruleaction->add($act2_input = [
+            'rules_id'    => $ruletid,
+            'action_type' => 'append',
+            'field'       => 'itilfollowup_template',
+            'value'       => $templateid,
+        ]);
+        $this->checkInput($ruleaction, $act2_id, $act2_input);
+
+        $user1 = new \User();
+        $user1->getFromDBbyName('glpi');
+        $this->assertGreaterThan(0, $user1->getID());
+
+        $user2 = new \User();
+        $user2->getFromDBbyName('tech');
+        $this->assertGreaterThan(0, $user2->getID());
+
+        $ticket = new \Ticket();
+        // Assigning technician after ticket is already closed should be blocked
+        $tickets_id = $ticket->add([
+            'name' => 'test ticket ' . __FUNCTION__,
+            'content' => __FUNCTION__,
+            '_actors' => [
+                'requester' => [
+                    [
+                        'items_id' => $user1->getID(),
+                        'itemtype' => 'User'
+                    ]
+                ],
+                'assign' => [
+                    [
+                        'items_id' => $user2->getID(),
+                        'itemtype' => 'User'
+                    ]
+                ],
+            ]
+        ]);
+        $this->assertGreaterThan(0, $tickets_id);
+
+        $ticket = new \Ticket();
+        $ticket->getFromDB($tickets_id);
+
+        $this->assertEquals(\CommonITILObject::WAITING, $ticket->fields['status']);
+
+        $this->createItem('ITILFollowup', [
+            'itemtype'               => $ticket::getType(),
+            'items_id'               => $tickets_id,
+            'content'                => 'simple followup content',
+            'date'                   => '2015-01-01 00:00:00',
+        ]);
+
+        $ticket = new \Ticket();
+        $ticket->getFromDB($tickets_id);
+
+        $this->assertEquals(\CommonITILObject::ASSIGNED, $ticket->fields['status']);
     }
 }

--- a/phpunit/functional/TicketTest.php
+++ b/phpunit/functional/TicketTest.php
@@ -7813,4 +7813,65 @@ HTML
         $ticket->loadActors();
         $this->assertEquals(0, $ticket->countUsers(\CommonITILActor::ASSIGN));
     }
+
+    public function testDoNotComputeStatusFollowup()
+    {
+        $this->login('glpi', 'glpi');
+
+        $user1 = new \User();
+        $user1->getFromDBbyName('glpi');
+        $this->assertGreaterThan(0, $user1->getID());
+
+        $user2 = new \User();
+        $user2->getFromDBbyName('tech');
+        $this->assertGreaterThan(0, $user2->getID());
+
+        $ticket = new \Ticket();
+        // Assigning technician after ticket is already closed should be blocked
+        $tickets_id = $ticket->add([
+            'name' => __FUNCTION__,
+            'content' => __FUNCTION__,
+            'status' => \CommonITILObject::WAITING,
+            '_actors' => [
+                'requester' => [
+                    [
+                        'items_id' => $user1->getID(),
+                        'itemtype' => 'User'
+                    ]
+                ],
+                'assign' => [
+                    [
+                        'items_id' => $user2->getID(),
+                        'itemtype' => 'User'
+                    ]
+                ],
+            ]
+        ]);
+        $this->assertGreaterThan(0, $tickets_id);
+
+        $this->createItem('ITILFollowup', [
+            'itemtype'               => $ticket::getType(),
+            'items_id'               => $tickets_id,
+            'content'                => 'do not compute status followup content',
+            'date'                   => '2015-01-01 00:00:00',
+            '_do_not_compute_status' => 1
+        ]);
+
+        $ticket = new \Ticket();
+        $ticket->getFromDB($tickets_id);
+
+        $this->assertEquals(\CommonITILObject::WAITING, $ticket->fields['status']);
+
+        $this->createItem('ITILFollowup', [
+            'itemtype'               => $ticket::getType(),
+            'items_id'               => $tickets_id,
+            'content'                => 'simple followup content',
+            'date'                   => '2015-01-01 00:00:00',
+        ]);
+
+        $ticket = new \Ticket();
+        $ticket->getFromDB($tickets_id);
+
+        $this->assertEquals(\CommonITILObject::ASSIGNED, $ticket->fields['status']);
+    }
 }

--- a/phpunit/functional/TicketTest.php
+++ b/phpunit/functional/TicketTest.php
@@ -7827,7 +7827,7 @@ HTML
         $this->assertGreaterThan(0, $user2->getID());
 
         $ticket = new \Ticket();
-        // Assigning technician after ticket is already closed should be blocked
+        // Create ticket with two actors (requester and technician)
         $tickets_id = $ticket->add([
             'name' => __FUNCTION__,
             'content' => __FUNCTION__,

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -8206,14 +8206,18 @@ abstract class CommonITILObject extends CommonDBTM
 
        // Add tasks in itilfollowup template if defined in itiltemplate
         foreach ($this->input['_itilfollowuptemplates_id'] as $fup_templates_id) {
-           // Insert new followup from template
-            $fup = new ITILFollowup();
-            $fup->add([
+            $values = [
                 '_itilfollowuptemplates_id' => $fup_templates_id,
                 'itemtype'                  => $this->getType(),
                 'items_id'                  => $this->getID(),
                 '_disablenotif'             => true,
-            ]);
+            ];
+            if (isset($this->input['_do_not_compute_status'])) {
+                $values['_do_not_compute_status'] = $this->input['_do_not_compute_status'];
+            }
+           // Insert new followup from template
+            $fup = new ITILFollowup();
+            $fup->add($values);
         }
     }
 

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -8211,7 +8211,7 @@ abstract class CommonITILObject extends CommonDBTM
                 'itemtype'                  => $this->getType(),
                 'items_id'                  => $this->getID(),
                 '_disablenotif'             => true,
-            '_do_not_compute_status' => $this->input['_do_not_compute_status'] ?? 0,
+                '_do_not_compute_status' => $this->input['_do_not_compute_status'] ?? 0,
             ];
            // Insert new followup from template
             $fup = new ITILFollowup();

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -8211,10 +8211,8 @@ abstract class CommonITILObject extends CommonDBTM
                 'itemtype'                  => $this->getType(),
                 'items_id'                  => $this->getID(),
                 '_disablenotif'             => true,
+            '_do_not_compute_status' => $this->input['_do_not_compute_status'] ?? 0,
             ];
-            if (isset($this->input['_do_not_compute_status'])) {
-                $values['_do_not_compute_status'] = $this->input['_do_not_compute_status'];
-            }
            // Insert new followup from template
             $fup = new ITILFollowup();
             $fup->add($values);

--- a/src/Features/ParentStatus.php
+++ b/src/Features/ParentStatus.php
@@ -120,6 +120,7 @@ trait ParentStatus
             && in_array($parentitem->fields["status"], $parentitem::getReopenableStatusArray())
             && $input['_status'] == $parentitem->fields["status"]
             && !$is_set_pending
+            && $input['_do_not_compute_status'] != true
         ) {
             if (
                 isset($parentitem::getAllStatusArray($parentitem->getType())[CommonITILObject::ASSIGNED])

--- a/src/Features/ParentStatus.php
+++ b/src/Features/ParentStatus.php
@@ -120,7 +120,6 @@ trait ParentStatus
             && in_array($parentitem->fields["status"], $parentitem::getReopenableStatusArray())
             && $input['_status'] == $parentitem->fields["status"]
             && !$is_set_pending
-            && (isset($input['_do_not_compute_status']) && !$input['_do_not_compute_status'])
         ) {
             if (
                 isset($parentitem::getAllStatusArray($parentitem->getType())[CommonITILObject::ASSIGNED])
@@ -135,6 +134,7 @@ trait ParentStatus
                     Session::isCron()
                     || Session::getCurrentInterface() == "helpdesk"
                     || $parentitem::isAllowedStatus($parentitem->fields["status"], CommonITILObject::ASSIGNED)
+                    || (isset($input['_do_not_compute_status']) && !$input['_do_not_compute_status'])
                 ) {
                     $needupdateparent = true;
                     // If begin date is defined, the status must be planned if it exists, rather than assigned.
@@ -154,6 +154,7 @@ trait ParentStatus
                     Session::isCron()
                     || Session::getCurrentInterface() == "helpdesk"
                     || $parentitem::isAllowedStatus($parentitem->fields["status"], CommonITILObject::INCOMING)
+                    || (isset($input['_do_not_compute_status']) && !$input['_do_not_compute_status'])
                 ) {
                     $needupdateparent = true;
                     $update['status'] = CommonITILObject::INCOMING;

--- a/src/Features/ParentStatus.php
+++ b/src/Features/ParentStatus.php
@@ -120,7 +120,7 @@ trait ParentStatus
             && in_array($parentitem->fields["status"], $parentitem::getReopenableStatusArray())
             && $input['_status'] == $parentitem->fields["status"]
             && !$is_set_pending
-            && $input['_do_not_compute_status'] != true
+            && !$input['_do_not_compute_status']
         ) {
             if (
                 isset($parentitem::getAllStatusArray($parentitem->getType())[CommonITILObject::ASSIGNED])

--- a/src/Features/ParentStatus.php
+++ b/src/Features/ParentStatus.php
@@ -131,10 +131,12 @@ trait ParentStatus
             ) {
                //check if lifecycle allowed new status
                 if (
-                    Session::isCron()
-                    || Session::getCurrentInterface() == "helpdesk"
-                    || $parentitem::isAllowedStatus($parentitem->fields["status"], CommonITILObject::ASSIGNED)
-                    || (isset($input['_do_not_compute_status']) && !$input['_do_not_compute_status'])
+                    (
+                        Session::isCron()
+                        || Session::getCurrentInterface() == "helpdesk"
+                        || $parentitem::isAllowedStatus($parentitem->fields["status"], CommonITILObject::ASSIGNED)
+                    )
+                    && (!isset($input['_do_not_compute_status']) || !$input['_do_not_compute_status'])
                 ) {
                     $needupdateparent = true;
                     // If begin date is defined, the status must be planned if it exists, rather than assigned.
@@ -151,10 +153,12 @@ trait ParentStatus
             } else {
                //check if lifecycle allowed new status
                 if (
-                    Session::isCron()
-                    || Session::getCurrentInterface() == "helpdesk"
-                    || $parentitem::isAllowedStatus($parentitem->fields["status"], CommonITILObject::INCOMING)
-                    || (isset($input['_do_not_compute_status']) && !$input['_do_not_compute_status'])
+                    (
+                        Session::isCron()
+                        || Session::getCurrentInterface() == "helpdesk"
+                        || $parentitem::isAllowedStatus($parentitem->fields["status"], CommonITILObject::INCOMING)
+                    )
+                    && (!isset($input['_do_not_compute_status']) || !$input['_do_not_compute_status'])
                 ) {
                     $needupdateparent = true;
                     $update['status'] = CommonITILObject::INCOMING;

--- a/src/Features/ParentStatus.php
+++ b/src/Features/ParentStatus.php
@@ -120,7 +120,7 @@ trait ParentStatus
             && in_array($parentitem->fields["status"], $parentitem::getReopenableStatusArray())
             && $input['_status'] == $parentitem->fields["status"]
             && !$is_set_pending
-            && !$input['_do_not_compute_status']
+            && (isset($input['_do_not_compute_status']) && !$input['_do_not_compute_status'])
         ) {
             if (
                 isset($parentitem::getAllStatusArray($parentitem->getType())[CommonITILObject::ASSIGNED])


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !35867
- Here is a brief description of what this PR does

When I have a rule that adds a follow-up template and changes the status, the status defined by my rule is overridden by the default status when a follow-up is added. This creates an inconsistency between the ticket created and the rule supposed to modify it.

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/36f91629-71b5-4bb5-9179-7b9b0c8cebfd)

