### PR TITLE
Small enhancements on custom objects

### DIFF
--- a/install/migrations/update_10.0.x_to_11.0.0/dropdowns.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/dropdowns.php
@@ -58,6 +58,7 @@ if (!$DB->tableExists('glpi_dropdowns_dropdowndefinitions')) {
             PRIMARY KEY (`id`),
             UNIQUE KEY `system_name` (`system_name`),
             KEY `is_active` (`is_active`),
+            KEY `label` (`label`),
             KEY `date_creation` (`date_creation`),
             KEY `date_mod` (`date_mod`)
     ) ENGINE=InnoDB DEFAULT CHARSET={$default_charset} COLLATE={$default_collation} ROW_FORMAT=DYNAMIC;
@@ -68,6 +69,7 @@ SQL;
         'after' => 'system_name',
         'update' => $DB::quoteName('system_name'),
     ]);
+    $migration->addKey('glpi_dropdowns_dropdowndefinitions', 'label');
 }
 
 if (!$DB->tableExists('glpi_dropdowns_dropdowns')) {
@@ -99,6 +101,5 @@ if (!$DB->tableExists('glpi_dropdowns_dropdowns')) {
 SQL;
     $DB->doQuery($query);
 } else {
-    // TODO Remove it before the GLPI 11.0 final release.
     $migration->dropField('glpi_dropdowns_dropdowns', 'is_deleted');
 }

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -9933,6 +9933,7 @@ CREATE TABLE `glpi_assets_assetdefinitions` (
   `date_mod` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `system_name` (`system_name`),
+  KEY `label` (`label`),
   KEY `is_active` (`is_active`),
   KEY `date_creation` (`date_creation`),
   KEY `date_mod` (`date_mod`)
@@ -10056,6 +10057,7 @@ CREATE TABLE `glpi_dropdowns_dropdowndefinitions` (
   `date_mod` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `system_name` (`system_name`),
+  KEY `label` (`label`),
   KEY `is_active` (`is_active`),
   KEY `date_creation` (`date_creation`),
   KEY `date_mod` (`date_mod`)
@@ -10098,9 +10100,14 @@ CREATE TABLE `glpi_assets_customfielddefinitions` (
   `itemtype` VARCHAR(255) NULL DEFAULT NULL,
   `default_value` text,
   `translations` JSON NOT NULL,
+  `date_creation` timestamp NULL DEFAULT NULL,
+  `date_mod` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`assets_assetdefinitions_id`, `system_name`),
-  KEY `system_name` (`system_name`)
+  KEY `system_name` (`system_name`),
+  KEY `label` (`label`),
+  KEY `date_creation` (`date_creation`),
+  KEY `date_mod` (`date_mod`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 DROP TABLE IF EXISTS `glpi_contracts_users`;

--- a/phpunit/functional/Glpi/Asset/AssetDefinitionTest.php
+++ b/phpunit/functional/Glpi/Asset/AssetDefinitionTest.php
@@ -455,6 +455,7 @@ class AssetDefinitionTest extends DbTestCase
                 'label' => 'Test',
             ])
         );
+        $definition = new AssetDefinition();
         $this->assertFalse($definition->add([
             'system_name' => 'test',
             'label' => 'Test',

--- a/phpunit/functional/Glpi/Asset/CustomFieldDefinitionTest.php
+++ b/phpunit/functional/Glpi/Asset/CustomFieldDefinitionTest.php
@@ -584,4 +584,46 @@ class CustomFieldDefinitionTest extends DbTestCase
         $_SESSION['glpilanguage'] = 'fr_FR';
         $this->assertEquals('test_fr', $field->getFriendlyName());
     }
+
+    public function testSystemNameUpdate(): void
+    {
+        $asset_definition = $this->initAssetDefinition();
+
+        $field = $this->createItem(
+            \Glpi\Asset\CustomFieldDefinition::class,
+            [
+                'assets_assetdefinitions_id' => $asset_definition->getID(),
+                'system_name' => 'test',
+                'type' => StringType::class,
+            ]
+        );
+
+        $updated = $field->update([
+            'id' => $field->getID(),
+            'system_name' => 'changed',
+        ]);
+        $this->assertFalse($updated);
+        $this->hasSessionMessages(ERROR, ['The system name cannot be changed.']);
+    }
+
+    public function testTypeUpdate(): void
+    {
+        $asset_definition = $this->initAssetDefinition();
+
+        $field = $this->createItem(
+            \Glpi\Asset\CustomFieldDefinition::class,
+            [
+                'assets_assetdefinitions_id' => $asset_definition->getID(),
+                'system_name' => 'test',
+                'type' => StringType::class,
+            ]
+        );
+
+        $updated = $field->update([
+            'id' => $field->getID(),
+            'type' => BooleanType::class,
+        ]);
+        $this->assertFalse($updated);
+        $this->hasSessionMessages(ERROR, ['The field type cannot be changed.']);
+    }
 }

--- a/phpunit/functional/Glpi/Dropdown/DropdownDefinitionTest.php
+++ b/phpunit/functional/Glpi/Dropdown/DropdownDefinitionTest.php
@@ -389,6 +389,7 @@ class DropdownDefinitionTest extends DbTestCase
                 'label' => 'Test',
             ])
         );
