### PR TITLE
fix(timeline): correct updating of reminders and reasons for waiting …

### DIFF
--- a/phpunit/functional/PendingReasonTest.php
+++ b/phpunit/functional/PendingReasonTest.php
@@ -466,9 +466,10 @@ class PendingReasonTest extends DbTestCase
         $this->login();
         $entity = getItemByTypeName('Entity', '_test_root_entity', true);
 
-        $currentDate = date('Y-m-d H:i:s');
-        $_SESSION['glpi_currenttime'] = $currentDate;
+        $current_date = '2025-01-31 12:00:00';
+        $date2 = '2025-01-31 13:00:00';
 
+        $_SESSION['glpi_currenttime'] = $current_date;
         // Create a set of pending reasons that will be reused in our test cases
         list(
             $pending_reason1,
@@ -498,7 +499,7 @@ class PendingReasonTest extends DbTestCase
                     'pendingreasons_id'           => $pending_reason1->getID(),
                     'followup_frequency'          => 3 * DAY_TIMESTAMP,
                     'followups_before_resolution' => 2,
-                    'last_bump_date'              => $currentDate,
+                    'last_bump_date'              => $current_date,
                 ],
             ],
             'expected' => [
@@ -508,7 +509,7 @@ class PendingReasonTest extends DbTestCase
                 'followups_before_resolution' => 2,
                 // Pending reason is attached to the last followup
                 'pending_timeline_index'      => 0,
-                'last_bump_date'              => $currentDate,
+                'last_bump_date'              => $current_date,
             ]
         ];
 
@@ -521,7 +522,7 @@ class PendingReasonTest extends DbTestCase
                     'pendingreasons_id'           => $pending_reason1->getID(),
                     'followup_frequency'          => 3 * DAY_TIMESTAMP,
                     'followups_before_resolution' => 2,
-                    'last_bump_date'              => $currentDate,
+                    'last_bump_date'              => $current_date,
                 ],
                 [
                     'type'           => TicketTask::class,
@@ -535,7 +536,7 @@ class PendingReasonTest extends DbTestCase
                 'followups_before_resolution' => 2,
                 // Pending reason is attached to the last task
                 'pending_timeline_index'      => 0,
-                'last_bump_date'              => $currentDate,
+                'last_bump_date'              => $current_date,
             ]
         ];
 
@@ -549,7 +550,7 @@ class PendingReasonTest extends DbTestCase
                     'pendingreasons_id'           => $pending_reason1->getID(),
                     'followup_frequency'          => 3 * DAY_TIMESTAMP,
                     'followups_before_resolution' => 2,
-                    'last_bump_date'              => $currentDate,
+                    'last_bump_date'              => $current_date,
                 ],
                 [
                     'type'                        => ITILFollowup::class,
@@ -557,7 +558,7 @@ class PendingReasonTest extends DbTestCase
                     'pendingreasons_id'           => $pending_reason2->getID(),
                     'followup_frequency'          => 2 * DAY_TIMESTAMP,
                     'followups_before_resolution' => 1,
-                    'last_bump_date'              => date('Y-m-d H:i:s', strtotime('+30 seconds', strtotime($currentDate))),
+                    'last_bump_date'              => $date2,
                 ],
 
             ],
@@ -568,7 +569,7 @@ class PendingReasonTest extends DbTestCase
                 'followups_before_resolution' => 1,
                 // The pending reason is always attached to the last follow-up, the second one changes the value of the first one
                 'pending_timeline_index'      => 1,
-                'last_bump_date'              => date('Y-m-d H:i:s', strtotime('+30 seconds', strtotime($currentDate))),
+                'last_bump_date'              => $date2,
             ]
         ];
 
@@ -604,7 +605,7 @@ class PendingReasonTest extends DbTestCase
                     'pendingreasons_id'           => $pending_reason1->getID(),
                     'followup_frequency'          => 3 * DAY_TIMESTAMP,
                     'followups_before_resolution' => 2,
-                    'last_bump_date'              => $currentDate,
+                    'last_bump_date'              => $current_date,
                 ],
                 [
                     'type'    => TicketTask::class,
@@ -616,7 +617,7 @@ class PendingReasonTest extends DbTestCase
                     'pendingreasons_id'           => $pending_reason2->getID(),
                     'followup_frequency'          => 0,
                     'followups_before_resolution' => 0,
-                    'last_bump_date'              => date('Y-m-d H:i:s', strtotime('+30 seconds', strtotime($currentDate))),
+                    'last_bump_date'              => $date2,
                 ],
             ],
             'expected' => [
@@ -626,7 +627,7 @@ class PendingReasonTest extends DbTestCase
                 'followups_before_resolution' => 0,
                 // Pending reason is attached to the third timeline item
                 'pending_timeline_index'      => 2,
-                'last_bump_date'              => date('Y-m-d H:i:s', strtotime('+30 seconds', strtotime($currentDate))),
+                'last_bump_date'              => $date2,
             ]
         ];
 
@@ -641,7 +642,7 @@ class PendingReasonTest extends DbTestCase
                     'pendingreasons_id'           => $pending_reason1->getID(),
                     'followup_frequency'          => 3 * DAY_TIMESTAMP,
                     'followups_before_resolution' => 2,
-                    'last_bump_date'              => $currentDate,
+                    'last_bump_date'              => $current_date,
                 ],
                 [
                     'type'                        => ITILFollowup::class,
@@ -649,7 +650,7 @@ class PendingReasonTest extends DbTestCase
                     'pendingreasons_id'           => $pending_reason1->getID(),
                     'followup_frequency'          => 3 * DAY_TIMESTAMP,
                     'followups_before_resolution' => 2,
-                    'last_bump_date'              => date('Y-m-d H:i:s', strtotime('+30 seconds', strtotime($currentDate))),
+                    'last_bump_date'              => $date2,
                 ],
             ],
             'expected' => [
@@ -659,7 +660,7 @@ class PendingReasonTest extends DbTestCase
                 'followups_before_resolution' => 2,
                 // Pending reason is attached to the first timeline item
                 'pending_timeline_index'      => 0,
-                'last_bump_date'              => $currentDate,
+                'last_bump_date'              => $current_date,
             ]
         ];
 
