### PR TITLE
Allow plugins to restrict their tags to specific events

### DIFF
--- a/src/NotificationTarget.php
+++ b/src/NotificationTarget.php
@@ -1467,7 +1467,7 @@ class NotificationTarget extends CommonDBChild
 
         if ($p['tag']) {
             if (is_array($p['events'])) {
-                $events = $this->getEvents();
+                $events = $this->getAllEvents();
                 $tmp = [];
 
                 foreach ($p['events'] as $event) {


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

When plugins restrict notification tag to specific plugin's events it show a php warning
`glpiphplog.WARNING:   *** PHP Warning (2): Undefined array key "plugin_*****" in src/NotificationTarget.php at line 1474`


Using `getAllEvents()` insted of `getEvents()` prevent the warning and make it work fine
