### PR TITLE
fix: add ticket content from promoted followup

### DIFF
--- a/front/ticket.form.php
+++ b/front/ticket.form.php
@@ -292,20 +292,7 @@ if (isset($_GET["id"]) && ($_GET["id"] > 0)) {
         $track::showKanban(0);
         Html::footer();
     } else {
-        $options = $_REQUEST;
         $menus = ["helpdesk", "ticket"];
-        if ($_GET['_promoted_fup_id']) {
-            $followup = new ITILFollowup();
-            if ($followup->getFromDB($_GET['_promoted_fup_id'])) {
-                $options['content'] = $followup->fields['content'];
-            };
-        }
-        if ($_GET['_promoted_task_id']) {
-            $ticketask = new TicketTask();
-            if ($ticketask->getFromDB($_GET['_promoted_task_id'])) {
-                $options['content'] = $ticketask->fields['content'];
-            };
-        }
-        Ticket::displayFullPageForItem(0, $menus, $options);
+        Ticket::displayFullPageForItem(0, $menus, $_REQUEST);
     }
 }

--- a/front/ticket.form.php
+++ b/front/ticket.form.php
@@ -292,7 +292,7 @@ if (isset($_GET["id"]) && ($_GET["id"] > 0)) {
         $track::showKanban(0);
         Html::footer();
     } else {
-        $otpions = $_REQUEST;
+        $options = $_REQUEST;
         $menus = ["helpdesk", "ticket"];
         if ($_GET['_promoted_fup_id']) {
             $followup = new ITILFollowup();

--- a/front/ticket.form.php
+++ b/front/ticket.form.php
@@ -292,7 +292,14 @@ if (isset($_GET["id"]) && ($_GET["id"] > 0)) {
         $track::showKanban(0);
         Html::footer();
     } else {
+        $otpions = $_REQUEST;
         $menus = ["helpdesk", "ticket"];
-        Ticket::displayFullPageForItem(0, $menus, $_REQUEST);
+        if ($_GET['_promoted_fup_id']) {
+            $followup = new ITILFollowup();
+            if ($followup->getFromDB($_GET['_promoted_fup_id'])) {
+                $options['content'] = $followup->fields['content'];
+            };
+        }
+        Ticket::displayFullPageForItem(0, $menus, $options);
     }
 }

--- a/front/ticket.form.php
+++ b/front/ticket.form.php
@@ -300,6 +300,12 @@ if (isset($_GET["id"]) && ($_GET["id"] > 0)) {
                 $options['content'] = $followup->fields['content'];
             };
         }
+        if ($_GET['_promoted_task_id']) {
+            $ticketask = new TicketTask();
+            if ($ticketask->getFromDB($_GET['_promoted_task_id'])) {
+                $options['content'] = $ticketask->fields['content'];
+            };
+        }
         Ticket::displayFullPageForItem(0, $menus, $options);
     }
 }

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -382,6 +382,18 @@ abstract class CommonITILObject extends CommonDBTM
                         ]);
                     }
                 }
+
+                $groups_id = array_key_exists('_groups_id_' . $actortypestring, $params) && $params['_groups_id_' . $actortypestring] > 0
+                    ? $params['_groups_id_' . $actortypestring] : 0;
+                if ($groups_id > 0) {
+                    $group_obj = new Group();
+                    if ($group_obj->getFromDB($groups_id)) {
+                        $fn_add_actor('Group', $groups_id, [
+                            'text'  => $group_obj->getName(),
+                            'title' => $group_obj->getRawCompleteName(),
+                        ]);
+                    }
+                }
             }
 
             // load default actors from itiltemplate passed from showForm in `params` var

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -4301,7 +4301,7 @@ JAVASCRIPT;
             $options['entities_id'] = $item->fields['entities_id'];
         }
 
-        $initial_creation = static::isNewID($ID) && !$this->hasSavedInput();
+        $initial_creation = static::isNewID($ID) && $this->hasSavedInput();
 
         $this->restoreInputAndDefaults($ID, $options, null, true);
 

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -4301,7 +4301,7 @@ JAVASCRIPT;
             $options['entities_id'] = $item->fields['entities_id'];
         }
 
-        $initial_creation = static::isNewID($ID) && $this->hasSavedInput();
+        $is_promoted = static::isNewID($ID) && $this->hasSavedInput();
 
         $this->restoreInputAndDefaults($ID, $options, null, true);
 
@@ -4320,7 +4320,7 @@ JAVASCRIPT;
             $options['_skip_promoted_fields'] = false;
         }
 
-        if ($initial_creation) {
+        if ($is_promoted) {
             // Override some values only for the initial load of a new ticket
             // Override defaut values from projecttask if needed
             if (isset($options['_projecttasks_id'])) {

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -4301,8 +4301,6 @@ JAVASCRIPT;
             $options['entities_id'] = $item->fields['entities_id'];
         }
 
-        $is_promoted = static::isNewID($ID) && $this->hasSavedInput();
-
         $this->restoreInputAndDefaults($ID, $options, null, true);
 
         if (isset($options['content'])) {
@@ -4320,7 +4318,7 @@ JAVASCRIPT;
             $options['_skip_promoted_fields'] = false;
         }
 
-        if ($is_promoted) {
+        if (static::isNewID($ID)) {
             // Override some values only for the initial load of a new ticket
             // Override defaut values from projecttask if needed
             if (isset($options['_projecttasks_id'])) {


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !36483
- When a follow-up or a task is promoted to ticket, the content of the new ticket is not filled. 

## Screenshots (if appropriate):


