### PR TITLE
Rename To and From mailcollector rule criteria

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ The present file will list all changes made to the project; according to the
 - New UI for searching for Ticket/Change/Problem solutions from the Knowledgebase.
 - Validations are only allowed on Tickets and Changes that are not solved or closed.
 - Searching project tasks in the legacy API is no longer restricted to only tasks the user is assigned to.
+- Renamed `From email header` and `To email header` criteria in the mails receiver rules to `From email address` and `To email address` respectively.
 
 ### Deprecated
 - Survey URL tags `TICKETCATEGORY_ID` and `TICKETCATEGORY_NAME` are deprecated and replaced by `ITILCATEGORY_ID` and `ITILCATEGORY_NAME` respectively.

--- a/src/RuleMailCollector.php
+++ b/src/RuleMailCollector.php
@@ -71,11 +71,11 @@ class RuleMailCollector extends Rule
         $criterias['content']['table']                  = '';
         $criterias['content']['type']                   = 'text';
 
-        $criterias['from']['name']                      = __('From email header');
+        $criterias['from']['name']                      = __('From email address');
         $criterias['from']['table']                     = '';
         $criterias['from']['type']                      = 'text';
 
-        $criterias['to']['name']                        = __('To email header');
+        $criterias['to']['name']                        = __('To email address');
         $criterias['to']['table']                       = '';
         $criterias['to']['type']                        = 'text';
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Based on discussion in #18783 and on the forum, the labels for the From and To mail collector rule criteria could cause confusion as they reference the headers but they instead have always been just the actual email address part of the header. The optional name part, was never passed to the rule engine.