### PR TITLE
Fix CLI database install command to support ssl

### DIFF
--- a/src/Console/Database/InstallCommand.php
+++ b/src/Console/Database/InstallCommand.php
@@ -9,6 +9,7 @@
  *
  * @copyright 2015-2025 Teclib' and contributors.
  * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @copyright 2025 Kyndryl Inc.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -230,12 +231,22 @@ class InstallCommand extends AbstractConfigureCommand implements ConfigurationCo
 
         mysqli_report(MYSQLI_REPORT_OFF);
         $mysqli = new \mysqli();
+        if ($this->db->dbssl) {
+            // set ssl config
+            $mysqli->ssl_set(
+                $this->db->dbsslkey,
+                $this->db->dbsslcert,
+                $this->db->dbsslca,
+                $this->db->dbsslcapath,
+                $this->db->dbsslcacipher
+            );
+        }
         if (intval($db_port) > 0) {
            // Network port
-            @$mysqli->connect($db_host, $db_user, $db_pass, null, $db_port);
+            @$mysqli->real_connect($db_host, $db_user, $db_pass, null, $db_port);
         } else {
            // Unix Domain Socket
-            @$mysqli->connect($db_host, $db_user, $db_pass, null, 0, $db_port);
+            @$mysqli->real_connect($db_host, $db_user, $db_pass, null, 0, $db_port);
         }
 
         if (0 !== $mysqli->connect_errno) {


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

- It fixes #19080 (issue number, if applicable)
- The GLPI CLI command `bin/console db:install` will be able to support SSL enabled connection config on `config_db.php` when installing GLPI database.

## Screenshots (if appropriate):

n/a

## Comment
As just following our company's OSS contribution rule, please allow to add copyright line.