### PR TITLE
Fix generic assets trashbin feature

### DIFF
--- a/front/asset/asset.form.php
+++ b/front/asset/asset.form.php
@@ -105,7 +105,7 @@ if (isset($_POST['add'])) {
     $asset->redirectToList();
 } elseif (isset($_POST['purge'])) {
     $asset->check($_POST['id'], PURGE);
-    if ($asset->delete($_POST)) {
+    if ($asset->delete($_POST, 1)) {
         Event::log(
             $_POST['id'],
             $asset::class,

--- a/src/Glpi/Asset/Asset.php
+++ b/src/Glpi/Asset/Asset.php
@@ -102,6 +102,11 @@ abstract class Asset extends CommonDBTM
         return ['assets', static::getDefinition()->getAssetClassName()];
     }
 
+    public function useDeletedToLockIfDynamic()
+    {
+        return false;
+    }
+
     public function rawSearchOptions()
     {
         $search_options = parent::rawSearchOptions();


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

1. To be able to use the trashbin on inventoriable assets, it is necessary to override the `useDeletedToLockIfDynamic` method.
2. The purge action was not working as expected.