### PR TITLE
Minor UI fixes on historical tab

### DIFF
--- a/templates/components/logs.html.twig
+++ b/templates/components/logs.html.twig
@@ -55,7 +55,7 @@
                      <i class="fas fa-filter"></i>
                      <span class="d-none d-xl-block">{{ __('Filter') }}</span>
                   </button>
-                  <a href="{{ csv_url }}" class="btn btn-sm text-capitalize btn-icon btn-outline-secondary">
+                  <a href="{{ csv_url }}" class="btn btn-sm text-capitalize btn-outline-secondary">
                      <i class="fas fa-file-download"></i>
                      <span class="d-none d-xl-block">{{ __('Export') }}</span>
                   </a>
@@ -132,7 +132,7 @@
    </table>
    </div>{# .table-responsive #}
 
-   <div class="ms-auto d-inline-flex align-items-center d-none d-md-block mb-2">
+   <div class="ms-auto d-inline-flex align-items-center d-none d-md-block mb-2 my-2">
         {{ __('Entries to show:') }}
         {% include 'components/dropdown/limit.html.twig' %}
    </div>


### PR DESCRIPTION
## Checklist before requesting a review

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Export button was too squished to the left of the icon. "Entries to show" section under table to directly against the results instead of having the small vertical margins other pager sections have.


