### PR TITLE
Standardize alerts UI and accessibility

### DIFF
--- a/src/NetworkPortInstantiation.php
+++ b/src/NetworkPortInstantiation.php
@@ -85,7 +85,11 @@ class NetworkPortInstantiation extends CommonDBChild
      **/
     public function showInstantiationForm(NetworkPort $netport, $options, $recursiveItems)
     {
-        echo "<div class='alert alert-info'>" . __s('No options available for this port type.') . "</div>";
+        // language=Twig
+        echo TemplateRenderer::getInstance()->renderFromStringTemplate(<<<TWIG
+            {% import 'components/alerts_macros.html.twig' as alerts %}
+            {{ alerts.callout_info(msg) }}
+TWIG, ['msg' => __('No options available for this port type.')]);
     }
 
     public function prepareInput($input)
@@ -334,9 +338,10 @@ class NetworkPortInstantiation extends CommonDBChild
         // language=Twig
         echo TemplateRenderer::getInstance()->renderFromStringTemplate(<<<TWIG
             {% import 'components/form/fields_macros.html.twig' as fields %}
+            {% import 'components/alerts_macros.html.twig' as alerts %}
             {% if alert is not empty %}
                 {% set alert_field %}
-                    <div class="alert alert-info mb-0">{{ alert }}</div>
+                    {{ alerts.callout_info(alert) }}
                 {% endset %}
                 {{ fields.htmlField('', alert_field, 'DeviceNetworkCard'|itemtype_name) }}
             {% else %}
@@ -408,10 +413,11 @@ TWIG, ['label' => __('MAC'), 'mac' => $netport->fields['mac']]);
         // language=Twig
         echo TemplateRenderer::getInstance()->renderFromStringTemplate(<<<TWIG
             {% import 'components/form/fields_macros.html.twig' as fields %}
+            {% import 'components/alerts_macros.html.twig' as alerts %}
             {% if recursive_items|length > 0 %}
                 {{ fields.dropdownField('Glpi\\\\Socket', 'sockets_id', socket_id, label) }}
             {% else %}
-                <div class="alert alert-info">{{ no_link_label }}</div>
+                {{ alerts.callout_info(no_link_label) }}
             {% endif %}
 TWIG, $twig_params);
     }

--- a/templates/central/messages.html.twig
+++ b/templates/central/messages.html.twig
@@ -31,35 +31,37 @@
  # ---------------------------------------------------------------------
  #}
 
+{% import 'components/alerts_macros.html.twig' as alerts %}
+
 <div class="message-area">
-   {% if messages.errors is defined and messages.errors|length > 0 %}
-      <div class="alert alert-important alert-danger d-flex" role="alert">
-         <i class="ti ti-alert-triangle fs-3x"></i>
-         <ul>
-            {% for error in messages.errors %}
-               <li>{{ error|raw }}</li>
-            {% endfor %}
-         </ul>
-      </div>
-   {% endif %}
-   {% if messages.warnings is defined and messages.warnings|length > 0 %}
-      <div class="alert alert-important alert-warning d-flex" role="alert">
-         <i class="ti ti-alert-triangle fs-3x"></i>
-         <ul>
-            {% for warning in messages.warnings %}
-               <li>{{ warning|raw }}</li>
-            {% endfor %}
-         </ul>
-      </div>
-   {% endif %}
-   {% if messages.infos is defined and messages.infos|length > 0 %}
-      <div class="alert alert-important alert-info d-flex" role="alert">
-         <i class="ti ti-info-circle fs-3x"></i>
-         <ul>
-            {% for info in messages.infos %}
-               <li>{{ info|raw }}</li>
-            {% endfor %}
-         </ul>
-      </div>
-   {% endif %}
+    {% if messages.errors is defined and messages.errors|length > 0 %}
+        {% set alert_messages %}
+            <ul>
+                {% for error in messages.errors %}
+                    <li>{{ error|raw }}</li>
+                {% endfor %}
+            </ul>
+        {% endset %}
+        {{ alerts.alert_danger(title: alert_messages, important: true) }}
+    {% endif %}
+    {% if messages.warnings is defined and messages.warnings|length > 0 %}
+        {% set alert_messages %}
+            <ul>
+                {% for warning in messages.warnings %}
+                    <li>{{ warning|raw }}</li>
+                {% endfor %}
+            </ul>
+        {% endset %}
+        {{ alerts.alert_warning(title: alert_messages, important: true) }}
+    {% endif %}
+    {% if messages.infos is defined and messages.infos|length > 0 %}
+        {% set alert_messages %}
+            <ul>
+                {% for info in messages.infos %}
+                    <li>{{ info|raw }}</li>
+                {% endfor %}
+            </ul>
+        {% endset %}
+        {{ alerts.alert_info(title: alert_messages, important: true) }}
+    {% endif %}
 </div>

--- a/templates/central/messages.html.twig
+++ b/templates/central/messages.html.twig
@@ -36,32 +36,32 @@
 <div class="message-area">
     {% if messages.errors is defined and messages.errors|length > 0 %}
         {% set alert_messages %}
-            <ul>
+            <ul class="m-0">
                 {% for error in messages.errors %}
                     <li>{{ error|raw }}</li>
                 {% endfor %}
             </ul>
         {% endset %}
-        {{ alerts.alert_danger(title: alert_messages, important: true) }}
+        {{ alerts.alert_danger(messages: alert_messages, important: true) }}
     {% endif %}
     {% if messages.warnings is defined and messages.warnings|length > 0 %}
         {% set alert_messages %}
-            <ul>
+            <ul class="m-0">
                 {% for warning in messages.warnings %}
                     <li>{{ warning|raw }}</li>
                 {% endfor %}
             </ul>
         {% endset %}
-        {{ alerts.alert_warning(title: alert_messages, important: true) }}
+        {{ alerts.alert_warning(messages: alert_messages, important: true) }}
     {% endif %}
     {% if messages.infos is defined and messages.infos|length > 0 %}
         {% set alert_messages %}
-            <ul>
+            <ul class="m-0">
                 {% for info in messages.infos %}
                     <li>{{ info|raw }}</li>
                 {% endfor %}
             </ul>
         {% endset %}
-        {{ alerts.alert_info(title: alert_messages, important: true) }}
+        {{ alerts.alert_info(messages: alert_messages, important: true) }}
     {% endif %}
 </div>

--- a/templates/components/alerts_macros.html.twig
+++ b/templates/components/alerts_macros.html.twig
@@ -31,71 +31,144 @@
  # ---------------------------------------------------------------------
  #}
 
-{% macro alert(alert_type = "", title = "", messages = [], icon = "", important = false) %}
-   <div class="alert alert-{{ alert_type }} {{ important ? "alert-important" : "" }}" role="alert">
-      <div class="d-flex">
-         <div>
-            <i class="{{ icon }} fs-2x alert-icon"></i>
-         </div>
-         <div>
-            {% if title|length %}
-               <h4 class="alert-title">
-                  {{ title }}
-               </h4>
+{#
+    Base alert and callout macro.
+    Options:
+        - id: string - The ID of the main alert element
+        - add_class: string - Additional classes to add to the main alert element
+        - dismissible: bool - Whether the alert should be dismissible
+        - alert: bool - If true, this is an actual alert and it will be announced by screen readers assertively as an alert
+#}
+{% macro alert(alert_type = "", title = "", messages = [], icon = "", important = false, options = {}) %}
+    {% set options = {
+        id: '',
+        add_class: '',
+        dismissible: false,
+        alert: true
+    }|merge(options) %}
+
+    {% set only_title = messages|length == 0 %}
+
+    <div {{ options.id is not empty ? ('id=' ~ options.id) : ''}}
+        class="flex-shrink-1 alert alert-{{ alert_type }} {{ important ? "alert-important" : "" }} {{ options.add_class }} {{ options.dismissible ? "alert-dismissible" : "" }}"
+        {{ options.alert ? 'role=alert' : '' }}>
+        <div class="d-flex {{ only_title ? 'align-items-center' : '' }}">
+            {% if icon is not empty %}
+                <div>
+                    <i class="{{ icon }} fs-2x alert-icon"></i>
+                </div>
             {% endif %}
-            {% if messages|length > 0 %}
-               <div class="text-muted">
-                  {% if messages is iterable %}
-                     {% for message in messages %}
-                        {{ message }}
-                        {% if loop.last %}<br />{% endif %}
-                     {% endfor %}
-                  {% else %}
-                     {{ messages }}
-                  {% endif %}
-               </div>
+            <div>
+                {% if title|length %}
+                    <span class="fs-4 alert-title {{ only_title ? 'mb-0' : '' }}">
+                        {{ title }}
+                    </span>
+                {% endif %}
+                {% if messages|length > 0 %}
+                    <div class="text-muted">
+                        {% if messages is iterable %}
+                            {% for message in messages %}
+                                {{ message }}
+                                {% if not loop.last %}<br />{% endif %}
+                            {% endfor %}
+                        {% else %}
+                            {{ messages }}
+                        {% endif %}
+                    </div>
+                {% endif %}
+            </div>
+            {% if options.dismissible %}
+                <a class="btn-close" data-bs-dismiss="alert" aria-label="{{ __('Close') }}"></a>
             {% endif %}
-         </div>
-      </div>
-   </div>
+        </div>
+    </div>
 {% endmacro %}
 
-{% macro alert_success(title = "", messages = [], important = false) %}
-   {{ _self.alert(
-      'success',
-      title,
-      messages,
-      "ti ti-check",
-      important
-   ) }}
+{% macro alert_success(title = "", messages = [], important = false, options = {}) %}
+    {{ _self.alert(
+        'success',
+        title,
+        messages,
+        "ti ti-check",
+        important,
+        options,
+    ) }}
 {% endmacro %}
 
-{% macro alert_info(title = "", messages = [], important = false) %}
-   {{ _self.alert(
-      'info',
-      title,
-      messages,
-      "ti ti-info-circle",
-      important
-   ) }}
+{% macro alert_info(title = "", messages = [], important = false, options = {}) %}
+    {{ _self.alert(
+        'info',
+        title,
+        messages,
+        "ti ti-info-circle",
+        important,
+        options,
+    ) }}
 {% endmacro %}
 
-{% macro alert_warning(title = "", messages = [], important = false) %}
-   {{ _self.alert(
-      'warning',
-      title,
-      messages,
-      "ti ti-alert-triangle",
-      important
-   ) }}
+{% macro alert_warning(title = "", messages = [], important = false, options = {}) %}
+    {{ _self.alert(
+        'warning',
+        title,
+        messages,
+        "ti ti-alert-triangle",
+        important,
+        options,
+    ) }}
 {% endmacro %}
 
-{% macro alert_danger(title = "", messages = [], important = false) %}
-   {{ _self.alert(
-      'danger',
-      title,
-      messages,
-      "ti ti-exclamation-circle",
-      important
-   ) }}
+{% macro alert_danger(title = "", messages = [], important = false, options = {}) %}
+    {{ _self.alert(
+        'danger',
+        title,
+        messages,
+        "ti ti-exclamation-circle",
+        important,
+        options,
+    ) }}
+{% endmacro %}
+
+{# Callouts - Like alerts visually (without the icon by default) but without the alert role or live region. Callouts won't be annouced by screen readers until they are focused #}
+{% macro callout_info(title = "", messages = [], important = false, options = {}) %}
+    {{ _self.callout(
+        'info',
+        title,
+        messages,
+        options.icon|default(false) ? "ti ti-info-circle" : '',
+        important,
+        options,
+    ) }}
+{% endmacro %}
+
+{% macro callout_warning(title = "", messages = [], important = false, options = {}) %}
+    {{ _self.callout(
+        'warning',
+        title,
+        messages,
+        options.icon|default(false) ? "ti ti-alert-triangle" : '',
+        important,
+        options,
+    ) }}
+{% endmacro %}
+
+{% macro callout_danger(title = "", messages = [], important = false, options = {}) %}
+    {{ _self.callout(
+        'danger',
+        title,
+        messages,
+        options.icon|default(false) ? "ti ti-exclamation-circle" : '',
+        important,
+        options,
+    ) }}
+{% endmacro %}
+
+{% macro callout(callout_type, title = '', messages = [], icon = '', important = false, options = {}) %}
+    {{ _self.alert(
+        callout_type,
+        title,
+        messages,
+        icon,
+        important,
+        { alert: false }|merge(options),
+    ) }}
 {% endmacro %}

--- a/templates/components/alerts_macros.html.twig
+++ b/templates/components/alerts_macros.html.twig
@@ -49,7 +49,7 @@
 
     {% set only_title = messages|length == 0 %}
 
-    <div {{ options.id is not empty ? ('id=' ~ options.id) : ''}}
+    <div {{ options.id is not empty ? ('id=' ~ options.id) : '' }}
         class="flex-shrink-1 alert alert-{{ alert_type }} {{ important ? "alert-important" : "" }} {{ options.add_class }} {{ options.dismissible ? "alert-dismissible" : "" }}"
         {{ options.alert ? 'role=alert' : '' }}>
         <div class="d-flex {{ only_title ? 'align-items-center' : '' }}">
@@ -169,6 +169,6 @@
         messages,
         icon,
         important,
-        { alert: false }|merge(options),
+        {alert: false}|merge(options),
     ) }}
 {% endmacro %}

--- a/templates/components/alerts_macros.html.twig
+++ b/templates/components/alerts_macros.html.twig
@@ -65,7 +65,7 @@
                     </span>
                 {% endif %}
                 {% if messages|length > 0 %}
-                    <div class="text-muted">
+                    <div class="{{ not important ? "text-muted" : "" }}">
                         {% if messages is iterable %}
                             {% for message in messages %}
                                 {{ message }}

--- a/templates/components/datatable.html.twig
+++ b/templates/components/datatable.html.twig
@@ -31,6 +31,8 @@
  # ---------------------------------------------------------------------
  #}
 
+{% import 'components/alerts_macros.html.twig' as alerts %}
+
 {% set datatable_id = datatable_id|default('datatable' ~ random()) %}
 {% if total_number < 1 and filters|length == 0 %}
     <table id="{{ datatable_id }}" class="table">
