### PR TITLE
Forms: add an option to close a ticket on creation

### DIFF
--- a/phpunit/functional/Glpi/Form/Destination/CommonITILField/StatusFieldTest.php
+++ b/phpunit/functional/Glpi/Form/Destination/CommonITILField/StatusFieldTest.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Form\Destination\CommonITILField;
+
+use CommonITILObject;
+use DbTestCase;
+use Glpi\Form\Destination\CommonITILField\SimpleValueConfig;
+use Glpi\Form\Destination\CommonITILField\StatusField;
+use Glpi\Form\Form;
+use Glpi\Tests\FormBuilder;
+use Glpi\Tests\FormTesterTrait;
+
+final class StatusFieldTest extends DbTestCase
+{
+    use FormTesterTrait;
+
+    public function testStatusWithoutConfig(): void
+    {
+        // Arrange: create a simple form
+        $form = $this->createForm(new FormBuilder());
+
+        // Act: submit form
+        $ticket = $this->sendFormAndGetCreatedTicket($form, []);
+
+        // Assert: the ticket should have its default status
+        $this->assertEquals(CommonITILObject::INCOMING, $ticket->fields['status']);
+    }
+
+    public function testStatusWithDefaultConfig(): void
+    {
+        // Arrange: create a simple form and set the "default" config
+        $form = $this->createForm(new FormBuilder());
+        $this->setStatusConfig(
+            $form,
+            new SimpleValueConfig(StatusField::DEFAULT_STATUS)
+        );
+
+        // Act: submit form
+        $ticket = $this->sendFormAndGetCreatedTicket($form, []);
+
+        // Assert: the ticket should have its default status
+        $this->assertEquals(CommonITILObject::INCOMING, $ticket->fields['status']);
+    }
+
+    public function testStatusWithClosedConfig(): void
+    {
+        // Arrange: create a simple form and set the "closed" config
+        $form = $this->createForm(new FormBuilder());
+        $this->setStatusConfig(
+            $form,
+            new SimpleValueConfig(CommonITILObject::CLOSED)
+        );
+
+        // Act: submit form
+        $ticket = $this->sendFormAndGetCreatedTicket($form, []);
+
+        // Assert: the ticket should have its default status
+        $this->assertEquals(CommonITILObject::CLOSED, $ticket->fields['status']);
+    }
+
+
+    private function setStatusConfig(Form $form, SimpleValueConfig $config): void
+    {
+        // Insert config
+        $destinations = $form->getDestinations();
+        $this->assertCount(1, $destinations);
+        $destination = current($destinations);
+        $this->updateItem(
+            $destination::getType(),
+            $destination->getId(),
+            ['config' => [StatusField::getKey() => $config->jsonSerialize()]],
+            ['config'],
+        );
+    }
+}

--- a/src/Glpi/Form/Destination/CommonITILField/StatusField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/StatusField.php
@@ -1,0 +1,131 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Form\Destination\CommonITILField;
+
+use CommonITILObject;
+use Glpi\Application\View\TemplateRenderer;
+use Glpi\DBAL\JsonFieldInterface;
+use Glpi\Form\AnswersSet;
+use Glpi\Form\Destination\AbstractConfigField;
+use Glpi\Form\Form;
+use InvalidArgumentException;
+use Override;
+
+class StatusField extends AbstractConfigField
+{
+    public const DEFAULT_STATUS = 'default_status';
+
+    #[Override]
+    public function getLabel(): string
+    {
+        return __("Status");
+    }
+
+    #[Override]
+    public function getConfigClass(): string
+    {
+        return SimpleValueConfig::class;
+    }
+
+    #[Override]
+    public function renderConfigForm(
+        Form $form,
+        JsonFieldInterface $config,
+        string $input_name,
+        array $display_options
+    ): string {
+        if (!$config instanceof SimpleValueConfig) {
+            throw new InvalidArgumentException("Unexpected config class");
+        }
+
+        $possible_values = [
+            self::DEFAULT_STATUS     => __("Default"),
+            CommonITILObject::CLOSED => __("Closed"),
+        ];
+
+        $template = <<<TWIG
+            {% import 'components/form/fields_macros.html.twig' as fields %}
+
+            {{ fields.dropdownArrayField(
+                input_name,
+                value,
+                possible_values,
+                '',
+                options|merge({
+                    'field_class'      : '',
+                    'no_label'         : true,
+                })
+            ) }}
+TWIG;
+
+        $twig = TemplateRenderer::getInstance();
+        return $twig->renderFromStringTemplate($template, [
+            'form_id'         => $form->fields['id'],
+            'value'           => $config->getValue(),
+            'possible_values' => $possible_values,
+            'input_name'      => $input_name . "[" . SimpleValueConfig::VALUE . "]",
+            'options'         => $display_options,
+        ]);
+    }
+
+    #[Override]
+    public function applyConfiguratedValueToInputUsingAnswers(
+        JsonFieldInterface $config,
+        array $input,
+        AnswersSet $answers_set
+    ): array {
+        if (!$config instanceof SimpleValueConfig) {
+            throw new InvalidArgumentException("Unexpected config class");
+        }
+
+        if ($config->getValue() != self::DEFAULT_STATUS) {
+            $input['status'] = $config->getValue();
+        }
+
+        return $input;
+    }
+
+    #[Override]
+    public function getDefaultConfig(Form $form): SimpleValueConfig
+    {
+        return new SimpleValueConfig(self::DEFAULT_STATUS);
+    }
+
+    #[Override]
+    public function getWeight(): int
+    {
+        return 25;
+    }
+}

--- a/src/Glpi/Form/Destination/FormDestinationTicket.php
+++ b/src/Glpi/Form/Destination/FormDestinationTicket.php
@@ -40,6 +40,7 @@ use Glpi\Form\Destination\CommonITILField\SLATTOField;
 use Glpi\Form\Destination\CommonITILField\SLATTRField;
 use Glpi\Form\Destination\CommonITILField\OLATTOField;
 use Glpi\Form\Destination\CommonITILField\OLATTRField;
+use Glpi\Form\Destination\CommonITILField\StatusField;
 use Override;
 use Ticket;
 
@@ -60,6 +61,7 @@ final class FormDestinationTicket extends AbstractCommonITILFormDestination
             new SLATTRField(),
             new OLATTOField(),
             new OLATTRField(),
+            new StatusField(),
         ]);
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

This option allow to have a form destination that will create a ticket with the closed status.
This is useful when you have a form that do not require any treatment after submission (for example some kind of poll).

Note: formcreator does this by allowing forms to have 0 target, which we don't want.
We prefer to keep a ticket to have a "trace" of the answers, even if it is closed immediately .

