### PR TITLE
Fix routing of plugins public PHP scripts

### DIFF
--- a/phpunit/functional/Glpi/Http/FirewallTest.php
+++ b/phpunit/functional/Glpi/Http/FirewallTest.php
@@ -92,6 +92,9 @@ class FirewallTest extends \DbTestCase
                             ],
                             'foo.php' => '',
                         ],
+                        'public' => [
+                            'css.php' => '',
+                        ],
                         'index.php' => '',
                     ]
                 ],
@@ -129,6 +132,8 @@ class FirewallTest extends \DbTestCase
             '/marketplace/myplugin/ajax/foo.php'        => $default_for_plugins_legacy,
             '/marketplace/myplugin/front/dir/bar.php'   => $default_for_plugins_legacy,
             '/marketplace/myplugin/front/foo.php'       => $default_for_plugins_legacy,
+            '/marketplace/myplugin/public/css.php'      => $default_for_plugins_legacy, // /public/css.php file accessed with its legacy path
+            '/marketplace/myplugin/css.php'             => $default_for_plugins_legacy, // /public/css.php file accessed with the expected path
             '/marketplace/myplugin/index.php'           => $default_for_plugins_legacy,
             '/marketplace/myplugin/PluginRoute'         => $default_for_symfony_routes,
 

--- a/src/Glpi/Http/Firewall.php
+++ b/src/Glpi/Http/Firewall.php
@@ -241,6 +241,9 @@ final class Firewall
         foreach ($this->plugins_dirs as $plugin_dir) {
             $expected_filenames = [
                 $plugin_dir . '/' . $plugin_key . $plugin_resource,
+
+                // A PHP script located in the `/public` directory of a plugin will not have the `/public` prefix in its URL
+                $plugin_dir . '/' . $plugin_key . '/public' . $plugin_resource,
             ];
             $resource_matches = [];
             if (\preg_match('#^(?<filename>.+\.php)(/.*)$#', $plugin_resource, $resource_matches)) {

--- a/src/Glpi/Http/LegacyRouterTrait.php
+++ b/src/Glpi/Http/LegacyRouterTrait.php
@@ -165,6 +165,20 @@ trait LegacyRouterTrait
                 $path = $filepath;
                 break;
             }
+
+            // All plugins public resources should now be accessed without explicitely using the `/public` path,
+            // e.g. `/plugins/myplugin/public/css.php` -> `/plugins/myplugin/css.php`.
+            $path_matches = [];
+            if (preg_match('#^/plugins/(?<plugin_key>[^\/]+)/public(?<plugin_resource>/.+)$#', $filepath, $path_matches) === 1) {
+                $new_path = sprintf('/plugins/%s%s', $path_matches['plugin_key'], $path_matches['plugin_resource']);
+                if ($this->getTargetFile($new_path) !== null) {
+                    // To not break URLs than can be found in the wild (in e-mail, forums, external apps configuration, ...),
+                    // please do not remove this behaviour before, at least, 2030 (about 5 years after GLPI 11.0.0 release).
+                    Toolbox::deprecated('Plugins URLs containing the `/public` path are deprecated. You should remove the `/public` prefix from the URL.');
+                    $path = $new_path;
+                    break;
+                }
+            }
         }
 
         if ($path === '') {


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

In GLPI 11.0, a request to `/plugins/myplugin/myscript.php` should serve the `/plugins/myplugin/public/myscript.php` file and the default firewall strategy should be the same as any other legacy PHP script of the plugin.

This PR:
 - fixes the default strategy applied to `/public/*.php` scripts,
 - handles URLs explicitely containing the `/public` path, but triggers a deprecation indicating that `/public` should not be present in the URL (URL `/plugins/myplugin/public/myscript.php` shoudl be replaced by `/plugins/myplugin/myscript.php`).