### PR TITLE
Forms: fix richtext editor margins

### DIFF
--- a/css/includes/components/_content-editable-inputs.scss
+++ b/css/includes/components/_content-editable-inputs.scss
@@ -95,11 +95,6 @@ $inline-input-padding: 2px 4px;
         padding: 0 !important;
     }
 
-    // Override some hard-set tinymce margins
-    .tox-sidebar-wrap {
-        margin-bottom: -20px;
-    }
-
     // Do not display file upload summary as it will only contains pasted images
     .fileupload {
         display: none;


### PR DESCRIPTION
## Description

Fix some margin issues, it seems one specific CSS rule is no longer needed and has been having a negative impact on the UI.

## Screenshots (if appropriate):

Before (textarea is missing because of bad margins):
![image](https://github.com/user-attachments/assets/aef3c89b-88a2-412c-8656-43c9f35284c0)


After:
![image](https://github.com/user-attachments/assets/c580d0c5-373a-4115-93ab-f6bd17182859)

