### PR TITLE
Prepare the work for FunctionalTesting using Symfony's WebTestCase

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,5 +20,7 @@
   <php>
     <!-- Code coverage requires about 1.5GB of memory. -->
     <ini name="memory_limit" value="2G" />
+    <env name="KERNEL_CLASS" value="Glpi\Kernel\Kernel" />
+    <env name="APP_ENV" value="testing" />
   </php>
 </phpunit>

--- a/phpunit/GLPIWebTestCase.php
+++ b/phpunit/GLPIWebTestCase.php
@@ -8,6 +8,7 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2025 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -32,13 +33,42 @@
  * ---------------------------------------------------------------------
  */
 
-namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
-use Glpi\Controller\ErrorController;
+class GLPIWebTestCase extends WebTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Session::destroy();
+    }
 
-return static function (ContainerConfigurator $container): void {
-    $container->extension('framework', [
-        'error_controller' => ErrorController::class,
-        'test' => $container->env() === 'testing',
-    ]);
-};
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        Session::destroy();
+    }
+
+    protected static function login(string $user_name = \TU_USER, string $user_pass = \TU_PASS, bool $noauto = true): void
+    {
+        Session::start();
+
+        $auth = new Auth();
+        self::assertTrue($auth->login($user_name, $user_pass, $noauto));
+    }
+
+    protected static function createAuthenticatedClient(
+        string $user_name = \TU_USER,
+        string $user_pass = \TU_PASS,
+        bool $noauto = true,
+        array $options = [],
+        array $server = [],
+    ): KernelBrowser {
+        $client = static::createClient($options, $server);
+
+        self::login($user_name, $user_pass, $noauto);
+
+        return $client;
+    }
+}

--- a/phpunit/bootstrap.php
+++ b/phpunit/bootstrap.php
@@ -53,8 +53,8 @@ require_once dirname(__DIR__) . '/vendor/autoload.php';
 $kernel = new Kernel('testing');
 $kernel->boot();
 
-if (!file_exists(GLPI_CONFIG_DIR . '/config_db.php')) {
-    echo("\nConfiguration file for tests not found\n\nrun: php bin/console database:install --env=testing ...\n\n");
+if (!file_exists($path = GLPI_CONFIG_DIR . '/config_db.php')) {
+    echo("\nConfiguration file for tests not found in \"$path\"\n\nrun: php bin/console database:install --env=testing ...\n\n");
     exit(1);
 }
 if (!defined('SKIP_UPDATES') && !Update::isDbUpToDate()) {
@@ -73,6 +73,7 @@ if (file_exists(GLPI_CONFIG_DIR . DIRECTORY_SEPARATOR . CacheManager::CONFIG_FIL
 }
 
 include_once __DIR__ . '/GLPITestCase.php';
+include_once __DIR__ . '/GLPIWebTestCase.php';
 include_once __DIR__ . '/DbTestCase.php';
 include_once __DIR__ . '/CsvTestCase.php';
 include_once __DIR__ . '/APIBaseClass.php';

--- a/phpunit/functional/Glpi/Controller/IndexControllerTest.php
+++ b/phpunit/functional/Glpi/Controller/IndexControllerTest.php
@@ -32,13 +32,25 @@
  * ---------------------------------------------------------------------
  */
 
-namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+namespace tests\units\Glpi\Controller;
 
-use Glpi\Controller\ErrorController;
+use Glpi\Exception\RedirectException;
+use GLPIWebTestCase;
 
-return static function (ContainerConfigurator $container): void {
-    $container->extension('framework', [
-        'error_controller' => ErrorController::class,
-        'test' => $container->env() === 'testing',
-    ]);
-};
+class IndexControllerTest extends GLPIWebTestCase
+{
+    public function testAuthenticatedIndex(): void
+    {
+        $client = static::createAuthenticatedClient();
+
+        try {
+            $client->request('GET', '/');
+        } catch (RedirectException $e) {
+            $response = $e->getResponse();
+            self::assertSame(302, $response->getStatusCode());
+            self::assertSame('/front/central.php', $response->getTargetUrl());
+            return;
+        }
+        self::fail('Expected RedirectException to be thrown');
+    }
+}

--- a/src/Glpi/Error/ErrorHandler.php
+++ b/src/Glpi/Error/ErrorHandler.php
@@ -40,6 +40,7 @@ use Glpi\Error\ErrorDisplayHandler\CliDisplayHandler;
 use Glpi\Error\ErrorDisplayHandler\HtmlErrorDisplayHandler;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
+use Psr\Log\NullLogger;
 use Symfony\Component\ErrorHandler\ErrorHandler as BaseErrorHandler;
 
 /**
@@ -76,7 +77,7 @@ final class ErrorHandler extends BaseErrorHandler
 
     private string $env;
 
-    public function __construct(LoggerInterface $logger)
+    public function __construct(?LoggerInterface $logger = null)
     {
         parent::__construct(debug: \GLPI_ENVIRONMENT_TYPE === GLPI::ENV_DEVELOPMENT);
 
@@ -87,6 +88,7 @@ final class ErrorHandler extends BaseErrorHandler
         $this->screamAt(self::FATAL_ERRORS, true); // Never silent fatal errors
         $this->throwAt(self::FATAL_ERRORS, true); // Convert fatal errors to exceptions
 
+        $logger ??= new NullLogger();
         $this->setDefaultLogger($logger, self::ERROR_LEVEL_MAP);
 
         self::$currentLogger = $logger;

--- a/src/Glpi/Kernel/Kernel.php
+++ b/src/Glpi/Kernel/Kernel.php
@@ -76,6 +76,16 @@ final class Kernel extends BaseKernel
 
     public function __destruct()
     {
+        $this->shutdown();
+    }
+
+    public function shutdown(): void
+    {
+        parent::shutdown();
+
+        \restore_error_handler();
+        \restore_exception_handler();
+
         $this->triggerGlobalsDeprecation();
     }
 


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

---

This code is the very first step towards easing testing by using existing Symfony-related tooling.

This code allows doing things like this that **can** work (because it's not yet fully tested on my machine and I only have a few amount of uncommitted test cases related to this):

```php
<?php

namespace tests\units\Glpi\Controller;

use GLPIWebTestCase;

class IndexControllerTest extends GLPIWebTestCase
{
    public function testNonAuthenticated(): void
    {
        $client = static::createClient();

        $client->request('GET', '/Helpdesk');

        self::assertResponseStatusCodeSame(302);
    }

    public function testAuthenticated(): void
    {
        $client = static::createAuthenticatedClient();

        $client->request('GET', '/Helpdesk');

        self::assertResponseStatusCodeSame(200);
    }
}
```

In the future, this will make it **much easier** to create functional tests by just spawning a kernel request call and asserting on HTML, XML or JSON output because Symfony already has tons of cool assertions for that purpose 👌

Another advantage is that some specific tests will need existing data in the database, and for that purpose, we can spawn some HTTP requests that will fill some forms or run the API to actually do the data addition (and even extract this in some utility Traits for reusability), and roll the changes back after the request, by wrapping the entire process in a database transaction and calling "rollback" on it at test's teardown.

A few small blockers though: all code using StreamedResponse won't (yet) be completely compatible because these streamed responses are harder to test with PHPUnit.
Not impossible, but you have to manually make the call to the internal closure and wrap it in an output buffer on which you'll make your assertions, so it's all manual stuff and cannot benefit from Symfony's assertions.