### PR TITLE
fix generated sql when Ticket::READMY is missing

### DIFF
--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -904,9 +904,7 @@ final class SQLProvider implements SearchProviderInterface
                             ];
                         }
                     } else {
-                        $criteria['OR'][] = [
-                            '0' => '1'
-                        ];
+                        $criteria['OR'][] = new QueryExpression('false');
                     }
                 }
                 break;
@@ -932,9 +930,7 @@ final class SQLProvider implements SearchProviderInterface
 
                 // If the user can't see public and private
                 if (!count($allowed_is_private)) {
-                    $criteria = [
-                        '0' => '1'
-                    ];
+                    $criteria = new QueryExpression('false');
                     break;
                 }
 
@@ -969,9 +965,7 @@ final class SQLProvider implements SearchProviderInterface
 
                 // If the user can't see public and private
                 if (!count($allowed_is_private)) {
-                    $criteria = [
-                        '0' => '1'
-                    ];
+                    $criteria = new QueryExpression('false');
                     break;
                 }
 

--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -782,7 +782,7 @@ final class SQLProvider implements SearchProviderInterface
                             ]
                         ];
                     } else {
-                        $criteria['OR'][] = "0";
+                        $criteria['OR'][] = new QueryExpression('false');
                     }
 
                     if (Session::haveRight("ticket", \Ticket::READGROUP)) {

--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -782,9 +782,7 @@ final class SQLProvider implements SearchProviderInterface
                             ]
                         ];
                     } else {
-                        $criteria['OR'][] = [
-                            '0' => '1'
-                        ];
+                        $criteria['OR'][] = "0";
                     }
 
                     if (Session::haveRight("ticket", \Ticket::READGROUP)) {


### PR DESCRIPTION
## Description

- Detected by @SebSept while working on #19048 
- in 10.0.18, where it works, the line is "1=0" to force a false condition (see https://github.com/glpi-project/glpi/blob/10.0.18/src/Search.php#L4424), and the current proposal resolves to true and so a lot of tickets appears without the right in session
- the bug probably started from #13072

Note: I'm note sure this is the best way to force a false SQL condition