### PR TITLE
Fix missing hidden fields needed for bulk kanban adds

### DIFF
--- a/js/src/vue/Kanban/Column.vue
+++ b/js/src/vue/Kanban/Column.vue
@@ -119,12 +119,19 @@
             itemtype_data: structuredClone(props.supported_itemtypes[itemtype]),
         };
         if (bulk) {
-            opened_form_data.value.itemtype_data.fields = {
-                bulk_item_list: {
-                    type: 'textarea',
-                    value: '',
+            const new_fields = opened_form_data.value.itemtype_data.fields;
+            // Delete all non-hidden fields
+            $.each(new_fields, (name, options) => {
+                if (options.type !== 'hidden') {
+                    delete new_fields[name];
                 }
+            });
+            // Add a textarea for the bulk item list
+            new_fields.bulk_item_list = {
+                type: 'textarea',
+                value: ''
             };
+            opened_form_data.value.itemtype_data.fields = new_fields;
         }
     }
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Missing hidden fields like `projects_id` was causing the creation of items in non-global Kanbans to fail or occur without the correct parent association. As far as I know, it only affects the Vue rewrite of the Kanban, so not GLPI 10.

No tests added here as the Kanabn lacks any Jest (issues importing some of the JS needed) or E2E tests at the moment. I am working on them for a different PR.