### PR TITLE
Fix escaping and unhandled param for Auth::getMethodName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -228,7 +228,7 @@ The present file will list all changes made to the project; according to the
 - The `$target` parameter has been removed from the `AuthLDAP::showLdapGroups()` method.
 - The `$target` parameter has been removed from the `Rule::showRulePreviewCriteriasForm()`, `Rule::showRulePreviewResultsForm()`, `RuleCollection::showRulesEnginePreviewCriteriasForm()`, and `RuleCollection::showRulesEnginePreviewResultsForm()` methods signature.
 - `Hooks::SHOW_IN_TIMELINE`/`show_in_timeline` plugin hook has been renamed to `Hooks::TIMELINE_ITEMS`/`timeline_items`.
-- `link` parameter for `Auth::getMethodName()` is now properly used instead of always showing the links. The default value remains false, so if you want to keep the previous behavior, you need to explicitly set it to false.
+- `Auth::getMethodName()` now only returns the name without a link. Use `Auth::getMethodLink()` to get a HTML-safe link.
 
 #### Deprecated
 - Usage of the `/marketplace` path for plugins URLs. All plugins URLs should now start with `/plugins`.
@@ -589,6 +589,7 @@ The present file will list all changes made to the project; according to the
 - `ajax/ticketsatisfaction.php` and `ajax/changesatisfaction.php` scripts. Access `ajax/commonitilsatisfaction.php` directly instead.
 - Usage of the `$cut` parameter in `formatUserName()` and `DbUtils::formatUserName()`.
 - Handling of the `delegate` right in `User::getSqlSearchResult()`.
+- Usage of the `$link` and `$name` parameters in `Auth::getMethodName()`.
 
 
 ## [10.0.18] 2025-02-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -228,6 +228,7 @@ The present file will list all changes made to the project; according to the
 - The `$target` parameter has been removed from the `AuthLDAP::showLdapGroups()` method.
 - The `$target` parameter has been removed from the `Rule::showRulePreviewCriteriasForm()`, `Rule::showRulePreviewResultsForm()`, `RuleCollection::showRulesEnginePreviewCriteriasForm()`, and `RuleCollection::showRulesEnginePreviewResultsForm()` methods signature.
 - `Hooks::SHOW_IN_TIMELINE`/`show_in_timeline` plugin hook has been renamed to `Hooks::TIMELINE_ITEMS`/`timeline_items`.
+- `link` parameter for `Auth::getMethodName()` is now properly used instead of always showing the links. The default value remains false, so if you want to keep the previous behavior, you need to explicitly set it to false.
 
 #### Deprecated
 - Usage of the `/marketplace` path for plugins URLs. All plugins URLs should now start with `/plugins`.

--- a/phpunit/functional/AuthTest.php
+++ b/phpunit/functional/AuthTest.php
@@ -35,6 +35,9 @@
 
 namespace tests\units;
 
+use Auth;
+use AuthLDAP;
+use AuthMail;
 use DbTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
@@ -190,5 +193,36 @@ class AuthTest extends DbTestCase
     {
         $auth = new \Auth();
         $this->assertSame($expected, $auth->validateLogin($login, $password, $noauto, $login_auth));
+    }
+
+    public function testGetMethodName()
+    {
+        $this->assertSame(AuthLDAP::getTypeName(1), Auth::getMethodName(Auth::LDAP, 0));
+        $this->assertSame(AuthMail::getTypeName(1), Auth::getMethodName(Auth::MAIL, 0));
+        $this->assertSame('CAS', Auth::getMethodName(Auth::CAS, 0));
+        $this->assertSame('x509 certificate authentication', Auth::getMethodName(Auth::X509, 0));
+        $this->assertSame('Other', Auth::getMethodName(Auth::EXTERNAL, 0));
+        $this->assertSame('GLPI internal database', Auth::getMethodName(Auth::DB_GLPI, 0));
+        $this->assertSame('API', Auth::getMethodName(Auth::API, 0));
+
+        $this->assertSame('LDAP directory: _local_ldap', Auth::getMethodLink(Auth::LDAP, getItemByTypeName(AuthLDAP::class, '_local_ldap', true)));
+    }
+
+    public function testGetMethodLink()
+    {
+        $this->login();
+
+        $this->assertSame(AuthLDAP::getTypeName(1), Auth::getMethodLink(Auth::LDAP, 0));
+        $this->assertSame(AuthMail::getTypeName(1), Auth::getMethodLink(Auth::MAIL, 0));
+        $this->assertSame('CAS', Auth::getMethodLink(Auth::CAS, 0));
+        $this->assertSame('x509 certificate authentication', Auth::getMethodLink(Auth::X509, 0));
+        $this->assertSame('Other', Auth::getMethodLink(Auth::EXTERNAL, 0));
+        $this->assertSame('GLPI internal database', Auth::getMethodLink(Auth::DB_GLPI, 0));
+        $this->assertSame('API', Auth::getMethodLink(Auth::API, 0));
+
+        $this->assertSame(
+            'LDAP directory: <a href="/glpi/front/authldap.form.php?id=1" title="_local_ldap">_local_ldap</a>',
+            Auth::getMethodLink(Auth::LDAP, getItemByTypeName(AuthLDAP::class, '_local_ldap', true))
+        );
     }
 }

