### PR TITLE
Restore the Plugin::getWebDir() behaviour

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -2771,7 +2771,12 @@ TWIG;
 
         Toolbox::deprecated('All plugins resources should be accessed from the `/plugins/` path.');
 
-        $directory = 'plugins/' . $plugin_key;
+        $directory = self::getPhpDir($plugin_key, false);
+        if ($directory === false) {
+            return false;
+        }
+
+        $directory = ltrim($directory, '/\\');
 
         if ($full) {
             $root = $use_url_base ? $CFG_GLPI['url_base'] : $CFG_GLPI["root_doc"];

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -2771,7 +2771,7 @@ TWIG;
 
         Toolbox::deprecated('All plugins resources should be accessed from the `/plugins/` path.');
 
-        $directory = '/plugins/' . $plugin_key;
+        $directory = 'plugins/' . $plugin_key;
 
         if ($full) {
             $root = $use_url_base ? $CFG_GLPI['url_base'] : $CFG_GLPI["root_doc"];


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Some plugins may require the `Plugin::getWebDir()` to have the same behaviour as in GLPI 10.0 to continue to work as expected. For instance, the **OauthSSO** plugin uses this method to compute a callback URL that must be registered in the Oauth provider side. If we replace `/marketplace/oauthsso/...` by `/plugins/oauthsso/...`, it will break the authentication feature of the plugin.

Restoring the existing behaviour (as it was before #17929) is preferable to prevent this kind of issues.

The plugin will still have to find a solution to migrate to the new URL, but if we preserve this behaviour, it will be possible to do it later, and to implement a feature that would permit to ask to the GLPI administrator a confirmation that the Oauth provider application has been updated before switching to this new URL.


