### PR TITLE
(fix) remove expired satisfaction

### DIFF
--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -5017,9 +5017,10 @@ JAVASCRIPT;
                         $options['criteria'][0]['value']      = self::CLOSED;
                         $options['criteria'][0]['link']       = 'AND';
 
+                        $duration = Entity::getUsedConfig('inquest_config', $_SESSION['glpiactive_entity'], 'inquest_duration');
                         $options['criteria'][1]['field']      = 60; // enquete generee
-                        $options['criteria'][1]['searchtype'] = 'contains';
-                        $options['criteria'][1]['value']      = '^';
+                        $options['criteria'][1]['searchtype'] = 'morethan';
+                        $options['criteria'][1]['value']      = date('Y-m-d H:i:s', strtotime('-' . $duration . 'days'));
                         $options['criteria'][1]['link']       = 'AND';
 
                         $options['criteria'][2]['field']      = 61; // date_answered


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x]  I have read the CONTRIBUTING document.
- [x]  I have performed a self-review of my code.
- [ ]  I have added tests that prove my fix is effective or that my feature works.
- [ ]  This change requires a documentation update.

## Description

- It fixes !36019
- Criteria that allowed to search for satisfaction surveys in progress also recovered satisfaction surveys which were expired. I have changed the criteria to select surveys X days after the expiry date

Screenshots (if appropriate):

![Capture d’écran du 2025-01-21 16-58-33](https://github.com/user-attachments/assets/2bfebf9a-3af8-49ff-8a58-93b4a66ea0bd)

![Capture d’écran du 2025-01-21 17-00-41](https://github.com/user-attachments/assets/a0e363e0-ca03-44e2-b2e4-b4ec39c33e5d)

