### PR TITLE
Useful note labels

### DIFF
--- a/templates/components/notepad/form.html.twig
+++ b/templates/components/notepad/form.html.twig
@@ -100,7 +100,11 @@
                         data-bs-toggle="collapse" data-bs-target="#{{ id }}"
                         aria-expanded="false" aria-controls="{{ id }}">
                     <i class="ti ti-notes me-1"></i>
-                    <span>#{{ id }}</span>
+                    {% set title = '#' ~ note['id'] ~ ' - ' ~ note['date_creation']|formatted_datetime %}
+                    {% if note['date_mod'] != note['date_creation'] %}
+                        {% set title = title ~ ' (' ~ __('Last update on %s')|format(note['date_mod']|formatted_datetime) ~ ')' %}
+                    {% endif %}
+                    <span>{{ title }}</span>
                 </button>
             </div>
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Makes note labels on the Notepad tabs more useful. The current format is the note's ID followed by a random number that is generated when the tab loads and shared between all notes. You end up with a list of notes like "#2084350", "#3084350", "#4084350". Refresh page and then the list is "#2345948", "#3345948", "#4345948".

New format: `#2 - 2025-02-16 19:02`, `#3 - 2025-02-16 19:02 (Last update on 2025-02-16 19:05)`