### PR TITLE
Remove /ajax prefix used in new form controllers

### DIFF
--- a/js/modules/Helpdesk/HelpdeskConfigController.js
+++ b/js/modules/Helpdesk/HelpdeskConfigController.js
@@ -179,7 +179,7 @@ export class GlpiHelpdeskConfigController
             ;
 
             // Send request
-            const url = `${CFG_GLPI.root_doc}/ajax/Config/Helpdesk/SetTilesOrder`;
+            const url = `${CFG_GLPI.root_doc}/Config/Helpdesk/SetTilesOrder`;
             const response = await fetch(url, {
                 method: 'POST',
                 body: form_data,
@@ -239,7 +239,7 @@ export class GlpiHelpdeskConfigController
             );
 
             // Send request
-            const url = `${CFG_GLPI.root_doc}/ajax/Config/Helpdesk/DeleteTile`;
+            const url = `${CFG_GLPI.root_doc}/Config/Helpdesk/DeleteTile`;
             const response = await fetch(url, {
                 method: 'POST',
                 body: form_data,

--- a/src/Glpi/Controller/Config/Helpdesk/DeleteTileController.php
+++ b/src/Glpi/Controller/Config/Helpdesk/DeleteTileController.php
@@ -57,7 +57,7 @@ final class DeleteTileController extends AbstractController
     }
 
     #[Route(
-        "/ajax/Config/Helpdesk/DeleteTile",
+        "/Config/Helpdesk/DeleteTile",
         name: "glpi_config_helpdesk_delete_tile",
         methods: "POST"
     )]

--- a/src/Glpi/Controller/Config/Helpdesk/SetTilesOrderController.php
+++ b/src/Glpi/Controller/Config/Helpdesk/SetTilesOrderController.php
@@ -55,7 +55,7 @@ final class SetTilesOrderController extends AbstractController
     }
 
     #[Route(
-        "/ajax/Config/Helpdesk/SetTilesOrder",
+        "/Config/Helpdesk/SetTilesOrder",
         name: "glpi_config_helpdesk_set_tiles_order",
         methods: "POST"
     )]


### PR DESCRIPTION
## Description

No longer needed after #18723.

