### PR TITLE
fix: add default ticket value in buildTicket collector

### DIFF
--- a/src/MailCollector.php
+++ b/src/MailCollector.php
@@ -1048,7 +1048,7 @@ class MailCollector extends CommonDBTM
         $play_rules = (isset($options['play_rules']) && $options['play_rules']);
         $headers = $this->getHeaders($message);
 
-        $tkt                 = [];
+        $tkt                 = Ticket::getDefaultValues();
         $tkt['_blacklisted'] = false;
        // For RuleTickets
         $tkt['_mailgate']    = $options['mailgates_id'];


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes #36087
- Adds the default values of a ticket in the ticket builder, which allows to play the rules when creating it. For example, the type and priority was not defined which prevented to launch rules that used these criteria


