### PR TITLE
Re-add the possibility to get Thread-Topic and Thread-Index from email header

### DIFF
--- a/src/MailCollector.php
+++ b/src/MailCollector.php
@@ -1574,6 +1574,18 @@ class MailCollector extends CommonDBTM
             }
         }
 
+        if (isset($message->threadtopic)) {
+            if ($threadtopic = $message->getHeader('threadtopic')) {
+                $mail_details['threadtopic'] = $threadtopic->getFieldValue();
+            }
+        }
+
+        if (isset($message->threadindex)) {
+            if ($threadindex = $message->getHeader('threadindex')) {
+                $mail_details['threadindex'] = threadindex->getFieldValue();
+            }
+        }
+
        //Add additional headers in X-
         foreach ($this->getAdditionnalHeaders($message) as $header => $value) {
             $mail_details[$header] = $value;

--- a/src/MailCollector.php
+++ b/src/MailCollector.php
@@ -1582,7 +1582,7 @@ class MailCollector extends CommonDBTM
 
         if (isset($message->threadindex)) {
             if ($threadindex = $message->getHeader('threadindex')) {
-                $mail_details['threadindex'] = threadindex->getFieldValue();
+                $mail_details['threadindex'] = $threadindex->getFieldValue();
             }
         }
 


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Re-added the email headers that are missing since 10.0.18: Thread-Topic and Thread-Index

## Screenshots (if appropriate):