@@ -50,9 +52,7 @@
         <tbody>
             <tr>
                 <td>
-                    <div class="alert alert-info">
-                        {{ __('No results found') }}
-                    </div>
+                    {{ alerts.callout_info(__('No results found')) }}
                 </td>
             </tr>
         </tbody>
@@ -294,9 +294,7 @@
                 {% else %}
                     <tr>
                         <td colspan="{{ total_cols }}">
-                            <div class="alert alert-info">
-                                {{ __('No results found') }}
-                            </div>
+                            {{ alerts.callout_info(__('No results found')) }}
                         </td>
                     </tr>
                 {% endif %}

--- a/templates/components/form/item_antivirus_item.html.twig
+++ b/templates/components/form/item_antivirus_item.html.twig
@@ -41,7 +41,7 @@
 {% endif %}
 
 {% if not has_antivirus %}
-    {{ alerts.alert_info(
+    {{ alerts.callout_info(
         __('No antivirus associated with the item')
     ) }}
 {% else %}

--- a/templates/components/form/item_remotemanagement_list.html.twig
+++ b/templates/components/form/item_remotemanagement_list.html.twig
@@ -60,8 +60,6 @@
         'showmassiveactions': canedit,
     }, with_context = false) }}
 {% else %}
-    {{ alerts.alert_info(
-        __('No results found')
-    ) }}
+    {{ alerts.callout_info(__('No results found')) }}
 {% endif %}
 

--- a/templates/components/form/item_virtualmachine.html.twig
+++ b/templates/components/form/item_virtualmachine.html.twig
@@ -42,7 +42,7 @@
 {% endif %}
 
 {% if not has_vm %}
-    {{ alerts.alert_info(
+    {{ alerts.callout_info(
         __('No virtualized environment associated with the item')
     ) }}
 {% endif %}

--- a/templates/components/itilobject/actors/main.html.twig
+++ b/templates/components/itilobject/actors/main.html.twig
@@ -32,6 +32,7 @@
  #}
 
 {% import 'components/form/fields_macros.html.twig' as fields %}
+{% import 'components/alerts_macros.html.twig' as alerts %}
 
 {% if display_actortypes is not defined %}
    {% set display_actortypes = ['requester', 'observer', 'assign'] %}
@@ -180,18 +181,18 @@
                <input class="form-check-input" type="checkbox" id="use_notification" name="_notifications_use_notification" />
                <label class="form-check-label" for="use_notification">{{ __('Email followup') }}</label>
             </div>
-            <div id="alert_notification_disable" class='alert alert-info d-flex align-items-center mb-4 d-none' role='alert'>
-               <i class='ti ti-info-circle fs-2x'></i>
-               <span class='ms-2'>
-                  {{ __('Notifications are disabled because:') }}
-                  <ul>
+             {% set alert_message %}
+                 <ul>
                      <li>{{ __('User does not have an email address.') }}</li>
                      <li>{{ __('User has disabled notifications from its preferences.') }}</li>
                      <li>{{ __('Notifications are disabled in this entity.') }}</li>
-                  </ul>
-                  {{ __('However, you can reactivate the notifications for this ticket.') }}
-               </span>
-            </div>
+                 </ul>
+                 {{ __('However, you can reactivate the notifications for this ticket.') }}
+             {% endset %}
+             {{ alerts.alert_info(title: __('Notifications are disabled because:'), messages: [alert_message], options: {
+                 id: 'alert_notification_disable',
+                 add_class: 'mb-4 d-none',
+             }) }}
             <input type="email" class="form-control" id="alternative_email" name="_notifications_alternative_email" />
          </div>
       </div>

--- a/templates/components/itilobject/fields_panel.html.twig
+++ b/templates/components/itilobject/fields_panel.html.twig
@@ -500,7 +500,7 @@ $(function() {
          $(this).removeClass('show');
       })
    }
-%});
+});
 
 $(function() {
     // Prevent display of accordion header tooltips when right panel is expanded

--- a/templates/components/itilobject/fields_panel.html.twig
+++ b/templates/components/itilobject/fields_panel.html.twig
@@ -32,6 +32,7 @@
  #}
 
 {% import 'components/form/fields_macros.html.twig' as fields %}
+{% import 'components/alerts_macros.html.twig' as alerts %}
 {% set field_options = {
    'full_width': true,
    'fields_template': itiltemplate,
@@ -300,7 +301,12 @@
              <div id="notes" class="accordion-collapse collapse {{ notes_show ? "show" : "" }}" aria-labelledby="notes-heading">
                 <div class="accordion-body row m-0 mt-n2">
                   {% for note in notes %}
-                     <div class="alert alert-info entitynote rich_text_container" role="alert">{{ note['content']|safe_html }}</div>
+                      {%- set note_content -%}
+                          <div class="mb-n3">
+                              {{ note['content']|safe_html }}
+                          </div>
+                      {%- endset -%}
+                      {{ alerts.callout_info(title: '', messages: [note_content], options: { add_class: 'entitynote rich_text_container' }) }}
                   {% endfor %}
                 </div>
              </div>
@@ -494,7 +500,7 @@ $(function() {
          $(this).removeClass('show');
       })
    }
-});
+%});
 
 $(function() {
     // Prevent display of accordion header tooltips when right panel is expanded

--- a/templates/components/itilobject/fields_panel.html.twig
+++ b/templates/components/itilobject/fields_panel.html.twig
@@ -306,7 +306,7 @@
                               {{ note['content']|safe_html }}
                           </div>
                       {%- endset -%}
-                      {{ alerts.callout_info(title: '', messages: [note_content], options: { add_class: 'entitynote rich_text_container' }) }}
+                      {{ alerts.callout_info(title: '', messages: [note_content], options: {add_class: 'entitynote rich_text_container'}) }}
                   {% endfor %}
                 </div>
              </div>

--- a/templates/components/itilobject/itilsatisfaction.html.twig
+++ b/templates/components/itilobject/itilsatisfaction.html.twig
@@ -32,6 +32,7 @@
  #}
 
 {% import "components/form/fields_macros.html.twig" as fields %}
+{% import 'components/alerts_macros.html.twig' as alerts %}
 
 {% block more_fields %}
     {% if url is defined %}
@@ -50,14 +51,7 @@
         {% else %}
             {% set message = __('After 12 hours, you can no longer modify your response.') %}
         {% endif %}
-        <div class="alert alert-info d-flex align-items-center" role="alert">
-            <div class="text-dark">
-                <span class="ms-2">
-                    <i class="ti ti-info-circle fs-1"></i>
-                    {{ message }}
-                </span>
-            </div>
-        </div>
+        {{ alerts.callout_info(message) }}
         {% if item.fields['date_answered'] is empty and expired %}
             {{ fields.htmlField(
                 '',

--- a/templates/components/itilobject/timeline/form_document_item.html.twig
+++ b/templates/components/itilobject/timeline/form_document_item.html.twig
@@ -138,7 +138,7 @@
                             {% endif %}
                         </div>
                         <div id="screen_capture_preview" class="w-100">
-                            <div class="previews overflow-x-scroll my-2 d-flex px-2"></div>
+                            <div class="previews overflow-x-auto my-2 d-flex px-2"></div>
                             <button type="button" name="stop_recording" class="btn btn-secondary d-none">{{ __('Stop recording') }}</button>
                         </div>
                         <hr class="my-1">
@@ -157,12 +157,6 @@
                     ) }}
                 {% endif %}
 
-                {% set max_size %}
-                    <div class="alert alert-info">
-                        {{ call("Document::getMaxUploadSize") }}
-                    </div>
-                {% endset %}
-
                 {{ fields.fileField(
                     'filename',
                     null,
@@ -171,7 +165,6 @@
                         'multiple': true,
                         'full_width': true,
                         'is_horizontal': false,
-                        'add_field_html': max_size,
                     }
                 ) }}
 

--- a/templates/components/itilobject/timeline/form_solution.html.twig
+++ b/templates/components/itilobject/timeline/form_solution.html.twig
@@ -92,7 +92,10 @@
             {{ call_plugin_hook('pre_item_form', {"item": subitem, 'options': params}) }}
 
             {% if item.getType() == 'Ticket' and item.countOpenChildrenOfSameType() > 0 %}
-               {{ alerts.alert_warning(__('Warning: non closed children tickets depends on current ticket. Are you sure you want to close it?'), [], true) }}
+               {{ alerts.alert_warning(
+                   title: __('Warning: non closed children tickets depends on current ticket. Are you sure you want to close it?'),
+                   important: true
+               ) }}
             {% endif %}
 
             <div class="row mx-n3 mx-xxl-auto">

--- a/templates/components/itilobject/timeline/form_solution.html.twig
+++ b/templates/components/itilobject/timeline/form_solution.html.twig
@@ -33,6 +33,7 @@
 
 {% extends 'components/itilobject/timeline/form_timeline_item.html.twig' %}
 {% import 'components/form/fields_macros.html.twig' as fields %}
+{% import 'components/alerts_macros.html.twig' as alerts %}
 
 {% set params = {'item': item}|merge(params|default({})) %}
 
@@ -91,10 +92,7 @@
             {{ call_plugin_hook('pre_item_form', {"item": subitem, 'options': params}) }}
 
             {% if item.getType() == 'Ticket' and item.countOpenChildrenOfSameType() > 0 %}
-               <div class="alert alert-important alert-warning">
-                  <i class="ti ti-info-circle fs-2x me-2"></i>
-                  <span>{{ __('Warning: non closed children tickets depends on current ticket. Are you sure you want to close it?') }}</span>
-               </div>
+               {{ alerts.alert_warning(__('Warning: non closed children tickets depends on current ticket. Are you sure you want to close it?'), [], true) }}
             {% endif %}
 
             <div class="row mx-n3 mx-xxl-auto">

--- a/templates/components/itilobject/timeline/form_validation.html.twig
+++ b/templates/components/itilobject/timeline/form_validation.html.twig
@@ -33,6 +33,7 @@
 
 {% extends 'components/itilobject/timeline/form_timeline_item.html.twig' %}
 {% import 'components/form/fields_macros.html.twig' as fields %}
+{% import 'components/alerts_macros.html.twig' as alerts %}
 
 {% set params = params|default({}) %}
 
@@ -43,30 +44,26 @@
          {{ entry_i['content']|raw }}
 
          {% if entry_i['comment_submission']|length %}
-            <div class='alert alert-info mt-2'>
-                <div class='d-flex'>
-                    <div><i class='ti ti-quote me-2'></i></div>
-                    <div class="rich_text_container">
-                        {{ entry_i['comment_submission']|enhanced_html({
-                            'user_mentions': true,
-                            'images_gallery': true
-                        }) }}
-                    </div>
-                </div>
-            </div>
+             {% set comment_submission %}
+                 <div class="rich_text_container mb-n3">
+                     {{ entry_i['comment_submission']|enhanced_html({
+                         'user_mentions': true,
+                         'images_gallery': true
+                     }) }}
+                 </div>
+             {% endset %}
+             {{ alerts.callout(callout_type: 'info', title: comment_submission, icon: 'ti ti-quote', options: { add_class: 'mt-2' }) }}
          {% endif %}
          {% if entry_i['comment_validation']|length %}
-            <div class='alert alert-info mt-2'>
-                <div class='d-flex'>
-                    <div><i class='ti ti-quote me-2'></i></div>
-                    <div class="rich_text_container">
-                        {{ entry_i['comment_validation']|enhanced_html({
-                            'user_mentions': true,
-                            'images_gallery': true
-                        }) }}
-                    </div>
-                </div>
-            </div>
+             {% set comment_validation %}
+                 <div class="rich_text_container mb-n3">
+                     {{ entry_i['comment_validation']|enhanced_html({
+                         'user_mentions': true,
+                         'images_gallery': true
+                     }) }}
+                 </div>
+             {% endset %}
+             {{ alerts.callout(callout_type: 'info', title: comment_validation, icon: 'ti ti-quote', options: { add_class: 'mt-2' }) }}
          {% endif %}
 
          {% if entry_i['can_answer'] %}

--- a/templates/components/itilobject/timeline/form_validation.html.twig
+++ b/templates/components/itilobject/timeline/form_validation.html.twig
@@ -52,7 +52,7 @@
                      }) }}
                  </div>
              {% endset %}
-             {{ alerts.callout(callout_type: 'info', title: comment_submission, icon: 'ti ti-quote', options: { add_class: 'mt-2' }) }}
+             {{ alerts.callout(callout_type: 'info', title: comment_submission, icon: 'ti ti-quote', options: {add_class: 'mt-2'}) }}
          {% endif %}
          {% if entry_i['comment_validation']|length %}
              {% set comment_validation %}
@@ -63,7 +63,7 @@
                      }) }}
                  </div>
              {% endset %}
-             {{ alerts.callout(callout_type: 'info', title: comment_validation, icon: 'ti ti-quote', options: { add_class: 'mt-2' }) }}
+             {{ alerts.callout(callout_type: 'info', title: comment_validation, icon: 'ti ti-quote', options: {add_class: 'mt-2'}) }}
          {% endif %}
 
          {% if entry_i['can_answer'] %}

--- a/templates/components/itilobject/timeline/form_validation.html.twig
+++ b/templates/components/itilobject/timeline/form_validation.html.twig
@@ -52,7 +52,7 @@
                      }) }}
                  </div>
              {% endset %}
-             {{ alerts.callout(callout_type: 'info', title: comment_submission, icon: 'ti ti-quote', options: {add_class: 'mt-2'}) }}
+             {{ alerts.callout(callout_type: 'info', messages: [comment_submission], icon: 'ti ti-quote', options: {add_class: 'bg-light mt-2'}) }}
          {% endif %}
          {% if entry_i['comment_validation']|length %}
              {% set comment_validation %}
@@ -63,7 +63,7 @@
                      }) }}
                  </div>
              {% endset %}
-             {{ alerts.callout(callout_type: 'info', title: comment_validation, icon: 'ti ti-quote', options: {add_class: 'mt-2'}) }}
+             {{ alerts.callout(callout_type: 'info', messages: [comment_validation], icon: 'ti ti-quote', options: {add_class: 'bg-light mt-2'}) }}
          {% endif %}
 
          {% if entry_i['can_answer'] %}

