### PR TITLE
Override maybeRecursive() in Socket class for Fields plugin

### DIFF
--- a/src/Socket.php
+++ b/src/Socket.php
@@ -83,6 +83,10 @@ class Socket extends CommonDBChild
         return false;
     }
 
+    public function maybeRecursive()
+    {
+        return false;
+    }
 
     public function defineTabs($options = [])
     {


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !36154
- Here is a brief description of what this PR does

when updating to the latest version of Fields plugin :  

```
Error during database query: ALTER TABLE `glpi_plugin_fields_<table_name>` ADD `is_recursive` TINYINT NOT NULL DEFAULT '0' AFTER `entities_id` ,  
  ADD INDEX `is_recursive` (`is_recursive`) - The error is Unknown column 'entities_id' in 'glpi_plugin_fields_<table_name>'.
```

Because `getItemForItemtype(“Glpi\Socket”)->maybeRecursive()` checks recursivity on the element returned by `getConnexityItem()` (Computer)

Complete this PR : https://github.com/glpi-project/glpi/pull/9710
