### PR TITLE
Add timeout for E2E CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,6 +222,7 @@ jobs:
     if: github.repository == 'glpi-project/glpi' || github.event_name != 'schedule'
     name: "E2E and web tests using latest PHP and MariaDB versions"
     runs-on: "ubuntu-latest"
+    timeout-minutes: 60
     env:
       COMPOSE_FILE: ".github/actions/docker-compose-app.yml:.github/actions/docker-compose-services.yml"
       APPLICATION_ROOT: "${{ github.workspace }}"


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Try to terminate E2E CI tests if they run for more than an hour.
Haven't solved the various issues that seem to be causing the 6 hour stalled E2E tests in #18577, but if this is going to be more common we should have some kind of reliable timeout set for the CI.