### PR TITLE
Prevent division by zero; fixes #19036

### DIFF
--- a/src/CommonITILValidation.php
+++ b/src/CommonITILValidation.php
@@ -1536,9 +1536,16 @@ abstract class CommonITILValidation extends CommonDBChild
             }
         }
 
+        $accepted = 0;
+        $refused  = 0;
+        if ($total) {
+            $accepted = round($statuses[self::ACCEPTED] * 100 / $total);
+            $refused  = round($statuses[self::REFUSED]  * 100 / $total);
+        }
+
         return self::computeValidation(
-            round($statuses[self::ACCEPTED] * 100 / $total),
-            round($statuses[self::REFUSED]  * 100 / $total),
+            $accepted,
+            $refused,
             $validation_percent
         );
     }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes #19036 
- Prevents division by zero.

I do not really understand why this issue is not already caught by tests suite. `TicketTest::testGlobalValidationUpdate()` seems to do the job; but `$total` in that case is always >= 1.


