### PR TITLE
Standardize "Informations" plural

### DIFF
--- a/js/glpi_dialog.js
+++ b/js/glpi_dialog.js
@@ -251,7 +251,7 @@ var glpi_ajax_dialog = function({
  * @param {function} alert.ok_callback - callback function called when "ok" button called
  */
 var glpi_alert = function({
-    title    = _n('Information', 'Information', 1),
+    title    = _n('Information', 'Informations', 1),
     message  = "",
     id       = "modal_" + Math.random().toString(36).substring(7),
     ok_callback = () => {},

--- a/js/misc.js
+++ b/js/misc.js
@@ -42,7 +42,7 @@ window.alert = function(message, caption) {
     if(typeof message == 'string') {
         message = message.replace("\n", '<br>');
     }
-    caption = caption || _n('Information', 'Information', 1);
+    caption = caption || _n('Information', 'Informations', 1);
 
     glpi_alert({
         title: caption,

--- a/src/CommonITILRecurrent.php
+++ b/src/CommonITILRecurrent.php
@@ -105,7 +105,7 @@ abstract class CommonITILRecurrent extends CommonDropdown
        // Tabs on CommonITILRecurrent items
         if ($item instanceof self) {
             $ong = [];
-            $ong[1] = _n('Information', 'Information', Session::getPluralNumber());
+            $ong[1] = _n('Information', 'Informations', Session::getPluralNumber());
             return $ong;
         }
 

--- a/src/Html.php
+++ b/src/Html.php
@@ -6002,7 +6002,7 @@ HTML;
          if(typeof message == 'string') {
             message = message.replace('\\n', '<br>');
          }
-         caption = caption || '" . _sn('Information', 'Information', 1) . "';
+         caption = caption || '" . _sn('Information', 'Informations', 1) . "';
 
          glpi_alert({
             title: caption,

--- a/src/Planning.php
+++ b/src/Planning.php
@@ -239,7 +239,7 @@ class Planning extends CommonGLPI
 
         switch ($value) {
             case static::INFO:
-                return _n('Information', 'Information', 1);
+                return _n('Information', 'Informations', 1);
 
             case static::TODO:
                 return __('To do');


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does

On Transiflex/POT file, the plural of "information" is "informations" instead of "information".

## Screenshots (if appropriate):


