### PR TITLE
Fix delete button to unassign VLAN from network port

### DIFF
--- a/src/NetworkPort.php
+++ b/src/NetworkPort.php
@@ -1153,7 +1153,7 @@ class NetworkPort extends CommonDBChild
                                         $output .= '<input type="hidden" name="items[NetworkPort_Vlan][' . $row['id'] . ']" value="' . $row['id'] . '">';
                                         $output .= '<input type="hidden" name="action_name" value="' . __('Delete permanently the relation with selected elements') . '">';
                                         $output .= '<input type="hidden" name="_glpi_csrf_token" value="' . Session::getNewCSRFToken() . '">';
-                                        $output .= '<button type="submit" title="' . __('Delete') . '" class="btn-link fas fa-trash"></button>';
+                                        $output .= '<button type="submit" title="' . __('Delete') . '" class="btn-link fas fa-trash" onclick="this.disabled=true;this.form.submit();"></button>';
                                         $output .= '</form>';
                                     }
                                        $output .= '<br/>';

--- a/src/NetworkPort.php
+++ b/src/NetworkPort.php
@@ -1118,6 +1118,7 @@ class NetworkPort extends CommonDBChild
                                     Vlan::getTable() . '.name',
                                     NetworkPort_Vlan::getTable() . '.tagged',
                                     Vlan::getTable() . '.tag',
+                                    NetworkPort_Vlan::getTable() . '.vlans_id'
                                 ],
                                 'FROM'   => NetworkPort_Vlan::getTable(),
                                 'INNER JOIN'   => [
@@ -1138,11 +1139,13 @@ class NetworkPort extends CommonDBChild
                                  );
                             } else {
                                 foreach ($vlans as $row) {
+                                        $output .= '<a href="/front/vlan.form.php?id=' . $row['vlans_id'] . '">';
                                         $output .= $row['name'];
                                     if (!empty($row['tag'])) {
                                         $output .= ' [' . $row['tag'] . ']';
                                     }
                                         $output .= ($row['tagged'] == 1 ? 'T' : 'U');
+                                        $output .= '</a>';
                                     if ($canedit) {
                                         $output .= '<form method="post" action="/front/massiveaction.php" class="d-inline-flex">';
                                         $output .= '<input type="hidden" name="massiveaction" value="MassiveAction:purge">';

--- a/src/NetworkPort.php
+++ b/src/NetworkPort.php
@@ -1144,7 +1144,17 @@ class NetworkPort extends CommonDBChild
                                     }
                                         $output .= ($row['tagged'] == 1 ? 'T' : 'U');
                                     if ($canedit) {
-                                        $output .= "<a title='" . __('Delete') . "' href='" . NetworkPort::getFormURLWithID($row['id']) . "&unassign_vlan=unassigned'> <i class='fas fa-trash'></i> <span class='sr-only'>" . __('Delete') . "</span></a>";
+                                        $output .= '<form method="post" action="/front/massiveaction.php" class="d-inline-flex">';
+                                        $output .= '<input type="hidden" name="massiveaction" value="MassiveAction:purge">';
+                                        $output .= '<input type="hidden" name="action" value="purge">';
+                                        $output .= '<input type="hidden" name="processor" value="MassiveAction">';
+                                        $output .= '<input type="hidden" name="is_delete" value="0">';
+                                        $output .= '<input type="hidden" name="initial_items[NetworkPort_Vlan][' . $row['id'] . ']" value="' . $row['id'] . '">';
+                                        $output .= '<input type="hidden" name="items[NetworkPort_Vlan][' . $row['id'] . ']" value="' . $row['id'] . '">';
+                                        $output .= '<input type="hidden" name="action_name" value="' . __('Delete permanently the relation with selected elements') . '">';
+                                        $output .= '<input type="hidden" name="_glpi_csrf_token" value="' . Session::getNewCSRFToken() . '">';
+                                        $output .= '<button type="submit" title="' . __('Delete') . '" class="btn-link fas fa-trash"></button>';
+                                        $output .= '</form>';
                                     }
                                        $output .= '<br/>';
                                 }


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable) #18845 
- Here is a brief description of what this PR does

I was able to reproduce #18845 when trying to remove a VLAN into https://glpi.example.com/front/networkequipment.form.php?id=XXX page so I decided to poke around and fix it. Clicking on the trash icon redirects to a broken page. I couldn't find any references to pass GET parameters and do some action on backend, but noticed that the Massive Actions works, so this passes the same parameters used to unassign a VLAN from port on https://glpi.example.com/front/networkport.form.php?id=XXX.

## Screenshots (if appropriate):

Unassign VLAN with this PR applied:

https://github.com/user-attachments/assets/89fc2faa-ea14-4076-b565-b63559725913

In the commit https://github.com/glpi-project/glpi/pull/18877/commits/56263a9cd7a6b7736cb4fa3d5aa1008921937466 I also added the hyperlink to the VLAN name to go to the VLAN form.

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/49a7014b-91ff-4771-a9fd-a8907ddf9be8" />
