### PR TITLE
Remove ref to missing lib/gridstack-extra.css file

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -1091,7 +1091,6 @@ TWIG,
 
             if (in_array('gridstack', $jslibs)) {
                 $tpl_vars['css_files'][] = ['path' => 'lib/gridstack.css'];
-                $tpl_vars['css_files'][] = ['path' => 'lib/gridstack-extra.css'];
                 Html::requireJs('gridstack');
             }
 


### PR DESCRIPTION
## Description

This was added in #18771 but it seems this file does not exist, which trigger a failed request on most pages.

## Screenshots

![image](https://github.com/user-attachments/assets/429d46ff-7aff-43f7-9948-ba49c3951f44)

![image](https://github.com/user-attachments/assets/8a5c602e-6c2a-48fe-9a7a-610b478bfa34)
