### PR TITLE
Fix(PHP): fix PHP doc arg type

### DIFF
--- a/inc/db.function.php
+++ b/inc/db.function.php
@@ -636,7 +636,7 @@ function getEntitiesRestrictRequest(
  * @param string $field             field where apply the limit (id != entities_id) (default '')
  * @param mixed $value              entity to restrict (if not set use $_SESSION['glpiactiveentities']).
  *                                  single item or array (default '')
- * @param boolean $is_recursive     need to use recursive process to find item
+ * @param boolean|string $is_recursive     need to use recursive process to find item
  *                                  (field need to be named recursive) (false by default, set to auto to automatic detection)
  * @param boolean $complete_request need to use a complete request and not a simple one
  *                                  when have acces to all entities (used for reminders)


### PR DESCRIPTION

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Prevent PHPStan error

```shell
Parameter #4 $is_recursive of function getEntitiesRestrictCriteria expects bool, string given.                                        
          🪪  argument.type    
``` 

with 

```php
'WHERE' => getEntitiesRestrictCriteria('glpi_plugin_credit_entities', '', $_SESSION['glpiactive_entity'], 'auto'),
```

_(field need to be named recursive) (false by default, **set to auto to automatic detection**)_

## Screenshots (if appropriate):