@@ -673,12 +674,12 @@ class PendingReasonTest extends DbTestCase
                     'pendingreasons_id'           => $pending_reason1->getID(),
                     'followup_frequency'          => 3 * DAY_TIMESTAMP,
                     'followups_before_resolution' => 2,
-                    'last_bump_date'              => $currentDate,
+                    'last_bump_date'              => $current_date,
                 ],
                 [
                     'type'                        => TicketTask::class,
                     'pending'                     => 1,
-                    'last_bump_date'              => date('Y-m-d H:i:s', strtotime('+30 seconds', strtotime($currentDate))),
+                    'last_bump_date'              => $date2,
                 ],
             ],
             'expected' => [
@@ -688,7 +689,7 @@ class PendingReasonTest extends DbTestCase
                 'followups_before_resolution' => 2,
                 // Pending reason is attached to the last followup
                 'pending_timeline_index'      => 0,
-                'last_bump_date'              => $currentDate,
+                'last_bump_date'              => $current_date,
             ]
         ];
 
@@ -700,7 +701,7 @@ class PendingReasonTest extends DbTestCase
                     'type'                        => ITILFollowup::class,
                     'pending'                     => 1,
                     'pendingreasons_id'           => 0,
-                    'last_bump_date'              => $currentDate,
+                    'last_bump_date'              => $current_date,
                 ],
                 [
                     'type'                        => ITILFollowup::class,
@@ -708,7 +709,7 @@ class PendingReasonTest extends DbTestCase
                     'pendingreasons_id'           => $pending_reason1->getID(),
                     'followup_frequency'          => 3 * DAY_TIMESTAMP,
                     'followups_before_resolution' => 2,
-                    'last_bump_date'              => date('Y-m-d H:i:s', strtotime('+30 seconds', strtotime($currentDate))),
+                    'last_bump_date'              => $date2,
                 ],
             ],
             'expected' => [
@@ -718,7 +719,7 @@ class PendingReasonTest extends DbTestCase
                 'followups_before_resolution' => 2,
                 // Pending reason is attached to the last timeline item
                 'pending_timeline_index'      => 1,
-                'last_bump_date'              => date('Y-m-d H:i:s', strtotime('+30 seconds', strtotime($currentDate))),
+                'last_bump_date'              => $date2,
             ]
         ];
 
@@ -732,7 +733,7 @@ class PendingReasonTest extends DbTestCase
                     'pendingreasons_id'           => $pending_reason1->getID(),
                     'followup_frequency'          => 3 * DAY_TIMESTAMP,
                     'followups_before_resolution' => 2,
-                    'last_bump_date'              => $currentDate,
+                    'last_bump_date'              => $current_date,
                 ],
                 [
                     'type'                        => ITILFollowup::class,
@@ -740,7 +741,7 @@ class PendingReasonTest extends DbTestCase
                     'pendingreasons_id'           => 0,
                     'followup_frequency'          => 0,
                     'followups_before_resolution' => 0,
-                    'last_bump_date'              => date('Y-m-d H:i:s', strtotime('+30 seconds', strtotime($currentDate))),
+                    'last_bump_date'              => $date2,
                 ],
             ],
             'expected' => [
@@ -750,7 +751,7 @@ class PendingReasonTest extends DbTestCase
                 'followups_before_resolution' => 0,
                 // Pending reason is attached to the last timeline item
                 'pending_timeline_index'      => 1,
-                'last_bump_date'              => date('Y-m-d H:i:s', strtotime('+30 seconds', strtotime($currentDate))),
+                'last_bump_date'              => $date2,
             ]
         ];
 
@@ -764,7 +765,7 @@ class PendingReasonTest extends DbTestCase
                     'pendingreasons_id'           => $pending_reason1->getID(),
                     'followup_frequency'          => 3 * DAY_TIMESTAMP,
                     'followups_before_resolution' => 2,
-                    'last_bump_date'              => $currentDate,
+                    'last_bump_date'              => $current_date,
                 ],
                 [
                     'type'                        => ITILFollowup::class,
@@ -772,7 +773,7 @@ class PendingReasonTest extends DbTestCase
                     'pendingreasons_id'           => $pending_reason2->getID(),
                     'followup_frequency'          => 2 * DAY_TIMESTAMP,
                     'followups_before_resolution' => 1,
-                    'last_bump_date'              => date('Y-m-d H:i:s', strtotime('+30 seconds', strtotime($currentDate))),
+                    'last_bump_date'              => $date2,
                 ],
             ],
             'expected' => [
@@ -782,7 +783,7 @@ class PendingReasonTest extends DbTestCase
                 'followups_before_resolution' => 1,
                 // Pending reason is attached to the last timeline item
                 'pending_timeline_index'      => 1,
-                'last_bump_date'              => date('Y-m-d H:i:s', strtotime('+30 seconds', strtotime($currentDate))),
+                'last_bump_date'              => $date2,
             ]
         ];
     }
@@ -882,9 +883,13 @@ class PendingReasonTest extends DbTestCase
 
         $entity = getItemByTypeName('Entity', '_test_root_entity', true);
 
-        $currentDate = date('Y-m-d H:i:s');
         $followup_frequency = 3 * DAY_TIMESTAMP;
-        $_SESSION['glpi_currenttime'] = $currentDate;
+
+        $current_date = '2025-01-31 12:00:00';
+        $date_before_bump = '2025-01-28 12:00:00';
+        $date_to_bump = '2025-01-28 11:59:59';
+
+        $_SESSION['glpi_currenttime'] = $current_date;
 
         $itilfollowuptemplate = $this->createItem(ITILFollowupTemplate::class, [
             'entities_id' => getItemByTypeName('Entity', '_test_root_entity', true),
@@ -914,7 +919,7 @@ class PendingReasonTest extends DbTestCase
                     'pendingreasons_id'           => $pending_reason1->getID(),
                     'followup_frequency'          => $followup_frequency,
                     'followups_before_resolution' => 2,
-                    'last_bump_date'              => $currentDate,
+                    'last_bump_date'              => $current_date,
                     'bump_count'                  => 0,
                 ],
             ],
