### PR TITLE
Fix routing of devices models/types URLs

### DIFF
--- a/phpunit/functional/Glpi/Http/LegacyItemtypeRouteListenerTest.php
+++ b/phpunit/functional/Glpi/Http/LegacyItemtypeRouteListenerTest.php
@@ -49,7 +49,7 @@ use Symfony\Component\Routing\Matcher\UrlMatcherInterface;
 final class LegacyItemtypeRouteListenerTest extends TestCase
 {
     #[DataProvider('provideItemtypes')]
-    public function testFindDbClass(string $path_info, string $expected_class_name): void
+    public function testFindGlpiClass(string $path_info, string $expected_class_name): void
     {
         $listener = new LegacyItemtypeRouteListener($this->getUrlMatcherMock());
         $request = $this->createRequest($path_info);
@@ -358,16 +358,7 @@ final class LegacyItemtypeRouteListenerTest extends TestCase
             yield $path => [$path, $class];
         }
 
-        $devices_paths = [
-            '/front/device.php',
-            '/front/devicemodel.php',
-            '/front/devicetype.php',
-            '/front/device.form.php',
-            '/front/devicemodel.form.php',
-            '/front/devicetype.form.php',
-        ];
-
-        $devices_names = [
+        $devices_classes = [
             \DeviceBattery::class,
             \DeviceCamera::class,
             \DeviceCase::class,
@@ -388,10 +379,26 @@ final class LegacyItemtypeRouteListenerTest extends TestCase
             \DeviceSoundCard::class,
         ];
 
-        foreach ($devices_names as $device) {
-            foreach ($devices_paths as $path) {
-                $fullPath = $path . '?itemtype=' . $device;
-                yield $fullPath => [$fullPath, $device];
+        foreach ($devices_classes as $device_class) {
+            $devices_paths = [
+                sprintf('/front/device.php?itemtype=%s', $device_class)      => $device_class,
+                sprintf('/front/device.form.php?itemtype=%s', $device_class) => $device_class,
+            ];
+
+            $model_class = $device_class . 'Model';
+            if (\class_exists($model_class)) {
+                $devices_paths[sprintf('/front/devicemodel.php?itemtype=%s', $model_class)] = $model_class;
+                $devices_paths[sprintf('/front/devicemodel.form.php?itemtype=%s', $model_class)] = $model_class;
+            }
+
+            $type_class = $device_class . 'Type';
+            if (\class_exists($type_class)) {
+                $devices_paths[sprintf('/front/devicetype.php?itemtype=%s', $type_class)] = $type_class;
+                $devices_paths[sprintf('/front/devicetype.form.php?itemtype=%s', $type_class)] = $type_class;
+            }
+
+            foreach ($devices_paths as $path => $class) {
+                yield $path => [$path, $class];
             }
         }
     }

--- a/src/Glpi/Http/Listener/LegacyItemtypeRouteListener.php
+++ b/src/Glpi/Http/Listener/LegacyItemtypeRouteListener.php
@@ -35,6 +35,8 @@
 namespace Glpi\Http\Listener;
 
 use CommonDevice;
+use CommonDeviceModel;
+use CommonDeviceType;
 use CommonDropdown;
 use CommonGLPI;
 use Glpi\Asset\Asset;
@@ -260,7 +262,7 @@ final readonly class LegacyItemtypeRouteListener implements EventSubscriberInter
         }
 
         $item = \getItemForItemtype($itemtype);
-        if ($item instanceof CommonDevice) {
+        if ($item instanceof CommonDevice || $item instanceof CommonDeviceModel || $item instanceof CommonDeviceType) {
             return $item::class;
         }
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

It fixes #18997.

`CommonDeviceModel` and `CommonDeviceType` URLs were not automatically forwarded to the generic controllers.