### PR TITLE
Changes the style of the reasons for waiting completed

### DIFF
--- a/src/PendingReason_Item.php
+++ b/src/PendingReason_Item.php
@@ -271,6 +271,10 @@ class PendingReason_Item extends CommonDBRelation
     ): bool {
         $pending_item = self::getLastPendingTimelineItemDataForItem($item);
 
+        if (!$pending_item) {
+            return false;
+        }
+
         return
             $pending_item->fields['items_id'] == $timeline_item->fields['id']
             && $pending_item->fields['itemtype'] == $timeline_item::getType()

--- a/templates/components/itilobject/timeline/pending_reasons_messages.html.twig
+++ b/templates/components/itilobject/timeline/pending_reasons_messages.html.twig
@@ -33,6 +33,21 @@
 
 {% set pending_reason_item_parent = call("PendingReason_Item::getForItem", [item]) %}
 
+{% set pending_reason_contexts = {
+   'pending': {
+      'className' : 'badge bg-blue-lt',
+      'icon' : '<i class="fas fa-pause me-1"></i>',
+      'text': __('Pending'),
+   },
+   'done': {
+      'className' : 'badge bg-transparent text-muted',
+      'icon' : '<i class="fas fa-solid fa-check"></i>',
+      'text' : __('Done'),
+   }
+} %}
+
+{% set pending_reason_selected_context = 'pending' %}
+
 {% if display_for_parent %}
    {% set pending_reason = pending_reason_item_parent ? call("PendingReason::getById", [pending_reason_item_parent.fields['pendingreasons_id']]) : false %}
 {% else %}
@@ -43,27 +58,13 @@
       item,
       pending_item
    ]) %}
-   {% set active_pending_icon %}
-      <i class="fas fa-pause me-1"></i>
-   {% endset %}
-   {% set done_pending_icon %}
-      <i class="fas fa-solid fa-check"></i>
-   {% endset %}
-   {% set pending_reason_option = is_latest_pending and pending_reason_item_parent != false ? {
-      'className' : 'badge bg-blue-lt',
-      'icon' : active_pending_icon,
-      'text': 'Pending',
-   } : {
-      'className' : 'badge bg-transparent text-muted',
-      'icon' : done_pending_icon,
-      'text' : 'Done',
-   } %}
+   {% set pending_reason_selected_context = is_latest_pending and pending_reason_item_parent != false ? 'pending' : 'done' %}
 {% endif %}
 
 {% if pending_reason %}
-   <span class="{{ pending_reason_option.className }} {{ display_for_parent ? "mt-1 w-100 text-truncate" : "" }}">
-      {{ pending_reason_option.icon }}
-      {{ __(pending_reason_option.text ~ ": %s")|format(pending_reason.getLink())|raw }}
+   <span class="{{ pending_reason_contexts[pending_reason_selected_context].className }} {{ display_for_parent ? "mt-1 w-100 text-truncate" : "" }}">
+      {{ pending_reason_contexts[pending_reason_selected_context].icon|raw }}
+      {{ (pending_reason_contexts[pending_reason_selected_context].text ~ ": %s"|format(pending_reason.getLink()))|raw }}
 
       {% if display_for_parent or call("PendingReason_Item::isLastPendingForItem", [
          item,

--- a/templates/components/itilobject/timeline/pending_reasons_messages.html.twig
+++ b/templates/components/itilobject/timeline/pending_reasons_messages.html.twig
@@ -49,7 +49,7 @@
    {% set done_pending_icon %}
       <i class="fas fa-solid fa-check"></i>
    {% endset %}
-   {% set pending_reason_option = is_latest_pending ? {
+   {% set pending_reason_option = is_latest_pending and pending_reason_item_parent != false ? {
       'className' : 'badge bg-blue-lt',
       'icon' : active_pending_icon,
       'text': 'Pending',

--- a/templates/components/itilobject/timeline/pending_reasons_messages.html.twig
+++ b/templates/components/itilobject/timeline/pending_reasons_messages.html.twig
@@ -39,12 +39,31 @@
    {% set pending_item = pending_item ?? call(entry['type'] ~ "::getById", [entry_i['id']]) %}
    {% set pending_reason_item = pending_item ? call("PendingReason_Item::getForItem", [pending_item]) : false %}
    {% set pending_reason = pending_reason_item ? call("PendingReason::getById", [pending_reason_item.fields['pendingreasons_id']]) : false %}
+   {% set is_latest_pending = call("PendingReason_Item::isLastPendingForItem", [
+      item,
+      pending_item
+   ]) %}
+   {% set active_pending_icon %}
+      <i class="fas fa-pause me-1"></i>
+   {% endset %}
+   {% set done_pending_icon %}
+      <i class="fas fa-solid fa-check"></i>
+   {% endset %}
+   {% set pending_reason_option = is_latest_pending ? {
+      'className' : 'badge bg-blue-lt',
+      'icon' : active_pending_icon,
+      'text': 'Pending',
+   } : {
+      'className' : 'badge bg-transparent text-muted',
+      'icon' : done_pending_icon,
+      'text' : 'Done',
+   } %}
 {% endif %}
 
 {% if pending_reason %}
-   <span class="badge bg-blue-lt {{ display_for_parent ? "mt-1 w-100 text-truncate" : "" }}">
-      <i class="fas fa-pause me-1"></i>
-      {{ __("Pending: %s")|format(pending_reason.getLink())|raw }}
+   <span class="{{ pending_reason_option.className }} {{ display_for_parent ? "mt-1 w-100 text-truncate" : "" }}">
+      {{ pending_reason_option.icon }}
+      {{ __(pending_reason_option.text ~ ": %s")|format(pending_reason.getLink())|raw }}
 
       {% if display_for_parent or call("PendingReason_Item::isLastPendingForItem", [
          item,


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It's fixes !36212
- This PR changes the style once the wait reasons are more active

## Screenshots (if appropriate):

Pending Reason Done
![Capture d’écran du 2025-02-06 16-14-12](https://github.com/user-attachments/assets/c1d6381f-b556-4b0e-b845-c41d86bb80f2)

Pending Reason Active
![Capture d’écran du 2025-02-06 16-14-49](https://github.com/user-attachments/assets/5bca26fa-fecd-437e-a6e6-a46def872bb3)



