### PR TITLE
Throw exception when no item is found by `getItemByTypeName()`

### DIFF
--- a/phpunit/functional/DbUtilsTest.php
+++ b/phpunit/functional/DbUtilsTest.php
@@ -860,9 +860,10 @@ class DbUtilsTest extends DbTestCase
         //test with new sub entity
         //Cache tests:
         //Cache is updated on entity creation; so even if we do not expect $hit; we got it.
-        $new_id = getItemByTypeName('Entity', 'Sub child entity', true);
-        if (!$new_id) {
-            $entity = new \Entity();
+        $entity = new \Entity();
+        if ($entity->getFromDBByCrit(['name' => 'Sub child entity'])) {
+            $new_id = $entity->getID();
+        } else {
             $new_id = $entity->add([
                 'name'         => 'Sub child entity',
                 'entities_id'  => $ent1
@@ -884,9 +885,10 @@ class DbUtilsTest extends DbTestCase
         }
 
         //test with another new sub entity
-        $new_id2 = getItemByTypeName('Entity', 'Sub child entity 2', true);
-        if (!$new_id2) {
-            $entity = new \Entity();
+        $entity = new \Entity();
+        if ($entity->getFromDBByCrit(['name' => 'Sub child entity 2'])) {
+            $new_id2 = $entity->getID();
+        } else {
             $new_id2 = $entity->add([
                 'name'         => 'Sub child entity 2',
                 'entities_id'  => $ent2
@@ -1030,9 +1032,10 @@ class DbUtilsTest extends DbTestCase
         //test with new sub entity
         //Cache tests:
         //Cache is updated on entity creation; so even if we do not expect $hit; we got it.
-        $new_id = getItemByTypeName('Entity', 'Sub child entity', true);
-        if (!$new_id) {
-            $entity = new \Entity();
+        $entity = new \Entity();
+        if ($entity->getFromDBByCrit(['name' => 'Sub child entity'])) {
+            $new_id = $entity->getID();
+        } else {
             $new_id = (int)$entity->add([
                 'name'         => 'Sub child entity',
                 'entities_id'  => $ent1
@@ -1053,9 +1056,10 @@ class DbUtilsTest extends DbTestCase
         }
 
         //test with another new sub entity
-        $new_id2 = getItemByTypeName('Entity', 'Sub child entity 2', true);
-        if (!$new_id2) {
-            $entity = new \Entity();
+        $entity = new \Entity();
+        if ($entity->getFromDBByCrit(['name' => 'Sub child entity 2'])) {
+            $new_id2 = $entity->getID();
+        } else {
             $new_id2 = (int)$entity->add([
                 'name'         => 'Sub child entity 2',
                 'entities_id'  => $ent1

--- a/phpunit/functional/Glpi/Inventory/Assets/NetworkPortTest.php
+++ b/phpunit/functional/Glpi/Inventory/Assets/NetworkPortTest.php
@@ -332,17 +332,14 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
         $data = $converter->convert($xml);
         $json = json_decode($data);
 
-        $neteq = getItemByTypeName('NetworkEquipment', 'My network equipment');
-        if ($neteq === false) {
-            $neteq = new \NetworkEquipment();
-            $this->assertGreaterThan(
-                0,
-                $neteq->add([
-                    'name'   => 'My network equipment',
-                    'entities_id'  => 0
-                ])
-            );
-        }
+        $neteq = new \NetworkEquipment();
+        $this->assertGreaterThan(
+            0,
+            $neteq->add([
+                'name'   => 'My network equipment',
+                'entities_id'  => 0
+            ])
+        );
 
         $asset = new \Glpi\Inventory\Asset\NetworkPort($neteq, $json->content->network_ports);
         $asset->setExtraData((array)$json->content);

--- a/src/Glpi/Dashboard/Dashboard.php
+++ b/src/Glpi/Dashboard/Dashboard.php
@@ -101,6 +101,15 @@ class Dashboard extends \CommonDBTM
     }
 
 
+    public function getID()
+    {
+        // Force usage of the `id` field
+        if (isset($this->fields['id'])) {
+            return (int)$this->fields['id'];
+        }
+        return -1;
+    }
+
     public function getFromDB($ID)
     {
         /** @var \DBmysql $DB */

--- a/tests/src/autoload/functions.php
+++ b/tests/src/autoload/functions.php
@@ -739,23 +739,26 @@ function loadDataset()
                     } else if ($k == 'items_id'  &&  isset($input['itemtype']) && isset($ids[$input['itemtype']][$v]) && !is_numeric($v)) {
                         $input[$k] = $ids[$input['itemtype']][$v];
                     } else if ($foreigntype && $foreigntype != 'UNKNOWN' && !is_numeric($v)) {
-                       // not found in ids array, then must get it from DB
-                        if ($obj = getItemByTypeName($foreigntype, $v)) {
-                            $input[$k] = $obj->getID();
-                        }
+                        // not found in ids array, then must get it from DB
+                        $foreign_id = getItemByTypeName($foreigntype, $v, true);
+                        $input[$k] = $foreign_id;
+
+                        $ids[$foreigntype][$v] = $foreign_id; // cache ID
                     }
                 }
 
-                if (isset($input['name']) && $item = getItemByTypeName($type, $input['name'])) {
-                    $input['id'] = $ids[$type][$input['name']] = $item->getField('id');
-                    $item->update($input);
+                $item = getItemForItemtype($type);
+                $name_field = $item::getNameField();
+
+                if (isset($input[$name_field]) && $item->getFromDBByCrit([$name_field => $input[$name_field]])) {
+                    // Update existing item
+                    $item->update([$item::getIndexName() => $item->getID()] + $input);
                 } else {
                     // Not found, create it
-                    $item = getItemForItemtype($type);
-                    $id = $item->add($input);
-                    if (isset($input['name'])) {
-                        $ids[$type][$input['name']] = $id;
-                    }
+                    $item->add($input);
+                }
+                if (isset($input[$name_field])) {
+                    $ids[$type][$input[$name_field]] = $item->getID(); // cache ID
                 }
             }
         }
@@ -774,17 +777,17 @@ function loadDataset()
 /**
  * Test helper, search an item from its type and name
  *
- * @param string  $type
- * @param string  $name
- * @param boolean $onlyid
- * @return CommonDBTM|false the item, or its id
+ * @param string    $type
+ * @param string    $name
+ * @param bool      $onlyid
+ * @return CommonDBTM|int the item, or its id
  */
-function getItemByTypeName($type, $name, $onlyid = false)
+function getItemByTypeName(string $type, string $name, bool $onlyid = false): CommonDBTM|int
 {
     $item = getItemForItemtype($type);
     $nameField = $type::getNameField();
-    if ($item->getFromDBByCrit([$nameField => $name])) {
-        return ($onlyid ? $item->getField('id') : $item);
+    if (!$item->getFromDBByCrit([$nameField => $name])) {
+        throw new \RuntimeException(sprintf('Unable to load the `%s` item with the name `%s`.', $type, $name));
     }
-    return false;
+    return ($onlyid ? $item->getID() : $item);
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

The `getItemByTypeName()` function currently returns `false` if the required item cannot be loaded, but our tests code is actually not expecting this to happen. I think this function should throw and exception in this case, to be sure that the corresponding test will fail instantly when this happen.