### PR TITLE
Standardize some strings

### DIFF
--- a/js/modules/Form/GeolocationField.js
+++ b/js/modules/Form/GeolocationField.js
@@ -84,7 +84,7 @@ class GeolocationField {
     #finalizeMap() {
         const geocoder = L.Control.geocoder({
             defaultMarkGeocode: false,
-            errorMessage: __('No result found'),
+            errorMessage: __('No results found'),
             placeholder: __('Search')
         });
         geocoder.on('markgeocode', (e) => {

--- a/src/CableStrand.php
+++ b/src/CableStrand.php
@@ -211,7 +211,7 @@ class CableStrand extends CommonDropdown
                 echo"</tr>";
             }
         } else {
-            echo "<p class='center b'>" . __s('No item found') . "</p>";
+            echo "<p class='center b'>" . __s('No results found') . "</p>";
         }
         echo "</table></div>";
     }

--- a/src/CartridgeItem_PrinterModel.php
+++ b/src/CartridgeItem_PrinterModel.php
@@ -187,7 +187,7 @@ class CartridgeItem_PrinterModel extends CommonDBRelation
             }
             echo "</div>";
         } else {
-            echo "<p class='center b'>" . __s('No item found') . "</p>";
+            echo "<p class='center b'>" . __s('No results found') . "</p>";
         }
     }
 }

--- a/src/ITILCategory.php
+++ b/src/ITILCategory.php
@@ -523,7 +523,7 @@ class ITILCategory extends CommonTreeDropdown
                 }
             }
         } else {
-            echo "<tr><th colspan='5'>" . __s('No item found') . "</th></tr>";
+            echo "<tr><th colspan='5'>" . __s('No results found') . "</th></tr>";
         }
 
         echo "</table></div>";

--- a/src/Item_Line.php
+++ b/src/Item_Line.php
@@ -258,7 +258,7 @@ class Item_Line extends CommonDBRelation
         }
 
         if (!count($items)) {
-            echo "<table class='tab_cadre_fixe'><tr><th>" . __s('No item found') . "</th></tr>";
+            echo "<table class='tab_cadre_fixe'><tr><th>" . __s('No results found') . "</th></tr>";
             echo "</table>";
         } else {
             if ($canedit) {

--- a/src/Item_SoftwareLicense.php
+++ b/src/Item_SoftwareLicense.php
@@ -500,7 +500,7 @@ class Item_SoftwareLicense extends CommonDBRelation
             echo "<tr class='tab_bg_1'><td class='center b'>" . __s('Total') . "</td>";
             echo "<td class='numeric b '>" . $tot . "</td></tr>\n";
         } else {
-            echo "<tr class='tab_bg_1'><td colspan='2 b'>" . __s('No item found') . "</td></tr>\n";
+            echo "<tr class='tab_bg_1'><td colspan='2 b'>" . __s('No results found') . "</td></tr>\n";
         }
         echo "</table></div>";
     }
@@ -631,7 +631,7 @@ JAVASCRIPT;
 
         if ($number < 1) {
             echo "<table class='tab_cadre_fixe'>";
-            echo "<tr><th>" . __s('No item found') . "</th></tr>";
+            echo "<tr><th>" . __s('No results found') . "</th></tr>";
             echo "</table></div>\n";
             return;
         }
@@ -976,7 +976,7 @@ JAVASCRIPT;
                 Html::closeForm();
             }
         } else { // Not found
-            echo __s('No item found');
+            echo __s('No results found');
         }
         Html::printAjaxPager(__s('Affected items'), $start, $number);
 

--- a/src/Item_SoftwareVersion.php
+++ b/src/Item_SoftwareVersion.php
@@ -506,7 +506,7 @@ class Item_SoftwareVersion extends CommonDBRelation
         echo "<div class='center'>";
         if ($number < 1) {
             echo "<table class='tab_cadre_fixe'>";
-            echo "<tr><th>" . __s('No item found') . "</th></tr>";
+            echo "<tr><th>" . __s('No results found') . "</th></tr>";
             echo "</table></div>\n";
             return;
         }
