### PR TITLE
Fix AJAX modal url/id escaping

### DIFF
--- a/phpunit/functional/HtmlTest.php
+++ b/phpunit/functional/HtmlTest.php
@@ -1129,4 +1129,23 @@ SCSS
     {
         $this->assertEquals($expected, \Html::sanitizeInputName($name));
     }
+
+    public static function domIdProvider(): iterable
+    {
+        yield [
+            'name'      => 'itemtype',
+            'expected'  => 'itemtype',
+        ];
+
+        yield [
+            'name'      => 'foo\'"$**_23-1',
+            'expected'  => 'foo_23-1',
+        ];
+    }
+
+    #[DataProvider('domIdProvider')]
+    public function testSanitizeDomId(string $name, string $expected): void
+    {
+        $this->assertEquals($expected, \Html::sanitizeInputName($name));
+    }
 }

--- a/src/Ajax.php
+++ b/src/Ajax.php
@@ -175,8 +175,7 @@ class Ajax
 
         $rand = mt_rand();
 
-        $domid  = htmlescape($domid);
-        $url    = htmlescape($url);
+        $domid  = Html::sanitizeDomId($domid);
         $title  = htmlescape($param['title']);
         $class  = htmlescape($param['dialog_class']);
         $height = (int) $param['height'];
@@ -202,6 +201,7 @@ HTML;
 
         $reloadonclose = $param['reloadonclose'] ? "true" : "false";
         $autoopen      = $param['autoopen'] ? "true" : "false";
+        $url           = json_encode($url);
         $js = <<<JAVASCRIPT
       $(function() {
          myModalEl{$rand} = document.getElementById('{$domid}');
@@ -211,7 +211,7 @@ HTML;
          $(myModalEl{$rand}).appendTo($("body"));
 
          myModalEl{$rand}.addEventListener('show.bs.modal', function () {
-            $('#iframe{$domid}').attr('src','{$url}').removeClass('hidden');
+            $('#iframe{$domid}').attr('src', {$url}).removeClass('hidden');
          });
          myModalEl{$rand}.addEventListener('hide.bs.modal', function () {
             if ({$reloadonclose}) {

--- a/src/Html.php
+++ b/src/Html.php
@@ -6566,4 +6566,15 @@ CSS;
     {
         return preg_replace('/[^a-z0-9_\[\]\-]/i', '', $name);
     }
+
+    /**
+     * Sanitize a DOM ID to prevent XSS.
+     *
+     * @param string $name
+     * @return string
+     */
+    public static function sanitizeDomId(string $name): string
+    {
+        return preg_replace('/[^a-z0-9_-]/i', '', $name);
+    }
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

Some variables in `Ajax::createIframeModalWindow()` were escaped using `htmlescape()` but were used in a JS context, resulting in an unexpected extra encoding.

![image](https://github.com/user-attachments/assets/be097d1c-6fa2-4d63-b832-5178f7ac4137)
