### PR TITLE
Remove extra break on Management Port (Network Ports - Asset)

### DIFF
--- a/src/NetworkPort.php
+++ b/src/NetworkPort.php
@@ -1181,8 +1181,12 @@ class NetworkPort extends CommonDBChild
                             break;
                         case 126: //IP address
                             $ips_iterator = $this->getIpsForPort('NetworkPort', $port['id']);
-                            foreach ($ips_iterator as $iprow) {
-                                $output .= '<br/>' . $iprow['name'];
+                            for ($i = 0; $i < count($ips_iterator); $i++) {
+                                if ($i > 0) {
+                                    $output .= '<br />';
+                                    $ips_iterator->next();
+                                }
+                                $output .= $ips_iterator->current()['name'];
                             }
                             break;
                         case 127:
@@ -1193,10 +1197,14 @@ class NetworkPort extends CommonDBChild
                                     'items_id'  => $port['id']
                                 ]
                             ]);
-                            foreach ($names_iterator as $namerow) {
+                            for ($i = 0; $i < count($names_iterator); $i++) {
+                                 if ($i > 0) {
+                                   $output .= '<br />';
+                                   $names_iterator->next();
+                                 }
                                  $netname = new NetworkName();
-                                 $netname->getFromDB($namerow['id']);
-                                 $output .= '<br/>' . $netname->getLink();
+                                 $netname->getFromDB($names_iterator->current()['id']);
+                                 $output .= $netname->getLink();
                             }
                             break;
                         default:


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does

## Screenshots (if appropriate):

This PR removes the extra break on **Management port** section:

<img width="1441" alt="image" src="https://github.com/user-attachments/assets/8a6e5459-5fa2-47b5-ad35-0cff2117f47d" />

After this PR:

<img width="1409" alt="image" src="https://github.com/user-attachments/assets/38e4b198-b649-4ce2-82c1-312f1434648d" />
