### PR TITLE
Helpdesk form: store direct access token in session once validated

### DIFF
--- a/js/modules/Forms/Condition/Engine.js
+++ b/js/modules/Forms/Condition/Engine.js
@@ -107,13 +107,6 @@ export class GlpiFormConditionEngine
             form_data.append(`answers[${entry[0]}]`, entry[1]);
         }
 
-        // Included direct access token if needed.
-        // Not great to have to do this normally, TOOD: find a better way.
-        const url_params = new URLSearchParams(window.location.search);
-        if (url_params.has('token')) {
-            form_data.append('token', url_params.get('token'));
-        }
-
         // Send request
         const url = `${CFG_GLPI.root_doc}/Form/Condition/Engine`;
         const response = await fetch(url, {

--- a/phpunit/functional/Glpi/Form/AccessControl/ControlType/AllowListTest.php
+++ b/phpunit/functional/Glpi/Form/AccessControl/ControlType/AllowListTest.php
@@ -40,6 +40,7 @@ use Glpi\DBAL\JsonFieldInterface;
 use Glpi\Form\AccessControl\AccessVote;
 use Glpi\Form\AccessControl\ControlType\AllowList;
 use Glpi\Form\AccessControl\FormAccessParameters;
+use Glpi\Form\Form;
 use Glpi\Tests\FormBuilder;
 use Glpi\Tests\FormTesterTrait;
 use Glpi\Form\AccessControl\ControlType\AllowListConfig;
@@ -199,7 +200,7 @@ class AllowListTest extends \DbTestCase
         $allow_list = new AllowList();
         $this->assertEquals(
             $expected,
-            $allow_list->canAnswer($config, $parameters)
+            $allow_list->canAnswer(new Form(), $config, $parameters)
         );
     }
 

--- a/phpunit/functional/Glpi/Form/AccessControl/ControlType/DirectAccessTest.php
+++ b/phpunit/functional/Glpi/Form/AccessControl/ControlType/DirectAccessTest.php
@@ -39,6 +39,7 @@ use Glpi\DBAL\JsonFieldInterface;
 use Glpi\Form\AccessControl\AccessVote;
 use Glpi\Form\AccessControl\ControlType\DirectAccess;
 use Glpi\Form\AccessControl\FormAccessParameters;
+use Glpi\Form\Form;
 use Glpi\Tests\FormBuilder;
 use Glpi\Tests\FormTesterTrait;
 use Glpi\Form\AccessControl\ControlType\DirectAccessConfig;
@@ -251,7 +252,7 @@ class DirectAccessTest extends \DBTestCase
         $direct_access = new DirectAccess();
         $this->assertEquals(
             $expected,
-            $direct_access->canAnswer($config, $parameters)
+            $direct_access->canAnswer(new Form(), $config, $parameters)
         );
     }
 

--- a/src/Glpi/Controller/Form/RendererController.php
+++ b/src/Glpi/Controller/Form/RendererController.php
@@ -103,10 +103,6 @@ final class RendererController extends AbstractController
             'my_tickets_url_param' => http_build_query($my_tickets_criteria),
             'visibility_engine_output' => $visibility_engine_output,
             'params' => $request->query->all(),
-
-            // Direct access token must be included in the form data as it will
-            // be checked in the submit answers controller.
-            'token' => $request->query->getString('token'),
         ]);
     }
 

--- a/src/Glpi/Controller/Form/Utils/CanCheckAccessPolicies.php
+++ b/src/Glpi/Controller/Form/Utils/CanCheckAccessPolicies.php
@@ -51,12 +51,7 @@ trait CanCheckAccessPolicies
             // Form administrators can bypass restrictions while previewing forms.
             $parameters = new FormAccessParameters(bypass_restriction: true);
         } else {
-            // URL parameters might be sent in GET or POST requests due to some
-            // technical limitations.
-            $url_parameters = $request->isMethod('POST')
-                ? $request->request->all()
-                : $request->query->all()
-            ;
+            $url_parameters = $request->query->all();
 
             // Load current user session info and URL parameters.
             $parameters = new FormAccessParameters(

--- a/src/Glpi/Form/AccessControl/ControlType/AllowList.php
+++ b/src/Glpi/Form/AccessControl/ControlType/AllowList.php
@@ -110,6 +110,7 @@ final class AllowList implements ControlTypeInterface
 
     #[Override]
     public function canAnswer(
+        Form $form,
         JsonFieldInterface $config,
         FormAccessParameters $parameters
     ): AccessVote {

--- a/src/Glpi/Form/AccessControl/ControlType/ControlTypeInterface.php
+++ b/src/Glpi/Form/AccessControl/ControlType/ControlTypeInterface.php
@@ -101,13 +101,9 @@ interface ControlTypeInterface
 
     /**
      * Check if the current user can answer the given form.
-     *
-     * @param JsonFieldInterface $config
-     * @param FormAccessParameters $parameters
-     *
-     * @return AccessVote
      */
     public function canAnswer(
+        Form $form,
         JsonFieldInterface $config,
         FormAccessParameters $parameters
     ): AccessVote;

--- a/src/Glpi/Form/AccessControl/FormAccessControlManager.php
+++ b/src/Glpi/Form/AccessControl/FormAccessControlManager.php
@@ -132,6 +132,7 @@ final class FormAccessControlManager
         }
 
         return $this->validateAccessControlsPolicies(
+            $form,
             $access_controls_policies,
             $parameters
         );
@@ -203,6 +204,7 @@ final class FormAccessControlManager
     }
 
     private function validateAccessControlsPolicies(
+        Form $form,
         array $policies,
         FormAccessParameters $parameters
     ): bool {
@@ -212,6 +214,7 @@ final class FormAccessControlManager
         /** @var FormAccessControl[] $policies */
         foreach ($policies as $policiy) {
             $votes[] = $policiy->getStrategy()->canAnswer(
+                $form,
                 $policiy->getConfig(),
                 $parameters
             );

--- a/templates/pages/form_renderer.html.twig
+++ b/templates/pages/form_renderer.html.twig
@@ -265,11 +265,6 @@
                 </div>
             </div>
         </div>
-
-        {# Include direct access token if supplied #}
-        {% if token %}
-            <input type="hidden" name="token" value="{{ token }}" />
-        {% endif %}
     </form>
 
     <script>(async () => {


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

As a reminder, this token allow a form to be accessed like this: `/Form/Render/{$id}?token={$token}`.

This works well when accessing a form but mean that any AJAX requested performed on the form page must also include this token to make sure the user is allowed to call it.

This is bad because it is hard to maintain (need to manually include the token everywhere) and non generic (the access policiy that deal with the token should not rely on external code that manually refer to its internal behavior).

The proposed solution is to store the submitted token in the session so it can easily be accessed by any ajax request using the session data.

This should not weaken the security as you still need the correct token to access the form in the first place.

