### PR TITLE
Fix computer link on virtualization tab

### DIFF
--- a/src/ItemVirtualMachine.php
+++ b/src/ItemVirtualMachine.php
@@ -207,7 +207,7 @@ class ItemVirtualMachine extends CommonDBChild
                 foreach ($hosts as $host) {
                     if ($computer->can($host['items_id'], READ)) {
                         $entries[] = [
-                            'name' => $computer->getLink($host['items_id']),
+                            'name' => $computer->getLink(),
                             'serial' => $computer->fields['serial'],
                             'comment' => $computer->fields['comment'],
                             'entity' => Dropdown::getDropdownName('glpi_entities', $computer->fields['entities_id'])


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Fixes the following error:
```
glpi.CRITICAL:   *** Uncaught PHP Exception TypeError: "array_key_exists(): Argument #2 ($array) must be of type array, int given" at CommonDBTM.php line 1488
  Backtrace :
  src/ItemVirtualMachine.php:210                     CommonDBTM->getLink()
  src/ItemVirtualMachine.php:114                     ItemVirtualMachine::showForVirtualMachine()
  src/CommonGLPI.php:681                             ItemVirtualMachine::displayTabContentForItem()
  ajax/common.tabs.php:112                           CommonGLPI::displayStandardTab()
  ...Glpi/Controller/LegacyFileLoadController.php:59 require()
  vendor/symfony/http-kernel/HttpKernel.php:101      Glpi\Controller\LegacyFileLoadController->Glpi\Controller\{closure}()
  ...ymfony/http-foundation/StreamedResponse.php:106 Symfony\Component\HttpKernel\HttpKernel::Symfony\Component\HttpKernel\{closure}()
  vendor/symfony/http-foundation/Response.php:423    Symfony\Component\HttpFoundation\StreamedResponse->sendContent()
  src/Glpi/Kernel/Kernel.php:238                     Symfony\Component\HttpFoundation\Response->send()
  public/index.php:58                                Glpi\Kernel\Kernel->sendResponse()
```