### PR TITLE
fix(dashboard): groups lost in session

### DIFF
--- a/ajax/dashboard.php
+++ b/ajax/dashboard.php
@@ -193,7 +193,7 @@ switch ($_REQUEST['action']) {
         Session::writeClose();
         if ($embed) {
             Session::destroy();
-            $grid->embed($_REQUEST, false);
+            $grid->initEmbedSession($_REQUEST);
         }
         echo $grid->getCardHtml($_REQUEST['card_id'], $_REQUEST);
         break;

--- a/ajax/dashboard.php
+++ b/ajax/dashboard.php
@@ -191,6 +191,10 @@ switch ($_REQUEST['action']) {
         }
 
         Session::writeClose();
+        if ($embed) {
+            Session::destroy();
+            $grid->embed($_REQUEST, false);
+        }
         echo $grid->getCardHtml($_REQUEST['card_id'], $_REQUEST);
         break;
 

--- a/front/central.php
+++ b/front/central.php
@@ -37,6 +37,8 @@
 global $CFG_GLPI;
 
 if (isset($_GET["embed"]) && isset($_GET["dashboard"])) {
+    ini_set('session.use_cookies', 0);
+    $_SESSION = [];
     $SECURITY_STRATEGY = 'no_check'; // Allow anonymous access for embed dashboards.
 }
 

--- a/front/central.php
+++ b/front/central.php
@@ -38,7 +38,6 @@ global $CFG_GLPI;
 
 if (isset($_GET["embed"]) && isset($_GET["dashboard"])) {
     ini_set('session.use_cookies', 0);
-    $_SESSION = [];
     $SECURITY_STRATEGY = 'no_check'; // Allow anonymous access for embed dashboards.
 }
 

--- a/src/Dashboard/Grid.php
+++ b/src/Dashboard/Grid.php
@@ -447,34 +447,14 @@ JAVASCRIPT;
 
 
     /**
-     * Show an embeded dashboard.
-     * We must check token validity to avoid displaying dashboard to invalid users
+     * Init embed session
      *
-     * @param array $params contains theses keys:
-     * - dashboard: the dashboard system name
-     * - entities_id: entity to init in session
-     * - is_recursive: do we need to display sub entities
-     * - token: the token to check
-     * @param bool $show if true, display the dashboard
+     * @param array
      *
-     * @return void (display)
+     * @return void
      */
-    public function embed(array $params = [], bool $show = true)
+    public function initEmbedSession(array $params = [])
     {
-        $defaults = [
-            'dashboard'    => '',
-            'entities_id'  => 0,
-            'is_recursive' => 0,
-            'token'        => ''
-        ];
-        $params = array_merge($defaults, $params);
-
-        if (!self::checkToken($params)) {
-            Html::displayRightError();
-            exit;
-        }
-
-        self::$embed = true;
 
         if (!isset($_SESSION['glpi_use_mode'])) {
             $_SESSION['glpi_use_mode'] = Session::NORMAL_MODE;
@@ -492,11 +472,41 @@ JAVASCRIPT;
         }
         $_SESSION['glpiactiveentities']        = $entities;
         $_SESSION['glpiactiveentities_string'] = "'" . implode("', '", $entities) . "'";
+    }
+
+
+    /**
+     * Show an embeded dashboard.
+     * We must check token validity to avoid displaying dashboard to invalid users
+     *
+     * @param array $params contains theses keys:
+     * - dashboard: the dashboard system name
+     * - entities_id: entity to init in session
+     * - is_recursive: do we need to display sub entities
+     * - token: the token to check
+     *
+     * @return void (display)
+     */
+    public function embed(array $params = [])
+    {
+        $defaults = [
+            'dashboard'    => '',
+            'entities_id'  => 0,
+            'is_recursive' => 0,
+            'token'        => ''
+        ];
+        $params = array_merge($defaults, $params);
+
+        if (!self::checkToken($params)) {
+            Html::displayRightError();
+            exit;
+        }
+
+        self::$embed = true;
+        $this->initEmbedSession($params);
 
         // show embeded dashboard
-        if ($show) {
-            $this->show(true, $params['token']);
-        }
+        $this->show(true, $params['token']);
     }
 
     public static function getToken(string $dasboard = "", int $entities_id = 0, int $is_recursive = 0): string

--- a/src/Dashboard/Grid.php
+++ b/src/Dashboard/Grid.php
@@ -455,10 +455,11 @@ JAVASCRIPT;
      * - entities_id: entity to init in session
      * - is_recursive: do we need to display sub entities
      * - token: the token to check
+     * @param bool $show if true, display the dashboard
      *
      * @return void (display)
      */
-    public function embed(array $params = [])
+    public function embed(array $params = [], bool $show = true)
     {
         $defaults = [
             'dashboard'    => '',
@@ -475,13 +476,15 @@ JAVASCRIPT;
 
         self::$embed = true;
 
+        if (!isset($_SESSION['glpi_use_mode'])) {
+            $_SESSION['glpi_use_mode'] = Session::NORMAL_MODE;
+        }
+
        // load minimal session
         $_SESSION["glpiactive_entity"]           = $params['entities_id'];
         $_SESSION["glpiactive_entity_recursive"] = $params['is_recursive'];
         $_SESSION["glpiname"]                    = 'embed_dashboard';
-        if (!isset($_SESSION['glpigroups'])) {
-            $_SESSION['glpigroups'] = [];
-        }
+        $_SESSION['glpigroups']                  = [];
         if ($params['is_recursive']) {
             $entities = getSonsOf("glpi_entities", $params['entities_id']);
         } else {
@@ -490,8 +493,10 @@ JAVASCRIPT;
         $_SESSION['glpiactiveentities']        = $entities;
         $_SESSION['glpiactiveentities_string'] = "'" . implode("', '", $entities) . "'";
 
-       // show embeded dashboard
-        $this->show(true, $params['token']);
+        // show embeded dashboard
+        if ($show) {
+            $this->show(true, $params['token']);
+        }
     }
 
     public static function getToken(string $dasboard = "", int $entities_id = 0, int $is_recursive = 0): string

--- a/src/Dashboard/Grid.php
+++ b/src/Dashboard/Grid.php
@@ -479,7 +479,9 @@ JAVASCRIPT;
         $_SESSION["glpiactive_entity"]           = $params['entities_id'];
         $_SESSION["glpiactive_entity_recursive"] = $params['is_recursive'];
         $_SESSION["glpiname"]                    = 'embed_dashboard';
-        $_SESSION["glpigroups"]                  = [];
+        if (!isset($_SESSION['glpigroups'])) {
+            $_SESSION['glpigroups'] = [];
+        }
         if ($params['is_recursive']) {
             $entities = getSonsOf("glpi_entities", $params['entities_id']);
         } else {

--- a/src/Dashboard/Grid.php
+++ b/src/Dashboard/Grid.php
@@ -455,12 +455,7 @@ JAVASCRIPT;
      */
     public function initEmbedSession(array $params = [])
     {
-
-        if (!isset($_SESSION['glpi_use_mode'])) {
-            $_SESSION['glpi_use_mode'] = Session::NORMAL_MODE;
-        }
-
-       // load minimal session
+        // load minimal session
         $_SESSION["glpiactive_entity"]           = $params['entities_id'];
         $_SESSION["glpiactive_entity_recursive"] = $params['is_recursive'];
         $_SESSION["glpiname"]                    = 'embed_dashboard';
@@ -472,6 +467,10 @@ JAVASCRIPT;
         }
         $_SESSION['glpiactiveentities']        = $entities;
         $_SESSION['glpiactiveentities_string'] = "'" . implode("', '", $entities) . "'";
+
+        if (!isset($_SESSION['glpi_use_mode'])) {
+            $_SESSION['glpi_use_mode'] = Session::NORMAL_MODE;
+        }
     }
 
 

--- a/src/Dashboard/Grid.php
+++ b/src/Dashboard/Grid.php
@@ -468,9 +468,7 @@ JAVASCRIPT;
         $_SESSION['glpiactiveentities']        = $entities;
         $_SESSION['glpiactiveentities_string'] = "'" . implode("', '", $entities) . "'";
 
-        if (!isset($_SESSION['glpi_use_mode'])) {
-            $_SESSION['glpi_use_mode'] = Session::NORMAL_MODE;
-        }
+        $_SESSION['glpi_use_mode'] = Session::NORMAL_MODE;
     }
 
 

--- a/src/Dashboard/Grid.php
+++ b/src/Dashboard/Grid.php
@@ -448,10 +448,6 @@ JAVASCRIPT;
 
     /**
      * Init embed session
-     *
-     * @param array
-     *
-     * @return void
      */
     public function initEmbedSession(array $params = [])
     {


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !36463
- Here is a brief description of what this PR does

The list of groups stored in `$_SESSION['glpigroups']` was systematically cleared when displaying a shared dashboard, causing the loss of access to elements shared via groups.

## Screenshots (if appropriate):


