### PR TITLE
Feat(rule mail collector): add criterion for quarantine released

### DIFF
--- a/phpunit/functional/RuleMailCollectorTest.php
+++ b/phpunit/functional/RuleMailCollectorTest.php
@@ -192,9 +192,9 @@ class RuleMailCollectorTest extends DbTestCase
                             'pattern'   => '/^(?!.*no).+$/i',
                         ],
                         [
-                            'criteria'  => 'x-ms-exchange-organization-expirationstarttimereason',
+                            'criteria'  => '_headers',
                             'condition' => Rule::PATTERN_NOT_CONTAIN,
-                            'pattern'   => 'QuarantineReleased',
+                            'pattern'   => 'X-MS-Exchange-Organization-ExpirationStartTimeReason: QuarantineReleased',
                         ],
                     ],
                 ],
@@ -214,9 +214,9 @@ class RuleMailCollectorTest extends DbTestCase
                             'pattern'   => '/^(?!.*no).+$/i',
                         ],
                         [
-                            'criteria'  => 'x-ms-exchange-organization-expirationstarttimereason',
+                            'criteria'  => '_headers',
                             'condition' => Rule::PATTERN_NOT_CONTAIN,
-                            'pattern'   => 'QuarantineReleased',
+                            'pattern'   => 'X-MS-Exchange-Organization-ExpirationStartTimeReason: QuarantineReleased',
                         ],
                     ],
                 ],

--- a/phpunit/functional/RuleMailCollectorTest.php
+++ b/phpunit/functional/RuleMailCollectorTest.php
@@ -158,7 +158,7 @@ class RuleMailCollectorTest extends DbTestCase
                         ],
                     ],
                 ],
-                'rule_match' => true,
+                'result_match' => true,
             ],
             [
                 'headers' =>
@@ -175,7 +175,7 @@ class RuleMailCollectorTest extends DbTestCase
                         ],
                     ],
                 ],
-                'rule_match' => false,
+                'result_match' => false,
             ],
             [
                 'headers' =>
@@ -198,7 +198,7 @@ class RuleMailCollectorTest extends DbTestCase
                         ],
                     ],
                 ],
-                'rule_match' => false,
+                'result_match' => false,
             ],
             [
                 'headers' =>
@@ -220,7 +220,7 @@ class RuleMailCollectorTest extends DbTestCase
                         ],
                     ],
                 ],
-                'rule_match' => true,
+                'result_match' => true,
             ],
         ];
     }
@@ -231,7 +231,7 @@ class RuleMailCollectorTest extends DbTestCase
     public function testHeaderCriterias(
         array $headers,
         array $rule_param,
-        bool $rule_match
+        bool $result_match
     ) {
         $this->login();
 
@@ -242,7 +242,7 @@ class RuleMailCollectorTest extends DbTestCase
         // Create rule
         $rule     = new \RuleMailCollector();
         $rule_id = $rule->add($rule_input = [
-            'name'         => 'test assign entity based on group',
+            'name'         => __FUNCTION__,
             'match'        => $rule_param['match'],
             'is_active'    => 1,
             'sub_type'     => 'RuleMailCollector',
@@ -275,7 +275,7 @@ class RuleMailCollectorTest extends DbTestCase
             ['headers' => $headers]
         );
 
-        if ($rule_match) {
+        if ($result_match) {
             $this->assertEquals(
                 [
                     '_refuse_email_no_response' => 1,

--- a/src/RuleMailCollector.php
+++ b/src/RuleMailCollector.php
@@ -110,8 +110,8 @@ class RuleMailCollector extends Rule
         $criterias['x-uce-status']['table']             = '';
         $criterias['x-uce-status']['type']              = 'text';
 
-        $criterias['x-ms-exchange-organization-expirationstarttimereason'] = [
-            'name'  => __('X-MS-Exchange-Organization-ExpirationStartTimeReason email header'),
+        $criterias['_headers'] = [
+            'name'  => __('Full email headers'),
             'table' => '',
             'type'  => 'text',
         ];

--- a/src/RuleMailCollector.php
+++ b/src/RuleMailCollector.php
@@ -110,6 +110,12 @@ class RuleMailCollector extends Rule
         $criterias['x-uce-status']['table']             = '';
         $criterias['x-uce-status']['type']              = 'text';
 
+        $criterias['x-ms-exchange-organization-expirationstarttimereason'] = [
+            'name'  => __('X-MS-Exchange-Organization-ExpirationStartTimeReason email header'),
+            'table' => '',
+            'type'  => 'text',
+        ];
+
         $criterias['received']['name']                  = __('Received email header');
         $criterias['received']['table']                 = '';
         $criterias['received']['type']                  = 'text';

--- a/src/RuleMailCollectorCollection.php
+++ b/src/RuleMailCollectorCollection.php
@@ -82,7 +82,7 @@ class RuleMailCollectorCollection extends RuleCollection
             $input['_headers'] = implode(
                 "\n",
                 array_map(
-                    fn($k, $v) => "$k: $v",
+                    fn($k, $v) => is_array($v) ? "$k: " . implode(', ', $v) : "$k: $v",
                     array_keys($params['headers']),
                     $params['headers']
                 )

--- a/src/RuleMailCollectorCollection.php
+++ b/src/RuleMailCollectorCollection.php
@@ -79,6 +79,14 @@ class RuleMailCollectorCollection extends RuleCollection
                     $input[$key] = $value;
                 }
             }
+            $input['_headers'] = implode(
+                "\n",
+                array_map(
+                    fn($k, $v) => "$k: $v",
+                    array_keys($params['headers']),
+                    $params['headers']
+                )
+            );
         }
 
        //Add all user's groups


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !36253
- Here is a brief description of what this PR does

When an email is quarantined by Microsoft and then released by an admin, GLPI considers it as an automated email and blocks it using the default rule:

![image](https://github.com/user-attachments/assets/b9743307-05bd-4cae-9d18-f63320cccd3d)

This PR adds a criterion to the default rule to identify that an email has been released from quarantine by modifying the rule as follows:

![image](https://github.com/user-attachments/assets/2482841e-9df3-4647-bc37-b157be3c1b86)

However, since this criterion is specific to Microsoft, the default rule is not modified. Users must add it manually if needed.

