### PR TITLE
feat(forms): Add new strategies for ITILActorField fields

### DIFF
--- a/phpunit/abstracts/AbstractActorFieldTest.php
+++ b/phpunit/abstracts/AbstractActorFieldTest.php
@@ -329,10 +329,6 @@ abstract class AbstractActorFieldTest extends DbTestCase
             '',
             json_encode((new QuestionTypeItemExtraDataConfig(Computer::class))->jsonSerialize())
         );
-        $builder->addDestination(
-            FormDestinationTicket::class,
-            "My ticket",
-        );
 
         return $this->createForm($builder);
     }

--- a/phpunit/abstracts/AbstractActorFieldTest.php
+++ b/phpunit/abstracts/AbstractActorFieldTest.php
@@ -32,7 +32,7 @@
  * ---------------------------------------------------------------------
  */
 
-namespace Glpi\PHPUnit\Tests\Glpi\Form\Destination\CommonITILField;
+namespace tests\units\Glpi\Form\Destination\CommonITILField;
 
 use Computer;
 use DbTestCase;

--- a/phpunit/functional/Glpi/Form/Destination/CommonITILField/AssigneeFieldTest.php
+++ b/phpunit/functional/Glpi/Form/Destination/CommonITILField/AssigneeFieldTest.php
@@ -477,8 +477,8 @@ final class AssigneeFieldTest extends AbstractActorFieldTest
 
         // Check actors
         $this->assertEquals(
-            array_map(fn(array $actor) => $actor['items_id'], $ticket->getActorsForType(CommonITILActor::ASSIGN)),
-            $expected_actors_ids
+            $expected_actors_ids,
+            array_map(fn(array $actor) => $actor['items_id'], $ticket->getActorsForType(CommonITILActor::ASSIGN))
         );
     }
 

--- a/phpunit/functional/Glpi/Form/Destination/CommonITILField/AssigneeFieldTest.php
+++ b/phpunit/functional/Glpi/Form/Destination/CommonITILField/AssigneeFieldTest.php
@@ -45,7 +45,6 @@ use Glpi\Form\Destination\FormDestinationTicket;
 use Glpi\Form\Form;
 use Glpi\Form\QuestionType\QuestionTypeActorsExtraDataConfig;
 use Glpi\Form\QuestionType\QuestionTypeAssignee;
-use Glpi\PHPUnit\Tests\Glpi\Form\Destination\CommonITILField\AbstractActorFieldTest;
 use Glpi\Tests\FormBuilder;
 use Group;
 use Override;
@@ -55,6 +54,8 @@ use Ticket;
 use TicketTemplate;
 use TicketTemplatePredefinedField;
 use User;
+
+include_once __DIR__ . '/../../../../../abstracts/AbstractActorFieldTest.php';
 
 final class AssigneeFieldTest extends AbstractActorFieldTest
 {

--- a/phpunit/functional/Glpi/Form/Destination/CommonITILField/AssigneeFieldTest.php
+++ b/phpunit/functional/Glpi/Form/Destination/CommonITILField/AssigneeFieldTest.php
@@ -36,27 +36,33 @@
 namespace tests\units\Glpi\Form\Destination\CommonITILField;
 
 use CommonITILActor;
-use DbTestCase;
 use Glpi\Form\AnswersHandler\AnswersHandler;
 use Glpi\Form\Destination\CommonITILField\ITILActorFieldStrategy;
 use Glpi\Form\Destination\CommonITILField\AssigneeField;
 use Glpi\Form\Destination\CommonITILField\AssigneeFieldConfig;
+use Glpi\Form\Destination\CommonITILField\ITILActorFieldConfig;
 use Glpi\Form\Destination\FormDestinationTicket;
 use Glpi\Form\Form;
 use Glpi\Form\QuestionType\QuestionTypeActorsExtraDataConfig;
 use Glpi\Form\QuestionType\QuestionTypeAssignee;
+use Glpi\PHPUnit\Tests\Glpi\Form\Destination\CommonITILField\AbstractActorFieldTest;
 use Glpi\Tests\FormBuilder;
-use Glpi\Tests\FormTesterTrait;
 use Group;
+use Override;
+use Session;
 use Supplier;
 use Ticket;
 use TicketTemplate;
 use TicketTemplatePredefinedField;
 use User;
 
-final class AssigneeFieldTest extends DbTestCase
+final class AssigneeFieldTest extends AbstractActorFieldTest
 {
-    use FormTesterTrait;
+    #[Override]
+    public function getFieldClass(): string
+    {
+        return AssigneeField::class;
+    }
 
     public function testAssigneeFromTemplate(): void
     {
@@ -141,6 +147,45 @@ final class AssigneeFieldTest extends DbTestCase
             config: $form_filler_config,
             answers: [],
             expected_actors_ids: [$auth->getUser()->getID()]
+        );
+    }
+
+    public function testAssigneeFormFillerSupervisor(): void
+    {
+        // Login is required to assign actors
+        $this->login();
+
+        $supervisor = $this->createItem(User::class, ['name' => 'testAssigneeFormFillerSupervisor Supervisor']);
+        $form = $this->createAndGetFormWithMultipleActorsQuestions();
+        $form_filler_supervisor_config = new AssigneeFieldConfig(
+            [ITILActorFieldStrategy::FORM_FILLER_SUPERVISOR]
+        );
+
+        // Need user to be logged in
+        $this->sendFormAndAssertTicketActors(
+            form: $form,
+            config: $form_filler_supervisor_config,
+            answers: [],
+            expected_actors_ids: []
+        );
+
+        // No supervisor set
+        $auth = $this->login();
+        $this->sendFormAndAssertTicketActors(
+            form: $form,
+            config: $form_filler_supervisor_config,
+            answers: [],
+            expected_actors_ids: []
+        );
+
+        $this->updateItem(User::class, Session::getLoginUserID(), ['users_id_supervisor' => $supervisor->getID()]);
+
+        // Supervisor set
+        $this->sendFormAndAssertTicketActors(
+            form: $form,
+            config: $form_filler_supervisor_config,
+            answers: [],
+            expected_actors_ids: [$supervisor->getID()]
         );
     }
 
@@ -391,9 +436,9 @@ final class AssigneeFieldTest extends DbTestCase
         );
     }
 