@@ -809,7 +809,7 @@ class Item_SoftwareVersion extends CommonDBRelation
                 Html::closeForm();
             }
         } else { // Not found
-            echo __s('No item found');
+            echo __s('No results found');
         }
         Html::printAjaxPager(self::getTypeName(Session::getPluralNumber()), $start, $number);
 
@@ -862,7 +862,7 @@ class Item_SoftwareVersion extends CommonDBRelation
             echo "<tr class='tab_bg_1'><td class='center b'>" . __s('Total') . "</td>";
             echo "<td class='numeric b'>" . $tot . "</td></tr>\n";
         } else {
-            echo "<tr class='tab_bg_1'><td colspan='2 b'>" . __s('No item found') . "</td></tr>\n";
+            echo "<tr class='tab_bg_1'><td colspan='2 b'>" . __s('No results found') . "</td></tr>\n";
         }
         echo "</table></div>";
     }
@@ -1197,7 +1197,7 @@ class Item_SoftwareVersion extends CommonDBRelation
                 Html::closeForm();
             }
         } else {
-            echo "<p class='center b'>" . __('No item found') . "</p>";
+            echo "<p class='center b'>" . __('No results found') . "</p>";
         }
         echo "</div>";
         if (
@@ -1331,7 +1331,7 @@ class Item_SoftwareVersion extends CommonDBRelation
                 Html::closeForm();
             }
         } else {
-            echo "<p class='center b'>" . __s('No item found') . "</p>";
+            echo "<p class='center b'>" . __s('No results found') . "</p>";
         }
 
         echo "</div>\n";

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -1658,7 +1658,7 @@ TWIG, $twig_params);
                 );
             }
         } else {
-            echo "<div class='center b'>" . __s('No item found') . "</div>";
+            echo "<div class='center b'>" . __s('No results found') . "</div>";
         }
     }
 

--- a/src/NetworkAlias.php
+++ b/src/NetworkAlias.php
@@ -393,7 +393,7 @@ class NetworkAlias extends FQDNLabel
 
         if ($number < 1) {
             echo "<table class='tab_cadre_fixe'>";
-            echo "<tr><th>" . htmlescape(self::getTypeName(1)) . "</th><th>" . __s('No item found') . "</th></tr>";
+            echo "<tr><th>" . htmlescape(self::getTypeName(1)) . "</th><th>" . __s('No results found') . "</th></tr>";
             echo "</table>";
         } else {
             Html::printAjaxPager(self::getTypeName($number), $start, $number);

--- a/src/ProjectCost.php
+++ b/src/ProjectCost.php
@@ -412,7 +412,7 @@ class ProjectCost extends CommonDBChild
             echo "<td class='right'>" . __s('Total cost') . '</td>';
             echo "<td class='numeric'>" . Html::formatNumber($total) . '</td></tr>';
         } else {
-            echo "<tr><th colspan='5'>" . __s('No item found') . "</th></tr>";
+            echo "<tr><th colspan='5'>" . __s('No results found') . "</th></tr>";
         }
         echo "</table>";
         echo "</div>";

--- a/src/ProjectTask.php
+++ b/src/ProjectTask.php
@@ -1482,7 +1482,7 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
             }
         } else {
             echo "<table class='tab_cadre_fixe'>";
-            echo "<tr><th>" . __s('No item found') . "</th></tr>";
+            echo "<tr><th>" . __s('No results found') . "</th></tr>";
             echo "</table>";
         }
 

--- a/src/Search.php
+++ b/src/Search.php
@@ -970,7 +970,7 @@ class Search
     public static function showError($type, $message = "")
     {
         if (strlen($message) == 0) {
-            $message = __('No item found');
+            $message = __('No results found');
         }
 
         $output = SearchEngine::getOutputForLegacyKey($type);

--- a/templates/components/datatable.html.twig
+++ b/templates/components/datatable.html.twig
@@ -51,7 +51,7 @@
             <tr>
                 <td>
                     <div class="alert alert-info">
-                        {{ __('No data') }}
+                        {{ __('No results found') }}
                     </div>
                 </td>
             </tr>
@@ -295,7 +295,7 @@
                     <tr>
                         <td colspan="{{ total_cols }}">
                             <div class="alert alert-info">
-                                {{ __('No data') }}
+                                {{ __('No results found') }}
                             </div>
                         </td>
                     </tr>

--- a/templates/components/form/item_remotemanagement_list.html.twig
+++ b/templates/components/form/item_remotemanagement_list.html.twig
@@ -61,7 +61,7 @@
     }, with_context = false) }}
 {% else %}
     {{ alerts.alert_info(
-        __('No item found')
+        __('No results found')
     ) }}
 {% endif %}
 

