### PR TITLE
Fix random failures on testComputeNextCreationDate

### DIFF
--- a/phpunit/abstracts/CommonITILRecurrentTest.php
+++ b/phpunit/abstracts/CommonITILRecurrentTest.php
@@ -493,8 +493,14 @@ abstract class CommonITILRecurrentTest extends DbTestCase
 
     public function testComputeNextCreationDate()
     {
+        // Always use a known date to a get a determinist result.
+        // If there are some specific dates for which these tests always fails,
+        // it should be confirmed by using these dates as `current_date` in a
+        // new entry of the data provider (and be fixed properly).
+        $_SESSION['glpi_currenttime'] = "2025-01-27 15:57:00";
+
         $provider = $this->computeNextCreationDateProvider();
-        foreach ($provider as $row) {
+        foreach ($provider as $i => $row) {
             $begin_date = $row['begin_date'];
             $end_date = $row['end_date'];
             $periodicity = $row['periodicity'];
@@ -505,9 +511,7 @@ abstract class CommonITILRecurrentTest extends DbTestCase
             $current_date = $row['current_date'] ?? null;
 
             // Handle dynamic date
-            $date_to_restore = null;
             if (!is_null($current_date)) {
-                $date_to_restore = Session::getCurrentTime();
                 $_SESSION['glpi_currenttime'] = $current_date;
             }
 
@@ -521,15 +525,11 @@ abstract class CommonITILRecurrentTest extends DbTestCase
                 $calendars_id
             );
 
-            $this->assertSame($expected_value, $value);
+            $this->assertSame($expected_value, $value, 'Test case #' . $i);
             if ($messages === null) {
                 $this->hasNoSessionMessage(ERROR);
             } else {
                 $this->hasSessionMessages(ERROR, $messages);
-            }
-
-            if (!is_null($date_to_restore)) {
-                $_SESSION['glpi_currenttime'] = $date_to_restore;
             }
         }
     }


### PR DESCRIPTION
## Description

The `testComputeNextCreationDate` test will often fail when executed at specific hours during the night (which often happens for @cconard96 as he is on a different timezone).

![image](https://github.com/user-attachments/assets/de4a1349-679a-410f-ae9a-956743d29905)

These changes makes the test deterministic and it should now always behave the same regardless of the current date (which is clearly something we want, if a specific date is problematic it should explicitly be added into the test suite and we should not have to wait for someone to trigger the CI at the right time to discover it).

Note: it does not fix the computation itself, someone else could look for it but it isn't high priority for now. 