### PR TITLE
Fix monaco themes in debug mode

### DIFF
--- a/js/modules/Monaco/MonacoEditor.js
+++ b/js/modules/Monaco/MonacoEditor.js
@@ -273,11 +273,11 @@ window.GLPI.Monaco = {
      * @return {Promise<string>}
      */
     colorizeText: async (text, language) => {
-        return import('../../../lib/monaco.js').then(() => {
-            window.GLPI.Monaco.registerGLPIThemes();
-            // Theme set here because colorize doesn't support specifying the theme in the options like colorizeElement does
-            window.monaco.editor.setTheme('glpi');
-            return window.monaco.editor.colorize(text, language);
+        const el = document.createElement('div');
+        $(el).attr('lang', language);
+        $(el).text(text);
+        return window.GLPI.Monaco.colorizeElement(el, language).then(() => {
+            return el.innerHTML;
         });
     },
     /**

--- a/js/src/vue/Debug/Widget/ThemeSwitcher.vue
+++ b/js/src/vue/Debug/Widget/ThemeSwitcher.vue
@@ -33,7 +33,7 @@
             for (let i = 0; i < textareas.length; i++) {
                 const textarea = textareas[i];
                 const editor = tinyMCE.get(textarea.id);
-                if (editor !== undefined) {
+                if (editor !== undefined && editor !== null) {
                     const editor_root_element = $(editor.dom.doc.documentElement);
                     const page_root_element = $(document.documentElement);
                     const to_copy = ['data-glpi-theme', 'data-glpi-theme-dark'];
@@ -43,6 +43,9 @@
                         }
                     }
                 }
+            }
+            if (window.monaco?.editor !== undefined) {
+                window.monaco.editor.setTheme(new_theme['is_dark'] ? 'glpi-dark' : 'glpi');
             }
         }
         emit('refreshButton');


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

If you have debug mode enabled and are using a dark theme, the Monaco editors such as the UI Customization editor were being shown in a light theme. This was because the `colorizeText` method used for syntax highlighting had to globally set the theme and it always set it to 'glpi' which is the custom light theme.

With this PR, `colorizeText` now creates a temporary element and then uses `colorizeElement` which can properly handle colorizing with a specific theme without messing with the themes of real editors.

I also added logic to handle switching the themes when using the theme switcher widget in the debug bar similar to how it handled switching TinyMCE styles.

