### PR TITLE
fix: The massive action Change Visibility displayed the wrong dropdown

### DIFF
--- a/phpunit/functional/MassiveActionTest.php
+++ b/phpunit/functional/MassiveActionTest.php
@@ -624,4 +624,71 @@ class MassiveActionTest extends DbTestCase
             );
         }
     }
+
+    public function testSaveSearchSpecificMassiveActionProvider()
+    {
+        $this->login();
+
+        $entity = getItemByTypeName('Entity', '_test_root_entity', true);
+        $uid = getItemByTypeName('User', TU_USER, true);
+        $bk = new \SavedSearch();
+        $this->assertTrue(
+            (bool)$bk->add([
+                'name'         => 'public root recursive',
+                'type'         => 1,
+                'itemtype'     => 'Ticket',
+                'users_id'     => $uid,
+                'is_private'   => 0,
+                'entities_id'  => $entity,
+                'is_recursive' => 1,
+                'url'          => 'front/ticket.php?itemtype=Ticket&sort=2&order=DESC&start=0&criteria[0][field]=5&criteria[0][searchtype]=equals&criteria[0][value]=' . $uid
+            ])
+        );
+
+        yield [
+            "action"       => "unset_default",
+            "item"         => $bk,
+            "ids"          => [$bk->getID()],
+            "input"        => $bk->input,
+            "ok"           => 1,
+            "ko"           => 0,
+            "action_class" => \SavedSearch::class
+        ];
+
+        yield [
+            "action"       => "change_entity",
+            "item"         => $bk,
+            "ids"          => [$bk->getID()],
+            "input"        => $bk->input,
+            "ok"           => 1,
+            "ko"           => 0,
+            "action_class" => \SavedSearch::class
+        ];
+
+        yield [
+            "action"       => "change_visibility",
+            "item"         => $bk,
+            "ids"          => [$bk->getID()],
+            "input"        => $bk->input,
+            "ok"           => 1,
+            "ko"           => 0,
+            "action_class" => \SavedSearch::class
+        ];
+    }
+
+    public function testaveSearchSpecificmassiveAction()
+    {
+        $provider = $this->testSaveSearchSpecificMassiveActionProvider();
+        foreach ($provider as $row) {
+            $this->processMassiveActionsForOneItemtype(
+                $row["action"],
+                $row["item"],
+                $row["ids"],
+                $row["input"],
+                $row["ok"],
+                $row["ko"],
+                $row["action_class"],
+            );
+        }
+    }
 }

--- a/src/SavedSearch.php
+++ b/src/SavedSearch.php
@@ -120,17 +120,12 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
                 echo '<br/>';
                 break;
             case 'change_visibility':
-                $rand = mt_rand();
                 echo __('Visibility');
                 Dropdown::showFromArray(
                     'is_private',
                     [
                         1  => __('Private'),
                         0  => __('Public')
-                    ],
-                    [
-                        'rand' => $rand,
-                        'value' => 0,
                     ],
                 );
                 break;
@@ -172,7 +167,7 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
                 }
                 break;
             case 'change_visibility':
-                if ($item->setVibility($ids, $input['is_private'])) {
+                if ($item->setVisibility($ids, $input['is_private'])) {
                     $ma->itemDone($item->getType(), $ids, MassiveAction::ACTION_OK);
                 } else {
                     $ma->itemDone($item->getType(), $ids, MassiveAction::ACTION_KO);
@@ -1223,11 +1218,11 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
      * Set visibility from massive actions
      *
      * @param array   $ids   Items IDs
-     * @param integer $is_private   VIsibility
+     * @param bool $is_private   Visibility
      *
      * @return boolean
      */
-    public function setVibility(array $ids, $is_private)
+    public function setVisibility(array $ids, bool $is_private)
     {
         /** @var \DBmysql $DB */
         global $DB;

--- a/src/SavedSearch.php
+++ b/src/SavedSearch.php
@@ -120,17 +120,12 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
                 echo '<br/>';
                 break;
             case 'change_visibility':
-                $rand = mt_rand();
                 echo __('Visibility');
                 Dropdown::showFromArray(
                     'is_private',
                     [
                         1  => __('Private'),
                         0  => __('Public')
-                    ],
-                    [
-                        'rand' => $rand,
-                        'value' => 0,
                     ],
                 );
                 break;

--- a/src/SavedSearch.php
+++ b/src/SavedSearch.php
@@ -120,12 +120,17 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
                 echo '<br/>';
                 break;
             case 'change_visibility':
+                $rand = mt_rand();
                 echo __('Visibility');
                 Dropdown::showFromArray(
                     'is_private',
                     [
                         1  => __('Private'),
                         0  => __('Public')
+                    ],
+                    [
+                        'rand' => $rand,
+                        'value' => 0,
                     ],
                 );
                 break;


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes #36622
- The massive "Change visibility" action did not display the correct dropdown. It displayed the ability to change the saved search entity.

## Screenshots (if appropriate):

![Capture d’écran du 2025-03-03 11-36-20](https://github.com/user-attachments/assets/536d916a-8a06-4c5d-a3cc-11409f6610c2)


