### PR TITLE
Do not call defineTabs from webhooks

### DIFF
--- a/src/QueuedWebhook.php
+++ b/src/QueuedWebhook.php
@@ -255,10 +255,8 @@ class QueuedWebhook extends CommonDBChild
                 $itemtype = $queued_webhook->fields['itemtype'];
                 $item = new $itemtype();
                 $item->getFromDB($queued_webhook->fields['items_id']);
-                $tabs = $item->defineTabs();
-                $has_history_tab = array_key_exists('Log$1', $tabs);
 
-                if ($has_history_tab) {
+                if ($item->dohistory) {
                     Log::history($queued_webhook->fields['items_id'], $queued_webhook->fields['itemtype'], [
                         30, $queued_webhook->fields['last_status_code'], $response->getStatusCode()
                     ], $queued_webhook->fields['id'], Log::HISTORY_SEND_WEBHOOK);


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Webhooks are sent inside an automatic action which may be triggered externally or under any user account. The `defineTabs` method in some cases relies on permission checks, notably CommonITILObject, which leads to PHP warnings and unexpected behavior. Instead of defining the tabs and checking them to see if a History tab exists, it should still be OK to simply check the `dohistory` property.

Part of !35208