### PR TITLE
todo list was broken

### DIFF
--- a/css/includes/components/itilobject/_timeline.scss
+++ b/css/includes/components/itilobject/_timeline.scss
@@ -483,6 +483,7 @@
             transition: all 200ms ease;
 
             .todo-list-state {
+                margin-top: .8rem;
                 order: inherit !important;
                 margin-left: 0.5rem !important;
             }
@@ -515,6 +516,14 @@
                         flex-direction: row-reverse;
                         justify-content: space-between;
 
+                        .timeline-header {
+                            margin-bottom: 0;
+
+                            .timeline-item-buttons {
+                                margin-top: 0;
+                            }
+                        }
+
                         .read-only-content {
                             .state {
                                 display: none;
@@ -528,6 +537,10 @@
 
                             &.done {
                                 text-decoration: line-through;
+                            }
+
+                            .timeline-badges {
+                                display: none;
                             }
                         }
                     }


### PR DESCRIPTION
The todo list mode was expected to be compact. With some recent changes, a few div appear where they should not.
I didn't check the main branch, but let me know if dedicated work is required

## Screenshots (if appropriate):

Before:
![image](https://github.com/user-attachments/assets/12c2a39a-cd0e-4e1f-98c9-5cc8a65328d7)

After
![image](https://github.com/user-attachments/assets/ddec4c67-652c-4273-8fbb-79f8ccf1fc17)

Not the same picture, but you should see the changes
