### PR TITLE
fix(forms): invalid `Go home` button on central interface

### DIFF
--- a/templates/pages/form_renderer.html.twig
+++ b/templates/pages/form_renderer.html.twig
@@ -1,4 +1,3 @@
-
 {#
  # ---------------------------------------------------------------------
  #
@@ -238,10 +237,18 @@
                     {{ __("Your form has been submitted successfully.") }}
                 </p>
                 <div class="mt-3 d-flex">
-                    <a class="btn btn-outline-secondary me-2" href="{{ path('/Helpdesk') }}">
-                        <i class="ti ti-home me-1"></i>
-                        <span>{{ __("Go home") }}</span>
-                    </a>
+                    {% if get_current_interface() == 'central' %}
+                        <a class="btn btn-outline-secondary me-2" href="{{ path('/ServiceCatalog') }}">
+                            <i class="ti ti-library me-1"></i>
+                            <span>{{ __("Go back to service catalog") }}</span>
+                        </a>
+                    {% else %}
+                        <a class="btn btn-outline-secondary me-2" href="{{ path('/Helpdesk') }}">
+                            <i class="ti ti-home me-1"></i>
+                            <span>{{ __("Go home") }}</span>
+                        </a>
+                    {% endif %}
+
                     <a class="btn btn-primary" href="{{ path('/front/ticket.php?' ~ my_tickets_url_param) }}">
                         <i class="ti ti-article me-1"></i>
                         <span>{{ __("See my tickets") }}</span>


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Replace invalid button "Go home" with "Go back to service catalog" when displayed on central interface

## Screenshots (if appropriate):

Helpdesk interface (current) :
![image](https://github.com/user-attachments/assets/37837677-b6fe-4f0f-97cd-2f80fe20fab1)

Central interface :
![image](https://github.com/user-attachments/assets/c76a0892-7ff3-4b0b-aaf0-ed8140501af3)

