### PR TITLE
Allow extra nodes in inventory file

### DIFF
--- a/src/Glpi/Inventory/Inventory.php
+++ b/src/Glpi/Inventory/Inventory.php
@@ -87,6 +87,7 @@ class Inventory
     private $request_query;
     /** @var bool */
     private bool $is_discovery = false;
+    private bool $strict_schema = false;
 
     /**
      * @param mixed   $data   Inventory data, optional
@@ -129,6 +130,9 @@ class Inventory
         $converter = new Converter();
 
         $schema = $converter->getSchema();
+        if (!$this->strict_schema) {
+            $schema->setFlexible(); //allow extra nodes in inventory file
+        }
 
         $schema->setExtraItemtypes($this->getExtraItemtypes());
 
@@ -1018,5 +1022,37 @@ class Inventory
             }
         }
         return $itemtypes;
+    }
+
+    /**
+     * Set schema validation strict (no additional properties allowed anywhere)
+     *
+     * @return self
+     */
+    public function setFlexibleSchema(): self
+    {
+        $this->strict_schema = false;
+        return $this;
+    }
+
+    /**
+     * Set schema validation strict (no additional properties allowed anywhere)
+     *
+     * @return self
+     */
+    public function setStrictSchema(): self
+    {
+        $this->strict_schema = true;
+        return $this;
+    }
+
+    /**
+     * Is scheam validation strict?
+     *
+     * @return bool
+     */
+    public function isSchemaStrict(): bool
+    {
+        return $this->strict_schema;
     }
 }


### PR DESCRIPTION
I've added methods/property to have control on that, not sure if it's necessary.
 It will depend if we want to keep `additionalProperties` in schema. If we plan to remove them in the future (when v10 has died), we can just force flexible for the moment, and we're done.