### PR TITLE
Fix non functional rule under sub entity

### DIFF
--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -5757,6 +5757,7 @@ class CommonDBTM extends CommonGLPI
         // Only process itemtype that are assets
         if (in_array($this->getType(), $CFG_GLPI['asset_types'])) {
             $ruleasset          = new RuleAssetCollection();
+            $ruleasset->setEntity($this->input['entities_id'] ?? $this->fields['entities_id']);
             $input              = $this->input;
             $input['_itemtype'] = $this->getType();
 


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !35995
- Here is a brief description of what this PR does

The rule engine doesn't seem to take the following rule into account when it's defined on a sub-entity.
When this rule is set on a root entity with recursion enabled, it's fine, but not when it's set only on a sub-entity.

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/40c47933-4e87-4ae1-915b-3f306fab908e)
