### PR TITLE
Reduce margin of hr elements in search results

### DIFF
--- a/css/includes/pages/_search.scss
+++ b/css/includes/pages/_search.scss
@@ -122,6 +122,10 @@
                     font-weight: 500;
                 }
 
+                hr {
+                    margin: 10px 0;
+                }
+
                 @include media-breakpoint-up(lg) {
                     thead:first-child {
                         th {


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Reduce vertical margins of `hr` elements which are used to separate items within the same cell from being 2x the page font size to 10px.

Before:
![Selection_449](https://github.com/user-attachments/assets/defbdb73-f4f7-4609-8645-fe0205ce81d0)

After:
![Selection_451](https://github.com/user-attachments/assets/668c34ea-28d9-4dd7-9c23-0e139b7bd0b4)

