### PR TITLE
Fix "Undefined array key" error on custom plug-in login provider

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -1122,9 +1122,10 @@ HTML;
         self::header_nocache();
 
         $theme = $_SESSION['glpipalette'] ?? 'auror';
+        $lang = $_SESSION['glpilanguage'] ?? $CFG_GLPI['language'];
 
         $tpl_vars = [
-            'lang'               => $CFG_GLPI["languages"][$_SESSION['glpilanguage']][3],
+            'lang'               => $CFG_GLPI["languages"][$lang][3],
             'title'              => $title,
             'theme'              => $theme,
             'is_anonymous_page'  => false,


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/da0d1516-33a7-4af9-8089-5166b8c1caca)

The plug-in https://github.com/edgardmessias/glpi-singlesignon/ adds OAuth login support for GLPI 10. When logging in, if user isn't authorized to login, it redirects to a custom page, but as the session isn't set (user isn't login), it throws a "Undefined array key" error when PHP display_errors directive is on.