@@ -923,7 +928,7 @@ class PendingReasonTest extends DbTestCase
                 'pendingreasons_id'           => $pending_reason1->getID(),
                 'followup_frequency'          => $followup_frequency,
                 'followups_before_resolution' => 2,
-                'last_bump_date'              => $currentDate,
+                'last_bump_date'              => $current_date,
                 'bump_count'                  => 0,
             ]
         ];
@@ -937,7 +942,7 @@ class PendingReasonTest extends DbTestCase
                     'pendingreasons_id'           => $pending_reason1->getID(),
                     'followup_frequency'          => $followup_frequency,
                     'followups_before_resolution' => 2,
-                    'last_bump_date'              => date('Y-m-d H:i:s', strtotime('-30 seconds', strtotime($currentDate))),
+                    'last_bump_date'              => $current_date,
                     'bump_count'                  => 0,
                 ],
             ],
@@ -946,12 +951,12 @@ class PendingReasonTest extends DbTestCase
                 'pendingreasons_id'           => $pending_reason1->getID(),
                 'followup_frequency'          => $followup_frequency,
                 'followups_before_resolution' => 2,
-                'last_bump_date'              => date('Y-m-d H:i:s', strtotime('-30 seconds', strtotime($currentDate))),
+                'last_bump_date'              => $current_date,
                 'bump_count'                  => 0,
             ]
         ];
 
-        // Case 3: follow up published one day ago
+        // Case 3: follow up published just before the bump date
         yield [
             'timeline' => [
                 [
@@ -960,7 +965,7 @@ class PendingReasonTest extends DbTestCase
                     'pendingreasons_id'           => $pending_reason1->getID(),
                     'followup_frequency'          => $followup_frequency,
                     'followups_before_resolution' => 2,
-                    'last_bump_date'              => date('Y-m-d H:i:s', strtotime('-' . DAY_TIMESTAMP . ' seconds', strtotime($currentDate))),
+                    'last_bump_date'              => $date_before_bump,
                     'bump_count'                  => 0,
                 ],
             ],
@@ -969,7 +974,7 @@ class PendingReasonTest extends DbTestCase
                 'pendingreasons_id'           => $pending_reason1->getID(),
                 'followup_frequency'          => $followup_frequency,
                 'followups_before_resolution' => 2,
-                'last_bump_date'              => date('Y-m-d H:i:s', strtotime('-' . DAY_TIMESTAMP . ' seconds', strtotime($currentDate))),
+                'last_bump_date'              => $date_before_bump,
                 'bump_count'                  => 0,
             ]
         ];
@@ -983,7 +988,7 @@ class PendingReasonTest extends DbTestCase
                     'pendingreasons_id'           => $pending_reason1->getID(),
                     'followup_frequency'          => $followup_frequency,
                     'followups_before_resolution' => 2,
-                    'last_bump_date'              => date('Y-m-d H:i:s', strtotime('-' . $followup_frequency + 1 . ' seconds', strtotime($currentDate))),
+                    'last_bump_date'              => $date_to_bump,
                     'bump_count'                  => 0,
                 ],
             ],
@@ -992,7 +997,7 @@ class PendingReasonTest extends DbTestCase
                 'pendingreasons_id'           => $pending_reason1->getID(),
                 'followup_frequency'          => $followup_frequency,
                 'followups_before_resolution' => 2,
-                'last_bump_date'              => $currentDate,
+                'last_bump_date'              => $current_date,
                 'bump_count'                  => 1,
             ]
         ];
@@ -1006,7 +1011,7 @@ class PendingReasonTest extends DbTestCase
                     'pendingreasons_id'           => $pending_reason1->getID(),
                     'followup_frequency'          => $followup_frequency,
                     'followups_before_resolution' => 2,
-                    'last_bump_date'              => date('Y-m-d H:i:s', strtotime('-' . $followup_frequency + 1 . ' seconds', strtotime($currentDate))),
+                    'last_bump_date'              => $date_to_bump,
                     'bump_count'                  => 1,
                 ],
             ],
@@ -1015,7 +1020,7 @@ class PendingReasonTest extends DbTestCase
                 'pendingreasons_id'           => $pending_reason1->getID(),
                 'followup_frequency'          => $followup_frequency,
                 'followups_before_resolution' => 2,
-                'last_bump_date'              => $currentDate,
+                'last_bump_date'              => $current_date,
                 'bump_count'                  => 2,
             ]
         ];
@@ -1029,7 +1034,7 @@ class PendingReasonTest extends DbTestCase
                     'pendingreasons_id'           => $pending_reason1->getID(),
                     'followup_frequency'          => $followup_frequency,
                     'followups_before_resolution' => 2,
-                    'last_bump_date'              => date('Y-m-d H:i:s', strtotime('-' . $followup_frequency + 1 . ' seconds', strtotime($currentDate))),
+                    'last_bump_date'              => $date_to_bump,
                     'bump_count'                  => 2,
                 ],
             ],
@@ -1038,7 +1043,7 @@ class PendingReasonTest extends DbTestCase
                 'pendingreasons_id'           => 0,
                 'followup_frequency'          => 0,
                 'followups_before_resolution' => 0,
-                'last_bump_date'              => $currentDate,
+                'last_bump_date'              => $current_date,
                 'bump_count'                  => 3,
             ]
         ];

--- a/phpunit/functional/PendingReasonTest.php
+++ b/phpunit/functional/PendingReasonTest.php
@@ -45,6 +45,8 @@ use Problem;
 use ProblemTask;
 use Ticket;
 use TicketTask;
