### PR TITLE
Fix: Add entry to VM Computer "Import information" on ESX inventory

### DIFF
--- a/src/Inventory/Asset/VirtualMachine.php
+++ b/src/Inventory/Asset/VirtualMachine.php
@@ -323,19 +323,21 @@ class VirtualMachine extends InventoryAsset
                         $vm->entities_id = $this->item->fields['entities_id'];
                         $computers_vm_id = $computervm->add($input);
 
-                        $rulesmatched = new \RuleMatchedLog();
-                        $agents_id = $this->agent->fields['id'];
-                        if (empty($agents_id)) {
-                            $agents_id = 0;
+                        if (isset($datarules['found_inventories'])) {
+                            $rulesmatched = new \RuleMatchedLog();
+                            $agents_id = $this->agent->fields['id'];
+                            if (empty($agents_id)) {
+                                $agents_id = 0;
+                            }
+                            $inputrulelog = [
+                                'date'      => date('Y-m-d H:i:s'),
+                                'rules_id'  => $datarules['rules_id'],
+                                'items_id'  => $computers_vm_id,
+                                'itemtype'  => $input['itemtype'],
+                                'agents_id' => $agents_id,
+                                'method'    => 'inventory'
+                            ];
                         }
-                        $inputrulelog = [
-                            'date'      => date('Y-m-d H:i:s'),
-                            'rules_id'  => $datarules['rules_id'],
-                            'items_id'  => $computers_vm_id,
-                            'itemtype'  => $input['itemtype'],
-                            'agents_id' => $agents_id,
-                            'method'    => 'inventory'
-                        ];
                         $rulesmatched->add($inputrulelog, [], false);
                     } else {
                         //refused by rules
@@ -366,7 +368,9 @@ class VirtualMachine extends InventoryAsset
                             'method'    => 'inventory'
                         ];
                         $rulesmatched->add($inputrulelog, [], false);
+                    }
 
+                    if (isset($datarules['_no_rule_matches']) && ($datarules['_no_rule_matches'] == '1') || isset($datarules['found_inventories'])) {
                         $computervm->update($input);
                     }
                 }

--- a/src/Inventory/Asset/VirtualMachine.php
+++ b/src/Inventory/Asset/VirtualMachine.php
@@ -351,7 +351,6 @@ class VirtualMachine extends InventoryAsset
                             'method'    => 'inventory'
                         ];
                         $rulesmatched->add($inputrulelog, [], false);
-                        trigger_error(print_r($inputrulelog, true));
 
                         $computervm->update($input);
                     }

--- a/src/Inventory/Asset/VirtualMachine.php
+++ b/src/Inventory/Asset/VirtualMachine.php
@@ -316,12 +316,27 @@ class VirtualMachine extends InventoryAsset
                     $input['states_id'] = $this->conf->states_id_default > 0 ? $this->conf->states_id_default : 0;
                     $input['entities_id'] = $this->main_asset->getEntityID();
                     $input  = Sanitizer::sanitize($input);
-                    $datarules = $rule->processAllRules($input);
+                    $datarules = $rule->processAllRules($input, [], ['class' => $input['itemtype'], 'return' => true]);
 
                     if (isset($datarules['_no_rule_matches']) && ($datarules['_no_rule_matches'] == '1') || isset($datarules['found_inventories'])) {
                         //this is a new one
                         $vm->entities_id = $this->item->fields['entities_id'];
                         $computers_vm_id = $computervm->add($input);
+
+                        $rulesmatched = new \RuleMatchedLog();
+                        $agents_id = $this->agent->fields['id'];
+                        if (empty($agents_id)) {
+                            $agents_id = 0;
+                        }
+                        $inputrulelog = [
+                            'date'      => date('Y-m-d H:i:s'),
+                            'rules_id'  => $datarules['rules_id'],
+                            'items_id'  => $computers_vm_id,
+                            'itemtype'  => $input['itemtype'],
+                            'agents_id' => $agents_id,
+                            'method'    => 'inventory'
+                        ];
+                        $rulesmatched->add($inputrulelog, [], false);
                     } else {
                         //refused by rules
                         continue;


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does

This is an improvement to the https://github.com/glpi-project/glpi/commit/2003e071797b1e8ed4362302b73649ba60040fcb commit. It's backported to GLPI 10 because actually only the "Import information" of ESX host asset is updated when an ESX inventory task updates the info of an asset. This commit also creates an import entry for every Computer assets created/updated by the same ESX remote inventory task (the https://github.com/glpi-project/glpi/commit/2003e071797b1e8ed4362302b73649ba60040fcb commit do not create an import entry for added Computer assets because ``processRules`` is run before the Computer is created so it cannot be associated to it).

We need to use 'return => true' on ``processAllRules`` and create the RuleMatchLog manually because the Agent wasn't being reported into the 11.0.2-alpha tag commit, as can be seen below:

![image](https://github.com/user-attachments/assets/cf18af52-daa5-4615-ad76-9343948b7e22)

The last entry is my PR and the other is the 11.0.2-alpha tag commit.

## Screenshots (if appropriate):


