### PR TITLE
Simplify the redirection to login form related code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -529,6 +529,8 @@ The present file will list all changes made to the project; according to the
 - `Search::outputData()`
 - `Search::sylk_clean()`
 - `Session::buildSessionName()`
+- `Session::redirectIfNotLoggedIn()`
+- `Session::redirectToLogin()`
 - `SlaLevel::showForSLA()`. Replaced by `LevelAgreementLevel::showForLA()`.
 - `SLM::setTicketCalendar()`
 - `SoftwareLicense::getSonsOf()`

--- a/front/item_device.common.form.php
+++ b/front/item_device.common.form.php
@@ -54,8 +54,6 @@ if (!($item_device instanceof Item_Devices)) {
     throw new BadRequestHttpException();
 }
 if (!$item_device->canView()) {
-   // Gestion timeout session
-    Session::redirectIfNotLoggedIn();
     throw new AccessDeniedHttpException();
 }
 

--- a/front/item_device.php
+++ b/front/item_device.php
@@ -47,7 +47,6 @@ if (!isset($_GET['itemtype']) || !class_exists($_GET['itemtype'])) {
 /** @var class-string $_GET['itemtype'] */
 $itemDevice = getItemForItemtype($_GET['itemtype']);
 if (!$itemDevice->canView()) {
-    Session::redirectIfNotLoggedIn();
     throw new AccessDeniedHttpException();
 }
 

--- a/front/knowbaseitem.php
+++ b/front/knowbaseitem.php
@@ -39,7 +39,6 @@ use Glpi\Exception\Http\AccessDeniedHttpException;
 global $CFG_GLPI;
 
 if (!Session::haveRightsOr('knowbase', [READ, KnowbaseItem::READFAQ])) {
-    Session::redirectIfNotLoggedIn();
     throw new AccessDeniedHttpException();
 }
 if (isset($_GET["id"])) {

--- a/front/updatepassword.php
+++ b/front/updatepassword.php
@@ -33,16 +33,13 @@
  * ---------------------------------------------------------------------
  */
 
-/**
- * @var array $CFG_GLPI
- */
-global $CFG_GLPI;
+use Glpi\Exception\Http\AccessDeniedHttpException;
 
 // Cannot use `Session::checkLoginUser()` as it block users that have their password expired to be able to change it.
 // Indeed, when password expired, sessions is loaded without profiles nor rights, and `Session::checkLoginUser()`
 // considers it as an invalid session.
 if (Session::getLoginUserID() === false) {
-    Html::redirectToLogin();
+    throw new AccessDeniedHttpException();
 }
 
 switch (Session::getCurrentInterface()) {

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -3151,13 +3151,9 @@ class CommonDBTM extends CommonGLPI
     {
         // Check item exists
         if (!$this->checkIfExistOrNew($ID)) {
-           // Gestion timeout session
-            Session::redirectIfNotLoggedIn();
             throw new NotFoundHttpException();
         } else {
             if (!$this->can($ID, $right, $input)) {
-               // Gestion timeout session
-                Session::redirectIfNotLoggedIn();
                 /** @var class-string<CommonDBTM> $itemtype */
                 $itemtype = static::getType();
                 $right_name = Session::getRightNameForError($itemtype::$rightname, $right);
@@ -3232,8 +3228,6 @@ class CommonDBTM extends CommonGLPI
     public function checkGlobal(int $right): void
     {
         if (!$this->canGlobal($right)) {
-           // Gestion timeout session
-            Session::redirectIfNotLoggedIn();
             /** @var class-string<CommonDBTM> $itemtype */
             $itemtype = static::getType();
             $right_name = Session::getRightNameForError($itemtype::$rightname, $right);

--- a/src/Glpi/Controller/LegacyFileLoadController.php
+++ b/src/Glpi/Controller/LegacyFileLoadController.php
@@ -67,7 +67,6 @@ final class LegacyFileLoadController implements PublicService
         $this->getRequest()->attributes->set('_glpi_ajax', true);
 
         \Session::setAjax();
-        \Html::setAjax();
     }
 
     private function getRequest(): ?Request

--- a/src/Glpi/Http/Listener/AccessErrorListener.php
+++ b/src/Glpi/Http/Listener/AccessErrorListener.php
@@ -72,18 +72,14 @@ final readonly class AccessErrorListener implements EventSubscriberInterface
 
         $response = null;
 
-        if (
-            $throwable instanceof SessionExpiredException
-            || (!Session::isAuthenticated() && $throwable instanceof AccessDeniedHttpException)
-        ) {
+        if ($throwable instanceof SessionExpiredException) {
             Session::destroy(); // destroy the session to prevent pesistence of unexpected data
 
             $response = new RedirectResponse(
                 sprintf(
-                    '%s/?redirect=%s%s',
+                    '%s/?redirect=%s&error=3',
                     $request->getBasePath(),
-                    \rawurlencode($request->getPathInfo() . '?' . $request->getQueryString()),
-                    $throwable instanceof SessionExpiredException ? '&error=3' : '',
+                    \rawurlencode($request->getPathInfo() . '?' . $request->getQueryString())
                 )
             );
         } elseif (

--- a/src/Glpi/Http/Listener/LegacyPostRequestActionsListener.php
+++ b/src/Glpi/Http/Listener/LegacyPostRequestActionsListener.php
@@ -48,7 +48,6 @@ final readonly class LegacyPostRequestActionsListener implements EventSubscriber
 
     public function onFinishRequest(): void
     {
-        \Html::resetAjaxParam();
         \Session::resetAjaxParam();
     }
 }

--- a/src/Html.php
+++ b/src/Html.php
@@ -57,12 +57,6 @@ use ScssPhp\ScssPhp\Compiler;
 class Html
 {
     /**
-     * Indicates whether the request is made in an AJAX context.
-     * @FIXME This flag is actually not set to true by all AJAX requests.
-     */
-    private static bool $is_ajax_request = false;
-
-    /**
      * Recursivly execute html_entity_decode on an array
      *
      * @param string|array $value
@@ -436,43 +430,6 @@ class Html
     public static function redirect($dest, $http_response_code = 302): never
     {
         throw new RedirectException($dest, $http_response_code);
-    }
-
-    /**
-     * Redirection to Login page
-     *
-     * @param string $params  param to add to URL (default '')
-     * @since 0.85
-     *
-     * @return void
-     **/
-    public static function redirectToLogin($params = '')
-    {
-        /**
-         * @var array $CFG_GLPI
-         */
-        global $CFG_GLPI;
-
-        $dest = $CFG_GLPI["root_doc"] . "/index.php";
-
-        if (!self::$is_ajax_request) {
-            $url_dest = preg_replace(
-                '/^' . preg_quote($CFG_GLPI["root_doc"], '/') . '/',
-                '',
-                $_SERVER['REQUEST_URI']
-            );
-            $dest .= "?redirect=" . rawurlencode($url_dest);
-        }
-
-        if (!empty($params)) {
-            if (str_contains($dest, '?')) {
-                $dest .= '&' . $params;
-            } else {
-                $dest .= '?' . $params;
-            }
-        }
-
-        self::redirect($dest);
     }
 
 
@@ -6584,22 +6541,6 @@ CSS;
 
             return IntlDateFormatter::formatObject($ts_date, 'MMMM Y', $_SESSION['glpilanguage'] ?? 'en_GB');
         }
-    }
-
-    /**
-     * Indicates that the request is made in an AJAX context.
-     */
-    public static function setAjax(): void
-    {
-        self::$is_ajax_request = true;
-    }
-
-    /**
-     * Unset the flag that indicates that the request is made in an AJAX context.
-     */
-    public static function resetAjaxParam(): void
-    {
-        self::$is_ajax_request = false;
     }
 
     /**


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

When a `AccessDeniedHttpException` is thrown, if the user is not authenticated, then it is automatically redirected to the login form. It permits to remove all manual calls to `Session::redirectIfNotLoggedIn()` and `Session::redirectToLogin()` and to reuse, for this behaviour, the redirection already existing in the `AccessErrorListener`.
