### PR TITLE
fix: add ticket content from promoted followup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -342,6 +342,7 @@ The present file will list all changes made to the project; according to the
 - `CommonDBTM::$deduplicate_queued_notifications` property.
 - `CommonDBTM::getCacheKeyForFriendlyName()`
 - `CommonDBTM::getSNMPCredential()`
+- `CommonDBTM::hasSavedInput()`
 - `CommonDBTM::showDebugInfo()`
 - `CommonDevice::title()`
 - `CommonDropdown::$first_level_menu`, `CommonDropdown::$second_level_menu` and `CommonDropdown::$third_level_menu` properties.

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -1216,14 +1216,6 @@ class CommonDBTM extends CommonGLPI
     }
 
     /**
-     * @return bool true if input data is saved in the session
-     */
-    protected function hasSavedInput(): bool
-    {
-        return isset($_SESSION['saveInput'][static::class]);
-    }
-
-    /**
      * Get the data saved in the session
      *
      * @since 0.84

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -380,6 +380,18 @@ abstract class CommonITILObject extends CommonDBTM
                         ]);
                     }
                 }
+
+                $groups_id = array_key_exists('_groups_id_' . $actortypestring, $params) && $params['_groups_id_' . $actortypestring] > 0
+                    ? $params['_groups_id_' . $actortypestring] : 0;
+                if ($groups_id > 0) {
+                    $group_obj = new Group();
+                    if ($group_obj->getFromDB($groups_id)) {
+                        $fn_add_actor('Group', $groups_id, [
+                            'text'  => $group_obj->getName(),
+                            'title' => $group_obj->getRawCompleteName(),
+                        ]);
+                    }
+                }
             }
 
             // load default actors from itiltemplate passed from showForm in `params` var

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -3545,15 +3545,13 @@ JAVASCRIPT;
             $options['entities_id'] = $item->fields['entities_id'];
         }
 
-        $initial_creation = static::isNewID($ID) && !$this->hasSavedInput();
-
         $this->restoreInputAndDefaults($ID, $options, null, true);
 
         if (!isset($options['_skip_promoted_fields'])) {
             $options['_skip_promoted_fields'] = false;
         }
 
-        if ($initial_creation) {
+        if (static::isNewID($ID)) {
             // Override some values only for the initial load of a new ticket
             // Override defaut values from projecttask if needed
             if (isset($options['_projecttasks_id'])) {

--- a/tests/cypress/e2e/ITILObject/ticket_promoted.cy.js
+++ b/tests/cypress/e2e/ITILObject/ticket_promoted.cy.js
@@ -1,0 +1,146 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+describe("Ticket Promoted", () => {
+
+    const content = 'Ticket content';
+    const requesterID = 2;
+    const techID = 4;
+    const projectTaskName = 'Project Name';
+    const categoryName = 'CatName';
+
+    const checkDescriptionInput = () => {
+        cy.get('#itil-form').first().within(() => {
+            cy.get('textarea[name="content"]')
+                .invoke('val')
+                .should('contains', content);
+        });
+    };
+
+    const checRequesterInput = () => {
+        cy.get('span[data-actortype="requester"]').should('have.attr', 'data-itemtype', 'User').should('have.attr', 'data-items-id', requesterID);
+    };
+
+    const checTechInput = (itemtype, itemID) => {
+        cy.get('span[data-actortype="assign"]')
+            .filter(`[data-itemtype="${itemtype}"][data-items-id="${itemID}"]`)
+            .should('exist');
+    };
+
+    const checkTitle = () => {
+        cy.get('input[name="name"]').should('have.value', projectTaskName);
+    };
+
+    beforeEach(() => {
+        cy.login();
+        cy.createWithAPI('Ticket', {
+            'name': 'Test ticket',
+            'content': '',
+        }).as('ticket_id').then((ticket_id) => {
+            cy.createWithAPI('ITILFollowup', {
+                'content': content,
+                'items_id': ticket_id,
+                'itemtype': 'Ticket',
+                'users_id': requesterID,
+            }).as('followup_id');
+            cy.createWithAPI('Group', {
+                'name': 'Group1',
+            }).as('group_id').then((group_id) => {
+                cy.createWithAPI('TicketTask', {
+                    'content': content,
+                    'tickets_id': ticket_id,
+                    'users_id': requesterID,
+                    'users_id_tech': techID,
+                    'groups_id_tech': group_id,
+                }).as('task_id');
+            });
+            cy.createWithAPI('ITILCategory', {
+                'name': `${categoryName}-${ticket_id}`,
+            }).as('itilcategory_id');
+        });
+
+        cy.createWithAPI('Project', {
+            'content': 'Project',
+        }).as('project_id').then((project_id) => {
+            cy.createWithAPI('ProjectTask', {
+                'name': projectTaskName,
+                'content': content,
+                'projects_id': project_id,
+            }).as('projecttask_id');
+        });
+    });
+
+    it('promote followup and change category', () => {
+        cy.get('@followup_id').then((followup_id) => {
+            cy.visit(`/front/ticket.form.php?_promoted_fup_id=${followup_id}`);
+        });
+        checkDescriptionInput();
+        checRequesterInput();
+        cy.get('@ticket_id').then((ticket_id) => {
+            cy.getDropdownByLabelText('Category').selectDropdownValue(`»${categoryName}-${ticket_id}`);
+        });
+        checkDescriptionInput();
+        checRequesterInput();
+    });
+
+    it('promote task and change category', () => {
+        cy.get('@task_id').then((task_id) => {
+            cy.visit(`/front/ticket.form.php?_promoted_task_id=${task_id}`);
+        });
+        checTechInput('User', techID);
+        checkDescriptionInput();
+        checRequesterInput();
+        cy.get('@group_id').then((group_id) => {
+            checTechInput('Group', group_id);
+        });
+        cy.get('@ticket_id').then((ticket_id) => {
+            cy.getDropdownByLabelText('Category').selectDropdownValue(`»${categoryName}-${ticket_id}`);
+        });
+        checTechInput('User', techID);
+        checkDescriptionInput();
+        checRequesterInput();
+    });
+
+    it('promote project task and change category', () => {
+        cy.get('@projecttask_id').then((projecttask_id) => {
+            cy.visit(`/front/ticket.form.php?_projecttasks_id=${projecttask_id}`);
+        });
+        checkTitle();
+        checkDescriptionInput();
+        cy.get('@ticket_id').then((ticket_id) => {
+            cy.getDropdownByLabelText('Category').selectDropdownValue(`»${categoryName}-${ticket_id}`);
+        });
+        checkTitle();
+        checkDescriptionInput();
+    });
+});


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !36483
- Add E2E tests for ticket promotion from follow-ups/tasks

When a follow-up or a task is promoted to a ticket, its content is not properly transferred. This PR adds end-to-end tests to verify that the content is correctly filled when converting a follow-up or a task into a ticket.

Related to #19040.

