### PR TITLE
Limit code coverage to PHPUnit unit/functional tests

### DIFF
--- a/.github/actions/test_tests-cache.sh
+++ b/.github/actions/test_tests-cache.sh
@@ -1,20 +1,9 @@
 #!/bin/bash
 set -e -u -x -o pipefail
 
-PHPUNIT_ADDITIONNAL_OPTIONS=""
-if [[ "${CODE_COVERAGE:-}" = true ]]; then
-  export COVERAGE_DIR="coverage-functional"
-  PHPUNIT_ADDITIONNAL_OPTIONS="--coverage-filter src --coverage-clover phpunit/$COVERAGE_DIR/clover.xml"
-
-else
-  PHPUNIT_ADDITIONNAL_OPTIONS="--no-coverage";
-fi
-
 for CONFIG in {"--use-default","--dsn=memcached://memcached","--dsn=redis://redis"}; do
   php bin/console cache:configure \
     --ansi --no-interaction \
     $CONFIG
-  vendor/bin/phpunit --group cache $PHPUNIT_ADDITIONNAL_OPTIONS $@
+  vendor/bin/phpunit --group cache $@
 done
-
-unset COVERAGE_DIR

--- a/.github/actions/test_tests-imap.sh
+++ b/.github/actions/test_tests-imap.sh
@@ -1,14 +1,4 @@
 #!/bin/bash
 set -e -u -x -o pipefail
 
-PHPUNIT_ADDITIONNAL_OPTIONS=""
-if [[ "$CODE_COVERAGE" = true ]]; then
-  export COVERAGE_DIR="coverage-imap"
-  PHPUNIT_ADDITIONNAL_OPTIONS="--coverage-filter src --coverage-clover phpunit/$COVERAGE_DIR/clover.xml"
-else
-  PHPUNIT_ADDITIONNAL_OPTIONS="--no-coverage";
-fi
-
-vendor/bin/phpunit $PHPUNIT_ADDITIONNAL_OPTIONS phpunit/imap
-
-unset COVERAGE_DIR
+vendor/bin/phpunit phpunit/imap $@

--- a/.github/actions/test_tests-ldap.sh
+++ b/.github/actions/test_tests-ldap.sh
@@ -1,13 +1,6 @@
 #!/bin/bash
 set -e -u -x -o pipefail
 
-ATOUM_ADDITIONNAL_OPTIONS=""
-if [[ "$CODE_COVERAGE" = true ]]; then
-  export COVERAGE_DIR="coverage-ldap"
-else
-  ATOUM_ADDITIONNAL_OPTIONS="--no-code-coverage";
-fi
-
 vendor/bin/atoum \
   -p 'php -d memory_limit=512M' \
   --debug \
@@ -16,8 +9,6 @@ vendor/bin/atoum \
   --bootstrap-file tests/bootstrap.php \
   --fail-if-void-methods \
   --fail-if-skipped-methods \
-  $ATOUM_ADDITIONNAL_OPTIONS \
+  --no-code-coverage \
   --max-children-number 1 \
   -d tests/LDAP
-
-unset COVERAGE_DIR

--- a/.github/actions/test_tests-phpunit.sh
+++ b/.github/actions/test_tests-phpunit.sh
@@ -3,13 +3,7 @@ set -e -u -x -o pipefail
 
 PHPUNIT_ADDITIONNAL_OPTIONS=""
 if [[ "${CODE_COVERAGE:-}" = true ]]; then
-  export COVERAGE_DIR="coverage-functional"
-  PHPUNIT_ADDITIONNAL_OPTIONS="--coverage-filter src --coverage-clover phpunit/$COVERAGE_DIR/clover.xml"
-
-else
-  PHPUNIT_ADDITIONNAL_OPTIONS="--no-coverage";
+  PHPUNIT_ADDITIONNAL_OPTIONS="--coverage-clover phpunit/coverage/clover.xml"
 fi
 
 vendor/bin/phpunit $PHPUNIT_ADDITIONNAL_OPTIONS $@
-
-unset COVERAGE_DIR

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -64,21 +64,10 @@ jobs:
       - name: "PHPUnit tests"
         run: |
           docker compose exec -T app .github/actions/test_tests-phpunit.sh
-      - name: "Functional tests"
-        run: |
-          docker compose exec -T app .github/actions/test_tests-functional.sh
-      - name: "LDAP tests"
-        run: |
-          .github/actions/init_initialize-ldap-fixtures.sh
-          docker compose exec -T app .github/actions/test_tests-ldap.sh
-      - name: "IMAP tests"
-        run: |
-          .github/actions/init_initialize-imap-fixtures.sh
-          docker compose exec -T app .github/actions/test_tests-imap.sh
       - name: "Codecov"
         uses: "codecov/codecov-action@v5"
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
-          files: ./phpunit/coverage-functional/clover.xml,./tests/coverage-functional/clover.xml,./tests/coverage-ldap/clover.xml,./tests/coverage-imap/clover.xml
+          files: ./phpunit/coverage/clover.xml
           override_branch: ${{ inputs.branch }}

--- a/.gitignore
+++ b/.gitignore
@@ -18,8 +18,6 @@
 /vendor/*
 !/vendor/.htaccess
 phpunit.xml
-/tests/code-coverage/
-/tests/coverage-*/
 /tests/cypress/screenshots/
 /tests/cypress/downloads/
 /tests/cypress/videos/
@@ -47,5 +45,6 @@ phpstan.neon
 /.phpunit.result.cache
 /phpunit/files/
 /phpunit/config
+/phpunit/coverage/
 *.phar
 .env

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,13 +5,20 @@
     bootstrap="phpunit/bootstrap.php"
     colors="true"
 >
+  <source>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </source>
+
   <testsuites>
     <testsuite name="Unit">
        <directory>phpunit/functional/</directory>
     </testsuite>
   </testsuites>
+
   <php>
-    <!-- 1G was not enough for when code coverage is enabled, 2G should be enough. -->
+    <!-- Code coverage requires about 1.5GB of memory. -->
     <ini name="memory_limit" value="2G" />
   </php>
 </phpunit>


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

IMHO, cache, IMAP and LDAP test suites should be considered as integration tests and should probably not be used to evaluate the code coverage. Indeed, they are not supposed to cover all use cases in all involved methods, and this should be done in the `phpunit/functional` test suite, using mocked connections instead of real remote services.

I also removed the code coverage in the remaining `atoum` tests, to be able to use `pcov` that is faster than `xdebug`.