### PR TITLE
Increase maximum alert delay

### DIFF
--- a/templates/pages/admin/entity/notifications.html.twig
+++ b/templates/pages/admin/entity/notifications.html.twig
@@ -71,7 +71,7 @@
    {% endif %}
    {{ fields.dropdownNumberField(field, item.fields[field], label, {
       min: 1,
-      max: 99,
+      max: 365,
       unit: unit,
       toadd: to_add + {
          0: __('No')


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !36172
- Here is a brief description of what this PR does

Increase the maximum alert delay from 100 hours to the equivalent of 1 year.

_As https://github.com/glpi-project/glpi/pull/18770_

_I tried replacing it with a number input to allow for a higher limit, but due to the inheritance mechanism of this field type, the solution seemed overly complex for its intended purpose. A one-year limit appears to be a good compromise, so I kept the dropdown._

## Screenshots (if appropriate):

Example:
![image](https://github.com/user-attachments/assets/da1f53c4-c71e-47fb-a075-494c04e3da36)


