### PR TITLE
Mail collector server and type should be required fields

### DIFF
--- a/phpunit/functional/TelemetryTest.php
+++ b/phpunit/functional/TelemetryTest.php
@@ -127,6 +127,8 @@ class TelemetryTest extends DbTestCase
             0,
             $collector->add([
                 'name'        => 'Collector1',
+                'mail_server' => 'test',
+                'server_type' => '/imap',
                 'is_active'   => 1
             ])
         );

--- a/phpunit/imap/MailCollectorTest.php
+++ b/phpunit/imap/MailCollectorTest.php
@@ -131,6 +131,8 @@ class MailCollectorTest extends DbTestCase
         $instance = new \MailCollector();
 
         $oinput = [
+            'mail_server' => 'test',
+            'server_type' => '/imap',
             'passwd'    => 'Ph34r',
             'is_active' => true
         ];
@@ -142,28 +144,37 @@ class MailCollectorTest extends DbTestCase
 
         //empty password means no password.
         $oinput = [
+            'mail_server' => 'test',
+            'server_type' => '/imap',
             'passwd'    => '',
             'is_active' => true
         ];
 
         $this->assertSame(
-            ['is_active' => true],
+            [
+                'mail_server' => 'test',
+                'server_type' => '/imap',
+                'is_active' => true,
+                'host' => '{test/imap}'
+            ],
             $instance->prepareInput($oinput, 'add')
         );
 
         //manage host
         $oinput = [
-            'mail_server' => 'mail.example.com'
+            'mail_server' => 'mail.example.com',
+            'server_type' => '/imap',
         ];
 
         $this->assertSame(
-            ['mail_server' => 'mail.example.com', 'host' => '{mail.example.com}'],
+            ['mail_server' => 'mail.example.com', 'server_type' => '/imap', 'host' => '{mail.example.com/imap}'],
             $instance->prepareInput($oinput, 'add')
         );
 
         //manage host
         $oinput = [
             'mail_server'     => 'mail.example.com',
+            'server_type' => '/imap',
             'server_port'     => 143,
             'server_mailbox'  => 'bugs'
         ];
@@ -171,21 +182,46 @@ class MailCollectorTest extends DbTestCase
         $this->assertSame(
             [
                 'mail_server'      => 'mail.example.com',
+                'server_type' => '/imap',
                 'server_port'      => 143,
                 'server_mailbox'   => 'bugs',
-                'host'             => '{mail.example.com:143}bugs'
+                'host'             => '{mail.example.com:143/imap}bugs'
             ],
             $instance->prepareInput($oinput, 'add')
         );
 
         $oinput = [
+            'mail_server' => 'mail.example.com',
+            'server_type' => '/imap',
             'passwd'          => 'Ph34r',
-            '_blank_passwd'   => true
+            '_blank_passwd'   => true,
         ];
         $this->assertSame(
-            ['passwd' => '', '_blank_passwd' => true],
+            [
+                'mail_server' => 'mail.example.com',
+                'server_type' => '/imap',
+                'passwd' => '',
+                '_blank_passwd' => true,
+                'host' => '{mail.example.com/imap}'
+            ],
             $instance->prepareInputForUpdate($oinput)
         );
+
+        unset($_SESSION['glpicronuserrunning']);
+        $this->assertFalse($instance->prepareInput(['mail_server' => '', 'server_type' => '/imap']));
+        $this->hasSessionMessages(ERROR, [
+            'Mandatory fields are not filled. Please correct: Server'
+        ]);
+
+        $this->assertFalse($instance->prepareInput(['mail_server' => 'test', 'server_type' => '']));
+        $this->hasSessionMessages(ERROR, [
+            'Mandatory fields are not filled. Please correct: Connection options'
+        ]);
+
+        $this->assertFalse($instance->prepareInput([]));
+        $this->hasSessionMessages(ERROR, [
+            'Mandatory fields are not filled. Please correct: Server, Connection options'
+        ]);
     }
 
     public function testCounts()
