### PR TITLE
Allow helpdesk forms fields to be preset using GET parameters

### DIFF
--- a/js/modules/Forms/EditorController.js
+++ b/js/modules/Forms/EditorController.js
@@ -31,7 +31,7 @@
  * ---------------------------------------------------------------------
  */
 
-/* global _, tinymce_editor_configs, getUUID, getRealInputWidth, sortable, tinymce, glpi_toast_error, bootstrap, setupAjaxDropdown, setupAdaptDropdown */
+/* global _, tinymce_editor_configs, getUUID, getRealInputWidth, sortable, tinymce, glpi_toast_info, glpi_toast_error, bootstrap, setupAjaxDropdown, setupAdaptDropdown */
 
 /**
  * Client code to handle users actions on the form_editor template
@@ -531,6 +531,12 @@ export class GlpiFormEditorController
             case "remove-horizontal-layout-slot":
                 this.#removeHorizontalLayoutSlot(
                     target.closest("[data-glpi-form-editor-horizontal-block-placeholder]")
+                );
+                break;
+
+            case "copy-uuid":
+                this.#copyQuestionUuidToClipboard(
+                    target.closest('[data-glpi-form-editor-question')
                 );
                 break;
 
@@ -2409,5 +2415,17 @@ export class GlpiFormEditorController
 
         // Remove default template placeholders
         horizontal_block.find('[data-glpi-form-editor-horizontal-block-placeholder]').remove();
+    }
+
+    #copyQuestionUuidToClipboard(question) {
+        // Generate missing UUIDs
+        this.computeState();
+
+        // Read UUID
+        const uuid = this.#getItemInput(question, 'uuid');
+
+        // Write to clipbaord and show info toast
+        navigator.clipboard.writeText(uuid);
+        glpi_toast_info(__("UUID copied successfully to clipboard."));
     }
 }

--- a/src/Glpi/Controller/Form/RendererController.php
+++ b/src/Glpi/Controller/Form/RendererController.php
@@ -102,6 +102,7 @@ final class RendererController extends AbstractController
             'unauthenticated_user' => !Session::isAuthenticated(),
             'my_tickets_url_param' => http_build_query($my_tickets_criteria),
             'visibility_engine_output' => $visibility_engine_output,
+            'params' => $request->query->all(),
 
             // Direct access token must be included in the form data as it will
             // be checked in the submit answers controller.

--- a/src/Glpi/Form/Question.php
+++ b/src/Glpi/Form/Question.php
@@ -183,6 +183,31 @@ final class Question extends CommonDBChild implements BlockInterface, Conditionn
         return parent::prepareInputForUpdate($input);
     }
 
+    public function setDefaultValueFromParameters(array $get): void
+    {
+        $name = $this->fields['name'];
+
+        // Normalize both input and expected values
+        $name = strtolower($name);
+        $name = str_replace(' ', '', $name);
+        $normalized_get = [];
+        foreach ($get as $param => $value) {
+            $param = strtolower($param);
+            $param = str_replace(' ', '', $param);
+            $normalized_get[$param] = $value;
+        }
+
+        // Apply value if defined
+        if (isset($normalized_get[$name])) {
+            $type = $this->getQuestionType();
+            $value = $type->formatPredefinedValue($normalized_get[$name]);
+
+            if ($value !== null) {
+                $this->fields['default_value'] = $value;
+            }
+        }
+    }
+
     private function prepareInput($input): array
     {
         // Set parent UUID

--- a/src/Glpi/Form/Question.php
+++ b/src/Glpi/Form/Question.php
@@ -185,22 +185,12 @@ final class Question extends CommonDBChild implements BlockInterface, Conditionn
 
     public function setDefaultValueFromParameters(array $get): void
     {
-        $name = $this->fields['name'];
-
-        // Normalize both input and expected values
-        $name = strtolower($name);
-        $name = str_replace(' ', '', $name);
-        $normalized_get = [];
-        foreach ($get as $param => $value) {
-            $param = strtolower($param);
-            $param = str_replace(' ', '', $param);
-            $normalized_get[$param] = $value;
-        }
+        $uuid = $this->fields['uuid'];
 
         // Apply value if defined
-        if (isset($normalized_get[$name])) {
+        if (isset($get[$uuid])) {
             $type = $this->getQuestionType();
-            $value = $type->formatPredefinedValue($normalized_get[$name]);
+            $value = $type->formatPredefinedValue($get[$uuid]);
 
             if ($value !== null) {
                 $this->fields['default_value'] = $value;

--- a/src/Glpi/Form/QuestionType/AbstractQuestionType.php
+++ b/src/Glpi/Form/QuestionType/AbstractQuestionType.php
@@ -35,14 +35,12 @@
 
 namespace Glpi\Form\QuestionType;
 
-use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\JsonFieldInterface;
 use Glpi\Form\Question;
 use Override;
 
 abstract class AbstractQuestionType implements QuestionTypeInterface
 {
-    #[Override]
     public function __construct()
     {
     }
@@ -183,5 +181,12 @@ abstract class AbstractQuestionType implements QuestionTypeInterface
     public function getSubTypeDefaultValue(?Question $question): ?string
     {
         return '';
+    }
+
+    #[Override]
+    public function formatPredefinedValue(string $value): ?string
+    {
+        // Do nothing by default
+        return null;
     }
 }

--- a/src/Glpi/Form/QuestionType/AbstractQuestionTypeShortAnswer.php
+++ b/src/Glpi/Form/QuestionType/AbstractQuestionTypeShortAnswer.php
@@ -166,4 +166,10 @@ TWIG;
     {
         return true;
     }
+
+    #[Override]
+    public function formatPredefinedValue(string $value): string
+    {
+        return $value;
+    }
 }

--- a/src/Glpi/Form/QuestionType/QuestionTypeInterface.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeInterface.php
@@ -231,4 +231,9 @@ interface QuestionTypeInterface
      * @return null|string
      */
     public function getSubTypeDefaultValue(?Question $question): ?string;