-    private function sendFormAndAssertTicketActors(
+    protected function sendFormAndAssertTicketActors(
         Form $form,
-        AssigneeFieldConfig $config,
+        ITILActorFieldConfig $config,
         array $answers,
         array $expected_actors_ids,
     ): void {
@@ -429,8 +474,6 @@ final class AssigneeFieldTest extends DbTestCase
         $this->assertCount(1, $created_items);
         /** @var Ticket $ticket */
         $ticket = current($created_items);
-
-        $a = $ticket->getActorsForType(CommonITILActor::ASSIGN);
 
         // Check actors
         $this->assertEquals(

--- a/phpunit/functional/Glpi/Form/Destination/CommonITILField/ObserverFieldTest.php
+++ b/phpunit/functional/Glpi/Form/Destination/CommonITILField/ObserverFieldTest.php
@@ -36,7 +36,6 @@
 namespace tests\units\Glpi\Form\Destination\CommonITILField;
 
 use CommonITILActor;
-use Computer;
 use Glpi\Form\AnswersHandler\AnswersHandler;
 use Glpi\Form\Destination\CommonITILField\ITILActorFieldConfig;
 use Glpi\Form\Destination\CommonITILField\ObserverFieldConfig;
@@ -45,10 +44,7 @@ use Glpi\Form\Destination\CommonITILField\ObserverField;
 use Glpi\Form\Destination\FormDestinationTicket;
 use Glpi\Form\Form;
 use Glpi\Form\QuestionType\QuestionTypeActorsExtraDataConfig;
-use Glpi\Form\QuestionType\QuestionTypeItem;
-use Glpi\Form\QuestionType\QuestionTypeItemExtraDataConfig;
 use Glpi\Form\QuestionType\QuestionTypeObserver;
-use Glpi\PHPUnit\Tests\Glpi\Form\Destination\CommonITILField\AbstractActorFieldTest;
 use Glpi\Tests\FormBuilder;
 use Group;
 use Override;
@@ -56,6 +52,8 @@ use Ticket;
 use TicketTemplate;
 use TicketTemplatePredefinedField;
 use User;
+
+include_once __DIR__ . '/../../../../../abstracts/AbstractActorFieldTest.php';
 
 final class ObserverFieldTest extends AbstractActorFieldTest
 {

--- a/phpunit/functional/Glpi/Form/Destination/CommonITILField/ObserverFieldTest.php
+++ b/phpunit/functional/Glpi/Form/Destination/CommonITILField/ObserverFieldTest.php
@@ -411,8 +411,8 @@ final class ObserverFieldTest extends AbstractActorFieldTest
 
         // Check actors
         $this->assertEquals(
-            array_map(fn(array $actor) => $actor['items_id'], $ticket->getActorsForType(CommonITILActor::OBSERVER)),
-            $expected_actors_ids
+            $expected_actors_ids,
+            array_map(fn(array $actor) => $actor['items_id'], $ticket->getActorsForType(CommonITILActor::OBSERVER))
         );
     }
 
@@ -426,23 +426,6 @@ final class ObserverFieldTest extends AbstractActorFieldTest
             '',
             json_encode((new QuestionTypeActorsExtraDataConfig(true))->jsonSerialize())
         );
-        return $this->createForm($builder);
-    }
-
-    private function createAndGetFormWithItemQuestions(): Form
-    {
-        $builder = new FormBuilder();
-        $builder->addQuestion(
-            'Computer question',
-            QuestionTypeItem::class,
-            '',
-            json_encode((new QuestionTypeItemExtraDataConfig(Computer::class))->jsonSerialize())
-        );
-        $builder->addDestination(
-            FormDestinationTicket::class,
-            "My ticket",
-        );
-
         return $this->createForm($builder);
     }
 }

--- a/phpunit/functional/Glpi/Form/Destination/CommonITILField/RequesterFieldTest.php
+++ b/phpunit/functional/Glpi/Form/Destination/CommonITILField/RequesterFieldTest.php
@@ -36,7 +36,6 @@
 namespace tests\units\Glpi\Form\Destination\CommonITILField;
 
 use CommonITILActor;
-use Computer;
 use Glpi\Form\AnswersHandler\AnswersHandler;
 use Glpi\Form\Destination\CommonITILField\ITILActorFieldConfig;
 use Glpi\Form\Destination\CommonITILField\RequesterFieldConfig;
@@ -45,10 +44,7 @@ use Glpi\Form\Destination\CommonITILField\RequesterField;
 use Glpi\Form\Destination\FormDestinationTicket;
 use Glpi\Form\Form;
 use Glpi\Form\QuestionType\QuestionTypeActorsExtraDataConfig;
-use Glpi\Form\QuestionType\QuestionTypeItem;
-use Glpi\Form\QuestionType\QuestionTypeItemExtraDataConfig;
 use Glpi\Form\QuestionType\QuestionTypeRequester;
-use Glpi\PHPUnit\Tests\Glpi\Form\Destination\CommonITILField\AbstractActorFieldTest;
 use Glpi\Tests\FormBuilder;
 use Group;
 use Override;
@@ -56,6 +52,8 @@ use Ticket;
 use TicketTemplate;
 use TicketTemplatePredefinedField;
 use User;
+
+include_once __DIR__ . '/../../../../../abstracts/AbstractActorFieldTest.php';
 
 final class RequesterFieldTest extends AbstractActorFieldTest
 {

--- a/phpunit/functional/Glpi/Form/Destination/CommonITILField/RequesterFieldTest.php
+++ b/phpunit/functional/Glpi/Form/Destination/CommonITILField/RequesterFieldTest.php
@@ -411,8 +411,8 @@ final class RequesterFieldTest extends AbstractActorFieldTest
 
         // Check actors
         $this->assertEquals(
-            array_map(fn(array $actor) => $actor['items_id'], $ticket->getActorsForType(CommonITILActor::REQUESTER)),
-            $expected_actors_ids
+            $expected_actors_ids,
+            array_map(fn(array $actor) => $actor['items_id'], $ticket->getActorsForType(CommonITILActor::REQUESTER))
         );
     }
 
@@ -426,23 +426,6 @@ final class RequesterFieldTest extends AbstractActorFieldTest
             '',
             json_encode((new QuestionTypeActorsExtraDataConfig(true))->jsonSerialize())
         );
-        return $this->createForm($builder);
-    }
-
-    private function createAndGetFormWithItemQuestions(): Form
-    {
-        $builder = new FormBuilder();
-        $builder->addQuestion(
-            'Computer question',
-            QuestionTypeItem::class,
-            '',
-            json_encode((new QuestionTypeItemExtraDataConfig(Computer::class))->jsonSerialize())
-        );
-        $builder->addDestination(
-            FormDestinationTicket::class,
-            "My ticket",
-        );
-
         return $this->createForm($builder);
     }
 }

--- a/phpunit/functional/Glpi/Form/Destination/CommonITILField/RequesterFieldTest.php
+++ b/phpunit/functional/Glpi/Form/Destination/CommonITILField/RequesterFieldTest.php
@@ -36,26 +36,34 @@
 namespace tests\units\Glpi\Form\Destination\CommonITILField;
 
 use CommonITILActor;
-use DbTestCase;
+use Computer;
 use Glpi\Form\AnswersHandler\AnswersHandler;
+use Glpi\Form\Destination\CommonITILField\ITILActorFieldConfig;
 use Glpi\Form\Destination\CommonITILField\RequesterFieldConfig;
 use Glpi\Form\Destination\CommonITILField\ITILActorFieldStrategy;
 use Glpi\Form\Destination\CommonITILField\RequesterField;
 use Glpi\Form\Destination\FormDestinationTicket;
 use Glpi\Form\Form;
 use Glpi\Form\QuestionType\QuestionTypeActorsExtraDataConfig;
+use Glpi\Form\QuestionType\QuestionTypeItem;
+use Glpi\Form\QuestionType\QuestionTypeItemExtraDataConfig;
 use Glpi\Form\QuestionType\QuestionTypeRequester;
+use Glpi\PHPUnit\Tests\Glpi\Form\Destination\CommonITILField\AbstractActorFieldTest;
 use Glpi\Tests\FormBuilder;
-use Glpi\Tests\FormTesterTrait;
 use Group;
+use Override;
 use Ticket;
 use TicketTemplate;
 use TicketTemplatePredefinedField;
 use User;
 
