### PR TITLE
Tweak tickets default request criteria

### DIFF
--- a/phpunit/functional/TicketTest.php
+++ b/phpunit/functional/TicketTest.php
@@ -48,11 +48,15 @@ use Group;
 use Group_Ticket;
 use ITILCategory;
 use Monolog\Logger;
+use Profile;
 use Profile_User;
+use ProfileRight;
 use Psr\Log\LogLevel;
+use Search;
 use Supplier;
 use Supplier_Ticket;
 use Symfony\Component\DomCrawler\Crawler;
+use Ticket;
 use Ticket_User;
 use TicketValidation;
 use User;
@@ -7873,5 +7877,80 @@ HTML
         $ticket->getFromDB($tickets_id);
 
         $this->assertEquals(\CommonITILObject::ASSIGNED, $ticket->fields['status']);
+    }
+
+    public function testTechniciansDontSeeSolvedTicketsByDefault(): void
+    {
+        // Make sure the tested profile does not have the right to see all the
+        // tickets to increase the test fidelity.
+        $technician_profile = getItemByTypeName(Profile::class, 'Technician', true);
+        $right = new ProfileRight();
+        $right->getFromDBByCrit([
+            'profiles_id' => $technician_profile,
+            'name'        => Ticket::$rightname,
+        ]);
+        $this->updateItem(ProfileRight::class, $right->getID(), [
+            'rights' => $right->fields['rights'] & ~Ticket::READALL,
+        ]);
+
+        // Need to login before creating the tickets to make sure they will be visible for our user.
+        $this->login('tech', 'tech');
+
+        // Arrange: create 3 open tickets and 2 solved.
+        $entity_id = $this->getTestRootEntity(true);
+        $to_create = [
+            'Ticket 1' => CommonITILObject::INCOMING,
+            'Ticket 2' => CommonITILObject::INCOMING,
+            'Ticket 3' => CommonITILObject::INCOMING,
+            'Ticket 4' => CommonITILObject::SOLVED,
+            'Ticket 5' => CommonITILObject::SOLVED,
+        ];
+        foreach ($to_create as $name => $status) {
+            $this->createItem(Ticket::class, [
+                'name'        => $name,
+                'content'     => '...',
+                'status'      => $status,
+                'entities_id' => $entity_id,
+            ]);
+        }
+
+        // Act: login as "tech" and get tickets using the default search request
+        $criteria = Ticket::getDefaultSearchRequest();
+        $results = Search::getDatas(Ticket::class, $criteria);
+
+        // Assert: only the non solved tickets should be found.
+        $this->assertEquals(3, $results['data']['totalcount']);
+    }
+
+    public function testHelpdeskUsersCanSeeSolvedTicketsByDefault(): void
+    {
+        // Need to login before creating the tickets to make sure they will be visible for our user.
+        $this->login('post-only', 'postonly');
+
+        // Arrange: create 3 open tickets, 2 solved and 1 closed.
+        $entity_id = $this->getTestRootEntity(true);
+        $to_create = [
+            'Ticket 1' => CommonITILObject::INCOMING,
+            'Ticket 2' => CommonITILObject::INCOMING,
+            'Ticket 3' => CommonITILObject::INCOMING,
+            'Ticket 4' => CommonITILObject::SOLVED,
+            'Ticket 5' => CommonITILObject::SOLVED,
+            'Ticket 6' => CommonITILObject::CLOSED,
+        ];
+        foreach ($to_create as $name => $status) {
+            $this->createItem(Ticket::class, [
+                'name'        => $name,
+                'content'     => '...',
+                'status'      => $status,
+                'entities_id' => $entity_id,
+            ]);
+        }
+
+        // Act: Get tickets using the default search request
+        $criteria = Ticket::getDefaultSearchRequest();
+        $results = Search::getDatas(Ticket::class, $criteria);
+
+        // Assert: only the non closed tickets should be found.
+        $this->assertEquals(5, $results['data']['totalcount']);
     }
 }

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -2586,20 +2586,23 @@ class Ticket extends CommonITILObject
      **/
     public static function getDefaultSearchRequest()
     {
-
-        $search = ['criteria' => [0 => ['field'      => 12,
-            'searchtype' => 'equals',
-            'value'      => 'notclosed'
-        ]
-        ],
-            'sort'     => 19,
+        // Technician don't want to be bothered by already solved items.
+        // On the other hand, it make sense for helpdesk users to see their
+        // own solved tickets.
+        $value = Session::getCurrentInterface() == 'central' ? 'notold' : 'notclosed';
+        $request = [
+            'criteria' => [
+                [
+                    'field'      => 12, // Status
+                    'searchtype' => 'equals',
+                    'value'      => $value
+                ]
+            ],
+            'sort'     => 19, // Last update
             'order'    => 'DESC'
         ];
 
-        if (Session::haveRight(self::$rightname, self::READALL)) {
-            $search['criteria'][0]['value'] = 'notold';
-        }
-        return $search;
+        return $request;
     }
 
 


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

The current behavior of `Ticket::getDefaultSearchRequest()` was a bit weird and caused an unexpected side effect for one of our client.

Indeed, it changes the default ticket criteria depending on whether or not the current user can see all the tickets.
It lead to confusion because two technicians will have different criteria if one of them is not allowed to see all tickets.

It feels more natural to tie this behavior to the used interface instead of a specific right.
This way all technicians have the same criteria.

Internal ref: !36367.
