### PR TITLE
Allow usage of the `APPROVAL` status in tickets

### DIFF
--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -9235,6 +9235,7 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
             ],
         ];
 
+        // allowed_statuses is set using default value, @see install/mysql/glpi-empty.sql ( table `glpi_tickettemplates` )
         $tables['glpi_tickettemplates'] = [
             [
                 'id' => 1,

--- a/install/migrations/update_10.0.x_to_11.0.0/itilobject_templates.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/itilobject_templates.php
@@ -58,7 +58,7 @@ foreach ($itil_type_tables as $table => $fkey_to_add) {
 
 // Add status_allowed field to all ITIL Object template tables
 $itiltemplate_tables = [
-    'glpi_tickettemplates'  => [1, 2, 3, 4, 5, 6],
+    'glpi_tickettemplates'  => [1, 10, 2, 3, 4, 5, 6],
     'glpi_changetemplates'  => [1, 9, 10, 7, 4, 11, 12, 5, 8, 6, 14, 13],
     'glpi_problemtemplates' => [1, 7, 2, 3, 4, 5, 8, 6],
 ];

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -7588,7 +7588,7 @@ CREATE TABLE `glpi_tickettemplates` (
   `entities_id` int unsigned NOT NULL DEFAULT '0',
   `is_recursive` tinyint NOT NULL DEFAULT '0',
   `comment` text,
-  `allowed_statuses` varchar(255) NOT NULL DEFAULT '[1,2,3,4,5,6]',
+  `allowed_statuses` varchar(255) NOT NULL DEFAULT '[1,10,2,3,4,5,6]',
   PRIMARY KEY (`id`),
   KEY `name` (`name`),
   KEY `entities_id` (`entities_id`),

--- a/phpunit/functional/PendingReasonTest.php
+++ b/phpunit/functional/PendingReasonTest.php
@@ -578,7 +578,7 @@ class PendingReasonTest extends DbTestCase
         foreach (
             [
                 Ticket::class => CommonITILObject::ASSIGNED,
-                Change::class => CommonITILObject::EVALUATION,
+                Change::class => Change::EVALUATION,
                 Problem::class => CommonITILObject::OBSERVED
             ] as $itemtype => $status
         ) {

--- a/phpunit/functional/TicketTest.php
+++ b/phpunit/functional/TicketTest.php
@@ -1982,7 +1982,16 @@ class TicketTest extends DbTestCase
         );
     }
 
-    public function changeTechRights(array $rights)
+    /**
+     * Update tech user rights (and relogin to apply these rights)
+     *
+     * $rights parameter is an array with the following format:
+     * key : object type (e.g. ticket)
+     * value : right (e.g. \Ticket::READNEWTICKET)
+     * @param array<string, int> $rights
+     * @throws \Exception
+     */
+    public function changeTechRights(array $rights): void
     {
         global $DB;
 
@@ -6846,6 +6855,23 @@ HTML
 
         $this->changeTechRight(\Ticket::READNEWTICKET);
         $this->assertTrue($ticket->canViewItem());
+    }
+
+    /**
+     * The right "View new tickets" should not include those with the "approval" status.
+     */
+    public function testUserCannotViewApprovalTicketsWithReadNewTicketRight()
+    {
+        $this->login();
+
+        $ticket = $this->createItem('Ticket', [
+            'name' => __FUNCTION__,
+            'content' => __FUNCTION__,
+            'status' => CommonITILObject::APPROVAL,
+        ]);
+
+        $this->changeTechRights(['ticket' => \Ticket::READNEWTICKET]);
+        $this->assertFalse($ticket->canViewItem());
     }
 
     public function testAssignToMe()

--- a/src/Change.php
+++ b/src/Change.php
@@ -51,7 +51,7 @@ class Change extends CommonITILObject
     public $grouplinkclass              = 'Change_Group';
     public $supplierlinkclass           = 'Change_Supplier';
 
-    public static $rightname                   = 'change';
+    public static $rightname            = 'change';
     protected $usenotepad               = true;
 
     const MATRIX_FIELD                  = 'priority_matrix';
@@ -64,8 +64,11 @@ class Change extends CommonITILObject
     const READALL                       = 1024;
 
    // Specific status for changes
-    const REFUSED                       = 13;
-    const CANCELED                      = 14;
+    public const EVALUATION             = 9;
+    public const TEST                   = 11;
+    public const QUALIFICATION          = 12;
+    public const REFUSED                = 13;
+    public const CANCELED               = 14;
 
     public static function getTypeName($nb = 0)
     {
@@ -703,19 +706,11 @@ class Change extends CommonITILObject
         return $tab;
     }
 
-
-    /**
-     * get the change status list
-     * To be overridden by class
-     *
-     * @param $withmetaforsearch boolean (default false)
-     *
-     * @return array
-     **/
     public static function getAllStatusArray($withmetaforsearch = false)
     {
 
-        $tab = [self::INCOMING      => _x('status', 'New'),
+        $tab = [
+            self::INCOMING      => _x('status', 'New'),
             self::EVALUATION    => __('Evaluation'),
             self::APPROVAL      => _n('Approval', 'Approvals', 1),
             self::ACCEPTED      => _x('status', 'Accepted'),

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -83,20 +83,18 @@ abstract class CommonITILObject extends CommonDBTM
     const STATUS_MATRIX_FIELD  = '';
 
 
-   // STATUS
+   // ITIL Object shared statuses
     const INCOMING      = 1; // new
-    const ASSIGNED      = 2; // assign
-    const PLANNED       = 3; // plan
-    const WAITING       = 4; // waiting
-    const SOLVED        = 5; // solved
-    const CLOSED        = 6; // closed
-    const ACCEPTED      = 7; // accepted
-    const OBSERVED      = 8; // observe
-    const EVALUATION    = 9; // evaluation
-    const APPROVAL      = 10; // approbation
-    const TEST          = 11; // test
-    const QUALIFICATION = 12; // qualification
+    const ASSIGNED      = 2; // processing (assigned)
+    const PLANNED       = 3; // processing (planned)
+    const WAITING       = 4; // pending
+    const SOLVED        = 5;
+    const CLOSED        = 6;
+    const ACCEPTED      = 7;
+    const OBSERVED      = 8;
+    const APPROVAL      = 10; // approval / validation
 
+    // --- timeline position
     const NO_TIMELINE       = -1;
     const TIMELINE_NOTSET   = 0;
     const TIMELINE_LEFT     = 1;
@@ -5132,7 +5130,7 @@ abstract class CommonITILObject extends CommonDBTM
     }
 
     /**
-     * Get status class
+     * Get CSS status class
      *
      * @since 9.3
      *
@@ -5142,12 +5140,12 @@ abstract class CommonITILObject extends CommonDBTM
     {
         $class = match ($status) {
             self::INCOMING, self::WAITING, self::CLOSED => 'circle-filled',
-            self::ASSIGNED, self::SOLVED, self::EVALUATION => 'circle',
+            self::ASSIGNED, self::SOLVED, Change::EVALUATION => 'circle',
             self::PLANNED => 'calendar',
             self::ACCEPTED => 'check-circle-filled',
             self::OBSERVED => 'eye',
-            self::APPROVAL, self::TEST => 'help',
-            self::QUALIFICATION => 'circle',
+            self::APPROVAL, Change::TEST => 'help',
+            Change::QUALIFICATION => 'circle',
             Change::REFUSED => 'circle-x',
             Change::CANCELED => 'ban',
             default => null
@@ -5191,16 +5189,16 @@ abstract class CommonITILObject extends CommonDBTM
             case self::OBSERVED:
                 $key = 'observe';
                 break;
-            case self::EVALUATION:
+            case Change::EVALUATION:
                 $key = 'eval';
                 break;
             case self::APPROVAL:
                 $key = 'approval';
                 break;
-            case self::TEST:
+            case Change::TEST:
                 $key = 'test';
                 break;
-            case self::QUALIFICATION:
+            case Change::QUALIFICATION:
                 $key = 'qualif';
                 break;
         }

--- a/src/Problem.php
+++ b/src/Problem.php
@@ -686,18 +686,10 @@ class Problem extends CommonITILObject
         return $tab;
     }
 
-    /**
-     * get the problem status list
-     *
-     * @param $withmetaforsearch  boolean  (false by default)
-     *
-     * @return array
-     **/
     public static function getAllStatusArray($withmetaforsearch = false)
     {
-
-       // To be overridden by class
-        $tab = [self::INCOMING => _x('status', 'New'),
+        $tab = [
+            self::INCOMING => _x('status', 'New'),
             self::ACCEPTED => _x('status', 'Accepted'),
             self::ASSIGNED => _x('status', 'Processing (assigned)'),
             self::PLANNED  => _x('status', 'Processing (planned)'),

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -254,10 +254,10 @@ class Ticket extends CommonITILObject
             return true;
         }
 
-        // Can see incoming tickets
+        // Can see tickets considered as new (incoming status)
         if (
             Session::haveRight(self::$rightname, self::READNEWTICKET)
-            && ($this->fields["status"] == self::INCOMING)
+            && $this->fields["status"] == self::INCOMING
         ) {
             return true;
         }
@@ -3270,19 +3270,11 @@ JAVASCRIPT;
         }
     }
 
-
-    /**
-     * get the Ticket status list
-     *
-     * @param boolean $withmetaforsearch  (false by default)
-     *
-     * @return array
-     **/
     public static function getAllStatusArray($withmetaforsearch = false)
     {
-
-       // To be overridden by class
-        $tab = [self::INCOMING => _x('status', 'New'),
+        $tab = [
+            self::INCOMING => _x('status', 'New'),
+            self::APPROVAL => _n('Approval', 'Approvals', 1),
             self::ASSIGNED => _x('status', 'Processing (assigned)'),
             self::PLANNED  => _x('status', 'Processing (planned)'),
             self::WAITING  => __('Pending'),
@@ -3297,6 +3289,7 @@ JAVASCRIPT;
             $tab['old']       = _x('status', 'Solved + Closed');
             $tab['all']       = __('All');
         }
+
         return $tab;
     }
 

--- a/templates/components/itilobject/fields_panel.html.twig
+++ b/templates/components/itilobject/fields_panel.html.twig
@@ -192,7 +192,13 @@
             ) }}
             </span>
 
+            {# status #}
             {{ include('components/itilobject/fields/status.html.twig') }}
+
+            {# validation #}
+            {% if item.fields['global_validation'] != 1 %}
+               {{ include('components/itilobject/fields/global_validation.html.twig') }}
+            {% endif %}
 
             {% if item.isField('requesttypes_id') %}
                {{ fields.dropdownField(
@@ -248,8 +254,6 @@
                   field_options
                ) }}
             {% endif %}
-
-            {{ include('components/itilobject/fields/global_validation.html.twig') }}
 
             {% if item.isField('externalid') %}
                {{ fields.textField('externalid', item.fields['externalid'], __('External ID'), field_options) }}


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

`Validation evolution` spec implementation, step 1 : `Pre-validation before arriving in the technicians’ queue`

[x] allow the usage of the `CommonITILObject::APPROVAL` status for tickets (not `ACCEPTED`/`REFUSED`)
[x] adapt "view new tickets" and "See All tickets" rights checks to take this status into account
[x] move "Approval" just below the status field in the right panel of ITIL objects
[x] hide this field when it is set to "Not subject to approval"
[x] check the automation of the rule engine (at least the possibility of sending an approval request) 