+use ITILFollowupTemplate;
+use SolutionTemplate;
 
 class PendingReasonTest extends DbTestCase
 {
@@ -464,6 +466,9 @@ class PendingReasonTest extends DbTestCase
         $this->login();
         $entity = getItemByTypeName('Entity', '_test_root_entity', true);
 
+        $currentDate = date('Y-m-d H:i:s');
+        $_SESSION['glpi_currenttime'] = $currentDate;
+
         // Create a set of pending reasons that will be reused in our test cases
         list(
             $pending_reason1,
@@ -493,6 +498,7 @@ class PendingReasonTest extends DbTestCase
                     'pendingreasons_id'           => $pending_reason1->getID(),
                     'followup_frequency'          => 3 * DAY_TIMESTAMP,
                     'followups_before_resolution' => 2,
+                    'last_bump_date'              => $currentDate,
                 ],
             ],
             'expected' => [
@@ -502,6 +508,7 @@ class PendingReasonTest extends DbTestCase
                 'followups_before_resolution' => 2,
                 // Pending reason is attached to the last followup
                 'pending_timeline_index'      => 0,
+                'last_bump_date'              => $currentDate,
             ]
         ];
 
@@ -514,6 +521,7 @@ class PendingReasonTest extends DbTestCase
                     'pendingreasons_id'           => $pending_reason1->getID(),
                     'followup_frequency'          => 3 * DAY_TIMESTAMP,
                     'followups_before_resolution' => 2,
+                    'last_bump_date'              => $currentDate,
                 ],
                 [
                     'type'           => TicketTask::class,
@@ -527,6 +535,7 @@ class PendingReasonTest extends DbTestCase
                 'followups_before_resolution' => 2,
                 // Pending reason is attached to the last task
                 'pending_timeline_index'      => 0,
+                'last_bump_date'              => $currentDate,
             ]
         ];
 
@@ -540,6 +549,7 @@ class PendingReasonTest extends DbTestCase
                     'pendingreasons_id'           => $pending_reason1->getID(),
                     'followup_frequency'          => 3 * DAY_TIMESTAMP,
                     'followups_before_resolution' => 2,
+                    'last_bump_date'              => $currentDate,
                 ],
                 [
                     'type'                        => ITILFollowup::class,
@@ -547,6 +557,7 @@ class PendingReasonTest extends DbTestCase
                     'pendingreasons_id'           => $pending_reason2->getID(),
                     'followup_frequency'          => 2 * DAY_TIMESTAMP,
                     'followups_before_resolution' => 1,
+                    'last_bump_date'              => date('Y-m-d H:i:s', strtotime('+30 seconds', strtotime($currentDate))),
                 ],
 
             ],
@@ -557,6 +568,7 @@ class PendingReasonTest extends DbTestCase
                 'followups_before_resolution' => 1,
                 // The pending reason is always attached to the last follow-up, the second one changes the value of the first one
                 'pending_timeline_index'      => 1,
+                'last_bump_date'              => date('Y-m-d H:i:s', strtotime('+30 seconds', strtotime($currentDate))),
             ]
         ];
 
@@ -592,6 +604,7 @@ class PendingReasonTest extends DbTestCase
                     'pendingreasons_id'           => $pending_reason1->getID(),
                     'followup_frequency'          => 3 * DAY_TIMESTAMP,
                     'followups_before_resolution' => 2,
+                    'last_bump_date'              => $currentDate,
                 ],
                 [
                     'type'    => TicketTask::class,
@@ -603,6 +616,7 @@ class PendingReasonTest extends DbTestCase
                     'pendingreasons_id'           => $pending_reason2->getID(),
                     'followup_frequency'          => 0,
                     'followups_before_resolution' => 0,
+                    'last_bump_date'              => date('Y-m-d H:i:s', strtotime('+30 seconds', strtotime($currentDate))),
                 ],
             ],
             'expected' => [
@@ -612,6 +626,7 @@ class PendingReasonTest extends DbTestCase
                 'followups_before_resolution' => 0,
                 // Pending reason is attached to the third timeline item
                 'pending_timeline_index'      => 2,
+                'last_bump_date'              => date('Y-m-d H:i:s', strtotime('+30 seconds', strtotime($currentDate))),
             ]
         ];
 
@@ -626,6 +641,7 @@ class PendingReasonTest extends DbTestCase
                     'pendingreasons_id'           => $pending_reason1->getID(),
                     'followup_frequency'          => 3 * DAY_TIMESTAMP,
                     'followups_before_resolution' => 2,
+                    'last_bump_date'              => $currentDate,
                 ],
                 [
                     'type'                        => ITILFollowup::class,
@@ -633,6 +649,7 @@ class PendingReasonTest extends DbTestCase
                     'pendingreasons_id'           => $pending_reason1->getID(),
                     'followup_frequency'          => 3 * DAY_TIMESTAMP,
                     'followups_before_resolution' => 2,
+                    'last_bump_date'              => date('Y-m-d H:i:s', strtotime('+30 seconds', strtotime($currentDate))),
                 ],
             ],
             'expected' => [
@@ -642,6 +659,7 @@ class PendingReasonTest extends DbTestCase
                 'followups_before_resolution' => 2,
                 // Pending reason is attached to the first timeline item
                 'pending_timeline_index'      => 0,
+                'last_bump_date'              => $currentDate,
             ]
         ];
 
@@ -655,10 +673,12 @@ class PendingReasonTest extends DbTestCase
                     'pendingreasons_id'           => $pending_reason1->getID(),
                     'followup_frequency'          => 3 * DAY_TIMESTAMP,
                     'followups_before_resolution' => 2,
+                    'last_bump_date'              => $currentDate,
                 ],
                 [
                     'type'                        => TicketTask::class,
                     'pending'                     => 1,
+                    'last_bump_date'              => date('Y-m-d H:i:s', strtotime('+30 seconds', strtotime($currentDate))),
                 ],
             ],
             'expected' => [
@@ -668,6 +688,7 @@ class PendingReasonTest extends DbTestCase
                 'followups_before_resolution' => 2,
                 // Pending reason is attached to the last followup
                 'pending_timeline_index'      => 0,
+                'last_bump_date'              => $currentDate,
             ]
         ];
 
