### PR TITLE
Use dedicated hanlders class instead of traits for forms conditions

### DIFF
--- a/src/Glpi/Form/Condition/ConditionHandler/ConditionHandlerInterface.php
+++ b/src/Glpi/Form/Condition/ConditionHandler/ConditionHandlerInterface.php
@@ -32,48 +32,21 @@
  * ---------------------------------------------------------------------
  */
 
-namespace Glpi\Form\Condition;
+namespace Glpi\Form\Condition\ConditionHandler;
 
-use Override;
+use Glpi\Form\Condition\InputTemplateKey;
+use Glpi\Form\Condition\ValueOperator;
 
-trait StringConditionTrait
+interface ConditionHandlerInterface
 {
-    #[Override]
-    public function getSupportedValueOperators(): array
-    {
-        return [
-            ValueOperator::EQUALS,
-            ValueOperator::NOT_EQUALS,
-            ValueOperator::CONTAINS,
-            ValueOperator::NOT_CONTAINS,
-        ];
-    }
+    /** @return ValueOperator[] */
+    public function getSupportedValueOperators(): array;
 
-    #[Override]
-    public function getInputTemplateKey(): InputTemplateKey
-    {
-        return InputTemplateKey::STRING;
-    }
+    public function getInputTemplateKey(): InputTemplateKey;
 
-    #[Override]
     public function applyValueOperator(
         mixed $a,
         ValueOperator $operator,
         mixed $b,
-    ): bool {
-        // Normalize strings.
-        $a = strtolower(strval($a));
-        $b = strtolower(strval($b));
-
-        return match ($operator) {
-            ValueOperator::EQUALS       => $a === $b,
-            ValueOperator::NOT_EQUALS   => $a !== $b,
-            ValueOperator::CONTAINS     => str_contains($b, $a),
-            ValueOperator::NOT_CONTAINS => !str_contains($b, $a),
-
-            // Unsupported operators
-            ValueOperator::GREATER_THAN, ValueOperator::GREATER_THAN_OR_EQUALS => false,
-            ValueOperator::LESS_THAN, ValueOperator::LESS_THAN_OR_EQUALS => false,
-        };
-    }
+    ): bool;
 }

--- a/src/Glpi/Form/Condition/ConditionHandler/NumberConditionHandler.php
+++ b/src/Glpi/Form/Condition/ConditionHandler/NumberConditionHandler.php
@@ -32,11 +32,13 @@
  * ---------------------------------------------------------------------
  */
 
-namespace Glpi\Form\Condition;
+namespace Glpi\Form\Condition\ConditionHandler;
 
+use Glpi\Form\Condition\InputTemplateKey;
+use Glpi\Form\Condition\ValueOperator;
 use Override;
 