--- a/phpunit/functional/AuthTest.php
+++ b/phpunit/functional/AuthTest.php
@@ -197,6 +197,10 @@ class AuthTest extends DbTestCase
 
     public function testGetMethodName()
     {
+        $autmail = $this->createItem(AuthMail::class, ['name' => 'mail.example.org']);
+
+        $local_ldap_id = getItemByTypeName(AuthLDAP::class, '_local_ldap', true);
+
         $this->assertSame(AuthLDAP::getTypeName(1), Auth::getMethodName(Auth::LDAP, 0));
         $this->assertSame(AuthMail::getTypeName(1), Auth::getMethodName(Auth::MAIL, 0));
         $this->assertSame('CAS', Auth::getMethodName(Auth::CAS, 0));
@@ -205,12 +209,22 @@ class AuthTest extends DbTestCase
         $this->assertSame('GLPI internal database', Auth::getMethodName(Auth::DB_GLPI, 0));
         $this->assertSame('API', Auth::getMethodName(Auth::API, 0));
 
-        $this->assertSame('LDAP directory: _local_ldap', Auth::getMethodLink(Auth::LDAP, getItemByTypeName(AuthLDAP::class, '_local_ldap', true)));
+        $this->assertSame('LDAP directory: _local_ldap', Auth::getMethodLink(Auth::LDAP, $local_ldap_id));
+
+        $this->assertSame('Email server: mail.example.org', Auth::getMethodLink(Auth::MAIL, $autmail->getID()));
+
+        $this->assertSame('CAS + LDAP directory: _local_ldap', Auth::getMethodName(Auth::CAS, $local_ldap_id));
+        $this->assertSame('x509 certificate authentication + LDAP directory: _local_ldap', Auth::getMethodName(Auth::X509, $local_ldap_id));
+        $this->assertSame('Other + LDAP directory: _local_ldap', Auth::getMethodName(Auth::EXTERNAL, $local_ldap_id));
     }
 
     public function testGetMethodLink()
     {
         $this->login();
+
+        $autmail = $this->createItem(AuthMail::class, ['name' => 'mail.example.org']);
+
+        $local_ldap_id = getItemByTypeName(AuthLDAP::class, '_local_ldap', true);
 
         $this->assertSame(AuthLDAP::getTypeName(1), Auth::getMethodLink(Auth::LDAP, 0));
         $this->assertSame(AuthMail::getTypeName(1), Auth::getMethodLink(Auth::MAIL, 0));
@@ -221,8 +235,41 @@ class AuthTest extends DbTestCase
         $this->assertSame('API', Auth::getMethodLink(Auth::API, 0));
 
         $this->assertSame(
-            'LDAP directory: <a href="/glpi/front/authldap.form.php?id=1" title="_local_ldap">_local_ldap</a>',
-            Auth::getMethodLink(Auth::LDAP, getItemByTypeName(AuthLDAP::class, '_local_ldap', true))
+            sprintf(
+                'LDAP directory: <a href="/glpi/front/authldap.form.php?id=%d" title="_local_ldap">_local_ldap</a>',
+                $local_ldap_id
+            ),
+            Auth::getMethodLink(Auth::LDAP, $local_ldap_id)
+        );
+
+        $this->assertSame(
+            sprintf(
+                'Email server: <a href="/glpi/front/authmail.form.php?id=%d" title="mail.example.org">mail.example.org</a>',
+                $autmail->getID()
+            ),
+            Auth::getMethodLink(Auth::MAIL, $autmail->getID())
+        );
+
+        $this->assertSame(
+            sprintf(
+                'CAS + LDAP directory: <a href="/glpi/front/authldap.form.php?id=%d" title="_local_ldap">_local_ldap</a>',
+                $local_ldap_id
+            ),
+            Auth::getMethodLink(Auth::CAS, $local_ldap_id)
+        );
+        $this->assertSame(
+            sprintf(
+                'x509 certificate authentication + LDAP directory: <a href="/glpi/front/authldap.form.php?id=%d" title="_local_ldap">_local_ldap</a>',
+                $local_ldap_id
+            ),
+            Auth::getMethodLink(Auth::X509, $local_ldap_id)
+        );
+        $this->assertSame(
+            sprintf(
+                'Other + LDAP directory: <a href="/glpi/front/authldap.form.php?id=%d" title="_local_ldap">_local_ldap</a>',
+                $local_ldap_id
+            ),
+            Auth::getMethodLink(Auth::EXTERNAL, $local_ldap_id)
         );
     }
 }