-final class RequesterFieldTest extends DbTestCase
+final class RequesterFieldTest extends AbstractActorFieldTest
 {
-    use FormTesterTrait;
+    #[Override]
+    public function getFieldClass(): string
+    {
+        return RequesterField::class;
+    }
 
     public function testRequesterFromTemplate(): void
     {
@@ -123,6 +131,48 @@ final class RequesterFieldTest extends DbTestCase
             config: $form_filler_config,
             answers: [],
             expected_actors_ids: [$auth->getUser()->getID()]
+        );
+    }
+
+    public function testRequesterFormFillerSupervisor(): void
+    {
+        $supervisor = $this->createItem(User::class, ['name' => 'testRequesterFormFillerSupervisor Supervisor']);
+        $user = $this->createItem(User::class, [
+            'name'                => 'testRequesterFormFillerSupervisor User',
+            'password'            => 'testRequesterFormFillerSupervisor User',
+            'password2'           => 'testRequesterFormFillerSupervisor User',
+            'users_id_supervisor' => $supervisor->getID()
+        ], ['password', 'password2']);
+
+        $form = $this->createAndGetFormWithMultipleActorsQuestions();
+        $form_filler_supervisor_config = new RequesterFieldConfig(
+            [ITILActorFieldStrategy::FORM_FILLER_SUPERVISOR]
+        );
+
+        // Need user to be logged in
+        $this->sendFormAndAssertTicketActors(
+            form: $form,
+            config: $form_filler_supervisor_config,
+            answers: [],
+            expected_actors_ids: []
+        );
+
+        // No supervisor set
+        $auth = $this->login();
+        $this->sendFormAndAssertTicketActors(
+            form: $form,
+            config: $form_filler_supervisor_config,
+            answers: [],
+            expected_actors_ids: []
+        );
+
+        // Supervisor set
+        $auth = $this->login($user->fields['name'], $user->fields['name']);
+        $this->sendFormAndAssertTicketActors(
+            form: $form,
+            config: $form_filler_supervisor_config,
+            answers: [],
+            expected_actors_ids: [$auth->getUser()->fields['users_id_supervisor']]
         );
     }
 
@@ -320,9 +370,9 @@ final class RequesterFieldTest extends DbTestCase
         );
     }
 
-    private function sendFormAndAssertTicketActors(
+    protected function sendFormAndAssertTicketActors(
         Form $form,
-        RequesterFieldConfig $config,
+        ITILActorFieldConfig $config,
         array $answers,
         array $expected_actors_ids,
     ): void {
@@ -376,6 +426,23 @@ final class RequesterFieldTest extends DbTestCase
             '',
             json_encode((new QuestionTypeActorsExtraDataConfig(true))->jsonSerialize())
         );
+        return $this->createForm($builder);
+    }
+
+    private function createAndGetFormWithItemQuestions(): Form
+    {
+        $builder = new FormBuilder();
+        $builder->addQuestion(
+            'Computer question',
+            QuestionTypeItem::class,
+            '',
+            json_encode((new QuestionTypeItemExtraDataConfig(Computer::class))->jsonSerialize())
+        );
+        $builder->addDestination(
+            FormDestinationTicket::class,
+            "My ticket",
+        );
+
         return $this->createForm($builder);
     }
 }

--- a/phpunit/src/Glpi/Form/Destination/CommonITILField/AbstractActorFieldTest.php
+++ b/phpunit/src/Glpi/Form/Destination/CommonITILField/AbstractActorFieldTest.php
@@ -1,5 +1,37 @@
 <?php
 
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
 namespace Glpi\PHPUnit\Tests\Glpi\Form\Destination\CommonITILField;
 
 use Computer;
@@ -49,12 +81,12 @@ abstract class AbstractActorFieldTest extends DbTestCase
             [
                 'name' => 'testUserActorsFromSpecificItemQuestions Computer 1',
                 'entities_id' => $this->getTestRootEntity(true),
-                '_users_id_tech' => [$users[0]->getID()]
+                'users_id_tech' => $users[0]->getID()
             ],
             [
                 'name' => 'testUserActorsFromSpecificItemQuestions Computer 2',
                 'entities_id' => $this->getTestRootEntity(true),
-                '_users_id' => [$users[1]->getID()]
+                'users_id' => $users[1]->getID()
             ],
         ]);
 
@@ -89,7 +121,7 @@ abstract class AbstractActorFieldTest extends DbTestCase
                     'items_id' => $computers[1]->getID(),
                 ]
             ],
-            expected_actors_ids: []
+            expected_actors_ids: [$users[1]->getID()]
         );
     }
 
@@ -114,12 +146,12 @@ abstract class AbstractActorFieldTest extends DbTestCase
             [
                 'name' => 'testTechUserActorsFromSpecificItemQuestions Computer 1',
                 'entities_id' => $this->getTestRootEntity(true),
-                '_users_id_tech' => [$users[0]->getID()]
+                'users_id_tech' => $users[0]->getID()
             ],
             [
                 'name' => 'testTechUserActorsFromSpecificItemQuestions Computer 2',
                 'entities_id' => $this->getTestRootEntity(true),
-                '_users_id' => [$users[1]->getID()]
+                'users_id' => $users[1]->getID()
             ],
         ]);
 
