### PR TITLE
Fix(inventory): 'uuid' criterion must be identical to what VirtualMachine does

### DIFF
--- a/src/RuleImportAsset.php
+++ b/src/RuleImportAsset.php
@@ -862,7 +862,11 @@ class RuleImportAsset extends Rule
                             ]
                         ];
                     } else {
-                        $it_criteria['WHERE'][] = ["$itemtable.uuid" => $input['uuid']];
+                        $it_criteria['WHERE'][] = [
+                            "RAW" => [
+                                "LOWER($itemtable.uuid)" => ComputerVirtualMachine::getUUIDRestrictCriteria($input['uuid'])
+                            ]
+                        ];
                     }
                     break;
 


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- Alternative to [#18921](https://github.com/glpi-project/glpi/pull/18921)

This PR enhances the **GLPI reconciliation engine** by integrating the `getUUIDRestrictCriteria()` method into **UUID-based matching rules**.  

Currently, **virtual machine processing** correctly identifies and associates computers using this method. However, the **reconciliation rules do not account for "mixed" UUIDs** in their queries, leading to inconsistencies.  

As a result, while the **native inventory** successfully links computers even when UUIDs are "mixed," the **reconciliation process fails to do so**.  

### **Use Case:**  

1️⃣ **Step 1: Importing an inventory file (Computer with Agent)**  
- The file contains `"uuid": "BC4C4D56-A9C6-6919-3FEE-FA0F3887B6A5"`.  
- GLPI correctly imports it as a `Computer` → ✅ **OK**  

2️⃣ **Step 2: ESX Inventory & VM Reconciliation**  
- The ESX inventory detects a VM with `"uuid": "564d4cbc-c6a9-1969-3fee-fa0f3887b6a5"`.  
- GLPI **correctly reconciles** it with the related computer, even though the UUID is "mixed."  
- During the process, the `Computer`'s UUID is updated to match the **ESX** one → ✅ **OK**  

3️⃣ **Step 3: Importing an inventory file (Computer without Agent / Agentless)**  
- The file contains `"uuid": "BC4C4D56-A9C6-6919-3FEE-FA0F3887B6A5"`.  
- Instead of reconciling it with the **existing** `Computer`, GLPI **creates a new one**.  
- This happens because the **UUID-based matching rules do not use `getUUIDRestrictCriteria()`** → ❌ **KO**  


This leads to an error in ESX (the virtual machine manager) because ESX cannot correctly identify the associated computer.

![image](https://github.com/user-attachments/assets/16e50b59-fd4b-493e-96a9-3e28a74f9a09)


## Screenshots (if appropriate):


