### PR TITLE
Simplify IndexController's handling to not break execution in testing

### DIFF
--- a/src/CronTask.php
+++ b/src/CronTask.php
@@ -1871,17 +1871,19 @@ TWIG, ['msg' => __('Last run list')]);
 
     /**
      * Call cron without time check
-     *
-     * @return boolean : true if launched
      **/
-    public static function callCronForce()
+    public static function callCronForce(bool $returnScript = false): bool | string
     {
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
         if (self::mustRunWebTasks()) {
             $path = $CFG_GLPI['root_doc'] . "/front/cron.php";
-            echo "<div style=\"background-image: url('$path');\"></div>";
+            $out = "<div style=\"background-image: url('$path');\"></div>";
+            if ($returnScript) {
+                return $out;
+            }
+            echo $out;
         }
 
         return true;

--- a/src/CronTask.php
+++ b/src/CronTask.php
@@ -1871,19 +1871,17 @@ TWIG, ['msg' => __('Last run list')]);
 
     /**
      * Call cron without time check
+     *
+     * @return boolean : true if launched
      **/
-    public static function callCronForce(bool $returnScript = false): bool | string
+    public static function callCronForce()
     {
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
         if (self::mustRunWebTasks()) {
             $path = $CFG_GLPI['root_doc'] . "/front/cron.php";
-            $out = "<div style=\"background-image: url('$path');\"></div>";
-            if ($returnScript) {
-                return $out;
-            }
-            echo $out;
+            echo "<div style=\"background-image: url('$path');\"></div>";
         }
 
         return true;
@@ -1894,7 +1892,7 @@ TWIG, ['msg' => __('Last run list')]);
      *
      * @return bool
      **/
-    protected static function mustRunWebTasks(): bool
+    public static function mustRunWebTasks(): bool
     {
         $web_tasks_count = countElementsInTable(self::getTable(), [
             'mode'  => self::MODE_INTERNAL, // "GLPI" mode

--- a/templates/pages/login.html.twig
+++ b/templates/pages/login.html.twig
@@ -126,6 +126,10 @@
 
 {% block footer_block %}
     {{ copyright_message|raw }}
+
+    {% if must_call_cron %}
+        <div style="background-image: url('{{ path('/front/cron.php') }}');"></div>
+    {% endif %}
 {% endblock %}
 
 {% block javascript_block %}


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works. 
- [x] I don't have tests but that's the reason of this fix: to create tests for it 😁 
- [ ] This change requires a documentation update.

## Description

All the existing logic is still kept the same, same order of execution, etc.
But instead of relying on the old `Html::redirect` code, we return properly set `RedirectResponse`, and the TOTP part is still rendered in a `HeaderlessStreamedResponse` for consistency (and for it to still work, basically...).

The changes in the spaces and indentation are just here because now we can decrease the indentation level thanks to early returns, reduces cognitive load when reading the code 👌

Note: existing controllers still using `HeaderlessStreamedResponse` or `StreamedResponse` will need refactoring in order to be testable by #19093