### PR TITLE
Add context when test fails due to unexpected log entries

### DIFF
--- a/phpunit/GLPITestCase.php
+++ b/phpunit/GLPITestCase.php
@@ -105,11 +105,21 @@ class GLPITestCase extends TestCase
             $this->assertIsArray($this->log_handler->getRecords());
             $clean_logs = array_map(
                 static function (\Monolog\LogRecord $entry): array {
-                    return [
+                    $clean_entry = [
                         'channel' => $entry->channel,
                         'level'   => $entry->level->name,
                         'message' => $entry->message,
+                        'context' => [],
                     ];
+                    if (isset($entry->context['exception']) && $entry->context['exception'] instanceof \Throwable) {
+                        /* @var \Throwable $exception */
+                        $exception = $entry->context['exception'];
+                        $clean_entry['context']['exception'] = [
+                            'message' => $exception->getMessage(),
+                            'trace'   => $exception->getTraceAsString(),
+                        ];
+                    }
+                    return $clean_entry;
                 },
                 $this->log_handler->getRecords()
             );


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Now we use the Symfony error handler, any non blocking PHP error is now sent to the error handler with a `['exception' => ErrorException]` context. We can therefore display this context in the tests results. This is a bit verbose, but it is often hard to find the exact source of the error without this information.

Before:
```
Unexpected entries in log in tests\units\ApplianceTest::GLPITestCase::tearDown:
Array
(
    [0] => Array
        (
            [channel] => glpi
            [level] => Warning
            [message] => Warning: Undefined array key "pictures" at AssetImage.php line 90
        )

)
```

After:
```
Unexpected entries in log in tests\units\ApplianceTest::GLPITestCase::tearDown:
Array
(
    [0] => Array
        (
            [channel] => glpi
            [level] => Warning
            [message] => Warning: Undefined array key "pictures" at AssetImage.php line 90
            [context] => Array
                (
                    [exception] => Array
                        (
                            [message] => Warning: Undefined array key "pictures" at AssetImage.php line 90
                            [trace] => #0 /var/www/glpi/src/Appliance.php(120): Appliance->managePictures(Array)
#1 /var/www/glpi/src/CommonDBTM.php(1356): Appliance->prepareInputForAdd(Array)
#2 /var/www/glpi/phpunit/functional/ApplianceTest.php(200): CommonDBTM->add(Array)
#3 /var/www/glpi/vendor/phpunit/phpunit/src/Framework/TestCase.php(1201): tests\units\ApplianceTest->testMetaSearch()
#4 /var/www/glpi/vendor/phpunit/phpunit/src/Framework/TestCase.php(498): PHPUnit\Framework\TestCase->runTest()
#5 /var/www/glpi/vendor/phpunit/phpunit/src/Framework/TestRunner/TestRunner.php(84): PHPUnit\Framework\TestCase->runBare()
#6 /var/www/glpi/vendor/phpunit/phpunit/src/Framework/TestCase.php(349): PHPUnit\Framework\TestRunner->run(Object(tests\units\ApplianceTest))
#7 /var/www/glpi/vendor/phpunit/phpunit/src/Framework/TestSuite.php(408): PHPUnit\Framework\TestCase->run()
#8 /var/www/glpi/vendor/phpunit/phpunit/src/TextUI/TestRunner.php(62): PHPUnit\Framework\TestSuite->run()
#9 /var/www/glpi/vendor/phpunit/phpunit/src/TextUI/Application.php(201): PHPUnit\TextUI\TestRunner->run(Object(PHPUnit\TextUI\Configuration\Configuration), Object(PHPUnit\Runner\ResultCache\DefaultResultCache), Object(PHPUnit\Framework\TestSuite))
#10 /var/www/glpi/vendor/phpunit/phpunit/phpunit(104): PHPUnit\TextUI\Application->run(Array)
#11 /var/www/glpi/vendor/bin/phpunit(122): include('/var/www/glpi/v...')
#12 {main}
                        )

                )

        )

)

```