### PR TITLE
Align AJAX tab loading spinner to center

### DIFF
--- a/src/Ajax.php
+++ b/src/Ajax.php
@@ -397,7 +397,7 @@ JAVASCRIPT;
                 updateCurrentTab();
                 return;
             }
-            $(target).html('<i class=\"fas fa-3x fa-spinner fa-pulse position-absolute m-5 start-50\"></i>');
+            $(target).html('<i class=\"fas fa-3x fa-spinner fa-pulse position-absolute m-5 ms-0 start-50\"></i>');
 
             $.get(url, function(data) {
                $(target).html(data);


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does:

When acessing the "Task executions" tab of GLPI Inventory plug-in, the spinner wasn't horizontally center aligned:

<img width="1161" alt="SCR-20250128-qhhc" src="https://github.com/user-attachments/assets/db93976d-6fb7-452a-9b36-b35a61e1b97f" />

This fix attempts to horizontally aligns the AJAX spinner:

<img width="1165" alt="SCR-20250128-qkch" src="https://github.com/user-attachments/assets/2fe48362-e42d-4bc7-ba68-959140f2d203" />

## Screenshots (if appropriate):