--- a/src/AuthMail.php
+++ b/src/AuthMail.php
@@ -47,7 +47,7 @@ class AuthMail extends CommonDBTM
 
     public static function getTypeName($nb = 0)
     {
-        return _n('Mail server', 'Mail servers', $nb);
+        return _n('Email server', 'Email servers', $nb);
     }
 
     public static function getSectorizedDetails(): array

--- a/src/AuthMail.php
+++ b/src/AuthMail.php
@@ -109,7 +109,7 @@ class AuthMail extends CommonDBTM
 
         $tab[] = [
             'id'                 => 'common',
-            'name'               => __('Email server')
+            'name'               => _n('Email server', 'Email servers', 1)
         ];
 
         $tab[] = [

--- a/src/RuleRight.php
+++ b/src/RuleRight.php
@@ -249,7 +249,7 @@ class RuleRight extends Rule
     {
         $crit = $this->getCriteria($ID);
         if (count($crit) && $crit['field'] == 'type') {
-            return Auth::getMethodName($pattern, 0);
+            return Auth::getMethodName((int) $pattern, 0);
         }
         return false;
     }

--- a/src/RuleRight.php
+++ b/src/RuleRight.php
@@ -199,7 +199,7 @@ class RuleRight extends Rule
 
             $criterias['MAIL_SERVER']['table']     = 'glpi_authmails';
             $criterias['MAIL_SERVER']['field']     = 'name';
-            $criterias['MAIL_SERVER']['name']      = __('Email server');
+            $criterias['MAIL_SERVER']['name']      = _n('Email server', 'Email servers', 1);
             $criterias['MAIL_SERVER']['linkfield'] = '';
             $criterias['MAIL_SERVER']['type']      = 'dropdown';
             $criterias['MAIL_SERVER']['virtual']   = true;

--- a/src/User.php
+++ b/src/User.php
@@ -2983,7 +2983,7 @@ JAVASCRIPT;
         if (!empty($ID)) {
             if (Session::haveRight(self::$rightname, self::READAUTHENT)) {
                 echo "<td>" . __s('Authentication') . "</td><td>";
-                echo htmlescape(Auth::getMethodName($this->fields["authtype"], $this->fields["auths_id"]));
+                echo Auth::getMethodName($this->fields["authtype"], $this->fields["auths_id"], true);
                 if (!empty($this->fields["date_sync"])) {
                     //TRANS: %s is the date of last sync
                     echo '<br>' . sprintf(
@@ -4362,7 +4362,7 @@ JAVASCRIPT;
                 if (isset($values['auths_id']) && !empty($values['auths_id'])) {
                     $auths_id = $values['auths_id'];
                 }
-                return Auth::getMethodName($values[$field], $auths_id);
+                return Auth::getMethodName($values[$field], $auths_id, true);
             case 'picture':
                 if (isset($options['html']) && $options['html']) {
                     return Html::image(

--- a/src/User.php
+++ b/src/User.php
@@ -2983,7 +2983,7 @@ JAVASCRIPT;
         if (!empty($ID)) {
             if (Session::haveRight(self::$rightname, self::READAUTHENT)) {
                 echo "<td>" . __s('Authentication') . "</td><td>";
-                echo Auth::getMethodName($this->fields["authtype"], $this->fields["auths_id"], true);
+                echo Auth::getMethodLink($this->fields["authtype"], $this->fields["auths_id"]);
                 if (!empty($this->fields["date_sync"])) {
                     //TRANS: %s is the date of last sync
                     echo '<br>' . sprintf(
@@ -4362,7 +4362,7 @@ JAVASCRIPT;
                 if (isset($values['auths_id']) && !empty($values['auths_id'])) {
                     $auths_id = $values['auths_id'];
                 }
-                return Auth::getMethodName($values[$field], $auths_id, true);
+                return Auth::getMethodLink($values[$field], $auths_id);
             case 'picture':
                 if (isset($options['html']) && $options['html']) {
                     return Html::image(


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

After some escaping fixes a few months ago, authentication sources with links (LDAP for example) were showing raw HTML on the user form instead of showing the link. I also noticed there was a `link` parameter for `Auth::getMethodName` which was ignored and at least for the last 13 years was not implemented. I've rewritten the method to take the `link` parameter into account and handle sanitization better.