### PR TITLE
feat(forms): Adding default value conversion between selectable question types

### DIFF
--- a/js/modules/Forms/EditorConvertedExtractedSelectableDefaultValue.js
+++ b/js/modules/Forms/EditorConvertedExtractedSelectableDefaultValue.js
@@ -6,7 +6,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2025 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------

--- a/js/modules/Forms/EditorConvertedExtractedSelectableDefaultValue.js
+++ b/js/modules/Forms/EditorConvertedExtractedSelectableDefaultValue.js
@@ -31,50 +31,37 @@
  * ---------------------------------------------------------------------
  */
 
-export class GlpiFormEditorConvertedExtractedDefaultValue
-{
+import { GlpiFormEditorConvertedExtractedDefaultValue, DATATYPE } from "./EditorConvertedExtractedDefaultValue.js";
+
+/**
+ * Represents a converted extracted default value for selectable fields (dropdowns, checkboxes, etc.)
+ *
+ * @extends GlpiFormEditorConvertedExtractedDefaultValue
+ */
+export class GlpiFormEditorConvertedExtractedSelectableDefaultValue extends GlpiFormEditorConvertedExtractedDefaultValue {
     /**
-     * Enum for data types
+     * The selectable options with their values and states
+     * @type {Object<string, {value: string, checked: boolean, uuid: string}>}
+     * @private
      */
-    static DATATYPE = {
-        STRING: 'string',
-        ARRAY_OF_STRINGS: 'array_of_strings',
-        DROPDOWN_ID: 'dropdown_id',
-        ARRAY_OF_DROPDOWN_IDS: 'array_of_dropdown_ids',
-    };
+    #options;
 
     /**
-     * @type {string}
+     * Creates a new selectable default value instance
+     *
+     * @param {Object<string, {value: string, checked: boolean, uuid: string}>} options - The selectable options
      */
-    #datatype;
-
-    /**
-     * @type {mixed}
-     */
-    #defaultValue;
-
-    /**
-     * @param {string} datatype
-     * @param {mixed} defaultValue
-     */
-    constructor(datatype, defaultValue) {
-        this.#datatype = datatype;
-        this.#defaultValue = defaultValue;
+    constructor(options) {
+        super(DATATYPE.ARRAY_OF_STRINGS, Object.entries(options).map((values) => values[1].value));
+        this.#options = options;
     }
 
     /**
-     * @returns {string}
+     * Gets the selectable options
+     *
+     * @returns {Object<string, {value: string, checked: boolean, uuid: string}>} The options
      */
-    getDatatype() {
-        return this.#datatype;
-    }
-
-    /**
-     * @returns {mixed}
-     */
-    getDefaultValue() {
-        return this.#defaultValue;
+    getOptions() {
+        return this.#options;
     }
 }
-
-export const DATATYPE = GlpiFormEditorConvertedExtractedDefaultValue.DATATYPE;

--- a/src/Glpi/Form/QuestionType/QuestionTypeDropdown.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeDropdown.php
@@ -93,12 +93,18 @@ final class QuestionTypeDropdown extends AbstractQuestionTypeSelectable
             import("{{ js_path('js/modules/Forms/QuestionDropdown.js') }}").then((m) => {
                 {% if question is not null %}
                     const container = $('div[data-glpi-form-editor-selectable-question-options="{{ rand }}"]');
-                    new m.GlpiFormQuestionTypeDropdown('{{ input_type|escape('js') }}', container);
+                    container.data(
+                        'manager',
+                        new m.GlpiFormQuestionTypeDropdown('{{ input_type|escape('js') }}', container)
+                    );
                 {% else %}
                     $(document).on('glpi-form-editor-question-type-changed', function(e, question, type) {
                         if (type === '{{ question_type|escape('js') }}') {
                             const container = question.find('div[data-glpi-form-editor-selectable-question-options]');
-                            new m.GlpiFormQuestionTypeDropdown('{{ input_type|escape('js') }}', container);
+                            container.data(
+                                'manager',
+                                new m.GlpiFormQuestionTypeDropdown('{{ input_type|escape('js') }}', container)
+                            );
                         }
                     });
 
@@ -106,7 +112,10 @@ final class QuestionTypeDropdown extends AbstractQuestionTypeSelectable
                         const question_type = question.find('input[data-glpi-form-editor-original-name="type"]').val();
                         if (question_type === '{{ question_type|escape('js') }}') {
                             const container = new_question.find('div[data-glpi-form-editor-selectable-question-options]');
-                            new m.GlpiFormQuestionTypeDropdown('{{ input_type|escape('js') }}', container);
+                            container.data(
+                                'manager',
+                                new m.GlpiFormQuestionTypeDropdown('{{ input_type|escape('js') }}', container)
+                            );
                         }
                     });
                 {% endif %}

--- a/templates/pages/admin/form/form_editor.html.twig
+++ b/templates/pages/admin/form/form_editor.html.twig
@@ -383,10 +383,12 @@
 (async () => {
     const modules = await Promise.all([
         import("{{ js_path('js/modules/Forms/EditorController.js') }}"),
-        import("{{ js_path('js/modules/Forms/EditorConvertedExtractedDefaultValue.js') }}")
+        import("{{ js_path('js/modules/Forms/EditorConvertedExtractedDefaultValue.js') }}"),
+        import("{{ js_path('js/modules/Forms/EditorConvertedExtractedSelectableDefaultValue.js') }}")
     ]);
     const GlpiFormEditorController = modules[0].GlpiFormEditorController;
     const EditorConvertedExtractedDefaultValue = modules[1].GlpiFormEditorConvertedExtractedDefaultValue;
+    const EditorConvertedExtractedSelectableDefaultValue = modules[2].GlpiFormEditorConvertedExtractedSelectableDefaultValue;
 
     const container_selector = "[data-glpi-form-editor-container]";
     const controller = new GlpiFormEditorController(
@@ -399,6 +401,7 @@
     // Temporary solution, would be better to import it directly where it is needed but the current
     // design doesn't allow it.
     $(container_selector).data('EditorConvertedExtractedDefaultValue', EditorConvertedExtractedDefaultValue);
+    $(container_selector).data('EditorConvertedExtractedSelectableDefaultValue', EditorConvertedExtractedSelectableDefaultValue);
 
     {% for question_type in question_types_manager.getQuestionTypes() %}
         controller.registerQuestionTypeOptions(

--- a/tests/cypress/e2e/form/form_convert_default_values.cy.js
+++ b/tests/cypress/e2e/form/form_convert_default_values.cy.js
@@ -117,4 +117,120 @@ describe('Convert default value form', () => {
         // Check if default value has been converted
         cy.findByRole('textbox', { name: 'Default value' }).should('have.value', default_value.replace(/\n/g, ''));
     });
+
+    it('test convert default value between radio and checkbox types', () => {
+        // Start with a "Radio" question type
+        cy.getDropdownByLabelText('Question type').selectDropdownValue('Radio');
+
+        // Add some options and check the second one as default
+        cy.findByRole('textbox', { name: 'Selectable option' }).type('Option 1');
+        cy.findAllByRole('textbox', { name: 'Selectable option' }).eq(1).type('Option 2');
+        cy.findAllByRole('textbox', { name: 'Selectable option' }).eq(2).type('Option 3');
+
+        // Check the second option
+        cy.findAllByRole('radio', { name: 'Default option' }).eq(1).check();
+
+        // Switch to Checkbox type
+        cy.getDropdownByLabelText('Question type').selectDropdownValue('Checkbox');
+
+        // The second option should remain checked and inputs should now be checkboxes
+        cy.findAllByRole('checkbox', { name: 'Default option' }).eq(1).should('be.checked');
+        cy.findAllByRole('checkbox', { name: 'Default option' }).should('have.length', 4);
+        cy.findAllByRole('checkbox', { name: 'Default option' }).eq(3).should('be.disabled');
+
+        // Switch back to radio type
+        cy.getDropdownByLabelText('Question type').selectDropdownValue('Radio');
+
+        // Verify the second option is still checked and inputs are back to radio
+        cy.findAllByRole('radio', { name: 'Default option' }).eq(1).should('be.checked');
+        cy.findAllByRole('radio', { name: 'Default option' }).should('have.length', 4);
+        cy.findAllByRole('radio', { name: 'Default option' }).eq(3).should('be.disabled');
+
+        // Save the form
+        cy.findByRole('button', { name: 'Save' }).click();
+
+        // Reload the page
+        cy.reload();
+
+        // Check if the default value is still the same
+        cy.findAllByRole('radio', { name: 'Default option' }).eq(1).should('be.checked');
+        cy.findAllByRole('radio', { name: 'Default option' }).should('have.length', 3);
+        cy.findAllByRole('radio', { name: 'Default option' }).should('not.be.disabled');
+        cy.findAllByRole('textbox', { name: 'Selectable option' }).should('not.have.value', '');
+    });
+
+    it('test convert default value between checkbox and dropdown type', () => {
+        // Start with a "Checkbox" question type
+        cy.getDropdownByLabelText('Question type').selectDropdownValue('Checkbox');
+
+        // Add some options and check the second one as default
+        cy.findByRole('textbox', { name: 'Selectable option' }).type('Option 1');
+        cy.findAllByRole('textbox', { name: 'Selectable option' }).eq(1).type('Option 2');
+        cy.findAllByRole('textbox', { name: 'Selectable option' }).eq(2).type('Option 3');
+
+        // Check the second option
+        cy.findAllByRole('checkbox', { name: 'Default option' }).eq(1).check();
+
+        // Switch to Dropdown type
+        cy.getDropdownByLabelText('Question type').selectDropdownValue('Dropdown');
+
+        // The second option should remain checked and inputs should now be checkboxes
+        cy.getDropdownByLabelText('Default option').should('have.text', 'Option 2');
+
+        // Switch back to checkbox type
+        cy.getDropdownByLabelText('Question type').selectDropdownValue('Checkbox');
+
+        // Verify the second option is still checked and inputs are back to radio
+        cy.findAllByRole('checkbox', { name: 'Default option' }).eq(1).should('be.checked');
+        cy.findAllByRole('checkbox', { name: 'Default option' }).should('have.length', 4);
+        cy.findAllByRole('checkbox', { name: 'Default option' }).eq(3).should('be.disabled');
+
+        // Save the form
+        cy.findByRole('button', { name: 'Save' }).click();
+
+        // Reload the page
+        cy.reload();
+
+        // Check if the default value is still the same
+        cy.findAllByRole('checkbox', { name: 'Default option' }).eq(1).should('be.checked');
+        cy.findAllByRole('checkbox', { name: 'Default option' }).should('have.length', 3);
+        cy.findAllByRole('checkbox', { name: 'Default option' }).should('not.be.disabled');
+        cy.findAllByRole('textbox', { name: 'Selectable option' }).should('not.have.value', '');
+    });
+
+    it('test convert default value between dropdown and radio type', () => {
+        // Start with a "Dropdown" question type
+        cy.getDropdownByLabelText('Question type').selectDropdownValue('Dropdown');
+
+        // Add some options and check the second one as default
+        cy.findByRole('textbox', { name: 'Selectable option' }).type('Option 1');
+        cy.findAllByRole('textbox', { name: 'Selectable option' }).eq(1).type('Option 2');
+        cy.findAllByRole('textbox', { name: 'Selectable option' }).eq(2).type('Option 3');
+
+        // Check the second option
+        cy.getDropdownByLabelText('Default option').selectDropdownValue('Option 2');
+
+        // Switch to Radio type
+        cy.getDropdownByLabelText('Question type').selectDropdownValue('Radio');
+
+        // The second option should remain checked and inputs should now be checkboxes
+        cy.findAllByRole('radio', { name: 'Default option' }).eq(1).should('be.checked');
+        cy.findAllByRole('radio', { name: 'Default option' }).should('have.length', 4);
+        cy.findAllByRole('radio', { name: 'Default option' }).eq(3).should('be.disabled');
+
+        // Switch back to dropdown type
+        cy.getDropdownByLabelText('Question type').selectDropdownValue('Dropdown');
+
+        // Verify the second option is still checked and inputs are back to radio
+        cy.getDropdownByLabelText('Default option').should('have.text', 'Option 2');
+
+        // Save the form
+        cy.findByRole('button', { name: 'Save' }).click();
+
+        // Reload the page
+        cy.reload();
+
+        // Check if the default value is still the same
+        cy.getDropdownByLabelText('Default option').should('have.text', 'Option 2');
+    });
 });


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Improve the form editor by adding support for converting default values between selectable question types (radio, checkbox, dropdown).

Now when switching between these types, the selected options and their states are properly preserved, providing a better user experience when editing forms.