@@ -234,7 +266,7 @@ abstract class AbstractActorFieldTest extends DbTestCase
         $form = $this->createAndGetFormWithItemQuestions();
         $config = new $config_class(
             strategies: [ITILActorFieldStrategy::TECH_GROUP_FROM_OBJECT_ANSWER],
-            specific_question_ids: [$this->getQuestionId($form, "Computer question")]
+            specific_question_ids: [$this->getQuestionId($form, 'Computer question')]
         );
         $groups = $this->createItems(Group::class, [
             ['name' => 'testGroupActorsFromSpecificItemQuestions Group 1'],

--- a/phpunit/src/Glpi/Form/Destination/CommonITILField/AbstractActorFieldTest.php
+++ b/phpunit/src/Glpi/Form/Destination/CommonITILField/AbstractActorFieldTest.php
@@ -1,0 +1,307 @@
+<?php
+
+namespace Glpi\PHPUnit\Tests\Glpi\Form\Destination\CommonITILField;
+
+use Computer;
+use DbTestCase;
+use Glpi\Form\Destination\CommonITILField\ITILActorFieldConfig;
+use Glpi\Form\Destination\CommonITILField\ITILActorFieldStrategy;
+use Glpi\Form\Destination\FormDestinationTicket;
+use Glpi\Form\Form;
+use Glpi\Form\QuestionType\QuestionTypeItem;
+use Glpi\Form\QuestionType\QuestionTypeItemExtraDataConfig;
+use Glpi\Tests\FormBuilder;
+use Glpi\Tests\FormTesterTrait;
+use Group;
+use User;
+
+abstract class AbstractActorFieldTest extends DbTestCase
+{
+    use FormTesterTrait;
+
+    abstract protected function sendFormAndAssertTicketActors(
+        Form $form,
+        ITILActorFieldConfig $config,
+        array $answers,
+        array $expected_actors_ids
+    );
+
+    abstract public function getFieldClass(): string;
+
+    public function testUserActorsFromSpecificItemQuestions(): void
+    {
+        // Login is required to assign actors
+        $this->login();
+
+        $field_inst = new ($this->getFieldClass())();
+        $config_class = $field_inst->getConfigClass();
+
+        $form = $this->createAndGetFormWithItemQuestions();
+        $config = new $config_class(
+            strategies: [ITILActorFieldStrategy::USER_FROM_OBJECT_ANSWER],
+            specific_question_ids: [$this->getQuestionId($form, "Computer question")]
+        );
+        $users = $this->createItems(User::class, [
+            ['name' => 'testUserActorsFromSpecificItemQuestions User 1'],
+            ['name' => 'testUserActorsFromSpecificItemQuestions User 2'],
+        ]);
+        $computers = $this->createItems(Computer::class, [
+            [
+                'name' => 'testUserActorsFromSpecificItemQuestions Computer 1',
+                'entities_id' => $this->getTestRootEntity(true),
+                '_users_id_tech' => [$users[0]->getID()]
+            ],
+            [
+                'name' => 'testUserActorsFromSpecificItemQuestions Computer 2',
+                'entities_id' => $this->getTestRootEntity(true),
+                '_users_id' => [$users[1]->getID()]
+            ],
+        ]);
+
+        // No answers
+        $this->sendFormAndAssertTicketActors(
+            form: $form,
+            config: $config,
+            answers: [],
+            expected_actors_ids: []
+        );
+
+        // Answer with first computer
+        $this->sendFormAndAssertTicketActors(
+            form: $form,
+            config: $config,
+            answers: [
+                'Computer question' => [
+                    'itemtype' => Computer::class,
+                    'items_id' => $computers[0]->getID(),
+                ]
+            ],
+            expected_actors_ids: []
+        );
+
+        // Answer with second computer
+        $this->sendFormAndAssertTicketActors(
+            form: $form,
+            config: $config,
+            answers: [
+                'Computer question' => [
+                    'itemtype' => Computer::class,
+                    'items_id' => $computers[1]->getID(),
+                ]
+            ],
+            expected_actors_ids: []
+        );
+    }
+
+    public function testTechUserActorsFromSpecificItemQuestions(): void
+    {
+        // Login is required to assign actors
+        $this->login();
+
+        $field_inst = new ($this->getFieldClass())();
+        $config_class = $field_inst->getConfigClass();
+
+        $form = $this->createAndGetFormWithItemQuestions();
+        $config = new $config_class(
+            strategies: [ITILActorFieldStrategy::TECH_USER_FROM_OBJECT_ANSWER],
+            specific_question_ids: [$this->getQuestionId($form, "Computer question")]
+        );
+        $users = $this->createItems(User::class, [
+            ['name' => 'testTechUserActorsFromSpecificItemQuestions User 1'],
+            ['name' => 'testTechUserActorsFromSpecificItemQuestions User 2'],
+        ]);
+        $computers = $this->createItems(Computer::class, [
+            [
+                'name' => 'testTechUserActorsFromSpecificItemQuestions Computer 1',
+                'entities_id' => $this->getTestRootEntity(true),
+                '_users_id_tech' => [$users[0]->getID()]
+            ],
+            [
+                'name' => 'testTechUserActorsFromSpecificItemQuestions Computer 2',
+                'entities_id' => $this->getTestRootEntity(true),
+                '_users_id' => [$users[1]->getID()]
+            ],
+        ]);
+
+        // No answers
+        $this->sendFormAndAssertTicketActors(
+            form: $form,
+            config: $config,
+            answers: [],
+            expected_actors_ids: []
+        );
+
+        // Answer with first computer
+        $this->sendFormAndAssertTicketActors(
+            form: $form,
+            config: $config,
+            answers: [
+                'Computer question' => [
+                    'itemtype' => Computer::class,
+                    'items_id' => $computers[0]->getID(),
+                ]
+            ],
+            expected_actors_ids: [$users[0]->getID()]
+        );
+
+        // Answer with second computer
+        $this->sendFormAndAssertTicketActors(
+            form: $form,
+            config: $config,
+            answers: [
+                'Computer question' => [
+                    'itemtype' => Computer::class,
+                    'items_id' => $computers[1]->getID(),
+                ]
+            ],
+            expected_actors_ids: []
+        );
+    }
+
+    public function testGroupActorsFromSpecificItemQuestions(): void
+    {
+        // Login is required to assign actors
+        $this->login();
+
+        $field_inst = new ($this->getFieldClass())();
+        $config_class = $field_inst->getConfigClass();
+
+        $form = $this->createAndGetFormWithItemQuestions();
+        $config = new $config_class(
+            strategies: [ITILActorFieldStrategy::GROUP_FROM_OBJECT_ANSWER],
+            specific_question_ids: [$this->getQuestionId($form, "Computer question")]
+        );
+        $groups = $this->createItems(Group::class, [
+            ['name' => 'testGroupActorsFromSpecificItemQuestions Group 1'],
+            ['name' => 'testGroupActorsFromSpecificItemQuestions Group 2'],
+        ]);
+        $computers = $this->createItems(Computer::class, [
+            [
+                'name' => 'testGroupActorsFromSpecificItemQuestions Computer 1',
+                'entities_id' => $this->getTestRootEntity(true),
+                '_groups_id' => [$groups[0]->getID()]
+            ],
+            [
+                'name' => 'testGroupActorsFromSpecificItemQuestions Computer 2',
+                'entities_id' => $this->getTestRootEntity(true),
+                '_groups_id_tech' => [$groups[1]->getID()]
+            ],
+        ]);
+
+        // No answers
+        $this->sendFormAndAssertTicketActors(
+            form: $form,
+            config: $config,
+            answers: [],
+            expected_actors_ids: []
+        );
+
+        // Answer with first computer
+        $this->sendFormAndAssertTicketActors(
+            form: $form,
+            config: $config,
+            answers: [
+                'Computer question' => [
+                    'itemtype' => Computer::class,
+                    'items_id' => $computers[0]->getID(),
+                ]
+            ],
+            expected_actors_ids: [$groups[0]->getID()]
+        );
+
+        // Answer with second computer
+        $this->sendFormAndAssertTicketActors(
+            form: $form,
+            config: $config,
+            answers: [
+                'Computer question' => [
+                    'itemtype' => Computer::class,
+                    'items_id' => $computers[1]->getID(),
+                ]
+            ],
+            expected_actors_ids: []
+        );
+    }
+
+    public function testTechGroupActorsFromSpecificItemQuestions(): void
+    {
+        // Login is required to assign actors
+        $this->login();
+
+        $field_inst = new ($this->getFieldClass())();
+        $config_class = $field_inst->getConfigClass();
+
+        $form = $this->createAndGetFormWithItemQuestions();
+        $config = new $config_class(
+            strategies: [ITILActorFieldStrategy::TECH_GROUP_FROM_OBJECT_ANSWER],
+            specific_question_ids: [$this->getQuestionId($form, "Computer question")]
+        );
+        $groups = $this->createItems(Group::class, [
+            ['name' => 'testGroupActorsFromSpecificItemQuestions Group 1'],
+            ['name' => 'testGroupActorsFromSpecificItemQuestions Group 2'],
+        ]);
+        $computers = $this->createItems(Computer::class, [
+            [
+                'name' => 'testGroupActorsFromSpecificItemQuestions Computer 1',
+                'entities_id' => $this->getTestRootEntity(true),
+                '_groups_id' => [$groups[0]->getID()]
+            ],
+            [
+                'name' => 'testGroupActorsFromSpecificItemQuestions Computer 2',
+                'entities_id' => $this->getTestRootEntity(true),
+                '_groups_id_tech' => [$groups[1]->getID()]
+            ],
+        ]);
+
+        // No answers
+        $this->sendFormAndAssertTicketActors(
+            form: $form,
+            config: $config,
+            answers: [],
+            expected_actors_ids: []
+        );
+
+        // Answer with first computer
+        $this->sendFormAndAssertTicketActors(
+            form: $form,
+            config: $config,
+            answers: [
+                'Computer question' => [
+                    'itemtype' => Computer::class,
+                    'items_id' => $computers[0]->getID(),
+                ]
+            ],
+            expected_actors_ids: []
+        );
+
+        // Answer with second computer
+        $this->sendFormAndAssertTicketActors(
+            form: $form,
+            config: $config,
+            answers: [
+                'Computer question' => [
+                    'itemtype' => Computer::class,
+                    'items_id' => $computers[1]->getID(),
+                ]
+            ],
+            expected_actors_ids: [$groups[1]->getID()]
+        );
+    }
+
+    private function createAndGetFormWithItemQuestions(): Form
+    {
+        $builder = new FormBuilder();
+        $builder->addQuestion(
+            'Computer question',
+            QuestionTypeItem::class,
+            '',
+            json_encode((new QuestionTypeItemExtraDataConfig(Computer::class))->jsonSerialize())
+        );
+        $builder->addDestination(
+            FormDestinationTicket::class,
+            "My ticket",
+        );
+
+        return $this->createForm($builder);
+    }
+}

--- a/src/Glpi/Form/Destination/CommonITILField/ITILActorField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ITILActorField.php
@@ -99,8 +99,12 @@ abstract class ITILActorField extends AbstractConfigField
                 'possible_values' => $this->getITILActorQuestionsValuesForDropdown($form),
             ],
 
-            // Specific additional config for USER_FROM_OBJECT_ANSWER and GROUP_FROM_OBJECT_ANSWER strategy
-            'group_object_answer_extra_field' => [
+            // Specific additional config for the following strategies:
+            // - USER_FROM_OBJECT_ANSWER
+            // - TECH_USER_OBJECT_ANSWER
+            // - GROUP_FROM_OBJECT_ANSWER
+            // - TECH_GROUP_OBJECT_ANSWER
+            'object_answer_extra_field' => [
                 'aria_label'      => __("Select questions..."),
                 'values'          => $config->getSpecificQuestionIds() ?? [],
                 'input_name'      => $input_name . "[" . ITILActorFieldConfig::SPECIFIC_QUESTION_IDS . "]",

--- a/src/Glpi/Form/Destination/CommonITILField/ITILActorFieldStrategy.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ITILActorFieldStrategy.php
@@ -271,8 +271,13 @@ enum ITILActorFieldStrategy: string
             return null;
         }
 
+        $actors_ids = $item->fields[$fk_field];
+        if (!is_array($actors_ids)) {
+            $actors_ids = [$actors_ids];
+        }
+
         return [
-            getItemtypeForForeignKeyField(str_replace('_tech', '', $fk_field)) => [(int) $item->fields[$fk_field]],
+            getItemtypeForForeignKeyField(str_replace('_tech', '', $fk_field)) => $actors_ids,
         ];
     }
 }