+        $definition = new DropdownDefinition();
         $this->assertFalse($definition->add([
             'system_name' => 'test',
             'label' => 'Test',

--- a/src/Glpi/Asset/CustomFieldDefinition.php
+++ b/src/Glpi/Asset/CustomFieldDefinition.php
@@ -54,6 +54,11 @@ final class CustomFieldDefinition extends CommonDBChild
         return _n('Custom field', 'Custom fields', $nb);
     }
 
+    public static function getNameField()
+    {
+        return 'label';
+    }
+
     public static function getIcon()
     {
         return 'ti ti-forms';
@@ -228,6 +233,11 @@ final class CustomFieldDefinition extends CommonDBChild
         if (!$this->validateSystemName($input)) {
             return false;
         }
+
+        if (empty($input['label'])) {
+            $input['label'] = $input['system_name'];
+        }
+
         $input = $this->prepareInputForAddAndUpdate($input);
         if ($input === false) {
             return false;
@@ -241,7 +251,30 @@ final class CustomFieldDefinition extends CommonDBChild
     public function prepareInputForUpdate($input)
     {
         // Cannot change type or system_name of existing field
-        unset($input['type'], $input['system_name']);
+        if (
+            array_key_exists('system_name', $input)
+            && $input['system_name'] !== $this->fields['system_name']
+        ) {
+            Session::addMessageAfterRedirect(
+                __s('The system name cannot be changed.'),
+                false,
+                ERROR
+            );
+            return false;
+        }
+
+        if (
+            array_key_exists('type', $input)
+            && $input['type'] !== $this->fields['type']
+        ) {
+            Session::addMessageAfterRedirect(
+                __s('The field type cannot be changed.'),
+                false,
+                ERROR
+            );
+            return false;
+        }
+
         $input = $this->prepareInputForAddAndUpdate($input);
         if ($input === false) {
             return false;

--- a/src/Glpi/CustomObject/AbstractDefinition.php
+++ b/src/Glpi/CustomObject/AbstractDefinition.php
@@ -129,6 +129,11 @@ abstract class AbstractDefinition extends CommonDBTM
         return (new $class())->getRights();
     }
 
+    public static function getNameField()
+    {
+        return 'label';
+    }
+
     public static function getIcon()
     {
         return 'ti ti-database-cog';
@@ -473,7 +478,10 @@ abstract class AbstractDefinition extends CommonDBTM
                 $has_errors = true;
             } else {
                 $existing_system_names = array_map(static fn ($d) => strtolower($d->fields['system_name'] ?? ''), static::getDefinitionManagerClass()::getInstance()->getDefinitions());
-                if (in_array(strtolower($input['system_name']), $existing_system_names, true)) {
+                if (
+                    ($this->isNewItem() || ($input['system_name'] !== $this->fields['system_name']))
+                    && in_array(strtolower($input['system_name']), $existing_system_names, true)
+                ) {
                     Session::addMessageAfterRedirect(
                         htmlescape(sprintf(
                             __('The system name must be unique.'),


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

The proposed changes correspond to small enhancements that I had to implement to make the generic assets classes fully compatible with the generic migration system introduced in #18938 .

- Add missing `getNameField()` overrides and corresponding DB keys.
- Add default custom field lable based on the system name.
- Add an error message when custom field type of system name is going to be changed.
- Add missing `date_creation`/`date_mod` fields on `glpi_assets_customfielddefinitions` table.
- Remove obsolete dev migration.