-trait NumberConditionTrait
+final class NumberConditionHandler implements ConditionHandlerInterface
 {
     #[Override]
     public function getSupportedValueOperators(): array

--- a/src/Glpi/Form/Condition/ConditionHandler/StringConditionHandler.php
+++ b/src/Glpi/Form/Condition/ConditionHandler/StringConditionHandler.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Form\Condition\ConditionHandler;
+
+use Glpi\Form\Condition\InputTemplateKey;
+use Glpi\Form\Condition\ValueOperator;
+use Override;
+
+final class StringConditionHandler implements ConditionHandlerInterface
+{
+    #[Override]
+    public function getSupportedValueOperators(): array
+    {
+        return [
+            ValueOperator::EQUALS,
+            ValueOperator::NOT_EQUALS,
+            ValueOperator::CONTAINS,
+            ValueOperator::NOT_CONTAINS,
+        ];
+    }
+
+    #[Override]
+    public function getInputTemplateKey(): InputTemplateKey
+    {
+        return InputTemplateKey::STRING;
+    }
+
+    #[Override]
+    public function applyValueOperator(
+        mixed $a,
+        ValueOperator $operator,
+        mixed $b,
+    ): bool {
+        // Normalize strings.
+        $a = strtolower(strval($a));
+        $b = strtolower(strval($b));
+
+        return match ($operator) {
+            ValueOperator::EQUALS       => $a === $b,
+            ValueOperator::NOT_EQUALS   => $a !== $b,
+            ValueOperator::CONTAINS     => str_contains($b, $a),
+            ValueOperator::NOT_CONTAINS => !str_contains($b, $a),
+
+            // Unsupported operators
+            ValueOperator::GREATER_THAN, ValueOperator::GREATER_THAN_OR_EQUALS => false,
+            ValueOperator::LESS_THAN, ValueOperator::LESS_THAN_OR_EQUALS => false,
+        };
+    }
+}

--- a/src/Glpi/Form/Condition/EditorManager.php
+++ b/src/Glpi/Form/Condition/EditorManager.php
@@ -125,7 +125,7 @@ final class EditorManager
 
         // Load possible value operators
         $dropdown_values = [];
-        foreach ($type->getSupportedValueOperators() as $operator) {
+        foreach ($type->getConditionHandler()->getSupportedValueOperators() as $operator) {
             $dropdown_values[$operator->value] = $operator->getLabel();
         }
 
@@ -144,7 +144,7 @@ final class EditorManager
         $type = $question->getType();
 
         if ($type instanceof UsedAsCriteriaInterface) {
-            return $type->getInputTemplateKey();
+            return $type->getConditionHandler()->getInputTemplateKey();
         }
 
         // Safe fallback

--- a/src/Glpi/Form/Condition/Engine.php
+++ b/src/Glpi/Form/Condition/Engine.php
@@ -141,7 +141,7 @@ final class Engine
             return false;
         }
 
-        return $question_type->applyValueOperator(
+        return $question_type->getConditionHandler()->applyValueOperator(
             $answer,
             $condition->getValueOperator(),
             $condition->getValue(),

--- a/src/Glpi/Form/Condition/UsedAsCriteriaInterface.php
+++ b/src/Glpi/Form/Condition/UsedAsCriteriaInterface.php
@@ -34,19 +34,12 @@
 
 namespace Glpi\Form\Condition;
 
+use Glpi\Form\Condition\ConditionHandler\ConditionHandlerInterface;
+
 /**
  * Items that implements this interface can be used as a criteria in a condition.
  */
 interface UsedAsCriteriaInterface
 {
-    /** @return ValueOperator[] */
-    public function getSupportedValueOperators(): array;
-
-    public function getInputTemplateKey(): InputTemplateKey;
-
-    public function applyValueOperator(
-        mixed $a,
-        ValueOperator $operator,
-        mixed $b,
-    ): bool;
+    public function getConditionHandler(): ConditionHandlerInterface;
 }

--- a/src/Glpi/Form/QuestionType/QuestionTypeEmail.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeEmail.php
@@ -35,15 +35,14 @@
 
 namespace Glpi\Form\QuestionType;
 
-use Glpi\Form\Condition\StringConditionTrait;
+use Glpi\Form\Condition\ConditionHandler\ConditionHandlerInterface;
+use Glpi\Form\Condition\ConditionHandler\StringConditionHandler;
 use Glpi\Form\Condition\UsedAsCriteriaInterface;
 use Override;
 use Session;
 
 final class QuestionTypeEmail extends AbstractQuestionTypeShortAnswer implements UsedAsCriteriaInterface
 {
-    use StringConditionTrait;
-
     #[Override]
     public function getInputType(): string
     {
@@ -66,5 +65,11 @@ final class QuestionTypeEmail extends AbstractQuestionTypeShortAnswer implements
     public function getWeight(): int
     {
         return 20;
+    }
+
+    #[Override]
+    public function getConditionHandler(): ConditionHandlerInterface
+    {
+        return new StringConditionHandler();
     }
 }

--- a/src/Glpi/Form/QuestionType/QuestionTypeNumber.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeNumber.php
@@ -35,14 +35,13 @@
 
 namespace Glpi\Form\QuestionType;
 
-use Glpi\Form\Condition\NumberConditionTrait;
+use Glpi\Form\Condition\ConditionHandler\ConditionHandlerInterface;
+use Glpi\Form\Condition\ConditionHandler\NumberConditionHandler;
 use Glpi\Form\Condition\UsedAsCriteriaInterface;
 use Override;
 
 final class QuestionTypeNumber extends AbstractQuestionTypeShortAnswer implements UsedAsCriteriaInterface
 {
-    use NumberConditionTrait;
-
     #[Override]
     public function getInputType(): string
     {
@@ -71,5 +70,11 @@ final class QuestionTypeNumber extends AbstractQuestionTypeShortAnswer implement
     public function getInputAttributes(): array
     {
         return ['step' => 'any'];
+    }
+
+    #[Override]
+    public function getConditionHandler(): ConditionHandlerInterface
+    {
+        return new NumberConditionHandler();
     }
 }

--- a/src/Glpi/Form/QuestionType/QuestionTypeShortText.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeShortText.php
@@ -35,14 +35,13 @@
 
 namespace Glpi\Form\QuestionType;
 
-use Glpi\Form\Condition\StringConditionTrait;
+use Glpi\Form\Condition\ConditionHandler\ConditionHandlerInterface;
+use Glpi\Form\Condition\ConditionHandler\StringConditionHandler;
 use Glpi\Form\Condition\UsedAsCriteriaInterface;
 use Override;
 
 final class QuestionTypeShortText extends AbstractQuestionTypeShortAnswer implements UsedAsCriteriaInterface
 {
-    use StringConditionTrait;
-
     #[Override]
     public function getInputType(): string
     {
@@ -65,5 +64,11 @@ final class QuestionTypeShortText extends AbstractQuestionTypeShortAnswer implem
     public function getWeight(): int
     {
         return 10;
+    }
+
+    #[Override]
+    public function getConditionHandler(): ConditionHandlerInterface
+    {
+        return new StringConditionHandler();
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
_-> No functional change._

## Description

While working on conditions I realized we are going to need to pick a different condition handler depending on the question parameters (e.g. the datetime question can contain only the time or the date or both depending on the options).

Doing this with traits in not ideal because you can't conditionally import one trait instead of another depending on the questions parameters.

With a dedicated `getConditionHandler()` method, we are free to do any computation we want to pick the right handler.