--- a/templates/pages/admin/form/itil_config_fields/itilactor.html.twig
+++ b/templates/pages/admin/form/itil_config_fields/itilactor.html.twig
@@ -70,12 +70,43 @@
         specific_answer_extra_field.possible_values,
         "",
         options|merge({
+            rand: random(),
             field_class: '',
             no_label: true,
             multiple: true,
             values: specific_answer_extra_field.values,
             aria_label: specific_answer_extra_field.aria_label,
             mb: '',
+            rand: random(),
         })
     ) }}
 </div>
+
+{% set group_object_strategies = [
+    CONFIG_SPECIFIC_USER_OBJECT_ANSWER,
+    CONFIG_SPECIFIC_TECH_USER_OBJECT_ANSWER,
+    CONFIG_SPECIFIC_GROUP_OBJECT_ANSWER,
+    CONFIG_SPECIFIC_TECH_GROUP_OBJECT_ANSWER
+] %}
+{% for strategy in group_object_strategies %}
+    <div
+        class="d-none"
+        data-glpi-itildestination-field-config-display-condition="{{ strategy }}"
+    >
+        {{ fields.dropdownArrayField(
+            group_object_answer_extra_field.input_name,
+            '',
+            group_object_answer_extra_field.possible_values,
+            "",
+            options|merge({
+                rand: random(),
+                field_class: '',
+                no_label: true,
+                multiple: true,
+                values: group_object_answer_extra_field.values,
+                aria_label: group_object_answer_extra_field.aria_label,
+                mb: '',
+            })
+        ) }}
+    </div>
+{% endfor %}

--- a/templates/pages/admin/form/itil_config_fields/itilactor.html.twig
+++ b/templates/pages/admin/form/itil_config_fields/itilactor.html.twig
@@ -93,17 +93,17 @@
         data-glpi-itildestination-field-config-display-condition="{{ strategy }}"
     >
         {{ fields.dropdownArrayField(
-            group_object_answer_extra_field.input_name,
+            object_answer_extra_field.input_name,
             '',
-            group_object_answer_extra_field.possible_values,
+            object_answer_extra_field.possible_values,
             "",
             options|merge({
                 rand: random(),
                 field_class: '',
                 no_label: true,
                 multiple: true,
-                values: group_object_answer_extra_field.values,
-                aria_label: group_object_answer_extra_field.aria_label,
+                values: object_answer_extra_field.values,
+                aria_label: object_answer_extra_field.aria_label,
                 mb: '',
             })
         ) }}

--- a/templates/pages/admin/form/itil_config_fields/itilactor.html.twig
+++ b/templates/pages/admin/form/itil_config_fields/itilactor.html.twig
@@ -77,7 +77,6 @@
             values: specific_answer_extra_field.values,
             aria_label: specific_answer_extra_field.aria_label,
             mb: '',
-            rand: random(),
         })
     ) }}
 </div>

