### PR TITLE
fix(NetowkrPortMetric): fix CSS

### DIFF
--- a/src/NetworkPortMetrics.php
+++ b/src/NetworkPortMetrics.php
@@ -175,7 +175,7 @@ class NetworkPortMetrics extends CommonDBChild
         ];
 
        //display bytes graph
-        echo "<div class='netports_metrics bytes'>";
+        echo "<div class='dashboard netports_metrics bytes'>";
         echo Widget::multipleLines($bytes_bar_conf);
         echo "</div>";
 
@@ -193,7 +193,7 @@ class NetworkPortMetrics extends CommonDBChild
         echo "</br>";
 
        //display error graph
-        echo "<div class='netports_metrics'>";
+        echo "<div class='dashboard netports_metrics'>";
         echo Widget::multipleLines($errors_bar_conf);
         echo "</div>";
     }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)

I noticed that the `CSS` applied to the `GLPI Dashboard` was not applied in the `NetworkPortMetric`, this PR fixes that


`GLPI Dashboard` :

![image](https://github.com/user-attachments/assets/a04d8f56-e9da-4750-8a22-b17bd693490e)


`NetworkPortMetric` : 

![image](https://github.com/user-attachments/assets/f0814092-fcd3-47a1-ad84-5c104d97949e)
 
`After` :

![image](https://github.com/user-attachments/assets/5c6f2f54-8287-40d6-ac84-cd7fde2f6db9)
 

Don't worry about the data, I used the script `php tools/fake_metrics.php`.
