### PR TITLE
Fix(Reservation): check for PURGE right instead of DELETE

### DIFF
--- a/src/Reservation.php
+++ b/src/Reservation.php
@@ -98,7 +98,7 @@ class Reservation extends CommonDBChild
         if (
             isset($this->fields["users_id"])
             && (($this->fields["users_id"] === Session::getLoginUserID())
-              || Session::haveRight("reservation", DELETE))
+              || Session::haveRight("reservation", PURGE))
         ) {
            // Processing Email
             if (!isset($this->input['_disablenotif']) && $CFG_GLPI["use_notifications"]) {


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !36205

The deletion notification does not work because `pre_deleteItem()` checks the `DELETE` right instead of the `PURGE` right.

The DELETE right does not exist on reservations

![image](https://github.com/user-attachments/assets/d84af814-1624-4f0e-890f-6121f0555e67)


## Screenshots (if appropriate):