--- a/templates/components/search/display_data.html.twig
+++ b/templates/components/search/display_data.html.twig
@@ -82,7 +82,7 @@
             {% if search_error %}
                 {{ alerts.alert_danger(__('An error occured during the search'), __('Consider changing the search criteria or adjusting the displayed columns.')) }}
             {% else %}
-                {{ alerts.alert_info(__('No item found')) }}
+                {{ alerts.alert_info(__('No results found')) }}
             {% endif %}
         {% endif %}
     </form>

--- a/templates/components/search/displaypreference_list.html.twig
+++ b/templates/components/search/displaypreference_list.html.twig
@@ -87,6 +87,6 @@
     </script>
 {% else %}
     <div class="alert alert-info">
-        {{ __('No item found') }}
+        {{ __('No results found') }}
     </div>
 {% endif %}

--- a/templates/components/search/table.html.twig
+++ b/templates/components/search/table.html.twig
@@ -111,7 +111,7 @@
                      {% if search_error %}
                         {{ alerts.alert_danger(__('An error occured during the search'), __('Consider changing the search criteria or adjusting the displayed columns.')) }}
                      {% else %}
-                        {{ alerts.alert_info(__('No item found')) }}
+                        {{ alerts.alert_info(__('No results found')) }}
                      {% endif %}
                   </td>
                </tr>

--- a/templates/layout/parts/profile_selector.html.twig
+++ b/templates/layout/parts/profile_selector.html.twig
@@ -194,7 +194,7 @@
                     loading: __("Loading..."),
                     loadError: __("Unexpected error."),
                     moreData: __("More..."),
-                    noData: __("No data found")
+                    noData: __("No entity found")
                 },
 
                 // load data by ajax

--- a/templates/pages/form_renderer.html.twig
+++ b/templates/pages/form_renderer.html.twig
@@ -245,10 +245,9 @@
                     {% else %}
                         <a class="btn btn-outline-secondary me-2" href="{{ path('/Helpdesk') }}">
                             <i class="ti ti-home me-1"></i>
-                            <span>{{ __("Go home") }}</span>
+                            <span>{{ __("Take me home") }}</span>
                         </a>
                     {% endif %}
-
                     <a class="btn btn-primary" href="{{ path('/front/ticket.php?' ~ my_tickets_url_param) }}">
                         <i class="ti ti-article me-1"></i>
                         <span>{{ __("See my tickets") }}</span>

--- a/templates/pages/setup/notification/group_notifications.html.twig
+++ b/templates/pages/setup/notification/group_notifications.html.twig
@@ -68,7 +68,7 @@
       </tbody>
    {% else %}
       <tbody>
-         <tr><td class="b center">{{ __('No item found') }}</td></tr>
+         <tr><td class="b center">{{ __('No results found') }}</td></tr>
       </tbody>
    {% endif %}
 </table>

--- a/templates/pages/tools/search_solution.twig
+++ b/templates/pages/tools/search_solution.twig
@@ -75,7 +75,7 @@
                 }) }}
             {% else %}
                 <div class="alert alert-info">
-                    {{ __('No data') }}
+                    {{ __('No results found') }}
                 </div>
             {% endif %}
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

While working on other things I discovered some duplicated strings. This leads to an inconsistent user experience and probably adds some difficulty for the translators.

Changes:
- No item/result/data/item strings unified to simply "No results found" except in specific cases like the dashboard where "No data found" may make more sense or there was a more specific string like "No racks found".
- "Take me home" and "Go Home" unified to "Take me home" which existed first.

