### PR TITLE
Auto resize dashboard selector

### DIFF
--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -1288,19 +1288,19 @@ class GLPIDashboard {
         const select = document.querySelector(this.elem_id+' .dashboard_select');
 
         select.addEventListener('change', (event) => {
-           let tempSelect = document.createElement('select'),
-               tempOption = document.createElement('option');
-           tempOption.textContent = event.target.options[event.target.selectedIndex].text;
-           tempSelect.style.cssText += `
+            let tempSelect = document.createElement('select'),
+                tempOption = document.createElement('option');
+            tempOption.textContent = event.target.options[event.target.selectedIndex].text;
+            tempSelect.style.cssText += `
               visibility: hidden;
               position: fixed;
            `;
-           tempSelect.appendChild(tempOption);
-           event.target.after(tempSelect);
+            tempSelect.appendChild(tempOption);
+            event.target.after(tempSelect);
           
-           const tempSelectWidth = tempSelect.getBoundingClientRect().width;
-           event.target.style.width = `${tempSelectWidth}px`;
-           tempSelect.remove();
+            const tempSelectWidth = tempSelect.getBoundingClientRect().width;
+            event.target.style.width = `${tempSelectWidth}px`;
+            tempSelect.remove();
         });
         
         select.dispatchEvent(new Event('change'));

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -138,6 +138,9 @@ class GLPIDashboard {
         // generate the css based on the grid width
         this.generateCss();
 
+        // set the width of the select box to match the selected option
+        this.resizeSelect();
+
         // init filters from storage
         this.initFilters();
         this.refreshDashboard();
@@ -1276,5 +1279,30 @@ class GLPIDashboard {
                 }),
             }
         });
+    }
+
+    /**
+    * Set the width of the select box to match the selected option
+    */
+    resizeSelect() {
+        const select = document.querySelector(this.elem_id+' .dashboard_select');
+
+        select.addEventListener('change', (event) => {
+           let tempSelect = document.createElement('select'),
+               tempOption = document.createElement('option');
+           tempOption.textContent = event.target.options[event.target.selectedIndex].text;
+           tempSelect.style.cssText += `
+              visibility: hidden;
+              position: fixed;
+           `;
+           tempSelect.appendChild(tempOption);
+           event.target.after(tempSelect);
+          
+           const tempSelectWidth = tempSelect.getBoundingClientRect().width;
+           event.target.style.width = `${tempSelectWidth}px`;
+           tempSelect.remove();
+        });
+        
+        select.dispatchEvent(new Event('change'));
     }
 }

--- a/src/Dashboard/Grid.php
+++ b/src/Dashboard/Grid.php
@@ -431,6 +431,28 @@ HTML;
       $(function () {
          new GLPIDashboard({$js_params})
       });
+
+     // Set the width of the select box to match the selected option
+      const select = document.querySelector('.dashboard .toolbar select.dashboard_select');
+
+      select.addEventListener('change', (event) => {
+         let tempSelect = document.createElement('select'),
+             tempOption = document.createElement('option');
+
+         tempOption.textContent = event.target.options[event.target.selectedIndex].text;
+         tempSelect.style.cssText += `
+            visibility: hidden;
+            position: fixed;
+         `;
+         tempSelect.appendChild(tempOption);
+         event.target.after(tempSelect);
+        
+         const tempSelectWidth = tempSelect.getBoundingClientRect().width;
+         event.target.style.width = `\${tempSelectWidth}px`;
+         tempSelect.remove();
+      });
+
+      select.dispatchEvent(new Event('change'));
 JAVASCRIPT;
         $js = Html::scriptBlock($js);
 

--- a/src/Dashboard/Grid.php
+++ b/src/Dashboard/Grid.php
@@ -431,28 +431,6 @@ HTML;
       $(function () {
          new GLPIDashboard({$js_params})
       });
-
-     // Set the width of the select box to match the selected option
-      const select = document.querySelector('.dashboard .toolbar select.dashboard_select');
-
-      select.addEventListener('change', (event) => {
-         let tempSelect = document.createElement('select'),
-             tempOption = document.createElement('option');
-
-         tempOption.textContent = event.target.options[event.target.selectedIndex].text;
-         tempSelect.style.cssText += `
-            visibility: hidden;
-            position: fixed;
-         `;
-         tempSelect.appendChild(tempOption);
-         event.target.after(tempSelect);
-        
-         const tempSelectWidth = tempSelect.getBoundingClientRect().width;
-         event.target.style.width = `\${tempSelectWidth}px`;
-         tempSelect.remove();
-      });
-
-      select.dispatchEvent(new Event('change'));
 JAVASCRIPT;
         $js = Html::scriptBlock($js);
 


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Depending on the Dashboard width it overlaps the select dropdown arrow.

Before this PR:

<img width="122" alt="SCR-20250129-lxrj" src="https://github.com/user-attachments/assets/3b2884d7-dfdd-46e2-8908-f3b0c237ad5a" />

After this PR, the select width is based on selected option width, respecting "min-width" CSS attribute:

![image](https://github.com/user-attachments/assets/69ac5d40-0169-4786-b2ac-2bf5f29c2796)

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does

## Screenshots (if appropriate):


