### PR TITLE
fix(ticket): images disabled in massive solution

### DIFF
--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -2822,9 +2822,7 @@ JAVASCRIPT;
                     'editor_id'         => $content_id,
                     'enable_fileupload' => false,
                     'enable_richtext'   => true,
-                            // Uploaded images processing is not able to handle multiple use of same uploaded file, so until this is fixed,
-                            // it is preferable to disable image pasting in rich text inside massive actions.
-                    'enable_images'     => false,
+                    'enable_images'     => true,
                     'cols'              => 12,
                     'rows'              => 80
                 ]);


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !36647

The bulk action on tickets, "Resolve selected tickets," has not allowed image uploads since https://github.com/glpi-project/glpi/pull/9085. However, the initial issue seems to be resolved, as reactivating the option makes the image correctly visible in the solutions of the affected tickets.

Let me know if I misunderstood the original issue!

## Screenshots (if appropriate):