@@ -200,6 +236,8 @@ class MailCollectorTest extends DbTestCase
         //Add an active collector
         $nid = (int)$instance->add([
             'name'      => 'Maille name',
+            'mail_server' => 'test',
+            'server_type' => '/imap',
             'is_active' => true
         ]);
         $this->assertGreaterThan(0, $nid);

--- a/src/MailCollector.php
+++ b/src/MailCollector.php
@@ -152,8 +152,27 @@ class MailCollector extends CommonDBTM
         $this->fields['is_active']    = 1;
     }
 
-    public function prepareInput(array $input, $mode = 'add'): array
+    public function prepareInput(array $input, $mode = 'add'): array|false
     {
+        $missing_fields = [];
+        if (($mode === 'add' || array_key_exists('mail_server', $input)) && empty($input['mail_server'])) {
+            $missing_fields[] = __('Server');
+        }
+        if (($mode === 'add' || array_key_exists('server_type', $input)) && empty($input['server_type'])) {
+            $missing_fields[] = __('Connection options');
+        }
+        if (!empty($missing_fields)) {
+            Session::addMessageAfterRedirect(
+                msg: htmlspecialchars(
+                    sprintf(
+                        __('Mandatory fields are not filled. Please correct: %s'),
+                        implode(', ', $missing_fields)
+                    )
+                ),
+                message_type: ERROR
+            );
+            return false;
+        }
 
         if (isset($input["passwd"])) {
             if (empty($input["passwd"])) {
@@ -163,7 +182,7 @@ class MailCollector extends CommonDBTM
             }
         }
 
-        if (isset($input['mail_server']) && !empty($input['mail_server'])) {
+        if (isset($input['mail_server'])) {
             $input["host"] = Toolbox::constructMailServerConfig($input);
         }
 
@@ -173,6 +192,9 @@ class MailCollector extends CommonDBTM
     public function prepareInputForUpdate($input)
     {
         $input = $this->prepareInput($input, 'update');
+        if ($input === false) {
+            return false;
+        }
 
         if (isset($input["_blank_passwd"]) && $input["_blank_passwd"]) {
             $input['passwd'] = '';
@@ -185,6 +207,9 @@ class MailCollector extends CommonDBTM
     public function prepareInputForAdd($input)
     {
         $input = $this->prepareInput($input, 'add');
+        if ($input === false) {
+            return false;
+        }
         return $input;
     }
 

--- a/src/MailCollector.php
+++ b/src/MailCollector.php
@@ -163,13 +163,14 @@ class MailCollector extends CommonDBTM
         }
         if (!empty($missing_fields)) {
             Session::addMessageAfterRedirect(
-                msg: htmlspecialchars(
+                htmlspecialchars(
                     sprintf(
                         __('Mandatory fields are not filled. Please correct: %s'),
                         implode(', ', $missing_fields)
                     )
                 ),
-                message_type: ERROR
+                false,
+                ERROR
             );
             return false;
         }

--- a/src/MailCollector.php
+++ b/src/MailCollector.php
@@ -152,7 +152,7 @@ class MailCollector extends CommonDBTM
         $this->fields['is_active']    = 1;
     }
 
-    public function prepareInput(array $input, $mode = 'add'): array|false
+    public function prepareInput(array $input, $mode = 'add')
     {
         $missing_fields = [];
         if (($mode === 'add' || array_key_exists('mail_server', $input)) && empty($input['mail_server'])) {

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -1949,7 +1949,7 @@ class Toolbox
         $tab = Toolbox::parseMailServerConnectString($value, false, $allow_plugins_protocols);
 
         echo "<tr class='tab_bg_1'><td>" . __('Server') . "</td>";
-        echo "<td><input size='30' class='form-control' type='text' name='mail_server' value=\"" . $tab['address'] . "\">";
+        echo "<td><input size='30' class='form-control' type='text' name='mail_server' value=\"" . $tab['address'] . "\" required>";
         echo "</td></tr>\n";
 
         echo "<tr class='tab_bg_1'><td>" . __('Connection options') . "</td><td>";


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

The server and server type need to be required fields for mail collectors. If the server is missing, a bunch of PHP warnings are encountered when loading the form. If the server type is missing, an exception is thrown when it tries connecting.