### PR TITLE
Fix Form incorrect access control checks

### DIFF
--- a/js/modules/Forms/Condition/Engine.js
+++ b/js/modules/Forms/Condition/Engine.js
@@ -107,6 +107,13 @@ export class GlpiFormConditionEngine
             form_data.append(`answers[${entry[0]}]`, entry[1]);
         }
 
+        // Included direct access token if needed.
+        // Not great to have to do this normally, TOOD: find a better way.
+        const url_params = new URLSearchParams(window.location.search);
+        if (url_params.has('token')) {
+            form_data.append('token', url_params.get('token'));
+        }
+
         // Send request
         const url = `${CFG_GLPI.root_doc}/Form/Condition/Engine`;
         const response = await fetch(url, {

--- a/src/Glpi/Controller/Form/Condition/EngineController.php
+++ b/src/Glpi/Controller/Form/Condition/EngineController.php
@@ -35,6 +35,7 @@
 namespace Glpi\Controller\Form\Condition;
 
 use Glpi\Controller\AbstractController;
+use Glpi\Controller\Form\Utils\CanCheckAccessPolicies;
 use Glpi\Exception\Http\NotFoundHttpException;
 use Glpi\Form\Condition\Engine;
 use Glpi\Form\Condition\EngineInput;
@@ -48,12 +49,14 @@ use Symfony\Component\Routing\Attribute\Route;
 
 final class EngineController extends AbstractController
 {
+    use CanCheckAccessPolicies;
+
     #[Route(
         "/Form/Condition/Engine",
         name: "glpi_form_condition_engine",
         methods: "POST"
     )]
-    #[SecurityStrategy(Firewall::STRATEGY_AUTHENTICATED)]
+    #[SecurityStrategy(Firewall::STRATEGY_NO_CHECK)]
     public function __invoke(Request $request): Response
     {
         // Load target form
@@ -62,6 +65,8 @@ final class EngineController extends AbstractController
         if (!$form) {
             throw new NotFoundHttpException();
         }
+
+        $this->checkFormAccessPolicies($form, $request);
 
         // Load engine input
         $input = new EngineInput(

--- a/src/Glpi/Controller/Form/QuestionActorsDropdownController.php
+++ b/src/Glpi/Controller/Form/QuestionActorsDropdownController.php
@@ -35,16 +35,13 @@
 namespace Glpi\Controller\Form;
 
 use Glpi\Controller\AbstractController;
-use Glpi\Exception\Http\AccessDeniedHttpException;
+use Glpi\Controller\Form\Utils\CanCheckAccessPolicies;
 use Glpi\Exception\Http\BadRequestHttpException;
 use Glpi\Exception\Http\NotFoundHttpException;
-use Glpi\Form\AccessControl\FormAccessControlManager;
-use Glpi\Form\AccessControl\FormAccessParameters;
 use Glpi\Form\Dropdown\FormActorsDropdown;
 use Glpi\Form\Form;
 use Glpi\Http\Firewall;
 use Glpi\Security\Attribute\SecurityStrategy;
-use Session;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -52,6 +49,8 @@ use Symfony\Component\Routing\Attribute\Route;
 
 final class QuestionActorsDropdownController extends AbstractController
 {
+    use CanCheckAccessPolicies;
+
     #[Route(
         "/Form/Question/ActorsDropdown",
         name: "glpi_form_question_actors_dropdown_value",
@@ -60,7 +59,8 @@ final class QuestionActorsDropdownController extends AbstractController
     #[SecurityStrategy(Firewall::STRATEGY_NO_CHECK)]
     public function __invoke(Request $request): Response
     {
-        $this->checkFormAccessPolicies($request);
+        $form = $this->loadTargetForm($request);
+        $this->checkFormAccessPolicies($form, $request);
 
         $options = [
             'allowed_types'    => $request->request->all('allowed_types'),
@@ -84,24 +84,5 @@ final class QuestionActorsDropdownController extends AbstractController
         }
 
         return $form;
-    }
-
-    private function checkFormAccessPolicies(Request $request)
-    {
-        $form_access_manager = FormAccessControlManager::getInstance();
-
-        if (!Session::haveRight(Form::$rightname, READ)) {
-            $form = $this->loadTargetForm($request);
-
-            // Load current user session info and URL parameters.
-            $parameters = new FormAccessParameters(
-                session_info: Session::getCurrentSessionInfo(),
-                url_parameters: $request->query->all(),
-            );
-
-            if (!$form_access_manager->canAnswerForm($form, $parameters)) {
-                throw new AccessDeniedHttpException();
-            }
-        }
     }
 }

--- a/src/Glpi/Controller/Form/RendererController.php
+++ b/src/Glpi/Controller/Form/RendererController.php
@@ -36,11 +36,9 @@
 namespace Glpi\Controller\Form;
 
 use Glpi\Controller\AbstractController;
-use Glpi\Exception\Http\AccessDeniedHttpException;
+use Glpi\Controller\Form\Utils\CanCheckAccessPolicies;
 use Glpi\Exception\Http\BadRequestHttpException;
 use Glpi\Exception\Http\NotFoundHttpException;
-use Glpi\Form\AccessControl\FormAccessControlManager;
-use Glpi\Form\AccessControl\FormAccessParameters;
 use Glpi\Form\Condition\Engine;
 use Glpi\Form\Condition\EngineInput;
 use Glpi\Form\Form;
@@ -54,6 +52,8 @@ use Symfony\Component\Routing\Attribute\Route;
 
 final class RendererController extends AbstractController
 {
+    use CanCheckAccessPolicies;
+
     private string $interface;
 
     public function __construct()
@@ -123,25 +123,5 @@ final class RendererController extends AbstractController
         }
 
         return $form;
-    }
-
-    private function checkFormAccessPolicies(Form $form, Request $request)
-    {
-        $form_access_manager = FormAccessControlManager::getInstance();
-
-        if (Session::haveRight(Form::$rightname, READ)) {
-            // Form administrators can bypass restrictions while previewing forms.
-            $parameters = new FormAccessParameters(bypass_restriction: true);
-        } else {
-            // Load current user session info and URL parameters.
-            $parameters = new FormAccessParameters(
-                session_info: Session::getCurrentSessionInfo(),
-                url_parameters: $request->query->all(),
-            );
-        }
-
-        if (!$form_access_manager->canAnswerForm($form, $parameters)) {
-            throw new AccessDeniedHttpException();
-        }
     }
 }

--- a/src/Glpi/Controller/Form/SubmitAnswerController.php
+++ b/src/Glpi/Controller/Form/SubmitAnswerController.php
@@ -36,11 +36,9 @@
 namespace Glpi\Controller\Form;
 
 use Glpi\Controller\AbstractController;
-use Glpi\Exception\Http\AccessDeniedHttpException;
+use Glpi\Controller\Form\Utils\CanCheckAccessPolicies;
 use Glpi\Exception\Http\BadRequestHttpException;
 use Glpi\Exception\Http\NotFoundHttpException;
-use Glpi\Form\AccessControl\FormAccessControlManager;
-use Glpi\Form\AccessControl\FormAccessParameters;
 use Glpi\Form\AnswersHandler\AnswersHandler;
 use Glpi\Form\AnswersSet;
 use Glpi\Form\EndUserInputNameProvider;
@@ -55,6 +53,8 @@ use Symfony\Component\Routing\Attribute\Route;
 
 final class SubmitAnswerController extends AbstractController
 {
+    use CanCheckAccessPolicies;
+
     #[SecurityStrategy(Firewall::STRATEGY_NO_CHECK)] // Some forms can be accessed anonymously
     #[Route(
         "/Form/SubmitAnswers",
@@ -87,26 +87,6 @@ final class SubmitAnswerController extends AbstractController
         }
 
         return $form;
-    }
-
-    private function checkFormAccessPolicies(Form $form, Request $request)
-    {
-        $form_access_manager = FormAccessControlManager::getInstance();
-
-        if (Session::haveRight(Form::$rightname, READ)) {
-            // Form administrators can bypass restrictions while previewing forms.
-            $parameters = new FormAccessParameters(bypass_restriction: true);
-        } else {
-            // Load current user session info and URL parameters.
-            $parameters = new FormAccessParameters(
-                session_info: Session::getCurrentSessionInfo(),
-                url_parameters: $request->request->all(),
-            );
-        }
-
-        if (!$form_access_manager->canAnswerForm($form, $parameters)) {
-            throw new AccessDeniedHttpException();
-        }
     }
 
     private function saveSubmittedAnswers(

--- a/src/Glpi/Controller/Form/Utils/CanCheckAccessPolicies.php
+++ b/src/Glpi/Controller/Form/Utils/CanCheckAccessPolicies.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Controller\Form\Utils;
+
+use Session;
+use Glpi\Exception\Http\AccessDeniedHttpException;
+use Glpi\Form\AccessControl\FormAccessControlManager;
+use Glpi\Form\AccessControl\FormAccessParameters;
+use Glpi\Form\Form;
+use Symfony\Component\HttpFoundation\Request;
+
+trait CanCheckAccessPolicies
+{
+    protected function checkFormAccessPolicies(Form $form, Request $request): void
+    {
+        $form_access_manager = FormAccessControlManager::getInstance();
+
+        if (Session::haveRight(Form::$rightname, READ)) {
+            // Form administrators can bypass restrictions while previewing forms.
+            $parameters = new FormAccessParameters(bypass_restriction: true);
+        } else {
+            // Load current user session info and URL parameters.
+            $parameters = new FormAccessParameters(
+                session_info: Session::getCurrentSessionInfo(),
+                url_parameters: $request->query->all(),
+            );
+        }
+
+        if ($form_access_manager->allowUnauthenticatedAccess($form)) {
+            return;
+        }
+
+        // Must be authenticated here
+        if (!$form_access_manager->canAnswerForm($form, $parameters)) {
+            throw new AccessDeniedHttpException();
+        }
+    }
+}

--- a/src/Glpi/Controller/Form/Utils/CanCheckAccessPolicies.php
+++ b/src/Glpi/Controller/Form/Utils/CanCheckAccessPolicies.php
@@ -65,10 +65,6 @@ trait CanCheckAccessPolicies
             );
         }
 
