### PR TITLE
Drop specific info already sent from GLPI framework

### DIFF
--- a/src/Glpi/Inventory/Asset/DatabaseInstance.php
+++ b/src/Glpi/Inventory/Asset/DatabaseInstance.php
@@ -190,7 +190,7 @@ class DatabaseInstance extends InventoryAsset
                 }
                 $inputrulelog = [
                     'date'      => date('Y-m-d H:i:s'),
-                    'rules_id'  => $data['rules_id'],
+                    'rules_id'  => $data['_ruleid'],
                     'items_id'  => $items_id,
                     'itemtype'  => $itemtype,
                     'agents_id' => $agents_id,

--- a/src/Glpi/Inventory/Asset/Monitor.php
+++ b/src/Glpi/Inventory/Asset/Monitor.php
@@ -176,7 +176,7 @@ class Monitor extends InventoryAsset
                 }
                 $inputrulelog = [
                     'date'      => date('Y-m-d H:i:s'),
-                    'rules_id'  => $data['rules_id'],
+                    'rules_id'  => $data['_ruleid'],
                     'items_id'  => $items_id,
                     'itemtype'  => $itemtype,
                     'agents_id' => $agents_id,

--- a/src/Glpi/Inventory/Asset/Peripheral.php
+++ b/src/Glpi/Inventory/Asset/Peripheral.php
@@ -178,7 +178,7 @@ class Peripheral extends InventoryAsset
                 }
                 $inputrulelog = [
                     'date'      => date('Y-m-d H:i:s'),
-                    'rules_id'  => $data['rules_id'],
+                    'rules_id'  => $data['_ruleid'],
                     'items_id'  => $items_id,
                     'itemtype'  => $itemtype,
                     'agents_id' => $agents_id,

--- a/src/Glpi/Inventory/Asset/Printer.php
+++ b/src/Glpi/Inventory/Asset/Printer.php
@@ -140,7 +140,7 @@ class Printer extends InventoryAsset
                 }
                 $inputrulelog = [
                     'date'      => date('Y-m-d H:i:s'),
-                    'rules_id'  => $data['rules_id'],
+                    'rules_id'  => $data['_ruleid'],
                     'items_id'  => $items_id,
                     'itemtype'  => $itemtype,
                     'agents_id' => $agents_id,

--- a/src/Glpi/Inventory/MainAsset/MainAsset.php
+++ b/src/Glpi/Inventory/MainAsset/MainAsset.php
@@ -601,7 +601,7 @@ abstract class MainAsset extends InventoryAsset
                     unset($this->data[$key]);
                 } else {
                     if ($datarules['action'] != RuleImportAsset::LINK_RESULT_DENIED) {
-                        $input['rules_id'] = $datarules['rules_id'];
+                        $input['rules_id'] = $datarules['_ruleid'];
                         $this->addRefused($input);
                     }
                 }

--- a/src/RuleImportAsset.php
+++ b/src/RuleImportAsset.php
@@ -900,7 +900,6 @@ class RuleImportAsset extends Rule
     {
         $class = $params['class'] ?? null;
         $rules_id = $this->fields['id'];
-        $output['rules_id'] = $rules_id;
 
         $rulesmatched = new RuleMatchedLog();
         $inputrulelog = [


### PR DESCRIPTION
GLPI Rules system output always contains a `_ruleid` entry with matching rule.
There is no need for an additional `rules_id` in the same output (it's specific to `RuleImportAsset`; it probably comes from original inventory migration) - that just adds confusion.