### PR TITLE
Fix PHPStan errors reported on PHP 8.4

### DIFF
--- a/src/Glpi/Api/HL/RoutePath.php
+++ b/src/Glpi/Api/HL/RoutePath.php
@@ -147,6 +147,9 @@ final class RoutePath
         if (!$is_hydrated) {
             [$controller, $method] = explode('::', $this->key);
             try {
+                if (!\is_a($controller, AbstractController::class, true)) {
+                    throw new \Exception('Invalid controller');
+                }
                 $this->controller = new ReflectionClass($controller);
                 $this->method = $this->controller->getMethod($method);
                 if (!$this->method->isPublic()) {

--- a/src/Glpi/Console/CommandLoader.php
+++ b/src/Glpi/Console/CommandLoader.php
@@ -446,9 +446,13 @@ class CommandLoader implements CommandLoaderInterface
                // Needed as a file located in root source dir of Glpi can be either namespaced either not.
                 continue;
             }
+            if (!is_a($classname_to_check, Command::class, true)) {
+                // Not a console command.
+                continue;
+            }
 
             $reflectionClass = new ReflectionClass($classname_to_check);
-            if ($reflectionClass->isInstantiable() && $reflectionClass->isSubclassOf(Command::class)) {
+            if ($reflectionClass->isInstantiable()) {
                 return new $classname_to_check();
             }
         }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

I used a more defensive code to make PHPStan happy.

It fixes the following errors that are reported only on PHP 8.4:
```
 ------ ------------------------------------------------------------------- 
  Line   src/Glpi/Api/HL/RoutePath.php                                      
 ------ ------------------------------------------------------------------- 
  150    Property Glpi\Api\HL\RoutePath::$controller                        
         (ReflectionClass<Glpi\Api\HL\Controller\AbstractController>|null)  
         does not accept ReflectionClass<object>.                           
         🪪  assign.propertyType                                            
 ------ ------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   src/Glpi/Console/CommandLoader.php                                    
 ------ ---------------------------------------------------------------------- 
  451    Call to method ReflectionClass<object>::isSubclassOf() with           
         'Symfony\\Component\\Console\\Command\\Command' will always evaluate  
         to false.                                                             
         🪪  method.impossibleType                                             
 ------ ---------------------------------------------------------------------- 
```