### PR TITLE
Fix autoload of non-PSR-4 namespaced plugin classes

### DIFF
--- a/src/autoload/legacy-autoloader.php
+++ b/src/autoload/legacy-autoloader.php
@@ -42,7 +42,7 @@
  */
 function glpi_autoload($classname)
 {
-    if (!str_starts_with($classname, 'Plugin')) {
+    if (!str_starts_with($classname, 'Plugin') && !str_starts_with($classname, NS_PLUG)) {
         return;
     }
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

The filter used to enhance the legacy autoloader performances was a bit aggressive. It was preventing files using the `GlpiPlugin\\` namespace to be loaded from the corresponding plugin `inc` directory.