### PR TITLE
Fix ONADD rules based on inventory agent tag

### DIFF
--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -5781,17 +5781,6 @@ class CommonDBTM extends CommonGLPI
                 $input['_auto'] = 0;
             }
 
-            //if agent exist pass the 'tag' to RuleAssetCollection
-            if (
-                Toolbox::hasTrait($this, \Glpi\Features\Inventoriable::class)
-                && method_exists($this, 'getInventoryAgent')
-            ) {
-                $agent = $this->getInventoryAgent();
-                if ($agent !== null) {
-                    $input['_tag'] = $agent->fields['tag'];
-                }
-            }
-
             // Set the condition (add or update)
             $output = $ruleasset->processAllRules($input, [], [], [
                 'condition' => $condition

--- a/src/Inventory/Asset/InventoryAsset.php
+++ b/src/Inventory/Asset/InventoryAsset.php
@@ -474,6 +474,12 @@ abstract class InventoryAsset
                 $input[$key] = $val;
             }
         }
+
+        if (isset($this->agent->fields['tag'])) {
+            // Pass the tag that can be used in rules criteria
+            $input['_tag'] = $this->agent->fields['tag'];
+        }
+
         return $input;
     }
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] ~I have added tests that prove my fix is effective or that my feature works.~ Tests were already present, but are not failing due to an unexplained reason.

## Description

I still cannot explain why the existing `tests\units\Glpi\Inventory\InventoryTest::testOtherSerialFromTag()` test was passing and therefore I cannot be sure that the corresponding feature was buggy. Anyway, it should not have work with the current logic that is:
1. When the inventory is handled, the agent is created with the `itemtype=Computer` `items_id=0` properties.
2. The computer is then created with `CommonDBTM::add()`.
3. Before it is actually created in DB, the rules are processed in `CommonDBTM::assetBusinessRules()`.
4. At this point, `$this->getInventoryAgent()` can only return `null`, because the computer has not yet any ID, and therefore no agent can be linked to it. No agent tag can be added in `$input['_tag']` and the rule criteria cannot be evaluated.

With the proposed change, the `$input['_tag']` is defined in the `InventoryAsset::handleInput()` method in order to be available for both creation and update operations.