--- a/tests/cypress/e2e/form/destination_config_fields/actors.cy.js
+++ b/tests/cypress/e2e/form/destination_config_fields/actors.cy.js
@@ -1,0 +1,197 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+const actorTypes = [
+    {
+        name: 'Requester',
+        type: 'requester',
+        dataAttr: 'requester',
+        defaultValue: 'User who filled the form'
+    },
+    {
+        name: 'Assignee',
+        type: 'assignee',
+        dataAttr: 'assign',
+        defaultValue: 'From template'
+    },
+    {
+        name: 'Observer',
+        type: 'observer',
+        dataAttr: 'observer',
+        defaultValue: 'From template'
+    }
+];
+
+describe('Actors configuration', () => {
+    actorTypes.forEach((actorConfig) => {
+        describe(`${actorConfig.name} configuration`, () => {
+            beforeEach(() => {
+                cy.login();
+                cy.changeProfile('Super-Admin', true);
+
+                cy.createFormWithAPI().as('form_id').visitFormTab('Form');
+
+                // Create actor, group and computer test data
+                cy.get('@form_id').then((form_id) => {
+                    const actor_name = `Test ${actorConfig.name} - ${form_id}`;
+                    const userParams = {
+                        name: actor_name,
+                    };
+
+                    // Add technician profile for assignees
+                    if (actorConfig.type === 'assignee') {
+                        userParams._profiles_id = 6;
+                    }
+
+                    cy.createWithAPI('User', userParams).as('actor_id');
+
+                    // Create a Group
+                    cy.createWithAPI('Group', {
+                        name: `Test Group - ${form_id}`,
+                    }).as('group_id');
+
+                    // Create a Computer with users and groups
+                    cy.get('@group_id').then((group_id) => {
+                        cy.createWithAPI('Computer', {
+                            name: `Test Computer - ${form_id}`,
+                            users_id: 7,
+                            users_id_tech: 7,
+                            groups_id: group_id,
+                            groups_id_tech: group_id,
+                        }).as('computer_id');
+                    });
+
+                    // Create actor question
+                    cy.findByRole('button', {'name': "Add a new question"}).click();
+                    cy.focused().type(`My ${actorConfig.name} question`);
+                    cy.getDropdownByLabelText('Question type').selectDropdownValue('Actors');
+                    cy.getDropdownByLabelText('Question sub type').selectDropdownValue(`${actorConfig.name}s`);
+                    cy.getDropdownByLabelText("Select an actor...").selectDropdownValue(actor_name);
+                    cy.findByRole('button', {'name': 'Save'}).click();
+                    cy.checkAndCloseAlert('Item successfully updated');
+
+                    // Create computer question
+                    cy.findByRole('button', {'name': "Add a new question"}).click();
+                    cy.focused().type("My Computer question");
+                    cy.getDropdownByLabelText('Question type').selectDropdownValue('Item');
+                    cy.getDropdownByLabelText('Question sub type').selectDropdownValue('GLPI Objects');
+                    cy.getDropdownByLabelText("Select an itemtype").selectDropdownValue('Computers');
+                    cy.findByRole('button', {'name': 'Save'}).click();
+
+                    // Go to destination tab and add ticket
+                    cy.findByRole('tab', { 'name': "Items to create" }).click();
+                    cy.findByRole('button', { 'name': "Add ticket" }).click();
+                    cy.checkAndCloseAlert('Item successfully added');
+                });
+            });
+
+            it('can use all possibles configuration options', () => {
+                const regionName = `${actorConfig.name}s configuration`;
+                const dropdownLabel = `${actorConfig.name}s`;
+
+                cy.findByRole('region', { 'name': regionName }).as("config");
+                cy.get('@config').getDropdownByLabelText(dropdownLabel).as("dropdown");
+
+                // Test default value
+                cy.get('@dropdown').should('have.text', actorConfig.defaultValue);
+
+                // Test hidden dropdowns
+                cy.get('@config').getDropdownByLabelText('Select actors...').should('not.exist');
+                cy.get('@config').getDropdownByLabelText('Select questions...').should('not.exist');
+
+                // Test common options
+                const commonOptions = [
+                    'From template',
+                    'User who filled the form',
+                    'Specific actors',
+                    'Answer from specific questions',
+                    `Answer to last "${actorConfig.name}s" question`,
+                    'User from GLPI object answer',
+                    'Tech user from GLPI object answer',
+                    'Group from GLPI object answer',
+                    'Tech group from GLPI object answer',
+                    'Supervisor of the user who filled the form'
+                ];
+
+                // Test each option
+                commonOptions.forEach((option) => {
+                    cy.get('@dropdown').selectDropdownValue(option);
+
+                    // Handle specific cases that need additional input
+                    if (option === 'Specific actors') {
+                        cy.get('@config').getDropdownByLabelText('Select actors...').as('specific_dropdown');
+                        cy.get('@form_id').then((form_id) => {
+                            const actor_name = `Test ${actorConfig.name} - ${form_id}`;
+                            cy.get('@specific_dropdown').selectDropdownValue(actor_name);
+                        });
+                    } else if (option === 'Answer from specific questions') {
+                        cy.get('@config').getDropdownByLabelText('Select questions...').as('question_dropdown');
+                        cy.get('@question_dropdown').selectDropdownValue(`My ${actorConfig.name} question`);
+                    } else if (option.includes('from GLPI object answer')) {
+                        cy.get('@config').getDropdownByLabelText('Select questions...').as('object_dropdown');
+                        cy.get('@object_dropdown').selectDropdownValue('My Computer question');
+                    }
+
+                    cy.findByRole('button', { 'name': 'Update item' }).click();
+                    cy.checkAndCloseAlert('Item successfully updated');
+                    cy.get('@dropdown').should('have.text', option);
+                });
+            });
+
+            it('can create ticket using default configuration', () => {
+                const regionName = `${actorConfig.name}s configuration`;
+                const dropdownLabel = `${actorConfig.name}s`;
+
+                cy.findByRole('region', { 'name': regionName }).as("config");
+                cy.get('@config').getDropdownByLabelText(dropdownLabel).as("dropdown");
+
+                // Set to "User who filled the form"
+                cy.get('@dropdown').selectDropdownValue('User who filled the form');
+                cy.findByRole('button', { 'name': 'Update item' }).click();
+                cy.checkAndCloseAlert('Item successfully updated');
+
+                // Preview and submit form
+                cy.findByRole('tab', { 'name': "Form" }).click();
+                cy.findByRole('link', { 'name': "Preview" })
+                    .invoke('removeAttr', 'target')
+                    .click();
+                cy.findByRole('button', { 'name': 'Send form' }).click();
+                cy.findByRole('link', { 'name': 'My test form' }).click();
+
+                // Verify actor in ticket
+                cy.findByRole('region', { 'name': "Actors" }).within(() => {
+                    cy.get(`select[data-actor-type="${actorConfig.dataAttr}"]`).contains('E2E Tests');
+                });
+            });
+        });
+    });
+});

--- a/tests/cypress/e2e/form/destination_config_fields/actors.cy.js
+++ b/tests/cypress/e2e/form/destination_config_fields/actors.cy.js
@@ -107,10 +107,8 @@ describe('Actors configuration', () => {
                     cy.getDropdownByLabelText("Select an itemtype").selectDropdownValue('Computers');
                     cy.findByRole('button', {'name': 'Save'}).click();
 
-                    // Go to destination tab and add ticket
-                    cy.findByRole('tab', { 'name': "Items to create" }).click();
-                    cy.findByRole('button', { 'name': "Add ticket" }).click();
-                    cy.checkAndCloseAlert('Item successfully added');
+                    // Go to destination tab
+                    cy.findByRole('tab', { 'name': "Items to create 1" }).click();
                 });
             });
 

--- a/tests/cypress/e2e/form/destination_config_fields/assignee.cy.js
+++ b/tests/cypress/e2e/form/destination_config_fields/assignee.cy.js
@@ -46,6 +46,22 @@ describe('Assignee configuration', () => {
                 _profiles_id: 6, // Technician
             }).as('assignee_id');
 
+            // Create a Group
+            cy.createWithAPI('Group', {
+                name: `Test Group - ${form_id}`,
+            }).as('group_id');
+
+            // Create a Computer with users_id, users_id_tech, groups_id and groups_id_tech
+            cy.get('@group_id').then((group_id) => {
+                cy.createWithAPI('Computer', {
+                    name: `Test Computer - ${form_id}`,
+                    users_id: 7, // E2E Tests user
+                    users_id_tech: 7, // E2E Tests user
+                    groups_id: group_id,
+                    groups_id_tech: group_id,
+                }).as('computer_id');
+            });
+
             cy.findByRole('button', {'name': "Add a new question"}).click();
             cy.focused().type("My Assignee question");
             cy.getDropdownByLabelText('Question type').selectDropdownValue('Actors');
