### PR TITLE
Correction of the doHookFunction placement for redefined menus.

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -1580,7 +1580,6 @@ TWIG,
         $menu            = self::generateMenuSession();
 
         $menu = Plugin::doHookFunction("redefine_menus", $menu);
-        
         $menu_active     = $menu[$sector]['content'][$active_item]['title'] ?? "";
 
         $tpl_vars = [


### PR DESCRIPTION
By default, when adding a menu with submenus, GLPI does not add the "active" class to the "dropdown-item" element.

This modification allows GLPI to retrieve the modified menus and add the "active" class.