### PR TITLE
fix(licence): user name display

### DIFF
--- a/src/Item_SoftwareLicense.php
+++ b/src/Item_SoftwareLicense.php
@@ -783,7 +783,7 @@ JAVASCRIPT;
                 'glpi_softwarelicenses.name AS license',
                 'glpi_softwarelicenses.id AS vID',
                 'glpi_softwarelicenses.softwares_id AS softid',
-                "$users_table.name AS itemname",
+                User::getFriendlyNameFields('itemname'),
                 "$users_table.id AS iID",
                 new QueryExpression($DB::quoteValue(User::class), 'item_type'),
                 new QueryExpression($DB::quoteValue(''), "serial"),

--- a/src/User.php
+++ b/src/User.php
@@ -6735,8 +6735,8 @@ JAVASCRIPT;
         $table  = self::getTable();
         return QueryFunction::if(
             condition: [
-                "$table.$first" => ['<>' => ''],
-                "$table.$second" => ['<>' => '']
+                "$table.$first" => ['<>', ''],
+                "$table.$second" => ['<>', '']
             ],
             true_expression: QueryFunction::concat(["$table.$first", new QueryExpression($DB::quoteValue(' ')), "$table.$second"]),
             false_expression: $table . '.' . self::getNameField(),


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !34567
- Here is a brief description of what this PR does

Since https://github.com/glpi-project/glpi/pull/18335, you can link a licence to a user, but it displays the user's login and not their first name + surname.

## Screenshots (if appropriate):

User:
![image](https://github.com/user-attachments/assets/47b54032-6535-4b66-a5c8-7d736986ae95)

Before:
![image](https://github.com/user-attachments/assets/0a902d57-cb56-4af3-86ea-37b09b9689bd)

After:
![image](https://github.com/user-attachments/assets/a1c5d87d-68d8-4798-95c0-3b6342f81f1c)