@@ -679,6 +700,7 @@ class PendingReasonTest extends DbTestCase
                     'type'                        => ITILFollowup::class,
                     'pending'                     => 1,
                     'pendingreasons_id'           => 0,
+                    'last_bump_date'              => $currentDate,
                 ],
                 [
                     'type'                        => ITILFollowup::class,
@@ -686,6 +708,7 @@ class PendingReasonTest extends DbTestCase
                     'pendingreasons_id'           => $pending_reason1->getID(),
                     'followup_frequency'          => 3 * DAY_TIMESTAMP,
                     'followups_before_resolution' => 2,
+                    'last_bump_date'              => date('Y-m-d H:i:s', strtotime('+30 seconds', strtotime($currentDate))),
                 ],
             ],
             'expected' => [
@@ -695,6 +718,7 @@ class PendingReasonTest extends DbTestCase
                 'followups_before_resolution' => 2,
                 // Pending reason is attached to the last timeline item
                 'pending_timeline_index'      => 1,
+                'last_bump_date'              => date('Y-m-d H:i:s', strtotime('+30 seconds', strtotime($currentDate))),
             ]
         ];
 
@@ -708,6 +732,7 @@ class PendingReasonTest extends DbTestCase
                     'pendingreasons_id'           => $pending_reason1->getID(),
                     'followup_frequency'          => 3 * DAY_TIMESTAMP,
                     'followups_before_resolution' => 2,
+                    'last_bump_date'              => $currentDate,
                 ],
                 [
                     'type'                        => ITILFollowup::class,
@@ -715,6 +740,7 @@ class PendingReasonTest extends DbTestCase
                     'pendingreasons_id'           => 0,
                     'followup_frequency'          => 0,
                     'followups_before_resolution' => 0,
+                    'last_bump_date'              => date('Y-m-d H:i:s', strtotime('+30 seconds', strtotime($currentDate))),
                 ],
             ],
             'expected' => [
@@ -724,6 +750,7 @@ class PendingReasonTest extends DbTestCase
                 'followups_before_resolution' => 0,
                 // Pending reason is attached to the last timeline item
                 'pending_timeline_index'      => 1,
+                'last_bump_date'              => date('Y-m-d H:i:s', strtotime('+30 seconds', strtotime($currentDate))),
             ]
         ];
 
@@ -737,6 +764,7 @@ class PendingReasonTest extends DbTestCase
                     'pendingreasons_id'           => $pending_reason1->getID(),
                     'followup_frequency'          => 3 * DAY_TIMESTAMP,
                     'followups_before_resolution' => 2,
+                    'last_bump_date'              => $currentDate,
                 ],
                 [
                     'type'                        => ITILFollowup::class,
@@ -744,6 +772,7 @@ class PendingReasonTest extends DbTestCase
                     'pendingreasons_id'           => $pending_reason2->getID(),
                     'followup_frequency'          => 2 * DAY_TIMESTAMP,
                     'followups_before_resolution' => 1,
+                    'last_bump_date'              => date('Y-m-d H:i:s', strtotime('+30 seconds', strtotime($currentDate))),
                 ],
             ],
             'expected' => [
@@ -753,6 +782,7 @@ class PendingReasonTest extends DbTestCase
                 'followups_before_resolution' => 1,
                 // Pending reason is attached to the last timeline item
                 'pending_timeline_index'      => 1,
+                'last_bump_date'              => date('Y-m-d H:i:s', strtotime('+30 seconds', strtotime($currentDate))),
             ]
         ];
     }
@@ -801,6 +831,7 @@ class PendingReasonTest extends DbTestCase
                     'pendingreasons_id',
                     'followup_frequency',
                     'followups_before_resolution',
+                    'last_bump_date',
                 ]);
             }
 
@@ -848,16 +879,30 @@ class PendingReasonTest extends DbTestCase
     protected function testCronPendingReasonAutobumpAutosolveProvider()
     {
         $this->login();
+
         $entity = getItemByTypeName('Entity', '_test_root_entity', true);
 
         $currentDate = date('Y-m-d H:i:s');
         $followup_frequency = 3 * DAY_TIMESTAMP;
+        $_SESSION['glpi_currenttime'] = $currentDate;
+
+        $itilfollowuptemplate = $this->createItem(ITILFollowupTemplate::class, [
+            'entities_id' => getItemByTypeName('Entity', '_test_root_entity', true),
+            'name' => 'test',
+            'content' => 'test',
+        ]);
+
+        $itilsolutiontemplate = $this->createItem(SolutionTemplate::class, [
+            'entities_id' => getItemByTypeName('Entity', '_test_root_entity', true),
+            'name' => 'test',
+            'content' => 'test',
+        ]);
 
         // Create a set of pending reasons that will be reused in our test cases
         list(
             $pending_reason1,
         ) = $this->createItems(\PendingReason::class, [
-            ['entities_id' => $entity, 'is_recursive' => true, 'name' => 'Pending 1'],
+            ['entities_id' => $entity, 'is_recursive' => true, 'name' => 'Pending 1', 'itilfollowuptemplates_id' => $itilfollowuptemplate->getID(), 'solutiontemplates_id' => $itilsolutiontemplate->getID()],
         ]);
 
         yield [
@@ -877,7 +922,7 @@ class PendingReasonTest extends DbTestCase
                 'pendingreasons_id'           => $pending_reason1->getID(),
                 'followup_frequency'          => $followup_frequency,
                 'followups_before_resolution' => 2,
-                'last_bump_date' => $currentDate,
+                'last_bump_date'              => $currentDate,
                 'bump_count'                  => 0,
             ]
         ];
@@ -947,6 +992,50 @@ class PendingReasonTest extends DbTestCase
                 'bump_count'                  => 1,
             ]
         ];
