### PR TITLE
fix: hide Plan this task in task form for unauthorized users

### DIFF
--- a/templates/components/itilobject/timeline/form_task.html.twig
+++ b/templates/components/itilobject/timeline/form_task.html.twig
@@ -383,8 +383,7 @@
                               <span>{{ __('Unplan') }}</span>
                            </button>
                         {% else %}
-                           {% set can_plan_task = item.isAllowedStatus(item.fields['status'], constant('CommonITILObject::PLANNED')) %}
-                           {% if can_plan_task %}
+                           {% if item.isAllowedStatus(item.fields['status'], constant('CommonITILObject::PLANNED')) %}
                               <button id="plan{{ rand }}" class="btn btn-outline-secondary text-truncate" onclick="showPlanUpdate{{ rand }}()" type="button">
                                  <i class="fas fa-calendar"></i>
                                  <span>{{ __('Plan this task') }}</span>

--- a/templates/components/itilobject/timeline/form_task.html.twig
+++ b/templates/components/itilobject/timeline/form_task.html.twig
@@ -383,10 +383,13 @@
                               <span>{{ __('Unplan') }}</span>
                            </button>
                         {% else %}
-                           <button id="plan{{ rand }}" class="btn btn-outline-secondary text-truncate" onclick="showPlanUpdate{{ rand }}()" type="button">
-                              <i class="fas fa-calendar"></i>
-                              <span>{{ __('Plan this task') }}</span>
-                           </button>
+                           {% set can_plan_task = item.isAllowedStatus(item.fields['status'], constant('CommonITILObject::PLANNED')) %}
+                           {% if can_plan_task %}
+                              <button id="plan{{ rand }}" class="btn btn-outline-secondary text-truncate" onclick="showPlanUpdate{{ rand }}()" type="button">
+                                 <i class="fas fa-calendar"></i>
+                                 <span>{{ __('Plan this task') }}</span>
+                              </button>
+                           {% endif %}
                         {% endif %}
                         <div id="viewplan{{ rand }}"></div>
                      </div>

--- a/templates/components/itilobject/timeline/form_task.html.twig
+++ b/templates/components/itilobject/timeline/form_task.html.twig
@@ -382,13 +382,11 @@
                               <i class="fas ti ti-calendar-off"></i>
                               <span>{{ __('Unplan') }}</span>
                            </button>
-                        {% else %}
-                           {% if item.isAllowedStatus(item.fields['status'], constant('CommonITILObject::PLANNED')) %}
-                              <button id="plan{{ rand }}" class="btn btn-outline-secondary text-truncate" onclick="showPlanUpdate{{ rand }}()" type="button">
-                                 <i class="fas fa-calendar"></i>
-                                 <span>{{ __('Plan this task') }}</span>
-                              </button>
-                           {% endif %}
+                        {% elseif item.isAllowedStatus(item.fields['status'], constant('CommonITILObject::PLANNED')) %}
+                           <button id="plan{{ rand }}" class="btn btn-outline-secondary text-truncate" onclick="showPlanUpdate{{ rand }}()" type="button">
+                              <i class="fas fa-calendar"></i>
+                              <span>{{ __('Plan this task') }}</span>
+                           </button>
                         {% endif %}
                         <div id="viewplan{{ rand }}"></div>
                      </div>


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

This PR allows to remove the "Plan this task" button from the task form if the user does not have permission to assign the status "Planned" to the ticket

![Capture d’écran du 2025-02-24 15-34-14](https://github.com/user-attachments/assets/dc4340f6-e648-41eb-9399-b22f206a0dd1)


- It fixes !36489
- Here is a brief description of what this PR does


