### PR TITLE
Recompute `.package.hash` when npm dependencies are changed

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -65,8 +65,6 @@ if (isset($_SERVER['argv']) && ['dependencies', 'install'] === array_slice($_SER
       exit($exit_code);
    }
 
-   file_put_contents('.package.hash', sha1_file('package-lock.json'));
-
    passthru('npm run-script build', $exit_code);
    if ($exit_code > 0) {
       exit($exit_code);

--- a/package.json
+++ b/package.json
@@ -69,6 +69,8 @@
     "scripts": {
         "build:pack": "webpack --config .webpack.config.js",
         "build": "npm run build:pack",
+        "dependencies:postinstall": "php -r \"file_put_contents('.package.hash', sha1_file('package-lock.json'));\"",
+        "dependencies": "npm run dependencies:postinstall",
         "test": "NODE_OPTIONS=\"--experimental-vm-modules\" jest --colors --forceExit --config tests/js/jest.config.js ./tests/js/**"
     },
     "devDependencies": {


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

When we introduced `npm` to fetch our front-end dependencies, we were not able to recompute the `.package.hash` file automatically from a `npm` event because there was at this time no event triggered after the `package-lock.json` file update.

The probem is that we have to manually call `bin/console dependencies:install` after a `npm install {package}` operation to recompute this `.package.hash` file.

More recently, a `dependencies` event have been introduced.
> The dependencies script is run any time an npm command causes changes to the node_modules directory. It is run AFTER the changes have been applied and the package.json and package-lock.json files have been updated.

We can rely on it to be sure that the `.package.hash` is always up-to-date when new dependencies are installed.