### PR TITLE
Fix alignment of select fields

### DIFF
--- a/css/legacy/includes/_styles.scss
+++ b/css/legacy/includes/_styles.scss
@@ -132,6 +132,7 @@
      display: none;
    }
 
+   .tab_cadre_fixe .select2-container,
    .tab_cadre_fixe .select2-container .select2-selection.select2-selection--single {
       max-width: 270px;
    }


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does

## Screenshots (if appropriate):

The select dropdown has been limited to a max width of 270px, but it's container not. It creates a situation where the select has it width limited but not it's container, which makes the buttons (like "i" [info] and "+" [toadd]) not aligned with the fields.

![image](https://github.com/user-attachments/assets/6a0c5e69-6000-4ce2-b5bc-3abf5d964851)

After applying this PR it's aligned as expected:

![image](https://github.com/user-attachments/assets/f75a0917-8eaf-4c48-a99e-601233942d30)

This behavior can be seen in Agent task properties page of GLPI Inventory plugin (https://glpi.example.com/plugins/glpiinventory/front/task.form.php?id=1) which uses a fixed width to their selects as seen in https://github.com/glpi-project/glpi-inventory-plugin/blob/c17dbab0b5ed6c8ae8bfb885ca44a40de47e0f34/inc/commonview.class.php#L193-L200