+
+    /**
+     * Apply a predefined value that will be used when rendering the form.
+     */
+    public function formatPredefinedValue(string $value): ?string;
 }

--- a/src/Glpi/Form/QuestionType/QuestionTypeLongText.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeLongText.php
@@ -170,4 +170,10 @@ TWIG;
     {
         return true;
     }
+
+    #[Override]
+    public function formatPredefinedValue(string $value): string
+    {
+        return $value;
+    }
 }

--- a/src/Glpi/Form/QuestionType/QuestionTypeRequestType.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeRequestType.php
@@ -138,4 +138,16 @@ TWIG;
     {
         return true;
     }
+
+    #[Override]
+    public function formatPredefinedValue(string $value): ?string
+    {
+        $value = strtolower($value);
+
+        return match ($value) {
+            'incident' => (string) Ticket::INCIDENT_TYPE,
+            'request' => (string) Ticket::DEMAND_TYPE,
+            default => null,
+        };
+    }
 }

--- a/src/Glpi/Form/QuestionType/QuestionTypeUrgency.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeUrgency.php
@@ -164,4 +164,19 @@ TWIG;
     {
         return true;
     }
+
+    #[Override]
+    public function formatPredefinedValue(string $value): ?string
+    {
+        $value = strtolower($value);
+
+        return match ($value) {
+            'very low', 'verylow' => "1",
+            'low' => "2",
+            'medium' => "3",
+            'high' => "4",
+            'very high', 'veryhigh' => "5",
+            default => null,
+        };
+    }
 }

--- a/templates/pages/admin/form/form_question.html.twig
+++ b/templates/pages/admin/form/form_question.html.twig
@@ -153,6 +153,16 @@
                                 <span>{{ __("Configure visiblity") }}</span>
                             </button>
                         </li>
+                        <li>
+                            <button
+                                type="button"
+                                class="dropdown-item"
+                                data-glpi-form-editor-on-click="copy-uuid"
+                            >
+                                <i class="ti ti-id-badge me-2"></i>
+                                <span>{{ __("Copy uuid") }}</span>
+                            </button>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/templates/pages/form_renderer.html.twig
+++ b/templates/pages/form_renderer.html.twig
@@ -121,6 +121,7 @@
 
                                         {% if form_block is instanceof('Glpi\\Form\\Question') %}
                                             {% set question_type = form_block.getQuestionType() %}
+                                            {{ form_block.setDefaultValueFromParameters(params) }}
                                         {% endif %}
 
                                         {% set skip_question = false %}

--- a/tests/cypress/e2e/form/form_rendering.cy.js
+++ b/tests/cypress/e2e/form/form_rendering.cy.js
@@ -1,0 +1,88 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+describe('Form rendering', () => {
+    it('Can preset form fields using GET parameters', () => {
+        // Set up a form with all questions types that support url initialization
+        cy.createWithAPI('Glpi\\Form\\Form', {
+            'name': 'Test form preview',
+        }).as('form_id');
+        cy.login();
+
+        cy.get('@form_id').then((form_id) => {
+            const tab = 'Glpi\\Form\\Form$1';
+            cy.visit(`/front/form/form.form.php?id=${form_id}&forcetab=${tab}`);
+        });
+        addQuestion('Name');
+        addQuestion('Email', 'Short answer', 'Emails');
+        addQuestion('Age', 'Short answer', 'Number');
+        addQuestion('Prefered software', 'Long answer');
+        addQuestion('Urgency', 'Urgency');
+        addQuestion('Request type', 'Request type');
+        cy.findByRole('button', { 'name': 'Save' }).click();
+        cy.checkAndCloseAlert('Item successfully updated');
+
+        // Go to the form and send preset values.
+        cy.get('@form_id').then((form_id) => {
+            const params = new URLSearchParams({
+                'nAMe' : 'My name', // case insensitive key
+                'email': 'myemail@teclib.com',
+                'age': 29,
+                'urgency' : 'very loW', // case insentive value
+                'requesttype': 'reQuest', // // case insentive value
+                'preferedsoftware': 'I really like GLPI',
+            });
+            cy.visit(`/Form/Render/${form_id}?${params}`);
+        });
+
+        // Validate each values
+        cy.findByRole('textbox', { 'name': 'Name' }).should('have.value', 'My name');
+        cy.findByRole('textbox', { 'name': 'Email' }).should('have.value', 'myemail@teclib.com');
+        cy.findByRole('spinbutton', { 'name': 'Age' }).should('have.value', '29');
+        cy.findByLabelText("Prefered software").awaitTinyMCE().should('have.text', 'I really like GLPI');
+        cy.getDropdownByLabelText('Urgency').should('have.text', "Very low");
+        cy.getDropdownByLabelText('Request type').should('have.text', "Request");
+    });
+});
+
+function addQuestion(name, type = null, subtype = null) {
+    // Would be faster do to this with the API but it requires a lot of code right now.
+    // TODO: use API instead
+    cy.findByRole('button', { 'name': 'Add a new question' }).click();
+    cy.focused().type(name);
+    if (type !== null) {
+        cy.getDropdownByLabelText('Question type').selectDropdownValue(type);
+    }
+    if (subtype !== null) {
+        cy.getDropdownByLabelText('Question sub type').selectDropdownValue(subtype);
+    }
+}


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

A feature that has often been requested and doesn't take much to add, preloading a form fields using GET parameters.

## Screenshot

![image](https://github.com/user-attachments/assets/04157b6f-ece0-45ce-8a81-8c1a9e5d2f16)
