### PR TITLE
Fix "Copy to clipboard"

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -1288,7 +1288,7 @@ HTML;
 
         if ($_SESSION['glpi_use_mode'] === Session::DEBUG_MODE) {
             $tpl_vars['js_modules'][] = ['path' => 'js/modules/Debug/Debug.js'];
-            $tpl_vars['js_files'][] = ['path' => 'js/clipboard.js'];
+            Html::requireJs('clipboard');
         }
 
        // Search

--- a/src/Html.php
+++ b/src/Html.php
@@ -1285,6 +1285,7 @@ HTML;
         $tpl_vars['js_files'][] = ['path' => 'public/lib/base.js'];
         $tpl_vars['js_files'][] = ['path' => 'js/webkit_fix.js'];
         $tpl_vars['js_files'][] = ['path' => 'js/common.js'];
+        $tpl_vars['js_files'][] = ['path' => 'js/clipboard.js'];
 
         if ($_SESSION['glpi_use_mode'] === Session::DEBUG_MODE) {
             $tpl_vars['js_modules'][] = ['path' => 'js/modules/Debug/Debug.js'];

--- a/src/Html.php
+++ b/src/Html.php
@@ -1285,10 +1285,10 @@ HTML;
         $tpl_vars['js_files'][] = ['path' => 'public/lib/base.js'];
         $tpl_vars['js_files'][] = ['path' => 'js/webkit_fix.js'];
         $tpl_vars['js_files'][] = ['path' => 'js/common.js'];
-        $tpl_vars['js_files'][] = ['path' => 'js/clipboard.js'];
 
         if ($_SESSION['glpi_use_mode'] === Session::DEBUG_MODE) {
             $tpl_vars['js_modules'][] = ['path' => 'js/modules/Debug/Debug.js'];
+            $tpl_vars['js_files'][] = ['path' => 'js/clipboard.js'];
         }
 
        // Search


### PR DESCRIPTION
When clicking on "Copy to clipboard" button when Debug mode is enabled, an error is thrown because the function "copyTextToClipboard" doesn't exist. I believe other UI parts apart of Debug mode also uses this functionality.

<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/92ad895a-0296-4a4f-937d-e7d7587bc605)
