### PR TITLE
Purge dropdown display preferences when a dropdown definition is purged

### DIFF
--- a/phpunit/functional/Glpi/Dropdown/DropdownDefinitionTest.php
+++ b/phpunit/functional/Glpi/Dropdown/DropdownDefinitionTest.php
@@ -416,27 +416,40 @@ class DropdownDefinitionTest extends DbTestCase
 
     public function testDelete()
     {
-        /** @var \Glpi\Dropdown\DropdownDefinition $definition */
+        // Create the definition
         $definition = $this->initDropdownDefinition('test');
 
+        $classname = $definition->getDropdownClassName();
+
+        // Validate that there are display preferences that will have to be deleted
+        $this->assertGreaterThan(
+            0,
+            getAllDataFromTable('glpi_displaypreferences', ['itemtype' => $classname])
+        );
+
+        // Create some items
         $this->createItem(
-            $definition->getDropdownClassName(),
+            $classname,
             [
                 'name' => 'test',
             ]
         );
 
+        // Delete the definition
         $this->assertTrue($definition->delete([
             'id' => $definition->getID(),
         ]));
+
+        // Items are deleted
         $this->assertCount(
             0,
-            getAllDataFromTable(
-                'glpi_dropdowns_dropdowns',
-                [
-                    'dropdowns_dropdowndefinitions_id' => $definition->getID(),
-                ]
-            )
+            getAllDataFromTable('glpi_dropdowns_dropdowns', ['dropdowns_dropdowndefinitions_id' => $definition->getID()])
+        );
+
+        // Display preferences are deleted
+        $this->assertCount(
+            0,
+            getAllDataFromTable('glpi_displaypreferences', ['itemtype' => $classname])
         );
     }
 

--- a/src/Glpi/Asset/AssetDefinition.php
+++ b/src/Glpi/Asset/AssetDefinition.php
@@ -385,19 +385,10 @@ TWIG, $twig_params);
             $this->onCapacityDisabled($capacity_classname);
         }
 
-        $related_classes = [
-            $this->getAssetClassName(),
-            $this->getAssetModelClassName(),
-            $this->getAssetTypeClassName(),
-        ];
-        foreach ($related_classes as $classname) {
-            (new $classname())->deleteByCriteria(
-                ['assets_assetdefinitions_id' => $this->getID()],
-                force: true,
-                history: false
-            );
-            (new \DisplayPreference())->deleteByCriteria(['itemtype' => $classname]);
-        }
+        $this->purgeConcreteClassFromDb($this->getAssetModelClassName());
+        $this->purgeConcreteClassFromDb($this->getAssetTypeClassName());
+
+        parent::cleanDBonPurge();
     }
 
     /**

--- a/src/Glpi/CustomObject/AbstractDefinition.php
+++ b/src/Glpi/CustomObject/AbstractDefinition.php
@@ -568,6 +568,26 @@ abstract class AbstractDefinition extends CommonDBTM
         }
     }
 
+    public function cleanDBonPurge()
+    {
+        $this->purgeConcreteClassFromDb($this->getCustomObjectClassName());
+    }
+
+    /**
+     * Delete from the database all the data related to the given concrete class.
+     *
+     * @param class-string<\CommonDBTM> $concrete_classname
+     */
+    final protected function purgeConcreteClassFromDb(string $concrete_classname): void
+    {
+        (new $concrete_classname())->deleteByCriteria(
+            [static::getForeignKeyField() => $this->getID()],
+            force: true,
+            history: false
+        );
+        (new \DisplayPreference())->deleteByCriteria(['itemtype' => $concrete_classname]);
+    }
+
     /**
      * Remove given rights from `profiles` field.
      *

--- a/src/Glpi/Dropdown/DropdownDefinition.php
+++ b/src/Glpi/Dropdown/DropdownDefinition.php
@@ -171,18 +171,4 @@ final class DropdownDefinition extends AbstractDefinition
             ]);
         }
     }
-
-    public function cleanDBonPurge()
-    {
-        $related_classes = [
-            $this->getDropdownClassName(),
-        ];
-        foreach ($related_classes as $classname) {
-            (new $classname())->deleteByCriteria(
-                ['dropdowns_dropdowndefinitions_id' => $this->getID()],
-                force: true,
-                history: false
-            );
-        }
-    }
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

To manually test #19033 , I sometimes have to delete the imported definition to and run the command to recreate them. I figured out that the dropdown concrete classes display preferences are not deleted when the corresponding dropdown definition is deleted. The result is that I had SQL errors when I reimported a dropdown definition with a previously used system name, due to DB unicity checks.