### PR TITLE
fix(central): planning widget rendering

### DIFF
--- a/js/planning.js
+++ b/js/planning.js
@@ -438,9 +438,17 @@ var GLPIPlanning  = {
                 }).done(function() {
                     // indicate to central page we're done rendering
                     if (!options.full_view) {
-                        setTimeout(function () {
-                            $(document).trigger('masonry_grid:layout');
-                        }, 100);
+                        // Observe changes in the DOM before triggering
+                        const observer = new MutationObserver((mutations, obs) => {
+                            if (document.readyState === 'complete') {
+                                obs.disconnect(); // Stop observation once the DOM is stable
+                                setTimeout(() => {
+                                    $(document).trigger('masonry_grid:layout');
+                                }, 100);
+                            }
+                        });
+
+                        observer.observe(document.body, { childList: true, subtree: true });
                     }
                 });
 


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !30072
- Here is a brief description of what this PR does

With Chrome or Edge, the planning widget in the personal view is displayed on top of the other elements. This is not the case with Firefox.

See: https://github.com/glpi-project/glpi/pull/17274

## Screenshots (if appropriate):


