### PR TITLE
Fix: Undefined array key on Asset import

### DIFF
--- a/src/Inventory/Asset/MainAsset.php
+++ b/src/Inventory/Asset/MainAsset.php
@@ -588,7 +588,7 @@ abstract class MainAsset extends InventoryAsset
                     //Only main item is stored as refused, not all APs
                     unset($this->data[$key]);
                 } else {
-                    if ($datarules['action'] != RuleImportAsset::LINK_RESULT_DENIED) {
+                    if (isset($datarules['action']) && $datarules['action'] != RuleImportAsset::LINK_RESULT_DENIED) {
                         $input['rules_id'] = $datarules['rules_id'];
                         $this->addRefused($input);
                     }


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does

## Screenshots (if appropriate):

The error "Undefined array key" is thrown on GLPI-Agent 1.12 when importing Inventory from a Windows machine when modifying the "Computer update (by serial + uuid)" from "Link if possible" (default) to "Link if possible, otherwise imports declined".

<img width="1112" alt="image" src="https://github.com/user-attachments/assets/344bd7dc-c367-4243-bed7-1e82854d7705" />

I did a ``error_log(print_r($datarules, true))`` before the if call and it returns the following:

```
(
    [rules_id] => 247
    [_ruleid] => 247
)
```

This ID reflects the rule ``Computer update (by serial + uuid)`` which refers to the Rule where it stopped and the asset hasn't been imported. Notice that there's no ``action`` key on the array. This PR do the ``action`` validation only if it's set.

The machine doesn't exist on the ``glpi_computers`` DB (it existed before but has been deleted). The inventory file of this machine is in attachment.

[server02-with-glpi-agent.json](https://github.com/user-attachments/files/18661894/server02-with-glpi-agent.json)