### PR TITLE
Do not alter current object when fetching its search options

### DIFF
--- a/phpunit/abstracts/RuleCommonITILObject.php
+++ b/phpunit/abstracts/RuleCommonITILObject.php
@@ -1743,13 +1743,16 @@ abstract class RuleCommonITILObject extends DbTestCase
 
     public function testAssignAppliance()
     {
+        $root_entity = \getItemByTypeName(Entity::class, '_test_root_entity', true);
+
         $this->login();
 
         //create appliance "appliance"
         $applianceTest1 = new \Appliance();
         $appliancetest1_id = $applianceTest1->add($applianceTest1_input = [
             "name"                  => "appliance",
-            "is_helpdesk_visible"   => true
+            "is_helpdesk_visible"   => true,
+            "entities_id"           => $root_entity,
         ]);
         $this->checkInput($applianceTest1, $appliancetest1_id, $applianceTest1_input);
 
@@ -1855,13 +1858,16 @@ abstract class RuleCommonITILObject extends DbTestCase
 
     public function testRegexAppliance()
     {
+        $root_entity = \getItemByTypeName(Entity::class, '_test_root_entity', true);
+
         $this->login();
 
         //create appliance "erp"
         $applianceTest1 = new \Appliance();
         $appliancetest1_id = $applianceTest1->add($applianceTest1_input = [
             "name"                  => "erp",
-            "is_helpdesk_visible"   => true
+            "is_helpdesk_visible"   => true,
+            "entities_id"           => $root_entity,
         ]);
         $this->checkInput($applianceTest1, $appliancetest1_id, $applianceTest1_input);
 
@@ -1965,13 +1971,16 @@ abstract class RuleCommonITILObject extends DbTestCase
 
     public function testAppendAppliance()
     {
+        $root_entity = \getItemByTypeName(Entity::class, '_test_root_entity', true);
+
         $this->login();
 
         //create appliance "erp"
         $applianceTest1 = new \Appliance();
         $appliancetest1_id = $applianceTest1->add($applianceTest1_input = [
             "name"                  => "erp",
-            "is_helpdesk_visible"   => true
+            "is_helpdesk_visible"   => true,
+            "entities_id"           => $root_entity,
         ]);
         $this->checkInput($applianceTest1, $appliancetest1_id, $applianceTest1_input);
 
@@ -1979,7 +1988,8 @@ abstract class RuleCommonITILObject extends DbTestCase
         $applianceTest2 = new \Appliance();
         $appliancetest2_id = $applianceTest2->add($applianceTest2_input = [
             "name"                  => "glpi",
-            "is_helpdesk_visible"   => true
+            "is_helpdesk_visible"   => true,
+            "entities_id"           => $root_entity,
         ]);
         $this->checkInput($applianceTest2, $appliancetest2_id, $applianceTest2_input);
 

--- a/phpunit/functional/Appliance_ItemTest.php
+++ b/phpunit/functional/Appliance_ItemTest.php
@@ -37,6 +37,7 @@ namespace tests\units;
 
 use Appliance_Item;
 use DbTestCase;
+use Entity;
 use Glpi\Asset\Capacity\HasAppliancesCapacity;
 use Glpi\Features\Clonable;
 use Toolbox;
@@ -94,15 +95,19 @@ class Appliance_ItemTest extends DbTestCase
         /** @var \DBmysql $DB */
         global $DB;
 
+        $entity_id = \getItemByTypeName(Entity::class, '_test_root_entity', true);
+
         $appliance = new \Appliance();
 
         $appliance_1 = (int)$appliance->add([
-            'name'   => 'Test appliance'
+            'name'        => 'Test appliance',
+            'entities_id' => $entity_id,
         ]);
         $this->assertGreaterThan(0, $appliance_1);
 
         $appliance_2 = (int)$appliance->add([
-            'name'   => 'Test appliance'
+            'name'        => 'Test appliance 2',
+            'entities_id' => $entity_id,
         ]);
         $this->assertGreaterThan(0, $appliance_2);
 

--- a/phpunit/functional/Appliance_Item_RelationTest.php
+++ b/phpunit/functional/Appliance_Item_RelationTest.php
@@ -36,6 +36,7 @@
 namespace tests\units;
 
 use DbTestCase;
+use Entity;
 
 class Appliance_Item_RelationTest extends DbTestCase
 {
@@ -53,10 +54,13 @@ class Appliance_Item_RelationTest extends DbTestCase
         /** @var \DBmysql $DB */
         global $DB;
 
+        $entity_id = \getItemByTypeName(Entity::class, '_test_root_entity', true);
+
         $appliance = new \Appliance();
 
         $appliances_id = (int)$appliance->add([
-            'name'   => 'Test appliance'
+            'name'        => 'Test appliance',
+            'entities_id' => $entity_id,
         ]);
         $this->assertGreaterThan(0, $appliances_id);
 

--- a/phpunit/functional/ComputerTest.php
+++ b/phpunit/functional/ComputerTest.php
@@ -36,6 +36,7 @@
 namespace tests\units;
 
 use DbTestCase;
+use Entity;
 use Glpi\Asset\Asset_PeripheralAsset;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Psr\Log\LogLevel;
@@ -639,6 +640,8 @@ class ComputerTest extends DbTestCase
 
     public function testClonedRelationNamesFromTemplate()
     {
+        $entity_id = \getItemByTypeName(Entity::class, '_test_root_entity', true);
+
         $this->login();
         $this->setEntity('_test_root_entity', true);
 
@@ -646,7 +649,8 @@ class ComputerTest extends DbTestCase
         $computer_template = new \Computer();
         $templates_id = $computer_template->add([
             'template_name' => __FUNCTION__ . '_template',
-            'is_template' => 1
+            'is_template'   => 1,
+            'entities_id'   => $entity_id,
         ]);
         $this->assertGreaterThan(0, $templates_id);
 

--- a/phpunit/functional/SearchTest.php
+++ b/phpunit/functional/SearchTest.php
@@ -1198,7 +1198,7 @@ class SearchTest extends DbTestCase
      */
     public function testGetSearchOptionsWException()
     {
-        $error = 'Duplicate key 12 (One search option/Any option) in tests\units\DupSearchOpt searchOptions!';
+        $error = 'Duplicate key `12` (`One search option`/`Any option`) in `tests\units\DupSearchOpt` search options.';
 
         $item = new DupSearchOpt();
         $item->searchOptions();

--- a/src/CommonDropdown.php
+++ b/src/CommonDropdown.php
@@ -932,7 +932,8 @@ abstract class CommonDropdown extends CommonDBTM
         }
 
         if (
-            $this->isField('knowbaseitemcategories_id')
+            !$this->isNewItem()
+            && $this->isField('knowbaseitemcategories_id')
             && $this->fields['knowbaseitemcategories_id']
         ) {
             $title = __s('FAQ');

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -9412,16 +9412,27 @@ abstract class CommonITILObject extends CommonDBTM
      */
     protected function setTechAndGroupFromHardware($input, $item)
     {
+        /** @var array $CFG_GLPI */
+        global $CFG_GLPI;
+
         if ($item != null) {
             // Auto assign tech from item
             $has_user_assigned  = $this->hasValidActorInInput($input, User::class, CommonITILActor::ASSIGN);
-            if (!$has_user_assigned && $item->isField('users_id_tech') && $item->fields['users_id_tech'] > 0) {
+            if (
+                !$has_user_assigned
+                && in_array($item::class, $CFG_GLPI['assignable_types'], true)
+                && $item->fields['users_id_tech'] > 0
+            ) {
                 $input['_users_id_assign'] = $item->fields['users_id_tech'];
             }
 
             // Auto assign group from item
             $has_group_assigned = $this->hasValidActorInInput($input, Group::class, CommonITILActor::ASSIGN);
-            if (!$has_group_assigned && $item->isField('groups_id_tech') && $item->fields['groups_id_tech'] > 0) {
+            if (
+                !$has_group_assigned
+                && in_array($item::class, $CFG_GLPI['assignable_types'], true)
+                && $item->fields['groups_id_tech'] > 0
+            ) {
                 $input['_groups_id_assign'] = $item->fields['groups_id_tech'];
             }
         }

--- a/src/Glpi/Features/AssetImage.php
+++ b/src/Glpi/Features/AssetImage.php
@@ -85,7 +85,7 @@ trait AssetImage
 
         $pictures = [];
         $pictures_removed = false;
-        if ($this->isField('pictures')) {
+        if (!$this->isNewItem() && $this->isField('pictures')) {
             $input_keys = array_keys($input);
             $pictures = importArrayFromDB($this->fields['pictures']);
             $to_remove = [];


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

When the `CommonDBTM::isField()` method is used on a "non-hydrated" object, the `CommonDBTM::getEmpty()` is triggerred, calling itself the `CommonDBTM::post_getEmpty()` method and the `item_empty` hook.

One of the side-effect of this is that `$this->fields['entities_id']` field is automatically set with the `$_SESSION['glpiactive_entity']` value for any `CommonDBTM::add()` operation. For all items created from the generic GLPI form, it will not change much, as the `entities_id` will be overriden by the form input, but for all objects created from anywhere else, it could hide the fact that the information is missing in the input. For instance, the following commit fixes an issue that has not been detected earlier due to this default `entities_id` value: 8e69433bbb733aee92fa77220a35824652eced90

Another side effect is that calling `CommonDBTM::rawSearchOptions()` may be altered the current object, because it often uses `CommonDBTM::isField()` to populate generic search options.

This is probably an unexpected behaviour. I am pretty sure that nobody expect the current object to be altered when using the `CommonDBTM::isField()`  or the `CommonDBTM::searchOptions()` methods.