### PR TITLE
Fix duplicate dashboards that replace other copies

### DIFF
--- a/phpunit/functional/Glpi/Dashboard/DashboardTest.php
+++ b/phpunit/functional/Glpi/Dashboard/DashboardTest.php
@@ -138,20 +138,17 @@ class DashboardTest extends DbTestCase
     public function testClone()
     {
         $clone_name = sprintf(__('Copy of %s'), "Test_Dashboard");
-        $clone_key  = \Toolbox::slugify($clone_name);
-        $this->assertEquals(
-            [
-                'title' => $clone_name,
-                'key'   => $clone_key
-            ],
-            $this->dashboard->cloneCurrent()
-        );
+        $clone_key_prefix = \Toolbox::slugify($clone_name);
+        $clone = $this->dashboard->cloneCurrent();
 
-        $this->assertTrue($this->dashboard->getFromDB($clone_key));
+        $this->assertEquals($clone_name, $clone['title']);
+
+        $this->assertStringStartsWith($clone_key_prefix, $clone['key']);
+
+        $this->assertTrue($this->dashboard->getFromDB($clone['key']));
         $this->assertEquals('core', $this->dashboard->fields['context']);
 
-        $this->assertEquals($clone_key, $this->getPrivateProperty('key'));
-        $this->assertEquals($clone_key, $this->getPrivateProperty('key'));
+        $this->assertEquals($clone['key'], $this->getPrivateProperty('key'));
         $items = $this->getPrivateProperty('items');
         $this->assertCount(3, $items);
         $this->assertCount(4, $this->getPrivateProperty('rights'));

--- a/phpunit/functional/Glpi/Dashboard/DashboardTest.php
+++ b/phpunit/functional/Glpi/Dashboard/DashboardTest.php
@@ -159,6 +159,26 @@ class DashboardTest extends DbTestCase
         }
     }
 
+    public function testCloneKeyUnicity()
+    {
+        $num_clones = 5;
+
+        $keys = [];
+
+        for ($i = 0; $i < $num_clones; $i++) {
+            $this->dashboard = new \Glpi\Dashboard\Dashboard('test_dashboard');
+
+            $clone = $this->dashboard->cloneCurrent();
+            $keys[] = $clone['key'];
+        }
+
+        $unique_keys = array_unique($keys);
+
+        $this->assertCount($num_clones, $unique_keys);
+
+        $this->assertEquals(count($keys), count($unique_keys));
+    }
+
 
     public function testGetAll()
     {

--- a/phpunit/functional/Glpi/Dashboard/DashboardTest.php
+++ b/phpunit/functional/Glpi/Dashboard/DashboardTest.php
@@ -162,14 +162,17 @@ class DashboardTest extends DbTestCase
     public function testCloneKeyUnicity()
     {
         $num_clones = 5;
+        $original_key = 'test_dashboard';
+        $this->dashboard = new \Glpi\Dashboard\Dashboard($original_key);
 
         $keys = [];
 
         for ($i = 0; $i < $num_clones; $i++) {
-            $this->dashboard = new \Glpi\Dashboard\Dashboard('test_dashboard');
-
+            $this->dashboard->load(true);
             $clone = $this->dashboard->cloneCurrent();
             $keys[] = $clone['key'];
+
+            $this->assertNotEquals($original_key, $clone['key']);
         }
 
         $unique_keys = array_unique($keys);

--- a/src/Dashboard/Dashboard.php
+++ b/src/Dashboard/Dashboard.php
@@ -387,7 +387,7 @@ class Dashboard extends \CommonDBTM
 
         $this->fields['name'] = sprintf(__('Copy of %s'), $this->fields['name']);
         $this->fields['users_id'] = Session::getLoginUserID();
-        $this->key = \Toolbox::slugify($this->fields['name']);
+        $this->key = \Toolbox::slugify($this->fields['name']) . '-' . Uuid::uuid4()->toString();
 
        // replace gridstack_id (with uuid V4) in the copy, to avoid cache issue
         $this->items = array_map(function (array $item) {


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !36527
- Here is a brief description of what this PR does

### Issue
When two different users duplicated the same dashboard, they received identical keys for their copies, causing the second duplication to overwrite the first one in the database.

### Fix
Modified the `cloneCurrent()` method in Dashboard.php to generate a unique key for each dashboard copy by incorporating a UUID, ensuring each duplicated dashboard receives a unique identifier regardless of the dashboard name.