### PR TITLE
Fix the retrieval of rule actions to include those from hooks

### DIFF
--- a/src/RuleTicket.php
+++ b/src/RuleTicket.php
@@ -291,7 +291,7 @@ class RuleTicket extends Rule
                         break;
 
                     case "append":
-                        $actions = $this->getActions();
+                        $actions = $this->getAllActions();
                         $value   = $action->fields["value"];
                         if (
                             isset($actions[$action->fields["field"]]["appendtoarray"])


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !36508
- Here is a brief description of what this PR does

**_Detected by Tag plugin issue_**

The processing of rule actions is limited to GLPI core actions, and does not include plugin actions (via hooks). This PR adds plugin actions.
From `getActions()` to `getAllActions()`