### PR TITLE
search option: fix negative conditions

### DIFF
--- a/phpunit/functional/SearchTest.php
+++ b/phpunit/functional/SearchTest.php
@@ -35,7 +35,10 @@
 
 namespace tests\units;
 
+use Appliance;
+use Appliance_Item;
 use CommonDBTM;
+use Computer;
 use DBConnection;
 use DbTestCase;
 use Glpi\Toolbox\Sanitizer;
@@ -3951,6 +3954,68 @@ class SearchTest extends DbTestCase
             'contains',
             "Group 1"
         );
+
+        list (
+            $computer_without_appliance,
+            $computer_appliance_1,
+            $computer_appliance_1_and_2,
+        ) = $this->createItems(Computer::class, [
+            ['name' => 'computer_without_appliance', 'entities_id' => $root],
+            ['name' => 'computer_appliance_1', 'entities_id' => $root],
+            ['name' => 'computer_appliance_1_and_2', 'entities_id' => $root],
+        ]);
+
+        list (
+            $appliance1,
+            $appliance2,
+        ) = $this->createItems(Appliance::class, [
+            ['name' => 'appliance1'],
+            ['name' => 'appliance2'],
+        ]);
+
+        $this->createItems(Appliance_Item::class, [
+            ['items_id' => $computer_appliance_1->getID(), 'appliances_id' => $appliance1->getID(), 'itemtype' => Computer::class],
+            ['items_id' => $computer_appliance_1_and_2->getID(), 'appliances_id' => $appliance1->getID(), 'itemtype' => Computer::class],
+            ['items_id' => $computer_appliance_1_and_2->getID(), 'appliances_id' => $appliance2->getID(), 'itemtype' => Computer::class],
+        ]);
+
+        $all_computers = ['computer_without_appliance', 'computer_appliance_1', 'computer_appliance_1_and_2'];
+        $base_condition = [
+            'link'       => 'AND',
+            'field'      => 1, // Name
+            'searchtype' => 'contains',
+            'value'      => "computer_",
+        ];
+        yield from $this->testCriteriaWithSubqueriesProvider_getAllCombination(
+            'Computer',
+            $base_condition,
+            $all_computers,
+            ['computer_appliance_1', 'computer_appliance_1_and_2'],
+            1210,
+            'equals',
+            $appliance1->getID(),
+        );
+
+        yield from $this->testCriteriaWithSubqueriesProvider_getAllCombination(
+            'Computer',
+            $base_condition,
+            $all_computers,
+            ['computer_appliance_1_and_2'],
+            1210,
+            'contains',
+            'appliance2',
+        );
+
+        yield from $this->testCriteriaWithSubqueriesProvider_getAllCombination(
+            'Computer',
+            $base_condition,
+            $all_computers,
+            ['computer_appliance_1', 'computer_appliance_1_and_2'],
+            1210,
+            'contains',
+            'appliance',
+        );
+
     }
 
     public function testCriteriaWithSubqueries(): void

--- a/phpunit/functional/SearchTest.php
+++ b/phpunit/functional/SearchTest.php
@@ -4015,7 +4015,6 @@ class SearchTest extends DbTestCase
             'contains',
             'appliance',
         );
-
     }
 
     public function testCriteriaWithSubqueries(): void