-        if ($form_access_manager->allowUnauthenticatedAccess($form)) {
-            return;
-        }
-
         // Must be authenticated here
         if (!$form_access_manager->canAnswerForm($form, $parameters)) {
             throw new AccessDeniedHttpException();

--- a/src/Glpi/Controller/Form/Utils/CanCheckAccessPolicies.php
+++ b/src/Glpi/Controller/Form/Utils/CanCheckAccessPolicies.php
@@ -51,10 +51,17 @@ trait CanCheckAccessPolicies
             // Form administrators can bypass restrictions while previewing forms.
             $parameters = new FormAccessParameters(bypass_restriction: true);
         } else {
+            // URL parameters might be sent in GET or POST requests due to some
+            // technical limitations.
+            $url_parameters = $request->isMethod('POST')
+                ? $request->request->all()
+                : $request->query->all()
+            ;
+
             // Load current user session info and URL parameters.
             $parameters = new FormAccessParameters(
                 session_info: Session::getCurrentSessionInfo(),
-                url_parameters: $request->query->all(),
+                url_parameters: $url_parameters,
             );
         }
 

--- a/templates/pages/form_renderer.html.twig
+++ b/templates/pages/form_renderer.html.twig
@@ -265,14 +265,12 @@
                 </div>
             </div>
         </div>
-    </div>
 
-    <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}" />
-
-    {# Include direct access token if supplied #}
-    {% if token %}
-        <input type="hidden" name="token" value="{{ token }}" />
-    {% endif %}
+        {# Include direct access token if supplied #}
+        {% if token %}
+            <input type="hidden" name="token" value="{{ token }}" />
+        {% endif %}
+    </form>
 
     <script>(async () => {
         // Load renderer controller


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works. **ℹNote: I wish #19093 could be merged so I could just make some HTTP requests on the actual controllers that needed changes and make the tests directly there 😄 **
- [ ] This change requires a documentation update.

## Description

- It fixes #19070

When allowing unauthenticated users to submit a form from a tokenized public URL, the Engine and SubmitAnswers routes returned HTTP 500 responses, making it impossible to actually submit a public form.
Only authenticated users could do it.
This PR fixes this behavior.

