### PR TITLE
Fix(Notification): Order by id ASC

### DIFF
--- a/src/NotificationTargetCommonITILObject.php
+++ b/src/NotificationTargetCommonITILObject.php
@@ -1364,7 +1364,7 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
                 'glpi_itilfollowups',
                 [
                     'WHERE'  => $followup_restrict,
-                    'ORDER'  => ['date_mod DESC', 'id ASC']
+                    'ORDER'  => ['date_mod DESC', 'id DESC']
                 ]
             );
             $data['followups'] = [];


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Related ticket : !35966 (@cedric-anne)


## Imagine the following scenario:

On a ticket, three actors reply to an email within the same minute (important). The follow-ups are correctly displayed in the ticket timeline

![image](https://github.com/user-attachments/assets/7fb3e01d-abbd-4038-bd96-e4f3545826eb)


 and recorded in the database.

```sql
MariaDB [10bugfixes]> select id, date_creation, date_mod, content from glpi_itilfollowups;
+----+---------------------+---------------------+------------+
| id | date_creation       | date_mod            | content    |
+----+---------------------+---------------------+------------+
| 90 | 2025-02-05 10:41:57 | 2025-02-05 10:41:57 | followup 1 |
| 91 | 2025-02-05 10:41:57 | 2025-02-05 10:41:57 | followup 2 |
| 92 | 2025-02-05 10:41:57 | 2025-02-05 10:41:57 | followup 3 |
+----+---------------------+---------------------+------------+
```

However, when GLPI generates notifications for these actors, the `##FOREACH LAST followups##` loop always includes the **first follow-up** instead of the latest one.

This issue occurs because the `NotificationTargetCommonITILObject` class retrieves follow-ups using the following query:

```php
$followups = getAllDataFromTable(
    'glpi_itilfollowups',
    [
        'WHERE'  => $followup_restrict,
        'ORDER'  => ['date_mod DESC', 'id ASC']
    ]
);
``` 

`date_mod` is identical, so `ORDER BY id` takes precedence

Which gives

```sql
MariaDB [10bugfixes]> select id, date_creation, date_mod, content from glpi_itilfollowups order by date_mod DESC, id ASC;
+----+---------------------+---------------------+------------+
| id | date_creation       | date_mod            | content    |
+----+---------------------+---------------------+------------+
| 90 | 2025-02-05 10:41:57 | 2025-02-05 10:41:57 | followup 1 |
| 91 | 2025-02-05 10:41:57 | 2025-02-05 10:41:57 | followup 2 |
| 92 | 2025-02-05 10:41:57 | 2025-02-05 10:41:57 | followup 3 |
+----+---------------------+---------------------+------------+
```

Subsequently, in `NotificationTemplate.php` (`process()`), the `##FOREACH LAST followups##` loop applies the following instruction:

```php
    if ($out[1][$id] == 'FIRST') {
        $foreachvalues = array_reverse($foreachvalues);
    }

    if (isset($out[2][$id]) && $out[2][$id]) {
        $foreachvalues = array_slice($foreachvalues, 0, $out[2][$id]);
    } else {
        $foreachvalues = array_slice($foreachvalues, 0, 1);
    }
```

As the key is not `FIRST` but `LAST`, array is not reversed.

And this

```php
$foreachvalues = array_slice($foreachvalues, 0, 1);
```

extracts only the first element of the array, which explains why the notification always displays the oldest follow-up instead of the most recent one.

## Let's now examine the result with follow-ups added at one-second intervals

Here is the result of loading data from the database:

```sql
MariaDB [10bugfixes]> select id, date_creation, date_mod, content from glpi_itilfollowups order by date_mod DESC, id ASC;
+----+---------------------+---------------------+------------+
| id | date_creation       | date_mod            | content    |
+----+---------------------+---------------------+------------+
| 92 | 2025-02-05 10:41:59 | 2025-02-05 10:41:59 | followup 3 |
| 91 | 2025-02-05 10:41:58 | 2025-02-05 10:41:58 | followup 2 |
| 90 | 2025-02-05 10:41:57 | 2025-02-05 10:41:57 | followup 1 |
+----+---------------------+---------------------+------------+
```
Under these conditions, the extraction performed by `NotificationTemplate.php` is correct

It extracts the first table element that corresponds to the last followup

My change aims to maintain the same sorting as if `date_mod` were usable (However, I must admit that I am unsure of the full impact of this change.)


We agree that this type of scenario remains exceptional—three follow-ups within the same second... Perhaps GLPI should consider saving timestamps with millisecond precision for follow-ups.

I'm not sure how the unit tests will behave (I'm somewhat hesitant about modifying or adapting this part of the code). Given that this is an extremely rare edge case, we can most likely avoid going any further on this matter.




## Screenshots (if appropriate):


