### PR TITLE
Add yesno formater in datatable.html.twig

### DIFF
--- a/templates/components/datatable.html.twig
+++ b/templates/components/datatable.html.twig
@@ -281,7 +281,7 @@
                                                 </div>
                                             {% endif %}
                                         {% elseif formatter == 'yesno' %}
-                                            {{ if entry[colkey] == 1 }}
+                                            {% if entry[colkey] == 1 %}
                                                 <div aria-label="{{ __('Yes') }}"><i class="ti ti-circle-check"></i></div>
                                             {{ else }}
                                                 <div aria-label="{{ __('No') }}"></div>

--- a/templates/components/datatable.html.twig
+++ b/templates/components/datatable.html.twig
@@ -281,7 +281,11 @@
                                                 </div>
                                             {% endif %}
                                         {% elseif formatter == 'yesno' %}
-                                            {{ entry[colkey] == 1 ? '<i class="ti ti-circle-check"></i>' : '' }}
+                                            {{ if entry[colkey] == 1 }}
+                                                <div aria-label="{{ __('Yes') }}"><i class="ti ti-circle-check"></i></div>
+                                            {{ else }}
+                                                <div aria-label="{{ __('No') }}"></div>
+                                            {% endif %}
                                         {% else %}
                                             {{ entry[colkey] }}
                                         {% endif %}

--- a/templates/components/datatable.html.twig
+++ b/templates/components/datatable.html.twig
@@ -281,7 +281,7 @@
                                                 </div>
                                             {% endif %}
                                         {% elseif formatter == 'yesno' %}
-                                            {{ entry[colkey] == 1 ? __('Yes') : __('No') }}
+                                            {{ entry[colkey] == 1 ? '<i class="ti ti-circle-check"></i>' : '' }}
                                         {% else %}
                                             {{ entry[colkey] }}
                                         {% endif %}

--- a/templates/components/datatable.html.twig
+++ b/templates/components/datatable.html.twig
@@ -283,7 +283,7 @@
                                         {% elseif formatter == 'yesno' %}
                                             {% if entry[colkey] == 1 %}
                                                 <div aria-label="{{ __('Yes') }}"><i class="ti ti-circle-check"></i></div>
-                                            {{ else }}
+                                            {% else %}
                                                 <div aria-label="{{ __('No') }}"></div>
                                             {% endif %}
                                         {% else %}

--- a/templates/components/datatable.html.twig
+++ b/templates/components/datatable.html.twig
@@ -280,6 +280,8 @@
                                                     {{ content }}
                                                 </div>
                                             {% endif %}
+                                        {% elseif formatter == 'yesno' %}
+                                            {{ entry[colkey] == 1 ? __('Yes') : __('No') }}
                                         {% else %}
                                             {{ entry[colkey] }}
                                         {% endif %}


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- Here is a brief description of what this PR does
Add a formatter for yes no values such as is_active, is_recursive, etc.

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/3e727b4a-a78d-460f-8487-99407be113e2)



