### PR TITLE
fix: Empty IN are not allowed

### DIFF
--- a/phpunit/functional/DbUtilsTest.php
+++ b/phpunit/functional/DbUtilsTest.php
@@ -732,6 +732,14 @@ class DbUtilsTest extends DbTestCase
             $it->getSql()
         );
 
+        // Entity value is empty array
+        $it->execute('glpi_entities', $instance->getEntitiesRestrictCriteria('glpi_entities', '', [], true));
+        $this->assertSame(0, $it->count());
+        $this->assertSame(
+            'SELECT * FROM `glpi_entities` WHERE (0)',
+            $it->getSql()
+        );
+
         //keep testing old method from db.function
         $this->assertSame(
             "WHERE ( `entities_id` IN ('3')  OR (`is_recursive`='1' AND `entities_id` IN (0, 1)) ) ",
@@ -752,6 +760,14 @@ class DbUtilsTest extends DbTestCase
         $it->execute('glpi_entities', getEntitiesRestrictCriteria('glpi_entities', '', 7, true));
         $this->assertSame(
             'SELECT * FROM `glpi_entities` WHERE (`glpi_entities`.`id` = \'7\')',
+            $it->getSql()
+        );
+
+        // Entity value is empty array
+        $it->execute('glpi_entities', getEntitiesRestrictCriteria('glpi_entities', '', [], true));
+        $this->assertSame(0, $it->count());
+        $this->assertSame(
+            'SELECT * FROM `glpi_entities` WHERE ((0))',
             $it->getSql()
         );
     }

--- a/phpunit/functional/DbUtilsTest.php
+++ b/phpunit/functional/DbUtilsTest.php
@@ -736,7 +736,7 @@ class DbUtilsTest extends DbTestCase
         $it->execute('glpi_entities', $instance->getEntitiesRestrictCriteria('glpi_entities', '', [], true));
         $this->assertSame(0, $it->count());
         $this->assertSame(
-            'SELECT * FROM `glpi_entities` WHERE (0)',
+            'SELECT * FROM `glpi_entities` WHERE false',
             $it->getSql()
         );
 
@@ -767,7 +767,7 @@ class DbUtilsTest extends DbTestCase
         $it->execute('glpi_entities', getEntitiesRestrictCriteria('glpi_entities', '', [], true));
         $this->assertSame(0, $it->count());
         $this->assertSame(
-            'SELECT * FROM `glpi_entities` WHERE ((0))',
+            'SELECT * FROM `glpi_entities` WHERE (false)',
             $it->getSql()
         );
     }

--- a/src/DBmysqlIterator.php
+++ b/src/DBmysqlIterator.php
@@ -556,8 +556,6 @@ class DBmysqlIterator implements SeekableIterator, Countable
                 $key = key($value);
                 $value = current($value);
                 $ret .= '((' . $key . ') ' . $this->analyseCriterion($value) . ')';
-            } elseif ($value === []) {
-                $ret .= '1=0'; //always false
             } else {
                 $ret .= DBmysql::quoteName($name) . ' ' . $this->analyseCriterion($value);
             }

--- a/src/DBmysqlIterator.php
+++ b/src/DBmysqlIterator.php
@@ -556,6 +556,8 @@ class DBmysqlIterator implements SeekableIterator, Countable
                 $key = key($value);
                 $value = current($value);
                 $ret .= '((' . $key . ') ' . $this->analyseCriterion($value) . ')';
+            } elseif ($value === []) {
+                $ret .= '1=0'; //always false
             } else {
                 $ret .= DBmysql::quoteName($name) . ' ' . $this->analyseCriterion($value);
             }

--- a/src/DbUtils.php
+++ b/src/DbUtils.php
@@ -853,6 +853,8 @@ final class DbUtils
             && $_SESSION['glpishowallentities']
         ) {
             return [];
+        } elseif ($value === []) {
+            return ['1' => 0];
         }
 
         if (empty($field)) {

--- a/src/DbUtils.php
+++ b/src/DbUtils.php
@@ -854,7 +854,7 @@ final class DbUtils
         ) {
             return [];
         } elseif ($value === []) {
-            return ['1' => 0];
+            return [new QueryExpression('false')];
         }
 
         if (empty($field)) {

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -187,10 +187,14 @@ class Dropdown
         }
 
         if ($params['readonly']) {
-            return '<span class="form-control" readonly'
+            $output = '<span class="form-control" readonly'
                 . ($params['width'] ? ' style="width: ' . $params["width"] . '"' : '') . '>'
                 . ($params['multiple'] ? implode(', ', $names) : $name)
                 . '</span>';
+            if ($params['display']) {
+                echo $output;
+            }
+            return $output;
         }
 
        // Manage entity_sons

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -1537,14 +1537,14 @@ class Profile extends CommonDBTM
            // Only root entity ones and recursive
             $options = [
                 'value'     => $this->fields[strtolower($itiltype) . "templates_id"],
-                'entity'    => 0
+                'condition' => ['entities_id' => 0]
             ];
             if (Session::isMultiEntitiesMode()) {
-                $options['condition'] = ['is_recursive' => 1];
+                $options['condition']['is_recursive'] = 1;
             }
            // Only add profile if on root entity
             if (!isset($_SESSION['glpiactiveentities'][0])) {
-                $options['readonly'] = true;
+                $options['addicon'] = false;
             }
 
             $tpl_class = $itiltype . 'Template';

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -1544,7 +1544,7 @@ class Profile extends CommonDBTM
             }
            // Only add profile if on root entity
             if (!isset($_SESSION['glpiactiveentities'][0])) {
-                $options['addicon'] = false;
+                $options['readonly'] = true;
             }
 
             $tpl_class = $itiltype . 'Template';


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !36401

When a user tries to modify the templates of a profile from an entity other than root, the list is empty because it must be done from the root entity, but this generates this error in the logs:
```
glpiphplog.CRITICAL:   *** Uncaught Exception RuntimeException: Empty IN are not allowed in .../src/DBmysqlIterator.php at line 589
  Backtrace :
  src/DBmysqlIterator.php:560                        DBmysqlIterator->analyseCriterion()
  src/DBmysqlIterator.php:315                        DBmysqlIterator->analyseCrit()
  src/DBmysqlIterator.php:111                        DBmysqlIterator->buildQuery()
  src/DBmysql.php:1105                               DBmysqlIterator->execute()
  src/DbUtils.php:1074                               DBmysql->request()
  src/DbUtils.php:889                                DbUtils->getAncestorsOf()
  inc/db.function.php:656                            DbUtils->getEntitiesRestrictCriteria()
  src/Dropdown.php:3136                              getEntitiesRestrictCriteria()
  ajax/getDropdownValue.php:50                       Dropdown::getDropdownValue()
  public/index.php:82                                require()
```

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/94cd4b45-1bdd-4faa-ab76-9a44c7096cea)