+
+        yield [
+            'timeline' => [
+                [
+                    'type'                        => ITILFollowup::class,
+                    'pending'                     => 1,
+                    'pendingreasons_id'           => $pending_reason1->getID(),
+                    'followup_frequency'          => $followup_frequency,
+                    'followups_before_resolution' => 2,
+                    'last_bump_date'              => date('Y-m-d H:i:s', strtotime('-' . $followup_frequency + 1 . ' seconds', strtotime($currentDate))),
+                    'bump_count'                  => 1,
+                ],
+            ],
+            'expected' => [
+                'status'                      => CommonITILObject::WAITING,
+                'pendingreasons_id'           => $pending_reason1->getID(),
+                'followup_frequency'          => $followup_frequency,
+                'followups_before_resolution' => 2,
+                'last_bump_date'              => $currentDate,
+                'bump_count'                  => 2,
+            ]
+        ];
+
+        yield [
+            'timeline' => [
+                [
+                    'type'                        => ITILFollowup::class,
+                    'pending'                     => 1,
+                    'pendingreasons_id'           => $pending_reason1->getID(),
+                    'followup_frequency'          => $followup_frequency,
+                    'followups_before_resolution' => 2,
+                    'last_bump_date'              => date('Y-m-d H:i:s', strtotime('-' . $followup_frequency + 1 . ' seconds', strtotime($currentDate))),
+                    'bump_count'                  => 2,
+                ],
+            ],
+            'expected' => [
+                'status'                      => CommonITILObject::SOLVED,
+                'pendingreasons_id'           => 0,
+                'followup_frequency'          => 0,
+                'followups_before_resolution' => 0,
+                'last_bump_date'              => $currentDate,
+                'bump_count'                  => 3,
+            ]
+        ];
     }
 
     public function testCronPendingReasonAutobumpAutosolve()
@@ -1001,11 +1090,13 @@ class PendingReasonTest extends DbTestCase
 
             $ticket_pending_data = PendingReason_Item::getForItem($ticket);
             $this->assertEquals($expected['status'], $ticket->fields['status']);
-            $this->assertEquals($expected['pendingreasons_id'], $ticket_pending_data->fields['pendingreasons_id']);
-            $this->assertEquals($expected['followup_frequency'], $ticket_pending_data->fields['followup_frequency']);
-            $this->assertEquals($expected['followups_before_resolution'], $ticket_pending_data->fields['followups_before_resolution']);
-            $this->assertEquals($expected['last_bump_date'], $ticket_pending_data->fields['last_bump_date']);
-            $this->assertEquals($expected['bump_count'], $ticket_pending_data->fields['bump_count']);
+            if ($ticket->fields['status'] == CommonITILObject::WAITING) {
+                $this->assertEquals($expected['pendingreasons_id'], $ticket_pending_data->fields['pendingreasons_id']);
+                $this->assertEquals($expected['followup_frequency'], $ticket_pending_data->fields['followup_frequency']);
+                $this->assertEquals($expected['followups_before_resolution'], $ticket_pending_data->fields['followups_before_resolution']);
+                $this->assertEquals($expected['last_bump_date'], $ticket_pending_data->fields['last_bump_date']);
+                $this->assertEquals($expected['bump_count'], $ticket_pending_data->fields['bump_count']);
+            }
         }
     }
 }

--- a/phpunit/functional/PendingReasonTest.php
+++ b/phpunit/functional/PendingReasonTest.php
@@ -775,7 +775,6 @@ class PendingReasonTest extends DbTestCase
                     $correct_timeline_item::getType(),
                     $last_timeline_item_pending_data->fields['itemtype']
                 );
-                $test = $correct_timeline_item->getID();
                 $this->assertEquals(
                     $correct_timeline_item->getID(),
                     $last_timeline_item_pending_data->fields['items_id']

--- a/phpunit/functional/PendingReasonTest.php
+++ b/phpunit/functional/PendingReasonTest.php
@@ -905,6 +905,7 @@ class PendingReasonTest extends DbTestCase
             ['entities_id' => $entity, 'is_recursive' => true, 'name' => 'Pending 1', 'itilfollowuptemplates_id' => $itilfollowuptemplate->getID(), 'solutiontemplates_id' => $itilsolutiontemplate->getID()],
         ]);
 
