### PR TITLE
Enhance plugin migration framework (2)

### DIFF
--- a/src/Glpi/Migration/MigrationException.php
+++ b/src/Glpi/Migration/MigrationException.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Migration;
+
+use RuntimeException;
+use Throwable;
+
+/**
+ * @final
+ */
+class MigrationException extends RuntimeException
+{
+    private string $localized_message;
+
+    public function __construct(
+        string $localized_message,
+        string $message = '',
+        int $code = 0,
+        ?Throwable $previous = null
+    ) {
+        $this->localized_message = $localized_message;
+
+        parent::__construct($message, $code, $previous);
+    }
+
+    public function getLocalizedMessage(): string
+    {
+        return $this->localized_message;
+    }
+}


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

1) Use item friendly name in import messages.

2) Try to detect unchanged JSON fields.
While working on #19033, I figured out that some items were considered as different because `$input['translations']`  value was `[]` while the `$this->fields['translations']` value was is JSON representation `"[]"`. I added a small check to consider a field as unchanged when the input is an array and the decoded version of the value contained in `$this->fields` is identical.

3) Forward session messages to progress indicator.
Until now, when an item add/update operation failed, the result was a generic message (`An unexpected error occured.`), without any indication of what really happens. If the item hook methods are implemented as expected, a rejection of an add/update operation should result in adding error messages in session. By forwarding them to the progress indicator, the administrator will be able to have meaningful messages, for instance `The system name must be unique.` then `Unable to create Asset definition "foo bar".`.