--- a/templates/components/itilobject/timeline/new_form.html.twig
+++ b/templates/components/itilobject/timeline/new_form.html.twig
@@ -60,7 +60,7 @@
                               entitybadge
                           )|raw }}
                       {% endset %}
-                      {{ alerts.callout_info(entity_msg) }}
+                      {{ alerts.callout_info(messages: [entity_msg], options: {add_class: 'bg-light'}) }}
                   {% endif %}
 
                   {{ include('components/itilobject/timeline/simple_form.html.twig', {

--- a/templates/components/itilobject/timeline/new_form.html.twig
+++ b/templates/components/itilobject/timeline/new_form.html.twig
@@ -31,6 +31,7 @@
  # ---------------------------------------------------------------------
  #}
 
+{% import 'components/alerts_macros.html.twig' as alerts %}
 {% set users_id = session('glpiID') %}
 
 <div class="itil-timeline">
@@ -45,28 +46,28 @@
                   <strong>{{ get_item_link('User', users_id) }}</strong>
                </div>
             </div>
-            <span class="mt-2 timeline-content left card">
+            <div class="mt-2 timeline-content left card">
                <div class="card-body">
                   {% if item.isNewItem() %}
-                     <div class="alert alert-info" role="alert">
-                        {% set entitybadge %}
-                           <span class="ms-1">
+                      {% set entity_msg %}
+                          {% set entitybadge %}
+                              <span class="ms-1">
                               {{ call('Entity::badgeCompletenameById', [item.fields['entities_id']])|raw }}
                            </span>
-                        {% endset %}
-
-                        {{ __('%1$s will be added in entity %2$s')|format(
-                           item.getTypeName(1),
-                           entitybadge
-                        )|raw }}
-                     </div>
+                          {% endset %}
+                          {{ __('%1$s will be added in entity %2$s')|format(
+                              item.getTypeName(1),
+                              entitybadge
+                          )|raw }}
+                      {% endset %}
+                      {{ alerts.callout_info(entity_msg) }}
                   {% endif %}
 
                   {{ include('components/itilobject/timeline/simple_form.html.twig', {
                      'no_form': true
                   }) }}
                </div>
-            </span>
+            </div>
          </div>
       </div>
    </div>

--- a/templates/components/logs.html.twig
+++ b/templates/components/logs.html.twig
@@ -32,11 +32,10 @@
  #}
 
 {% import 'components/form/fields_macros.html.twig' as fields %}
+{% import 'components/alerts_macros.html.twig' as alerts %}
 
 {% if total_number < 1 %}
-   <div class="alert alert-info">
-      {{ __('No historical') }}
-   </div>
+    {{ alerts.callout_info(__('No historical')) }}
 {% else %}
 
    {{ include('components/pager.html.twig', {count: filtered_number}) }}

--- a/templates/components/messages_after_redirect_alerts.html.twig
+++ b/templates/components/messages_after_redirect_alerts.html.twig
@@ -31,6 +31,8 @@
  # ---------------------------------------------------------------------
  #}
 
+{% import 'components/alerts_macros.html.twig' as alerts %}
+
 {% set messages = pull_messages() %}
 {% if messages|length %}
 
@@ -39,21 +41,11 @@
       {% set class = '' %}
       {% set title = '' %}
       {% if type == constant('ERROR') %}
-         {% set class = 'alert-danger' %}
-         {% set title = _n('Error', 'Errors', 1) %}
+          {{ alerts.alert_danger(_n('Error', 'Errors', 1), [mesage|raw], true) }}
       {% elseif type == constant('WARNING') %}
-         {% set class = 'alert-warning' %}
-         {% set title = __('Warning') %}
+          {{ alerts.alert_warning(__('Warning'), [mesage|raw], true) }}
       {% else %}
-         {% set class = 'alert-info' %}
-         {% set title = _n('Information', 'Information', 1) %}
+          {{ alerts.alert_info(_n('Information', 'Information', 1), [mesage|raw], true) }}
       {% endif %}
-
-      <div class="alert alert-important {{ class }}" role="alert">
-         <h3>{{ title }}</h3>
-         <p>
-            {{ message|raw }}
-         </p>
-      </div>
    {% endfor %}
 {% endif %}

--- a/templates/components/search/criteria_filter.html.twig
+++ b/templates/components/search/criteria_filter.html.twig
@@ -31,15 +31,14 @@
  # ---------------------------------------------------------------------
  #}
 
+{% import 'components/alerts_macros.html.twig' as alerts %}
+
 {# Display the Filter tab #}
 <div class="row">
     {# Add a bit of padding with the container class #}
     <div class="col-12 search-container container">
         {# Info section detailling the purpose of the filter #}
-        <div class="alert alert-info mt-1">
-            <h3 class="fw-normal"><i class="ti ti-info-circle me-1"></i>{{ info_title }}</h3>
-            <p class="text-muted">{{ info_description }}</p>
-        </div>
+        {{ alerts.callout_info(info_title, [info_description]) }}
 
         {# Do not show filters until enabled #}
         <div id="manage_filter_ux" class="{{ filter_enabled ? "" : "d-none" }}">

--- a/templates/components/search/display_data.html.twig
+++ b/templates/components/search/display_data.html.twig
@@ -82,7 +82,7 @@
             {% if search_error %}
                 {{ alerts.alert_danger(__('An error occured during the search'), __('Consider changing the search criteria or adjusting the displayed columns.')) }}
             {% else %}
-                {{ alerts.alert_info(__('No results found')) }}
+                {{ alerts.callout_info(__('No results found')) }}
             {% endif %}
         {% endif %}
     </form>

--- a/templates/components/search/displaypreference_config.html.twig
+++ b/templates/components/search/displaypreference_config.html.twig
@@ -32,31 +32,28 @@
  #}
 
 {% import 'components/form/fields_macros.html.twig' as fields %}
+{% import 'components/alerts_macros.html.twig' as alerts %}
 
 <div id="tabsbody" class="m-n2 display_preference_config">
     <input type="hidden" name="itemtype" value="{{ itemtype }}">
     <input type="hidden" name="users_id" value="{{ users_id }}">
     {% if not available_itemtype %}
-        <div class="alert alert-danger">
-            {{ __('These preferences cannot be edited at this time. The item type no longer exists or is provided by a plugin that is not enabled.') }}
-        </div>
+        {{ alerts.alert_danger(__('These preferences cannot be edited at this time. The item type no longer exists or is provided by a plugin that is not enabled.')) }}
     {% else %}
         {% if is_global %}
             <div class="my-1 me-1">
-                <div class="alert alert-secondary">
-                    <i class="ti ti-info-circle"></i>
-                    <i>{{ __('These preferences are used by everyone that does not have a personal view configured.') }}</i>
-                </div>
+                {{ alerts.callout_info(__('These preferences are used by everyone that does not have a personal view configured.')) }}
             </div>
         {% endif %}
         {% if not is_global and not has_personal %}
-            <div class="alert alert-warning mt-3">
+            {% set no_personal_msg %}
                 {{ __('No personal criteria. Create personal parameters?') }}
                 <button type="button" class="btn btn-primary ms-3" name="activate" value="1">
                     <i class="ti ti-plus"></i>
                     <span>{{ __('Create') }}</span>
                 </button>
-            </div>
+            {% endset %}
+            {{ alerts.callout_warning(no_personal_msg) }}
         {% else %}
             <div class="pt-3">
                 {% if available_to_add|length > 0 %}

--- a/templates/components/search/displaypreference_list.html.twig
+++ b/templates/components/search/displaypreference_list.html.twig
@@ -32,6 +32,7 @@
  #}
 
 {% import 'components/form/basic_inputs_macros.html.twig' as inputs %}
+{% import 'components/alerts_macros.html.twig' as alerts %}
 
 {% if preferences|length > 0 %}
     <div class="my-3">
@@ -86,7 +87,5 @@
         });
     </script>
 {% else %}
-    <div class="alert alert-info">
-        {{ __('No results found') }}
-    </div>
+    {{ alerts.callout_info(__('No results found')) }}
 {% endif %}

--- a/templates/components/search/table.html.twig
+++ b/templates/components/search/table.html.twig
@@ -109,9 +109,9 @@
                <tr>
                   <td colspan="{{ data['data']['cols']|length }}">
                      {% if search_error %}
-                        {{ alerts.alert_danger(__('An error occured during the search'), __('Consider changing the search criteria or adjusting the displayed columns.')) }}
+                        {{ alerts.alert_danger(__('An error occured during the search'), [__('Consider changing the search criteria or adjusting the displayed columns.')]) }}
                      {% else %}
-                        {{ alerts.alert_info(__('No results found')) }}
+                        {{ alerts.callout_info(__('No results found')) }}
                      {% endif %}
                   </td>
                </tr>

--- a/templates/components/user/password_security_checks.html.twig
+++ b/templates/components/user/password_security_checks.html.twig
@@ -33,7 +33,9 @@
 
 {% set field = field|default('password') %}
 {% if config('use_password_security') %}
+   <label for="password_min_length">{{ __('Password minimum length') }}</label>
    <span id="password_min_length" class="text-danger">{{ config('password_min_length') }}</span>
+   <br>
    {% set checks = {
       password_need_number: __('Digit'),
       password_need_letter: __('Lowercase'),

--- a/templates/error_block.html.twig
+++ b/templates/error_block.html.twig
@@ -34,12 +34,12 @@
 
 <div class="card">
     <div class="card-body">
-        {%- set link -%}
+        {% set link %}
             {% if link_url is not empty %}
                 <a href="{{ link_url }}">{{ link_text }}</a>
             {% endif %}
-        {%- endset -%}
-        {{ alerts.alert_danger(message, link_url is not empty ? [link] : [], true) }}
+        {% endset %}
+        {{ alerts.alert_danger(title: message, messages: link_url is not empty ? [link] : [], important: true) }}
         {% if trace is not empty %}
             <pre data-testid="stack-trace">{{ trace }}</pre>
         {% endif %}

--- a/templates/error_block.html.twig
+++ b/templates/error_block.html.twig
@@ -30,23 +30,16 @@
  # ---------------------------------------------------------------------
  #}
 
+{% import 'components/alerts_macros.html.twig' as alerts %}
+
 <div class="card">
     <div class="card-body">
-        <div role="alert" class="alert alert-danger alert-important">
-            <div class="d-flex">
-                <div class="me-2">
-                    <i class="ti ti-alert-triangle fs-2x"></i>
-                </div>
-                <div>
-                    {{ message }}
-                    {% if link_url is not empty %}
-                        <br>
-                        <a href="{{ link_url }}">{{ link_text }}</a>
-                    {% endif %}
-                </div>
-            </div>
-        </div>
-
+        {%- set link -%}
+            {% if link_url is not empty %}
+                <a href="{{ link_url }}">{{ link_text }}</a>
+            {% endif %}
+        {%- endset -%}
+        {{ alerts.alert_danger(message, link_url is not empty ? [link] : [], true) }}
         {% if trace is not empty %}
             <pre data-testid="stack-trace">{{ trace }}</pre>
         {% endif %}

--- a/templates/install/agree_unstable.html.twig
+++ b/templates/install/agree_unstable.html.twig
@@ -32,21 +32,25 @@
  #}
 
 {% import 'components/form/fields_macros.html.twig' as fields %}
+{% import 'components/alerts_macros.html.twig' as alerts %}
 
-<div class="alert alert-warning">
-   <strong>
-      {% if is_dev %}
-         {{ __('You are using a development version, be careful!') }}
-      {% else %}
-         {{ __('You are using a pre-release version, be careful!') }}
-      {% endif %}
-   </strong>
-   <br>
-   {{ fields.checkboxField('agree_unstable', 0, __('I know I am using a unstable version.'), {
-      required: true,
-      id: 'agree_unstable'
-   }) }}
-</div>
+{% set title %}
+    {% if is_dev %}
+        {{ __('You are using a development version, be careful!') }}
+    {% else %}
+        {{ __('You are using a pre-release version, be careful!') }}
+    {% endif %}
+{% endset %}
+{% set message %}
+    {{ fields.checkboxField('agree_unstable', 0, __('I know I am using a unstable version.'), {
+        required: true,
+        id: 'agree_unstable',
+        field_class: 'col-12',
+        label_class: 'col-10',
+        input_class: 'col-2',
+    }) }}
+{% endset %}
+{{ alerts.alert_warning(title, [message]) }}
 <script>
    $(function() {
        $('[name=from_update]').on('click', function(event){

--- a/templates/install/step0.html.twig
+++ b/templates/install/step0.html.twig
@@ -40,7 +40,7 @@
          {{ __("Select 'Upgrade' to update your version of GLPI from an earlier version") }}
       {% endset %}
 
-      {{ alerts.alert_info(
+      {{ alerts.callout_info(
          __('Installation or update of GLPI'),
          alert_messages
       ) }}

--- a/templates/install/step1.html.twig
+++ b/templates/install/step1.html.twig
@@ -31,23 +31,14 @@
  # ---------------------------------------------------------------------
  #}
 
+{% import 'components/alerts_macros.html.twig' as alerts %}
+
 {% if config_write_denied %}
     <h3>{{ __("Checking write access to configuration files") }}</h3>
-    <div class="alert alert-danger" role="alert">
-        <div class="d-flex">
-            <div>
-                <i class="ti ti-alert-circle me-2"></i>
-            </div>
-            <div>
-                <h4 class="alert-title">{{ __('Write access denied for configuration files') }}</h4>
-                <div class="text-secondary">
-                    {{ __('A temporary write access to the following files is required: %s.')|format('`' ~ config_files_to_update|join('`, `') ~ '`') }}
-                    <br />
-                    {{ __('Write access to these files can be removed once the operation is finished.') }}
-                </div>
-            </div>
-        </div>
-    </div>
+    {{ alerts.alert_danger(__('Write access denied for configuration files', [
+        __('A temporary write access to the following files is required: %s.')|format('`' ~ config_files_to_update|join('`, `') ~ '`'),
+        __('Write access to these files can be removed once the operation is finished.')
+    ])) }}
 {% else %}
     <h3>{{ __("Checking of the compatibility of your environment with the execution of GLPI") }}</h3>
     {{ include('install/blocks/requirements_table.html.twig', {requirements: requirements}, with_context = false) }}

--- a/templates/install/update.invalid_database.html.twig
+++ b/templates/install/update.invalid_database.html.twig
@@ -31,7 +31,8 @@
  # ---------------------------------------------------------------------
  #}
 
-<div class="alert alert-warning"><strong>{{ message }}</strong></div>
+{% import 'components/alerts_macros.html.twig' as alerts %}
+{{ alerts.alert_warning(message) }}
 
 <form action="install.php" method="post" class="d-inline" data-submit-once>
     <button type="submit" name="submit" class="btn btn-warning">

--- a/templates/layout/parts/profile_selector.html.twig
+++ b/templates/layout/parts/profile_selector.html.twig
@@ -89,7 +89,7 @@
                 {% set shortcut = __('⌥ (option) + ⌘ (command) + E') %}
             {% endif %}
             {% set kb_message %}
-                {{ __("Tip: You can call this modal with %s keys combination")|format('<kbd>' ~ shortcut ~ '</kbd>')|raw }}
+                {{ __("Tip: You can call this modal with %s keys combination")|e|format('<kbd>' ~ shortcut ~ '</kbd>')|raw }}
             {% endset %}
             {{ alerts.callout_info(kb_message) }}
 
@@ -97,7 +97,7 @@
                 <i class="ti ti-chevrons-down" title="{{ __('+ sub-entities') }}"></i>
             {% endset %}
             {% set child_entity_msg %}
-                {{ __('Click on the %s icon to load the elements of the selected entity, as well as its sub-entities.')|format(recursive_icon)|raw }}
+                {{ __('Click on the %s icon to load the elements of the selected entity, as well as its sub-entities.')|e|format(recursive_icon)|raw }}
             {% endset %}
             {{ alerts.callout_info(child_entity_msg) }}
 

--- a/templates/layout/parts/profile_selector.html.twig
+++ b/templates/layout/parts/profile_selector.html.twig
@@ -31,6 +31,7 @@
  # ---------------------------------------------------------------------
  #}
 
+{% import 'components/alerts_macros.html.twig' as alerts %}
 {% set rand = random() %}
 
 <div class="dropdown dropstart">
@@ -83,22 +84,22 @@
         <div class="dropdown-menu p-3">
             <h3>{{ __('Select the desired entity') }}</h3>
 
-            <div class="alert alert-info" role="alert">
-                {% set shortcut = __('Ctrl + Alt + E') %}
-                {% if platform == constant("donatj\\UserAgent\\Platforms::MACINTOSH") %}
-                    {% set shortcut = __('⌥ (option) + ⌘ (command) + E') %}
-                {% endif %}
+            {% set shortcut = __('Ctrl + Alt + E') %}
+            {% if platform == constant("donatj\\UserAgent\\Platforms::MACINTOSH") %}
+                {% set shortcut = __('⌥ (option) + ⌘ (command) + E') %}
+            {% endif %}
+            {% set kb_message %}
                 {{ __("Tip: You can call this modal with %s keys combination")|format('<kbd>' ~ shortcut ~ '</kbd>')|raw }}
-            </div>
-            <div class="alert alert-info" role="alert">
-                <i class="ti ti-info-circle-filled"></i>
-                <span class="ms-2">
-                {% set recursive_icon %}
-                    <i class="ti ti-chevrons-down" title="{{ __('+ sub-entities') }}"></i>
-                {% endset %}
+            {% endset %}
+            {{ alerts.callout_info(kb_message) }}
+
+            {% set recursive_icon %}
+                <i class="ti ti-chevrons-down" title="{{ __('+ sub-entities') }}"></i>
+            {% endset %}
+            {% set child_entity_msg %}
                 {{ __('Click on the %s icon to load the elements of the selected entity, as well as its sub-entities.')|format(recursive_icon)|raw }}
-                </span>
-            </div>
+            {% endset %}
+            {{ alerts.callout_info(child_entity_msg) }}
 
             {% set switch_to_full_structure_id = 'switch_to_full_structure_' ~ rand %}
             <form

--- a/templates/layout/parts/saved_searches_list.html.twig
+++ b/templates/layout/parts/saved_searches_list.html.twig
@@ -31,10 +31,10 @@
  # ---------------------------------------------------------------------
  #}
 
+{% import 'components/alerts_macros.html.twig' as alerts %}
+
 {% if saved_searches|length == 0 %}
-   <div class="alert alert-info" role="alert">
-      {{ __('You have not recorded any saved searches yet') }}
-   </div>
+    {{ alerts.callout_info(__('You have not recorded any saved searches yet')) }}
 {% endif %}
 
 <div class='sortable-savedsearches'>

--- a/templates/maintenance.html.twig
+++ b/templates/maintenance.html.twig
@@ -32,36 +32,35 @@
  #}
 
 {% extends 'layout/page_card_notlogged.html.twig' %}
+{% import 'components/alerts_macros.html.twig' as alerts %}
 
 {% block content_block %}
-<div class="flex-fill d-flex align-items-center justify-content-center">
-   <div class="container-tight py-6">
-      <div class="empty">
-         <i class="fas fa-tools fa-3x mb-3"></i>
+    <div class="flex-fill d-flex align-items-center justify-content-center">
+        <div class="container-tight py-6">
+            <div class="empty">
+                <i class="fas fa-tools fa-3x mb-3"></i>
 
-         <p class="empty-title">{{ __('Temporarily down for maintenance') }}</p>
+                <p class="empty-title">{{ __('Temporarily down for maintenance') }}</p>
 
-         <p class="empty-subtitle text-muted">
-            {{ __('Sorry for the inconvenience but we’re performing some maintenance at the moment. We’ll be back online shortly!') }}
-         </p>
+                <p class="empty-subtitle text-muted">
+                    {{ __('Sorry for the inconvenience but we’re performing some maintenance at the moment. We’ll be back online shortly!') }}
+                </p>
 
-         {% if maintenance_text|length %}
-            <div class="alert alert-warning mt-4">
-               {{ maintenance_text }}
+                {% if maintenance_text|length %}
+                    {{ alerts.callout_warning(maintenance_text) }}
+                {% endif %}
+                <div class="empty-action">
+                    <a href="{{ index_path() }}" class="btn btn-primary">
+                        <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewbox="0 0 24 24" stroke-width="2" stroke="currentcolor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                            <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+                            <line x1="5" y1="12" x2="19" y2="12"></line>
+                            <line x1="5" y1="12" x2="11" y2="18"></line>
+                            <line x1="5" y1="12" x2="11" y2="6"></line>
+                        </svg>
+                        {{ __('Take me home') }}
+                    </a>
+                </div>
             </div>
-         {% endif %}
-         <div class="empty-action">
-            <a href="{{ index_path() }}" class="btn btn-primary">
-               <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewbox="0 0 24 24" stroke-width="2" stroke="currentcolor" fill="none" stroke-linecap="round" stroke-linejoin="round">
-                  <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
-                  <line x1="5" y1="12" x2="19" y2="12"></line>
-                  <line x1="5" y1="12" x2="11" y2="18"></line>
-                  <line x1="5" y1="12" x2="11" y2="6"></line>
-               </svg>
-               {{ __('Take me home') }}
-            </a>
-         </div>
-      </div>
-   </div>
-</div>
+        </div>
+    </div>
 {% endblock %}

--- a/templates/pages/2fa/2fa_config.html.twig
+++ b/templates/pages/2fa/2fa_config.html.twig
@@ -32,6 +32,7 @@
  #}
 
 {% import 'components/form/fields_macros.html.twig' as fields %}
+{% import 'components/alerts_macros.html.twig' as alerts %}
 
 <div class="spaced">
    {% if canedit %}
@@ -47,9 +48,7 @@
       </tr>
       <tr class="tab_bg_1">
          <td colspan="2">
-            <div class="alert alert-info">
-               {{ __('If 2FA is enforced, users with access to this %s will be required to use 2FA at login even if this is not their default')|format(item.getTypeName(1)) }}
-            </div>
+             {{ alerts.callout_info(__('If 2FA is enforced, users with access to this %s will be required to use 2FA at login even if this is not their default')|format(item.getTypeName(1))) }}
          </td>
       </tr>
       <tr class="tab_bg_1">

--- a/templates/pages/2fa/2fa_status.html.twig
+++ b/templates/pages/2fa/2fa_status.html.twig
@@ -88,7 +88,7 @@
                             const backup_code_container = $('#backup_codes');
                             if (codes.length === 0) {
                                 // An error occured
-                                backup_code_container.html(`{{ alerts.alert_danger(__('An error occured')) }}`);
+                                backup_code_container.html('{{ alerts.alert_danger(__('An error occured'))|e('js') }}');
                             } else {
                                 //Remove any previous code table
                                 backup_code_container.find('table').remove();
@@ -121,7 +121,7 @@
                         },
                         error: function() {
                             const backup_code_container = $('#backup_codes');
-                            backup_code_container.html(`{{ alerts.alert_danger(__('An error occured')) }}`);
+                            backup_code_container.html('{{ alerts.alert_danger(__('An error occured'))|e('js') }}');
                             backup_code_container.removeClass('d-none');
                         }
                     });

--- a/templates/pages/2fa/2fa_status.html.twig
+++ b/templates/pages/2fa/2fa_status.html.twig
@@ -31,106 +31,105 @@
  # ---------------------------------------------------------------------
  #}
 
-<form method="post" action="#" data-submit-once>
-   <div class="alert alert-info">
-      <h1>{{ __('2FA Enabled') }}</h1>
-      <h2>
-         {% if enforcement == constant('Glpi\\Security\\TOTPManager::ENFORCEMENT_MANDATORY_GRACE_PERIOD') %}
-            {{ __('2FA grace period ends %s')|format(grace_period_end|relative_datetime) }}
-         {% elseif enforcement == constant('Glpi\\Security\\TOTPManager::ENFORCEMENT_MANDATORY') %}
-            {{ __('Mandatory') }}
-         {% else %}
-            {{ __('Optional') }}
-         {% endif %}
-      </h2>
-   </div>
-   <div id="backup_codes" class="d-none py-2" style="width: fit-content;">
-      <h3 class="mb-2 alert alert-warning">{{ __('Backup codes (This is the only time these will be shown)') }}</h3>
-      <h4 class="mb-2">{{ __('These are one-time use codes in case your authenticator is inaccessible') }}</h4>
-   </div>
-   <div>
-      <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}">
-      {% if enforcement != constant('Glpi\\Security\\TOTPManager::ENFORCEMENT_MANDATORY') %}
-         <button type="submit" class="btn btn-danger" name="disable_2fa">
-            {{ __('Disable 2FA') }}
-         </button>
-      {% else %}
-         <button type="submit" class="btn btn-danger" name="reset_2fa">
-            {{ __('Reset 2FA') }}
-         </button>
-      {% endif %}
-      <button type="button" class="btn btn-outline-secondary" name="regenerate_backup_codes">
-         {{ __('Regenerate backup codes') }}
-      </button>
-      <script>
-         $(function() {
-            $('#backup_codes').on('click', 'button[name="copy_backup_codes"]', function() {
-                const codes = [];
-                $('#backup_codes').find('td.backup-code').each(function () {
-                    codes.push($(this).text());
-                });
-                const newline = navigator.platform.match(/Windows/) ? "\r\n" : "\n";
-                navigator.clipboard.writeText(codes.join(newline));
-                const btn = $(this);
+{% import 'components/alerts_macros.html.twig' as alerts %}
 
-                btn.find('i').removeClass('ti ti-copy').addClass('ti ti-check');
-                btn.removeClass('btn-outline-secondary').addClass('btn-success');
-                btn.text('{{ __('Copied') }}');
-            });
-            $('button[name="regenerate_backup_codes"]').on('click', function() {
-               $.ajax({
-                  url: CFG_GLPI.root_doc + '/ajax/2fa.php',
-                  method: 'POST',
-                  data: {
-                      regenerate_backup_codes: 1
-                  },
-                  success: function(data) {
-                     const codes = JSON.parse(data);
-                     const backup_code_container = $('#backup_codes');
-                     if (codes.length === 0) {
-                        // An error occured
-                        backup_code_container.html('{{ __('An error occured') }}');
-                     } else {
-                        //Remove any previous code table
-                        backup_code_container.find('table').remove();
-                        backup_code_container.append(`<table class="table table-bordered mx-auto text-center" style="width: fit-content"><tbody></tbody></table>`);
-                        const table_body = backup_code_container.find('tbody');
-                        $.each(codes, function(index, value) {
-                           let code_item = $('<tr><td class="backup-code"></td></tr>');
-                           // Stylize the codes to make them easier to read and reduce ambiguity
-                           for (let i = 0; i < value.length; i++) {
-                              if (isNaN(value[i])) {
-                                 if (value[i] === value[i].toUpperCase()) {
-                                    code_item.find('td').append($('<u></u>').text(value[i]));
-                                 } else {
-                                     code_item.find('td').append(value[i]);
-                                 }
-                              } else {
-                                  code_item.find('td').append($('<span></span>').addClass('text-info').text(value[i]));
-                              }
-                           }
-                            table_body.append(code_item);
-                        });
-                        table_body.append(`<tr><td>
+<form method="post" action="#" data-submit-once>
+    {% set tfa_status %}
+        {% if enforcement == constant('Glpi\\Security\\TOTPManager::ENFORCEMENT_MANDATORY_GRACE_PERIOD') %}
+            {{ __('2FA grace period ends %s')|format(grace_period_end|relative_datetime) }}
+        {% elseif enforcement == constant('Glpi\\Security\\TOTPManager::ENFORCEMENT_MANDATORY') %}
+            {{ __('Mandatory') }}
+        {% else %}
+            {{ __('Optional') }}
+        {% endif %}
+    {% endset %}
+    {{ alerts.callout_info(__('2FA Enabled'), [tfa_status]) }}
+    <div id="backup_codes" class="d-none py-2" style="width: fit-content;">
+        {{ alerts.alert_warning(__('Backup codes (This is the only time these will be shown)'), [__('These are one-time use codes in case your authenticator is inaccessible')]) }}
+    </div>
+    <div>
+        <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}">
+        {% if enforcement != constant('Glpi\\Security\\TOTPManager::ENFORCEMENT_MANDATORY') %}
+            <button type="submit" class="btn btn-danger" name="disable_2fa">
+                {{ __('Disable 2FA') }}
+            </button>
+        {% else %}
+            <button type="submit" class="btn btn-danger" name="reset_2fa">
+                {{ __('Reset 2FA') }}
+            </button>
+        {% endif %}
+        <button type="button" class="btn btn-outline-secondary" name="regenerate_backup_codes">
+            {{ __('Regenerate backup codes') }}
+        </button>
+        <script>
+            $(function() {
+                $('#backup_codes').on('click', 'button[name="copy_backup_codes"]', function() {
+                    const codes = [];
+                    $('#backup_codes').find('td.backup-code').each(function () {
+                        codes.push($(this).text());
+                    });
+                    const newline = navigator.platform.match(/Windows/) ? "\r\n" : "\n";
+                    navigator.clipboard.writeText(codes.join(newline));
+                    const btn = $(this);
+
+                    btn.find('i').removeClass('ti ti-copy').addClass('ti ti-check');
+                    btn.removeClass('btn-outline-secondary').addClass('btn-success');
+                    btn.text('{{ __('Copied') }}');
+                });
+                $('button[name="regenerate_backup_codes"]').on('click', function() {
+                    $.ajax({
+                        url: CFG_GLPI.root_doc + '/ajax/2fa.php',
+                        method: 'POST',
+                        data: {
+                            regenerate_backup_codes: 1
+                        },
+                        success: function(data) {
+                            const codes = JSON.parse(data);
+                            const backup_code_container = $('#backup_codes');
+                            if (codes.length === 0) {
+                                // An error occured
+                                backup_code_container.html(`{{ alerts.alert_danger(__('An error occured')) }}`);
+                            } else {
+                                //Remove any previous code table
+                                backup_code_container.find('table').remove();
+                                backup_code_container.append(`<table class="table table-bordered mx-auto text-center" style="width: fit-content"><tbody></tbody></table>`);
+                                const table_body = backup_code_container.find('tbody');
+                                $.each(codes, function(index, value) {
+                                    let code_item = $('<tr><td class="backup-code"></td></tr>');
+                                    // Stylize the codes to make them easier to read and reduce ambiguity
+                                    for (let i = 0; i < value.length; i++) {
+                                        if (isNaN(value[i])) {
+                                            if (value[i] === value[i].toUpperCase()) {
+                                                code_item.find('td').append($('<u></u>').text(value[i]));
+                                            } else {
+                                                code_item.find('td').append(value[i]);
+                                            }
+                                        } else {
+                                            code_item.find('td').append($('<span></span>').addClass('text-info').text(value[i]));
+                                        }
+                                    }
+                                    table_body.append(code_item);
+                                });
+                                table_body.append(`<tr><td>
                             <button class="btn btn-outline-secondary" type="button" name="copy_backup_codes">
                                 <i class="ti ti-copy"></i>
                                 {{ __('Copy backup codes') }}
                             </button>
                         </td></tr>`);
-                     }
-                     backup_code_container.removeClass('d-none');
-                  },
-                  error: function() {
-                     const backup_code_container = $('#backup_codes');
-                     backup_code_container.html('{{ __('An error occured') }}');
-                     backup_code_container.removeClass('d-none');
-                  }
-               });
+                            }
+                            backup_code_container.removeClass('d-none');
+                        },
+                        error: function() {
+                            const backup_code_container = $('#backup_codes');
+                            backup_code_container.html(`{{ alerts.alert_danger(__('An error occured')) }}`);
+                            backup_code_container.removeClass('d-none');
+                        }
+                    });
+                });
+                {% if regenerate_backup_codes %}
+                $('button[name="regenerate_backup_codes"]').trigger('click');
+                {% endif %}
             });
-            {% if regenerate_backup_codes %}
-             $('button[name="regenerate_backup_codes"]').trigger('click');
-            {% endif %}
-         });
-      </script>
-   </div>
+        </script>
+    </div>
 </form>

--- a/templates/pages/admin/assetdefinition/capacities.html.twig
+++ b/templates/pages/admin/assetdefinition/capacities.html.twig
@@ -82,11 +82,11 @@
                                 {{ capacity.getDescription() }}
                             </small>
                             {% endif %}
-                            <span class="alert-capacity text-red d-none" data-capacity="{{ get_class(capacity) }}">
+                            <span class="alert-capacity text-red d-none" data-capacity="{{ get_class(capacity) }}" role="alert">
                                 <i class="ti ti-alert-triangle fs-2"></i>
                                 <span>
                                     {{ capacity.getCapacityUsageDescription(classname) }}
-                                <span
+                                </span>
                             </span>
                         </div>
                         <div class="me-2 ms-auto">

--- a/templates/pages/admin/entity/assistance.html.twig
+++ b/templates/pages/admin/entity/assistance.html.twig
@@ -33,6 +33,7 @@
 
 {% extends "generic_show_form.html.twig" %}
 {% import 'components/form/fields_macros.html.twig' as fields %}
+{% import 'components/alerts_macros.html.twig' as alerts %}
 
 {% block form_fields %}
     {% set inheritable_params = {
@@ -109,13 +110,11 @@
 
     {{ fields.smallTitle(__('Automatic closing configuration')) }}
     {% if closeticket_disabled or purgeticket_disabled %}
-        <div class="alert alert-info">
-            <i class="ti ti-info-circle"></i>
-            <div>
-                {{ closeticket_disabled ? __('Close ticket action is disabled.') : '' }}
-                {{ purgeticket_disabled ? __('Purge ticket action is disabled.') : '' }}
-            </div>
-        </div>
+        {% set message %}
+            {{ closeticket_disabled ? __('Close ticket action is disabled.') : '' }}
+            {{ purgeticket_disabled ? __('Purge ticket action is disabled.') : '' }}
+        {% endset %}
+        {{ alerts.callout_info(message) }}
     {% endif %}
     {{ fields.dropdownNumberField('autoclose_delay', item.fields['autoclose_delay'], __('Automatic closing of solved tickets after'), {
         full_width: true,

--- a/templates/pages/admin/entity/custom_ui.html.twig
+++ b/templates/pages/admin/entity/custom_ui.html.twig
@@ -33,6 +33,7 @@
 
 {% extends "generic_show_form.html.twig" %}
 {% import 'components/form/fields_macros.html.twig' as fields %}
+{% import 'components/alerts_macros.html.twig' as alerts %}
 {% set params  = params ?? [] %}
 
 {% block form_fields %}
@@ -44,7 +45,10 @@
         {% set inherited_value = enabled_css_inherited_value %}
         {% set show_editor = (inherited_value is null or inherited_value == 1) and item.fields['enable_custom_css'] != 0 %}
         <div id="custom_css_container" class="custom_css_container {{ show_editor ? '' : 'd-none' }}" style="height: 400px"></div>
-        <div class="alert alert-info {{ item.fields['enable_custom_css'] == 0 ? '' : 'd-none' }}">{{ __('Custom CSS is disabled') }}</div>
+        {{ alerts.callout_info(
+            title: __('Custom CSS is disabled'),
+            options: { add_class: item.fields['enable_custom_css'] == 0 ? '' : 'd-none' }
+        )  }}
         <script>
             const refreshCustomCSSEditor = () => {
                 if (window.monaco !== undefined) {

--- a/templates/pages/admin/entity/custom_ui.html.twig
+++ b/templates/pages/admin/entity/custom_ui.html.twig
@@ -47,8 +47,8 @@
         <div id="custom_css_container" class="custom_css_container {{ show_editor ? '' : 'd-none' }}" style="height: 400px"></div>
         {{ alerts.callout_info(
             title: __('Custom CSS is disabled'),
-            options: { add_class: item.fields['enable_custom_css'] == 0 ? '' : 'd-none' }
-        )  }}
+            options: {add_class: item.fields['enable_custom_css'] == 0 ? '' : 'd-none'}
+        ) }}
         <script>
             const refreshCustomCSSEditor = () => {
                 if (window.monaco !== undefined) {

--- a/templates/pages/admin/form/access_control.html.twig
+++ b/templates/pages/admin/form/access_control.html.twig
@@ -31,6 +31,8 @@
  # ---------------------------------------------------------------------
  #}
 
+{% import 'components/alerts_macros.html.twig' as alerts %}
+
 {# @var \Glpi\Form\Form form #}
 {# @var \Glpi\Form\AccessControl\FormAccessControl[] access_controls #}
 {# @var string[] warnings #}
@@ -47,13 +49,7 @@
             {% if warnings|length > 0 %}
                 <div class="mb-5">
                     {% for warning in warnings %}
-                        <div
-                            class="alert alert-warning d-flex align-items-center"
-                            role="alert"
-                        >
-                            <i class="ti ti-alert-triangle me-2"></i>
-                            {{ warning }}
-                        </div>
+                        {{ alerts.alert_warning(warning) }}
                     {% endfor %}
                 </div>
             {% endif %}
@@ -74,6 +70,7 @@
                 >
                     <h3 class="d-flex align-items-center">
                         <i class="{{ strategy.getIcon() }} me-2"></i>
+                        {{ strategy.getLabel() }}
                         {{ strategy.getLabel() }}
                         <label class="form-check mb-0 ms-auto form-switch">
                             <input

--- a/templates/pages/admin/form/access_control.html.twig
+++ b/templates/pages/admin/form/access_control.html.twig
@@ -71,7 +71,6 @@
                     <h3 class="d-flex align-items-center">
                         <i class="{{ strategy.getIcon() }} me-2"></i>
                         {{ strategy.getLabel() }}
-                        {{ strategy.getLabel() }}
                         <label class="form-check mb-0 ms-auto form-switch">
                             <input
                                 type="hidden"

--- a/templates/pages/admin/inventory/upload_form.html.twig
+++ b/templates/pages/admin/inventory/upload_form.html.twig
@@ -32,17 +32,17 @@
  #}
 
 {% import 'components/form/fields_macros.html.twig' as fields %}
+{% import 'components/alerts_macros.html.twig' as alerts %}
 
 <form method='POST' enctype='multipart/form-data'>
     <h2>
         {{ __("Import inventory files") }}
     </h2>
-    <div class="alert alert-info" role="alert">
-        <p>
-            {{ __("You can use this menu to upload one or several inventory files. Files must have a known extension (%1\$s).\n")|format(inventory_extensions|join(', ')) }}<br>
-            {{ __('It is also possible to upload a compressed archive directly with a collection of inventory files.') }}
-        </p>
-    </div>
+    {% set help_message %}
+        {{ __("You can use this menu to upload one or several inventory files. Files must have a known extension (%1\$s).\n")|format(inventory_extensions|join(', ')) }}<br>
+        {{ __('It is also possible to upload a compressed archive directly with a collection of inventory files.') }}
+    {% endset %}
+    {{ alerts.callout_info(help_message) }}
     {{ fields.fileField(
         'inventory_files[]',
         '',

--- a/templates/pages/admin/inventory/upload_result.html.twig
+++ b/templates/pages/admin/inventory/upload_result.html.twig
@@ -62,7 +62,7 @@
                                 <td>{{ filename }}</td>
                                 <td>
                                     <span class="{{ result['success'] ? 'text-success' : 'text-danger' }}">
-                                        <i class="ti {{ result['success'] ? 'ti-check' : 'ti-alert-triange' }}"></i>
+                                        <i class="ti {{ result['success'] ? 'ti-check' : 'ti-alert-triangle' }}"></i>
                                         {{ result['message'] }}
                                     </span>
                                 </td>

--- a/templates/pages/admin/rules/engine_preview_criteria.html.twig
+++ b/templates/pages/admin/rules/engine_preview_criteria.html.twig
@@ -33,6 +33,7 @@
 
 {% import 'components/form/fields_macros.html.twig' as fields %}
 {% import 'components/form/basic_inputs_macros.html.twig' as inputs %}
+{% import 'components/alerts_macros.html.twig' as alerts %}
 
 {% if input|length %}
    <div class="card">
@@ -68,7 +69,5 @@
       </div>
    </div>
 {% else %}
-   <div class="alert alert-danger">
-      <span>{{ __('No element to be tested') }}</span>
-   </div>
+   {{ alerts.callout_info(__('No element to be tested')) }}
 {% endif %}

--- a/templates/pages/admin/rules/engine_summary.html.twig
+++ b/templates/pages/admin/rules/engine_summary.html.twig
@@ -31,7 +31,9 @@
  # ---------------------------------------------------------------------
  #}
 
-<div class="alert alert-info">
+{% import 'components/alerts_macros.html.twig' as alerts %}
+
+{% set message %}
    {% if collection.stop_on_first_match %}
       <span>{{ __('The engine will stop after the first matched rule.') }}</span>
    {% else %}
@@ -45,4 +47,5 @@
    {% if collection.isRuleUseConditions %}
       <span>{{ __('The rules are conditional based on a type of action.') }}</span>
    {% endif %}
-</div>
+{% endset %}
+{{ alerts.callout_info(message) }}

--- a/templates/pages/admin/transfer_list.html.twig
+++ b/templates/pages/admin/transfer_list.html.twig
@@ -33,67 +33,64 @@
 
 {% import 'components/form/fields_macros.html.twig' as fields %}
 {% import 'components/form/basic_inputs_macros.html.twig' as inputs %}
+{% import 'components/alerts_macros.html.twig' as alerts %}
 {% set transfer_list = transfer_list|default({}) %}
 {% set rand = random() %}
 
 <div class="asset">
-   {% if transfer_list|length > 0 %}
-      <div class="alert alert-info">
-         {{ __('You can continue to add elements to be transferred or execute the transfer now.') }}
-         <br>
-         {{ __('Think of making a backup before transfering items.') }}
-      </div>
-      {{ fields.dropdownField('Transfer', 'id', 0, __('Transfer mode'), {
-         rand: rand,
-         comments: false,
-         toupdate: {
-            value_fieldname: 'id',
-            to_update: 'transfer_form',
-            url: config('root_doc') ~ '/ajax/transfers.php',
-         }
-      }) }}
-      <div id="transfer_form">
-         <form action="{{ config('root_doc') ~ '/front/transfer.action.php' }}" method="post">
-            <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}" />
-            {{ inputs.button('clear', __('Clear the list of elements to be transferred'), 'submit', 'clear') }}
-         </form>
-      </div>
-      <table class="table table-striped">
-         <thead>
+    {% if transfer_list|length > 0 %}
+        {{ alerts.callout_info(__('You can continue to add elements to be transferred or execute the transfer now.'), [
+            __('Think of making a backup before transfering items.')
+        ]) }}
+        {{ fields.dropdownField('Transfer', 'id', 0, __('Transfer mode'), {
+            rand: rand,
+            comments: false,
+            toupdate: {
+                value_fieldname: 'id',
+                to_update: 'transfer_form',
+                url: config('root_doc') ~ '/ajax/transfers.php',
+            }
+        }) }}
+        <div id="transfer_form">
+            <form action="{{ config('root_doc') ~ '/front/transfer.action.php' }}" method="post">
+                <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}" />
+                {{ inputs.button('clear', __('Clear the list of elements to be transferred'), 'submit', 'clear') }}
+            </form>
+        </div>
+        <table class="table table-striped">
+            <thead>
             <tr>
-               <th colspan="4">{{ __('Items to transfer') }}</th>
+                <th colspan="4">{{ __('Items to transfer') }}</th>
             </tr>
             <tr>
-               <th>{{ _n('Type', 'Types', 1) }}</th>
-               <th>{{ 'Entity'|itemtype_name }}</th>
-               <th>{{ __('ID') }}</th>
-               <th>{{ __('Name') }}</th>
+                <th>{{ _n('Type', 'Types', 1) }}</th>
+                <th>{{ 'Entity'|itemtype_name }}</th>
+                <th>{{ __('ID') }}</th>
+                <th>{{ __('Name') }}</th>
             </tr>
-         </thead>
-         <tbody>
+            </thead>
+            <tbody>
             {% for itemtype, items in transfer_list %}
-               {% for item in items %}
-                  <tr>
-                     <td>{{ itemtype|itemtype_name }}</td>
-                     <td>{{ item['locname'] }}</td>
-                     <td>{{ item['id'] }}</td>
-                     <td>{{ item['name']|default('(' ~ item['id'] ~ ')') }}</td>
-                  </tr>
-               {% endfor %}
+                {% for item in items %}
+                    <tr>
+                        <td>{{ itemtype|itemtype_name }}</td>
+                        <td>{{ item['locname'] }}</td>
+                        <td>{{ item['id'] }}</td>
+                        <td>{{ item['name']|default('(' ~ item['id'] ~ ')') }}</td>
+                    </tr>
+                {% endfor %}
             {% endfor %}
-         </tbody>
-      </table>
-      {% do call('Ajax::updateItemOnSelectEvent', [
-         "dropdown_id" ~ rand,
-         "transfer_form",
-         config('root_doc') ~ '/ajax/transfers.php',
-         {
-            "id": "__VALUE__"
-         }
-      ]) %}
-   {% else %}
-      <div class="alert alert-danger">
-         {{ __('No selected element or badly defined operation') }}
-      </div>
-   {% endif %}
+            </tbody>
+        </table>
+        {% do call('Ajax::updateItemOnSelectEvent', [
+            "dropdown_id" ~ rand,
+            "transfer_form",
+            config('root_doc') ~ '/ajax/transfers.php',
+            {
+                "id": "__VALUE__"
+            }
+        ]) %}
+    {% else %}
+        {{ alerts.alert_danger(__('No selected element or badly defined operation')) }}
+    {% endif %}
 </div>

--- a/templates/pages/admin/user.substitute.html.twig
+++ b/templates/pages/admin/user.substitute.html.twig
@@ -32,119 +32,111 @@
  #}
 
 {% import 'components/form/fields_macros.html.twig' as fields %}
+{% import 'components/alerts_macros.html.twig' as alerts %}
 
 {% set id      = item.fields['id'] ?? -1 %}
 
 <div class="asset">
 
-{% if canedit %}
-   <form name="asset_form" method="post" action="{{ item.getFormURL() }}" enctype="multipart/form-data" data-submit-once>
-{% endif %}
+    {% if canedit %}
+        <form name="asset_form" method="post" action="{{ item.getFormURL() }}" enctype="multipart/form-data" data-submit-once>
+    {% endif %}
 
-   <div id="mainformtable">
+    <div id="mainformtable">
+        {{ call_plugin_hook(constant('Glpi\\Plugin\\Hooks::PRE_ITEM_FORM'), {'item': item, 'options': params}) }}
 
-      {{ call_plugin_hook(constant('Glpi\\Plugin\\Hooks::PRE_ITEM_FORM'), {'item': item, 'options': params}) }}
+        <div class="card-body d-flex flex-wrap">
+            <div class="col-12 col-xxl-{{ item_has_pictures ? '9' : '12' }} flex-column">
+                <div class="d-flex flex-row flex-wrap flex-xl-nowrap">
+                    <div class="row flex-row align-items-start flex-grow-1">
+                        <div class="row flex-row">
+                            <input type="hidden" name="users_id" value={{ user.fields['id'] }} />
 
-      <div class="card-body d-flex flex-wrap">
-         <div class="col-12 col-xxl-{{ item_has_pictures ? '9' : '12' }} flex-column">
-            <div class="d-flex flex-row flex-wrap flex-xl-nowrap">
-               <div class="row flex-row align-items-start flex-grow-1">
-                  <div class="row flex-row">
-                     <input type="hidden" name="users_id" value={{ user.fields['id'] }} />
+                            <div class="row col-12 col-sm-12 mb-4">
+                                {{ alerts.callout_info(__('Substitutes are users who can approve or refuse tickets on your behalf.')) }}
+                            </div>
 
-                     <div class="row col-12 col-sm-12 mb-4">
-                        <div class="alert alert-info" style="margin: 0 auto; max-width: 900px">
-                           <span>
-                              <i class="ti ti-info-circle"></i>&nbsp;{{ __('Substitutes are users who can approve or refuse tickets on your behalf.') }}
-                           </span>
-                        </div>
-                     </div>
+                            {{ fields.datetimeField(
+                                'substitution_start_date',
+                                user.fields['substitution_start_date'],
+                                __('Start date ')
+                            ) }}
 
-                     {{ fields.datetimeField(
-                        'substitution_start_date',
-                        user.fields['substitution_start_date'],
-                        __('Start date ')
-                     ) }}
+                            {{ fields.datetimeField(
+                                'substitution_end_date',
+                                user.fields['substitution_end_date'],
+                                __('End date ')
+                            ) }}
 
-                     {{ fields.datetimeField(
-                        'substitution_end_date',
-                        user.fields['substitution_end_date'],
-                        __('End date ')
-                     ) }}
+                            {{ fields.dropdownField(
+                                'User',
+                                'substitutes',
+                                [],
+                                __('Validation substitutes'),
+                                {
+                                    'multiple': 'multiple',
+                                    'used': [user.fields['id']],
+                                    'value': substitutes,
+                                    'right': 'create_ticket_validate',
+                                }
+                            ) }}
 
-                     {{ fields.dropdownField(
-                        'User',
-                        'substitutes',
-                        [],
-                        __('Validation substitutes'),
-                        {
-                              'multiple': 'multiple',
-                              'used': [user.fields['id']],
-                              'value': substitutes,
-                              'right': 'create_ticket_validate',
-                        }
-                     ) }}
+                            {{ fields.nullField }}
 
-                     {{ fields.nullField }}
+                            {% if delegators|length > 0 %}
+                                <div class="row col-12 col-sm-12 mb-4 mt-5">
+                                    {{ alerts.callout_info(__('Delegators are users who gave you the right to approve or refuse tickets on their behalf.')) }}
+                                </div>
 
-                     {% if delegators|length > 0 %}
-                        <div class="row col-12 col-sm-12 mb-4 mt-5">
-                           <div class="alert alert-info" style="margin: 0 auto; max-width: 900px">
-                              <span>
-                                 <i class="ti ti-info-circle"></i>&nbsp;{{ __('Delegators are users who gave you the right to approve or refuse tickets on their behalf.') }}
-                              </span>
-                           </div>
-                        </div>
+                                <div>
+                                    <div class="card">
+                                        <div class="table-responsive">
+                                            <table class="table card-table table-hover table-striped">
+                                                <thead>
+                                                <tr>
+                                                    <th style="width: 33%;">{{ __('Name') }}</th>
+                                                    <th style="width: 33%;">{{ __('Substitution start date') }}</th>
+                                                    <th style="width: 33%;">{{ __('Substitution end date') }}</th>
+                                                </tr>
+                                                </thead>
+                                                <tbody>
+                                                {% for delegator in delegators %}
+                                                    {% set delegator = get_item('User', delegator) %}
+                                                    <tr>
+                                                        <td valign="top">{{ delegator.getFriendlyName() }}</td>
+                                                        <td valign="top">{{ delegator.fields['substitution_start_date'] }}</td>
+                                                        <td valign="top">{{ delegator.fields['substitution_end_date'] }}</td>
+                                                    </tr>
+                                                {% endfor %}
+                                                </tbody>
+                                            </table>
+                                        </div>
+                                    </div>
+                                </div>
+                            {% endif %}
 
-                        <div>
-                           <div class="card">
-                              <div class="table-responsive">
-                                 <table class="table card-table table-hover table-striped">
-                                 <thead>
-                                    <tr>
-                                       <th style="width: 33%;">{{ __('Name') }}</th>
-                                       <th style="width: 33%;">{{ __('Substitution start date') }}</th>
-                                       <th style="width: 33%;">{{ __('Substitution end date') }}</th>
-                                    </tr>
-                                 </thead>
-                                 <tbody>
-                                 {% for delegator in delegators %}
-                                    {% set delegator = get_item('User', delegator) %}
-                                    <tr>
-                                       <td valign="top">{{ delegator.getFriendlyName() }}</td>
-                                       <td valign="top">{{ delegator.fields['substitution_start_date'] }}</td>
-                                       <td valign="top">{{ delegator.fields['substitution_end_date'] }}</td>
-                                    </tr>
-                                 {% endfor %}
-                                 </tbody>
-                                 </table>
-                              </div>
-                           </div>
-                        </div>
-                     {% endif %}
+                        </div> {# .row #}
+                    </div> {# .row #}
+                </div> {# .flex-row #}
+            </div>
+        </div> {# .card-body #}
 
-                  </div> {# .row #}
-               </div> {# .row #}
-            </div> {# .flex-row #}
-         </div>
-      </div> {# .card-body #}
+        <div class="row">
+            {{ call_plugin_hook(constant('Glpi\\Plugin\\Hooks::POST_ITEM_FORM'), {'item': item, 'options': params}) }}
+        </div>
 
-      <div class="row">
-         {{ call_plugin_hook(constant('Glpi\\Plugin\\Hooks::POST_ITEM_FORM'), {'item': item, 'options': params}) }}
-      </div>
+        {% if canedit %}
+            <div class="card-body mx-n2 mb-4 border-top d-flex flex-row-reverse align-items-start flex-wrap">
+                <button class="btn btn-primary me-2" type="submit" name="update" value="1">
+                    <i class="ti ti-device-floppy"></i>
+                    <span>{{ _x('button', 'Save') }}</span>
+                </button>
+            </div>
 
-      {% if canedit %}
-         <div class="card-body mx-n2 mb-4 border-top d-flex flex-row-reverse align-items-start flex-wrap">
-            <button class="btn btn-primary me-2" type="submit" name="update" value="1">
-               <i class="ti ti-device-floppy"></i>
-               <span>{{ _x('button', 'Save') }}</span>
-            </button>
-         </div>
-
-         <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}" />
-      </div> {# #mainformtable #}
-   </form> {# [name=asset_form] #}
-   {% else %}
-      </div> {# #mainformtable #}
+            <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}" />
+        {% endif %}
+    </div> {# #mainformtable #}
+    {% if canedit %}
+        </form> {# [name=asset_form] #}
    {% endif %}
 </div>

--- a/templates/pages/helpdesk/index.html.twig
+++ b/templates/pages/helpdesk/index.html.twig
@@ -32,6 +32,7 @@
  #}
 
 {% extends "layout/page_skeleton.html.twig" %}
+{% import 'components/alerts_macros.html.twig' as alerts %}
 
 {% block content %}
     {# We override the parent width using .force-full-width because we need our background images and colors to bleed
@@ -69,22 +70,18 @@
             <div class="container-xl">
                 {# Display password alerts #}
                 {% if password_alert|length %}
-                    <div class="alert alert-warning alert-dismissible bg-white" role="alert">
-                        <div class="d-flex mb-2">
-                            <div>
-                                <i class="ti ti-alert-triangle me-1"></i>
-                            </div>
-                            <div>
-                                {{ password_alert }}
-                            </div>
-                        </div>
-
+                    {% set reset_password %}
                         <div class="btn-list">
                             <a class="btn btn-outline-warning" href="{{ path('/front/updatepassword.php') }} ">
                                 {{ __('Update my password') }}
                             </a>
                         </div>
-                    </div>
+                    {% endset %}
+                    {{ alerts.alert_warning(
+                        title: password_alert,
+                        messages: [reset_password],
+                        options: { dismissible: true }
+                    ) }}
                 {% endif %}
 
                 {# TODO: deprecate this hook and make a new one that doesn't expect a table as a container #}

--- a/templates/pages/helpdesk/index.html.twig
+++ b/templates/pages/helpdesk/index.html.twig
@@ -80,7 +80,7 @@
                     {{ alerts.alert_warning(
                         title: password_alert,
                         messages: [reset_password],
-                        options: { dismissible: true }
+                        options: {dismissible: true}
                     ) }}
                 {% endif %}
 

--- a/templates/pages/login_error.html.twig
+++ b/templates/pages/login_error.html.twig
@@ -32,28 +32,17 @@
  #}
 
 {% extends 'layout/page_card_notlogged.html.twig' %}
+{% import 'components/alerts_macros.html.twig' as alerts %}
 
 {% block content_block %}
-<div class="alert alert-warning">
-    <div class="d-flex align-items-center">
-        <div class="me-4">
-            <i class="ti ti-alert-triangle fa-2x"></i>
-        </div>
-        <div>
-            <h4 class="alert-title">
-                {{ _n('Error', 'Errors', 1) }}
-            </h4>
-            <div>
-                {% for error in errors %}
-                    {{ error }}<br />
-                {% endfor %}
-            </div>
-
-            <a href="{{ login_url }}" class="btn btn-primary mt-3">
-                <i class="ti ti-login"></i>
-                <span>{{ __('Log in again') }}</span>
-            </a>
-        </div>
-    </div>
-</div>
+    {% set message %}
+        {% for error in errors %}
+            {{ error }}<br />
+        {% endfor %}
+        <a href="{{ login_url }}" class="btn btn-primary mt-3">
+            <i class="ti ti-login"></i>
+            <span>{{ __('Log in again') }}</span>
+        </a>
+    {% endset %}
+    {{ alerts.alert_danger(_n('Error', 'Errors', 1), [message]) }}
 {% endblock %}

--- a/templates/pages/setup/authentication.html.twig
+++ b/templates/pages/setup/authentication.html.twig
@@ -31,6 +31,8 @@
  # ---------------------------------------------------------------------
  #}
 
+{% import 'components/alerts_macros.html.twig' as alerts %}
+
 <div class="container">
    <div class="row justify-content-evenly">
       <div class="col-12 col-xxl-4">
@@ -52,10 +54,7 @@
                      <span>{{ 'AuthLDAP'|itemtype_name }}</span>
                   </a>
                {% else %}
-                  <div class="alert alert-important alert-warning m-3">
-                    <i class="ti ti-alert-triangle me-2"></i>
-                    {{ __('The LDAP extension of your PHP parser isn’t installed') }}
-                  </div>
+                   {{ alerts.alert_warning(__('The LDAP extension of your PHP parser isn’t installed')) }}
                {% endif %}
 
                <a class="list-group-item list-group-item-action" href="{{ path('front/authmail.php') }}">

--- a/templates/pages/setup/authentication/other_ext_setup.html.twig
+++ b/templates/pages/setup/authentication/other_ext_setup.html.twig
@@ -33,6 +33,7 @@
 
 {% import 'components/form/fields_macros.html.twig' as fields %}
 {% import 'components/form/basic_inputs_macros.html.twig' as inputs %}
+{% import 'components/alerts_macros.html.twig' as alerts %}
 
 <div class="asset card">
    <form name="cas" action="{{ path('/front/auth.others.php') }}" method="post">
@@ -43,7 +44,7 @@
                   <div class="row flex-row mx-0">
                      {{ fields.smallTitle(__('CAS authentication')) }}
                      {% if config['cas_host'] is not empty %}
-                        <div class="alert alert-info">{{ _x('authentication', 'Enabled') }}</div>
+                        {{ alerts.callout_info(_x('authentication', 'Enabled')) }}
                      {% endif %}
                      {{ fields.textField('cas_host', config['cas_host'], __('CAS Host')) }}
                      {{ fields.htmlField('', call('Auth::dropdownCasVersion', [config['cas_version'], {
@@ -55,7 +56,7 @@
 
                      {{ fields.smallTitle(__('x509 certificate authentication')) }}
                      {% if config['x509_email_field'] is not empty %}
-                        <div class="alert alert-info">{{ _x('authentication', 'Enabled') }}</div>
+                        {{ alerts.callout_info(_x('authentication', 'Enabled')) }}
                      {% endif %}
                      {{ fields.textField(
                         'x509_email_field',
@@ -80,7 +81,7 @@
 
                      {{ fields.smallTitle(__('Other authentication sent in the HTTP request')) }}
                      {% if config['ssovariables_id'] is not empty and config['ssovariables_id'] != 0 %}
-                        <div class="alert alert-info">{{ _x('authentication', 'Enabled') }}</div>
+                        {{ alerts.callout_info(_x('authentication', 'Enabled')) }}
                      {% endif %}
                      {{ fields.dropdownField('SsoVariable', 'ssovariables_id', config['ssovariables_id'], 'SsoVariable'|itemtype_name(1)) }}
                      {{ fields.textField('ssologout_url', config['ssologout_url'], __('SSO logout url')) }}

--- a/templates/pages/setup/crontask/crontask.html.twig
+++ b/templates/pages/setup/crontask/crontask.html.twig
@@ -32,6 +32,7 @@
  #}
 
 {% import 'components/form/fields_macros.html.twig' as fields %}
+{% import 'components/alerts_macros.html.twig' as alerts %}
 
 <div class="asset {{ bg }}">
    {{ include('components/form/header.html.twig') }}
@@ -146,9 +147,7 @@
                               {{ item_meta.next_run_display }}
                            {% endif %}
                            {% if config('maintenance_mode') %}
-                              <div class="alert alert-warning">
-                                 {{ __('Maintenance mode enabled, running tasks is disabled') }}
-                              </div>
+                               {{ alerts.callout_warning(__('Maintenance mode enabled, running tasks is disabled')) }}
                            {% elseif can_execute and launch %}
                               {# ID and CSRF token fields are defined in components/form/buttons.html.twig #}
                               <button class="btn btn-primary" type="submit" name="execute" value="{{ item.fields['name'] }}">{{ __('Execute') }}</button>

--- a/templates/pages/setup/general/dbreplica_setup.html.twig
+++ b/templates/pages/setup/general/dbreplica_setup.html.twig
@@ -34,6 +34,7 @@
 {% extends "pages/setup/general/base_form.html.twig" %}
 {% import 'components/form/fields_macros.html.twig' as fields %}
 {% import 'components/form/basic_inputs_macros.html.twig' as inputs %}
+{% import 'components/alerts_macros.html.twig' as alerts %}
 
 {% block config_fields %}
 <div class="hr-text">
@@ -95,10 +96,7 @@
                 <div id="collapse-primary" class="accordion-collapse collapse" aria-labelledby="heading-primary" data-bs-parent="#accordion-primary">
                     <div class="accordion-body">
                     {% if primary_unknown %}
-                        <div class="alert alert-danger" role="alert">
-                            <span class="text-secondary">{{ __('MySQL server returned an error:') }}</span>
-                            <p class="mt-2">{{ replication_status['primary']['error'] }}</p>
-                        </div>
+                        {{ alerts.alert_danger(__('MySQL server returned an error'), [replication_status['primary']['error']]) }}
                     {% else %}
                         <ul class="p-0 list-unstyled space-y-3">
                             <li>
@@ -164,10 +162,7 @@
                 <div id="collapse-replica{{ replica_num }}" class="accordion-collapse collapse" aria-labelledby="heading-replica{{ replica_num }}" data-bs-parent="#accordion-replica{{ replica_num }}">
                     <div class="accordion-body">
                     {% if replica_unkown %}
-                        <div class="alert alert-danger" role="alert">
-                            <span class="text-secondary">{{ __('MySQL server returned an error:') }}</span>
-                            <p class="mt-2">{{ replica_data['error'] }}</p>
-                        </div>
+                        {{ alerts.alert_danger(__('MySQL server returned an error'), [replica_data['error']]) }}
                     {% else %}
                         <ul class="p-0 list-unstyled space-y-3">
                             <li>
@@ -226,13 +221,7 @@
                         {# Display errors if slave_io_running or slave_sql_running are not running #}
                         {% set display_alert = (replica_data['slave_io_running'] != 'Yes' or replica_data['slave_sql_running'] != 'Yes') and (replica_data['last_io_error']|length or replica_data['last_sql_error']|length) %}
                         {% if display_alert %}
-                            <div class="alert alert-danger" role="alert">
-                                <span class="text-secondary">{{ __('MySQL server returned an error:') }}</span>
-                                <p class="mt-2">
-                                    {{ replica_data['last_io_error'] }}
-                                    {{ replica_data['last_sql_error'] }}
-                                </p>
-                            </div>
+                            {{ alerts.alert_danger(__('MySQL server returned an error'), [replica_data['last_io_error'], replica_data['last_sql_error']]) }}
                         {% endif %}
                     {% endif %}
                     </div>

--- a/templates/pages/setup/general/glpinetwork_setup.html.twig
+++ b/templates/pages/setup/general/glpinetwork_setup.html.twig
@@ -33,32 +33,27 @@
 
 {% extends 'pages/setup/general/base_form.html.twig' %}
 {% import 'components/form/fields_macros.html.twig' as fields %}
+{% import 'components/alerts_macros.html.twig' as alerts %}
 
 {% block config_fields %}
     {{ fields.largeTitle(__('Registration')) }}
 
     {% if registration_key is empty %}
-        <div class="alert alert-info">
-            <div class="alert-title">{{ __('A registration key is needed to use some advanced features (like the plugin marketplace) in GLPI') }}</div>
-            <span class="text-secondary">
-                <a href="{{ constant('GLPI_NETWORK_SERVICES') }}">
-                    {{ __('Register on %1$s!')|format(__('GLPI Network')) }}
-                </a>
-                <br>
-                {{ __("And retrieve your key to paste it below") }}
-            </span>
-        </div>
+        {% set register_message %}
+            <a href="{{ constant('GLPI_NETWORK_SERVICES') }}">
+                {{ __('Register on %1$s!')|format(__('GLPI Network')) }}
+            </a>
+            <br>
+            {{ __("And retrieve your key to paste it below") }}
+        {% endset %}
+        {{ alerts.callout_info(__('A registration key is needed to use some advanced features (like the plugin marketplace) in GLPI'), [register_message]) }}
     {% endif %}
 
     {% if not services_available %}
-        <div class="alert alert-warning">
-            <div class="alert-title">{{ __('%1$s services website seems to be unavailable from your network or offline!')|format(__('GLPI Network')) }}</div>
-            <span class="text-secondary">
-                {% if curl_error is not null %}
-                    {{ __('Error was: %s')|format(curl_error) }}
-                {% endif %}
-            </span>
-        </div>
+        {{ alerts.alert_warning(
+            __('%1$s services website seems to be unavailable from your network or offline!')|format(__('GLPI Network')),
+            curl_error is not null ? [__('Error was: %s')|format(curl_error)] : []
+        ) }}
     {% endif %}
 
     {{ fields.textareaField('glpinetwork_registration_key', registration_key, __('Registration key'), {

--- a/templates/pages/setup/general/management_setup.html.twig
+++ b/templates/pages/setup/general/management_setup.html.twig
@@ -40,7 +40,7 @@
     <div>
         {{ alerts.callout_info(
             title: __('The maximum upload size is primarily determined by the "upload_max_filesize" and "post_max_size" PHP settings. The setting below is to further restrict the uploads for just GLPI.'),
-            options: { add_class: 'mx-2' }
+            options: {add_class: 'mx-2'}
         ) }}
     </div>
    {{ fields.numberField('document_max_size', config['document_max_size'], __('Document files maximum size (Mio)'), {

--- a/templates/pages/setup/general/management_setup.html.twig
+++ b/templates/pages/setup/general/management_setup.html.twig
@@ -33,14 +33,16 @@
 
 {% extends "pages/setup/general/base_form.html.twig" %}
 {% import 'components/form/fields_macros.html.twig' as fields %}
+{% import 'components/alerts_macros.html.twig' as alerts %}
 
 {% block config_fields %}
    {{ fields.largeTitle(__('Documents setup'), 'ti ti-files') }}
     <div>
-        <div class="alert alert-info mx-2">
-            {{ __('The maximum upload size is primarily determined by the "upload_max_filesize" and "post_max_size" PHP settings. The setting below is to further restrict the uploads for just GLPI.') }}
-        </div>
-    <div>
+        {{ alerts.callout_info(
+            title: __('The maximum upload size is primarily determined by the "upload_max_filesize" and "post_max_size" PHP settings. The setting below is to further restrict the uploads for just GLPI.'),
+            options: { add_class: 'mx-2' }
+        ) }}
+    </div>
    {{ fields.numberField('document_max_size', config['document_max_size'], __('Document files maximum size (Mio)'), {
       min: 1
    }) }}

--- a/templates/pages/setup/mailcollector/folder_list.html.twig
+++ b/templates/pages/setup/mailcollector/folder_list.html.twig
@@ -31,6 +31,8 @@
  # ---------------------------------------------------------------------
  #}
 
+{% import 'components/alerts_macros.html.twig' as alerts %}
+
 {% macro display_folder(folder, input_id) %}
    <li class="cursor-pointer" data-input-id="{{ input_id }}">
       <i class="ti ti-folder"></i>
@@ -54,5 +56,5 @@
       {% endif %}
    </ul>
 {% else %}
-   <div class="alert alert-danger">{{ __('An error occurred trying to connect to collector.') }}</div>
+    {{ alerts.alert_danger(__('An error occurred trying to connect to collector.')) }}
 {% endif %}

--- a/templates/pages/setup/mailcollector/setup_form.html.twig
+++ b/templates/pages/setup/mailcollector/setup_form.html.twig
@@ -33,6 +33,7 @@
 
 {% extends "generic_show_form.html.twig" %}
 {% import 'components/form/fields_macros.html.twig' as fields %}
+{% import 'components/alerts_macros.html.twig' as alerts %}
 {% set params  = params ?? [] %}
 
 {% set params = params|merge({
@@ -49,12 +50,9 @@
 
 {% block form_fields %}
    {% if item.fields['errors'] %}
-      <div class="alert alert-danger">
-         {{ __('%1$s: %2$s')|format(
-               _n('Error', 'Errors', get_plural_number()),
-               item.fields['errors']
-         ) }}
-      </div>
+       {{ alerts.callout_danger(
+           __('%1$s: %2$s')|format(_n('Error', 'Errors', get_plural_number()), item.fields['errors'])
+       ) }}
    {% endif %}
 
    {{ fields.textField(

--- a/templates/pages/setup/notification/mailing_setting.html.twig
+++ b/templates/pages/setup/notification/mailing_setting.html.twig
@@ -32,6 +32,7 @@
  #}
 
 {% import 'components/form/fields_macros.html.twig' as fields %}
+{% import 'components/alerts_macros.html.twig' as alerts %}
 
 {% if (config('notifications_mailing') == 1) %}
     {% set rand = random() %}
@@ -199,10 +200,13 @@
                 <span>{{ 'AuthMail'|itemtype_name }}</span>
             </div>
 
-            <div id="oauth_redirect_alert_{{ rand }}" class="d-flex alert alert-info mx-2">
-                <i class="ti ti-info-circle fs-2x alert-icon"></i>
-                {{ __('Once the form has been validated, you will be redirected to your supplierʼs authentication page if necessary.') }}
-            </div>
+            {{ alerts.callout_info(
+                title=__('Once the form has been validated, you will be redirected to your supplierʼs authentication page if necessary.'),
+                options={
+                    add_class: 'mx-2',
+                    id: "oauth_redirect_alert_" ~ rand
+                }
+            ) }}
 
             {{ fields.dropdownArrayField(
                 'smtp_oauth_provider',
@@ -406,13 +410,9 @@
         </div>
     </form>
 {% else %}
-    <div class="row">
-        <div class="col">
-            <div class="alert alert-info">
-                <i class="ti ti-info-circle fs-2x alert-icon"></i>
-                {{ __('Notifications are disabled.') }}
-                <a href="{{ config('root_doc') }}/front/setup.notification.php">{{ __('See configuration') }}</a>
-            </div>
-        </div>
-    </div>
+    {% set alert_content %}
+        {{ __('Notifications are disabled.') }}
+        <a class="link-info" href="{{ config('root_doc') }}/front/setup.notification.php">{{ __('See configuration') }}</a>
+    {% endset %}
+    {{ alerts.alert_info(alert_content) }}
 {% endif %}

--- a/templates/pages/setup/notification/mailing_setting.html.twig
+++ b/templates/pages/setup/notification/mailing_setting.html.twig
@@ -201,11 +201,8 @@
             </div>
 
             {{ alerts.callout_info(
-                title=__('Once the form has been validated, you will be redirected to your supplierʼs authentication page if necessary.'),
-                options={
-                    add_class: 'mx-2',
-                    id: "oauth_redirect_alert_" ~ rand
-                }
+                title: __('Once the form has been validated, you will be redirected to your supplierʼs authentication page if necessary.'),
+                options: {add_class: 'mx-2', id: "oauth_redirect_alert_" ~ rand}
             ) }}
 
             {{ fields.dropdownArrayField(

--- a/templates/pages/setup/notification/translation_debug.html.twig
+++ b/templates/pages/setup/notification/translation_debug.html.twig
@@ -32,6 +32,7 @@
  #}
 
 {% import 'components/form/fields_macros.html.twig' as fields %}
+{% import 'components/alerts_macros.html.twig' as alerts %}
 
 <div class="asset">
     {{ fields.largeTitle(__('Preview')) }}
@@ -58,10 +59,7 @@
             }) }}
         </div>
     {% else %}
-        <div class="alert alert-info d-flex align-items-center m-0" role="alert">
-            <i class="ti ti-info-circle me-1"></i>
-            {{ __('The preview is not available for the notifications related to %s.')|format(template.fields['itemtype']|itemtype_name(get_plural_number())) }}
-        </div>
+        {{ alerts.callout_info(__('The preview is not available for the notifications related to %s.')|format(template.fields['itemtype']|itemtype_name(get_plural_number())))  }}
     {% endif %}
 
     {% if data is not null %}

--- a/templates/pages/setup/notification/translation_debug.html.twig
+++ b/templates/pages/setup/notification/translation_debug.html.twig
@@ -59,7 +59,7 @@
             }) }}
         </div>
     {% else %}
-        {{ alerts.callout_info(__('The preview is not available for the notifications related to %s.')|format(template.fields['itemtype']|itemtype_name(get_plural_number())))  }}
+        {{ alerts.callout_info(__('The preview is not available for the notifications related to %s.')|format(template.fields['itemtype']|itemtype_name(get_plural_number()))) }}
     {% endif %}
 
     {% if data is not null %}

--- a/templates/pages/setup/setup_notifications.html.twig
+++ b/templates/pages/setup/setup_notifications.html.twig
@@ -31,6 +31,8 @@
  # ---------------------------------------------------------------------
  #}
 
+{% import 'components/alerts_macros.html.twig' as alerts %}
+
 {% if can_update_config or has_active_mode %}
    <div class="container">
       <div class="d-flex justify-content-center">
@@ -42,10 +44,7 @@
                </div>
 
                {% if use_notifications and not has_active_mode %}
-                  <div class="alert alert-important alert-warning m-3">
-                     <i class="ti ti-alert-triangle me-2"></i>
-                     {{ __('You must enable at least one notification mode.') }}
-                  </div>
+                   {{ alerts.alert_warning(__('You must enable at least one notification mode.'), [], true, { add_class: 'm-3' }) }}
                {% endif %}
 
                <ul class="list-group list-group-flush">
@@ -110,10 +109,11 @@
                   </a>
                {% else %}
                   <div class="list-group-item">
-                     <div class="alert alert-important alert-warning m-3">
-                        <i class="ti ti-alert-triangle me-2"></i>
-                        {{ __('Unable to configure notifications: please configure at least one notification type using the above configuration.') }}
-                     </div>
+                      {{ alerts.alert_warning(
+                          title=__('Unable to configure notifications: please configure at least one notification type using the above configuration.'),
+                          important=true,
+                          options={ add_class: 'm-3' }
+                      ) }}
                   </div>
                {% endif %}
 

--- a/templates/pages/setup/setup_notifications.html.twig
+++ b/templates/pages/setup/setup_notifications.html.twig
@@ -44,7 +44,11 @@
                </div>
 
                {% if use_notifications and not has_active_mode %}
-                   {{ alerts.alert_warning(__('You must enable at least one notification mode.'), [], true, { add_class: 'm-3' }) }}
+                   {{ alerts.alert_warning(
+                       title: __('You must enable at least one notification mode.'),
+                       important: true,
+                       options: {add_class: 'm-3'}
+                   ) }}
                {% endif %}
 
                <ul class="list-group list-group-flush">
@@ -110,9 +114,9 @@
                {% else %}
                   <div class="list-group-item">
                       {{ alerts.alert_warning(
-                          title=__('Unable to configure notifications: please configure at least one notification type using the above configuration.'),
-                          important=true,
-                          options={ add_class: 'm-3' }
+                          title: __('Unable to configure notifications: please configure at least one notification type using the above configuration.'),
+                          important: true,
+                          options: {add_class: 'm-3'}
                       ) }}
                   </div>
                {% endif %}

--- a/templates/pages/tools/kb/comments.html.twig
+++ b/templates/pages/tools/kb/comments.html.twig
@@ -31,6 +31,8 @@
  # ---------------------------------------------------------------------
  #}
 
+{% import 'components/alerts_macros.html.twig' as alerts %}
+
 {% macro kb_comment(comment, level, can_comment) %}
     {% set has_answers = comment['answers'] is defined and comment['answers']|length > 0 %}
     <li id="kbcomment{{ comment['id'] }}" class="comment {{ level > 0 ? 'subcomment' : '' }} timeline-item KnowbaseItemComment {{ has_answers ? "has_answers" : "" }}"
@@ -114,9 +116,7 @@
 {% endif %}
 
 {% if comments|length == 0 %}
-    <div class="alert alert-info">
-        {{ __('No comments') }}
-    </div>
+    {{ alerts.callout_info(__('No comments')) }}
 {% else %}
     <div class="forcomments timeline_history">
         <ul class="comments">

--- a/templates/pages/tools/savedsearch/alert_list_notification.html.twig
+++ b/templates/pages/tools/savedsearch/alert_list_notification.html.twig
@@ -31,36 +31,39 @@
  # ---------------------------------------------------------------------
  #}
 
+{% import 'components/alerts_macros.html.twig' as alerts %}
+
 <div class="center">
-   <div class="my-2">
-      {% if notifications|length %}
-         {{ _n('Notification used:', 'Notifications used:', notifications|length) }}
-         {% if has_profile_right('notification', constant('UPDATE')) %}
-            {% for notification in notifications %}
-               {% if not loop.first %}, {% endif %}
-               <a href="{{ 'Notification'|itemtype_form_path(notification['id']) }}">{{ notification['name'] }}</a>
-            {% endfor %}
-         {% else %}
-            {{ notifications|map(n => n['name'])|join(', ') }}
-         {% endif %}
-      {% else %}
-         <div class="alert alert-warning">
-            {{ __('Notification does not exist') }}
-            {% if params.canedit %}
-               <br>
-               <a href="{{ search.getLinkURL() }}&amp;create_notif=true">{{ __('Create it now') }}</a>
-               {% set params = params|merge({
-                  'canedit': false
-               }) %}
+    <div class="my-2">
+        {% if notifications|length %}
+            {{ _n('Notification used:', 'Notifications used:', notifications|length) }}
+            {% if has_profile_right('notification', constant('UPDATE')) %}
+                {% for notification in notifications %}
+                    {% if not loop.first %}, {% endif %}
+                    <a href="{{ 'Notification'|itemtype_form_path(notification['id']) }}">{{ notification['name'] }}</a>
+                {% endfor %}
+            {% else %}
+                {{ notifications|map(n => n['name'])|join(', ') }}
             {% endif %}
-         </div>
-      {% endif %}
-   </div>
-   <div class="my-2">
-      {% if params['canedit'] and not (params['withtemplate'] is not empty and params['withtemplate'] == 2) %}
-         <a class="btn btn-primary" href="{{ 'SavedSearch_Alert'|itemtype_form_path }}?savedsearches_id={{ search.fields['id'] }}&amp;withtemplate={{ params['withtemplate'] }}">
-            {{ __('Add an alert') }}
-         </a>
-      {% endif %}
-   </div>
+        {% else %}
+            {%- set message -%}
+                {%- if params.canedit -%}
+                    <a href="{{ search.getLinkURL() }}&amp;create_notif=true">{{ __('Create it now') }}</a>
+                {%- endif -%}
+            {%- endset -%}
+            {{ alerts.alert_warning(__('Notification does not exist'), message is not empty ? [message] : []) }}
+            {% if params.canedit %}
+                {% set params = params|merge({
+                    'canedit': false
+                }) %}
+            {% endif %}
+        {% endif %}
+    </div>
+    <div class="my-2">
+        {% if params['canedit'] and not (params['withtemplate'] is not empty and params['withtemplate'] == 2) %}
+            <a class="btn btn-primary" href="{{ 'SavedSearch_Alert'|itemtype_form_path }}?savedsearches_id={{ search.fields['id'] }}&amp;withtemplate={{ params['withtemplate'] }}">
+                {{ __('Add an alert') }}
+            </a>
+        {% endif %}
+    </div>
 </div>

--- a/templates/pages/tools/search_solution.twig
+++ b/templates/pages/tools/search_solution.twig
@@ -31,6 +31,7 @@
  #}
 
 {% import 'components/form/basic_inputs_macros.html.twig' as inputs %}
+{% import 'components/alerts_macros.html.twig' as alerts %}
 
 {% set container_id = 'container' ~ random() %}
 
@@ -74,9 +75,7 @@
                     no_limit_display: true,
                 }) }}
             {% else %}
-                <div class="alert alert-info">
-                    {{ __('No results found') }}
-                </div>
+                {{ alerts.callout_info(__('No results found')) }}
             {% endif %}
 
         </div>

--- a/templates/password_form.html.twig
+++ b/templates/password_form.html.twig
@@ -32,11 +32,10 @@
  #}
 
 {% import 'components/form/fields_macros.html.twig' as fields %}
+{% import 'components/alerts_macros.html.twig' as alerts %}
 
 {% if must_change_password is defined and must_change_password %}
-    <div class="alert alert-warning">
-        <div class="alert-title">{{ __('Your password has expired. You must change it to be able to login.') }}</div>
-    </div>
+    {{ alerts.alert_warning(__('Your password has expired. You must change it to be able to login.')) }}
 {% endif %}
 {% if token_ok is defined and token_ok == false %}
     {{ __('Your password reset request has expired or is invalid. Please renew it.') }}
@@ -87,10 +86,10 @@
             }) }}
 
             {% if config('use_password_security') %}
-                <div class="alert alert-warning">
-                    <h3>{{ __('Password security policy') }}</h3>
+                {% set messages %}
                     {{ include('components/user/password_security_checks.html.twig') }}
-                </div>
+                {% endset %}
+                {{ alerts.callout_warning(__('Password security policy'), [messages]) }}
             {% else %}
                 <script>
                     function passwordCheck() {
@@ -121,11 +120,7 @@
         </div>
 
         {% if errors is defined and errors|length > 0 %}
-            <div class="alert alert-danger mt-2">
-                {% for error in errors %}
-                    <br>{{ error }}
-                {% endfor %}
-            </div>
+            {{ alerts.alert_danger(_n('Error', 'Errors', 1), errors) }}
         {% endif %}
     </form>
 {% endif %}


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Originally, I was just trying to standardize the alerts UI since we had a lot of alerts not using the macro and the UI was not consistent. I then realized that there were accessibility things to address. Some "alerts" really aren't supposed to be alerts because it would be annoying and unhelpful for a screen reader to announce their content immediately when the elements load.

Changes I made in this PR:

1. Moved most "alert" type elements to use the macros from "alert_macros.html.twig".
2. Add dismissible alert support.
3. Add macros for "Callouts" which are visually the same as alerts (except no icon by default), but don't have the "alert" role.
4. Fix issue where <br> was not being added between alert messages.
5. Fix issue with alerts extending past parent containers.
6. Fix improper use of h4 in alert macro by replacing with span with the fs-4 class.
7. Fix alignment of alert title when there are no messages

There could still be more to do with alert accessibility like removing interactive content. Alerts should only have textual content because while screen readers will announce the content, it does not force the focus to change to the alert.
https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/alert_role#description