### PR TITLE
Fix - Validation status when requesting a new validation after reject

### DIFF
--- a/src/CommonITILValidation.php
+++ b/src/CommonITILValidation.php
@@ -315,11 +315,7 @@ abstract class CommonITILValidation extends CommonDBChild
         $mailsend = false;
         if ($item->getFromDB($this->fields[static::$items_id])) {
             // Set global validation to waiting
-            if (
-                ($item->fields['global_validation'] == self::ACCEPTED)
-                || ($item->fields['global_validation'] == self::NONE)
-                || ($item->fields['global_validation'] == self::REFUSED)
-            ) {
+            if (((int) $item->fields['global_validation']) !== self::WAITING) {
                 $input = [
                     'id'                    => $this->fields[static::$items_id],
                     'global_validation'     => self::WAITING,

--- a/src/CommonITILValidation.php
+++ b/src/CommonITILValidation.php
@@ -318,6 +318,7 @@ abstract class CommonITILValidation extends CommonDBChild
             if (
                 ($item->fields['global_validation'] == self::ACCEPTED)
                 || ($item->fields['global_validation'] == self::NONE)
+                || ($item->fields['global_validation'] == self::REFUSED)
             ) {
                 $input = [
                     'id'                    => $this->fields[static::$items_id],


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !36625
- Here is a brief description of what this PR does

This PR fixes an issue where, after rejecting an approval request and submitting a new one, the approval status incorrectly remains `Rejected` instead of changing to `Waiting for approval`



