### PR TITLE
Fix mistake in conditions tests

### DIFF
--- a/tests/cypress/e2e/form/editor/conditions.cy.js
+++ b/tests/cypress/e2e/form/editor/conditions.cy.js
@@ -549,24 +549,28 @@ describe ('Conditions', () => {
         preview();
 
         // The form questions are all empty, we expect the following default state
-        validateThatQuestionIsVisible("My question used as a criteria");
         validateThatQuestionIsVisible("My question that is always visible");
         validateThatQuestionIsNotVisible("My question that is visible if some criteria are met");
         validateThatQuestionIsVisible("My question that is hidden if some criteria are met");
 
+        // Note: after changing the answer, make sure that the first value that is being
+        // checked has a different visibility that in the previous assertions.
+        // Indeed, if we don't do that the assertion might be validated instantly
+        // before the UI is updated with the new visibilities.
+        // By checking for a different value, we make sure the first assertion can't
+        // run until the UI is updated - thus making the other assertions safe.
+
         // Set first answer to "Expected answer 1" and check the displayed content again.
         setTextAnswer("My question used as a criteria", "Expected answer 1");
-        validateThatQuestionIsVisible("My question used as a criteria");
-        validateThatQuestionIsVisible("My question that is always visible");
         validateThatQuestionIsVisible("My question that is visible if some criteria are met");
         validateThatQuestionIsVisible("My question that is hidden if some criteria are met");
+        validateThatQuestionIsVisible("My question that is always visible");
 
         // Set first answer to "Expected answer 2" and check the displayed content again.
         setTextAnswer("My question used as a criteria", "Expected answer 2");
-        validateThatQuestionIsVisible("My question used as a criteria");
-        validateThatQuestionIsVisible("My question that is always visible");
-        validateThatQuestionIsVisible("My question that is visible if some criteria are met");
         validateThatQuestionIsNotVisible("My question that is hidden if some criteria are met");
+        validateThatQuestionIsNotVisible("My question that is visible if some criteria are met");
+        validateThatQuestionIsVisible("My question that is always visible");
     });
 
     it('conditions are applied on comments', () => {
@@ -609,23 +613,27 @@ describe ('Conditions', () => {
         preview();
 
         // The form questions are all empty, we expect the following default state
-        validateThatQuestionIsVisible("My question used as a criteria");
         validateThatCommentIsVisible("My comment that is always visible");
-        validateThatCommentIsNotVisible("My comment that is visible if some criteria are met");
         validateThatCommentIsVisible("My comment that is hidden if some criteria are met");
+        validateThatCommentIsNotVisible("My comment that is visible if some criteria are met");
+
+        // Note: after changing the answer, make sure that the first value that is being
+        // checked has a different visibility that in the previous assertions.
+        // Indeed, if we don't do that the assertion might be validated instantly
+        // before the UI is updated with the new visibilities.
+        // By checking for a different value, we make sure the first assertion can't
+        // run until the UI is updated - thus making the other assertions safe.
 
         // Set first answer to "Expected answer 1" and check the displayed content again.
         setTextAnswer("My question used as a criteria", "Expected answer 1");
-        validateThatQuestionIsVisible("My question used as a criteria");
-        validateThatCommentIsVisible("My comment that is always visible");
         validateThatCommentIsVisible("My comment that is visible if some criteria are met");
         validateThatCommentIsVisible("My comment that is hidden if some criteria are met");
+        validateThatCommentIsVisible("My comment that is always visible");
 
         // Set first answer to "Expected answer 2" and check the displayed content again.
         setTextAnswer("My question used as a criteria", "Expected answer 2");
-        validateThatQuestionIsVisible("My question used as a criteria");
-        validateThatCommentIsVisible("My comment that is always visible");
-        validateThatCommentIsVisible("My comment that is visible if some criteria are met");
         validateThatCommentIsNotVisible("My comment that is hidden if some criteria are met");
+        validateThatCommentIsNotVisible("My comment that is visible if some criteria are met");
+        validateThatCommentIsVisible("My comment that is always visible");
     });
 });


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

There was a mistake in the `conditions are applied on questions` and `conditions are applied on comments` tests that went unnoticed due to some racing condition.

Indeed, the `"My question/comment that is visible if some criteria are met"` item should be hidden in the last step of the test as it is only visible if the answer is `Expected answer 1` and we have `Expected answer 2` in the final step.

The issue is that this assertion would work both way (not visible / is visible) due to how the tests are executed:
* When checking if the item is visible, the result is instantly true because the item is visible in the previous step of the test so the UI didn't have time to update yet.
* When checking if the item is not visible, cypress will see it is not true so it will wait a bit which give the needed time for the UI to update itself with the correct visibility - thus validating the assertion.

I've fixed the wrong assertion and tweaked the order of the assertions to make sure this kind of scenario is no longer possible.