+        // Case 1: followup just published
         yield [
             'timeline' => [
                 [
@@ -927,6 +928,7 @@ class PendingReasonTest extends DbTestCase
             ]
         ];
 
+        // Case 2: task just published
         yield [
             'timeline' => [
                 [
@@ -949,6 +951,7 @@ class PendingReasonTest extends DbTestCase
             ]
         ];
 
+        // Case 3: follow up that will soon be bumped
         yield [
             'timeline' => [
                 [
@@ -957,7 +960,7 @@ class PendingReasonTest extends DbTestCase
                     'pendingreasons_id'           => $pending_reason1->getID(),
                     'followup_frequency'          => $followup_frequency,
                     'followups_before_resolution' => 2,
-                    'last_bump_date'              => date('Y-m-d H:i:s', strtotime('-' . DAY_TIMESTAMP . ' seconds', strtotime($currentDate))),
+                    'last_bump_date'              => date('Y-m-d H:i:s', strtotime('-' . $followup_frequency . ' seconds', strtotime($currentDate))),
                     'bump_count'                  => 0,
                 ],
             ],
@@ -966,11 +969,12 @@ class PendingReasonTest extends DbTestCase
                 'pendingreasons_id'           => $pending_reason1->getID(),
                 'followup_frequency'          => $followup_frequency,
                 'followups_before_resolution' => 2,
-                'last_bump_date'              => date('Y-m-d H:i:s', strtotime('-' . DAY_TIMESTAMP . ' seconds', strtotime($currentDate))),
+                'last_bump_date'              => date('Y-m-d H:i:s', strtotime('-' . $followup_frequency . ' seconds', strtotime($currentDate))),
                 'bump_count'                  => 0,
             ]
         ];
 
+        // Case 4: follow up that will be bumped one time
         yield [
             'timeline' => [
                 [
@@ -993,6 +997,7 @@ class PendingReasonTest extends DbTestCase
             ]
         ];
 
+        // Case 5: follow up that will be bumped two times
         yield [
             'timeline' => [
                 [
@@ -1015,6 +1020,7 @@ class PendingReasonTest extends DbTestCase
             ]
         ];
 
+        // Case 6: follow up that will be bumped three times. Close the ticket
         yield [
             'timeline' => [
                 [

--- a/phpunit/functional/PendingReasonTest.php
+++ b/phpunit/functional/PendingReasonTest.php
@@ -951,7 +951,7 @@ class PendingReasonTest extends DbTestCase
             ]
         ];
 
-        // Case 3: follow up that will soon be bumped
+        // Case 3: follow up published one day ago
         yield [
             'timeline' => [
                 [
@@ -960,7 +960,7 @@ class PendingReasonTest extends DbTestCase
                     'pendingreasons_id'           => $pending_reason1->getID(),
                     'followup_frequency'          => $followup_frequency,
                     'followups_before_resolution' => 2,
-                    'last_bump_date'              => date('Y-m-d H:i:s', strtotime('-' . $followup_frequency . ' seconds', strtotime($currentDate))),
+                    'last_bump_date'              => date('Y-m-d H:i:s', strtotime('-' . DAY_TIMESTAMP . ' seconds', strtotime($currentDate))),
                     'bump_count'                  => 0,
                 ],
             ],
@@ -969,7 +969,7 @@ class PendingReasonTest extends DbTestCase
                 'pendingreasons_id'           => $pending_reason1->getID(),
                 'followup_frequency'          => $followup_frequency,
                 'followups_before_resolution' => 2,
-                'last_bump_date'              => date('Y-m-d H:i:s', strtotime('-' . $followup_frequency . ' seconds', strtotime($currentDate))),
+                'last_bump_date'              => date('Y-m-d H:i:s', strtotime('-' . DAY_TIMESTAMP . ' seconds', strtotime($currentDate))),
                 'bump_count'                  => 0,
             ]
         ];

--- a/src/Features/ParentStatus.php
+++ b/src/Features/ParentStatus.php
@@ -66,11 +66,15 @@ trait ParentStatus
                     'followup_frequency'          => $input['followup_frequency'] ?? 0,
                     'followups_before_resolution' => $input['followups_before_resolution'] ?? 0,
                     'previous_status'             => $parentitem->fields['status'],
+                    'last_bump_date'              => $input["last_bump_date"] ?? $_SESSION["glpi_currenttime"],
+                    'bump_count'                  => $input["bump_count"] ?? 0,
                 ]);
                 PendingReason_Item::createForItem($this, [
                     'pendingreasons_id'           => $input['pendingreasons_id'] ?? 0,
                     'followup_frequency'          => $input['followup_frequency'] ?? 0,
                     'followups_before_resolution' => $input['followups_before_resolution'] ?? 0,
+                    'last_bump_date'              => $input["last_bump_date"] ?? $_SESSION["glpi_currenttime"],
+                    'bump_count'                  => $input["bump_count"] ?? 0,
                 ]);
             }
         }

--- a/src/PendingReasonCron.php
+++ b/src/PendingReasonCron.php
@@ -90,9 +90,10 @@ class PendingReasonCron extends CommonDBTM
 
         $now = date("Y-m-d H:i:s");
 