--- a/src/Appliance.php
+++ b/src/Appliance.php
@@ -314,19 +314,22 @@ class Appliance extends CommonDBTM
         ];
 
         $tab[] = [
-            'id'                 => '1210',
-            'table'              => self::getTable(),
-            'field'              => 'name',
-            'name'               => __('Name'),
-            'forcegroupby'       => true,
-            'datatype'           => 'itemlink',
-            'itemlink_type'      => 'Appliance',
-            'massiveaction'      => false,
-            'joinparams'         => [
-                'condition'  => ['NEWTABLE.is_deleted' => 0],
+            'id'            => '1210',
+            'table'         => self::getTable(),
+            'field'         => 'name',
+            'name'          => __('Name'),
+            'datatype'      => 'dropdown',
+            'searchtype'    => ['equals','notequals','contains'],
+            'massiveaction' => false,
+            'forcegroupby'  => true,
+            'use_subquery'  => true,
+            'joinparams'    =>  [
                 'beforejoin' => [
                     'table'      => Appliance_Item::getTable(),
-                    'joinparams' => ['jointype' => 'itemtype_item']
+                    'joinparams' => [
+                        'jointype' => 'itemtype_item',
+                        'field'    => 'items_id',
+                    ],
                 ]
             ]
         ];

--- a/src/Appliance.php
+++ b/src/Appliance.php
@@ -318,12 +318,12 @@ class Appliance extends CommonDBTM
             'table'         => self::getTable(),
             'field'         => 'name',
             'name'          => __('Name'),
-            'datatype'      => 'dropdown',
-            'searchtype'    => ['equals','notequals','contains'],
+            'datatype'      => 'itemlink',
             'massiveaction' => false,
             'forcegroupby'  => true,
             'use_subquery'  => true,
             'joinparams'    =>  [
+                'condition'  => ['NEWTABLE.is_deleted' => 0],
                 'beforejoin' => [
                     'table'      => Appliance_Item::getTable(),
                     'joinparams' => [

--- a/src/Search.php
+++ b/src/Search.php
@@ -5446,6 +5446,7 @@ JAVASCRIPT;
             $child_table = $searchopt[$ID]['table'];
             $link_table = $beforejoin['table'];
             $linked_fk = $beforejoin['joinparams']['linkfield'] ?? getForeignKeyFieldForTable($searchopt[$ID]['table']);
+
             // Handle extra condition (e.g. filtering group type)
             $addcondition = '';
             if (isset($beforejoin['joinparams']['condition'])) {

--- a/src/Search.php
+++ b/src/Search.php
@@ -5441,12 +5441,11 @@ JAVASCRIPT;
         if ($use_subquery_on_id_search || $use_subquery_on_text_search) {
             // Compute tables and fields names
             $main_table = getTableForItemType($itemtype);
+            $fk = getForeignKeyFieldForTable($main_table);
             $beforejoin = $searchopt[$ID]['joinparams']['beforejoin'];
-            $fk = $beforejoin['joinparams']['field'] ?? getForeignKeyFieldForTable($main_table);
             $child_table = $searchopt[$ID]['table'];
             $link_table = $beforejoin['table'];
             $linked_fk = $beforejoin['joinparams']['linkfield'] ?? getForeignKeyFieldForTable($searchopt[$ID]['table']);
-
             // Handle extra condition (e.g. filtering group type)
             $addcondition = '';
             if (isset($beforejoin['joinparams']['condition'])) {
@@ -5471,6 +5470,9 @@ JAVASCRIPT;
                 //     FROM `glpi_groups_tickets`
                 //     WHERE `groups_id` = '4' AND `glpi_groups_tickets`.`type` = '3'
                 // )
+                if ($beforejoin['table'] === $link_table && isset($beforejoin['joinparams']['field'])) {
+                    $fk = $beforejoin['joinparams']['field'];
+                }
                 if (is_numeric($val) && (int)$val === 0) {
                     // Special case, search criteria is empty
                     $subquery_operator = $subquery_operator == "IN" ? "NOT IN" : "IN";

--- a/src/Search.php
+++ b/src/Search.php
@@ -5441,8 +5441,8 @@ JAVASCRIPT;
         if ($use_subquery_on_id_search || $use_subquery_on_text_search) {
             // Compute tables and fields names
             $main_table = getTableForItemType($itemtype);
-            $fk = getForeignKeyFieldForTable($main_table);
             $beforejoin = $searchopt[$ID]['joinparams']['beforejoin'];
+            $fk = $beforejoin['joinparams']['field'] ?? getForeignKeyFieldForTable($main_table);
             $child_table = $searchopt[$ID]['table'];
             $link_table = $beforejoin['table'];
             $linked_fk = $beforejoin['joinparams']['linkfield'] ?? getForeignKeyFieldForTable($searchopt[$ID]['table']);

--- a/src/Search.php
+++ b/src/Search.php
@@ -5461,6 +5461,12 @@ JAVASCRIPT;
                 $addcondition = $addcondition . " ";
             }
 
+            // If the purpose of the search is to verify whether an item of type ‘itemtype1’ is related to an item of type ‘itemtype2’
+            // (e.g. : computer and application) and that this relationship is saved in a table via a pair (‘items_id’, ‘itemtype’),
+            // the target field in the relational table will not be `items_id` but `itemtype2_id`.
+
+            // This will result in an error, because the `itemtype2_id` does not exist.
+            // To resolve this issue, the name of the target field must be explicitly declared in order to correctly retrieve the ID of `itemtype'.
             if ($beforejoin['table'] === $link_table && isset($beforejoin['joinparams']['field'])) {
                 $fk = $beforejoin['joinparams']['field'];
             }

--- a/src/Search.php
+++ b/src/Search.php
@@ -5461,6 +5461,9 @@ JAVASCRIPT;
                 $addcondition = $addcondition . " ";
             }
 
+            if ($beforejoin['table'] === $link_table && isset($beforejoin['joinparams']['field'])) {
+                $fk = $beforejoin['joinparams']['field'];
+            }
             if ($use_subquery_on_id_search) {
                 // Subquery for "Is not", "Not + is", "Not under" and "Not + Under" search types
                 // As an example, when looking for tickets that don't have a
@@ -5471,9 +5474,6 @@ JAVASCRIPT;
                 //     FROM `glpi_groups_tickets`
                 //     WHERE `groups_id` = '4' AND `glpi_groups_tickets`.`type` = '3'
                 // )
-                if ($beforejoin['table'] === $link_table && isset($beforejoin['joinparams']['field'])) {
-                    $fk = $beforejoin['joinparams']['field'];
-                }
                 if (is_numeric($val) && (int)$val === 0) {
                     // Special case, search criteria is empty
                     $subquery_operator = $subquery_operator == "IN" ? "NOT IN" : "IN";


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- Complete this PR : #13684

If the purpose of the search is to verify whether an item of type ‘itemtype1’ is related to an item of type ‘itemtype2’ (e.g: computer and application) and that this relationship is saved in a table via a pair (‘items_id’, ‘itemtype’), the target field in the relational table will not be `items_id` but `itemtype2_id`. This will result in an error, because the `itemtype2_id` does not exist. To resolve this issue, the name of the target field must be explicitly declared in order to correctly retrieve the ID of `itemtype'.

Default view:
![Capture d’écran du 2025-03-28 16-46-17](https://github.com/user-attachments/assets/9711e1d5-41ff-4218-a216-ca1d0b6ae550)

Before
![Capture d’écran du 2025-03-28 16-42-54](https://github.com/user-attachments/assets/1b4c4534-0210-4a50-9a7b-f11355080f5e)

After:
![Capture d’écran du 2025-03-28 16-45-31](https://github.com/user-attachments/assets/12459486-6f65-4b7e-b023-dc278c1d6fa5)


In the example, I try to retrieve all tickets that do not contain a tag from the tag plugin.

This PR complements this PR: https://github.com/pluginsGLPI/tag/pull/230
