### PR TITLE
Move specific legacy API code in the legacy API class

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -1784,12 +1784,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Api/API.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Method Glpi\\\\Api\\\\APIRest\\:\\:getItemtype\\(\\) should return bool but returns string\\.$#',
-	'identifier' => 'return.type',
-	'count' => 2,
-	'path' => __DIR__ . '/src/Glpi/Api/APIRest.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method Glpi\\\\Api\\\\APIRest\\:\\:parseIncomingParams\\(\\) with return type void returns string but should not return anything\\.$#',
 	'identifier' => 'return.void',
 	'count' => 1,

--- a/src/Document.php
+++ b/src/Document.php
@@ -311,19 +311,6 @@ class Document extends CommonDBTM
         }
     }
 
-    public function post_getFromDB()
-    {
-        if (
-            isAPI()
-            && ((isset($_SERVER['HTTP_ACCEPT']) && $_SERVER['HTTP_ACCEPT'] === 'application/octet-stream')
-              || (isset($_GET['alt']) && $_GET['alt'] === 'media'))
-        ) {
-            // This is a API request to download the document
-            $this->send();
-            exit();
-        }
-    }
-
     public function prepareInputForUpdate($input)
     {
         // security (don't accept filename from $_REQUEST)

--- a/src/Glpi/Api/APIRest.php
+++ b/src/Glpi/Api/APIRest.php
@@ -275,6 +275,26 @@ class APIRest extends API
                 default:
                 case "GET": // retrieve item(s)
                     if (
+                        $itemtype === \Document::class
+                        && $id > 0
+                        && (
+                            ($_SERVER['HTTP_ACCEPT'] ?? null) === 'application/octet-stream'
+                            || ($this->parameters['alt'] ?? null) === 'media'
+                        )
+                    ) {
+                        // Raw document download
+                        $document = new \Document();
+                        if (!$document->getFromDB($id)) {
+                            $this->messageNotfoundError();
+                        }
+                        if (!$document->can($id, READ)) {
+                            $this->messageRightError();
+                        }
+                        $document->send();
+                        exit();
+                    }
+
+                    if (
                         $id > 0
                         || ($id !== false && $id == 0 && $itemtype == "Entity")
                     ) {
@@ -373,7 +393,7 @@ class APIRest extends API
      *                            (default true)
      * @param boolean $all_assets if we can have allasset virtual type (default false)
      *
-     * @return boolean
+     * @return false|class-string<\CommonDBTM>
      */
     private function getItemtype($index = 0, $recursive = true, $all_assets = false)
     {


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

The `Document::post_getFromDB()` code is only used by the legacy REST API. I try to remove all `exit/die` usages in the code executed from `ajax/front` endpoints. Moving it in the `APIRest` class helps to identify remaining occurences to fix.