### PR TITLE
Show msg on ITIL tabs for user when there are no results

### DIFF
--- a/templates/components/datatable.html.twig
+++ b/templates/components/datatable.html.twig
@@ -37,12 +37,14 @@
         <thead>
         {% if super_header is defined and super_header is not empty %}
             {% set super_header_label = super_header is array ? super_header['label'] : super_header %}
-            {% set super_header_raw = super_header is array ? super_header['is_raw'] : false %}
-            <tr>
-                <th colspan="1">
-                    {{ super_header_raw ? super_header_label|raw : super_header_label }}
-                </th>
-            </tr>
+            {% if super_header_label is not empty %}
+                {% set super_header_raw = super_header is array ? super_header['is_raw'] : false %}
+                <tr>
+                    <th colspan="1">
+                        {{ super_header_raw ? super_header_label|raw : super_header_label }}
+                    </th>
+                </tr>
+            {% endif %}
         {% endif %}
         </thead>
         <tbody>

--- a/templates/components/form/item_itilobject_item_list.html.twig
+++ b/templates/components/form/item_itilobject_item_list.html.twig
@@ -50,32 +50,30 @@
         {% endif %}
     {% endif %}
 
-    {% if number > 0 %}
-        {% set values = [] %}
+    {% set values = [] %}
 
-        {% for data in iterator %}
-            {% set values = values|merge({(values|length) : {'id' : item.getID(), 'item_id' : data["id"], 'itemtype' : itemtype_1, 'associated_elements' : ''}}) %}
-        {% endfor %}
+    {% for data in iterator %}
+        {% set values = values|merge({(values|length) : {'id' : item.getID(), 'item_id' : data["id"], 'itemtype' : itemtype_1, 'associated_elements' : ''}}) %}
+    {% endfor %}
 
-        {% set common_columns = call(itemtype_1 ~ '::getCommonDatatableColumns', []) %}
-        {% set entries = call(itemtype_1 ~ '::getDatatableEntries', [values]) %}
-        {% set datatable_params = {
-            'super_header': {
-                'label': superheader,
-                'is_raw': superheader_raw,
-            },
-            'is_tab': true,
-            'nopager': true,
-            'nofilter': true,
-            'nosort': true,
-            'entries': entries,
-            'total_number': entries|length,
-            'showmassiveactions': canedit,
-        } %}
-        {% set merged_params = datatable_params|merge(common_columns) %}
+    {% set common_columns = call(itemtype_1 ~ '::getCommonDatatableColumns', []) %}
+    {% set entries = call(itemtype_1 ~ '::getDatatableEntries', [values]) %}
+    {% set datatable_params = {
+        'super_header': {
+            'label': superheader,
+            'is_raw': superheader_raw,
+        },
+        'is_tab': true,
+        'nopager': true,
+        'nofilter': true,
+        'nosort': true,
+        'entries': entries,
+        'total_number': entries|length,
+        'showmassiveactions': canedit,
+    } %}
+    {% set merged_params = datatable_params|merge(common_columns) %}
 
-        {{ include('components/datatable.html.twig', merged_params, with_context = false) }}
-    {% endif %}
+    {{ include('components/datatable.html.twig', merged_params, with_context = false) }}
 </div>
 
 {% if showform %}


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

When there were no tickets/changes/problems for a user, these tabs were completely empty. Now, it will show the "No data" message like any other datatable/sublist.

