### PR TITLE
Fix plugins generic URLs handling

### DIFF
--- a/src/Glpi/Kernel/Kernel.php
+++ b/src/Glpi/Kernel/Kernel.php
@@ -140,13 +140,6 @@ final class Kernel extends BaseKernel
         if (\is_file($path = $this->getProjectDir() . '/routes/' . $this->environment . '.php')) {
             (require $path)($routes->withPath($path), $this);
         }
-
-        // Plugin-specific routes
-        $routes->add(PluginsRouterListener::ROUTE_NAME, '/plugins/{plugin_name}/{path_rest}')
-            ->requirements([
-                'plugin_name' => '^[a-zA-Z0-9_-]+$',
-                'path_rest' => '.*',
-            ]);
     }
 
     private function triggerGlobalsDeprecation(): void

--- a/src/Glpi/Kernel/ListenersPriority.php
+++ b/src/Glpi/Kernel/ListenersPriority.php
@@ -82,9 +82,15 @@ final class ListenersPriority
         // requested URI matches an existing file.
         HttpListener\LegacyRouterListener::class        => 400,
 
+        // This listener allows matching plugins routes at runtime.
+        // It must be executed prior to the `LegacyItemtypeRouteListener` to be sure that any legacy route
+        // override in plugins will be taken into account before trying to forward to a generic controller.
+        HttpListener\PluginsRouterListener::class       => 375,
+
         // Map legacy scripts URLS (e.g. `/front/computer.php`) to modern controllers.
-        // Must be executed after the `LegacyRouterListener` to ensure to use the legacy script if it exists.
-        HttpListener\LegacyItemtypeRouteListener::class => 375,
+        // Must be executed after the `LegacyRouterListener` to ensure to use the legacy script if it exists
+        // and after the `PluginsRouterListener` to allow plugin to bypass generic controllers.
+        HttpListener\LegacyItemtypeRouteListener::class => 350,
 
         // Legacy URLs redirections.
         // Must be executed before the Symfony router, to prevent `NotFoundHttpException` to be thrown.
@@ -92,14 +98,6 @@ final class ListenersPriority
         // Symfony's Router priority is 32.
         // @see \Symfony\Component\HttpKernel\EventListener\RouterListener::getSubscribedEvents()
         HttpListener\RedirectLegacyRouteListener::class => 33,
-
-        // This listener allows matching plugins routes at runtime,
-        //   that's why it's executed right after Symfony's Router,
-        //   and also after GLPI's config is set.
-        //
-        // Symfony's Router priority is 32.
-        // @see \Symfony\Component\HttpKernel\EventListener\RouterListener::getSubscribedEvents()
-        HttpListener\PluginsRouterListener::class       => 31,
 
         // Redefine the `$_SERVER['PHP_SELF']` variables that it still used to retrieve the "current path".
         // Must be called as late as possible, just before controllers execution.


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.

## Description

It fixes #19132.

When the plugin routing was implemented in #17641, some technical limitations forces us to add a "fake" route to detect plugins URLs and then handle them after the Symfony routing using a dedicated listener. The problem is that it conflicts with the way to detect the specific controllers in the `LegacyItemtypeRouteListener`, see https://github.com/glpi-project/glpi/blob/f4c1d9f285510e6f12e1bba28aec20ec79b1dca3/src/Glpi/Http/Listener/LegacyItemtypeRouteListener.php#L84-L90

Now we have reorganize the GLPI bootstraping to do it entirely after the kernel boot, we can remove this "fake" route and call the `PluginsRouterListener` earlier.