### PR TITLE
feat: Include asset name in rule engine processing

### DIFF
--- a/src/RuleAsset.php
+++ b/src/RuleAsset.php
@@ -181,9 +181,6 @@ class RuleAsset extends Rule
     {
         $actions                                = parent::getActions();
 
-        $actions['name']['name']              = __('Name');
-        $actions['name']['type']              = 'text';
-
         $actions['states_id']['name']           = __('Status');
         $actions['states_id']['type']           = 'dropdown';
         $actions['states_id']['table']          = 'glpi_states';

--- a/src/RuleAsset.php
+++ b/src/RuleAsset.php
@@ -89,6 +89,9 @@ class RuleAsset extends Rule
             return $criterias;
         }
 
+        $criterias['name']['name']              = __('Name');
+        $criterias['name']['type']              = 'text';
+
         $criterias['_auto']['name']            = __('Automatic inventory');
         $criterias['_auto']['type']            = 'yesno';
         $criterias['_auto']['table']           = '';
@@ -177,6 +180,9 @@ class RuleAsset extends Rule
     public function getActions()
     {
         $actions                                = parent::getActions();
+
+        $actions['name']['name']              = __('Name');
+        $actions['name']['type']              = 'text';
 
         $actions['states_id']['name']           = __('Status');
         $actions['states_id']['type']           = 'dropdown';


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !36441
- This PR adds the ability to select in the assets rule engine, the name of the element in the criteria and actions.

## Screenshots (if appropriate):

![Capture d’écran du 2025-02-27 09-45-00](https://github.com/user-attachments/assets/e8d9ba03-f4bb-43e0-bb48-490a4dbf27d7)



