### PR TITLE
Use GET method to read install progress

### DIFF
--- a/js/modules/ProgressBar.js
+++ b/js/modules/ProgressBar.js
@@ -139,9 +139,7 @@ export class ProgressBar
 
         setTimeout(async () => {
             try {
-                const res = await fetch(`${CFG_GLPI.root_doc}/progress/check/${_this.#parameters.key}`, {
-                    method: 'POST',
-                });
+                const res = await fetch(`${CFG_GLPI.root_doc}/progress/check/${_this.#parameters.key}`);
 
                 if (res.status === 404) {
                     throw new Error('Not found');

--- a/src/Glpi/Controller/ProgressController.php
+++ b/src/Glpi/Controller/ProgressController.php
@@ -48,7 +48,7 @@ class ProgressController extends AbstractController
     ) {
     }
 
-    #[Route("/progress/check/{key}", methods: 'POST')]
+    #[Route("/progress/check/{key}", methods: 'GET')]
     #[SecurityStrategy(Firewall::STRATEGY_NO_CHECK)]
     public function check(string $key): Response
     {


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

The `/progress/check` endpoint is a read-only endpoint. It should use the `GET` method.