-        $pending_items = new PendingReason_Item();
-        $data = $pending_items->find([
-            [
+        $data = $DB->request([
+            'SELECT' => 'id',
+            'FROM'   => PendingReason_Item::getTable(),
+            'WHERE'  => [
                 'pendingreasons_id'  => ['>', 0],
                 'followup_frequency' => ['>', 0],
                 'itemtype'           => $targets

--- a/src/PendingReasonCron.php
+++ b/src/PendingReasonCron.php
@@ -90,10 +90,9 @@ class PendingReasonCron extends CommonDBTM
 
         $now = date("Y-m-d H:i:s");
 
-        $data = $DB->request([
-            'SELECT' => 'id',
-            'FROM'   => PendingReason_Item::getTable(),
-            'WHERE'  => [
+        $pending_items = new PendingReason_Item();
+        $data = $pending_items->find([
+            [
                 'pendingreasons_id'  => ['>', 0],
                 'followup_frequency' => ['>', 0],
                 'itemtype'           => $targets
@@ -144,7 +143,7 @@ class PendingReasonCron extends CommonDBTM
                 $success = $pending_item->update([
                     'id'             => $pending_item->getID(),
                     'bump_count'     => $pending_item->fields['bump_count'] + 1,
-                    'last_bump_date' => date("Y-m-d H:i:s"),
+                    'last_bump_date' => $_SESSION['glpi_currenttime'],
                 ]);
 
                 if (!$success) {

--- a/src/PendingReasonCron.php
+++ b/src/PendingReasonCron.php
@@ -88,7 +88,7 @@ class PendingReasonCron extends CommonDBTM
             Problem::getType(),
         ];
 
-        $now = date("Y-m-d H:i:s");
+        $now = $_SESSION['glpi_currenttime'];
 
         $data = $DB->request([
             'SELECT' => 'id',

--- a/src/PendingReason_Item.php
+++ b/src/PendingReason_Item.php
@@ -403,25 +403,22 @@ class PendingReason_Item extends CommonDBRelation
 
         // Let's check if there is any real updates before going any further
         $pending_updates = [];
+
         $fields_to_check_for_updates = ['pendingreasons_id', 'followup_frequency', 'followups_before_resolution'];
         foreach ($fields_to_check_for_updates as $field) {
             if (
                 isset($new_timeline_item->input[$field])
-                && $new_timeline_item->input[$field] != $last_pending->fields[$field]
             ) {
                 $pending_updates[$field] = $new_timeline_item->input[$field];
+            } else {
+                $pending_updates[$field] = 0;
             }
         }
 
-        // No actual updates -> nothing to be done
-        if (count($pending_updates) == 0) {
-            return;
+        if ($new_timeline_item::class === ITILFollowup::class) {
+            self::createForItem($new_timeline_item, $pending_updates);
         }
 
-        // Update last pending item and parent
-        $last_pending_timeline_item = new $last_pending->fields['itemtype']();
-        $last_pending_timeline_item->getFromDB($last_pending->fields['items_id']);
-        self::updateForItem($last_pending_timeline_item, $pending_updates);
         self::updateForItem($new_timeline_item->input['_job'], $pending_updates);
     }
 

--- a/src/PendingReason_Item.php
+++ b/src/PendingReason_Item.php
@@ -411,15 +411,16 @@ class PendingReason_Item extends CommonDBRelation
             ) {
                 $pending_updates[$field] = $new_timeline_item->input[$field];
             } else {
-                $pending_updates[$field] = 0;
+                $pending_updates[$field] = "0";
             }
         }
 
-        if ($new_timeline_item::class === ITILFollowup::class) {
-            self::createForItem($new_timeline_item, $pending_updates);
-        }
+        self::createForItem($new_timeline_item, $pending_updates);
 
-        self::updateForItem($new_timeline_item->input['_job'], $pending_updates);
+        // If the ticket is already pending and the follow-up is pending, updating the ticket waiting is not necessary
+        if (!($new_timeline_item::class === ITILFollowup::class && $pending_updates['pendingreasons_id'] === "0")) {
+            self::updateForItem($new_timeline_item->input['_job'], $pending_updates);
+        }
     }
 
     /**

--- a/src/PendingReason_Item.php
+++ b/src/PendingReason_Item.php
@@ -96,7 +96,9 @@ class PendingReason_Item extends CommonDBRelation
 
         $fields['itemtype'] = $item::getType();
         $fields['items_id'] = $item->getID();
-        //$fields['last_bump_date'] = $_SESSION['glpi_currenttime'];
+        if (!isset($fields['last_bump_date'])) {
+            $fields['last_bump_date'] = $_SESSION['glpi_currenttime'];
+        }
         $success = $em->add($fields);
         if (!$success) {
             trigger_error("Failed to create PendingReason_Item", E_USER_WARNING);

--- a/src/PendingReason_Item.php
+++ b/src/PendingReason_Item.php
@@ -96,7 +96,7 @@ class PendingReason_Item extends CommonDBRelation
 
         $fields['itemtype'] = $item::getType();
         $fields['items_id'] = $item->getID();
-        $fields['last_bump_date'] = $_SESSION['glpi_currenttime'];
+        //$fields['last_bump_date'] = $_SESSION['glpi_currenttime'];
         $success = $em->add($fields);
         if (!$success) {
             trigger_error("Failed to create PendingReason_Item", E_USER_WARNING);
@@ -374,18 +374,16 @@ class PendingReason_Item extends CommonDBRelation
         CommonDBTM $new_timeline_item
     ): void {
         $last_pending = self::getLastPendingTimelineItemDataForItem($new_timeline_item->input['_job']);
-
-        // Let's check if there is any real updates before going any further
-        $pending_updates = [];
-
-        if (isset($new_timeline_item->input['last_bump_date'])) {
-            $pending_updates['last_bump_date'] = $new_timeline_item->input['last_bump_date'];
-        }
+        $ticket_pending_updates = [];
 
         // There is no existing pending data on previous timeline items for this ticket
         // Nothing to be done here since the goal of this method is to update active pending data
         if (!$last_pending) {
             return;
+        }
+
+        if (isset($new_timeline_item->input['last_bump_date'])) {
+            $ticket_pending_updates['last_bump_date'] = $new_timeline_item->input['last_bump_date'];
         }
 
         // The new timeline item is the latest pending reason
@@ -395,7 +393,7 @@ class PendingReason_Item extends CommonDBRelation
             $last_pending->fields['itemtype'] == $new_timeline_item::getType()
             && $last_pending->fields['items_id'] == $new_timeline_item->getID()
         ) {
-            self::updateForItem($new_timeline_item->input['_job'], $pending_updates);
+            self::updateForItem($new_timeline_item->input['_job'], $ticket_pending_updates);
             return;
         }
 
@@ -409,30 +407,35 @@ class PendingReason_Item extends CommonDBRelation
         // was added on a CommonITILObject which already had pending data
         // This mean the user might be trying to update the existing pending reason data
 
+        // Let's check if there is any real updates before going any further
+        $pending_updates_timeline_item = [];
+
         $fields_to_check_for_updates = ['pendingreasons_id', 'followup_frequency', 'followups_before_resolution'];
         foreach ($fields_to_check_for_updates as $field) {
             if (
                 isset($new_timeline_item->input[$field])
                 && $new_timeline_item->input[$field] != $last_pending->fields[$field]
             ) {
-                $pending_updates[$field] = $new_timeline_item->input[$field];
+                $pending_updates_timeline_item[$field] = $new_timeline_item->input[$field];
             }
         }
 
         // No actual updates -> nothing to be done
-        if (count($pending_updates) == 0) {
+        if (count($pending_updates_timeline_item) == 0) {
             return;
         }
 
-        $pending_updates_timeline_item = $pending_updates;
+        $ticket_pending_updates += $pending_updates_timeline_item;
+        $pending_updates_timeline_item = $ticket_pending_updates;
+
         $pending_updates_timeline_item['items_id'] = $new_timeline_item->getID();
         $pending_updates_timeline_item['itemtype'] = $new_timeline_item::getType();
 
         // Update last pending item and parent
-        if ($pending_updates['pendingreasons_id'] > 0 || $new_timeline_item::getType() !== $last_pending::getType()) {
+        if ($ticket_pending_updates['pendingreasons_id'] > 0 || $new_timeline_item::getType() !== $last_pending::getType()) {
             self::createForItem($new_timeline_item, $pending_updates_timeline_item);
         }
-        self::updateForItem($new_timeline_item->input['_job'], $pending_updates);
+        self::updateForItem($new_timeline_item->input['_job'], $ticket_pending_updates);
     }
 
     /**


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !36212
- This PR changes the behavior when changing the reason of expectations in a ticket already pending.

If the reason for waiting is changed via a follow-up, the date of publication of the follow-up will be the new initial date to perform the reminders. Before, the initial date was unchanged. It remained the publication date of the ticket holder.

To change a reason for waiting without losing the time already elapsed, it will be necessary to select the reason for waiting by modifying the tracking that generated it.