@@ -53,6 +69,15 @@ describe('Assignee configuration', () => {
             cy.getDropdownByLabelText("Select an actor...").selectDropdownValue(assignee_name);
             cy.findByRole('button', {'name': 'Save'}).click();
             cy.checkAndCloseAlert('Item successfully updated');
+
+            cy.findByRole('button', {'name': "Add a new question"}).click();
+            cy.focused().type("My Computer question");
+            cy.getDropdownByLabelText('Question type').selectDropdownValue('Item');
+            cy.getDropdownByLabelText('Question sub type').selectDropdownValue('GLPI Objects');
+            cy.getDropdownByLabelText("Select an itemtype").selectDropdownValue('Computers');
+
+            // Save form
+            cy.findByRole('button', {'name': 'Save'}).click();
 
             // Go to destination tab
             cy.findByRole('tab', { 'name': "Items to create 1" }).click();
@@ -116,6 +141,49 @@ describe('Assignee configuration', () => {
         cy.findByRole('button', { 'name': 'Update item' }).click();
         cy.checkAndCloseAlert('Item successfully updated');
         cy.get('@assignees_dropdown').should('have.text', 'Answer to last "Assignees" question');
+
+        // Switch to "Supervisor of the user who filled the form"
+        cy.get('@assignees_dropdown').selectDropdownValue('Supervisor of the user who filled the form');
+        cy.findByRole('button', { 'name': 'Update item' }).click();
+        cy.checkAndCloseAlert('Item successfully updated');
+        cy.get('@assignees_dropdown').should('have.text', 'Supervisor of the user who filled the form');
+
+        // Switch to "User from GLPI object answer"
+        cy.get('@assignees_dropdown').selectDropdownValue('User from GLPI object answer');
+        cy.get('@config').getDropdownByLabelText('Select questions...').as('user_object_answer_dropdown');
+        cy.get('@user_object_answer_dropdown').selectDropdownValue('My Computer question');
+
+        cy.findByRole('button', { 'name': 'Update item' }).click();
+        cy.checkAndCloseAlert('Item successfully updated');
+        cy.get('@assignees_dropdown').should('have.text', 'User from GLPI object answer');
+        cy.get('@user_object_answer_dropdown').should('have.text', '×My Computer question');
+
+        // Switch to "Tech user from GLPI object answer"
+        cy.get('@assignees_dropdown').selectDropdownValue('Tech user from GLPI object answer');
+        cy.get('@config').getDropdownByLabelText('Select questions...').as('tech_user_object_answer_dropdown');
+
+        cy.findByRole('button', { 'name': 'Update item' }).click();
+        cy.checkAndCloseAlert('Item successfully updated');
+        cy.get('@assignees_dropdown').should('have.text', 'Tech user from GLPI object answer');
+        cy.get('@tech_user_object_answer_dropdown').should('have.text', '×My Computer question');
+
+        // Switch to "Group from GLPI object answer"
+        cy.get('@assignees_dropdown').selectDropdownValue('Group from GLPI object answer');
+        cy.get('@config').getDropdownByLabelText('Select questions...').as('group_object_answer_dropdown');
+
+        cy.findByRole('button', { 'name': 'Update item' }).click();
+        cy.checkAndCloseAlert('Item successfully updated');
+        cy.get('@assignees_dropdown').should('have.text', 'Group from GLPI object answer');
+        cy.get('@group_object_answer_dropdown').should('have.text', '×My Computer question');
+
+        // Switch to "Tech group from GLPI object answer"
+        cy.get('@assignees_dropdown').selectDropdownValue('Tech group from GLPI object answer');
+        cy.get('@config').getDropdownByLabelText('Select questions...').as('tech_group_object_answer_dropdown');
+
+        cy.findByRole('button', { 'name': 'Update item' }).click();
+        cy.checkAndCloseAlert('Item successfully updated');
+        cy.get('@assignees_dropdown').should('have.text', 'Tech group from GLPI object answer');
+        cy.get('@tech_group_object_answer_dropdown').should('have.text', '×My Computer question');
     });
 
     it('can create ticket using default configuration', () => {

--- a/tests/cypress/e2e/form/destination_config_fields/observer.cy.js
+++ b/tests/cypress/e2e/form/destination_config_fields/observer.cy.js
@@ -45,6 +45,22 @@ describe('Observer configuration', () => {
                 name: observer_name,
             }).as('observer_id');
 
+            // Create a Group
+            cy.createWithAPI('Group', {
+                name: `Test Group - ${form_id}`,
+            }).as('group_id');
+
+            // Create a Computer with users_id, users_id_tech, groups_id and groups_id_tech
+            cy.get('@group_id').then((group_id) => {
+                cy.createWithAPI('Computer', {
+                    name: `Test Computer - ${form_id}`,
+                    users_id: 7, // E2E Tests user
+                    users_id_tech: 7, // E2E Tests user
+                    groups_id: group_id,
+                    groups_id_tech: group_id,
+                }).as('computer_id');
+            });
+
             cy.findByRole('button', {'name': "Add a new question"}).click();
             cy.focused().type("My Observer question");
             cy.getDropdownByLabelText('Question type').selectDropdownValue('Actors');
@@ -52,6 +68,15 @@ describe('Observer configuration', () => {
             cy.getDropdownByLabelText("Select an actor...").selectDropdownValue(observer_name);
             cy.findByRole('button', {'name': 'Save'}).click();
             cy.checkAndCloseAlert('Item successfully updated');
+
+            cy.findByRole('button', {'name': "Add a new question"}).click();
+            cy.focused().type("My Computer question");
+            cy.getDropdownByLabelText('Question type').selectDropdownValue('Item');
+            cy.getDropdownByLabelText('Question sub type').selectDropdownValue('GLPI Objects');
+            cy.getDropdownByLabelText("Select an itemtype").selectDropdownValue('Computers');
+
+            // Save form
+            cy.findByRole('button', {'name': 'Save'}).click();
 
             // Go to destination tab
             cy.findByRole('tab', { 'name': "Items to create 1" }).click();
@@ -115,6 +140,43 @@ describe('Observer configuration', () => {
         cy.findByRole('button', { 'name': 'Update item' }).click();
         cy.checkAndCloseAlert('Item successfully updated');
         cy.get('@observers_dropdown').should('have.text', 'Answer to last "Observers" question');
+
+        // Switch to "User from GLPI object answer"
+        cy.get('@observers_dropdown').selectDropdownValue('User from GLPI object answer');
+        cy.get('@config').getDropdownByLabelText('Select questions...').as('user_object_answer_dropdown');
+        cy.get('@user_object_answer_dropdown').selectDropdownValue('My Computer question');
+
+        cy.findByRole('button', { 'name': 'Update item' }).click();
+        cy.checkAndCloseAlert('Item successfully updated');
+        cy.get('@observers_dropdown').should('have.text', 'User from GLPI object answer');
+        cy.get('@user_object_answer_dropdown').should('have.text', '×My Computer question');
+
+        // Switch to "Tech user from GLPI object answer"
+        cy.get('@observers_dropdown').selectDropdownValue('Tech user from GLPI object answer');
+        cy.get('@config').getDropdownByLabelText('Select questions...').as('tech_user_object_answer_dropdown');
+
+        cy.findByRole('button', { 'name': 'Update item' }).click();
+        cy.checkAndCloseAlert('Item successfully updated');
+        cy.get('@observers_dropdown').should('have.text', 'Tech user from GLPI object answer');
+        cy.get('@tech_user_object_answer_dropdown').should('have.text', '×My Computer question');
+
+        // Switch to "Group from GLPI object answer"
+        cy.get('@observers_dropdown').selectDropdownValue('Group from GLPI object answer');
+        cy.get('@config').getDropdownByLabelText('Select questions...').as('group_object_answer_dropdown');
+
+        cy.findByRole('button', { 'name': 'Update item' }).click();
+        cy.checkAndCloseAlert('Item successfully updated');
+        cy.get('@observers_dropdown').should('have.text', 'Group from GLPI object answer');
+        cy.get('@group_object_answer_dropdown').should('have.text', '×My Computer question');
+
+        // Switch to "Tech group from GLPI object answer"
+        cy.get('@observers_dropdown').selectDropdownValue('Tech group from GLPI object answer');
+        cy.get('@config').getDropdownByLabelText('Select questions...').as('tech_group_object_answer_dropdown');
+
+        cy.findByRole('button', { 'name': 'Update item' }).click();
+        cy.checkAndCloseAlert('Item successfully updated');
+        cy.get('@observers_dropdown').should('have.text', 'Tech group from GLPI object answer');
+        cy.get('@tech_group_object_answer_dropdown').should('have.text', '×My Computer question');
     });
 
     it('can create ticket using default configuration', () => {

--- a/tests/cypress/e2e/form/destination_config_fields/requester.cy.js
+++ b/tests/cypress/e2e/form/destination_config_fields/requester.cy.js
@@ -50,6 +50,30 @@ describe('Requester configuration', () => {
             cy.getDropdownByLabelText('Question type').selectDropdownValue('Actors');
             cy.getDropdownByLabelText('Question sub type').selectDropdownValue('Requesters');
             cy.getDropdownByLabelText("Select an actor...").selectDropdownValue(requester_name);
+
+            // Create a Group
+            cy.createWithAPI('Group', {
+                name: `Test Group - ${form_id}`,
+            }).as('group_id');
+
+            // Create a Computer with users_id, users_id_tech, groups_id and groups_id_tech
+            cy.get('@group_id').then((group_id) => {
+                cy.createWithAPI('Computer', {
+                    name: `Test Computer - ${form_id}`,
+                    users_id: 7, // E2E Tests user
+                    users_id_tech: 7, // E2E Tests user
+                    groups_id: group_id,
+                    groups_id_tech: group_id,
+                }).as('computer_id');
+            });
+
+            cy.findByRole('button', {'name': "Add a new question"}).click();
+            cy.focused().type("My Computer question");
+            cy.getDropdownByLabelText('Question type').selectDropdownValue('Item');
+            cy.getDropdownByLabelText('Question sub type').selectDropdownValue('GLPI Objects');
+            cy.getDropdownByLabelText("Select an itemtype").selectDropdownValue('Computers');
+
+            // Save form
             cy.findByRole('button', {'name': 'Save'}).click();
             cy.checkAndCloseAlert('Item successfully updated');
 
@@ -84,6 +108,12 @@ describe('Requester configuration', () => {
         cy.checkAndCloseAlert('Item successfully updated');
         cy.get('@requesters_dropdown').should('have.text', 'User who filled the form');
 
+        // Switch to "Supervisor of the user who filled the form"
+        cy.get('@requesters_dropdown').selectDropdownValue('Supervisor of the user who filled the form');
+        cy.findByRole('button', { 'name': 'Update item' }).click();
+        cy.checkAndCloseAlert('Item successfully updated');
+        cy.get('@requesters_dropdown').should('have.text', 'Supervisor of the user who filled the form');
+
         // Switch to "Specific actors"
         cy.get('@requesters_dropdown').selectDropdownValue('Specific actors');
         cy.get('@config').getDropdownByLabelText('Select actors...').as('specific_requesters_dropdown');
@@ -115,6 +145,43 @@ describe('Requester configuration', () => {
         cy.findByRole('button', { 'name': 'Update item' }).click();
         cy.checkAndCloseAlert('Item successfully updated');
         cy.get('@requesters_dropdown').should('have.text', 'Answer to last "Requesters" question');
+
+        // Switch to "User from GLPI object answer"
+        cy.get('@requesters_dropdown').selectDropdownValue('User from GLPI object answer');
+        cy.get('@config').getDropdownByLabelText('Select questions...').as('user_object_answer_dropdown');
+        cy.get('@user_object_answer_dropdown').selectDropdownValue('My Computer question');
+
+        cy.findByRole('button', { 'name': 'Update item' }).click();
+        cy.checkAndCloseAlert('Item successfully updated');
+        cy.get('@requesters_dropdown').should('have.text', 'User from GLPI object answer');
+        cy.get('@user_object_answer_dropdown').should('have.text', '×My Computer question');
+
+        // Switch to "Tech user from GLPI object answer"
+        cy.get('@requesters_dropdown').selectDropdownValue('Tech user from GLPI object answer');
+        cy.get('@config').getDropdownByLabelText('Select questions...').as('tech_user_object_answer_dropdown');
+
+        cy.findByRole('button', { 'name': 'Update item' }).click();
+        cy.checkAndCloseAlert('Item successfully updated');
+        cy.get('@requesters_dropdown').should('have.text', 'Tech user from GLPI object answer');
+        cy.get('@tech_user_object_answer_dropdown').should('have.text', '×My Computer question');
+
+        // Switch to "Group from GLPI object answer"
+        cy.get('@requesters_dropdown').selectDropdownValue('Group from GLPI object answer');
+        cy.get('@config').getDropdownByLabelText('Select questions...').as('group_object_answer_dropdown');
+
+        cy.findByRole('button', { 'name': 'Update item' }).click();
+        cy.checkAndCloseAlert('Item successfully updated');
+        cy.get('@requesters_dropdown').should('have.text', 'Group from GLPI object answer');
+        cy.get('@group_object_answer_dropdown').should('have.text', '×My Computer question');
+
+        // Switch to "Tech group from GLPI object answer"
+        cy.get('@requesters_dropdown').selectDropdownValue('Tech group from GLPI object answer');
+        cy.get('@config').getDropdownByLabelText('Select questions...').as('tech_group_object_answer_dropdown');
+
+        cy.findByRole('button', { 'name': 'Update item' }).click();
+        cy.checkAndCloseAlert('Item successfully updated');
+        cy.get('@requesters_dropdown').should('have.text', 'Tech group from GLPI object answer');
+        cy.get('@tech_group_object_answer_dropdown').should('have.text', '×My Computer question');
     });
 
     it('can create ticket using default configuration', () => {


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] This change requires a documentation update.

## Description

Des stratégies implémentés dans FormCreator sont manquantes.
Ajout des stratégies : 
- Supervisor of the user who filled the form
- User from GLPI object answer
- Tech user from GLPI object answer
- Group from GLPI object answer
- Tech group from GLPI object answer

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/7e56932c-8978-48dd-ad24-7b7b19ae10aa)
![image](https://github.com/user-attachments/assets/2720e028-4b8c-4be7-9dab-4a5b9915e970)