### PR TITLE
Handle exceptions thrown by streamed responses

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -55,6 +55,6 @@ $request = Request::createFromGlobals();
 
 $response = $kernel->handle($request);
 
-$response->send();
+$kernel->sendResponse($request, $response);
 
 $kernel->terminate($request, $response);


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

This will restore a special handling of exceptions thrown during the sending of a streamed responses (mainly used by legacy scripts). It may fix the bug reported in #18827 and  in https://github.com/glpi-project/glpi/pull/18577#issuecomment-2618686333
