### PR TITLE
Add meaningful/random default values for global constants stubs

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -50,12 +50,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/front/commonitilvalidation.form.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Strict comparison using \\!\\=\\= between null and \'development\' will always evaluate to true\\.$#',
-	'identifier' => 'notIdentical.alwaysTrue',
-	'count' => 1,
-	'path' => __DIR__ . '/front/css.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Instanceof between CommonDropdown and CommonDropdown will always evaluate to true\\.$#',
 	'identifier' => 'instanceof.alwaysTrue',
 	'count' => 1,
@@ -122,12 +116,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/front/item_device.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Strict comparison using \\!\\=\\= between null and \'development\' will always evaluate to true\\.$#',
-	'identifier' => 'notIdentical.alwaysTrue',
-	'count' => 1,
-	'path' => __DIR__ . '/front/locale.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Call to an undefined method Glpi\\\\Mail\\\\SMTP\\\\OauthProvider\\\\ProviderInterface\\:\\:getState\\(\\)\\.$#',
 	'identifier' => 'method.notFound',
 	'count' => 1,
@@ -138,24 +126,6 @@ $ignoreErrors[] = [
 	'identifier' => 'match.unhandled',
 	'count' => 1,
 	'path' => __DIR__ . '/front/stat.graph.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^If condition is always false\\.$#',
-	'identifier' => 'if.alwaysFalse',
-	'count' => 1,
-	'path' => __DIR__ . '/install/empty_data.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Strict comparison using \\=\\=\\= between null and \'testing\' will always evaluate to false\\.$#',
-	'identifier' => 'identical.alwaysFalse',
-	'count' => 1,
-	'path' => __DIR__ . '/install/empty_data.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Ternary operator condition is always false\\.$#',
-	'identifier' => 'ternary.alwaysFalse',
-	'count' => 2,
-	'path' => __DIR__ . '/install/empty_data.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^PHPDoc tag @var with type DBmysql is not subtype of native type DB\\.$#',
@@ -636,12 +606,6 @@ $ignoreErrors[] = [
 	'identifier' => 'function.alreadyNarrowedType',
 	'count' => 1,
 	'path' => __DIR__ . '/src/CartridgeItem.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^If condition is always false\\.$#',
-	'identifier' => 'if.alwaysFalse',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Central.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Call to function method_exists\\(\\) with \\$this\\(Certificate\\) and \'prepareGroupFields\' will always evaluate to true\\.$#',
@@ -1328,30 +1292,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/DBConnection.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Default value of the parameter \\#10 \\$config_dir \\(null\\) of method DBConnection\\:\\:createMainConfig\\(\\) is incompatible with type string\\.$#',
-	'identifier' => 'parameter.defaultValue',
-	'count' => 1,
-	'path' => __DIR__ . '/src/DBConnection.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Default value of the parameter \\#10 \\$config_dir \\(null\\) of method DBConnection\\:\\:createSlaveConnectionFile\\(\\) is incompatible with type string\\.$#',
-	'identifier' => 'parameter.defaultValue',
-	'count' => 1,
-	'path' => __DIR__ . '/src/DBConnection.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Default value of the parameter \\#3 \\$config_dir \\(null\\) of method DBConnection\\:\\:updateConfigProperties\\(\\) is incompatible with type string\\.$#',
-	'identifier' => 'parameter.defaultValue',
-	'count' => 1,
-	'path' => __DIR__ . '/src/DBConnection.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Default value of the parameter \\#4 \\$config_dir \\(null\\) of method DBConnection\\:\\:updateConfigProperty\\(\\) is incompatible with type string\\.$#',
-	'identifier' => 'parameter.defaultValue',
-	'count' => 1,
-	'path' => __DIR__ . '/src/DBConnection.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method DBConnection\\:\\:showAllReplicateDelay\\(\\) should return string\\|null but return statement is missing\\.$#',
 	'identifier' => 'return.missing',
 	'count' => 1,
@@ -1802,12 +1742,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/GLPI.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Default value of the parameter \\#1 \\$config_dir \\(null\\) of method GLPIKey\\:\\:__construct\\(\\) is incompatible with type string\\.$#',
-	'identifier' => 'parameter.defaultValue',
-	'count' => 1,
-	'path' => __DIR__ . '/src/GLPIKey.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method GLPIKey\\:\\:keyExists\\(\\) should return string but returns bool\\.$#',
 	'identifier' => 'return.type',
 	'count' => 1,
@@ -1830,18 +1764,6 @@ $ignoreErrors[] = [
 	'identifier' => 'notIdentical.alwaysTrue',
 	'count' => 1,
 	'path' => __DIR__ . '/src/GLPIMailer.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Cannot cast list\\<string\\>\\|null to string\\.$#',
-	'identifier' => 'cast.string',
-	'count' => 1,
-	'path' => __DIR__ . '/src/GLPINetwork.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Expression in empty\\(\\) is always falsy\\.$#',
-	'identifier' => 'empty.expr',
-	'count' => 1,
-	'path' => __DIR__ . '/src/GLPINetwork.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Dead catch \\- Glpi\\\\Exception\\\\PasswordTooWeakException is never thrown in the try block\\.$#',
@@ -2144,12 +2066,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Api/HL/Search.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Default value of the parameter \\#2 \\$env \\(null\\) of method Glpi\\\\Application\\\\ErrorHandler\\:\\:__construct\\(\\) is incompatible with type string\\.$#',
-	'identifier' => 'parameter.defaultValue',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Application/ErrorHandler.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Instanceof between Psr\\\\Log\\\\LoggerInterface and Psr\\\\Log\\\\LoggerInterface will always evaluate to true\\.$#',
 	'identifier' => 'instanceof.alwaysTrue',
 	'count' => 1,
@@ -2166,18 +2082,6 @@ $ignoreErrors[] = [
 	'identifier' => 'notIdentical.alwaysTrue',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Glpi/Application/ErrorHandler.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Default value of the parameter \\#2 \\$cachedir \\(null\\) of method Glpi\\\\Application\\\\View\\\\TemplateRenderer\\:\\:__construct\\(\\) is incompatible with type string\\.$#',
-	'identifier' => 'parameter.defaultValue',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Application/View/TemplateRenderer.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Strict comparison using \\!\\=\\= between null and \'production\' will always evaluate to true\\.$#',
-	'identifier' => 'notIdentical.alwaysTrue',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Application/View/TemplateRenderer.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Strict comparison using \\=\\=\\= between null and 2 will always evaluate to false\\.$#',
@@ -2254,18 +2158,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Call to function is_string\\(\\) with string will always evaluate to true\\.$#',
 	'identifier' => 'function.alreadyNarrowedType',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Cache/CacheManager.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Default value of the parameter \\#1 \\$config_dir \\(null\\) of method Glpi\\\\Cache\\\\CacheManager\\:\\:__construct\\(\\) is incompatible with type string\\.$#',
-	'identifier' => 'parameter.defaultValue',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Cache/CacheManager.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Default value of the parameter \\#2 \\$cache_dir \\(null\\) of method Glpi\\\\Cache\\\\CacheManager\\:\\:__construct\\(\\) is incompatible with type string\\.$#',
-	'identifier' => 'parameter.defaultValue',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Glpi/Cache/CacheManager.php',
 ];
@@ -2378,12 +2270,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/CalDAV/Plugin/Browser.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Strict comparison using \\=\\=\\= between null and \'development\' will always evaluate to false\\.$#',
-	'identifier' => 'identical.alwaysFalse',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/CalDAV/Plugin/Browser.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Call to an undefined method Glpi\\\\CalDAV\\\\Contracts\\\\CalDAVCompatibleItemInterface\\:\\:getFromDB\\(\\)\\.$#',
 	'identifier' => 'method.notFound',
 	'count' => 1,
@@ -2412,12 +2298,6 @@ $ignoreErrors[] = [
 	'identifier' => 'function.alreadyNarrowedType',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Glpi/Console/Application.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Strict comparison using \\!\\=\\= between null and \'development\' will always evaluate to true\\.$#',
-	'identifier' => 'notIdentical.alwaysTrue',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Console/Build/GenerateCodeManifestCommand.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^PHPDoc tag @var with type SplFileInfo is not subtype of native type DirectoryIterator\\.$#',
@@ -2504,12 +2384,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Controller/ApiController.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Strict comparison using \\=\\=\\= between null and \'development\' will always evaluate to false\\.$#',
-	'identifier' => 'identical.alwaysFalse',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Controller/ErrorController.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method Glpi\\\\Controller\\\\LegacyFileLoadController\\:\\:getRequest\\(\\) never returns null so it can be removed from the return type\\.$#',
 	'identifier' => 'return.unusedType',
 	'count' => 1,
@@ -2556,12 +2430,6 @@ $ignoreErrors[] = [
 	'identifier' => 'function.alreadyNarrowedType',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Glpi/Dashboard/Filters/DatesModFilter.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Strict comparison using \\!\\=\\= between null and \'development\' will always evaluate to true\\.$#',
-	'identifier' => 'notIdentical.alwaysTrue',
-	'count' => 2,
-	'path' => __DIR__ . '/src/Glpi/Dashboard/Grid.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Call to an undefined static method CommonDBVisible\\:\\:getVisibilityCriteria\\(\\)\\.$#',
@@ -3086,64 +2954,10 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Inventory/MainAsset/Unmanaged.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Call to function in_array\\(\\) with arguments null, array\\{\'development\', \'testing\'\\} and true will always evaluate to false\\.$#',
-	'identifier' => 'function.impossibleType',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Kernel/Kernel.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Method Glpi\\\\Kernel\\\\Kernel\\:\\:getLogDir\\(\\) should return string but returns null\\.$#',
-	'identifier' => 'return.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Kernel/Kernel.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Negated boolean expression is always true\\.$#',
-	'identifier' => 'booleanNot.alwaysTrue',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Marketplace/Api/Plugins.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Left side of && is always false\\.$#',
-	'identifier' => 'booleanAnd.leftAlwaysFalse',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Marketplace/Controller.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Result of && is always false\\.$#',
-	'identifier' => 'booleanAnd.alwaysFalse',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Marketplace/Controller.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Strict comparison using \\!\\=\\= between int and false will always evaluate to true\\.$#',
 	'identifier' => 'notIdentical.alwaysTrue',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Glpi/Marketplace/Controller.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Strict comparison using \\=\\=\\= between 0 and 1 will always evaluate to false\\.$#',
-	'identifier' => 'identical.alwaysFalse',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Marketplace/Controller.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Strict comparison using \\=\\=\\= between 0 and 2 will always evaluate to false\\.$#',
-	'identifier' => 'identical.alwaysFalse',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Marketplace/Controller.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Right side of && is always false\\.$#',
-	'identifier' => 'booleanAnd.rightAlwaysFalse',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Marketplace/View.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Strict comparison using \\!\\=\\= between null and \'CLOUD\' will always evaluate to true\\.$#',
-	'identifier' => 'notIdentical.alwaysTrue',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Marketplace/View.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^PHPDoc tag @phpstan\\-return has invalid value \\(\\{client_id\\: string, user_id\\: string, scopes\\: string\\[\\]\\}\\)\\: Unexpected token "\\{", expected type at offset 79 on line 4$#',
@@ -3154,12 +2968,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Call to function is_array\\(\\) with array will always evaluate to true\\.$#',
 	'identifier' => 'function.alreadyNarrowedType',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/RichText/RichText.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^If condition is always false\\.$#',
-	'identifier' => 'if.alwaysFalse',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Glpi/RichText/RichText.php',
 ];
@@ -3185,12 +2993,6 @@ $ignoreErrors[] = [
 	'message' => '#^Negated boolean expression is always true\\.$#',
 	'identifier' => 'booleanNot.alwaysTrue',
 	'count' => 2,
-	'path' => __DIR__ . '/src/Glpi/Search/Input/QueryBuilder.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Strict comparison using \\=\\=\\= between null and \'development\' will always evaluate to false\\.$#',
-	'identifier' => 'identical.alwaysFalse',
-	'count' => 1,
 	'path' => __DIR__ . '/src/Glpi/Search/Input/QueryBuilder.php',
 ];
 $ignoreErrors[] = [
@@ -3434,28 +3236,10 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/System/Diagnostic/SourceCodeIntegrityChecker.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Default value of the parameter \\#1 \\$directory \\(null\\) of method Glpi\\\\System\\\\Log\\\\LogParser\\:\\:__construct\\(\\) is incompatible with type string\\.$#',
-	'identifier' => 'parameter.defaultValue',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/System/Log/LogParser.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method Glpi\\\\System\\\\Log\\\\LogViewer\\:\\:getMenuContent\\(\\) never returns false so it can be removed from the return type\\.$#',
 	'identifier' => 'return.unusedType',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Glpi/System/Log/LogViewer.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Strict comparison using \\!\\=\\= between string and null will always evaluate to true\\.$#',
-	'identifier' => 'notIdentical.alwaysTrue',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/System/RequirementsManager.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Method Glpi\\\\UI\\\\ThemeManager\\:\\:getCustomThemesDirectory\\(\\) should return string but returns null\\.$#',
-	'identifier' => 'return.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/UI/ThemeManager.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Default value of the parameter \\#1 \\$history \\(int\\) of method Group\\:\\:post_updateItem\\(\\) is incompatible with type bool\\.$#',
@@ -3544,7 +3328,7 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Negated boolean expression is always true\\.$#',
 	'identifier' => 'booleanNot.alwaysTrue',
-	'count' => 2,
+	'count' => 1,
 	'path' => __DIR__ . '/src/Html.php',
 ];
 $ignoreErrors[] = [
@@ -3567,12 +3351,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	'message' => '#^Strict comparison using \\=\\=\\= between float and \'\\-\' will always evaluate to false\\.$#',
-	'identifier' => 'identical.alwaysFalse',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Html.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Strict comparison using \\=\\=\\= between null and \'development\' will always evaluate to false\\.$#',
 	'identifier' => 'identical.alwaysFalse',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Html.php',
@@ -5456,12 +5234,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Toolbox.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Default value of the parameter \\#3 \\$config_dir \\(null\\) of method Toolbox\\:\\:writeConfig\\(\\) is incompatible with type string\\.$#',
-	'identifier' => 'parameter.defaultValue',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Toolbox.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^If condition is always true\\.$#',
 	'identifier' => 'if.alwaysTrue',
 	'count' => 1,
@@ -5510,12 +5282,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Toolbox.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Result of && is always false\\.$#',
-	'identifier' => 'booleanAnd.alwaysFalse',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Toolbox.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Result of \\|\\| is always true\\.$#',
 	'identifier' => 'booleanOr.alwaysTrue',
 	'count' => 1,
@@ -5524,12 +5290,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Strict comparison using \\!\\=\\= between null and CommonDBTM will always evaluate to true\\.$#',
 	'identifier' => 'notIdentical.alwaysTrue',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Toolbox.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Strict comparison using \\=\\=\\= between null and true will always evaluate to false\\.$#',
-	'identifier' => 'identical.alwaysFalse',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Toolbox.php',
 ];

--- a/stubs/glpi_constants.php
+++ b/stubs/glpi_constants.php
@@ -37,51 +37,58 @@
 // Please try to keep them alphabetically ordered.
 // Keep in sync with the dynamicConstantNames config option in the PHPStan config file
 
-// Directories constants
-define('GLPI_CACHE_DIR', null);
-define('GLPI_CONFIG_DIR', null);
-define('GLPI_CRON_DIR', null);
-define('GLPI_DOC_DIR', null);
-define('GLPI_GRAPH_DIR', null);
-define('GLPI_INVENTORY_DIR', null);
-define('GLPI_LOCAL_I18N_DIR', null);
-define('GLPI_LOCK_DIR', null);
-define('GLPI_LOG_DIR', null);
-define('GLPI_MARKETPLACE_DIR', null);
-define('GLPI_PICTURE_DIR', null);
-define('GLPI_PLUGIN_DOC_DIR', null);
-define('GLPI_RSS_DIR', null);
-define('GLPI_SESSION_DIR', null);
-define('GLPI_THEMES_DIR', null);
-define('GLPI_TMP_DIR', null);
-define('GLPI_UPLOAD_DIR', null);
-define('GLPI_VAR_DIR', null);
+// Wrap in a function to be sure to never declare any variable in the global scope.
+(static function () {
+    $random_val = static fn (array $values) => $values[array_rand($values)];
 
-// Optionnal constants
-define('GLPI_FORCE_MAIL', null);
-define('GLPI_LOG_LVL', null);
-define('GLPI_STRICT_DEPRECATED', null);
+    // Directories constants
+    define('GLPI_CACHE_DIR', dirname(__FILE__, 2) . '/files/_cache');
+    define('GLPI_CONFIG_DIR', dirname(__FILE__, 2) . '/config');
+    define('GLPI_CRON_DIR', dirname(__FILE__, 2) . '/files/_cron');
+    define('GLPI_DOC_DIR', dirname(__FILE__, 2) . '/files');
+    define('GLPI_GRAPH_DIR', dirname(__FILE__, 2) . '/files/_graphs');
+    define('GLPI_INVENTORY_DIR', dirname(__FILE__, 2) . '/files/_inventories');
+    define('GLPI_LOCAL_I18N_DIR', dirname(__FILE__, 2) . '/files/_locales');
+    define('GLPI_LOCK_DIR', dirname(__FILE__, 2) . '/files/_lock');
+    define('GLPI_LOG_DIR', dirname(__FILE__, 2) . '/files/_log');
+    define('GLPI_MARKETPLACE_DIR', dirname(__FILE__, 2) . '/marketplace');
+    define('GLPI_PICTURE_DIR', dirname(__FILE__, 2) . '/files/_pictures');
+    define('GLPI_PLUGIN_DOC_DIR', dirname(__FILE__, 2) . '/files/_plugins');
+    define('GLPI_RSS_DIR', dirname(__FILE__, 2) . '/files/_rss');
+    define('GLPI_SESSION_DIR', dirname(__FILE__, 2) . '/files/_sessions');
+    define('GLPI_THEMES_DIR', dirname(__FILE__, 2) . '/files/_themes');
+    define('GLPI_TMP_DIR', dirname(__FILE__, 2) . '/files/_tmp');
+    define('GLPI_UPLOAD_DIR', dirname(__FILE__, 2) . '/files/_uploads');
+    define('GLPI_VAR_DIR', dirname(__FILE__, 2) . '/files');
 
-// Other constants
-define('GLPI_AJAX_DASHBOARD', null);
-define('GLPI_ALLOW_IFRAME_IN_RICH_TEXT', null);
-define('GLPI_CALDAV_IMPORT_STATE', null);
-define('GLPI_CENTRAL_WARNINGS', null);
-define('GLPI_DOCUMENTATION_ROOT_URL', null);
-define('GLPI_DISABLE_ONLY_FULL_GROUP_BY_SQL_MODE', null);
-define('GLPI_ENVIRONMENT_TYPE', null);
-define('GLPI_INSTALL_MODE', null);
-define('GLPI_MARKETPLACE_ALLOW_OVERRIDE', null);
-define('GLPI_MARKETPLACE_ENABLE', null);
-define('GLPI_MARKETPLACE_MANUAL_DOWNLOADS', null);
-define('GLPI_MARKETPLACE_PLUGINS_API_URI', null);
-define('GLPI_MARKETPLACE_PRERELEASES', null);
-define('GLPI_NETWORK_REGISTRATION_API_URL', null);
-define('GLPI_NETWORK_MAIL', null);
-define('GLPI_NETWORK_SERVICES', null);
-define('GLPI_SERVERSIDE_URL_ALLOWLIST', []);
-define('GLPI_TELEMETRY_URI', null);
-define('GLPI_TEXT_MAXSIZE', null);
-define('GLPI_USER_AGENT_EXTRA_COMMENTS', null);
-define('GLPI_WEBHOOK_ALLOW_RESPONSE_SAVING', 0);
-define('PLUGINS_DIRECTORIES', ['/a', '/b', '/c']);
+    // Optionnal constants
+    if ($random_val([false, true]) === true) {
+        define('GLPI_FORCE_MAIL', 'example@glpi-project.org');
+        define('GLPI_LOG_LVL', 'DEBUG');
+        define('GLPI_STRICT_DEPRECATED', true);
+    }
+
+    // Other constants
+    define('GLPI_AJAX_DASHBOARD', $random_val([false, true]));
+    define('GLPI_ALLOW_IFRAME_IN_RICH_TEXT', $random_val([false, true]));
+    define('GLPI_CALDAV_IMPORT_STATE', $random_val([0, 1, 2]));
+    define('GLPI_CENTRAL_WARNINGS', $random_val([false, true]));
+    define('GLPI_DOCUMENTATION_ROOT_URL', 'https://links.glpi-project.org');
+    define('GLPI_DISABLE_ONLY_FULL_GROUP_BY_SQL_MODE', $random_val([false, true]));
+    define('GLPI_ENVIRONMENT_TYPE', $random_val(['development', 'testing', 'staging', 'production']));
+    define('GLPI_INSTALL_MODE', $random_val(['GIT', 'TARBALL']));
+    define('GLPI_MARKETPLACE_ALLOW_OVERRIDE', $random_val([false, true]));
+    define('GLPI_MARKETPLACE_ENABLE', $random_val([0, 1, 2, 3]));
+    define('GLPI_MARKETPLACE_MANUAL_DOWNLOADS', $random_val([false, true]));
+    define('GLPI_MARKETPLACE_PLUGINS_API_URI', 'https://services.glpi-network.com/api/marketplace/');
+    define('GLPI_MARKETPLACE_PRERELEASES', $random_val([false, true]));
+    define('GLPI_NETWORK_REGISTRATION_API_URL', 'https://services.glpi-network.com/api/registration/');
+    define('GLPI_NETWORK_MAIL', 'glpi@teclib.com');
+    define('GLPI_NETWORK_SERVICES', 'https://services.glpi-network.com');
+    define('GLPI_SERVERSIDE_URL_ALLOWLIST', $random_val([[], ['/^.*$/']]));
+    define('GLPI_TELEMETRY_URI', 'https://telemetry.glpi-project.org');
+    define('GLPI_TEXT_MAXSIZE', $random_val([1000, 2000, 3000, 4000]));
+    define('GLPI_USER_AGENT_EXTRA_COMMENTS', $random_val(['', 'app-version:5']));
+    define('GLPI_WEBHOOK_ALLOW_RESPONSE_SAVING', $random_val([false, true]));
+    define('PLUGINS_DIRECTORIES', [dirname(__FILE__, 2) . '/plugins', dirname(__FILE__, 2) . '/marketplace']);
+})();


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

While working on #18790, I had to add new errors in the PHPStan baseline due to default `null` values of our constants stubs.

1. They are often incompatible with the expected values. Using an expected value fixes issues like `Default value of the parameter #10 $config_dir (null) of method DBConnection::createMainConfig() is incompatible with type string.`.
2. Always using the same value make PHPStan unhappy when it finds a comparison operation based on the contant value. Using a random but still valid value fixes issues like `Strict comparison using !== between null and 'development' will always evaluate to true.`.