### PR TITLE
User forms UI twig and cleanup

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -5054,12 +5054,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/User.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Negated boolean expression is always false\\.$#',
-	'identifier' => 'booleanNot.alwaysFalse',
-	'count' => 1,
-	'path' => __DIR__ . '/src/User.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Negated boolean expression is always true\\.$#',
 	'identifier' => 'booleanNot.alwaysTrue',
 	'count' => 1,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The present file will list all changes made to the project; according to the
 - Cloning templates (such as computer templates)
 - Creating a template from an existing item (such as a computer). This action is only available from the Actions menu within the item form (bulk action not allowed).
 - Massive action for users to reapply authorization assignment rules.
+- Massive action for users to send a password reset email.
 
 ### Changed
 - ITIL Objects can now be linked to any other ITIL Objects similar to the previous Ticket/Ticket links.

--- a/js/fileupload.js
+++ b/js/fileupload.js
@@ -151,7 +151,7 @@ var displayUploadedFile = function(file, tag, editor, input_name, filecontainer)
 
     // Delete button
     var elementsIdToRemove = {0:file.id, 1:`${file.id}2`};
-    $('<span class="ti ti-circle-x pointer"></span>').click(() => {
+    $('<span class="ti ti-circle-x pointer remove_file_upload"></span>').on('click', () => {
         deleteImagePasted(elementsIdToRemove, tag.tag, editor);
     }).appendTo(p);
 };

--- a/src/CommonDBChild.php
+++ b/src/CommonDBChild.php
@@ -871,7 +871,7 @@ abstract class CommonDBChild extends CommonDBConnexity
             $result .= "<span id='add" . $lower_name . "button' class='ti ti-plus cursor-pointer'" .
               " title=\"" . __s('Add') . "\"" .
                 "\" onClick=\"var row = $('#" . $div_id . "');
-                             row.append('<br>" .
+                             row.append('" .
                static::getJSCodeToAddForItemChild($field_name, $child_count_js_var) . "');
                             $child_count_js_var++;\"
                ><span class='sr-only'>" . __s('Add')  . "</span></span>";
@@ -956,7 +956,7 @@ abstract class CommonDBChild extends CommonDBConnexity
         }
 
         if ($canedit) {
-            $result .= "<div id='$div_id'>";
+            $result .= "<div id='$div_id' class='d-flex flex-column'>";
            // No Child display field
             if ($count == 0) {
                 $current_item->getEmpty();

--- a/src/UserEmail.php
+++ b/src/UserEmail.php
@@ -187,10 +187,10 @@ class UserEmail extends CommonDBChild
     public static function getJSCodeToAddForItemChild($field_name, $child_count_js_var)
     {
 
-        return "<input title=\'" . __s('Default email') . "\' type=\'radio\' name=\'_default_email\'" .
+        return "<div class=\'d-flex\'><input title=\'" . __s('Default email') . "\' type=\'radio\' name=\'_default_email\'" .
              " value=\'-'+" . htmlescape($child_count_js_var) . "+'\'>&nbsp;" .
              "<input type=\'text\' size=\'30\' class=\'form-control\' " . "name=\'" . htmlescape($field_name) .
-             "[-'+" . htmlescape($child_count_js_var) . "+']\'>";
+             "[-'+" . htmlescape($child_count_js_var) . "+']\'></div>";
     }
 
 

--- a/templates/components/form/header.html.twig
+++ b/templates/components/form/header.html.twig
@@ -55,8 +55,9 @@
 {# - This template is called from another twig template (as opposed to from PHP and most likely a legacy form) OR is in a modal #}
 {# - Not from a twig template and it is a new item #}
 {% set include_header_content = no_header == false and ((in_twig is defined or _get._in_modal|default(false)) or (in_twig is not defined and item.isNewID(item.fields['id']))) %}
+{% set canedit = params['canedit']|default(item.canEdit(item.fields['id'])) %}
 
-{% if open_form and item.canEdit(item.fields['id']) %}
+{% if open_form and canedit %}
 <form id="main-form" name="asset_form" method="post" action="{{ target }}" {{ formoptions|raw }} enctype="multipart/form-data" data-submit-once>
    {% if item.isField("entities_id") %}
        <input type="hidden" name="entities_id" value="{{ entity_id }}" />

--- a/templates/components/user/password_security_checks.html.twig
+++ b/templates/components/user/password_security_checks.html.twig
@@ -32,40 +32,53 @@
  #}
 
 {% set field = field|default('password') %}
+{% set list_view = list_view|default(false) %}
+
 {% if config('use_password_security') %}
-   <span id="password_min_length" class="text-danger">{{ config('password_min_length') }}</span>
-   {% set checks = {
-      password_need_number: __('Digit'),
-      password_need_letter: __('Lowercase'),
-      password_need_caps: __('Uppercase'),
-      password_need_symbol: __('Symbol')
-   } %}
-   {% if config('password_need_number') or config('password_need_letter') or config('password_need_caps') or config('password_need_symbol') %}
-      {% set check_fields %}
-         {% for name, label in checks|filter((v, k) => config(k)) %}
-            <span id="{{ name }}" class="text-danger">{{ label }}</span>
-            {% if not loop.last %}
-               <span>, </span>
+    <{{ list_view ? 'ul' : 'span' }} class="password-security-checks">
+       <{{ list_view ? 'li' : 'span' }} id="password_min_length" class="text-danger">{{ __('Minimum length: %s')|format(config('password_min_length')) }}</{{ list_view ? 'li' : 'span' }}>
+       {% set checks = {
+           password_need_number: __('Digit'),
+           password_need_letter: __('Lowercase'),
+           password_need_caps: __('Uppercase'),
+           password_need_symbol: __('Symbol')
+       } %}
+        {% if config('password_need_number') or config('password_need_letter') or config('password_need_caps') or config('password_need_symbol') %}
+            {% set check_fields %}
+                {% if not list_view %}
+                    <span>, </span>
+                {% endif %}
+                {% for name, label in checks|filter((v, k) => config(k)) %}
+                    <{{ list_view ? 'li' : 'span' }} id="{{ name }}" class="text-danger">{{ label }}</{{ list_view ? 'li' : 'span' }}>
+                {% if not loop.last and not list_view %}
+                    <span>, </span>
+                {% endif %}
+                {% endfor %}
+            {% endset %}
+            {% if list_view %}
+                <li>
             {% endif %}
-         {% endfor %}
-      {% endset %}
-      <span>{{ __('%1$s: %2$s')|format(__('Password must contains'), check_fields|raw)|raw }}</span>
-   {% endif %}
+            <{{ list_view ? 'ul' : 'span' }} >{{ __('%1$s: %2$s')|format(__('Password must contain'), check_fields|raw)|raw }}</{{ list_view ? 'ul' : 'span' }}>
+            {% if list_view %}
+                </li>
+            {% endif %}
+        {% endif %}
+    </{{ list_view ? 'ul' : 'span' }}>
 
-   <script>
-      function passwordCheck() {
-          const pwd = $('#{{ field }}').val();
-          const meet_min_length = pwd.length >= {{ config('password_min_length') }};
-          const meet_need_number = {{ config('password_need_number') }} ? pwd.match(/[0-9]/g) : true;
-          const meet_need_letter = {{ config('password_need_letter') }} ? pwd.match(/[a-z]/g) : true;
-          const meet_need_caps = {{ config('password_need_caps') }} ? pwd.match(/[A-Z]/g) : true;
-          const meet_need_symbol = {{ config('password_need_symbol') }} ? pwd.match(/[^a-zA-Z0-9]/g) : true;
+    <script>
+        function passwordCheck() {
+            const pwd = $('#{{ field }}').val();
+            const meet_min_length = pwd.length >= {{ config('password_min_length') }};
+            const meet_need_number = {{ config('password_need_number') }} ? !!pwd.match(/[0-9]/g) : true;
+            const meet_need_letter = {{ config('password_need_letter') }} ? !!pwd.match(/[a-z]/g) : true;
+            const meet_need_caps = {{ config('password_need_caps') }} ? !!pwd.match(/[A-Z]/g) : true;
+            const meet_need_symbol = {{ config('password_need_symbol') }} ? !!pwd.match(/[^a-zA-Z0-9]/g) : true;
 
-          $('#password_min_length').toggleClass('text-danger', !meet_min_length).toggleClass('text-success', meet_min_length);
-          $('#password_need_number').toggleClass('text-danger', !meet_need_number).toggleClass('text-success', meet_need_number);
-          $('#password_need_letter').toggleClass('text-danger', !meet_need_letter).toggleClass('text-success', meet_need_letter);
-          $('#password_need_caps').toggleClass('text-danger', !meet_need_caps).toggleClass('text-success', meet_need_caps);
-          $('#password_need_symbol').toggleClass('text-danger', !meet_need_symbol).toggleClass('text-success', meet_need_symbol);
-      }
-   </script>
+            $('#password_min_length').toggleClass('text-danger', !meet_min_length).toggleClass('text-success', meet_min_length);
+            $('#password_need_number').toggleClass('text-danger', !meet_need_number).toggleClass('text-success', meet_need_number);
+            $('#password_need_letter').toggleClass('text-danger', !meet_need_letter).toggleClass('text-success', meet_need_letter);
+            $('#password_need_caps').toggleClass('text-danger', !meet_need_caps).toggleClass('text-success', meet_need_caps);
+            $('#password_need_symbol').toggleClass('text-danger', !meet_need_symbol).toggleClass('text-success', meet_need_symbol);
+        }
+    </script>
 {% endif %}

--- a/templates/components/user/picture.html.twig
+++ b/templates/components/user/picture.html.twig
@@ -36,9 +36,13 @@
 {% set anonymized = enable_anonymization and entity_config('anonymize_support_agents', session('glpiactive_entity')) != constant('Entity::ANONYMIZE_DISABLED') %}
 {% set user = user_object ?? get_item('User', users_id) %}
 {% set with_link = with_link ?? true %}
-{% set user_thumbnail = user.getThumbnailPicturePath(enable_anonymization) %}
-{% if user_thumbnail == null and not entity_config('display_users_initials', session('glpiactive_entity')) %}
-    {% set user_thumbnail = user.getPicturePath(enable_anonymization) %}
+{% if not force_initials %}
+    {% set user_thumbnail = user.getThumbnailPicturePath(enable_anonymization) %}
+    {% if user_thumbnail == null and not entity_config('display_users_initials', session('glpiactive_entity')) %}
+        {% set user_thumbnail = user.getPicturePath(enable_anonymization) %}
+    {% endif %}
+{% else %}
+    {% set user_thumbnail = null %}
 {% endif %}
 
 {% if with_link and not anonymized %}

--- a/templates/pages/admin/user/change_other_password.html.twig
+++ b/templates/pages/admin/user/change_other_password.html.twig
@@ -1,0 +1,74 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2025 Teclib' and contributors.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+{% import 'components/form/fields_macros.html.twig' as fields %}
+
+{% set full_width = full_width|default(false) %}
+{% if item.isNewItem() %}
+    {{ fields.checkboxField('_init_password', 0, __('Send an email to the user to set their own new password.'), {
+        full_width: full_width,
+    }) }}
+{% endif %}
+{{ fields.passwordField('password', '', __('Password'), {
+    id: 'password',
+    clearable: false,
+    additional_attributes: {
+        autocomplete: 'off',
+    },
+    full_width: full_width,
+}) }}
+{{ fields.passwordField('password2', '', __('Confirm password'), {
+    clearable: false,
+    additional_attributes: {
+        autocomplete: 'off',
+    },
+    full_width: full_width,
+}) }}
+{% if config('use_password_security') %}
+    {{ fields.htmlField('password_checks', include('components/user/password_security_checks.html.twig', {list_view: true}), __('Password security policy'), {
+        full_width: full_width,
+    }) }}
+{% endif %}
+<script>
+    $('input[name=_init_password]').on('change', function() {
+        $('input[name=password]').closest('.form-field')
+            .toggleClass('d-none', $(this).is(':checked'))
+            .val('');
+        $('input[name=password2]').closest('.form-field')
+            .toggleClass('d-none', $(this).is(':checked'))
+            .val('');
+        $('.password-security-checks').closest('.form-field').toggleClass('d-none', $(this).is(':checked'));
+    });
+    {% if config('use_password_security') %}
+        $('input[name=password]').on('input', passwordCheck);
+    {% endif %}
+</script>

--- a/templates/pages/admin/user/user.html.twig
+++ b/templates/pages/admin/user/user.html.twig
@@ -1,0 +1,321 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2025 Teclib' and contributors.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+{% import 'components/form/fields_macros.html.twig' as fields %}
+{% import 'components/form/modals_macros.html.twig' as modals %}
+
+{% set params  = params ?? [] %}
+{% set rand_field = rand|default(random()) %}
+{% set field_options = {
+    rand: rand_field
+} %}
+
+{% set internal_auth = item.fields['authtype'] == constant('Auth::DB_GLPI') %}
+{% set external_auth = not internal_auth %}
+{# Simple form used when creating users from a ticket #}
+{% set simple_form = params.simplified_form|default(false) %}
+{% set is_my_form = item.getID() == session('glpiID') %}
+{# Preference form = My Settings page #}
+{% set is_preference_form = is_preference_form|default(false) %}
+{% set target = path(is_preference_form ? '/front/preference.php' : '/front/user.form.php') %}
+
+<div class="asset {{ bg }}">
+    <form id="main-form" name="asset_form" method="post" action="{{ target }}" enctype="multipart/form-data" data-submit-once>
+        <div class="card-body d-flex flex-wrap">
+            <div class="col-12 col-xxl-12 flex-column">
+                <div class="d-flex flex-row flex-wrap flex-xl-nowrap">
+                    <div class="row flex-row align-items-start flex-grow-1">
+                        <div class="row flex-row">
+                            <input type="hidden" name="id" value="{{ session('glpiID') }}" />
+                            {% if (item.isNewItem() or internal_auth) and not is_preference_form %}
+                                {{ fields.textField('name', item.fields['name'], __('Login')) }}
+                            {% else %}
+                                {% set login_field %}
+                                    <span class="fw-bold">{{ item.fields['name'] }}</span>
+                                    <input type="hidden" name="name" value="{{ item.fields['name'] }}" />
+                                {% endset %}
+                                {{ fields.htmlField(
+                                    'name',
+                                    login_field,
+                                    __('Login')
+                                ) }}
+                            {% endif %}
+
+                            {% if not simple_form and not item.isNewItem() %}
+                                {{ include('pages/admin/user/user_picture_field.html.twig') }}
+                            {% else %}
+                                {{ fields.nullField() }}
+                            {% endif %}
+
+                            {% if not is_preference_form and show_sync_field %}
+                                {{ fields.htmlField(
+                                    'sync_field',
+                                    item.fields['sync_field']|default(constant('Dropdown::EMPTY_VALUE')),
+                                    __('Synchronization field')
+                                ) }}
+                                {{ fields.nullField() }}
+                            {% endif %}
+
+                            {{ fields.textField('realname', item.fields['realname'], __('Surname'), {
+                                readonly: external_auth,
+                            }) }}
+                            {{ fields.textField('firstname', item.fields['firstname'], __('First name'), {
+                                readonly: external_auth,
+                            }) }}
+
+                            {% if timezones is not null %}
+                                {{ fields.dropdownArrayField('timezone', item.fields['timezone'], timezones, __('Timezone'), field_options|merge({
+                                    display_emptychoice: true,
+                                    emptylabel: __('Use server configuration')
+                                })) }}
+                            {% elseif has_profile_right('config', constant('READ')) %}
+                                {% set tz_not_config = __('Timezone usage has not been activated.') ~ ' ' ~ __('Run the "%1$s" command to activate it.')|format('php bin/console database:enable_timezones') %}
+                                {{ fields.htmlField('', tz_not_config, __('Timezone'), field_options) }}
+                            {% endif %}
+
+                            {% if not is_preference_form %}
+                                {{ fields.dropdownYesNo('is_active', item.fields['is_active'], __('Active'), {
+                                    readonly: not higher_rights,
+                                    helper: not higher_rights ? __('Not enough rights to change this field') : ''
+                                }) }}
+                            {% endif %}
+
+                            {% if not simple_form and not is_preference_form %}
+                                {{ fields.datetimeField('begin_date', item.fields['begin_date'], __('Valid since'), {
+                                    clearable: true,
+                                    readonly: not higher_rights,
+                                }) }}
+                                {{ fields.datetimeField('end_date', item.fields['end_date'], __('Valid until'), {
+                                    clearable: true,
+                                    readonly: not higher_rights,
+                                }) }}
+                            {% endif %}
+
+                            {% if not is_preference_form and not item.isNewItem() and has_profile_right('user', constant('User::READAUTHENT')) %}
+                                {% set auth_field %}
+                                    {{ call('Auth::getMethodLink', [item.fields['authtype'], item.fields['auths_id']])|raw }}
+                                    {% if item.fields['date_sync'] is not empty %}
+                                        <br>
+                                        {{ __('Last synchronization on %s')|format(item.fields['date_sync']|formatted_datetime) }}
+                                    {% endif %}
+                                    {% if item.fields['last_login'] %}
+                                        <br>
+                                        {{ __('Last login on %s')|format(item.fields['last_login']|formatted_datetime) }}
+                                    {% endif %}
+                                    {% if item.fields['user_dn'] %}
+                                        <br>
+                                        {{ __('%1$s: %2$s')|format(
+                                            __('User DN'),
+                                            item.fields['user_dn']
+                                        ) }}
+                                    {% endif %}
+                                    {% if item.fields['is_deleted_ldap'] %}
+                                        <br>
+                                        {{ __('User missing in LDAP directory') }}
+                                    {% endif %}
+                                    {% if item.fields['2fa'] is not same as null %}
+                                        <br>
+                                        {{ __('2FA enabled') }}
+                                        {% if has_profile_right('user', constant('User::UPDATEAUTHENT')) %}
+                                            <button type="submit" name="disable_2fa" class="btn btn-outline-danger btn-sm ms-1" data-bs-toggle="tooltip"
+                                                    title="{{ __('If 2FA is mandatory for this user, they will be required to set it back up the next time they log in.') }}">
+                                                {{ __('Disable') }}
+                                            </button>
+                                        {% endif %}
+                                    {% endif %}
+                                {% endset %}
+                                {{ fields.htmlField('_auth', auth_field, __('Authentication')) }}
+                            {% elseif item.isNewItem() %}
+                                <input type="hidden" name="authtype" value="1" />
+                            {% endif %}
+
+                            {% if not simple_form and not is_preference_form %}
+                                {{ fields.dropdownField('UserCategory', 'usercategories_id', item.fields['usercategories_id'], _n('Category', 'Categories', 1)) }}
+                            {% endif %}
+                            {% if not simple_form %}
+                                {% if not is_preference_form %}
+                                    {{ fields.dropdownField('UserTitle', 'usertitles_id', item.fields['usertitles_id'], _x('person', 'Title')) }}
+                                    {{ fields.textareaField('comment', item.fields['comment'], __('Comments')) }}
+                                {% endif %}
+                                {{ fields.textField('registration_number', item.fields['registration_number'], __('Administrative number')) }}
+                            {% endif %}
+                            {% if not item.isNewItem() %}
+                                {{ fields.dropdownField('Location', 'locations_id', item.fields['locations_id'], 'Location'|itemtype_name, {
+                                    entity: entities
+                                }) }}
+                            {% endif %}
+
+                            {% if item.isNewItem() %}
+                                {{ fields.smallTitle(_n('Authorization', 'Authorizations', 1)) }}
+                                {{ fields.dropdownYesNo('_is_recursive', 0, __('Recursive')) }}
+                                {{ fields.dropdownField('Profile', '_profiles_id', call('Profile::getDefault'), 'Profile'|itemtype_name(1)) }}
+                                {{ fields.dropdownField('Entity', '_entities_id', params.entities_id|default(session('glpiactive_entity')), 'Entity'|itemtype_name(1), {
+                                    display_emptychoice: false,
+                                    entity: session('glpiactiveentities')
+                                }) }}
+                            {% else %}
+                                {% if higher_rights or is_my_form %}
+                                    {{ fields.dropdownArrayField(
+                                        name: 'profiles_id',
+                                        value: item.fields['profiles_id'],
+                                        elements: profiles,
+                                        label: __('Default profile'),
+                                        options: {
+                                            display_emptychoice: true,
+                                        }
+                                    ) }}
+                                {% endif %}
+                                {% if higher_rights or is_preference_form%}
+                                    {{ fields.dropdownField('Entity', 'entities_id', item.fields['entities_id']|default(-1), __('Default entity'), {
+                                        toadd: {
+                                            '-1': __('Full structure')
+                                        },
+                                        entity: entities,
+                                    }) }}
+                                {% endif %}
+                                {% if higher_rights %}
+                                    {{ fields.dropdownArrayField(
+                                        name: 'groups_id',
+                                        value: item.fields['groups_id'],
+                                        elements: groups,
+                                        label: __('Default group'),
+                                        options: {
+                                            display_emptychoice: true,
+                                        }
+                                    ) }}
+                                    {{ fields.dropdownField('User', 'users_id_supervisor', item.fields['users_id_supervisor'], __('Supervisor'), {
+                                        entity: session('glpiactive_entity'),
+                                        entity_sons: session('glpiactive_entity_recursive'),
+                                        used: [item.getID()],
+                                        right: 'all'
+                                    }) }}
+                                {% endif %}
+
+                                {% if enable_nickname %}
+                                    {{ fields.textField('nickname', item.fields['nickname'], __('Nickname')) }}
+                                {% endif %}
+                            {% endif %}
+
+                            {% if is_preference_form %}
+                                {% set lang_dropdown %}
+                                    {% do call('Dropdown::showLanguages', ['language', {
+                                        value: item.fields['language']|default(config('language'))
+                                    }]) %}
+                                {% endset %}
+                                {{ fields.htmlField('lang_dropdown', lang_dropdown, __('Language')) }}
+                                {{ fields.dropdownArrayField('use_mode', item.fields['use_mode'], {
+                                    (constant('Session::NORMAL_MODE')): __('Normal'),
+                                    (constant('Session::DEBUG_MODE')): __('Debug'),
+                                }, __('Use GLPI in mode')) }}
+                            {% endif %}
+
+                            {{ fields.smallTitle(__('Contact information')) }}
+                            {% set emails_field %}
+                                {{ call('UserEmail::showForUser', [item]) }}
+                                {{ call('UserEmail::showAddEmailButton', [item]) }}
+                            {% endset %}
+                            {{ fields.htmlField('_useremails', emails_field, _n('Email', 'Emails', get_plural_number())) }}
+                            {{ fields.textField('phone', item.fields['phone'], 'Phone'|itemtype_name(1)) }}
+                            {{ fields.textField('mobile', item.fields['mobile'], __('Mobile phone')) }}
+                            {% if not simple_form %}
+                                {{ fields.textField('phone2', item.fields['phone2'], __('Phone 2')) }}
+                            {% endif %}
+
+                            {% if not item.isNewItem() and (caneditpassword or is_preference_form) %}
+                                {{ fields.smallTitle(__('Passwords and access keys')) }}
+                                {{ fields.passwordField('api_token', item.fields['api_token'], __('API token'), {
+                                    can_regenerate: true,
+                                    is_disclosable: true,
+                                    clearable: false,
+                                    is_copyable: true,
+                                    additional_attributes: {
+                                        autocomplete: 'off',
+                                    },
+                                }) }}
+                                {% if not external_auth %}
+                                    {% set change_pw_field %}
+                                        {% if is_preference_form %}
+                                            <a role="button" class="btn btn-outline-secondary btn-sm" href="{{ path('/front/updatepassword.php') }}">
+                                                <i class="ti ti-lock"></i>
+                                                {{ __('Change password') }}
+                                            </a>
+                                        {% else %}
+                                            {{ modals.modal(__('Change password'), include('pages/admin/user/change_other_password.html.twig', {full_width: true}), {
+                                                id: 'modal_password_' ~ rand_field,
+                                            }) }}
+                                            <button type="button" class="btn btn-outline-secondary btn-sm" data-bs-toggle="modal" data-bs-target="#modal_password_{{ rand_field }}">
+                                                <i class="ti ti-lock"></i>
+                                                {{ __('Change password') }}
+                                            </button>
+                                            <div class="text-warning d-none" data-password-change-pending>
+                                                {{ __('Password change pending') }}
+                                            </div>
+                                            <script>
+                                                $('#modal_password_{{ rand_field }}').on('hide.bs.modal', () => {
+                                                    $('[data-password-change-pending]').toggleClass('d-none', $('#modal_password_{{ rand_field }} input[name=password]').val() === '');
+                                                });
+                                            </script>
+                                        {% endif %}
+                                    {% endset %}
+                                    {{ fields.htmlField('_change_pw', change_pw_field, __('Password')) }}
+                                {% endif %}
+                            {% endif %}
+                            {% if item.isNewItem() %}
+                                {{ fields.smallTitle(__('Passwords and access keys')) }}
+                                <div>
+                                    {{ include('pages/admin/user/change_other_password.html.twig') }}
+                                </div>
+                            {% endif %}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </form>
+    {% if not is_preference_form %}
+        {% if no_form_buttons is not defined or no_form_buttons == false %}
+            {{ include('components/form/buttons.html.twig') }}
+        {% endif %}
+        {% if params['formfooter'] is null or params['formfooter'] == true %}
+            <div class="card-footer mx-n2 mb-n2">
+                {{ include('components/form/dates.html.twig') }}
+            </div>
+        {% endif %}
+    {% else %}
+        <div class="card-body mx-n2 border-top d-flex flex-row-reverse align-items-start flex-wrap">
+            <button class="btn btn-primary me-2" type="submit" name="update" value="1">
+                <i class="ti ti-device-floppy"></i>
+                <span>{{ _x('button', 'Save') }}</span>
+            </button>
+        </div>
+    {% endif %}
+</div>

--- a/templates/pages/admin/user/user_picture_field.html.twig
+++ b/templates/pages/admin/user/user_picture_field.html.twig
@@ -1,0 +1,119 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2025 Teclib' and contributors.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+{% import 'components/form/fields_macros.html.twig' as fields %}
+{% import 'components/form/basic_inputs_macros.html.twig' as inputs %}
+{% import 'components/form/modals_macros.html.twig' as modals %}
+
+{% set can_update = item.canUpdate() and item.canUpdateItem() %}
+{% set avatar %}
+    {{ include('components/user/picture.html.twig', {
+        user_object: item,
+        with_link: false,
+        avatar_size: 'avatar-xl'
+    }) }}
+{% endset %}
+{% set avatar_initials %}
+    {{ include('components/user/picture.html.twig', {
+        user_object: item,
+        with_link: false,
+        avatar_size: 'avatar-xl',
+        force_initials: true
+    }) }}
+{% endset %}
+
+{% set picture_field %}
+    <div
+        {% if can_update %}
+            class="cursor-pointer flex-shrink-1" title="{{ __('Change picture') }}" role="button" data-bs-toggle="modal" data-bs-target="#modal_picture_{{ rand_field }}"
+        {% endif %}>
+        <div data-current-avatar>{{ avatar }}</div>
+        <div data-default-avatar class="d-none">{{ avatar_initials }}</div>
+        <div class="avatar avatar-xl rounded d-none" data-preview-avatar>
+            <img src="" alt="{{ __('Preview') }}" class="img-fluid" />
+        </div>
+    </div>
+    {% if can_update %}
+        {% set modal_content %}
+            <div class="text-center">
+                <div data-current-avatar>{{ avatar }}</div>
+                <div data-default-avatar class="d-none">{{ avatar_initials }}</div>
+                <div class="avatar avatar-xl rounded d-none" data-preview-avatar>
+                    <img src="" alt="{{ __('Preview') }}" class="img-fluid" />
+                </div>
+                {{ inputs.file('picture', null, {
+                    onlyimages: true,
+                    multiple: false,
+                }) }}
+                {% if item.fields['picture'] is not empty %}
+                    {{ fields.checkboxField('_blank_picture', 0, __('Clear'), {
+                        additional_attributes: {
+                            onclick: '$(this).closest(".modal").find("[data-current-avatar], [data-default-avatar], .fileupload").toggleClass("d-none");'
+                        }
+                    }) }}
+                {% endif %}
+                <script type="module">
+                    function updateAvatarVisibilities() {
+                        // Cannot rely on 'fileuploadprocessstop' event or files property as they flat out don't work. fileupload_info content is not updated fast enough to be seen from change event.
+                        const has_pending_file = $('#modal_picture_{{ rand_field }} [data-preview-avatar] img').attr('src') !== '';
+                        const will_clear = $('#modal_picture_{{ rand_field }} input[name=_blank_picture]').is(':checked');
+
+                        $('[data-preview-avatar]').toggleClass('d-none', !has_pending_file || will_clear);
+                        $('[data-current-avatar]').toggleClass('d-none', has_pending_file || will_clear);
+                        $('[data-default-avatar]').toggleClass('d-none', !will_clear);
+                    }
+
+                    $('#modal_picture_{{ rand_field }}').on('mouseup', '.remove_file_upload', (e) => {
+                        // Click handler doesn't work. Don't know. So much wasted time. Some other handler probably blocks it.
+                        $('#modal_picture_{{ rand_field }} [data-preview-avatar] img').attr('src', '');
+                        updateAvatarVisibilities();
+                    });
+                    $('#modal_picture_{{ rand_field }} input[type=file]').on('change', (e) => {
+                        // fileuploadprocessstop event doesn't work on the file input or .fileupload. Maybe doesn't work at all.
+                        const preview_img = URL.createObjectURL(e.target.files[0]);
+                        $('[data-preview-avatar] img').attr('src', preview_img);
+                        updateAvatarVisibilities();
+                    });
+                    $('#modal_picture_{{ rand_field }} input[name=_blank_picture]').on('change', (e) => {
+                        updateAvatarVisibilities();
+                    });
+                </script>
+            </div>
+        {% endset %}
+        {{ modals.modal(__('Change picture'), modal_content, {
+            id: 'modal_picture_' ~ rand_field,
+        }) }}
+    {% endif %}
+{% endset %}
+{{ fields.htmlField('_picture', picture_field, _n('Picture', 'Pictures', 1), {
+    wrapper_class: 'form-control-plaintext d-flex'
+}) }}

--- a/tests/cypress/e2e/Admin/user.cy.js
+++ b/tests/cypress/e2e/Admin/user.cy.js
@@ -1,0 +1,72 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+describe('User form', () => {
+    beforeEach(() => {
+        cy.login();
+        cy.changeProfile('Super-Admin');
+    });
+    it('Change my password field', () => {
+        cy.visit('/front/preference.php');
+        cy.get('.nav-item').contains('Main').click();
+        cy.findByRole('button', { name: /Change password/ }).click();
+        cy.url().should('include', '/front/updatepassword.php');
+    });
+    it('Change other password field', () => {
+        cy.visit('/front/user.form.php?id=4');
+        cy.findByRole('tab', { name: 'User' }).click();
+        cy.findByRole('button', { name: /Change password/ }).click();
+        cy.findByRole('dialog').should('be.visible').within(() => {
+            cy.findByLabelText('Password').should('be.visible').closest('form').should('exist');
+            cy.findByLabelText('Confirm password').should('be.visible').closest('form').should('exist');
+        });
+    });
+    it('Change user picture', () => {
+        cy.visit('/front/user.form.php?id=4');
+        cy.findByRole('tab', { name: 'User' }).click();
+        cy.findByTitle('Change picture').click();
+        cy.findByRole('dialog').should('be.visible').within(() => {
+            cy.get('[data-current-avatar]').should('be.visible');
+            cy.get('[data-default-avatar]').should('not.be.visible');
+            cy.get('[data-preview-avatar]').should('not.be.visible');
+            cy.get('input[type="file"]').selectFile('fixtures/uploads/foo.png');
+            cy.get('[data-preview-avatar]').should('be.visible');
+            cy.get('[data-default-avatar]').should('not.be.visible');
+            cy.get('[data-current-avatar]').should('not.be.visible');
+            cy.get('.fileupload .remove_file_upload').click();
+            cy.get('[data-current-avatar]').should('be.visible');
+            cy.get('[data-default-avatar]').should('not.be.visible');
+            cy.get('[data-preview-avatar]').should('not.be.visible');
+        });
+    });
+});

--- a/tests/cypress/e2e/Admin/user.cy.js
+++ b/tests/cypress/e2e/Admin/user.cy.js
@@ -52,7 +52,7 @@ describe('User form', () => {
         });
     });
     it('Change user picture', () => {
-        cy.visit('/front/user.form.php?id=4');
+        cy.visit('/front/user.form.php?id=7');
         cy.findByRole('tab', { name: 'User' }).click();
         cy.findByTitle('Change picture').click();
         cy.findByRole('dialog').should('be.visible').within(() => {


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] This change requires a documentation update.

## Description

This was going to just be a simple migration of the User forms to Twig, but the old layout looked worse when migrated as-is. In both the old and new, the form felt cluttered as well. The picture and password sections specifically felt messy.

Changes:
- Merge of regular User form and the "My user/My settings" user form into a single template, but still only showing certain fields on the My Settings page.
- New UI/UX for changing user pictures. The old display of having the picture, file upload and clear checkbox directly in the form took up a lot of room and didn't look right with the new form layout. Now, only the picture is shown. When you hover over the picture, you get a pointer and tooltip to indicate you can click to change the picture. This opens a modal that lets you go back to the default picture (initials), or upload a new one. Unlike the previous UI, this new one updates the displayed picture in real time to show what the new image will be once the form is saved.
- Simplified password management
  - New user form shows the same fields as before
  - Existing internal user forms only show a "Change password" button in the "Passwords and access keys" section (was "Remote access keys") at the bottom of the form. This opens a modal to prompt for a new password. The checkbox to randomize the password and send an email (labeled "Send an email to the user to set their own new password") is not present.
  - You own "My settings" user form shows a similar "Change password" button, but it redirects you to the regular password update form which was previously not linked anywhere except when the password was expired.
  - New massive action for sending password reset emails. This action does not randomize the current password like the "Send an email to the user to set their own new password" checkbox does.
- Moved "Last login" to "Authentication" field of the form
- Moved emails and phone numbers to a "Contact information" section.
- Cleaner password requirement list. Now shows a "Minimum length" label instead of just printing the minimum length.

## Screenshots

Original form:
![Selection_437](https://github.com/user-attachments/assets/10672aed-d0ed-4dee-8b4c-f7c5e6023353)


Super-Admin looking at own, full user form:
![Selection_442](https://github.com/user-attachments/assets/0180e9ca-f2e4-4803-b270-03a5359edf03)

LDAP User form:
![Selection_443](https://github.com/user-attachments/assets/324710f5-3ba7-4f74-a444-0907f6a04a3d)

Technician looking at super-admin form:
![Selection_444](https://github.com/user-attachments/assets/38d61904-c5e5-4113-872f-22222970122b)

Looking at own "My settings" form:
![Selection_445](https://github.com/user-attachments/assets/fc5d86ca-46de-4d3b-b37e-dcd2c0df7628)

New user form (Ability to set picture for a new user was already missing):
![Selection_446](https://github.com/user-attachments/assets/90944d7e-374f-4d8c-9fef-2cbbcbeaa959)

Change other user's password:
![Selection_447](https://github.com/user-attachments/assets/3d6c59d6-6285-4ae5-a7d0-3367693ed70b)

Change password field text after setting new password, but before saving the form:
![Selection_448](https://github.com/user-attachments/assets/0f96d481-9f68-4983-acdf-eda2e2084bee)
