### PR TITLE
Fix CommonDBTM input const type to allow false value for phpstan

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -1220,12 +1220,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/CommonDBTM.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Call to function is_array\\(\\) with array\\<mixed\\> will always evaluate to true\\.$#',
-	'identifier' => 'function.alreadyNarrowedType',
-	'count' => 1,
-	'path' => __DIR__ . '/src/CommonDBTM.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^If condition is always false\\.$#',
 	'identifier' => 'if.alwaysFalse',
 	'count' => 2,
@@ -1342,12 +1336,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Right side of \\|\\| is always false\\.$#',
 	'identifier' => 'booleanOr.rightAlwaysFalse',
-	'count' => 1,
-	'path' => __DIR__ . '/src/CommonDBTM.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Strict comparison using \\=\\=\\= between array\\<mixed\\> and false will always evaluate to false\\.$#',
-	'identifier' => 'identical.alwaysFalse',
 	'count' => 1,
 	'path' => __DIR__ . '/src/CommonDBTM.php',
 ];

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -58,7 +58,7 @@ class CommonDBTM extends CommonGLPI
     /**
      * Add/Update fields input. Filled during add/update process.
      *
-     * @var mixed[]|bool
+     * @var mixed[]|false
      */
     public $input = [];
 

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -58,7 +58,7 @@ class CommonDBTM extends CommonGLPI
     /**
      * Add/Update fields input. Filled during add/update process.
      *
-     * @var mixed[]
+     * @var mixed[]|bool
      */
     public $input = [];
 


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

https://github.com/pluginsGLPI/uninstall/pull/130

Exemple from Uninstall plugin : 
![image](https://github.com/user-attachments/assets/8abbce85-18e2-4522-9c1e-7f1c4ae7c43e)

Got this phpstan5 error : 
![image](https://github.com/user-attachments/assets/dc553a22-d7aa-43a7-8152-9899f6b86985)
