### PR TITLE
Implement MainAsset type choice for Generic assets

### DIFF
--- a/phpunit/functional/Appliance_ItemTest.php
+++ b/phpunit/functional/Appliance_ItemTest.php
@@ -48,7 +48,7 @@ class Appliance_ItemTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [HasAppliancesCapacity::class]);
+        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasAppliancesCapacity::class)]);
 
         $this->login(); // tab will be available only if corresponding right is available in the current session
 
@@ -68,7 +68,7 @@ class Appliance_ItemTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [HasAppliancesCapacity::class]);
+        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasAppliancesCapacity::class)]);
 
         foreach ($CFG_GLPI['appliance_types'] as $itemtype) {
             if (!Toolbox::hasTrait($itemtype, Clonable::class)) {

--- a/phpunit/functional/Appliance_ItemTest.php
+++ b/phpunit/functional/Appliance_ItemTest.php
@@ -37,6 +37,7 @@ namespace tests\units;
 use Appliance_Item;
 use DbTestCase;
 use Entity;
+use Glpi\Asset\Capacity;
 use Glpi\Asset\Capacity\HasAppliancesCapacity;
 use Glpi\Features\Clonable;
 use Toolbox;
@@ -48,7 +49,7 @@ class Appliance_ItemTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasAppliancesCapacity::class)]);
+        $this->initAssetDefinition(capacities: [new Capacity(name: HasAppliancesCapacity::class)]);
 
         $this->login(); // tab will be available only if corresponding right is available in the current session
 
@@ -68,7 +69,7 @@ class Appliance_ItemTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasAppliancesCapacity::class)]);
+        $this->initAssetDefinition(capacities: [new Capacity(name: HasAppliancesCapacity::class)]);
 
         foreach ($CFG_GLPI['appliance_types'] as $itemtype) {
             if (!Toolbox::hasTrait($itemtype, Clonable::class)) {

--- a/phpunit/functional/Certificate_ItemTest.php
+++ b/phpunit/functional/Certificate_ItemTest.php
@@ -47,7 +47,7 @@ class Certificate_ItemTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [HasCertificatesCapacity::class]);
+        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasCertificatesCapacity::class)]);
 
         $this->login(); // tab will be available only if corresponding right is available in the current session
 
@@ -67,7 +67,7 @@ class Certificate_ItemTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [HasCertificatesCapacity::class]);
+        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasCertificatesCapacity::class)]);
 
         foreach ($CFG_GLPI['certificate_types'] as $itemtype) {
             if (!Toolbox::hasTrait($itemtype, Clonable::class)) {

--- a/phpunit/functional/Certificate_ItemTest.php
+++ b/phpunit/functional/Certificate_ItemTest.php
@@ -36,6 +36,7 @@ namespace tests\units;
 
 use Certificate_Item;
 use DbTestCase;
+use Glpi\Asset\Capacity;
 use Glpi\Asset\Capacity\HasCertificatesCapacity;
 use Glpi\Features\Clonable;
 use Toolbox;
@@ -47,7 +48,7 @@ class Certificate_ItemTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasCertificatesCapacity::class)]);
+        $this->initAssetDefinition(capacities: [new Capacity(name: HasCertificatesCapacity::class)]);
 
         $this->login(); // tab will be available only if corresponding right is available in the current session
 
@@ -67,7 +68,7 @@ class Certificate_ItemTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasCertificatesCapacity::class)]);
+        $this->initAssetDefinition(capacities: [new Capacity(name: HasCertificatesCapacity::class)]);
 
         foreach ($CFG_GLPI['certificate_types'] as $itemtype) {
             if (!Toolbox::hasTrait($itemtype, Clonable::class)) {

--- a/phpunit/functional/Contract_ItemTest.php
+++ b/phpunit/functional/Contract_ItemTest.php
@@ -47,7 +47,7 @@ class Contract_ItemTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [HasContractsCapacity::class]);
+        $this->initAssetDefinition(capacities: [new \GLpi\Asset\Capacity(name: HasContractsCapacity::class)]);
 
         $this->login(); // tab will be available only if corresponding right is available in the current session
 
@@ -67,7 +67,7 @@ class Contract_ItemTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [HasContractsCapacity::class]);
+        $this->initAssetDefinition(capacities: [new \GLpi\Asset\Capacity(name: HasContractsCapacity::class)]);
 
         foreach ($CFG_GLPI['contract_types'] as $itemtype) {
             if (!Toolbox::hasTrait($itemtype, Clonable::class)) {

--- a/phpunit/functional/DatabaseInstanceTest.php
+++ b/phpunit/functional/DatabaseInstanceTest.php
@@ -36,6 +36,7 @@ namespace tests\units;
 
 use DatabaseInstance;
 use DbTestCase;
+use Glpi\Asset\Capacity;
 use Glpi\Asset\Capacity\HasDatabaseInstanceCapacity;
 use Glpi\Features\Clonable;
 use Toolbox;
@@ -47,7 +48,7 @@ class DatabaseInstanceTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasDatabaseInstanceCapacity::class)]);
+        $this->initAssetDefinition(capacities: [new Capacity(name: HasDatabaseInstanceCapacity::class)]);
 
         $this->login(); // tab will be available only if corresponding right is available in the current session
 
@@ -67,7 +68,7 @@ class DatabaseInstanceTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasDatabaseInstanceCapacity::class)]);
+        $this->initAssetDefinition(capacities: [new Capacity(name: HasDatabaseInstanceCapacity::class)]);
 
         foreach ($CFG_GLPI['databaseinstance_types'] as $itemtype) {
             if (!Toolbox::hasTrait($itemtype, Clonable::class)) {

--- a/phpunit/functional/DatabaseInstanceTest.php
+++ b/phpunit/functional/DatabaseInstanceTest.php
@@ -47,7 +47,7 @@ class DatabaseInstanceTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [HasDatabaseInstanceCapacity::class]);
+        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasDatabaseInstanceCapacity::class)]);
 
         $this->login(); // tab will be available only if corresponding right is available in the current session
 
@@ -67,7 +67,7 @@ class DatabaseInstanceTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [HasDatabaseInstanceCapacity::class]);
+        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasDatabaseInstanceCapacity::class)]);
 
         foreach ($CFG_GLPI['databaseinstance_types'] as $itemtype) {
             if (!Toolbox::hasTrait($itemtype, Clonable::class)) {

--- a/phpunit/functional/Document_ItemTest.php
+++ b/phpunit/functional/Document_ItemTest.php
@@ -48,7 +48,7 @@ class Document_ItemTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [HasDocumentsCapacity::class]);
+        $this->initAssetDefinition(capacities: [new \GLpi\Asset\Capacity(name: HasDocumentsCapacity::class)]);
 
         $this->login(); // tab will be available only if corresponding right is available in the current session
 
@@ -68,7 +68,7 @@ class Document_ItemTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [HasDocumentsCapacity::class]);
+        $this->initAssetDefinition(capacities: [new \GLpi\Asset\Capacity(name: HasDocumentsCapacity::class)]);
 
         foreach ($CFG_GLPI['itemdevices_types'] as $itemtype) {
             if (!Toolbox::hasTrait($itemtype, Clonable::class)) {

--- a/phpunit/functional/Domain_ItemTest.php
+++ b/phpunit/functional/Domain_ItemTest.php
@@ -47,7 +47,7 @@ class Domain_ItemTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [HasDomainsCapacity::class]);
+        $this->initAssetDefinition(capacities: [new \GLpi\Asset\Capacity(name: HasDomainsCapacity::class)]);
 
         $this->login(); // tab will be available only if corresponding right is available in the current session
 
@@ -67,7 +67,7 @@ class Domain_ItemTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [HasDomainsCapacity::class]);
+        $this->initAssetDefinition(capacities: [new \GLpi\Asset\Capacity(name: HasDomainsCapacity::class)]);
 
         foreach ($CFG_GLPI['domain_types'] as $itemtype) {
             if (!Toolbox::hasTrait($itemtype, Clonable::class)) {

--- a/phpunit/functional/Glpi/Asset/AssetDefinitionTest.php
+++ b/phpunit/functional/Glpi/Asset/AssetDefinitionTest.php
@@ -57,8 +57,8 @@ class AssetDefinitionTest extends DbTestCase
             ],
             'output'   => [
                 'capacities' => json_encode([
-                    HasDocumentsCapacity::class,
-                    HasInfocomCapacity::class,
+                    HasDocumentsCapacity::class => new \Glpi\Asset\Capacity(name: HasDocumentsCapacity::class),
+                    HasInfocomCapacity::class => new \Glpi\Asset\Capacity(name: HasInfocomCapacity::class),
                 ]),
             ],
             'messages' => [],

--- a/phpunit/functional/Glpi/Asset/AssetDefinitionTest.php
+++ b/phpunit/functional/Glpi/Asset/AssetDefinitionTest.php
@@ -38,6 +38,7 @@ use Computer;
 use DbTestCase;
 use Glpi\Asset\AssetDefinition;
 use Glpi\Asset\AssetDefinitionManager;
+use Glpi\Asset\Capacity;
 use Glpi\Asset\Capacity\HasDocumentsCapacity;
 use Glpi\Asset\Capacity\HasInfocomCapacity;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -51,14 +52,18 @@ class AssetDefinitionTest extends DbTestCase
         yield [
             'input'    => [
                 'capacities' => [
-                    HasDocumentsCapacity::class,
-                    HasInfocomCapacity::class,
+                    [
+                        'name' => HasDocumentsCapacity::class,
+                    ],
+                    [
+                        'name' => HasInfocomCapacity::class,
+                    ],
                 ],
             ],
             'output'   => [
                 'capacities' => json_encode([
-                    HasDocumentsCapacity::class => new \Glpi\Asset\Capacity(name: HasDocumentsCapacity::class),
-                    HasInfocomCapacity::class => new \Glpi\Asset\Capacity(name: HasInfocomCapacity::class),
+                    new Capacity(name: HasDocumentsCapacity::class),
+                    new Capacity(name: HasInfocomCapacity::class),
                 ]),
             ],
             'messages' => [],
@@ -67,8 +72,12 @@ class AssetDefinitionTest extends DbTestCase
         yield [
             'input'    => [
                 'capacities' => [
-                    Computer::class, // not a capacity
-                    HasInfocomCapacity::class,
+                    [
+                        'name' => Computer::class, // not a capacity
+                    ],
+                    [
+                        'name' => HasInfocomCapacity::class,
+                    ],
                 ],
             ],
             'output'   => false,

--- a/phpunit/functional/Glpi/Asset/AssetTest.php
+++ b/phpunit/functional/Glpi/Asset/AssetTest.php
@@ -141,9 +141,14 @@ class AssetTest extends DbTestCase
 
     public function testSearchOptionsUnicity(): void
     {
-        $capacities = AssetDefinitionManager::getInstance()->getAvailableCapacities();
+        $capacities = [];
+        foreach (array_keys(\Glpi\Asset\AssetDefinitionManager::getInstance()->getAvailableCapacities()) as $available_capacity) {
+            if ($available_capacity !== \Glpi\Asset\Capacity\IsInventoriableCapacity::class) {
+                $capacities[] = new \Glpi\Asset\Capacity(name: $available_capacity);
+            }
+        }
         $definition = $this->initAssetDefinition(
-            capacities: array_keys($capacities)
+            capacities: $capacities
         );
 
         $asset = $this->createItem($definition->getAssetClassName(), [

--- a/phpunit/functional/Glpi/Asset/AssetTest.php
+++ b/phpunit/functional/Glpi/Asset/AssetTest.php
@@ -36,6 +36,8 @@ namespace tests\units\Glpi\Asset;
 
 use DbTestCase;
 use Glpi\Asset\AssetDefinitionManager;
+use Glpi\Asset\Capacity;
+use Glpi\Asset\Capacity\CapacityInterface;
 use Glpi\Asset\CustomFieldType\DropdownType;
 use Glpi\Asset\CustomFieldType\StringType;
 
@@ -141,12 +143,10 @@ class AssetTest extends DbTestCase
 
     public function testSearchOptionsUnicity(): void
     {
-        $capacities = [];
-        foreach (array_keys(\Glpi\Asset\AssetDefinitionManager::getInstance()->getAvailableCapacities()) as $available_capacity) {
-            if ($available_capacity !== \Glpi\Asset\Capacity\IsInventoriableCapacity::class) {
-                $capacities[] = new \Glpi\Asset\Capacity(name: $available_capacity);
-            }
-        }
+        $capacities = array_map(
+            fn (CapacityInterface $capacity) => new Capacity(name: $capacity::class),
+            AssetDefinitionManager::getInstance()->getAvailableCapacities()
+        );
         $definition = $this->initAssetDefinition(
             capacities: $capacities
         );

--- a/phpunit/functional/Glpi/Asset/Asset_PeripheralAssetTest.php
+++ b/phpunit/functional/Glpi/Asset/Asset_PeripheralAssetTest.php
@@ -47,7 +47,7 @@ class Asset_PeripheralAssetTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [HasPeripheralAssetsCapacity::class]);
+        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasPeripheralAssetsCapacity::class)]);
 
         $this->login(); // tab will be available only if corresponding right is available in the current session
 
@@ -67,7 +67,7 @@ class Asset_PeripheralAssetTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [HasPeripheralAssetsCapacity::class]);
+        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasPeripheralAssetsCapacity::class)]);
 
         foreach ($CFG_GLPI['directconnect_types'] as $itemtype) {
             if (!Toolbox::hasTrait($itemtype, Clonable::class)) {

--- a/phpunit/functional/Glpi/Asset/Asset_PeripheralAssetTest.php
+++ b/phpunit/functional/Glpi/Asset/Asset_PeripheralAssetTest.php
@@ -36,6 +36,7 @@ namespace tests\units\Glpi\Asset;
 
 use DbTestCase;
 use Glpi\Asset\Asset_PeripheralAsset;
+use Glpi\Asset\Capacity;
 use Glpi\Asset\Capacity\HasPeripheralAssetsCapacity;
 use Glpi\Features\Clonable;
 use Toolbox;
@@ -47,7 +48,7 @@ class Asset_PeripheralAssetTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasPeripheralAssetsCapacity::class)]);
+        $this->initAssetDefinition(capacities: [new Capacity(name: HasPeripheralAssetsCapacity::class)]);
 
         $this->login(); // tab will be available only if corresponding right is available in the current session
 
@@ -67,7 +68,7 @@ class Asset_PeripheralAssetTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasPeripheralAssetsCapacity::class)]);
+        $this->initAssetDefinition(capacities: [new Capacity(name: HasPeripheralAssetsCapacity::class)]);
 
         foreach ($CFG_GLPI['directconnect_types'] as $itemtype) {
             if (!Toolbox::hasTrait($itemtype, Clonable::class)) {

--- a/phpunit/functional/Glpi/Asset/Capacity/AllowedInGlobalSearchCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/AllowedInGlobalSearchCapacityTest.php
@@ -46,21 +46,21 @@ class AllowedInGlobalSearchCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\AllowedInGlobalSearchCapacity::class,
-                \Glpi\Asset\Capacity\HasNotepadCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\AllowedInGlobalSearchCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
         $definition_3 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\AllowedInGlobalSearchCapacity::class,
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\AllowedInGlobalSearchCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_3  = $definition_3->getAssetClassName();
@@ -90,15 +90,15 @@ class AllowedInGlobalSearchCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\AllowedInGlobalSearchCapacity::class,
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\AllowedInGlobalSearchCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\AllowedInGlobalSearchCapacity::class,
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\AllowedInGlobalSearchCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();

--- a/phpunit/functional/Glpi/Asset/Capacity/AllowedInGlobalSearchCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/AllowedInGlobalSearchCapacityTest.php
@@ -36,6 +36,7 @@ namespace tests\units\Glpi\Asset\Capacity;
 
 use DbTestCase;
 use Entity;
+use Glpi\Asset\Capacity;
 use Log;
 
 class AllowedInGlobalSearchCapacityTest extends DbTestCase
@@ -46,21 +47,21 @@ class AllowedInGlobalSearchCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\AllowedInGlobalSearchCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\AllowedInGlobalSearchCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
         $definition_3 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\AllowedInGlobalSearchCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\AllowedInGlobalSearchCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_3  = $definition_3->getAssetClassName();
@@ -90,15 +91,15 @@ class AllowedInGlobalSearchCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\AllowedInGlobalSearchCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\AllowedInGlobalSearchCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\AllowedInGlobalSearchCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\AllowedInGlobalSearchCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();

--- a/phpunit/functional/Glpi/Asset/Capacity/HasAntivirusCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/HasAntivirusCapacityTest.php
@@ -37,6 +37,7 @@ namespace tests\units\Glpi\Asset\Capacity;
 use DbTestCase;
 use DisplayPreference;
 use Entity;
+use Glpi\Asset\Capacity;
 use Glpi\PHPUnit\Tests\Glpi\Asset\CapacityUsageTestTrait;
 use ItemAntivirus;
 use Log;
@@ -45,9 +46,9 @@ class HasAntivirusCapacityTest extends DbTestCase
 {
     use CapacityUsageTestTrait;
 
-    protected function getTargetCapacity(): string
+    protected function getTargetCapacity(): Capacity
     {
-        return \Glpi\Asset\Capacity\HasAntivirusCapacity::class;
+        return new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasAntivirusCapacity::class);
     }
 
     public function testCapacityActivation(): void
@@ -58,21 +59,21 @@ class HasAntivirusCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasAntivirusCapacity::class,
-                \Glpi\Asset\Capacity\HasNotepadCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasAntivirusCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
         $definition_3 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasAntivirusCapacity::class,
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasAntivirusCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_3  = $definition_3->getAssetClassName();
@@ -129,15 +130,15 @@ class HasAntivirusCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasAntivirusCapacity::class,
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasAntivirusCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasAntivirusCapacity::class,
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasAntivirusCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
@@ -224,7 +225,7 @@ class HasAntivirusCapacityTest extends DbTestCase
     public function testCloneAsset()
     {
         $definition = $this->initAssetDefinition(
-            capacities: [\Glpi\Asset\Capacity\HasAntivirusCapacity::class]
+            capacities: [new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasAntivirusCapacity::class)]
         );
         $class = $definition->getAssetClassName();
         $entity = $this->getTestRootEntity(true);

--- a/phpunit/functional/Glpi/Asset/Capacity/HasAntivirusCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/HasAntivirusCapacityTest.php
@@ -46,9 +46,9 @@ class HasAntivirusCapacityTest extends DbTestCase
 {
     use CapacityUsageTestTrait;
 
-    protected function getTargetCapacity(): Capacity
+    protected function getTargetCapacity(): string
     {
-        return new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasAntivirusCapacity::class);
+        return \Glpi\Asset\Capacity\HasAntivirusCapacity::class;
     }
 
     public function testCapacityActivation(): void
@@ -59,21 +59,21 @@ class HasAntivirusCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasAntivirusCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasAntivirusCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
         $definition_3 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasAntivirusCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasAntivirusCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_3  = $definition_3->getAssetClassName();
@@ -130,15 +130,15 @@ class HasAntivirusCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasAntivirusCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasAntivirusCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasAntivirusCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasAntivirusCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
@@ -225,7 +225,7 @@ class HasAntivirusCapacityTest extends DbTestCase
     public function testCloneAsset()
     {
         $definition = $this->initAssetDefinition(
-            capacities: [new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasAntivirusCapacity::class)]
+            capacities: [new Capacity(name: \Glpi\Asset\Capacity\HasAntivirusCapacity::class)]
         );
         $class = $definition->getAssetClassName();
         $entity = $this->getTestRootEntity(true);

--- a/phpunit/functional/Glpi/Asset/Capacity/HasAppliancesCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/HasAppliancesCapacityTest.php
@@ -39,6 +39,7 @@ use Appliance_Item;
 use DbTestCase;
 use DisplayPreference;
 use Entity;
+use Glpi\Asset\Capacity;
 use Glpi\PHPUnit\Tests\Glpi\Asset\CapacityUsageTestTrait;
 use Log;
 
@@ -46,9 +47,9 @@ class HasAppliancesCapacityTest extends DbTestCase
 {
     use CapacityUsageTestTrait;
 
-    protected function getTargetCapacity(): string
+    protected function getTargetCapacity(): Capacity
     {
-        return \Glpi\Asset\Capacity\HasAppliancesCapacity::class;
+        return new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasAppliancesCapacity::class);
     }
 
     public function testCapacityActivation(): void
@@ -59,21 +60,21 @@ class HasAppliancesCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasAppliancesCapacity::class,
-                \Glpi\Asset\Capacity\HasNotepadCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasAppliancesCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
         $definition_3 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasAppliancesCapacity::class,
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasAppliancesCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_3  = $definition_3->getAssetClassName();
@@ -131,15 +132,15 @@ class HasAppliancesCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasAppliancesCapacity::class,
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasAppliancesCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasAppliancesCapacity::class,
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasAppliancesCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();

--- a/phpunit/functional/Glpi/Asset/Capacity/HasAppliancesCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/HasAppliancesCapacityTest.php
@@ -47,9 +47,9 @@ class HasAppliancesCapacityTest extends DbTestCase
 {
     use CapacityUsageTestTrait;
 
-    protected function getTargetCapacity(): Capacity
+    protected function getTargetCapacity(): string
     {
-        return new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasAppliancesCapacity::class);
+        return \Glpi\Asset\Capacity\HasAppliancesCapacity::class;
     }
 
     public function testCapacityActivation(): void
@@ -60,21 +60,21 @@ class HasAppliancesCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasAppliancesCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasAppliancesCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
         $definition_3 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasAppliancesCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasAppliancesCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_3  = $definition_3->getAssetClassName();
@@ -132,15 +132,15 @@ class HasAppliancesCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasAppliancesCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasAppliancesCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasAppliancesCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasAppliancesCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();

--- a/phpunit/functional/Glpi/Asset/Capacity/HasCertificatesCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/HasCertificatesCapacityTest.php
@@ -47,9 +47,9 @@ class HasCertificatesCapacityTest extends DbTestCase
 {
     use CapacityUsageTestTrait;
 
-    protected function getTargetCapacity(): Capacity
+    protected function getTargetCapacity(): string
     {
-        return new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasCertificatesCapacity::class);
+        return \Glpi\Asset\Capacity\HasCertificatesCapacity::class;
     }
 
     public function testCapacityActivation(): void
@@ -60,21 +60,21 @@ class HasCertificatesCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasCertificatesCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasCertificatesCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
         $definition_3 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasCertificatesCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasCertificatesCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
             ]
         );
         $classname_3  = $definition_3->getAssetClassName();
@@ -134,15 +134,15 @@ class HasCertificatesCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasCertificatesCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasCertificatesCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasCertificatesCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasCertificatesCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();

--- a/phpunit/functional/Glpi/Asset/Capacity/HasCertificatesCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/HasCertificatesCapacityTest.php
@@ -39,6 +39,7 @@ use Certificate_Item;
 use DbTestCase;
 use DisplayPreference;
 use Entity;
+use Glpi\Asset\Capacity;
 use Glpi\PHPUnit\Tests\Glpi\Asset\CapacityUsageTestTrait;
 use Log;
 
@@ -46,9 +47,9 @@ class HasCertificatesCapacityTest extends DbTestCase
 {
     use CapacityUsageTestTrait;
 
-    protected function getTargetCapacity(): string
+    protected function getTargetCapacity(): Capacity
     {
-        return \Glpi\Asset\Capacity\HasCertificatesCapacity::class;
+        return new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasCertificatesCapacity::class);
     }
 
     public function testCapacityActivation(): void
@@ -59,21 +60,21 @@ class HasCertificatesCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
-                \Glpi\Asset\Capacity\HasCertificatesCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasCertificatesCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
         $definition_3 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasCertificatesCapacity::class,
-                \Glpi\Asset\Capacity\HasNotepadCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasCertificatesCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
             ]
         );
         $classname_3  = $definition_3->getAssetClassName();
@@ -133,15 +134,15 @@ class HasCertificatesCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasCertificatesCapacity::class,
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasCertificatesCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasCertificatesCapacity::class,
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasCertificatesCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();

--- a/phpunit/functional/Glpi/Asset/Capacity/HasContractsCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/HasContractsCapacityTest.php
@@ -48,9 +48,9 @@ class HasContractsCapacityTest extends DbTestCase
 {
     use CapacityUsageTestTrait;
 
-    protected function getTargetCapacity(): Capacity
+    protected function getTargetCapacity(): string
     {
-        return new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasContractsCapacity::class);
+        return \Glpi\Asset\Capacity\HasContractsCapacity::class;
     }
 
     /**
@@ -75,14 +75,14 @@ class HasContractsCapacityTest extends DbTestCase
         // Enable capacity, the itemtype should now be registered
         $definition = $this->enableCapacity(
             $definition,
-            $this->getTargetCapacity()->getName()
+            $this->getTargetCapacity()
         );
         $this->assertContains($class, $CFG_GLPI["contract_types"]);
 
         // Disable capacity, the itemtype should no longer be registered
         $definition = $this->disableCapacity(
             $definition,
-            $this->getTargetCapacity()->getName()
+            $this->getTargetCapacity()
         );
         $this->assertNotContains($class, $CFG_GLPI["contract_types"]);
     }
@@ -117,7 +117,7 @@ class HasContractsCapacityTest extends DbTestCase
         // Enable capacity, the tab should now be registered
         $definition = $this->enableCapacity(
             $definition,
-            $this->getTargetCapacity()->getName()
+            $this->getTargetCapacity()
         );
         $this->assertArrayHasKey($tab_name, $subject->defineAllTabs());
     }
@@ -132,7 +132,7 @@ class HasContractsCapacityTest extends DbTestCase
     {
         // Create custom asset definition with the target capacity enabled
         $definition = $this->initAssetDefinition(
-            capacities: [$this->getTargetCapacity()]
+            capacities: [new Capacity(name: $this->getTargetCapacity())]
         );
         $class = $definition->getAssetClassName();
         $entity = $this->getTestRootEntity(true);
@@ -176,7 +176,7 @@ class HasContractsCapacityTest extends DbTestCase
         // Disable capacity, linked item should be deleted
         $definition = $this->disableCapacity(
             $definition,
-            $this->getTargetCapacity()->getName()
+            $this->getTargetCapacity()
         );
         $items = (new Contract_Item())->find([
             'itemtype' => $subject::getType(),
@@ -196,8 +196,8 @@ class HasContractsCapacityTest extends DbTestCase
         // Create custom asset definition with the target capacity enabled
         $definition = $this->initAssetDefinition(
             capacities: [
-                $this->getTargetCapacity(),
-                new \Glpi\Asset\Capacity(name: HasHistoryCapacity::class)
+                new Capacity(name: $this->getTargetCapacity()),
+                new Capacity(name: HasHistoryCapacity::class)
             ]
         );
         $class = $definition->getAssetClassName();
@@ -255,7 +255,7 @@ class HasContractsCapacityTest extends DbTestCase
         // be deleted
         $definition = $this->disableCapacity(
             $definition,
-            $this->getTargetCapacity()->getName()
+            $this->getTargetCapacity()
         );
         $count_logs = countElementsInTable(Log::getTable(), [
             'itemtype' => $contract::getType(),
@@ -277,7 +277,7 @@ class HasContractsCapacityTest extends DbTestCase
     {
         // Create custom asset definition with the target capacity enabled
         $definition = $this->initAssetDefinition(
-            capacities: [$this->getTargetCapacity()]
+            capacities: [new Capacity(name: $this->getTargetCapacity())]
         );
         $class = $definition->getAssetClassName();
 
@@ -315,7 +315,7 @@ class HasContractsCapacityTest extends DbTestCase
         // deleted
         $definition = $this->disableCapacity(
             $definition,
-            $this->getTargetCapacity()->getName()
+            $this->getTargetCapacity()
         );
         $count_display_preferences = countElementsInTable(
             DisplayPreference::getTable(),
@@ -329,7 +329,7 @@ class HasContractsCapacityTest extends DbTestCase
     public function testCloneAsset()
     {
         $definition = $this->initAssetDefinition(
-            capacities: [new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasContractsCapacity::class)]
+            capacities: [new Capacity(name: \Glpi\Asset\Capacity\HasContractsCapacity::class)]
         );
         $class = $definition->getAssetClassName();
         $entity = $this->getTestRootEntity(true);

--- a/phpunit/functional/Glpi/Asset/Capacity/HasContractsCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/HasContractsCapacityTest.php
@@ -39,6 +39,7 @@ use Contract_Item;
 use DbTestCase;
 use DisplayPreference;
 use Glpi\Asset\Asset;
+use Glpi\Asset\Capacity;
 use Glpi\Asset\Capacity\HasHistoryCapacity;
 use Glpi\PHPUnit\Tests\Glpi\Asset\CapacityUsageTestTrait;
 use Log;
@@ -47,9 +48,9 @@ class HasContractsCapacityTest extends DbTestCase
 {
     use CapacityUsageTestTrait;
 
-    protected function getTargetCapacity(): string
+    protected function getTargetCapacity(): Capacity
     {
-        return \Glpi\Asset\Capacity\HasContractsCapacity::class;
+        return new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasContractsCapacity::class);
     }
 
     /**
@@ -74,14 +75,14 @@ class HasContractsCapacityTest extends DbTestCase
         // Enable capacity, the itemtype should now be registered
         $definition = $this->enableCapacity(
             $definition,
-            $this->getTargetCapacity()
+            $this->getTargetCapacity()->getName()
         );
         $this->assertContains($class, $CFG_GLPI["contract_types"]);
 
         // Disable capacity, the itemtype should no longer be registered
         $definition = $this->disableCapacity(
             $definition,
-            $this->getTargetCapacity()
+            $this->getTargetCapacity()->getName()
         );
         $this->assertNotContains($class, $CFG_GLPI["contract_types"]);
     }
@@ -116,7 +117,7 @@ class HasContractsCapacityTest extends DbTestCase
         // Enable capacity, the tab should now be registered
         $definition = $this->enableCapacity(
             $definition,
-            $this->getTargetCapacity()
+            $this->getTargetCapacity()->getName()
         );
         $this->assertArrayHasKey($tab_name, $subject->defineAllTabs());
     }
@@ -175,7 +176,7 @@ class HasContractsCapacityTest extends DbTestCase
         // Disable capacity, linked item should be deleted
         $definition = $this->disableCapacity(
             $definition,
-            $this->getTargetCapacity()
+            $this->getTargetCapacity()->getName()
         );
         $items = (new Contract_Item())->find([
             'itemtype' => $subject::getType(),
@@ -196,7 +197,7 @@ class HasContractsCapacityTest extends DbTestCase
         $definition = $this->initAssetDefinition(
             capacities: [
                 $this->getTargetCapacity(),
-                HasHistoryCapacity::class
+                new \Glpi\Asset\Capacity(name: HasHistoryCapacity::class)
             ]
         );
         $class = $definition->getAssetClassName();
@@ -254,7 +255,7 @@ class HasContractsCapacityTest extends DbTestCase
         // be deleted
         $definition = $this->disableCapacity(
             $definition,
-            $this->getTargetCapacity()
+            $this->getTargetCapacity()->getName()
         );
         $count_logs = countElementsInTable(Log::getTable(), [
             'itemtype' => $contract::getType(),
@@ -314,7 +315,7 @@ class HasContractsCapacityTest extends DbTestCase
         // deleted
         $definition = $this->disableCapacity(
             $definition,
-            $this->getTargetCapacity()
+            $this->getTargetCapacity()->getName()
         );
         $count_display_preferences = countElementsInTable(
             DisplayPreference::getTable(),
@@ -328,7 +329,7 @@ class HasContractsCapacityTest extends DbTestCase
     public function testCloneAsset()
     {
         $definition = $this->initAssetDefinition(
-            capacities: [\Glpi\Asset\Capacity\HasContractsCapacity::class]
+            capacities: [new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasContractsCapacity::class)]
         );
         $class = $definition->getAssetClassName();
         $entity = $this->getTestRootEntity(true);

--- a/phpunit/functional/Glpi/Asset/Capacity/HasDatabaseInstanceCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/HasDatabaseInstanceCapacityTest.php
@@ -44,9 +44,9 @@ class HasDatabaseInstanceCapacityTest extends DbTestCase
 {
     use CapacityUsageTestTrait;
 
-    protected function getTargetCapacity(): Capacity
+    protected function getTargetCapacity(): string
     {
-        return new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasDatabaseInstanceCapacity::class);
+        return \Glpi\Asset\Capacity\HasDatabaseInstanceCapacity::class;
     }
 
     public function testCapacityActivation(): void
@@ -57,21 +57,21 @@ class HasDatabaseInstanceCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasDatabaseInstanceCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasDatabaseInstanceCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
         $definition_3 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasDatabaseInstanceCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasDatabaseInstanceCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
             ]
         );
         $classname_3  = $definition_3->getAssetClassName();
@@ -110,15 +110,15 @@ class HasDatabaseInstanceCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasDatabaseInstanceCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasDatabaseInstanceCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasDatabaseInstanceCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasDatabaseInstanceCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();

--- a/phpunit/functional/Glpi/Asset/Capacity/HasDatabaseInstanceCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/HasDatabaseInstanceCapacityTest.php
@@ -37,15 +37,16 @@ namespace tests\units\Glpi\Asset\Capacity;
 use DatabaseInstance;
 use DbTestCase;
 use Entity;
+use Glpi\Asset\Capacity;
 use Glpi\PHPUnit\Tests\Glpi\Asset\CapacityUsageTestTrait;
 
 class HasDatabaseInstanceCapacityTest extends DbTestCase
 {
     use CapacityUsageTestTrait;
 
-    protected function getTargetCapacity(): string
+    protected function getTargetCapacity(): Capacity
     {
-        return \Glpi\Asset\Capacity\HasDatabaseInstanceCapacity::class;
+        return new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasDatabaseInstanceCapacity::class);
     }
 
     public function testCapacityActivation(): void
@@ -56,21 +57,21 @@ class HasDatabaseInstanceCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasDatabaseInstanceCapacity::class,
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasDatabaseInstanceCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
         $definition_3 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasDatabaseInstanceCapacity::class,
-                \Glpi\Asset\Capacity\HasNotepadCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasDatabaseInstanceCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
             ]
         );
         $classname_3  = $definition_3->getAssetClassName();
@@ -109,15 +110,15 @@ class HasDatabaseInstanceCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasDatabaseInstanceCapacity::class,
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasDatabaseInstanceCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasDatabaseInstanceCapacity::class,
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasDatabaseInstanceCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();

--- a/phpunit/functional/Glpi/Asset/Capacity/HasDevicesCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/HasDevicesCapacityTest.php
@@ -38,17 +38,13 @@ use DbTestCase;
 use DeviceHardDrive;
 use DisplayPreference;
 use Entity;
+use Glpi\Asset\Capacity;
 use Item_DeviceHardDrive;
 use Item_Devices;
 use Log;
 
 class HasDevicesCapacityTest extends DbTestCase
 {
-    protected function getTargetCapacity(): string
-    {
-        return new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasDevicesCapacity::class);
-    }
-
     public function testCapacityActivation(): void
     {
         global $CFG_GLPI;
@@ -57,21 +53,21 @@ class HasDevicesCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasDevicesCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasDevicesCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
         $definition_3 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasDevicesCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasDevicesCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_3  = $definition_3->getAssetClassName();
@@ -161,15 +157,15 @@ class HasDevicesCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasDevicesCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasDevicesCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasDevicesCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasDevicesCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
@@ -265,7 +261,7 @@ class HasDevicesCapacityTest extends DbTestCase
     public function testCloneAsset()
     {
         $definition = $this->initAssetDefinition(
-            capacities: [new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasDevicesCapacity::class)]
+            capacities: [new Capacity(name: \Glpi\Asset\Capacity\HasDevicesCapacity::class)]
         );
         $class = $definition->getAssetClassName();
         $entity = $this->getTestRootEntity(true);
@@ -311,7 +307,7 @@ class HasDevicesCapacityTest extends DbTestCase
         $entity_id = $this->getTestRootEntity(true);
 
         $definition = $this->initAssetDefinition(
-            capacities: [new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasDevicesCapacity::class)]
+            capacities: [new Capacity(name: \Glpi\Asset\Capacity\HasDevicesCapacity::class)]
         );
 
         $asset = $this->createItem($definition->getAssetClassName(), [
@@ -350,7 +346,7 @@ class HasDevicesCapacityTest extends DbTestCase
 
         $definition = $this->initAssetDefinition(
             system_name: 'TestAsset',
-            capacities: [new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasDevicesCapacity::class)]
+            capacities: [new Capacity(name: \Glpi\Asset\Capacity\HasDevicesCapacity::class)]
         );
         $capacity = new \Glpi\Asset\Capacity\HasDevicesCapacity();
 

--- a/phpunit/functional/Glpi/Asset/Capacity/HasDevicesCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/HasDevicesCapacityTest.php
@@ -46,7 +46,7 @@ class HasDevicesCapacityTest extends DbTestCase
 {
     protected function getTargetCapacity(): string
     {
-        return \Glpi\Asset\Capacity\HasDevicesCapacity::class;
+        return new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasDevicesCapacity::class);
     }
 
     public function testCapacityActivation(): void
@@ -57,21 +57,21 @@ class HasDevicesCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasDevicesCapacity::class,
-                \Glpi\Asset\Capacity\HasNotepadCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasDevicesCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
         $definition_3 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasDevicesCapacity::class,
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasDevicesCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_3  = $definition_3->getAssetClassName();
@@ -161,15 +161,15 @@ class HasDevicesCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasDevicesCapacity::class,
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasDevicesCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasDevicesCapacity::class,
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasDevicesCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
@@ -265,7 +265,7 @@ class HasDevicesCapacityTest extends DbTestCase
     public function testCloneAsset()
     {
         $definition = $this->initAssetDefinition(
-            capacities: [\Glpi\Asset\Capacity\HasDevicesCapacity::class]
+            capacities: [new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasDevicesCapacity::class)]
         );
         $class = $definition->getAssetClassName();
         $entity = $this->getTestRootEntity(true);
@@ -311,7 +311,7 @@ class HasDevicesCapacityTest extends DbTestCase
         $entity_id = $this->getTestRootEntity(true);
 
         $definition = $this->initAssetDefinition(
-            capacities: [\Glpi\Asset\Capacity\HasDevicesCapacity::class]
+            capacities: [new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasDevicesCapacity::class)]
         );
 
         $asset = $this->createItem($definition->getAssetClassName(), [
@@ -350,7 +350,7 @@ class HasDevicesCapacityTest extends DbTestCase
 
         $definition = $this->initAssetDefinition(
             system_name: 'TestAsset',
-            capacities: [\Glpi\Asset\Capacity\HasDevicesCapacity::class]
+            capacities: [new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasDevicesCapacity::class)]
         );
         $capacity = new \Glpi\Asset\Capacity\HasDevicesCapacity();
 

--- a/phpunit/functional/Glpi/Asset/Capacity/HasDocumentsCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/HasDocumentsCapacityTest.php
@@ -49,9 +49,9 @@ class HasDocumentsCapacityTest extends DbTestCase
 {
     use CapacityUsageTestTrait;
 
-    protected function getTargetCapacity(): Capacity
+    protected function getTargetCapacity(): string
     {
-        return new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasDocumentsCapacity::class);
+        return \Glpi\Asset\Capacity\HasDocumentsCapacity::class;
     }
 
     public function testCapacityActivation(): void
@@ -62,21 +62,21 @@ class HasDocumentsCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasDocumentsCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasDocumentsCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
         $definition_3 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasDocumentsCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasDocumentsCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_3  = $definition_3->getAssetClassName();
@@ -127,15 +127,15 @@ class HasDocumentsCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasDocumentsCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasDocumentsCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasDocumentsCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasDocumentsCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
@@ -227,7 +227,7 @@ class HasDocumentsCapacityTest extends DbTestCase
 
         $definition = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasDocumentsCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasDocumentsCapacity::class),
             ]
         );
         $classname  = $definition->getAssetClassName();
@@ -260,7 +260,7 @@ class HasDocumentsCapacityTest extends DbTestCase
     public function testCloneAsset()
     {
         $definition = $this->initAssetDefinition(
-            capacities: [new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasDocumentsCapacity::class)]
+            capacities: [new Capacity(name: \Glpi\Asset\Capacity\HasDocumentsCapacity::class)]
         );
         $class = $definition->getAssetClassName();
         $entity = $this->getTestRootEntity(true);

--- a/phpunit/functional/Glpi/Asset/Capacity/HasDocumentsCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/HasDocumentsCapacityTest.php
@@ -40,6 +40,7 @@ use Document;
 use Document_Item;
 use Entity;
 use Glpi\Asset\Asset;
+use Glpi\Asset\Capacity;
 use Glpi\PHPUnit\Tests\Glpi\Asset\CapacityUsageTestTrait;
 use Iterator;
 use Log;
@@ -48,9 +49,9 @@ class HasDocumentsCapacityTest extends DbTestCase
 {
     use CapacityUsageTestTrait;
 
-    protected function getTargetCapacity(): string
+    protected function getTargetCapacity(): Capacity
     {
-        return \Glpi\Asset\Capacity\HasDocumentsCapacity::class;
+        return new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasDocumentsCapacity::class);
     }
 
     public function testCapacityActivation(): void
@@ -61,21 +62,21 @@ class HasDocumentsCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasDocumentsCapacity::class,
-                \Glpi\Asset\Capacity\HasNotepadCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasDocumentsCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
         $definition_3 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasDocumentsCapacity::class,
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasDocumentsCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_3  = $definition_3->getAssetClassName();
@@ -126,15 +127,15 @@ class HasDocumentsCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasDocumentsCapacity::class,
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasDocumentsCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasDocumentsCapacity::class,
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasDocumentsCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
@@ -226,7 +227,7 @@ class HasDocumentsCapacityTest extends DbTestCase
 
         $definition = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasDocumentsCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasDocumentsCapacity::class),
             ]
         );
         $classname  = $definition->getAssetClassName();
@@ -259,7 +260,7 @@ class HasDocumentsCapacityTest extends DbTestCase
     public function testCloneAsset()
     {
         $definition = $this->initAssetDefinition(
-            capacities: [\Glpi\Asset\Capacity\HasDocumentsCapacity::class]
+            capacities: [new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasDocumentsCapacity::class)]
         );
         $class = $definition->getAssetClassName();
         $entity = $this->getTestRootEntity(true);

--- a/phpunit/functional/Glpi/Asset/Capacity/HasDomainsCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/HasDomainsCapacityTest.php
@@ -48,9 +48,9 @@ class HasDomainsCapacityTest extends DbTestCase
 {
     use CapacityUsageTestTrait;
 
-    protected function getTargetCapacity(): Capacity
+    protected function getTargetCapacity(): string
     {
-        return new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasDomainsCapacity::class);
+        return \Glpi\Asset\Capacity\HasDomainsCapacity::class;
     }
 
     public function testCapacityActivation(): void
@@ -61,21 +61,21 @@ class HasDomainsCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasDomainsCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasDomainsCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
         $definition_3 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasDomainsCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasDomainsCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_3  = $definition_3->getAssetClassName();
@@ -132,15 +132,15 @@ class HasDomainsCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasDomainsCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasDomainsCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasDomainsCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasDomainsCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();

--- a/phpunit/functional/Glpi/Asset/Capacity/HasDomainsCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/HasDomainsCapacityTest.php
@@ -40,6 +40,7 @@ use Domain;
 use Domain_Item;
 use DomainRelation;
 use Entity;
+use Glpi\Asset\Capacity;
 use Glpi\PHPUnit\Tests\Glpi\Asset\CapacityUsageTestTrait;
 use Log;
 
@@ -47,9 +48,9 @@ class HasDomainsCapacityTest extends DbTestCase
 {
     use CapacityUsageTestTrait;
 
-    protected function getTargetCapacity(): string
+    protected function getTargetCapacity(): Capacity
     {
-        return \Glpi\Asset\Capacity\HasDomainsCapacity::class;
+        return new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasDomainsCapacity::class);
     }
 
     public function testCapacityActivation(): void
@@ -60,21 +61,21 @@ class HasDomainsCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasDomainsCapacity::class,
-                \Glpi\Asset\Capacity\HasNotepadCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasDomainsCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
         $definition_3 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasDomainsCapacity::class,
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasDomainsCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_3  = $definition_3->getAssetClassName();
@@ -131,15 +132,15 @@ class HasDomainsCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasDomainsCapacity::class,
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasDomainsCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasDomainsCapacity::class,
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasDomainsCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();

--- a/phpunit/functional/Glpi/Asset/Capacity/HasHistoryCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/HasHistoryCapacityTest.php
@@ -36,6 +36,7 @@ namespace tests\units\Glpi\Asset\Capacity;
 
 use DbTestCase;
 use Entity;
+use Glpi\Asset\Capacity;
 use Log;
 
 class HasHistoryCapacityTest extends DbTestCase
@@ -46,21 +47,21 @@ class HasHistoryCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
         $definition_3 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasDocumentsCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasDocumentsCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_3  = $definition_3->getAssetClassName();
@@ -90,13 +91,13 @@ class HasHistoryCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
@@ -144,7 +145,7 @@ class HasHistoryCapacityTest extends DbTestCase
 
         $definition = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname  = $definition->getAssetClassName();
@@ -174,7 +175,7 @@ class HasHistoryCapacityTest extends DbTestCase
         $entity_id = $this->getTestRootEntity(true);
 
         $definition = $this->initAssetDefinition(
-            capacities: [new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class)]
+            capacities: [new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class)]
         );
 
         $asset_1 = $this->createItem($definition->getAssetClassName(), [
@@ -212,7 +213,7 @@ class HasHistoryCapacityTest extends DbTestCase
     {
         // Create custom asset definition with the target capacity enabled
         $definition = $this->initAssetDefinition(
-            capacities: [new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class)]
+            capacities: [new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class)]
         );
 
         // Check that the capacity can be disabled

--- a/phpunit/functional/Glpi/Asset/Capacity/HasHistoryCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/HasHistoryCapacityTest.php
@@ -46,21 +46,21 @@ class HasHistoryCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
-                \Glpi\Asset\Capacity\HasNotepadCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasNotepadCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
         $definition_3 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasDocumentsCapacity::class,
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasDocumentsCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_3  = $definition_3->getAssetClassName();
@@ -90,13 +90,13 @@ class HasHistoryCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
@@ -144,7 +144,7 @@ class HasHistoryCapacityTest extends DbTestCase
 
         $definition = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname  = $definition->getAssetClassName();
@@ -174,7 +174,7 @@ class HasHistoryCapacityTest extends DbTestCase
         $entity_id = $this->getTestRootEntity(true);
 
         $definition = $this->initAssetDefinition(
-            capacities: [\Glpi\Asset\Capacity\HasHistoryCapacity::class]
+            capacities: [new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class)]
         );
 
         $asset_1 = $this->createItem($definition->getAssetClassName(), [
@@ -212,7 +212,7 @@ class HasHistoryCapacityTest extends DbTestCase
     {
         // Create custom asset definition with the target capacity enabled
         $definition = $this->initAssetDefinition(
-            capacities: [\Glpi\Asset\Capacity\HasHistoryCapacity::class]
+            capacities: [new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class)]
         );
 
         // Check that the capacity can be disabled

--- a/phpunit/functional/Glpi/Asset/Capacity/HasImpactCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/HasImpactCapacityTest.php
@@ -51,21 +51,21 @@ class HasImpactCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasImpactCapacity::class,
-                \Glpi\Asset\Capacity\HasNotepadCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasImpactCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
         $definition_3 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasImpactCapacity::class,
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasImpactCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_3  = $definition_3->getAssetClassName();
@@ -106,15 +106,15 @@ class HasImpactCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasImpactCapacity::class,
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasImpactCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasImpactCapacity::class,
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasImpactCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
@@ -171,7 +171,7 @@ class HasImpactCapacityTest extends DbTestCase
         $entity_id = $this->getTestRootEntity(true);
 
         $definition = $this->initAssetDefinition(
-            capacities: [\Glpi\Asset\Capacity\HasImpactCapacity::class]
+            capacities: [new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasImpactCapacity::class)]
         );
         $capacity = new \Glpi\Asset\Capacity\HasImpactCapacity();
 
@@ -218,7 +218,7 @@ class HasImpactCapacityTest extends DbTestCase
         $entity_id = $this->getTestRootEntity(true);
 
         $definition = $this->initAssetDefinition(
-            capacities: [\Glpi\Asset\Capacity\HasImpactCapacity::class]
+            capacities: [new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasImpactCapacity::class)]
         );
         $capacity = new \Glpi\Asset\Capacity\HasImpactCapacity();
 

--- a/phpunit/functional/Glpi/Asset/Capacity/HasImpactCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/HasImpactCapacityTest.php
@@ -37,7 +37,7 @@ namespace tests\units\Glpi\Asset\Capacity;
 use Config;
 use DbTestCase;
 use Entity;
-use Glpi\PHPUnit\Tests\Glpi\Asset\CapacityUsageTestTrait;
+use Glpi\Asset\Capacity;
 use Impact;
 use ImpactRelation;
 
@@ -51,21 +51,21 @@ class HasImpactCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasImpactCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasImpactCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
         $definition_3 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasImpactCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasImpactCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_3  = $definition_3->getAssetClassName();
@@ -106,15 +106,15 @@ class HasImpactCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasImpactCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasImpactCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasImpactCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasImpactCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
@@ -171,7 +171,7 @@ class HasImpactCapacityTest extends DbTestCase
         $entity_id = $this->getTestRootEntity(true);
 
         $definition = $this->initAssetDefinition(
-            capacities: [new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasImpactCapacity::class)]
+            capacities: [new Capacity(name: \Glpi\Asset\Capacity\HasImpactCapacity::class)]
         );
         $capacity = new \Glpi\Asset\Capacity\HasImpactCapacity();
 
@@ -218,7 +218,7 @@ class HasImpactCapacityTest extends DbTestCase
         $entity_id = $this->getTestRootEntity(true);
 
         $definition = $this->initAssetDefinition(
-            capacities: [new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasImpactCapacity::class)]
+            capacities: [new Capacity(name: \Glpi\Asset\Capacity\HasImpactCapacity::class)]
         );
         $capacity = new \Glpi\Asset\Capacity\HasImpactCapacity();
 

--- a/phpunit/functional/Glpi/Asset/Capacity/HasInfocomCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/HasInfocomCapacityTest.php
@@ -47,9 +47,9 @@ class HasInfocomCapacityTest extends DbTestCase
 {
     use CapacityUsageTestTrait;
 
-    protected function getTargetCapacity(): Capacity
+    protected function getTargetCapacity(): string
     {
-        return new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasInfocomCapacity::class);
+        return \Glpi\Asset\Capacity\HasInfocomCapacity::class;
     }
 
     public function testCapacityActivation(): void
@@ -60,21 +60,21 @@ class HasInfocomCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasInfocomCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasInfocomCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
         $definition_3 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasDocumentsCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasInfocomCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasDocumentsCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasInfocomCapacity::class),
             ]
         );
         $classname_3  = $definition_3->getAssetClassName();
@@ -153,15 +153,15 @@ class HasInfocomCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasInfocomCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasInfocomCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasInfocomCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasInfocomCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
@@ -263,7 +263,7 @@ class HasInfocomCapacityTest extends DbTestCase
     public function testCloneAsset()
     {
         $definition = $this->initAssetDefinition(
-            capacities: [new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasInfocomCapacity::class)]
+            capacities: [new Capacity(name: \Glpi\Asset\Capacity\HasInfocomCapacity::class)]
         );
         $class = $definition->getAssetClassName();
         $entity = $this->getTestRootEntity(true);

--- a/phpunit/functional/Glpi/Asset/Capacity/HasInfocomCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/HasInfocomCapacityTest.php
@@ -38,6 +38,7 @@ use DbTestCase;
 use DisplayPreference;
 use Entity;
 use Glpi\Asset\Asset;
+use Glpi\Asset\Capacity;
 use Glpi\PHPUnit\Tests\Glpi\Asset\CapacityUsageTestTrait;
 use Infocom;
 use Log;
@@ -46,9 +47,9 @@ class HasInfocomCapacityTest extends DbTestCase
 {
     use CapacityUsageTestTrait;
 
-    protected function getTargetCapacity(): string
+    protected function getTargetCapacity(): Capacity
     {
-        return \Glpi\Asset\Capacity\HasInfocomCapacity::class;
+        return new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasInfocomCapacity::class);
     }
 
     public function testCapacityActivation(): void
@@ -59,21 +60,21 @@ class HasInfocomCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
-                \Glpi\Asset\Capacity\HasInfocomCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasInfocomCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasNotepadCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
         $definition_3 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasDocumentsCapacity::class,
-                \Glpi\Asset\Capacity\HasInfocomCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasDocumentsCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasInfocomCapacity::class),
             ]
         );
         $classname_3  = $definition_3->getAssetClassName();
@@ -152,15 +153,15 @@ class HasInfocomCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
-                \Glpi\Asset\Capacity\HasInfocomCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasInfocomCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
-                \Glpi\Asset\Capacity\HasInfocomCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasInfocomCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
@@ -262,7 +263,7 @@ class HasInfocomCapacityTest extends DbTestCase
     public function testCloneAsset()
     {
         $definition = $this->initAssetDefinition(
-            capacities: [\Glpi\Asset\Capacity\HasInfocomCapacity::class]
+            capacities: [new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasInfocomCapacity::class)]
         );
         $class = $definition->getAssetClassName();
         $entity = $this->getTestRootEntity(true);

--- a/phpunit/functional/Glpi/Asset/Capacity/HasKnowbaseCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/HasKnowbaseCapacityTest.php
@@ -46,9 +46,9 @@ class HasKnowbaseCapacityTest extends DbTestCase
 {
     use CapacityUsageTestTrait;
 
-    protected function getTargetCapacity(): Capacity
+    protected function getTargetCapacity(): string
     {
-        return new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasKnowbaseCapacity::class);
+        return \Glpi\Asset\Capacity\HasKnowbaseCapacity::class;
     }
 
     public function testCapacityActivation(): void
@@ -60,21 +60,21 @@ class HasKnowbaseCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasKnowbaseCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasKnowbaseCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
         $definition_3 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasKnowbaseCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasKnowbaseCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_3  = $definition_3->getAssetClassName();
@@ -113,15 +113,15 @@ class HasKnowbaseCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasKnowbaseCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasKnowbaseCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasKnowbaseCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasKnowbaseCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
@@ -195,7 +195,7 @@ class HasKnowbaseCapacityTest extends DbTestCase
     public function testCloneAsset()
     {
         $definition = $this->initAssetDefinition(
-            capacities: [new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasKnowbaseCapacity::class)]
+            capacities: [new Capacity(name: \Glpi\Asset\Capacity\HasKnowbaseCapacity::class)]
         );
         $class = $definition->getAssetClassName();
         $entity = $this->getTestRootEntity(true);

--- a/phpunit/functional/Glpi/Asset/Capacity/HasKnowbaseCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/HasKnowbaseCapacityTest.php
@@ -36,6 +36,7 @@ namespace tests\units\Glpi\Asset\Capacity;
 
 use DbTestCase;
 use Entity;
+use Glpi\Asset\Capacity;
 use Glpi\PHPUnit\Tests\Glpi\Asset\CapacityUsageTestTrait;
 use KnowbaseItem;
 use KnowbaseItem_Item;
@@ -45,9 +46,9 @@ class HasKnowbaseCapacityTest extends DbTestCase
 {
     use CapacityUsageTestTrait;
 
-    protected function getTargetCapacity(): string
+    protected function getTargetCapacity(): Capacity
     {
-        return \Glpi\Asset\Capacity\HasKnowbaseCapacity::class;
+        return new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasKnowbaseCapacity::class);
     }
 
     public function testCapacityActivation(): void
@@ -59,21 +60,21 @@ class HasKnowbaseCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasKnowbaseCapacity::class,
-                \Glpi\Asset\Capacity\HasNotepadCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasKnowbaseCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
         $definition_3 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasKnowbaseCapacity::class,
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasKnowbaseCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_3  = $definition_3->getAssetClassName();
@@ -112,15 +113,15 @@ class HasKnowbaseCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasKnowbaseCapacity::class,
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasKnowbaseCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasKnowbaseCapacity::class,
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasKnowbaseCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
@@ -194,7 +195,7 @@ class HasKnowbaseCapacityTest extends DbTestCase
     public function testCloneAsset()
     {
         $definition = $this->initAssetDefinition(
-            capacities: [\Glpi\Asset\Capacity\HasKnowbaseCapacity::class]
+            capacities: [new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasKnowbaseCapacity::class)]
         );
         $class = $definition->getAssetClassName();
         $entity = $this->getTestRootEntity(true);

--- a/phpunit/functional/Glpi/Asset/Capacity/HasLinksCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/HasLinksCapacityTest.php
@@ -37,6 +37,7 @@ namespace tests\units\Glpi\Asset\Capacity;
 use DbTestCase;
 use DisplayPreference;
 use Entity;
+use Glpi\Asset\Capacity;
 use Glpi\PHPUnit\Tests\Glpi\Asset\CapacityUsageTestTrait;
 use Link;
 use Link_Itemtype;
@@ -47,9 +48,9 @@ class HasLinksCapacityTest extends DbTestCase
 {
     use CapacityUsageTestTrait;
 
-    protected function getTargetCapacity(): string
+    protected function getTargetCapacity(): Capacity
     {
-        return \Glpi\Asset\Capacity\HasLinksCapacity::class;
+        return new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasLinksCapacity::class);
     }
 
     public function testCapacityActivation(): void
@@ -60,21 +61,21 @@ class HasLinksCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasLinksCapacity::class,
-                \Glpi\Asset\Capacity\HasNotepadCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasLinksCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
         $definition_3 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasLinksCapacity::class,
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasLinksCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_3  = $definition_3->getAssetClassName();
@@ -124,15 +125,15 @@ class HasLinksCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasLinksCapacity::class,
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasLinksCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasLinksCapacity::class,
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasLinksCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();

--- a/phpunit/functional/Glpi/Asset/Capacity/HasLinksCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/HasLinksCapacityTest.php
@@ -48,9 +48,9 @@ class HasLinksCapacityTest extends DbTestCase
 {
     use CapacityUsageTestTrait;
 
-    protected function getTargetCapacity(): Capacity
+    protected function getTargetCapacity(): string
     {
-        return new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasLinksCapacity::class);
+        return \Glpi\Asset\Capacity\HasLinksCapacity::class;
     }
 
     public function testCapacityActivation(): void
@@ -61,21 +61,21 @@ class HasLinksCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasLinksCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasLinksCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
         $definition_3 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasLinksCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasLinksCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_3  = $definition_3->getAssetClassName();
@@ -125,15 +125,15 @@ class HasLinksCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasLinksCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasLinksCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasLinksCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasLinksCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();

--- a/phpunit/functional/Glpi/Asset/Capacity/HasNetworkPortCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/HasNetworkPortCapacityTest.php
@@ -37,6 +37,7 @@ namespace tests\units\Glpi\Asset\Capacity;
 use DbTestCase;
 use DisplayPreference;
 use Entity;
+use Glpi\Asset\Capacity;
 use Glpi\PHPUnit\Tests\Glpi\Asset\CapacityUsageTestTrait;
 use Log;
 use NetworkPort;
@@ -45,9 +46,9 @@ class HasNetworkPortCapacityTest extends DbTestCase
 {
     use CapacityUsageTestTrait;
 
-    protected function getTargetCapacity(): string
+    protected function getTargetCapacity(): Capacity
     {
-        return \Glpi\Asset\Capacity\HasNetworkPortCapacity::class;
+        return new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNetworkPortCapacity::class);
     }
 
     public function testCapacityActivation(): void
@@ -58,21 +59,20 @@ class HasNetworkPortCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasNetworkPortCapacity::class,
-                \Glpi\Asset\Capacity\HasNetworkPortCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNetworkPortCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
         $definition_3 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasNetworkPortCapacity::class,
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNetworkPortCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_3  = $definition_3->getAssetClassName();
@@ -126,17 +126,17 @@ class HasNetworkPortCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
-                \Glpi\Asset\Capacity\HasDomainsCapacity::class,
-                \Glpi\Asset\Capacity\HasNetworkPortCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasDomainsCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNetworkPortCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
-                \Glpi\Asset\Capacity\HasDomainsCapacity::class,
-                \Glpi\Asset\Capacity\HasNetworkPortCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasDomainsCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNetworkPortCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
@@ -227,7 +227,7 @@ class HasNetworkPortCapacityTest extends DbTestCase
     {
         $definition = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasNetworkPortCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNetworkPortCapacity::class),
             ]
         );
         $class = $definition->getAssetClassName();

--- a/phpunit/functional/Glpi/Asset/Capacity/HasNetworkPortCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/HasNetworkPortCapacityTest.php
@@ -46,9 +46,9 @@ class HasNetworkPortCapacityTest extends DbTestCase
 {
     use CapacityUsageTestTrait;
 
-    protected function getTargetCapacity(): Capacity
+    protected function getTargetCapacity(): string
     {
-        return new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNetworkPortCapacity::class);
+        return \Glpi\Asset\Capacity\HasNetworkPortCapacity::class;
     }
 
     public function testCapacityActivation(): void
@@ -59,20 +59,20 @@ class HasNetworkPortCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNetworkPortCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasNetworkPortCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
         $definition_3 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNetworkPortCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasNetworkPortCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_3  = $definition_3->getAssetClassName();
@@ -126,17 +126,17 @@ class HasNetworkPortCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasDomainsCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNetworkPortCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasDomainsCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasNetworkPortCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasDomainsCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNetworkPortCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasDomainsCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasNetworkPortCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
@@ -227,7 +227,7 @@ class HasNetworkPortCapacityTest extends DbTestCase
     {
         $definition = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNetworkPortCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasNetworkPortCapacity::class),
             ]
         );
         $class = $definition->getAssetClassName();

--- a/phpunit/functional/Glpi/Asset/Capacity/HasNotepadCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/HasNotepadCapacityTest.php
@@ -48,9 +48,9 @@ class HasNotepadCapacityTest extends DbTestCase
 {
     use CapacityUsageTestTrait;
 
-    protected function getTargetCapacity(): Capacity
+    protected function getTargetCapacity(): string
     {
-        return new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class);
+        return \Glpi\Asset\Capacity\HasNotepadCapacity::class;
     }
 
     public function testCapacityActivation(): void
@@ -65,23 +65,23 @@ class HasNotepadCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
             ],
             profiles: $profiles
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasDocumentsCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasDocumentsCapacity::class),
             ],
             profiles: $profiles
         );
         $classname_2  = $definition_2->getAssetClassName();
         $definition_3 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasDocumentsCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasDocumentsCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
             ],
             profiles: $profiles
         );
@@ -128,15 +128,15 @@ class HasNotepadCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
@@ -223,7 +223,7 @@ class HasNotepadCapacityTest extends DbTestCase
 
         $definition = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
             ]
         );
         $classname  = $definition->getAssetClassName();
@@ -287,7 +287,7 @@ class HasNotepadCapacityTest extends DbTestCase
     public function testCloneAsset()
     {
         $definition = $this->initAssetDefinition(
-            capacities: [new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class)]
+            capacities: [new Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class)]
         );
         $class = $definition->getAssetClassName();
         $entity = $this->getTestRootEntity(true);

--- a/phpunit/functional/Glpi/Asset/Capacity/HasNotepadCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/HasNotepadCapacityTest.php
@@ -38,6 +38,7 @@ use DbTestCase;
 use DisplayPreference;
 use Entity;
 use Glpi\Asset\Asset;
+use Glpi\Asset\Capacity;
 use Glpi\PHPUnit\Tests\Glpi\Asset\CapacityUsageTestTrait;
 use Log;
 use Notepad;
@@ -47,9 +48,9 @@ class HasNotepadCapacityTest extends DbTestCase
 {
     use CapacityUsageTestTrait;
 
-    protected function getTargetCapacity(): string
+    protected function getTargetCapacity(): Capacity
     {
-        return \Glpi\Asset\Capacity\HasNotepadCapacity::class;
+        return new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class);
     }
 
     public function testCapacityActivation(): void
@@ -64,23 +65,23 @@ class HasNotepadCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
-                \Glpi\Asset\Capacity\HasNotepadCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
             ],
             profiles: $profiles
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasDocumentsCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasDocumentsCapacity::class),
             ],
             profiles: $profiles
         );
         $classname_2  = $definition_2->getAssetClassName();
         $definition_3 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasDocumentsCapacity::class,
-                \Glpi\Asset\Capacity\HasNotepadCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasDocumentsCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
             ],
             profiles: $profiles
         );
@@ -127,15 +128,15 @@ class HasNotepadCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
-                \Glpi\Asset\Capacity\HasNotepadCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
-                \Glpi\Asset\Capacity\HasNotepadCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
@@ -222,7 +223,7 @@ class HasNotepadCapacityTest extends DbTestCase
 
         $definition = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasNotepadCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
             ]
         );
         $classname  = $definition->getAssetClassName();
@@ -286,7 +287,7 @@ class HasNotepadCapacityTest extends DbTestCase
     public function testCloneAsset()
     {
         $definition = $this->initAssetDefinition(
-            capacities: [\Glpi\Asset\Capacity\HasNotepadCapacity::class]
+            capacities: [new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class)]
         );
         $class = $definition->getAssetClassName();
         $entity = $this->getTestRootEntity(true);

--- a/phpunit/functional/Glpi/Asset/Capacity/HasOperatingSystemCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/HasOperatingSystemCapacityTest.php
@@ -37,6 +37,7 @@ namespace tests\units\Glpi\Asset\Capacity;
 use DbTestCase;
 use DisplayPreference;
 use Glpi\Asset\Asset;
+use Glpi\Asset\Capacity;
 use Glpi\Asset\Capacity\HasHistoryCapacity;
 use Glpi\PHPUnit\Tests\Glpi\Asset\CapacityUsageTestTrait;
 use Item_OperatingSystem;
@@ -46,9 +47,9 @@ class HasOperatingSystemCapacityTest extends DbTestCase
 {
     use CapacityUsageTestTrait;
 
-    protected function getTargetCapacity(): string
+    protected function getTargetCapacity(): Capacity
     {
-        return \Glpi\Asset\Capacity\HasOperatingSystemCapacity::class;
+        return new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasOperatingSystemCapacity::class);
     }
 
     /**
@@ -73,14 +74,14 @@ class HasOperatingSystemCapacityTest extends DbTestCase
         // Enable capacity, the itemtype should now be registered
         $definition = $this->enableCapacity(
             $definition,
-            $this->getTargetCapacity()
+            $this->getTargetCapacity()->getName()
         );
         $this->assertContains($class, $CFG_GLPI["operatingsystem_types"]);
 
         // Disable capacity, the itemtype should no longer be registered
         $definition = $this->disableCapacity(
             $definition,
-            $this->getTargetCapacity()
+            $this->getTargetCapacity()->getName()
         );
         $this->assertNotContains($class, $CFG_GLPI["operatingsystem_types"]);
     }
@@ -111,7 +112,7 @@ class HasOperatingSystemCapacityTest extends DbTestCase
         // Enable capacity, the tab should now be registered
         $definition = $this->enableCapacity(
             $definition,
-            $this->getTargetCapacity()
+            $this->getTargetCapacity()->getName()
         );
         $this->assertArrayHasKey($tab_name, $subject->defineAllTabs());
 
@@ -150,7 +151,7 @@ class HasOperatingSystemCapacityTest extends DbTestCase
         // Enable capactity, search option count should increase
         $definition = $this->enableCapacity(
             $definition,
-            $this->getTargetCapacity()
+            $this->getTargetCapacity()->getName()
         );
         $this->assertCount(
             $base_search_options_count + $count_to_add,
@@ -160,7 +161,7 @@ class HasOperatingSystemCapacityTest extends DbTestCase
         // Disable capacity, search option count should decrease back to base
         $definition = $this->disableCapacity(
             $definition,
-            $this->getTargetCapacity()
+            $this->getTargetCapacity()->getName()
         );
         $this->assertCount(
             $base_search_options_count,
@@ -205,7 +206,7 @@ class HasOperatingSystemCapacityTest extends DbTestCase
         // Disable capacity, linked item should be deleted
         $definition = $this->disableCapacity(
             $definition,
-            $this->getTargetCapacity()
+            $this->getTargetCapacity()->getName()
         );
         $items = (new Item_OperatingSystem())->find([
             'itemtype' => $subject::getType(),
@@ -226,7 +227,7 @@ class HasOperatingSystemCapacityTest extends DbTestCase
         $definition = $this->initAssetDefinition(
             capacities: [
                 $this->getTargetCapacity(),
-                HasHistoryCapacity::class
+                new \Glpi\Asset\Capacity(name: HasHistoryCapacity::class)
             ]
         );
         $class = $definition->getAssetClassName();
@@ -270,7 +271,7 @@ class HasOperatingSystemCapacityTest extends DbTestCase
         // and "OperatingSystem" should be deleted
         $definition = $this->disableCapacity(
             $definition,
-            $this->getTargetCapacity()
+            $this->getTargetCapacity()->getName()
         );
         $count_logs = countElementsInTable(Log::getTable(), [
             'itemtype' => $class,
@@ -328,7 +329,7 @@ class HasOperatingSystemCapacityTest extends DbTestCase
         // The two OS search options should be deleted
         $definition = $this->disableCapacity(
             $definition,
-            $this->getTargetCapacity()
+            $this->getTargetCapacity()->getName()
         );
         $count_display_preferences = countElementsInTable(
             DisplayPreference::getTable(),
@@ -342,7 +343,7 @@ class HasOperatingSystemCapacityTest extends DbTestCase
     public function testCloneAsset()
     {
         $definition = $this->initAssetDefinition(
-            capacities: [\Glpi\Asset\Capacity\HasOperatingSystemCapacity::class]
+            capacities: [new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasOperatingSystemCapacity::class)]
         );
         $class = $definition->getAssetClassName();
         $entity = $this->getTestRootEntity(true);

--- a/phpunit/functional/Glpi/Asset/Capacity/HasOperatingSystemCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/HasOperatingSystemCapacityTest.php
@@ -47,9 +47,9 @@ class HasOperatingSystemCapacityTest extends DbTestCase
 {
     use CapacityUsageTestTrait;
 
-    protected function getTargetCapacity(): Capacity
+    protected function getTargetCapacity(): string
     {
-        return new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasOperatingSystemCapacity::class);
+        return \Glpi\Asset\Capacity\HasOperatingSystemCapacity::class;
     }
 
     /**
@@ -74,14 +74,14 @@ class HasOperatingSystemCapacityTest extends DbTestCase
         // Enable capacity, the itemtype should now be registered
         $definition = $this->enableCapacity(
             $definition,
-            $this->getTargetCapacity()->getName()
+            $this->getTargetCapacity()
         );
         $this->assertContains($class, $CFG_GLPI["operatingsystem_types"]);
 
         // Disable capacity, the itemtype should no longer be registered
         $definition = $this->disableCapacity(
             $definition,
-            $this->getTargetCapacity()->getName()
+            $this->getTargetCapacity()
         );
         $this->assertNotContains($class, $CFG_GLPI["operatingsystem_types"]);
     }
@@ -112,7 +112,7 @@ class HasOperatingSystemCapacityTest extends DbTestCase
         // Enable capacity, the tab should now be registered
         $definition = $this->enableCapacity(
             $definition,
-            $this->getTargetCapacity()->getName()
+            $this->getTargetCapacity()
         );
         $this->assertArrayHasKey($tab_name, $subject->defineAllTabs());
 
@@ -151,7 +151,7 @@ class HasOperatingSystemCapacityTest extends DbTestCase
         // Enable capactity, search option count should increase
         $definition = $this->enableCapacity(
             $definition,
-            $this->getTargetCapacity()->getName()
+            $this->getTargetCapacity()
         );
         $this->assertCount(
             $base_search_options_count + $count_to_add,
@@ -161,7 +161,7 @@ class HasOperatingSystemCapacityTest extends DbTestCase
         // Disable capacity, search option count should decrease back to base
         $definition = $this->disableCapacity(
             $definition,
-            $this->getTargetCapacity()->getName()
+            $this->getTargetCapacity()
         );
         $this->assertCount(
             $base_search_options_count,
@@ -179,7 +179,7 @@ class HasOperatingSystemCapacityTest extends DbTestCase
     {
         // Create custom asset definition with the target capacity enabled
         $definition = $this->initAssetDefinition(
-            capacities: [$this->getTargetCapacity()]
+            capacities: [new Capacity($this->getTargetCapacity())]
         );
         $class = $definition->getAssetClassName();
 
@@ -206,7 +206,7 @@ class HasOperatingSystemCapacityTest extends DbTestCase
         // Disable capacity, linked item should be deleted
         $definition = $this->disableCapacity(
             $definition,
-            $this->getTargetCapacity()->getName()
+            $this->getTargetCapacity()
         );
         $items = (new Item_OperatingSystem())->find([
             'itemtype' => $subject::getType(),
@@ -226,8 +226,8 @@ class HasOperatingSystemCapacityTest extends DbTestCase
         // Create custom asset definition with the target capacity enabled
         $definition = $this->initAssetDefinition(
             capacities: [
-                $this->getTargetCapacity(),
-                new \Glpi\Asset\Capacity(name: HasHistoryCapacity::class)
+                new Capacity(name: $this->getTargetCapacity()),
+                new Capacity(name: HasHistoryCapacity::class)
             ]
         );
         $class = $definition->getAssetClassName();
@@ -271,7 +271,7 @@ class HasOperatingSystemCapacityTest extends DbTestCase
         // and "OperatingSystem" should be deleted
         $definition = $this->disableCapacity(
             $definition,
-            $this->getTargetCapacity()->getName()
+            $this->getTargetCapacity()
         );
         $count_logs = countElementsInTable(Log::getTable(), [
             'itemtype' => $class,
@@ -290,7 +290,7 @@ class HasOperatingSystemCapacityTest extends DbTestCase
     {
         // Create custom asset definition with the target capacity enabled
         $definition = $this->initAssetDefinition(
-            capacities: [$this->getTargetCapacity()]
+            capacities: [new Capacity(name: $this->getTargetCapacity())]
         );
         $class = $definition->getAssetClassName();
 
@@ -329,7 +329,7 @@ class HasOperatingSystemCapacityTest extends DbTestCase
         // The two OS search options should be deleted
         $definition = $this->disableCapacity(
             $definition,
-            $this->getTargetCapacity()->getName()
+            $this->getTargetCapacity()
         );
         $count_display_preferences = countElementsInTable(
             DisplayPreference::getTable(),
@@ -343,7 +343,7 @@ class HasOperatingSystemCapacityTest extends DbTestCase
     public function testCloneAsset()
     {
         $definition = $this->initAssetDefinition(
-            capacities: [new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasOperatingSystemCapacity::class)]
+            capacities: [new Capacity(name: \Glpi\Asset\Capacity\HasOperatingSystemCapacity::class)]
         );
         $class = $definition->getAssetClassName();
         $entity = $this->getTestRootEntity(true);

--- a/phpunit/functional/Glpi/Asset/Capacity/HasPeripheralAssetsCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/HasPeripheralAssetsCapacityTest.php
@@ -51,21 +51,21 @@ class HasPeripheralAssetsCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasPeripheralAssetsCapacity::class,
-                \Glpi\Asset\Capacity\HasNotepadCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasPeripheralAssetsCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
         $definition_3 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasPeripheralAssetsCapacity::class,
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasPeripheralAssetsCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_3  = $definition_3->getAssetClassName();
@@ -122,15 +122,15 @@ class HasPeripheralAssetsCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasPeripheralAssetsCapacity::class,
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasPeripheralAssetsCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasPeripheralAssetsCapacity::class,
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasPeripheralAssetsCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
@@ -219,7 +219,7 @@ class HasPeripheralAssetsCapacityTest extends DbTestCase
     public function testCloneAsset()
     {
         $definition = $this->initAssetDefinition(
-            capacities: [\Glpi\Asset\Capacity\HasPeripheralAssetsCapacity::class]
+            capacities: [new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasPeripheralAssetsCapacity::class)]
         );
         $class = $definition->getAssetClassName();
         $entity = $this->getTestRootEntity(true);
@@ -262,7 +262,7 @@ class HasPeripheralAssetsCapacityTest extends DbTestCase
 
         foreach ($CFG_GLPI['directconnect_types'] as $peripheral_itemtype) {
             $definition = $this->initAssetDefinition(
-                capacities: [\Glpi\Asset\Capacity\HasPeripheralAssetsCapacity::class]
+                capacities: [new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasPeripheralAssetsCapacity::class)]
             );
             $class = $definition->getAssetClassName();
 
@@ -305,7 +305,7 @@ class HasPeripheralAssetsCapacityTest extends DbTestCase
         $entity_id = $this->getTestRootEntity(true);
 
         $definition = $this->initAssetDefinition(
-            capacities: [\Glpi\Asset\Capacity\HasPeripheralAssetsCapacity::class]
+            capacities: [new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasPeripheralAssetsCapacity::class)]
         );
         $class = $definition->getAssetClassName();
 

--- a/phpunit/functional/Glpi/Asset/Capacity/HasPeripheralAssetsCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/HasPeripheralAssetsCapacityTest.php
@@ -38,6 +38,7 @@ use DbTestCase;
 use DisplayPreference;
 use Entity;
 use Glpi\Asset\Asset_PeripheralAsset;
+use Glpi\Asset\Capacity;
 use Log;
 use Monitor;
 
@@ -51,21 +52,21 @@ class HasPeripheralAssetsCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasPeripheralAssetsCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasPeripheralAssetsCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
         $definition_3 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasPeripheralAssetsCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasPeripheralAssetsCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_3  = $definition_3->getAssetClassName();
@@ -122,15 +123,15 @@ class HasPeripheralAssetsCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasPeripheralAssetsCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasPeripheralAssetsCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasPeripheralAssetsCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasPeripheralAssetsCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
@@ -219,7 +220,7 @@ class HasPeripheralAssetsCapacityTest extends DbTestCase
     public function testCloneAsset()
     {
         $definition = $this->initAssetDefinition(
-            capacities: [new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasPeripheralAssetsCapacity::class)]
+            capacities: [new Capacity(name: \Glpi\Asset\Capacity\HasPeripheralAssetsCapacity::class)]
         );
         $class = $definition->getAssetClassName();
         $entity = $this->getTestRootEntity(true);
@@ -262,7 +263,7 @@ class HasPeripheralAssetsCapacityTest extends DbTestCase
 
         foreach ($CFG_GLPI['directconnect_types'] as $peripheral_itemtype) {
             $definition = $this->initAssetDefinition(
-                capacities: [new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasPeripheralAssetsCapacity::class)]
+                capacities: [new Capacity(name: \Glpi\Asset\Capacity\HasPeripheralAssetsCapacity::class)]
             );
             $class = $definition->getAssetClassName();
 
@@ -305,7 +306,7 @@ class HasPeripheralAssetsCapacityTest extends DbTestCase
         $entity_id = $this->getTestRootEntity(true);
 
         $definition = $this->initAssetDefinition(
-            capacities: [new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasPeripheralAssetsCapacity::class)]
+            capacities: [new Capacity(name: \Glpi\Asset\Capacity\HasPeripheralAssetsCapacity::class)]
         );
         $class = $definition->getAssetClassName();
 

--- a/phpunit/functional/Glpi/Asset/Capacity/HasPlugCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/HasPlugCapacityTest.php
@@ -46,9 +46,9 @@ class HasPlugCapacityTest extends DbTestCase
 {
     use CapacityUsageTestTrait;
 
-    protected function getTargetCapacity(): Capacity
+    protected function getTargetCapacity(): string
     {
-        return new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasPlugCapacity::class);
+        return \Glpi\Asset\Capacity\HasPlugCapacity::class;
     }
 
     public function testCapacityActivation(): void
@@ -59,21 +59,21 @@ class HasPlugCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasPlugCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasPlugCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
         $definition_3 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasPlugCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasPlugCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_3  = $definition_3->getAssetClassName();
@@ -112,15 +112,15 @@ class HasPlugCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasPlugCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasPlugCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasPlugCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasPlugCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
@@ -199,7 +199,7 @@ class HasPlugCapacityTest extends DbTestCase
     public function testCloneAsset()
     {
         $definition = $this->initAssetDefinition(
-            capacities: [new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasPlugCapacity::class)]
+            capacities: [new Capacity(name: \Glpi\Asset\Capacity\HasPlugCapacity::class)]
         );
         $class = $definition->getAssetClassName();
         $entity = $this->getTestRootEntity(true);

--- a/phpunit/functional/Glpi/Asset/Capacity/HasPlugCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/HasPlugCapacityTest.php
@@ -36,6 +36,7 @@ namespace tests\units\Glpi\Asset\Capacity;
 
 use DbTestCase;
 use Entity;
+use Glpi\Asset\Capacity;
 use Item_Plug;
 use Glpi\PHPUnit\Tests\Glpi\Asset\CapacityUsageTestTrait;
 use Log;
@@ -45,9 +46,9 @@ class HasPlugCapacityTest extends DbTestCase
 {
     use CapacityUsageTestTrait;
 
-    protected function getTargetCapacity(): string
+    protected function getTargetCapacity(): Capacity
     {
-        return \Glpi\Asset\Capacity\HasPlugCapacity::class;
+        return new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasPlugCapacity::class);
     }
 
     public function testCapacityActivation(): void
@@ -58,21 +59,21 @@ class HasPlugCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasPlugCapacity::class,
-                \Glpi\Asset\Capacity\HasNotepadCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasPlugCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
         $definition_3 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasPlugCapacity::class,
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasPlugCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_3  = $definition_3->getAssetClassName();
@@ -111,15 +112,15 @@ class HasPlugCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasPlugCapacity::class,
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasPlugCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasPlugCapacity::class,
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasPlugCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
@@ -198,7 +199,7 @@ class HasPlugCapacityTest extends DbTestCase
     public function testCloneAsset()
     {
         $definition = $this->initAssetDefinition(
-            capacities: [\Glpi\Asset\Capacity\HasPlugCapacity::class]
+            capacities: [new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasPlugCapacity::class)]
         );
         $class = $definition->getAssetClassName();
         $entity = $this->getTestRootEntity(true);

--- a/phpunit/functional/Glpi/Asset/Capacity/HasRemoteManagementCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/HasRemoteManagementCapacityTest.php
@@ -37,6 +37,7 @@ namespace tests\units\Glpi\Asset\Capacity;
 use DbTestCase;
 use DisplayPreference;
 use Entity;
+use Glpi\Asset\Capacity;
 use Glpi\PHPUnit\Tests\Glpi\Asset\CapacityUsageTestTrait;
 use Item_RemoteManagement;
 use Log;
@@ -45,9 +46,9 @@ class HasRemoteManagementCapacityTest extends DbTestCase
 {
     use CapacityUsageTestTrait;
 
-    protected function getTargetCapacity(): string
+    protected function getTargetCapacity(): Capacity
     {
-        return \Glpi\Asset\Capacity\HasRemoteManagementCapacity::class;
+        return new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasRemoteManagementCapacity::class);
     }
 
     public function testCapacityActivation(): void
@@ -58,21 +59,21 @@ class HasRemoteManagementCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasRemoteManagementCapacity::class,
-                \Glpi\Asset\Capacity\HasNotepadCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasRemoteManagementCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
         $definition_3 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasRemoteManagementCapacity::class,
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasRemoteManagementCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_3  = $definition_3->getAssetClassName();
@@ -122,15 +123,15 @@ class HasRemoteManagementCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasRemoteManagementCapacity::class,
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasRemoteManagementCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasRemoteManagementCapacity::class,
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasRemoteManagementCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
@@ -217,7 +218,7 @@ class HasRemoteManagementCapacityTest extends DbTestCase
     public function testCloneAsset()
     {
         $definition = $this->initAssetDefinition(
-            capacities: [\Glpi\Asset\Capacity\HasRemoteManagementCapacity::class]
+            capacities: [new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasRemoteManagementCapacity::class)]
         );
         $class = $definition->getAssetClassName();
         $entity = $this->getTestRootEntity(true);

--- a/phpunit/functional/Glpi/Asset/Capacity/HasRemoteManagementCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/HasRemoteManagementCapacityTest.php
@@ -46,9 +46,9 @@ class HasRemoteManagementCapacityTest extends DbTestCase
 {
     use CapacityUsageTestTrait;
 
-    protected function getTargetCapacity(): Capacity
+    protected function getTargetCapacity(): string
     {
-        return new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasRemoteManagementCapacity::class);
+        return \Glpi\Asset\Capacity\HasRemoteManagementCapacity::class;
     }
 
     public function testCapacityActivation(): void
@@ -59,21 +59,21 @@ class HasRemoteManagementCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasRemoteManagementCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasRemoteManagementCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
         $definition_3 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasRemoteManagementCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasRemoteManagementCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_3  = $definition_3->getAssetClassName();
@@ -123,15 +123,15 @@ class HasRemoteManagementCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasRemoteManagementCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasRemoteManagementCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasRemoteManagementCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasRemoteManagementCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
@@ -218,7 +218,7 @@ class HasRemoteManagementCapacityTest extends DbTestCase
     public function testCloneAsset()
     {
         $definition = $this->initAssetDefinition(
-            capacities: [new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasRemoteManagementCapacity::class)]
+            capacities: [new Capacity(name: \Glpi\Asset\Capacity\HasRemoteManagementCapacity::class)]
         );
         $class = $definition->getAssetClassName();
         $entity = $this->getTestRootEntity(true);

--- a/phpunit/functional/Glpi/Asset/Capacity/HasSocketCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/HasSocketCapacityTest.php
@@ -39,6 +39,7 @@ use Computer;
 use DbTestCase;
 use DisplayPreference;
 use Entity;
+use Glpi\Asset\Capacity;
 use Glpi\PHPUnit\Tests\Glpi\Asset\CapacityUsageTestTrait;
 use Glpi\Socket;
 use Log;
@@ -47,9 +48,9 @@ class HasSocketCapacityTest extends DbTestCase
 {
     use CapacityUsageTestTrait;
 
-    protected function getTargetCapacity(): string
+    protected function getTargetCapacity(): Capacity
     {
-        return \Glpi\Asset\Capacity\HasSocketCapacity::class;
+        return new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasSocketCapacity::class);
     }
 
     public function testCapacityActivation(): void
@@ -60,21 +61,20 @@ class HasSocketCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasSocketCapacity::class,
-                \Glpi\Asset\Capacity\HasSocketCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasSocketCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
         $definition_3 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasSocketCapacity::class,
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasSocketCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_3  = $definition_3->getAssetClassName();
@@ -128,15 +128,15 @@ class HasSocketCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
-                \Glpi\Asset\Capacity\HasSocketCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasSocketCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
-                \Glpi\Asset\Capacity\HasSocketCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasSocketCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
@@ -253,7 +253,7 @@ class HasSocketCapacityTest extends DbTestCase
     {
         $definition = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasSocketCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasSocketCapacity::class),
             ]
         );
         $class = $definition->getAssetClassName();

--- a/phpunit/functional/Glpi/Asset/Capacity/HasSocketCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/HasSocketCapacityTest.php
@@ -48,9 +48,9 @@ class HasSocketCapacityTest extends DbTestCase
 {
     use CapacityUsageTestTrait;
 
-    protected function getTargetCapacity(): Capacity
+    protected function getTargetCapacity(): string
     {
-        return new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasSocketCapacity::class);
+        return \Glpi\Asset\Capacity\HasSocketCapacity::class;
     }
 
     public function testCapacityActivation(): void
@@ -61,20 +61,20 @@ class HasSocketCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasSocketCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasSocketCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
         $definition_3 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasSocketCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasSocketCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_3  = $definition_3->getAssetClassName();
@@ -128,15 +128,15 @@ class HasSocketCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasSocketCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasSocketCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasSocketCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasSocketCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
@@ -253,7 +253,7 @@ class HasSocketCapacityTest extends DbTestCase
     {
         $definition = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasSocketCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasSocketCapacity::class),
             ]
         );
         $class = $definition->getAssetClassName();

--- a/phpunit/functional/Glpi/Asset/Capacity/HasSoftwaresCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/HasSoftwaresCapacityTest.php
@@ -54,21 +54,21 @@ class HasSoftwaresCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasSoftwaresCapacity::class,
-                \Glpi\Asset\Capacity\HasNotepadCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasSoftwaresCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
         $definition_3 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasSoftwaresCapacity::class,
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasSoftwaresCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_3  = $definition_3->getAssetClassName();
@@ -109,15 +109,15 @@ class HasSoftwaresCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasSoftwaresCapacity::class,
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasSoftwaresCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasSoftwaresCapacity::class,
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasSoftwaresCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
@@ -229,7 +229,7 @@ class HasSoftwaresCapacityTest extends DbTestCase
     public function testCloneAsset()
     {
         $definition = $this->initAssetDefinition(
-            capacities: [\Glpi\Asset\Capacity\HasSoftwaresCapacity::class]
+            capacities: [new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasSoftwaresCapacity::class)]
         );
         $class = $definition->getAssetClassName();
         $entity = $this->getTestRootEntity(true);
@@ -303,7 +303,7 @@ class HasSoftwaresCapacityTest extends DbTestCase
     public function testIsUsed(): void
     {
         $definition = $this->initAssetDefinition(
-            capacities: [\Glpi\Asset\Capacity\HasSoftwaresCapacity::class]
+            capacities: [new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasSoftwaresCapacity::class)]
         );
         $class    = $definition->getAssetClassName();
         $capacity = new \Glpi\Asset\Capacity\HasSoftwaresCapacity();
@@ -376,7 +376,7 @@ class HasSoftwaresCapacityTest extends DbTestCase
     public function testGetCapacityUsageDescription(): void
     {
         $definition = $this->initAssetDefinition(
-            capacities: [\Glpi\Asset\Capacity\HasSoftwaresCapacity::class]
+            capacities: [new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasSoftwaresCapacity::class)]
         );
         $class    = $definition->getAssetClassName();
         $capacity = new \Glpi\Asset\Capacity\HasSoftwaresCapacity();

--- a/phpunit/functional/Glpi/Asset/Capacity/HasSoftwaresCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/HasSoftwaresCapacityTest.php
@@ -37,6 +37,7 @@ namespace tests\units\Glpi\Asset\Capacity;
 use DbTestCase;
 use Entity;
 use Glpi\Asset\Asset;
+use Glpi\Asset\Capacity;
 use Item_SoftwareLicense;
 use Item_SoftwareVersion;
 use Log;
@@ -54,21 +55,21 @@ class HasSoftwaresCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasSoftwaresCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasSoftwaresCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
         $definition_3 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasSoftwaresCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasSoftwaresCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_3  = $definition_3->getAssetClassName();
@@ -109,15 +110,15 @@ class HasSoftwaresCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasSoftwaresCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasSoftwaresCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasSoftwaresCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasSoftwaresCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
@@ -229,7 +230,7 @@ class HasSoftwaresCapacityTest extends DbTestCase
     public function testCloneAsset()
     {
         $definition = $this->initAssetDefinition(
-            capacities: [new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasSoftwaresCapacity::class)]
+            capacities: [new Capacity(name: \Glpi\Asset\Capacity\HasSoftwaresCapacity::class)]
         );
         $class = $definition->getAssetClassName();
         $entity = $this->getTestRootEntity(true);
@@ -303,7 +304,7 @@ class HasSoftwaresCapacityTest extends DbTestCase
     public function testIsUsed(): void
     {
         $definition = $this->initAssetDefinition(
-            capacities: [new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasSoftwaresCapacity::class)]
+            capacities: [new Capacity(name: \Glpi\Asset\Capacity\HasSoftwaresCapacity::class)]
         );
         $class    = $definition->getAssetClassName();
         $capacity = new \Glpi\Asset\Capacity\HasSoftwaresCapacity();
@@ -376,7 +377,7 @@ class HasSoftwaresCapacityTest extends DbTestCase
     public function testGetCapacityUsageDescription(): void
     {
         $definition = $this->initAssetDefinition(
-            capacities: [new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasSoftwaresCapacity::class)]
+            capacities: [new Capacity(name: \Glpi\Asset\Capacity\HasSoftwaresCapacity::class)]
         );
         $class    = $definition->getAssetClassName();
         $capacity = new \Glpi\Asset\Capacity\HasSoftwaresCapacity();

--- a/phpunit/functional/Glpi/Asset/Capacity/HasVirtualMachineCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/HasVirtualMachineCapacityTest.php
@@ -46,9 +46,9 @@ class HasVirtualMachineCapacityTest extends DbTestCase
 {
     use CapacityUsageTestTrait;
 
-    protected function getTargetCapacity(): Capacity
+    protected function getTargetCapacity(): string
     {
-        return new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasVirtualMachineCapacity::class);
+        return \Glpi\Asset\Capacity\HasVirtualMachineCapacity::class;
     }
 
     public function testCapacityActivation(): void
@@ -59,21 +59,21 @@ class HasVirtualMachineCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasVirtualMachineCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasVirtualMachineCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
         $definition_3 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasVirtualMachineCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasVirtualMachineCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_3  = $definition_3->getAssetClassName();
@@ -132,15 +132,15 @@ class HasVirtualMachineCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasVirtualMachineCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasVirtualMachineCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasVirtualMachineCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasVirtualMachineCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
@@ -227,7 +227,7 @@ class HasVirtualMachineCapacityTest extends DbTestCase
     public function testCloneAsset()
     {
         $definition = $this->initAssetDefinition(
-            capacities: [new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasVirtualMachineCapacity::class)]
+            capacities: [new Capacity(name: \Glpi\Asset\Capacity\HasVirtualMachineCapacity::class)]
         );
         $class = $definition->getAssetClassName();
         $entity = $this->getTestRootEntity(true);

--- a/phpunit/functional/Glpi/Asset/Capacity/HasVirtualMachineCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/HasVirtualMachineCapacityTest.php
@@ -37,6 +37,7 @@ namespace tests\units\Glpi\Asset\Capacity;
 use DbTestCase;
 use DisplayPreference;
 use Entity;
+use Glpi\Asset\Capacity;
 use Glpi\PHPUnit\Tests\Glpi\Asset\CapacityUsageTestTrait;
 use ItemVirtualMachine;
 use Log;
@@ -45,9 +46,9 @@ class HasVirtualMachineCapacityTest extends DbTestCase
 {
     use CapacityUsageTestTrait;
 
-    protected function getTargetCapacity(): string
+    protected function getTargetCapacity(): Capacity
     {
-        return \Glpi\Asset\Capacity\HasVirtualMachineCapacity::class;
+        return new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasVirtualMachineCapacity::class);
     }
 
     public function testCapacityActivation(): void
@@ -58,21 +59,21 @@ class HasVirtualMachineCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasVirtualMachineCapacity::class,
-                \Glpi\Asset\Capacity\HasNotepadCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasVirtualMachineCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
         $definition_3 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasVirtualMachineCapacity::class,
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasVirtualMachineCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_3  = $definition_3->getAssetClassName();
@@ -131,15 +132,15 @@ class HasVirtualMachineCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasVirtualMachineCapacity::class,
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasVirtualMachineCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasVirtualMachineCapacity::class,
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasVirtualMachineCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
@@ -226,7 +227,7 @@ class HasVirtualMachineCapacityTest extends DbTestCase
     public function testCloneAsset()
     {
         $definition = $this->initAssetDefinition(
-            capacities: [\Glpi\Asset\Capacity\HasVirtualMachineCapacity::class]
+            capacities: [new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasVirtualMachineCapacity::class)]
         );
         $class = $definition->getAssetClassName();
         $entity = $this->getTestRootEntity(true);

--- a/phpunit/functional/Glpi/Asset/Capacity/HasVolumesCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/HasVolumesCapacityTest.php
@@ -47,9 +47,9 @@ class HasVolumesCapacityTest extends DbTestCase
 {
     use CapacityUsageTestTrait;
 
-    protected function getTargetCapacity(): Capacity
+    protected function getTargetCapacity(): string
     {
-        return new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasVolumesCapacity::class);
+        return \Glpi\Asset\Capacity\HasVolumesCapacity::class;
     }
 
     public function testCapacityActivation(): void
@@ -60,21 +60,21 @@ class HasVolumesCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasVolumesCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasVolumesCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
         $definition_3 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasVolumesCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasVolumesCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_3  = $definition_3->getAssetClassName();
@@ -136,15 +136,15 @@ class HasVolumesCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasVolumesCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasVolumesCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasVolumesCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasVolumesCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
@@ -231,7 +231,7 @@ class HasVolumesCapacityTest extends DbTestCase
     public function testCloneAsset()
     {
         $definition = $this->initAssetDefinition(
-            capacities: [new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasVolumesCapacity::class)]
+            capacities: [new Capacity(name: \Glpi\Asset\Capacity\HasVolumesCapacity::class)]
         );
         $class = $definition->getAssetClassName();
         $entity = $this->getTestRootEntity(true);

--- a/phpunit/functional/Glpi/Asset/Capacity/HasVolumesCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/HasVolumesCapacityTest.php
@@ -38,6 +38,7 @@ use DbTestCase;
 use DisplayPreference;
 use Entity;
 use Glpi\Asset\Asset;
+use Glpi\Asset\Capacity;
 use Glpi\PHPUnit\Tests\Glpi\Asset\CapacityUsageTestTrait;
 use Item_Disk;
 use Log;
@@ -46,9 +47,9 @@ class HasVolumesCapacityTest extends DbTestCase
 {
     use CapacityUsageTestTrait;
 
-    protected function getTargetCapacity(): string
+    protected function getTargetCapacity(): Capacity
     {
-        return \Glpi\Asset\Capacity\HasVolumesCapacity::class;
+        return new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasVolumesCapacity::class);
     }
 
     public function testCapacityActivation(): void
@@ -59,21 +60,21 @@ class HasVolumesCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasVolumesCapacity::class,
-                \Glpi\Asset\Capacity\HasNotepadCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasVolumesCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
         $definition_3 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasVolumesCapacity::class,
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasVolumesCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_3  = $definition_3->getAssetClassName();
@@ -135,15 +136,15 @@ class HasVolumesCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasVolumesCapacity::class,
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasVolumesCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasVolumesCapacity::class,
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasVolumesCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
@@ -230,7 +231,7 @@ class HasVolumesCapacityTest extends DbTestCase
     public function testCloneAsset()
     {
         $definition = $this->initAssetDefinition(
-            capacities: [\Glpi\Asset\Capacity\HasVolumesCapacity::class]
+            capacities: [new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasVolumesCapacity::class)]
         );
         $class = $definition->getAssetClassName();
         $entity = $this->getTestRootEntity(true);

--- a/phpunit/functional/Glpi/Asset/Capacity/IsInventoriableCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/IsInventoriableCapacityTest.php
@@ -289,10 +289,7 @@ class IsInventoriableCapacityTest extends DbTestCase
         //make sure configuration has been updated in database
         $this->assertEquals(
             \Glpi\Inventory\MainAsset\GenericNetworkAsset::class,
-            $definition->getCapacityConfigurationValue(
-                \Glpi\Asset\Capacity\IsInventoriableCapacity::class,
-                'inventory_mainasset'
-            )
+            $definition->getCapacityConfiguration(\Glpi\Asset\Capacity\IsInventoriableCapacity::class)->getValue('inventory_mainasset')
         );
 
         //computer specific rule should no longer be present

--- a/phpunit/functional/Glpi/Asset/Capacity/IsInventoriableCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/IsInventoriableCapacityTest.php
@@ -35,17 +35,14 @@
 namespace tests\units\Glpi\Asset\Capacity;
 
 use DbTestCase;
-use DisplayPreference;
 use Entity;
-use Glpi\Tests\Asset\CapacityUsageTestTrait;
-use Log;
-use ReservationItem;
+use Glpi\Asset\Capacity;
 
 class IsInventoriableCapacityTest extends DbTestCase
 {
-    protected function getTargetCapacity(): \Glpi\Asset\Capacity
+    protected function getTargetCapacity(): string
     {
-        return new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\IsInventoriableCapacity::class);
+        return \Glpi\Asset\Capacity\IsInventoriableCapacity::class;
     }
 
     public function testCapacityActivation(): void
@@ -54,21 +51,21 @@ class IsInventoriableCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\IsInventoriableCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\IsInventoriableCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
         $definition_3 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\IsInventoriableCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\IsInventoriableCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_3  = $definition_3->getAssetClassName();
@@ -104,15 +101,15 @@ class IsInventoriableCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\IsInventoriableCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\IsInventoriableCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\IsInventoriableCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\IsInventoriableCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
@@ -158,14 +155,12 @@ class IsInventoriableCapacityTest extends DbTestCase
 
     public function testIsUsed(): void
     {
-        global $DB;
-
         // Retrieve the test root entity
         $entity_id = $this->getTestRootEntity(true);
 
         // Create custom asset definition with the target capacity enabled
         $definition = $this->initAssetDefinition(
-            capacities: [$this->getTargetCapacity()]
+            capacities: [new Capacity(name: $this->getTargetCapacity())]
         );
 
         // Create a non-dynamic test subject
@@ -176,7 +171,7 @@ class IsInventoriableCapacityTest extends DbTestCase
         ]);
 
         // Check that the capacity can be disabled
-        $capacity = new ($this->getTargetCapacity()->getName());
+        $capacity = new ($this->getTargetCapacity());
         $this->assertFalse($capacity->isUsed($definition->getAssetClassName()));
 
         // Create a dynamic test subject
@@ -187,7 +182,7 @@ class IsInventoriableCapacityTest extends DbTestCase
         ]);
 
         // Check that the capacity can't be safely disabled
-        $capacity = new ($this->getTargetCapacity()->getName());
+        $capacity = new ($this->getTargetCapacity());
         $this->assertTrue($capacity->isUsed($definition->getAssetClassName()));
     }
 
@@ -199,16 +194,14 @@ class IsInventoriableCapacityTest extends DbTestCase
      */
     public function testGetCapacityUsageDescription(): void
     {
-        global $DB;
-
-        $capacity = new ($this->getTargetCapacity()->getName());
+        $capacity = new ($this->getTargetCapacity());
 
         // Retrieve the test root entity
         $entity_id = $this->getTestRootEntity(true);
 
         // Create custom asset definition with the target capacity enabled
         $definition = $this->initAssetDefinition(
-            capacities: [$this->getTargetCapacity()]
+            capacities: [new Capacity(name: $this->getTargetCapacity())]
         );
 
         // Create a non-dynamic test subject
@@ -255,7 +248,7 @@ class IsInventoriableCapacityTest extends DbTestCase
 
         $definition = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(
+                new Capacity(
                     name: \Glpi\Asset\Capacity\IsInventoriableCapacity::class,
                     config: new \Glpi\Asset\CapacityConfig([
                         'inventory_mainasset' => \Glpi\Inventory\MainAsset\GenericAsset::class
@@ -282,12 +275,12 @@ class IsInventoriableCapacityTest extends DbTestCase
             $definition->update([
                 'id' => $definition->getID(),
                 'capacities' => [
-                    new \Glpi\Asset\Capacity(
-                        name: \Glpi\Asset\Capacity\IsInventoriableCapacity::class,
-                        config: new \Glpi\Asset\CapacityConfig([
+                    [
+                        'name' => \Glpi\Asset\Capacity\IsInventoriableCapacity::class,
+                        'config' => [
                             'inventory_mainasset' => \Glpi\Inventory\MainAsset\GenericNetworkAsset::class
-                        ])
-                    )
+                        ]
+                    ]
                 ]
             ])
         );
@@ -297,7 +290,7 @@ class IsInventoriableCapacityTest extends DbTestCase
         $this->assertEquals(
             \Glpi\Inventory\MainAsset\GenericNetworkAsset::class,
             $definition->getCapacityConfigurationValue(
-                $definition->getCapacity(\Glpi\Asset\Capacity\IsInventoriableCapacity::class),
+                \Glpi\Asset\Capacity\IsInventoriableCapacity::class,
                 'inventory_mainasset'
             )
         );

--- a/phpunit/functional/Glpi/Asset/Capacity/IsProjectAssetCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/IsProjectAssetCapacityTest.php
@@ -37,6 +37,7 @@ namespace tests\units\Glpi\Asset\Capacity;
 use DbTestCase;
 use DisplayPreference;
 use Entity;
+use Glpi\Asset\Capacity;
 use Glpi\PHPUnit\Tests\Glpi\Asset\CapacityUsageTestTrait;
 use Item_Project;
 use Log;
@@ -46,9 +47,9 @@ class IsProjectAssetCapacityTest extends DbTestCase
 {
     use CapacityUsageTestTrait;
 
-    protected function getTargetCapacity(): string
+    protected function getTargetCapacity(): Capacity
     {
-        return \Glpi\Asset\Capacity\IsProjectAssetCapacity::class;
+        return new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\IsProjectAssetCapacity::class);
     }
 
     public function testCapacityActivation(): void
@@ -59,21 +60,21 @@ class IsProjectAssetCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
-                \Glpi\Asset\Capacity\IsProjectAssetCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\IsProjectAssetCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasNotepadCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
         $definition_3 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasDocumentsCapacity::class,
-                \Glpi\Asset\Capacity\IsProjectAssetCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasDocumentsCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\IsProjectAssetCapacity::class),
             ]
         );
         $classname_3  = $definition_3->getAssetClassName();
@@ -119,15 +120,15 @@ class IsProjectAssetCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
-                \Glpi\Asset\Capacity\IsProjectAssetCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\IsProjectAssetCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
-                \Glpi\Asset\Capacity\IsProjectAssetCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\IsProjectAssetCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
@@ -228,7 +229,7 @@ class IsProjectAssetCapacityTest extends DbTestCase
     public function testCloneAsset()
     {
         $definition = $this->initAssetDefinition(
-            capacities: [\Glpi\Asset\Capacity\IsProjectAssetCapacity::class]
+            capacities: [new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\IsProjectAssetCapacity::class)]
         );
         $class = $definition->getAssetClassName();
         $entity = $this->getTestRootEntity(true);

--- a/phpunit/functional/Glpi/Asset/Capacity/IsProjectAssetCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/IsProjectAssetCapacityTest.php
@@ -47,9 +47,9 @@ class IsProjectAssetCapacityTest extends DbTestCase
 {
     use CapacityUsageTestTrait;
 
-    protected function getTargetCapacity(): Capacity
+    protected function getTargetCapacity(): string
     {
-        return new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\IsProjectAssetCapacity::class);
+        return \Glpi\Asset\Capacity\IsProjectAssetCapacity::class;
     }
 
     public function testCapacityActivation(): void
@@ -60,21 +60,21 @@ class IsProjectAssetCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\IsProjectAssetCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\IsProjectAssetCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
         $definition_3 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasDocumentsCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\IsProjectAssetCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasDocumentsCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\IsProjectAssetCapacity::class),
             ]
         );
         $classname_3  = $definition_3->getAssetClassName();
@@ -120,15 +120,15 @@ class IsProjectAssetCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\IsProjectAssetCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\IsProjectAssetCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\IsProjectAssetCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\IsProjectAssetCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
@@ -229,7 +229,7 @@ class IsProjectAssetCapacityTest extends DbTestCase
     public function testCloneAsset()
     {
         $definition = $this->initAssetDefinition(
-            capacities: [new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\IsProjectAssetCapacity::class)]
+            capacities: [new Capacity(name: \Glpi\Asset\Capacity\IsProjectAssetCapacity::class)]
         );
         $class = $definition->getAssetClassName();
         $entity = $this->getTestRootEntity(true);

--- a/phpunit/functional/Glpi/Asset/Capacity/IsRackableCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/IsRackableCapacityTest.php
@@ -51,21 +51,21 @@ class IsRackableCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\IsRackableCapacity::class,
-                \Glpi\Asset\Capacity\HasNotepadCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\IsRackableCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
         $definition_3 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\IsRackableCapacity::class,
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\IsRackableCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_3  = $definition_3->getAssetClassName();
@@ -109,15 +109,15 @@ class IsRackableCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\IsRackableCapacity::class,
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\IsRackableCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\IsRackableCapacity::class,
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\IsRackableCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
@@ -241,7 +241,7 @@ class IsRackableCapacityTest extends DbTestCase
         $entity_id = $this->getTestRootEntity(true);
 
         $definition = $this->initAssetDefinition(
-            capacities: [\Glpi\Asset\Capacity\IsRackableCapacity::class]
+            capacities: [new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\IsRackableCapacity::class)]
         );
 
         $asset = $this->createItem($definition->getAssetClassName(), [
@@ -279,7 +279,7 @@ class IsRackableCapacityTest extends DbTestCase
 
         $definition = $this->initAssetDefinition(
             system_name: 'TestAsset',
-            capacities: [\Glpi\Asset\Capacity\IsRackableCapacity::class]
+            capacities: [new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\IsRackableCapacity::class)]
         );
         $capacity = new \Glpi\Asset\Capacity\IsRackableCapacity();
 

--- a/phpunit/functional/Glpi/Asset/Capacity/IsRackableCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/IsRackableCapacityTest.php
@@ -37,6 +37,7 @@ namespace tests\units\Glpi\Asset\Capacity;
 use DbTestCase;
 use DisplayPreference;
 use Entity;
+use Glpi\Asset\Capacity;
 use Item_Rack;
 use Log;
 use Rack;
@@ -51,21 +52,21 @@ class IsRackableCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\IsRackableCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\IsRackableCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
         $definition_3 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\IsRackableCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\IsRackableCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_3  = $definition_3->getAssetClassName();
@@ -109,15 +110,15 @@ class IsRackableCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\IsRackableCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\IsRackableCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\IsRackableCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\IsRackableCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
@@ -241,7 +242,7 @@ class IsRackableCapacityTest extends DbTestCase
         $entity_id = $this->getTestRootEntity(true);
 
         $definition = $this->initAssetDefinition(
-            capacities: [new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\IsRackableCapacity::class)]
+            capacities: [new Capacity(name: \Glpi\Asset\Capacity\IsRackableCapacity::class)]
         );
 
         $asset = $this->createItem($definition->getAssetClassName(), [
@@ -279,7 +280,7 @@ class IsRackableCapacityTest extends DbTestCase
 
         $definition = $this->initAssetDefinition(
             system_name: 'TestAsset',
-            capacities: [new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\IsRackableCapacity::class)]
+            capacities: [new Capacity(name: \Glpi\Asset\Capacity\IsRackableCapacity::class)]
         );
         $capacity = new \Glpi\Asset\Capacity\IsRackableCapacity();
 

--- a/phpunit/functional/Glpi/Asset/Capacity/IsReservableCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/IsReservableCapacityTest.php
@@ -37,6 +37,7 @@ namespace tests\units\Glpi\Asset\Capacity;
 use DbTestCase;
 use DisplayPreference;
 use Entity;
+use Glpi\Asset\Capacity;
 use Glpi\PHPUnit\Tests\Glpi\Asset\CapacityUsageTestTrait;
 use Log;
 use ReservationItem;
@@ -45,9 +46,9 @@ class IsReservableCapacityTest extends DbTestCase
 {
     use CapacityUsageTestTrait;
 
-    protected function getTargetCapacity(): string
+    protected function getTargetCapacity(): Capacity
     {
-        return \Glpi\Asset\Capacity\IsReservableCapacity::class;
+        return new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\IsReservableCapacity::class);
     }
 
     public function testCapacityActivation(): void
@@ -58,21 +59,21 @@ class IsReservableCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\IsReservableCapacity::class,
-                \Glpi\Asset\Capacity\HasNotepadCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\IsReservableCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
         $definition_3 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\IsReservableCapacity::class,
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\IsReservableCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_3  = $definition_3->getAssetClassName();
@@ -122,15 +123,15 @@ class IsReservableCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\IsReservableCapacity::class,
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\IsReservableCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\IsReservableCapacity::class,
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\IsReservableCapacity::class),
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();

--- a/phpunit/functional/Glpi/Asset/Capacity/IsReservableCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/IsReservableCapacityTest.php
@@ -46,9 +46,9 @@ class IsReservableCapacityTest extends DbTestCase
 {
     use CapacityUsageTestTrait;
 
-    protected function getTargetCapacity(): Capacity
+    protected function getTargetCapacity(): string
     {
-        return new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\IsReservableCapacity::class);
+        return \Glpi\Asset\Capacity\IsReservableCapacity::class;
     }
 
     public function testCapacityActivation(): void
@@ -59,21 +59,21 @@ class IsReservableCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\IsReservableCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\IsReservableCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasNotepadCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();
         $definition_3 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\IsReservableCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\IsReservableCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_3  = $definition_3->getAssetClassName();
@@ -123,15 +123,15 @@ class IsReservableCapacityTest extends DbTestCase
 
         $definition_1 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\IsReservableCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\IsReservableCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_1  = $definition_1->getAssetClassName();
         $definition_2 = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\IsReservableCapacity::class),
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\IsReservableCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $classname_2  = $definition_2->getAssetClassName();

--- a/phpunit/functional/Glpi/Asset/CustomFieldDefinitionTest.php
+++ b/phpunit/functional/Glpi/Asset/CustomFieldDefinitionTest.php
@@ -57,7 +57,7 @@ class CustomFieldDefinitionTest extends DbTestCase
     {
         $asset_definition = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $asset_classname = $asset_definition->getAssetClassName();
@@ -288,7 +288,7 @@ class CustomFieldDefinitionTest extends DbTestCase
         $opt_id_offset = 45000;
         $asset_definition = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
 
@@ -498,7 +498,7 @@ class CustomFieldDefinitionTest extends DbTestCase
     {
         $asset_definition = $this->initAssetDefinition(
             capacities: [
-                \Glpi\Asset\Capacity\HasHistoryCapacity::class,
+                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $field_1 = new \Glpi\Asset\CustomFieldDefinition();

--- a/phpunit/functional/Glpi/Asset/CustomFieldDefinitionTest.php
+++ b/phpunit/functional/Glpi/Asset/CustomFieldDefinitionTest.php
@@ -35,6 +35,7 @@
 namespace tests\units\Glpi\Asset;
 
 use DbTestCase;
+use Glpi\Asset\Capacity;
 use Glpi\Asset\CustomFieldType\BooleanType;
 use Glpi\Asset\CustomFieldType\DateTimeType;
 use Glpi\Asset\CustomFieldType\DateType;
@@ -57,7 +58,7 @@ class CustomFieldDefinitionTest extends DbTestCase
     {
         $asset_definition = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $asset_classname = $asset_definition->getAssetClassName();
@@ -288,7 +289,7 @@ class CustomFieldDefinitionTest extends DbTestCase
         $opt_id_offset = 45000;
         $asset_definition = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
 
@@ -498,7 +499,7 @@ class CustomFieldDefinitionTest extends DbTestCase
     {
         $asset_definition = $this->initAssetDefinition(
             capacities: [
-                new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
+                new Capacity(name: \Glpi\Asset\Capacity\HasHistoryCapacity::class),
             ]
         );
         $field_1 = new \Glpi\Asset\CustomFieldDefinition();

--- a/phpunit/functional/Glpi/Inventory/Assets/NetworkEquipmentTest.php
+++ b/phpunit/functional/Glpi/Inventory/Assets/NetworkEquipmentTest.php
@@ -2783,6 +2783,7 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
         $networkEquipment = getItemByTypeName('NetworkEquipment', '_test_networkequipment_1');
 
         $asset = new \Glpi\Inventory\Asset\NetworkPort($networkEquipment, (array)$json->content->network_ports);
+        $asset->setMainAsset(new \Glpi\Inventory\MainAsset\NetworkEquipment($networkEquipment, []));
 
         $result = $asset->prepare();
         $this->assertCount(1, $result);

--- a/phpunit/functional/Glpi/Inventory/Assets/NetworkPortTest.php
+++ b/phpunit/functional/Glpi/Inventory/Assets/NetworkPortTest.php
@@ -341,6 +341,7 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
         );
 
         $asset = new \Glpi\Inventory\Asset\NetworkPort($neteq, $json->content->network_ports);
+        $asset->setMainAsset(new \Glpi\Inventory\MainAsset\NetworkEquipment($neteq, []));
         $asset->setExtraData((array)$json->content);
         $results = $asset->prepare();
 

--- a/phpunit/functional/Glpi/Inventory/GenericAssetInventoryTest.php
+++ b/phpunit/functional/Glpi/Inventory/GenericAssetInventoryTest.php
@@ -41,7 +41,7 @@ class GenericAssetInventoryTest extends InventoryTestCase
     /**
      * Inventory a generic smartphone asset
      *
-     * @param array<class-string> $capacities Capacities to activate
+     * @param \Glpi\Asset\Capacity[] $capacities Capacities to activate
      *
      * @return \Glpi\Asset\Asset
      */
@@ -56,7 +56,7 @@ class GenericAssetInventoryTest extends InventoryTestCase
             capacities: array_merge(
                 $capacities,
                 [
-                    \Glpi\Asset\Capacity\IsInventoriableCapacity::class
+                    new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\IsInventoriableCapacity::class)
                 ]
             )
         );
@@ -234,7 +234,7 @@ class GenericAssetInventoryTest extends InventoryTestCase
     public function testImportSmartphoneWOS()
     {
         //create Smartphone generic asset
-        $asset = $this->inventorySmartphone([\Glpi\Asset\Capacity\HasOperatingSystemCapacity::class]);
+        $asset = $this->inventorySmartphone([new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasOperatingSystemCapacity::class)]);
 
         //operating system
         $ios = new \Item_OperatingSystem();
@@ -261,7 +261,7 @@ class GenericAssetInventoryTest extends InventoryTestCase
     public function testImportSmartphoneWVolumes()
     {
         //create Smartphone generic asset
-        $asset = $this->inventorySmartphone([\Glpi\Asset\Capacity\HasVolumesCapacity::class]);
+        $asset = $this->inventorySmartphone([new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasVolumesCapacity::class)]);
         $classname = $asset::class;
         $assets_id = $asset->getID();
 
@@ -327,7 +327,13 @@ class GenericAssetInventoryTest extends InventoryTestCase
         global $DB;
 
         //create Smartphone generic asset
-        $asset = $this->inventorySmartphone(array_keys(\Glpi\Asset\AssetDefinitionManager::getInstance()->getAvailableCapacities()));
+        $capacities = [];
+        foreach (array_keys(\Glpi\Asset\AssetDefinitionManager::getInstance()->getAvailableCapacities()) as $available_capacity) {
+            if ($available_capacity !== \Glpi\Asset\Capacity\IsInventoriableCapacity::class) {
+                $capacities[] = new \Glpi\Asset\Capacity(name: $available_capacity);
+            }
+        }
+        $asset = $this->inventorySmartphone($capacities);
         $classname = $asset::class;
         $assets_id = $asset->getID();
 
@@ -745,7 +751,7 @@ class GenericAssetInventoryTest extends InventoryTestCase
     }
 
     /**
-     * Inventory a generic smartphone asset
+     * Inventory a generic server asset
      *
      * @param array<class-string> $capacities Capacities to activate
      *
@@ -762,13 +768,13 @@ class GenericAssetInventoryTest extends InventoryTestCase
             capacities: array_merge(
                 $capacities,
                 [
-                    \Glpi\Asset\Capacity\IsInventoriableCapacity::class
+                    new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\IsInventoriableCapacity::class)
                 ]
             )
         );
         $classname  = $definition->getAssetClassName();
 
-        //we take a standard phone inventory and just change itemtype to Smartphone
+        //we take a standard phone inventory and just change itemtype to Server
         $json = json_decode(file_get_contents(self::INV_FIXTURES . 'computer_1.json'));
         $json->itemtype = $classname;
         $inventory = $this->doInventory($json);
@@ -834,7 +840,6 @@ class GenericAssetInventoryTest extends InventoryTestCase
             'date_mod' => $asset->fields['date_mod'],
             'autoupdatesystems_id' => $autoupdatesystems_id,
             'locations_id' => 0,
-            //'networks_id' => 0,
             'assets_assetdefinitions_id' => $definition->getID(),
             'assets_assettypes_id' => $types_id,
             'assets_assetmodels_id' => $models_id,
@@ -845,12 +850,10 @@ class GenericAssetInventoryTest extends InventoryTestCase
             'is_dynamic' => 1,
             'users_id' => 0,
             'states_id' => 0,
-            //'ticket_tco' => '0.0000',
             'uuid' => '4c4c4544-0034-3010-8048-b6c04f503732',
             'date_creation' => $asset->fields['date_creation'],
             'is_recursive' => 0,
             'last_inventory_update' => $asset->fields['last_inventory_update'],
-            //'last_boot' => '2020-06-09 07:58:08',
             'groups_id' => [],
             'groups_id_tech' => [],
         ];
@@ -899,7 +902,6 @@ class GenericAssetInventoryTest extends InventoryTestCase
         $computer_criteria['WHERE'] = ['itemtype' => $classname];
         $iterator = $DB->request($computer_criteria);
         $this->assertCount(1, $iterator);
-        //$this->assertSame('Computer import (by serial + uuid)', $iterator->current()['name']);
         $this->assertSame($classname . ' import (by serial + uuid)', $iterator->current()['name']);
         $this->assertSame(\Glpi\Inventory\Request::INVENT_QUERY, $iterator->current()['method']);
 
@@ -965,7 +967,7 @@ class GenericAssetInventoryTest extends InventoryTestCase
     public function testImportServerWOS()
     {
         //create Server generic asset
-        $asset = $this->inventoryServer([\Glpi\Asset\Capacity\HasOperatingSystemCapacity::class]);
+        $asset = $this->inventoryServer([new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\HasOperatingSystemCapacity::class)]);
 
         //operating system
         $ios = new \Item_OperatingSystem();
@@ -990,7 +992,13 @@ class GenericAssetInventoryTest extends InventoryTestCase
         global $DB;
 
         //create Server generic asset
-        $asset = $this->inventoryServer(array_keys(\Glpi\Asset\AssetDefinitionManager::getInstance()->getAvailableCapacities()));
+        $capacities = [];
+        foreach (array_keys(\Glpi\Asset\AssetDefinitionManager::getInstance()->getAvailableCapacities()) as $available_capacity) {
+            if ($available_capacity !== \Glpi\Asset\Capacity\IsInventoriableCapacity::class) {
+                $capacities[] = new \Glpi\Asset\Capacity(name: $available_capacity);
+            }
+        }
+        $asset = $this->inventoryServer($capacities);
         $classname = $asset::class;
         $assets_id = $asset->getID();
 
@@ -1410,7 +1418,6 @@ class GenericAssetInventoryTest extends InventoryTestCase
             ],
             'Item_DeviceNetworkCard' => [],
             'Item_DeviceDrive' => [],
-            // 'Item_DeviceBattery' is not tested here, see self::checkComputer1Batteries()
             'Item_DeviceGraphicCard' => [],
             'Item_DeviceSoundCard' => [
                 [
@@ -2011,7 +2018,7 @@ class GenericAssetInventoryTest extends InventoryTestCase
         //create Server generic asset
         $definition = $this->initAssetDefinition(
             system_name: 'Server' . $this->getUniqueString(),
-            capacities: [\Glpi\Asset\Capacity\IsInventoriableCapacity::class]
+            capacities: [new \Glpi\Asset\Capacity(name: \Glpi\Asset\Capacity\IsInventoriableCapacity::class)]
         );
         $classname  = $definition->getAssetClassName();
 

--- a/phpunit/functional/Glpi/Inventory/GenericNetworkAssetInventoryTest.php
+++ b/phpunit/functional/Glpi/Inventory/GenericNetworkAssetInventoryTest.php
@@ -34,7 +34,6 @@
 
 namespace tests\units\Glpi\Inventory;
 
-use Glpi\Asset\Capacity;
 use InventoryTestCase;
 
 class GenericNetworkAssetInventoryTest extends InventoryTestCase

--- a/phpunit/functional/Glpi/Inventory/GenericNetworkAssetInventoryTest.php
+++ b/phpunit/functional/Glpi/Inventory/GenericNetworkAssetInventoryTest.php
@@ -1,0 +1,619 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Inventory;
+
+use Glpi\Asset\Capacity;
+use InventoryTestCase;
+
+class GenericNetworkAssetInventoryTest extends InventoryTestCase
+{
+    /**
+     * Inventory a generic network equipment asset
+     *
+     * @param \Glpi\Asset\Capacity[] $capacities Capacities to activate
+     *
+     * @return \Glpi\Asset\Asset
+     */
+    private function inventoryNetworkEquipment(array $capacities = []): \Glpi\Asset\Asset
+    {
+        /** @var \DBmysql $DB */
+        global $DB;
+
+        //create Cisco generic asset
+        $definition = $this->initAssetDefinition(
+            system_name: 'SpecificNetworkEquipment' . $this->getUniqueString(),
+            capacities: array_merge(
+                $capacities,
+                [
+                    new \Glpi\Asset\Capacity(
+                        name: \Glpi\Asset\Capacity\IsInventoriableCapacity::class,
+                        config: new \Glpi\Asset\CapacityConfig([
+                            'inventory_mainasset' => \Glpi\Inventory\MainAsset\GenericNetworkAsset::class
+                        ])
+                    )
+                ]
+            )
+        );
+        $classname  = $definition->getAssetClassName();
+
+        //we take a standard network equipment inventory and just change itemtype to SpecificNetworkEquipment
+        //tests are the same than InventoryTest::testImportNetworkEquipment()
+        $json = json_decode(file_get_contents(self::INV_FIXTURES . 'networkequipment_1.json'));
+        $json->itemtype = $classname;
+        $json->deviceid = 'a-network-deviceid';
+
+        $date_now = date('Y-m-d H:i:s');
+        $_SESSION['glpi_currenttime'] = $date_now;
+
+        $inventory = $this->doInventory($json);
+
+        //check inventory metadata
+        $metadata = $inventory->getMetadata();
+        $this->assertCount(5, $metadata);
+        $this->assertSame('a-network-deviceid', $metadata['deviceid']);
+        $this->assertSame('4.1', $metadata['version']);
+        $this->assertSame($classname, $metadata['itemtype']);
+        $this->assertNull($metadata['port']);
+        $this->assertSame('netinventory', $metadata['action']);
+
+        //check created agent
+        $agenttype = $DB->request(['FROM' => \AgentType::getTable(), 'WHERE' => ['name' => 'Core']])->current();
+        $agents = $DB->request(['FROM' => \Agent::getTable()]);
+        $this->assertCount(1, $agents);
+        $agent = $agents->current();
+        $this->assertIsArray($agent);
+        $this->assertSame('a-network-deviceid', $agent['deviceid']);
+        $this->assertSame('a-network-deviceid', $agent['name']);
+        $this->assertSame($classname, $agent['itemtype']);
+        $this->assertSame($agenttype['id'], $agent['agenttypes_id']);
+        $this->assertGreaterThan(0, $agent['items_id']);
+
+        //get model, manufacturer, ...
+        $autoupdatesystems = $DB->request(['FROM' => \AutoupdateSystem::getTable(), 'WHERE' => ['name' => 'GLPI Native Inventory']])->current();
+        $this->assertIsArray($autoupdatesystems);
+        $autoupdatesystems_id = $autoupdatesystems['id'];
+
+        $cmodels = $DB->request(['FROM' => $definition->getAssetModelClassName()::getTable(), 'WHERE' => ['name' => 'UCS 6248UP 48-Port']])->current();
+        $this->assertIsArray($cmodels);
+        $models_id = $cmodels['id'];
+
+        $ctypes = $DB->request(['FROM' => $definition->getAssetTypeClassName()::getTable(), 'WHERE' => ['name' => 'Networking']])->current();
+        $this->assertIsArray($ctypes);
+        $types_id = $ctypes['id'];
+
+        $cmanuf = $DB->request(['FROM' => \Manufacturer::getTable(), 'WHERE' => ['name' => 'Cisco']])->current();
+        $this->assertIsArray($cmanuf);
+        $manufacturers_id = $cmanuf['id'];
+
+        $cloc = $DB->request(['FROM' => \Location::getTable(), 'WHERE' => ['name' => 'paris.pa3']])->current();
+        $this->assertIsArray($cloc);
+        $locations_id = $cloc['id'];
+
+        //check created asset
+        $equipments = $DB->request(['FROM' => $classname::getTable(), 'WHERE' => ['is_dynamic' => 1]]);
+        //no agent with deviceid equals to "foo"
+        $this->assertCount(1, $equipments);
+        $equipments_id = $equipments->current()['id'];
+
+        $equipment = new $classname();
+        $this->assertTrue($equipment->getFromDB($equipments_id));
+
+        $expected = [
+            'id' => $equipments_id,
+            'assets_assetdefinitions_id' => $equipment->fields['assets_assetdefinitions_id'],
+            'assets_assetmodels_id' => $models_id,
+            'assets_assettypes_id' => $types_id,
+            'name' => 'ucs6248up-cluster-pa3-B',
+            'uuid' => null,
+            'comment' => null,
+            'serial' => 'SSI1912014B',
+            'otherserial' => null,
+            'contact' => 'noc@glpi-project.org',
+            'contact_num' => null,
+            'users_id' => 0,
+            'users_id_tech' => 0,
+            'locations_id' => $locations_id,
+            'manufacturers_id' => $manufacturers_id,
+            'states_id' => 0,
+            'entities_id' => 0,
+            'is_recursive' => 0,
+            'is_deleted' => 0,
+            'is_template' => 0,
+            'is_dynamic' => 1,
+            'template_name' => null,
+            'autoupdatesystems_id' => $autoupdatesystems_id,
+            'date_creation' => $equipment->fields['date_creation'],
+            'date_mod' => $equipment->fields['date_mod'],
+            'last_inventory_update' => $date_now,
+            'custom_fields' => '[]',
+            'groups_id' => [],
+            'groups_id_tech' => [],
+            /**
+            Present in standard NetworkEquipment
+            'ram' => null,
+            'networks_id' => 0,
+            'ticket_tco' => '0.0000',
+            'sysdescr' => null,
+            'cpu' => 4,
+            'uptime' => '482 days, 05:42:18.50',
+            'snmpcredentials_id' => $snmpcredentials_id,
+             */
+        ];
+        $this->assertIsArray($equipment->fields);
+        $this->assertSame($expected, $equipment->fields);
+
+        //check matchedlogs
+        $neteq_criteria = [
+            'FROM' => \RuleMatchedLog::getTable(),
+            'LEFT JOIN' => [
+                \Rule::getTable() => [
+                    'ON' => [
+                        \RuleMatchedLog::getTable() => 'rules_id',
+                        \Rule::getTable() => 'id'
+                    ]
+                ]
+            ],
+            'WHERE' => ['itemtype' => $classname]
+        ];
+
+        $iterator = $DB->request($neteq_criteria);
+        $this->assertCount(1, $iterator);
+        foreach ($iterator as $neteq) {
+            $this->assertSame($classname . ' import (by serial)', $neteq['name']);
+            $this->assertSame($equipments_id, $neteq['items_id']);
+            $this->assertSame(\Glpi\Inventory\Request::INVENT_QUERY, $neteq['method']);
+        }
+
+        //check created asset
+        $assets_id = $inventory->getAgent()->fields['items_id'];
+        $this->assertGreaterThan(0, $assets_id);
+        $asset = new $classname();
+        $this->assertTrue($asset->getFromDB($assets_id));
+
+        return $asset;
+    }
+
+    /**
+     * Test Generic Network Asset inventory
+     *
+     * @return void
+     */
+    public function testImportNetworkEquipment(): void
+    {
+        global $DB;
+
+        //create Network Equipment generic asset
+        $asset = $this->inventoryNetworkEquipment();
+
+        $equipments_id = $asset->getID();
+        $classname = $asset::class;
+
+        //no network ports
+        $iterator = $DB->request([
+            'FROM'   => \NetworkPort::getTable(),
+            'WHERE'  => [
+                'items_id'           => $equipments_id,
+                'itemtype'           => $classname,
+            ],
+        ]);
+        $this->assertCount(0, $iterator);
+
+        //no port connection
+        $connections = $DB->request(['FROM' => \NetworkPort_NetworkPort::getTable()]);
+        $this->assertCount(0, $connections);
+
+        //no unmanageds
+        $unmanageds = $DB->request(['FROM' => \Unmanaged::getTable()]);
+        $this->assertCount(0, $unmanageds);
+
+        //no devices
+        //check for components
+        $components = [];
+        $allcount = 0;
+        foreach (\Item_Devices::getItemAffinities('NetworkEquipment') as $link_type) {
+            $link        = getItemForItemtype($link_type);
+            $iterator = $DB->request($link->getTableGroupCriteria($asset));
+            $allcount += count($iterator);
+            $components[$link_type] = [];
+
+            foreach ($iterator as $row) {
+                $lid = $row['id'];
+                unset($row['id']);
+                $components[$link_type][$lid] = $row;
+            }
+        }
+
+        $expecteds = [
+            'Item_DeviceFirmware' => 0,
+            'Item_DeviceMemory' => 0,
+            'Item_DeviceHardDrive' => 0,
+            'Item_DeviceNetworkCard' => 0,
+            'Item_DevicePci' => 0,
+            'Item_DevicePowerSupply' => 0,
+            'Item_DeviceGeneric' => 0,
+            'Item_DeviceSimcard' => 0,
+        ];
+
+        foreach ($expecteds as $type => $count) {
+            $this->assertSame(
+                $count,
+                count($components[$type]),
+                sprintf(
+                    'Expected %1$s %2$s, got %3$s of them',
+                    $count,
+                    $type,
+                    count($components[$type])
+                )
+            );
+        }
+    }
+
+    /**
+     * Test Generic Network Asset inventory with network ports
+     *
+     * @return void
+     */
+    public function testImportNetworkEquipmentWPorts(): void
+    {
+        global $DB;
+
+        //create Network Equipment generic asset
+        $asset = $this->inventoryNetworkEquipment([
+            new \Glpi\Asset\Capacity(
+                name: \Glpi\Asset\Capacity\HasNetworkPortCapacity::class
+            )
+        ]);
+
+        $equipments_id = $asset->getID();
+        $classname = $asset::class;
+
+        //check network ports
+        $expected_count = 164;
+        $iterator = $DB->request([
+            'FROM'   => \NetworkPort::getTable(),
+            'WHERE'  => [
+                'items_id'           => $equipments_id,
+                'itemtype'           => $classname,
+            ],
+        ]);
+        $this->assertCount($expected_count, $iterator);
+
+        //first port on GenericAsset, last on std inventory
+        $expecteds = [
+            0 => [
+                'logical_number' => 0,
+                'name' => 'Management',
+                'instantiation_type' => 'NetworkPortAggregate',
+                'mac' => '8c:60:4f:8d:ae:fc',
+            ],
+        ];
+
+        $ips = [
+            'Management' => [
+                '10.2.5.10',
+                '192.168.12.5',
+            ]
+        ];
+
+        $i = 0;
+        $netport = new \NetworkPort();
+        foreach ($iterator as $port) {
+            $ports_id = $port['id'];
+            $this->assertTrue($netport->getFromDB($ports_id));
+            $instantiation = $netport->getInstantiation();
+            if ($port['instantiation_type'] === null) {
+                $this->assertFalse($instantiation);
+            } else {
+                $this->assertInstanceOf($port['instantiation_type'], $instantiation);
+            }
+
+            unset($port['id']);
+            unset($port['date_creation']);
+            unset($port['date_mod']);
+            unset($port['comment']);
+
+            if (isset($expecteds[$i])) {
+                $expected = $expecteds[$i];
+                $expected = $expected + [
+                    'items_id' => $equipments_id,
+                    'itemtype' => $classname,
+                    'entities_id' => 0,
+                    'is_recursive' => 0,
+                    'is_deleted' => 0,
+                    'is_dynamic' => 1,
+                    'ifmtu' => 0,
+                    'ifspeed' => 0,
+                    'ifinternalstatus' => null,
+                    'ifconnectionstatus' => 0,
+                    'iflastchange' => null,
+                    'ifinbytes' => 0,
+                    'ifinerrors' => 0,
+                    'ifoutbytes' => 0,
+                    'ifouterrors' => 0,
+                    'ifstatus' => null,
+                    'ifdescr' => null,
+                    'ifalias' => null,
+                    'portduplex' => null,
+                    'trunk' => 0,
+                    'lastup' => null
+                ];
+
+                $this->assertIsArray($port);
+                $this->assertEquals($expected, $port);
+            } else {
+                $this->assertSame($classname, $port['itemtype']);
+                $this->assertSame($equipments_id, $port['items_id']);
+                $this->assertSame('NetworkPortEthernet', $port['instantiation_type'], print_r($port, true));
+                $this->assertMatchesRegularExpression(
+                    '/^(?:(?:[0-9a-f]{2}[\:]{1}){5}|(?:[0-9a-f]{2}[-]{1}){5}|(?:[0-9a-f]{2}){5})[0-9a-f]{2}$/i',
+                    $port['mac']
+                );
+                $this->assertSame(1, $port['is_dynamic']);
+            }
+            ++$i;
+
+            //check for ips
+            $ip_iterator = $DB->request([
+                'SELECT'       => [
+                    \IPAddress::getTable() . '.name',
+                    \IPAddress::getTable() . '.version'
+                ],
+                'FROM'   => \IPAddress::getTable(),
+                'INNER JOIN'   => [
+                    \NetworkName::getTable()   => [
+                        'ON'  => [
+                            \IPAddress::getTable()     => 'items_id',
+                            \NetworkName::getTable()   => 'id', [
+                                'AND' => [\IPAddress::getTable() . '.itemtype'  => \NetworkName::getType()]
+                            ]
+                        ]
+                    ]
+                ],
+                'WHERE'  => [
+                    \NetworkName::getTable() . '.itemtype'  => \NetworkPort::getType(),
+                    \NetworkName::getTable() . '.items_id'  => $ports_id
+                ]
+            ]);
+
+            $this->assertCount(count($ips[$port['name']] ?? []), $ip_iterator);
+            if (isset($ips[$port['name']])) {
+                foreach ($ip_iterator as $ip) {
+                    $this->assertIsArray($ips[$port['name']]);
+                    $this->assertTrue(in_array($ip['name'], $ips[$port['name']]));
+                }
+            }
+        }
+
+        //ports connections
+        $connections = $DB->request(['FROM' => \NetworkPort_NetworkPort::getTable()]);
+        $this->assertCount(5, $connections);
+
+        //unmanaged equipments
+        $unmanageds = $DB->request(['FROM' => \Unmanaged::getTable()]);
+        $this->assertCount(5, $unmanageds);
+
+        $expecteds = [
+            'sw2-mgmt-eqnx' => "Cisco IOS Software, C2960 Software (C2960-LANLITEK9-M), Version 12.2(50)SE5, RELEASE SOFTWARE (fc1)
+Technical Support: http://www.cisco.com/techsupport
+Copyright (c) 1986-2010 by Cisco Systems, Inc.
+Compiled Tue 28-Sep-10 13:44 by prod_rel_team",
+            'n9k-1-pa3' => 'Cisco Nexus Operating System (NX-OS) Software, Version 7.0(3)I7(6)',
+            'n9k-2-pa3' => 'Cisco Nexus Operating System (NX-OS) Software, Version 7.0(3)I7(6)',
+        ];
+
+        foreach ($unmanageds as $unmanaged) {
+            $this->assertTrue(in_array($unmanaged['name'], array_keys($expecteds)), $unmanaged['name']);
+            $this->assertSame($expecteds[$unmanaged['name']], $unmanaged['sysdescr']);
+        }
+
+        $mlogs = new \RuleMatchedLog();
+        $found = $mlogs->find();
+        $this->assertCount(6, $found);//1 equipment, 5 unmanageds
+
+        $unmanaged_criteria = [
+            'FROM' => \RuleMatchedLog::getTable(),
+            'LEFT JOIN' => [
+                \Rule::getTable() => [
+                    'ON' => [
+                        \RuleMatchedLog::getTable() => 'rules_id',
+                        \Rule::getTable() => 'id'
+                    ]
+                ]
+            ],
+            'WHERE' => ['itemtype' => \Unmanaged::class]
+        ];
+        $iterator = $DB->request($unmanaged_criteria);
+        $this->assertCount(5, $iterator);
+        foreach ($iterator as $unmanaged) {
+            $this->assertSame('Global import (by ip+ifdescr)', $unmanaged['name']);
+            $this->assertSame(\Glpi\Inventory\Request::INVENT_QUERY, $unmanaged['method']);
+        }
+    }
+
+    /**
+     * Test Generic Network Asset inventory with devices
+     *
+     * @return void
+     */
+    public function testImportNetworkEquipmentWDevices(): void
+    {
+        global $DB;
+
+        //create Network Equipment generic asset
+        $asset = $this->inventoryNetworkEquipment([
+            new \Glpi\Asset\Capacity(
+                name: \Glpi\Asset\Capacity\HasDevicesCapacity::class
+            )
+        ]);
+
+        $equipments_id = $asset->getID();
+        $classname = $asset::class;
+
+        //check for components
+        $components = [];
+        $allcount = 0;
+        foreach (\Item_Devices::getItemAffinities('NetworkEquipment') as $link_type) {
+            $link        = getItemForItemtype($link_type);
+            $iterator = $DB->request($link->getTableGroupCriteria($asset));
+            $allcount += count($iterator);
+            $components[$link_type] = [];
+
+            foreach ($iterator as $row) {
+                $lid = $row['id'];
+                unset($row['id']);
+                $components[$link_type][$lid] = $row;
+            }
+        }
+
+        $expecteds = [
+            'Item_DeviceFirmware' => 1,
+            'Item_DeviceMemory' => 0,
+            'Item_DeviceHardDrive' => 0,
+            'Item_DeviceNetworkCard' => 0,
+            'Item_DevicePci' => 0,
+            'Item_DevicePowerSupply' => 0,
+            'Item_DeviceGeneric' => 0,
+            'Item_DeviceSimcard' => 0,
+        ];
+
+        foreach ($expecteds as $type => $count) {
+            $this->assertSame(
+                $count,
+                count($components[$type]),
+                sprintf(
+                    'Expected %1$s %2$s, got %3$s of them',
+                    $count,
+                    $type,
+                    count($components[$type])
+                )
+            );
+        }
+
+        $expecteds = [
+            'Item_DeviceFirmware' => [
+                [
+                    'items_id' => $equipments_id,
+                    'itemtype' => $classname,
+                    'devicefirmwares_id' => 104,
+                    'is_deleted' => 0,
+                    'is_dynamic' => 1,
+                    'entities_id' => 0,
+                    'is_recursive' => 0,
+                    'serial' => null,
+                    'otherserial' => null,
+                    'locations_id' => 0,
+                    'states_id' => 0,
+                ]
+            ],
+            'Item_DeviceMemory' => [],
+            'Item_DeviceHardDrive' => [],
+            'Item_DeviceNetworkCard' => [],
+            'Item_DevicePci' => [],
+            'Item_DevicePowerSupply' => [],
+            'Item_DeviceGeneric' => [],
+            'Item_DeviceSimcard' => [],
+        ];
+
+        foreach ($expecteds as $type => $expected) {
+            $component = array_values($components[$type]);
+            //hack to replace expected fkeys
+            foreach ($expected as $i => &$row) {
+                foreach (array_keys($row) as $key) {
+                    if (isForeignKeyField($key)) {
+                        $row[$key] = $component[$i][$key];
+                    }
+                }
+            }
+            $this->assertIsArray($component);
+            $this->assertSame($expected, $component);
+        }
+    }
+
+    public function testRulesCreation(): void
+    {
+        /** @var \DBmysql $DB */
+        global $DB;
+
+        $rules = new \RuleImportAsset();
+        $this->assertTrue($rules->initRules());
+
+        $criteria = [
+            'COUNT' => 'cnt',
+            'FROM' => \RuleImportAsset::getTable(),
+            'LEFT JOIN' => [
+                'glpi_rulecriterias' => [
+                    'FKEY' => [
+                        'glpi_rules' => 'id',
+                        'glpi_rulecriterias' => 'rules_id'
+                    ]
+                ]
+            ],
+            'WHERE' => [
+                'sub_type' => \RuleImportAsset::class,
+                'criteria' => 'itemtype',
+                'pattern' => \NetworkEquipment::class
+            ]
+        ];
+        $iterator = $DB->request($criteria);
+        $tpl_rules_count = $iterator->current()['cnt'];
+        $this->assertGreaterThanOrEqual(6, $tpl_rules_count);
+
+        //create Network generic asset
+        $definition = $this->initAssetDefinition(
+            system_name: 'SpecificNetworkEquipment' . $this->getUniqueString(),
+            capacities: array_merge(
+                [],
+                [
+                    new \Glpi\Asset\Capacity(
+                        name: \Glpi\Asset\Capacity\IsInventoriableCapacity::class,
+                        config: new \Glpi\Asset\CapacityConfig(['inventory_mainasset' => \Glpi\Inventory\MainAsset\GenericNetworkAsset::class])
+                    )
+                ]
+            )
+        );
+
+        $classname  = $definition->getAssetClassName();
+
+        $criteria['WHERE']['pattern'] = $classname;
+        $iterator = $DB->request($criteria);
+        $this->assertSame($tpl_rules_count, $iterator->current()['cnt']);
+
+        // Disable capacity and check that rules have been cleaned
+        $this->assertTrue($definition->update(['id' => $definition->getID(), 'capacities' => []]));
+
+        $iterator = $DB->request($criteria);
+        $this->assertSame(0, $iterator->current()['cnt']);
+    }
+}

--- a/phpunit/functional/Glpi/Inventory/GenericPrinterAssetInventoryTest.php
+++ b/phpunit/functional/Glpi/Inventory/GenericPrinterAssetInventoryTest.php
@@ -1,0 +1,291 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Inventory;
+
+use Glpi\Asset\Capacity;
+use InventoryTestCase;
+
+class GenericPrinterAssetInventoryTest extends InventoryTestCase
+{
+    /**
+     * Inventory a generic network equipment asset
+     *
+     * @param \Glpi\Asset\Capacity[] $capacities Capacities to activate
+     *
+     * @return \Glpi\Asset\Asset
+     */
+    private function inventoryPrinter(array $capacities = []): \Glpi\Asset\Asset
+    {
+        /** @var \DBmysql $DB */
+        global $DB;
+
+        //create HPLaser generic asset
+        $definition = $this->initAssetDefinition(
+            system_name: 'HPLaser' . $this->getUniqueString(),
+            capacities: array_merge(
+                $capacities,
+                [
+                    new \Glpi\Asset\Capacity(
+                        name: \Glpi\Asset\Capacity\IsInventoriableCapacity::class,
+                        config: new \Glpi\Asset\CapacityConfig([
+                            'inventory_mainasset' => \Glpi\Inventory\MainAsset\GenericPrinterAsset::class
+                        ])
+                    )
+                ]
+            )
+        );
+        $classname  = $definition->getAssetClassName();
+
+        //we take a standard network equipment inventory and just change itemtype to HPLaser
+        //tests are inspired from Asset/PrinterTest::testSnmpPrinterManagementPortAdded()
+        $json = json_decode(file_get_contents(self::INV_FIXTURES . 'printer_2.json'));
+        $json->itemtype = $classname;
+        $json->deviceid = 'a-printer-deviceid';
+
+        $date_now = date('Y-m-d H:i:s');
+        $_SESSION['glpi_currenttime'] = $date_now;
+
+        $inventory = $this->doInventory($json);
+
+        //check inventory metadata
+        $metadata = $inventory->getMetadata();
+        $this->assertCount(5, $metadata);
+        $this->assertSame('a-printer-deviceid', $metadata['deviceid']);
+        //$this->assertSame('4.1', $metadata['version']);
+        $this->assertSame($classname, $metadata['itemtype']);
+        $this->assertNull($metadata['port']);
+        $this->assertSame('netinventory', $metadata['action']);
+
+        //check created agent
+        $agenttype = $DB->request(['FROM' => \AgentType::getTable(), 'WHERE' => ['name' => 'Core']])->current();
+        $agents = $DB->request(['FROM' => \Agent::getTable()]);
+        $this->assertCount(1, $agents);
+        $agent = $agents->current();
+        $this->assertIsArray($agent);
+        $this->assertSame('a-printer-deviceid', $agent['deviceid']);
+        $this->assertSame('a-printer-deviceid', $agent['name']);
+        $this->assertSame($classname, $agent['itemtype']);
+        $this->assertSame($agenttype['id'], $agent['agenttypes_id']);
+        $this->assertGreaterThan(0, $agent['items_id']);
+
+        //get model, manufacturer, ...
+        $autoupdatesystems = $DB->request(['FROM' => \AutoupdateSystem::getTable(), 'WHERE' => ['name' => 'GLPI Native Inventory']])->current();
+        $this->assertIsArray($autoupdatesystems);
+        $autoupdatesystems_id = $autoupdatesystems['id'];
+
+        $cmodels = $DB->request(['FROM' => $definition->getAssetModelClassName()::getTable(), 'WHERE' => ['name' => 'Canon MX 5970']])->current();
+        $this->assertIsArray($cmodels);
+        $models_id = $cmodels['id'];
+
+        $ctypes = $DB->request(['FROM' => $definition->getAssetTypeClassName()::getTable(), 'WHERE' => ['name' => 'Printer']])->current();
+        $this->assertIsArray($ctypes);
+        $types_id = $ctypes['id'];
+
+        $cmanuf = $DB->request(['FROM' => \Manufacturer::getTable(), 'WHERE' => ['name' => 'Canon']])->current();
+        $this->assertIsArray($cmanuf);
+        $manufacturers_id = $cmanuf['id'];
+
+        $locations_id = 0;
+
+        //check created asset
+        $equipments = $DB->request(['FROM' => $classname::getTable(), 'WHERE' => ['is_dynamic' => 1]]);
+        //no agent with deviceid equals to "foo"
+        $this->assertCount(1, $equipments);
+        $printers_id = $equipments->current()['id'];
+
+        $equipment = new $classname();
+        $this->assertTrue($equipment->getFromDB($printers_id));
+
+        $expected = [
+            'id' => $printers_id,
+            'assets_assetdefinitions_id' => $equipment->fields['assets_assetdefinitions_id'],
+            'assets_assetmodels_id' => $models_id,
+            'assets_assettypes_id' => $types_id,
+            'name' => 'MX5970',
+            'uuid' => null,
+            'comment' => null,
+            'serial' => 'SDFSDF9874',
+            'otherserial' => null,
+            'contact' => null,
+            'contact_num' => null,
+            'users_id' => 0,
+            'users_id_tech' => 0,
+            'locations_id' => $locations_id,
+            'manufacturers_id' => $manufacturers_id,
+            'states_id' => 0,
+            'entities_id' => 0,
+            'is_recursive' => 0,
+            'is_deleted' => 0,
+            'is_template' => 0,
+            'is_dynamic' => 1,
+            'template_name' => null,
+            'autoupdatesystems_id' => $autoupdatesystems_id,
+            'date_creation' => $equipment->fields['date_creation'],
+            'date_mod' => $equipment->fields['date_mod'],
+            'last_inventory_update' => $date_now,
+            'custom_fields' => '[]',
+            'groups_id' => [],
+            'groups_id_tech' => [],
+        ];
+        $this->assertIsArray($equipment->fields);
+        $this->assertSame($expected, $equipment->fields);
+
+        //check matchedlogs
+        $neteq_criteria = [
+            'FROM' => \RuleMatchedLog::getTable(),
+            'LEFT JOIN' => [
+                \Rule::getTable() => [
+                    'ON' => [
+                        \RuleMatchedLog::getTable() => 'rules_id',
+                        \Rule::getTable() => 'id'
+                    ]
+                ]
+            ],
+            'WHERE' => ['itemtype' => $classname]
+        ];
+
+        $iterator = $DB->request($neteq_criteria);
+        $this->assertCount(1, $iterator);
+        foreach ($iterator as $neteq) {
+            $this->assertSame($classname . ' import (by serial)', $neteq['name']);
+            $this->assertSame($printers_id, $neteq['items_id']);
+            $this->assertSame(\Glpi\Inventory\Request::INVENT_QUERY, $neteq['method']);
+        }
+
+        //check created asset
+        $assets_id = $inventory->getAgent()->fields['items_id'];
+        $this->assertGreaterThan(0, $assets_id);
+        $asset = new $classname();
+        $this->assertTrue($asset->getFromDB($assets_id));
+
+        return $asset;
+    }
+
+    /**
+     * Test Generic Printer Asset inventory
+     *
+     * @return void
+     */
+    public function testImportPrinter(): void
+    {
+        //create Printer generic asset
+        $asset = $this->inventoryPrinter();
+
+        $printers_id = $asset->getID();
+        $classname = $asset::class;
+
+        //no network ports
+        $np = new \NetworkPort();
+        $this->assertFalse($np->getFromDbByCrit(['itemtype' => $classname, 'items_id' => $printers_id]));
+    }
+
+    /**
+     * Test Generic Network Asset inventory with network ports
+     *
+     * @return void
+     */
+    public function testImportNetworkEquipmentWPorts(): void
+    {
+        //create Printer generic asset
+        $asset = $this->inventoryPrinter([
+            new \Glpi\Asset\Capacity(
+                name: \Glpi\Asset\Capacity\HasNetworkPortCapacity::class
+            )
+        ]);
+
+        $printers_id = $asset->getID();
+        $classname = $asset::class;
+
+        //check network ports
+        $np = new \NetworkPort();
+        $this->assertTrue($np->getFromDbByCrit(['itemtype' => $classname, 'items_id' => $printers_id, 'instantiation_type' => 'NetworkPortAggregate']));
+        $this->assertTrue($np->getFromDbByCrit(['itemtype' => $classname, 'items_id' => $printers_id, 'instantiation_type' => 'NetworkPortEthernet']));
+    }
+
+    public function testRulesCreation(): void
+    {
+        global $DB;
+
+        $rules = new \RuleImportAsset();
+        $this->assertTrue($rules->initRules());
+
+        $criteria = [
+            'COUNT' => 'cnt',
+            'FROM' => \RuleImportAsset::getTable(),
+            'LEFT JOIN' => [
+                'glpi_rulecriterias' => [
+                    'FKEY' => [
+                        'glpi_rules' => 'id',
+                        'glpi_rulecriterias' => 'rules_id'
+                    ]
+                ]
+            ],
+            'WHERE' => [
+                'sub_type' => \RuleImportAsset::class,
+                'criteria' => 'itemtype',
+                'pattern' => \Printer::class
+            ]
+        ];
+        $iterator = $DB->request($criteria);
+        $tpl_rules_count = $iterator->current()['cnt'];
+        $this->assertGreaterThanOrEqual(6, $tpl_rules_count);
+
+        //create Network generic asset
+        $definition = $this->initAssetDefinition(
+            system_name: 'SpecificNetworkEquipment' . $this->getUniqueString(),
+            capacities: array_merge(
+                [],
+                [
+                    new \Glpi\Asset\Capacity(
+                        name: \Glpi\Asset\Capacity\IsInventoriableCapacity::class,
+                        config: new \Glpi\Asset\CapacityConfig(['inventory_mainasset' => \Glpi\Inventory\MainAsset\GenericPrinterAsset::class])
+                    )
+                ]
+            )
+        );
+
+        $classname  = $definition->getAssetClassName();
+
+        $criteria['WHERE']['pattern'] = $classname;
+        $iterator = $DB->request($criteria);
+        $this->assertSame($tpl_rules_count, $iterator->current()['cnt']);
+
+        // Disable capacity and check that rules have been cleaned
+        $this->assertTrue($definition->update(['id' => $definition->getID(), 'capacities' => []]));
+
+        $iterator = $DB->request($criteria);
+        $this->assertSame(0, $iterator->current()['cnt']);
+    }
+}

--- a/phpunit/functional/Glpi/Inventory/GenericPrinterAssetInventoryTest.php
+++ b/phpunit/functional/Glpi/Inventory/GenericPrinterAssetInventoryTest.php
@@ -34,7 +34,6 @@
 
 namespace tests\units\Glpi\Inventory;
 
-use Glpi\Asset\Capacity;
 use InventoryTestCase;
 
 class GenericPrinterAssetInventoryTest extends InventoryTestCase

--- a/phpunit/functional/Glpi/Inventory/InventoryTest.php
+++ b/phpunit/functional/Glpi/Inventory/InventoryTest.php
@@ -1921,13 +1921,13 @@ class InventoryTest extends InventoryTestCase
         $this->assertSame('netinventory', $metadata['action']);
 
         global $DB;
-       //check created agent
+        //check created agent
         $agenttype = $DB->request(['FROM' => \AgentType::getTable(), 'WHERE' => ['name' => 'Core']])->current();
         $agents = $DB->request(['FROM' => \Agent::getTable()]);
-       //no agent with deviceid equals to "foo"
+        //no agent with deviceid equals to "foo"
         $this->assertCount(0, $agents);
 
-       //get model, manufacturer, ...
+        //get model, manufacturer, ...
         $autoupdatesystems = $DB->request(['FROM' => \AutoupdateSystem::getTable(), 'WHERE' => ['name' => 'GLPI Native Inventory']])->current();
         $this->assertIsArray($autoupdatesystems);
         $autoupdatesystems_id = $autoupdatesystems['id'];

--- a/phpunit/functional/Glpi/Migration/AbstractPluginMigrationTest.php
+++ b/phpunit/functional/Glpi/Migration/AbstractPluginMigrationTest.php
@@ -40,6 +40,7 @@ use DbTestCase;
 use DropdownTranslation;
 use Entity;
 use Glpi\Asset\AssetDefinition;
+use Glpi\Asset\Capacity;
 use Glpi\Asset\Capacity\HasInfocomCapacity;
 use Glpi\Dropdown\DropdownDefinition;
 use Glpi\Message\MessageType;
@@ -673,7 +674,7 @@ class AbstractPluginMigrationTest extends DbTestCase
         $definition = $this->initAssetDefinition(
             'MyCustomAsset',
             capacities: [
-                new \Glpi\Asset\Capacity(name: HasInfocomCapacity::class),
+                new Capacity(name: HasInfocomCapacity::class),
             ]
         );
 

--- a/phpunit/functional/Glpi/Migration/AbstractPluginMigrationTest.php
+++ b/phpunit/functional/Glpi/Migration/AbstractPluginMigrationTest.php
@@ -673,7 +673,7 @@ class AbstractPluginMigrationTest extends DbTestCase
         $definition = $this->initAssetDefinition(
             'MyCustomAsset',
             capacities: [
-                HasInfocomCapacity::class,
+                new \Glpi\Asset\Capacity(name: HasInfocomCapacity::class),
             ]
         );
 

--- a/phpunit/functional/Glpi/Migration/GenericobjectPluginMigrationTest.php
+++ b/phpunit/functional/Glpi/Migration/GenericobjectPluginMigrationTest.php
@@ -40,6 +40,7 @@ use Domain_Item;
 use DropdownTranslation;
 use FieldUnicity;
 use Glpi\Asset\AssetDefinition;
+use Glpi\Asset\Capacity;
 use Glpi\Asset\Capacity\AllowedInGlobalSearchCapacity;
 use Glpi\Asset\Capacity\HasContractsCapacity;
 use Glpi\Asset\Capacity\HasDevicesCapacity;
@@ -176,16 +177,16 @@ class GenericobjectPluginMigrationTest extends DbTestCase
                 'picture'        => null,
                 'is_active'      => true,
                 'capacities'     => [
-                    AllowedInGlobalSearchCapacity::class => new \Glpi\Asset\Capacity(name: AllowedInGlobalSearchCapacity::class),
-                    HasContractsCapacity::class => new \Glpi\Asset\Capacity(HasContractsCapacity::class),
-                    HasDevicesCapacity::class => new \Glpi\Asset\Capacity(HasDevicesCapacity::class),
-                    HasDocumentsCapacity::class => new \Glpi\Asset\Capacity(HasDocumentsCapacity::class),
-                    HasHistoryCapacity::class => new \Glpi\Asset\Capacity(HasHistoryCapacity::class),
-                    HasInfocomCapacity::class => new \Glpi\Asset\Capacity(HasInfocomCapacity::class),
-                    HasNetworkPortCapacity::class => new \Glpi\Asset\Capacity(HasNetworkPortCapacity::class),
-                    HasNotepadCapacity::class => new \Glpi\Asset\Capacity(HasNotepadCapacity::class),
-                    IsProjectAssetCapacity::class => new \Glpi\Asset\Capacity(IsProjectAssetCapacity::class),
-                    IsReservableCapacity::class => new \Glpi\Asset\Capacity(IsReservableCapacity::class),
+                    ['name' => AllowedInGlobalSearchCapacity::class, 'config' => []],
+                    ['name' => HasContractsCapacity::class, 'config' => []],
+                    ['name' => HasDevicesCapacity::class, 'config' => []],
+                    ['name' => HasDocumentsCapacity::class, 'config' => []],
+                    ['name' => HasHistoryCapacity::class, 'config' => []],
+                    ['name' => HasInfocomCapacity::class, 'config' => []],
+                    ['name' => HasNetworkPortCapacity::class, 'config' => []],
+                    ['name' => HasNotepadCapacity::class, 'config' => []],
+                    ['name' => IsProjectAssetCapacity::class, 'config' => []],
+                    ['name' => IsReservableCapacity::class, 'config' => []],
                 ],
                 'profiles'       => [
                     1 => 33,
@@ -840,17 +841,7 @@ class GenericobjectPluginMigrationTest extends DbTestCase
             );
 
             foreach ($expected_fields as $key => $expected_value) {
-                if ($key === 'capacities') {
-                    $this->assertJson(
-                        $item->fields[$key],
-                        sprintf('`%s` field of the `%s` item does not contain a valid JSON string', $key, $name)
-                    );
-                    $this->assertEqualsCanonicalizing(
-                        $expected_value,
-                        $this->callPrivateMethod($item, 'getDecodedCapacities'),
-                        sprintf('`%s` field of the `%s` item does not match the expected value', $key, $name)
-                    );
-                } elseif (\is_array($expected_value)) {
+                if (\is_array($expected_value)) {
                     $this->assertJson(
                         $item->fields[$key],
                         sprintf('`%s` field of the `%s` item does not contain a valid JSON string', $key, $name)

--- a/phpunit/functional/Glpi/Migration/GenericobjectPluginMigrationTest.php
+++ b/phpunit/functional/Glpi/Migration/GenericobjectPluginMigrationTest.php
@@ -176,16 +176,16 @@ class GenericobjectPluginMigrationTest extends DbTestCase
                 'picture'        => null,
                 'is_active'      => true,
                 'capacities'     => [
-                    AllowedInGlobalSearchCapacity::class,
-                    HasContractsCapacity::class,
-                    HasDevicesCapacity::class,
-                    HasDocumentsCapacity::class,
-                    HasHistoryCapacity::class,
-                    HasInfocomCapacity::class,
-                    HasNetworkPortCapacity::class,
-                    HasNotepadCapacity::class,
-                    IsProjectAssetCapacity::class,
-                    IsReservableCapacity::class,
+                    AllowedInGlobalSearchCapacity::class => new \Glpi\Asset\Capacity(name: AllowedInGlobalSearchCapacity::class),
+                    HasContractsCapacity::class => new \Glpi\Asset\Capacity(HasContractsCapacity::class),
+                    HasDevicesCapacity::class => new \Glpi\Asset\Capacity(HasDevicesCapacity::class),
+                    HasDocumentsCapacity::class => new \Glpi\Asset\Capacity(HasDocumentsCapacity::class),
+                    HasHistoryCapacity::class => new \Glpi\Asset\Capacity(HasHistoryCapacity::class),
+                    HasInfocomCapacity::class => new \Glpi\Asset\Capacity(HasInfocomCapacity::class),
+                    HasNetworkPortCapacity::class => new \Glpi\Asset\Capacity(HasNetworkPortCapacity::class),
+                    HasNotepadCapacity::class => new \Glpi\Asset\Capacity(HasNotepadCapacity::class),
+                    IsProjectAssetCapacity::class => new \Glpi\Asset\Capacity(IsProjectAssetCapacity::class),
+                    IsReservableCapacity::class => new \Glpi\Asset\Capacity(IsReservableCapacity::class),
                 ],
                 'profiles'       => [
                     1 => 33,
@@ -840,7 +840,17 @@ class GenericobjectPluginMigrationTest extends DbTestCase
             );
 
             foreach ($expected_fields as $key => $expected_value) {
-                if (\is_array($expected_value)) {
+                if ($key === 'capacities') {
+                    $this->assertJson(
+                        $item->fields[$key],
+                        sprintf('`%s` field of the `%s` item does not contain a valid JSON string', $key, $name)
+                    );
+                    $this->assertEqualsCanonicalizing(
+                        $expected_value,
+                        $this->callPrivateMethod($item, 'getDecodedCapacities'),
+                        sprintf('`%s` field of the `%s` item does not match the expected value', $key, $name)
+                    );
+                } elseif (\is_array($expected_value)) {
                     $this->assertJson(
                         $item->fields[$key],
                         sprintf('`%s` field of the `%s` item does not contain a valid JSON string', $key, $name)

--- a/phpunit/functional/Glpi/SocketTest.php
+++ b/phpunit/functional/Glpi/SocketTest.php
@@ -35,6 +35,7 @@
 namespace tests\units\Glpi;
 
 use DbTestCase;
+use Glpi\Asset\Capacity;
 use Glpi\Asset\Capacity\HasSocketCapacity;
 use Glpi\Features\Clonable;
 use Glpi\Socket;
@@ -47,7 +48,7 @@ class SocketTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasSocketCapacity::class)]);
+        $this->initAssetDefinition(capacities: [new Capacity(name: HasSocketCapacity::class)]);
 
         $this->login(); // tab will be available only if corresponding right is available in the current session
 
@@ -67,7 +68,7 @@ class SocketTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasSocketCapacity::class)]);
+        $this->initAssetDefinition(capacities: [new Capacity(name: HasSocketCapacity::class)]);
 
         foreach ($CFG_GLPI['socket_types'] as $itemtype) {
             if (!Toolbox::hasTrait($itemtype, Clonable::class)) {

--- a/phpunit/functional/Glpi/SocketTest.php
+++ b/phpunit/functional/Glpi/SocketTest.php
@@ -47,7 +47,7 @@ class SocketTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [HasSocketCapacity::class]);
+        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasSocketCapacity::class)]);
 
         $this->login(); // tab will be available only if corresponding right is available in the current session
 
@@ -67,7 +67,7 @@ class SocketTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [HasSocketCapacity::class]);
+        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasSocketCapacity::class)]);
 
         foreach ($CFG_GLPI['socket_types'] as $itemtype) {
             if (!Toolbox::hasTrait($itemtype, Clonable::class)) {

--- a/phpunit/functional/InfocomTest.php
+++ b/phpunit/functional/InfocomTest.php
@@ -37,6 +37,7 @@ namespace tests\units;
 use Cartridge;
 use Consumable;
 use DbTestCase;
+use Glpi\Asset\Capacity;
 use Glpi\Asset\Capacity\HasInfocomCapacity;
 use Glpi\Features\Clonable;
 use Infocom;
@@ -50,7 +51,7 @@ class InfocomTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasInfocomCapacity::class)]);
+        $this->initAssetDefinition(capacities: [new Capacity(name: HasInfocomCapacity::class)]);
 
         $this->login(); // tab will be available only if corresponding right is available in the current session
 
@@ -74,7 +75,7 @@ class InfocomTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasInfocomCapacity::class)]);
+        $this->initAssetDefinition(capacities: [new Capacity(name: HasInfocomCapacity::class)]);
 
         foreach ($CFG_GLPI['infocom_types'] as $itemtype) {
             if (!Toolbox::hasTrait($itemtype, Clonable::class)) {

--- a/phpunit/functional/InfocomTest.php
+++ b/phpunit/functional/InfocomTest.php
@@ -50,7 +50,7 @@ class InfocomTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [HasInfocomCapacity::class]);
+        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasInfocomCapacity::class)]);
 
         $this->login(); // tab will be available only if corresponding right is available in the current session
 
@@ -74,7 +74,7 @@ class InfocomTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [HasInfocomCapacity::class]);
+        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasInfocomCapacity::class)]);
 
         foreach ($CFG_GLPI['infocom_types'] as $itemtype) {
             if (!Toolbox::hasTrait($itemtype, Clonable::class)) {

--- a/phpunit/functional/ItemAntivirusTest.php
+++ b/phpunit/functional/ItemAntivirusTest.php
@@ -47,7 +47,7 @@ class ItemAntivirusTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [HasAntivirusCapacity::class]);
+        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasAntivirusCapacity::class)]);
 
         $this->login(); // tab will be available only if corresponding right is available in the current session
 
@@ -67,7 +67,7 @@ class ItemAntivirusTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [HasAntivirusCapacity::class]);
+        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasAntivirusCapacity::class)]);
 
         foreach ($CFG_GLPI['itemantivirus_types'] as $itemtype) {
             if (!Toolbox::hasTrait($itemtype, Clonable::class)) {

--- a/phpunit/functional/ItemAntivirusTest.php
+++ b/phpunit/functional/ItemAntivirusTest.php
@@ -35,6 +35,7 @@
 namespace tests\units;
 
 use DbTestCase;
+use Glpi\Asset\Capacity;
 use Glpi\Asset\Capacity\HasAntivirusCapacity;
 use Glpi\Features\Clonable;
 use ItemAntivirus;
@@ -47,7 +48,7 @@ class ItemAntivirusTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasAntivirusCapacity::class)]);
+        $this->initAssetDefinition(capacities: [new Capacity(name: HasAntivirusCapacity::class)]);
 
         $this->login(); // tab will be available only if corresponding right is available in the current session
 
@@ -67,7 +68,7 @@ class ItemAntivirusTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasAntivirusCapacity::class)]);
+        $this->initAssetDefinition(capacities: [new Capacity(name: HasAntivirusCapacity::class)]);
 
         foreach ($CFG_GLPI['itemantivirus_types'] as $itemtype) {
             if (!Toolbox::hasTrait($itemtype, Clonable::class)) {

--- a/phpunit/functional/ItemVirtualMachineTest.php
+++ b/phpunit/functional/ItemVirtualMachineTest.php
@@ -47,7 +47,7 @@ class ItemVirtualMachineTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [HasVirtualMachineCapacity::class]);
+        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasVirtualMachineCapacity::class)]);
 
         $this->login(); // tab will be available only if corresponding right is available in the current session
 
@@ -67,7 +67,7 @@ class ItemVirtualMachineTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [HasVirtualMachineCapacity::class]);
+        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasVirtualMachineCapacity::class)]);
 
         foreach ($CFG_GLPI['itemvirtualmachines_types'] as $itemtype) {
             if (!Toolbox::hasTrait($itemtype, Clonable::class)) {

--- a/phpunit/functional/ItemVirtualMachineTest.php
+++ b/phpunit/functional/ItemVirtualMachineTest.php
@@ -35,6 +35,7 @@
 namespace tests\units;
 
 use DbTestCase;
+use Glpi\Asset\Capacity;
 use Glpi\Asset\Capacity\HasVirtualMachineCapacity;
 use Glpi\Features\Clonable;
 use ItemVirtualMachine;
@@ -47,7 +48,7 @@ class ItemVirtualMachineTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasVirtualMachineCapacity::class)]);
+        $this->initAssetDefinition(capacities: [new Capacity(name: HasVirtualMachineCapacity::class)]);
 
         $this->login(); // tab will be available only if corresponding right is available in the current session
 
@@ -67,7 +68,7 @@ class ItemVirtualMachineTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasVirtualMachineCapacity::class)]);
+        $this->initAssetDefinition(capacities: [new Capacity(name: HasVirtualMachineCapacity::class)]);
 
         foreach ($CFG_GLPI['itemvirtualmachines_types'] as $itemtype) {
             if (!Toolbox::hasTrait($itemtype, Clonable::class)) {

--- a/phpunit/functional/Item_DevicesTest.php
+++ b/phpunit/functional/Item_DevicesTest.php
@@ -48,7 +48,7 @@ class Item_DevicesTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [HasDevicesCapacity::class]);
+        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasDevicesCapacity::class)]);
 
         $this->login(); // tab will be available only if corresponding right is available in the current session
 
@@ -68,7 +68,7 @@ class Item_DevicesTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [HasDevicesCapacity::class]);
+        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasDevicesCapacity::class)]);
 
         foreach ($CFG_GLPI['itemdevices_types'] as $itemtype) {
             if (!Toolbox::hasTrait($itemtype, Clonable::class)) {

--- a/phpunit/functional/Item_DevicesTest.php
+++ b/phpunit/functional/Item_DevicesTest.php
@@ -35,6 +35,7 @@
 namespace tests\units;
 
 use DbTestCase;
+use Glpi\Asset\Capacity;
 use Glpi\Asset\Capacity\HasDevicesCapacity;
 use Glpi\Features\Clonable;
 use Item_Devices;
@@ -48,7 +49,7 @@ class Item_DevicesTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasDevicesCapacity::class)]);
+        $this->initAssetDefinition(capacities: [new Capacity(name: HasDevicesCapacity::class)]);
 
         $this->login(); // tab will be available only if corresponding right is available in the current session
 
@@ -68,7 +69,7 @@ class Item_DevicesTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasDevicesCapacity::class)]);
+        $this->initAssetDefinition(capacities: [new Capacity(name: HasDevicesCapacity::class)]);
 
         foreach ($CFG_GLPI['itemdevices_types'] as $itemtype) {
             if (!Toolbox::hasTrait($itemtype, Clonable::class)) {

--- a/phpunit/functional/Item_DiskTest.php
+++ b/phpunit/functional/Item_DiskTest.php
@@ -47,7 +47,7 @@ class Item_DiskTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [HasVolumesCapacity::class]);
+        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasVolumesCapacity::class)]);
 
         $this->login(); // tab will be available only if corresponding right is available in the current session
 
@@ -67,7 +67,7 @@ class Item_DiskTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [HasVolumesCapacity::class]);
+        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasVolumesCapacity::class)]);
 
         foreach ($CFG_GLPI['disk_types'] as $itemtype) {
             if (!Toolbox::hasTrait($itemtype, Clonable::class)) {

--- a/phpunit/functional/Item_DiskTest.php
+++ b/phpunit/functional/Item_DiskTest.php
@@ -35,6 +35,7 @@
 namespace tests\units;
 
 use DbTestCase;
+use Glpi\Asset\Capacity;
 use Glpi\Asset\Capacity\HasVolumesCapacity;
 use Glpi\Features\Clonable;
 use Item_Disk;
@@ -47,7 +48,7 @@ class Item_DiskTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasVolumesCapacity::class)]);
+        $this->initAssetDefinition(capacities: [new Capacity(name: HasVolumesCapacity::class)]);
 
         $this->login(); // tab will be available only if corresponding right is available in the current session
 
@@ -67,7 +68,7 @@ class Item_DiskTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasVolumesCapacity::class)]);
+        $this->initAssetDefinition(capacities: [new Capacity(name: HasVolumesCapacity::class)]);
 
         foreach ($CFG_GLPI['disk_types'] as $itemtype) {
             if (!Toolbox::hasTrait($itemtype, Clonable::class)) {

--- a/phpunit/functional/Item_EnvironmentTest.php
+++ b/phpunit/functional/Item_EnvironmentTest.php
@@ -47,7 +47,7 @@ class Item_EnvironmentTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [IsInventoriableCapacity::class]);
+        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: IsInventoriableCapacity::class)]);
 
         $this->login(); // tab will be available only if corresponding right is available in the current session
 
@@ -77,7 +77,7 @@ class Item_EnvironmentTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [IsInventoriableCapacity::class]);
+        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: IsInventoriableCapacity::class)]);
 
         foreach ($CFG_GLPI['environment_types'] as $itemtype) {
             if (!Toolbox::hasTrait($itemtype, Clonable::class)) {

--- a/phpunit/functional/Item_EnvironmentTest.php
+++ b/phpunit/functional/Item_EnvironmentTest.php
@@ -35,6 +35,7 @@
 namespace tests\units;
 
 use DbTestCase;
+use Glpi\Asset\Capacity;
 use Glpi\Asset\Capacity\IsInventoriableCapacity;
 use Glpi\Features\Clonable;
 use Item_Environment;
@@ -47,7 +48,7 @@ class Item_EnvironmentTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: IsInventoriableCapacity::class)]);
+        $this->initAssetDefinition(capacities: [new Capacity(name: IsInventoriableCapacity::class)]);
 
         $this->login(); // tab will be available only if corresponding right is available in the current session
 
@@ -77,7 +78,7 @@ class Item_EnvironmentTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: IsInventoriableCapacity::class)]);
+        $this->initAssetDefinition(capacities: [new Capacity(name: IsInventoriableCapacity::class)]);
 
         foreach ($CFG_GLPI['environment_types'] as $itemtype) {
             if (!Toolbox::hasTrait($itemtype, Clonable::class)) {

--- a/phpunit/functional/Item_OperatingSystemTest.php
+++ b/phpunit/functional/Item_OperatingSystemTest.php
@@ -47,7 +47,7 @@ class Item_OperatingSystemTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [HasOperatingSystemCapacity::class]);
+        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasOperatingSystemCapacity::class)]);
 
         $this->login(); // tab will be available only if corresponding right is available in the current session
 
@@ -67,7 +67,7 @@ class Item_OperatingSystemTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [HasOperatingSystemCapacity::class]);
+        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasOperatingSystemCapacity::class)]);
 
         foreach ($CFG_GLPI['operatingsystem_types'] as $itemtype) {
             if (!Toolbox::hasTrait($itemtype, Clonable::class)) {

--- a/phpunit/functional/Item_OperatingSystemTest.php
+++ b/phpunit/functional/Item_OperatingSystemTest.php
@@ -35,6 +35,7 @@
 namespace tests\units;
 
 use DbTestCase;
+use Glpi\Asset\Capacity;
 use Glpi\Asset\Capacity\HasOperatingSystemCapacity;
 use Glpi\Features\Clonable;
 use Item_OperatingSystem;
@@ -47,7 +48,7 @@ class Item_OperatingSystemTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasOperatingSystemCapacity::class)]);
+        $this->initAssetDefinition(capacities: [new Capacity(name: HasOperatingSystemCapacity::class)]);
 
         $this->login(); // tab will be available only if corresponding right is available in the current session
 
@@ -67,7 +68,7 @@ class Item_OperatingSystemTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasOperatingSystemCapacity::class)]);
+        $this->initAssetDefinition(capacities: [new Capacity(name: HasOperatingSystemCapacity::class)]);
 
         foreach ($CFG_GLPI['operatingsystem_types'] as $itemtype) {
             if (!Toolbox::hasTrait($itemtype, Clonable::class)) {

--- a/phpunit/functional/Item_PlugTest.php
+++ b/phpunit/functional/Item_PlugTest.php
@@ -47,7 +47,7 @@ class Item_PlugTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [HasPlugCapacity::class]);
+        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasPlugCapacity::class)]);
 
         $this->login(); // tab will be available only if corresponding right is available in the current session
 
@@ -67,7 +67,7 @@ class Item_PlugTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [HasPlugCapacity::class]);
+        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasPlugCapacity::class)]);
 
         foreach ($CFG_GLPI['plug_types'] as $itemtype) {
             if (!Toolbox::hasTrait($itemtype, Clonable::class)) {

--- a/phpunit/functional/Item_PlugTest.php
+++ b/phpunit/functional/Item_PlugTest.php
@@ -35,6 +35,7 @@
 namespace tests\units;
 
 use DbTestCase;
+use Glpi\Asset\Capacity;
 use Glpi\Asset\Capacity\HasPlugCapacity;
 use Glpi\Features\Clonable;
 use Item_Plug;
@@ -47,7 +48,7 @@ class Item_PlugTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasPlugCapacity::class)]);
+        $this->initAssetDefinition(capacities: [new Capacity(name: HasPlugCapacity::class)]);
 
         $this->login(); // tab will be available only if corresponding right is available in the current session
 
@@ -67,7 +68,7 @@ class Item_PlugTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasPlugCapacity::class)]);
+        $this->initAssetDefinition(capacities: [new Capacity(name: HasPlugCapacity::class)]);
 
         foreach ($CFG_GLPI['plug_types'] as $itemtype) {
             if (!Toolbox::hasTrait($itemtype, Clonable::class)) {

--- a/phpunit/functional/Item_ProcessTest.php
+++ b/phpunit/functional/Item_ProcessTest.php
@@ -47,7 +47,7 @@ class Item_ProcessTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [IsInventoriableCapacity::class]);
+        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: IsInventoriableCapacity::class)]);
 
         $this->login(); // tab will be available only if corresponding right is available in the current session
 
@@ -77,7 +77,7 @@ class Item_ProcessTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [IsInventoriableCapacity::class]);
+        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: IsInventoriableCapacity::class)]);
 
         foreach ($CFG_GLPI['process_types'] as $itemtype) {
             if (!Toolbox::hasTrait($itemtype, Clonable::class)) {

--- a/phpunit/functional/Item_ProcessTest.php
+++ b/phpunit/functional/Item_ProcessTest.php
@@ -35,6 +35,7 @@
 namespace tests\units;
 
 use DbTestCase;
+use Glpi\Asset\Capacity;
 use Glpi\Asset\Capacity\IsInventoriableCapacity;
 use Glpi\Features\Clonable;
 use Item_Process;
@@ -47,7 +48,7 @@ class Item_ProcessTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: IsInventoriableCapacity::class)]);
+        $this->initAssetDefinition(capacities: [new Capacity(name: IsInventoriableCapacity::class)]);
 
         $this->login(); // tab will be available only if corresponding right is available in the current session
 
@@ -77,7 +78,7 @@ class Item_ProcessTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: IsInventoriableCapacity::class)]);
+        $this->initAssetDefinition(capacities: [new Capacity(name: IsInventoriableCapacity::class)]);
 
         foreach ($CFG_GLPI['process_types'] as $itemtype) {
             if (!Toolbox::hasTrait($itemtype, Clonable::class)) {

--- a/phpunit/functional/Item_ProjectTest.php
+++ b/phpunit/functional/Item_ProjectTest.php
@@ -47,7 +47,7 @@ class Item_ProjectTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [IsProjectAssetCapacity::class]);
+        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: IsProjectAssetCapacity::class)]);
 
         $this->login(); // tab will be available only if corresponding right is available in the current session
 
@@ -67,7 +67,7 @@ class Item_ProjectTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [IsProjectAssetCapacity::class]);
+        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: IsProjectAssetCapacity::class)]);
 
         foreach ($CFG_GLPI['project_asset_types'] as $itemtype) {
             if (!Toolbox::hasTrait($itemtype, Clonable::class)) {

--- a/phpunit/functional/Item_ProjectTest.php
+++ b/phpunit/functional/Item_ProjectTest.php
@@ -35,6 +35,7 @@
 namespace tests\units;
 
 use DbTestCase;
+use Glpi\Asset\Capacity;
 use Glpi\Asset\Capacity\IsProjectAssetCapacity;
 use Glpi\Features\Clonable;
 use Item_Project;
@@ -47,7 +48,7 @@ class Item_ProjectTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: IsProjectAssetCapacity::class)]);
+        $this->initAssetDefinition(capacities: [new Capacity(name: IsProjectAssetCapacity::class)]);
 
         $this->login(); // tab will be available only if corresponding right is available in the current session
 
@@ -67,7 +68,7 @@ class Item_ProjectTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: IsProjectAssetCapacity::class)]);
+        $this->initAssetDefinition(capacities: [new Capacity(name: IsProjectAssetCapacity::class)]);
 
         foreach ($CFG_GLPI['project_asset_types'] as $itemtype) {
             if (!Toolbox::hasTrait($itemtype, Clonable::class)) {

--- a/phpunit/functional/Item_RemoteManagementTest.php
+++ b/phpunit/functional/Item_RemoteManagementTest.php
@@ -47,7 +47,7 @@ class Item_RemoteManagementTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [HasRemoteManagementCapacity::class]);
+        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasRemoteManagementCapacity::class)]);
 
         $this->login(); // tab will be available only if corresponding right is available in the current session
 
@@ -67,7 +67,7 @@ class Item_RemoteManagementTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [HasRemoteManagementCapacity::class]);
+        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasRemoteManagementCapacity::class)]);
 
         foreach ($CFG_GLPI['remote_management_types'] as $itemtype) {
             if (!Toolbox::hasTrait($itemtype, Clonable::class)) {

--- a/phpunit/functional/Item_RemoteManagementTest.php
+++ b/phpunit/functional/Item_RemoteManagementTest.php
@@ -35,6 +35,7 @@
 namespace tests\units;
 
 use DbTestCase;
+use Glpi\Asset\Capacity;
 use Glpi\Asset\Capacity\HasRemoteManagementCapacity;
 use Glpi\Features\Clonable;
 use Item_RemoteManagement;
@@ -47,7 +48,7 @@ class Item_RemoteManagementTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasRemoteManagementCapacity::class)]);
+        $this->initAssetDefinition(capacities: [new Capacity(name: HasRemoteManagementCapacity::class)]);
 
         $this->login(); // tab will be available only if corresponding right is available in the current session
 
@@ -67,7 +68,7 @@ class Item_RemoteManagementTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasRemoteManagementCapacity::class)]);
+        $this->initAssetDefinition(capacities: [new Capacity(name: HasRemoteManagementCapacity::class)]);
 
         foreach ($CFG_GLPI['remote_management_types'] as $itemtype) {
             if (!Toolbox::hasTrait($itemtype, Clonable::class)) {

--- a/phpunit/functional/Item_SoftwareLicenseTest.php
+++ b/phpunit/functional/Item_SoftwareLicenseTest.php
@@ -47,7 +47,7 @@ class Item_SoftwareLicenseTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [HasSoftwaresCapacity::class]);
+        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasSoftwaresCapacity::class)]);
 
         foreach ($CFG_GLPI['software_types'] as $itemtype) {
             if (!Toolbox::hasTrait($itemtype, Clonable::class)) {

--- a/phpunit/functional/Item_SoftwareLicenseTest.php
+++ b/phpunit/functional/Item_SoftwareLicenseTest.php
@@ -35,6 +35,7 @@
 namespace tests\units;
 
 use DbTestCase;
+use Glpi\Asset\Capacity;
 use Glpi\Asset\Capacity\HasSoftwaresCapacity;
 use Glpi\Features\Clonable;
 use Item_SoftwareLicense;
@@ -47,7 +48,7 @@ class Item_SoftwareLicenseTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasSoftwaresCapacity::class)]);
+        $this->initAssetDefinition(capacities: [new Capacity(name: HasSoftwaresCapacity::class)]);
 
         foreach ($CFG_GLPI['software_types'] as $itemtype) {
             if (!Toolbox::hasTrait($itemtype, Clonable::class)) {

--- a/phpunit/functional/Item_SoftwareVersionTest.php
+++ b/phpunit/functional/Item_SoftwareVersionTest.php
@@ -50,7 +50,7 @@ class Item_SoftwareVersionTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [HasSoftwaresCapacity::class]);
+        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasSoftwaresCapacity::class)]);
 
         $this->login(); // tab will be available only if corresponding right is available in the current session
 
@@ -70,7 +70,7 @@ class Item_SoftwareVersionTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [HasSoftwaresCapacity::class]);
+        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasSoftwaresCapacity::class)]);
 
         foreach ($CFG_GLPI['software_types'] as $itemtype) {
             if (!Toolbox::hasTrait($itemtype, Clonable::class)) {

--- a/phpunit/functional/Item_SoftwareVersionTest.php
+++ b/phpunit/functional/Item_SoftwareVersionTest.php
@@ -35,6 +35,7 @@
 namespace tests\units;
 
 use DbTestCase;
+use Glpi\Asset\Capacity;
 use Glpi\Asset\Capacity\HasSoftwaresCapacity;
 use Glpi\Features\Clonable;
 use Item_SoftwareVersion;
@@ -50,7 +51,7 @@ class Item_SoftwareVersionTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasSoftwaresCapacity::class)]);
+        $this->initAssetDefinition(capacities: [new Capacity(name: HasSoftwaresCapacity::class)]);
 
         $this->login(); // tab will be available only if corresponding right is available in the current session
 
@@ -70,7 +71,7 @@ class Item_SoftwareVersionTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasSoftwaresCapacity::class)]);
+        $this->initAssetDefinition(capacities: [new Capacity(name: HasSoftwaresCapacity::class)]);
 
         foreach ($CFG_GLPI['software_types'] as $itemtype) {
             if (!Toolbox::hasTrait($itemtype, Clonable::class)) {

--- a/phpunit/functional/KnowbaseItem_ItemTest.php
+++ b/phpunit/functional/KnowbaseItem_ItemTest.php
@@ -35,6 +35,7 @@
 namespace test\units;
 
 use DbTestCase;
+use Glpi\Asset\Capacity;
 use Glpi\Asset\Capacity\HasKnowbaseCapacity;
 use Glpi\Features\Clonable;
 use KnowbaseItem_Item;
@@ -47,7 +48,7 @@ class KnowbaseItem_ItemTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasKnowbaseCapacity::class)]);
+        $this->initAssetDefinition(capacities: [new Capacity(name: HasKnowbaseCapacity::class)]);
 
         $this->login(); // tab will be available only if corresponding right is available in the current session
 
@@ -67,7 +68,7 @@ class KnowbaseItem_ItemTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasKnowbaseCapacity::class)]);
+        $this->initAssetDefinition(capacities: [new Capacity(name: HasKnowbaseCapacity::class)]);
 
         foreach ($CFG_GLPI['kb_types'] as $itemtype) {
             if (!Toolbox::hasTrait($itemtype, Clonable::class)) {

--- a/phpunit/functional/KnowbaseItem_ItemTest.php
+++ b/phpunit/functional/KnowbaseItem_ItemTest.php
@@ -47,7 +47,7 @@ class KnowbaseItem_ItemTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [HasKnowbaseCapacity::class]);
+        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasKnowbaseCapacity::class)]);
 
         $this->login(); // tab will be available only if corresponding right is available in the current session
 
@@ -67,7 +67,7 @@ class KnowbaseItem_ItemTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [HasKnowbaseCapacity::class]);
+        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasKnowbaseCapacity::class)]);
 
         foreach ($CFG_GLPI['kb_types'] as $itemtype) {
             if (!Toolbox::hasTrait($itemtype, Clonable::class)) {

--- a/phpunit/functional/ManualLinkTest.php
+++ b/phpunit/functional/ManualLinkTest.php
@@ -47,7 +47,7 @@ class ManualLinkTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [HasLinksCapacity::class]);
+        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasLinksCapacity::class)]);
 
         $this->login(); // tab will be available only if corresponding right is available in the current session
 
@@ -67,7 +67,7 @@ class ManualLinkTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [HasLinksCapacity::class]);
+        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasLinksCapacity::class)]);
 
         foreach ($CFG_GLPI['link_types'] as $itemtype) {
             if (!Toolbox::hasTrait($itemtype, Clonable::class)) {

--- a/phpunit/functional/ManualLinkTest.php
+++ b/phpunit/functional/ManualLinkTest.php
@@ -35,6 +35,7 @@
 namespace tests\units;
 
 use DbTestCase;
+use Glpi\Asset\Capacity;
 use Glpi\Asset\Capacity\HasLinksCapacity;
 use Glpi\Features\Clonable;
 use ManualLink;
@@ -47,7 +48,7 @@ class ManualLinkTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasLinksCapacity::class)]);
+        $this->initAssetDefinition(capacities: [new Capacity(name: HasLinksCapacity::class)]);
 
         $this->login(); // tab will be available only if corresponding right is available in the current session
 
@@ -67,7 +68,7 @@ class ManualLinkTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasLinksCapacity::class)]);
+        $this->initAssetDefinition(capacities: [new Capacity(name: HasLinksCapacity::class)]);
 
         foreach ($CFG_GLPI['link_types'] as $itemtype) {
             if (!Toolbox::hasTrait($itemtype, Clonable::class)) {

--- a/phpunit/functional/NetworkPortTest.php
+++ b/phpunit/functional/NetworkPortTest.php
@@ -35,6 +35,7 @@
 namespace tests\units;
 
 use DbTestCase;
+use Glpi\Asset\Capacity;
 use Glpi\Asset\Capacity\HasNetworkPortCapacity;
 use Glpi\Features\Clonable;
 use NetworkPort;
@@ -47,7 +48,7 @@ class NetworkPortTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasNetworkPortCapacity::class)]);
+        $this->initAssetDefinition(capacities: [new Capacity(name: HasNetworkPortCapacity::class)]);
 
         $this->login(); // tab will be available only if corresponding right is available in the current session
 
@@ -67,7 +68,7 @@ class NetworkPortTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasNetworkPortCapacity::class)]);
+        $this->initAssetDefinition(capacities: [new Capacity(name: HasNetworkPortCapacity::class)]);
 
         foreach ($CFG_GLPI['networkport_types'] as $itemtype) {
             if (!Toolbox::hasTrait($itemtype, Clonable::class)) {

--- a/phpunit/functional/NetworkPortTest.php
+++ b/phpunit/functional/NetworkPortTest.php
@@ -47,7 +47,7 @@ class NetworkPortTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [HasNetworkPortCapacity::class]);
+        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasNetworkPortCapacity::class)]);
 
         $this->login(); // tab will be available only if corresponding right is available in the current session
 
@@ -67,7 +67,7 @@ class NetworkPortTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [HasNetworkPortCapacity::class]);
+        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasNetworkPortCapacity::class)]);
 
         foreach ($CFG_GLPI['networkport_types'] as $itemtype) {
             if (!Toolbox::hasTrait($itemtype, Clonable::class)) {

--- a/phpunit/functional/ReservationTest.php
+++ b/phpunit/functional/ReservationTest.php
@@ -45,7 +45,7 @@ class ReservationTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [IsReservableCapacity::class]);
+        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: IsReservableCapacity::class)]);
 
         $this->login(); // tab will be available only if corresponding right is available in the current session
 

--- a/phpunit/functional/ReservationTest.php
+++ b/phpunit/functional/ReservationTest.php
@@ -35,6 +35,7 @@
 namespace tests\units;
 
 use DbTestCase;
+use Glpi\Asset\Capacity;
 use Glpi\Asset\Capacity\IsReservableCapacity;
 use PHPUnit\Framework\Attributes\DataProvider;
 
@@ -45,7 +46,7 @@ class ReservationTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: IsReservableCapacity::class)]);
+        $this->initAssetDefinition(capacities: [new Capacity(name: IsReservableCapacity::class)]);
 
         $this->login(); // tab will be available only if corresponding right is available in the current session
 

--- a/phpunit/functional/SearchTest.php
+++ b/phpunit/functional/SearchTest.php
@@ -41,6 +41,7 @@ use DbTestCase;
 use Document;
 use Document_Item;
 use Entity;
+use Glpi\Asset\Capacity;
 use Glpi\Asset\Capacity\HasDocumentsCapacity;
 use Group_User;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -4351,10 +4352,10 @@ class SearchTest extends DbTestCase
         $document_2 = $this->createTxtDocument();
         $document_3 = $this->createTxtDocument();
 
-        $definition_1  = $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasDocumentsCapacity::class)]);
+        $definition_1  = $this->initAssetDefinition(capacities: [new Capacity(name: HasDocumentsCapacity::class)]);
         $asset_class_1 = $definition_1->getAssetClassName();
 
-        $definition_2  = $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasDocumentsCapacity::class)]);
+        $definition_2  = $this->initAssetDefinition(capacities: [new Capacity(name: HasDocumentsCapacity::class)]);
         $asset_class_2 = $definition_2->getAssetClassName();
 
         // Assets for first class

--- a/phpunit/functional/SearchTest.php
+++ b/phpunit/functional/SearchTest.php
@@ -4351,10 +4351,10 @@ class SearchTest extends DbTestCase
         $document_2 = $this->createTxtDocument();
         $document_3 = $this->createTxtDocument();
 
-        $definition_1  = $this->initAssetDefinition(capacities: [HasDocumentsCapacity::class]);
+        $definition_1  = $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasDocumentsCapacity::class)]);
         $asset_class_1 = $definition_1->getAssetClassName();
 
-        $definition_2  = $this->initAssetDefinition(capacities: [HasDocumentsCapacity::class]);
+        $definition_2  = $this->initAssetDefinition(capacities: [new \Glpi\Asset\Capacity(name: HasDocumentsCapacity::class)]);
         $asset_class_2 = $definition_2->getAssetClassName();
 
         // Assets for first class

--- a/phpunit/src/Glpi/Asset/CapacityUsageTestTrait.php
+++ b/phpunit/src/Glpi/Asset/CapacityUsageTestTrait.php
@@ -42,9 +42,9 @@ trait CapacityUsageTestTrait
     /**
      * Get the tested capacity class.
      *
-     * @return Capacity
+     * @return class-string<\Glpi\Asset\Capacity\CapacityInterface>
      */
-    abstract protected function getTargetCapacity(): Capacity;
+    abstract protected function getTargetCapacity(): string;
 
     abstract public static function provideIsUsed(): iterable;
 
@@ -70,7 +70,7 @@ trait CapacityUsageTestTrait
 
         // Create custom asset definition with the target capacity enabled
         $definition = $this->initAssetDefinition(
-            capacities: [$this->getTargetCapacity()]
+            capacities: [new Capacity(name: $this->getTargetCapacity())]
         );
 
         // Create our test subject
@@ -80,7 +80,7 @@ trait CapacityUsageTestTrait
         ]);
 
         // Check that the capacity can be disabled
-        $capacity = new ($this->getTargetCapacity()->getName());
+        $capacity = new ($this->getTargetCapacity());
         $this->assertFalse($capacity->isUsed($definition->getAssetClassName()));
 
         // Create item
@@ -139,14 +139,14 @@ trait CapacityUsageTestTrait
     ): void {
         global $DB;
 
-        $capacity = new ($this->getTargetCapacity()->getName());
+        $capacity = new ($this->getTargetCapacity());
 
         // Retrieve the test root entity
         $entity_id = $this->getTestRootEntity(true);
 
         // Create custom asset definition with the target capacity enabled
         $definition = $this->initAssetDefinition(
-            capacities: [$this->getTargetCapacity()]
+            capacities: [new Capacity(name: $this->getTargetCapacity())]
         );
 
         // Create our test subject

--- a/phpunit/src/Glpi/Asset/CapacityUsageTestTrait.php
+++ b/phpunit/src/Glpi/Asset/CapacityUsageTestTrait.php
@@ -34,6 +34,7 @@
 
 namespace Glpi\PHPUnit\Tests\Glpi\Asset;
 
+use Glpi\Asset\Capacity;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 trait CapacityUsageTestTrait
@@ -41,9 +42,9 @@ trait CapacityUsageTestTrait
     /**
      * Get the tested capacity class.
      *
-     * @return string
+     * @return Capacity
      */
-    abstract protected function getTargetCapacity(): string;
+    abstract protected function getTargetCapacity(): Capacity;
 
     abstract public static function provideIsUsed(): iterable;
 
@@ -79,7 +80,7 @@ trait CapacityUsageTestTrait
         ]);
 
         // Check that the capacity can be disabled
-        $capacity = new ($this->getTargetCapacity());
+        $capacity = new ($this->getTargetCapacity()->getName());
         $this->assertFalse($capacity->isUsed($definition->getAssetClassName()));
 
         // Create item
@@ -138,7 +139,7 @@ trait CapacityUsageTestTrait
     ): void {
         global $DB;
 
-        $capacity = new ($this->getTargetCapacity());
+        $capacity = new ($this->getTargetCapacity()->getName());
 
         // Retrieve the test root entity
         $entity_id = $this->getTestRootEntity(true);

--- a/src/Glpi/Asset/Asset.php
+++ b/src/Glpi/Asset/Asset.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2025 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -507,10 +506,5 @@ abstract class Asset extends CommonDBTM
             $relations = [...$relations, ...$capacity->getCloneRelations()];
         }
         return array_unique($relations);
-    }
-
-    public function getCapacity($capacity_classname): ?CapacityInterface
-    {
-        return static::getDefinition()->getCapacity($capacity_classname);
     }
 }

--- a/src/Glpi/Asset/Asset.php
+++ b/src/Glpi/Asset/Asset.php
@@ -39,6 +39,7 @@ use CommonDBTM;
 use Dropdown;
 use Entity;
 use Glpi\Application\View\TemplateRenderer;
+use Glpi\Asset\Capacity\CapacityInterface;
 use Glpi\CustomObject\CustomObjectTrait;
 use Group;
 use Group_Item;
@@ -506,5 +507,10 @@ abstract class Asset extends CommonDBTM
             $relations = [...$relations, ...$capacity->getCloneRelations()];
         }
         return array_unique($relations);
+    }
+
+    public function getCapacity($capacity_classname): ?CapacityInterface
+    {
+        return static::getDefinition()->getCapacity($capacity_classname);
     }
 }

--- a/src/Glpi/Asset/AssetDefinition.php
+++ b/src/Glpi/Asset/AssetDefinition.php
@@ -341,7 +341,7 @@ TWIG, $twig_params);
         parent::post_addItem();
 
         // Trigger the `onCapacityEnabled` hooks.
-        $added_capacities = $this->decodedCapacities($this->fields['capacities']);
+        $added_capacities = $this->decodeCapacities($this->fields['capacities']);
         foreach ($added_capacities as $capacity) {
             $this->onCapacityEnabled($capacity);
         }
@@ -371,8 +371,8 @@ TWIG, $twig_params);
         parent::post_updateItem();
 
         if (in_array('capacities', $this->updates)) {
-            $new_capacities = $this->decodedCapacities($this->fields['capacities']);
-            $old_capacities = $this->decodedCapacities($this->oldvalues['capacities']);
+            $new_capacities = $this->decodeCapacities($this->fields['capacities']);
+            $old_capacities = $this->decodeCapacities($this->oldvalues['capacities']);
 
             $added_capacities = array_diff_key($new_capacities, $old_capacities);
             foreach ($added_capacities as $capacity) {
@@ -617,16 +617,16 @@ TWIG, $twig_params);
     }
 
     /**
-     * Get configuration value for capacity.
+     * Get configuration for the given capacity.
      */
-    public function getCapacityConfigurationValue(string $capacity_classname, string $key, mixed $default = null): mixed
+    public function getCapacityConfiguration(string $capacity_classname): CapacityConfig
     {
         $capacities = $this->getDecodedCapacitiesField();
         if (isset($capacities[$capacity_classname])) {
-            return $capacities[$capacity_classname]->getConfig()->getValue($key, $default);
+            return $capacities[$capacity_classname]->getConfig();
         }
 
-        return null;
+        return new CapacityConfig();
     }
 
     /**
@@ -636,7 +636,7 @@ TWIG, $twig_params);
      */
     private function getDecodedCapacitiesField(): array
     {
-        return $this->decodedCapacities($this->fields['capacities']);
+        return $this->decodeCapacities($this->fields['capacities']);
     }
 
     /**
@@ -644,7 +644,7 @@ TWIG, $twig_params);
      *
      * @return \Glpi\Asset\Capacity[]
      */
-    private function decodedCapacities(string $encoded): array
+    private function decodeCapacities(string $encoded): array
     {
         $decoded_capacities = json_decode($encoded, associative: true);
 

--- a/src/Glpi/Asset/AssetDefinitionManager.php
+++ b/src/Glpi/Asset/AssetDefinitionManager.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2025 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------

--- a/src/Glpi/Asset/AssetModel.php
+++ b/src/Glpi/Asset/AssetModel.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2025 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------

--- a/src/Glpi/Asset/AssetType.php
+++ b/src/Glpi/Asset/AssetType.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2025 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------

--- a/src/Glpi/Asset/Capacity.php
+++ b/src/Glpi/Asset/Capacity.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2025 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -41,7 +40,7 @@ class Capacity implements JsonSerializable
 {
     public function __construct(
         private string $name,
-        private ?CapacityConfig $config = null,
+        private CapacityConfig $config = new CapacityConfig(),
     ) {
     }
 
@@ -50,7 +49,7 @@ class Capacity implements JsonSerializable
         return $this->name;
     }
 
-    public function getConfig(): ?CapacityConfig
+    public function getConfig(): CapacityConfig
     {
         return $this->config;
     }
@@ -65,7 +64,7 @@ class Capacity implements JsonSerializable
     {
         return [
             'name' => $this->name,
-            'config' => $this->config,
+            'config' => $this->config->jsonSerialize(),
         ];
     }
 }

--- a/src/Glpi/Asset/Capacity.php
+++ b/src/Glpi/Asset/Capacity.php
@@ -33,25 +33,39 @@
  * ---------------------------------------------------------------------
  */
 
-namespace Glpi\Inventory\MainAsset;
+namespace Glpi\Asset;
 
-class GenericAsset extends Computer
+use JsonSerializable;
+
+class Capacity implements JsonSerializable
 {
-    protected function getModelsFieldName(): string
-    {
-        /** @var \Glpi\Asset\Asset $item */
-        $item = $this->item;
-        $model_classname = $item->getDefinition()->getAssetModelClassName();
-
-        return getForeignKeyFieldForItemType($model_classname);
+    public function __construct(
+        private string $name,
+        private ?CapacityConfig $config = null,
+    ) {
     }
 
-    protected function getTypesFieldName(): string
+    public function getName(): string
     {
-        /** @var \Glpi\Asset\Asset $item */
-        $item = $this->item;
-        $type_classname = $item->getDefinition()->getAssetTypeClassName();
+        return $this->name;
+    }
 
-        return getForeignKeyFieldForItemType($type_classname);
+    public function getConfig(): ?CapacityConfig
+    {
+        return $this->config;
+    }
+
+    public function setConfig(CapacityConfig $config): self
+    {
+        $this->config = $config;
+        return $this;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'name' => $this->name,
+            'config' => $this->config,
+        ];
     }
 }

--- a/src/Glpi/Asset/Capacity/AbstractCapacity.php
+++ b/src/Glpi/Asset/Capacity/AbstractCapacity.php
@@ -62,6 +62,11 @@ abstract class AbstractCapacity implements CapacityInterface
         return '';
     }
 
+    public function getConfigurationForm(string $fieldname_prefix, ?CapacityConfig $current_config): ?string
+    {
+        return null;
+    }
+
     public function getSearchOptions(string $classname): array
     {
         return [];

--- a/src/Glpi/Asset/Capacity/AbstractCapacity.php
+++ b/src/Glpi/Asset/Capacity/AbstractCapacity.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2025 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -49,8 +48,6 @@ use Log;
  */
 abstract class AbstractCapacity implements CapacityInterface
 {
-    protected ?CapacityConfig $configuration = null;
-
     /**
      * Constructor.
      *
@@ -189,15 +186,15 @@ abstract class AbstractCapacity implements CapacityInterface
     {
     }
 
-    public function onCapacityEnabled(string $classname): void
+    public function onCapacityEnabled(string $classname, CapacityConfig $config): void
     {
     }
 
-    public function onCapacityDisabled(string $classname): void
+    public function onCapacityDisabled(string $classname, CapacityConfig $config): void
     {
     }
 
-    public function onCapacityUpdated(string $classname, ?CapacityConfig $original_config, ?CapacityConfig $updated_config): void
+    public function onCapacityUpdated(string $classname, CapacityConfig $old_config, CapacityConfig $new_config): void
     {
     }
 
@@ -351,20 +348,5 @@ abstract class AbstractCapacity implements CapacityInterface
                 [$itemtype]
             )
         );
-    }
-
-    public function setConfiguration(?CapacityConfig $capacity_config): void
-    {
-        $this->configuration = $capacity_config;
-    }
-
-    public function getConfiguration(): ?CapacityConfig
-    {
-        return $this->configuration;
-    }
-
-    public function getConfigurationValue(string $entry): mixed
-    {
-        return $this->configuration?->getConfig($entry);
     }
 }

--- a/src/Glpi/Asset/Capacity/AbstractCapacity.php
+++ b/src/Glpi/Asset/Capacity/AbstractCapacity.php
@@ -39,6 +39,7 @@ use CommonDBRelation;
 use DisplayPreference;
 use Glpi\Asset\Asset;
 use Glpi\Asset\AssetDefinition;
+use Glpi\Asset\CapacityConfig;
 use Log;
 
 /**
@@ -48,6 +49,8 @@ use Log;
  */
 abstract class AbstractCapacity implements CapacityInterface
 {
+    protected ?CapacityConfig $configuration = null;
+
     /**
      * Constructor.
      *
@@ -191,6 +194,10 @@ abstract class AbstractCapacity implements CapacityInterface
     }
 
     public function onCapacityDisabled(string $classname): void
+    {
+    }
+
+    public function onCapacityUpdated(string $classname, ?CapacityConfig $original_config, ?CapacityConfig $updated_config): void
     {
     }
 
@@ -344,5 +351,20 @@ abstract class AbstractCapacity implements CapacityInterface
                 [$itemtype]
             )
         );
+    }
+
+    public function setConfiguration(?CapacityConfig $capacity_config): void
+    {
+        $this->configuration = $capacity_config;
+    }
+
+    public function getConfiguration(): ?CapacityConfig
+    {
+        return $this->configuration;
+    }
+
+    public function getConfigurationValue(string $entry): mixed
+    {
+        return $this->configuration?->getConfig($entry);
     }
 }

--- a/src/Glpi/Asset/Capacity/AllowedInGlobalSearchCapacity.php
+++ b/src/Glpi/Asset/Capacity/AllowedInGlobalSearchCapacity.php
@@ -34,6 +34,7 @@
 
 namespace Glpi\Asset\Capacity;
 
+use Glpi\Asset\CapacityConfig;
 use Override;
 
 class AllowedInGlobalSearchCapacity extends AbstractCapacity
@@ -69,7 +70,7 @@ class AllowedInGlobalSearchCapacity extends AbstractCapacity
         $this->registerToTypeConfig('globalsearch_types', $classname);
     }
 
-    public function onCapacityDisabled(string $classname): void
+    public function onCapacityDisabled(string $classname, CapacityConfig $config): void
     {
         $this->unregisterFromTypeConfig('globalsearch_types', $classname);
     }

--- a/src/Glpi/Asset/Capacity/CapacityInterface.php
+++ b/src/Glpi/Asset/Capacity/CapacityInterface.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2025 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -114,27 +113,22 @@ interface CapacityInterface
      * Method executed when capacity is enabled on given asset class.
      *
      * @param class-string<\Glpi\Asset\Asset> $classname
-     * @return void
      */
-    public function onCapacityEnabled(string $classname): void;
+    public function onCapacityEnabled(string $classname, CapacityConfig $config): void;
 
     /**
      * Method executed when capacity is disabled on given asset class.
      *
      * @param class-string<\Glpi\Asset\Asset> $classname
-     * @return void
      */
-    public function onCapacityDisabled(string $classname): void;
+    public function onCapacityDisabled(string $classname, CapacityConfig $config): void;
 
     /**
      * Method executed when capacity is updated on given asset class.
      *
      * @param class-string<\Glpi\Asset\Asset> $classname
-     * @param CapacityConfig|null $original_config
-     * @param CapacityConfig|null $updated_config
-     * @return void
      */
-    public function onCapacityUpdated(string $classname, ?CapacityConfig $original_config, ?CapacityConfig $updated_config): void;
+    public function onCapacityUpdated(string $classname, CapacityConfig $old_config, CapacityConfig $new_config): void;
 
     /**
      * Method executed during creation of an object instance (i.e. during `__construct()` method execution).
@@ -143,29 +137,4 @@ interface CapacityInterface
      * @return void
      */
     public function onObjectInstanciation(Asset $object): void;
-
-    /**
-     * Set capacity configuration
-     *
-     * @param ?CapacityConfig $capacity_config
-     *
-     * @return void
-     */
-    public function setConfiguration(?CapacityConfig $capacity_config): void;
-
-    /**
-     * Get capacity configuration
-     *
-     * @return ?CapacityConfig
-     */
-    public function getConfiguration(): ?CapacityConfig;
-
-    /**
-     * Get configuration entry from capacity
-     *
-     * @param string $entry
-     *
-     * @return mixed
-     */
-    public function getConfigurationValue(string $entry): mixed;
 }

--- a/src/Glpi/Asset/Capacity/CapacityInterface.php
+++ b/src/Glpi/Asset/Capacity/CapacityInterface.php
@@ -36,6 +36,7 @@
 namespace Glpi\Asset\Capacity;
 
 use Glpi\Asset\Asset;
+use Glpi\Asset\CapacityConfig;
 
 interface CapacityInterface
 {
@@ -126,10 +127,45 @@ interface CapacityInterface
     public function onCapacityDisabled(string $classname): void;
 
     /**
+     * Method executed when capacity is updated on given asset class.
+     *
+     * @param class-string<\Glpi\Asset\Asset> $classname
+     * @param CapacityConfig|null $original_config
+     * @param CapacityConfig|null $updated_config
+     * @return void
+     */
+    public function onCapacityUpdated(string $classname, ?CapacityConfig $original_config, ?CapacityConfig $updated_config): void;
+
+    /**
      * Method executed during creation of an object instance (i.e. during `__construct()` method execution).
      *
      * @param Asset $object
      * @return void
      */
     public function onObjectInstanciation(Asset $object): void;
+
+    /**
+     * Set capacity configuration
+     *
+     * @param ?CapacityConfig $capacity_config
+     *
+     * @return void
+     */
+    public function setConfiguration(?CapacityConfig $capacity_config): void;
+
+    /**
+     * Get capacity configuration
+     *
+     * @return ?CapacityConfig
+     */
+    public function getConfiguration(): ?CapacityConfig;
+
+    /**
+     * Get configuration entry from capacity
+     *
+     * @param string $entry
+     *
+     * @return mixed
+     */
+    public function getConfigurationValue(string $entry): mixed;
 }

--- a/src/Glpi/Asset/Capacity/CapacityInterface.php
+++ b/src/Glpi/Asset/Capacity/CapacityInterface.php
@@ -63,6 +63,15 @@ interface CapacityInterface
     public function getIcon(): string;
 
     /**
+     * Get the capacity configuration form.
+     *
+     * @param string $fieldname_prefix  The field name prefix to add to the fields (`name="{$fieldname_prefix}[my_config_key]"`).
+     *
+     * @return string|null The configuration form in HTML format, or `null` if there is no configuration form.
+     */
+    public function getConfigurationForm(string $fieldname_prefix, ?CapacityConfig $current_config): ?string;
+
+    /**
      * Get the search options related to the capacity.
      *
      * @param class-string<\Glpi\Asset\Asset> $classname

--- a/src/Glpi/Asset/Capacity/HasAntivirusCapacity.php
+++ b/src/Glpi/Asset/Capacity/HasAntivirusCapacity.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2025 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -36,6 +35,7 @@
 namespace Glpi\Asset\Capacity;
 
 use CommonGLPI;
+use Glpi\Asset\CapacityConfig;
 use ItemAntivirus;
 use Session;
 use Override;
@@ -92,7 +92,7 @@ class HasAntivirusCapacity extends AbstractCapacity
         CommonGLPI::registerStandardTab($classname, ItemAntivirus::class, 55);
     }
 
-    public function onCapacityDisabled(string $classname): void
+    public function onCapacityDisabled(string $classname, CapacityConfig $config): void
     {
         // Unregister from types
         $this->unregisterFromTypeConfig('itemantivirus_types', $classname);

--- a/src/Glpi/Asset/Capacity/HasAppliancesCapacity.php
+++ b/src/Glpi/Asset/Capacity/HasAppliancesCapacity.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2025 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -38,6 +37,7 @@ namespace Glpi\Asset\Capacity;
 use Appliance;
 use Appliance_Item;
 use CommonGLPI;
+use Glpi\Asset\CapacityConfig;
 use Override;
 use Session;
 
@@ -87,7 +87,7 @@ class HasAppliancesCapacity extends AbstractCapacity
         CommonGLPI::registerStandardTab($classname, Appliance_Item::class, 85);
     }
 
-    public function onCapacityDisabled(string $classname): void
+    public function onCapacityDisabled(string $classname, CapacityConfig $config): void
     {
         $this->unregisterFromTypeConfig('appliance_types', $classname);
 

--- a/src/Glpi/Asset/Capacity/HasCertificatesCapacity.php
+++ b/src/Glpi/Asset/Capacity/HasCertificatesCapacity.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2025 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -38,6 +37,7 @@ namespace Glpi\Asset\Capacity;
 use Certificate;
 use Certificate_Item;
 use CommonGLPI;
+use Glpi\Asset\CapacityConfig;
 use Override;
 use Session;
 
@@ -97,7 +97,7 @@ class HasCertificatesCapacity extends AbstractCapacity
         );
     }
 
-    public function onCapacityDisabled(string $classname): void
+    public function onCapacityDisabled(string $classname, CapacityConfig $config): void
     {
         // Unregister from document types
         $this->unregisterFromTypeConfig('certificate_types', $classname);

--- a/src/Glpi/Asset/Capacity/HasContractsCapacity.php
+++ b/src/Glpi/Asset/Capacity/HasContractsCapacity.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2025 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -38,6 +37,7 @@ namespace Glpi\Asset\Capacity;
 use CommonGLPI;
 use Contract;
 use Contract_Item;
+use Glpi\Asset\CapacityConfig;
 use Override;
 
 class HasContractsCapacity extends AbstractCapacity
@@ -96,7 +96,7 @@ class HasContractsCapacity extends AbstractCapacity
     }
 
     // #Override
-    public function onCapacityDisabled(string $classname): void
+    public function onCapacityDisabled(string $classname, CapacityConfig $config): void
     {
         // Unregister from contracts types
         $this->unregisterFromTypeConfig('contract_types', $classname);

--- a/src/Glpi/Asset/Capacity/HasDatabaseInstanceCapacity.php
+++ b/src/Glpi/Asset/Capacity/HasDatabaseInstanceCapacity.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2025 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -38,6 +37,7 @@ namespace Glpi\Asset\Capacity;
 use CommonGLPI;
 use Database;
 use DatabaseInstance;
+use Glpi\Asset\CapacityConfig;
 use Override;
 use Session;
 
@@ -89,7 +89,7 @@ class HasDatabaseInstanceCapacity extends AbstractCapacity
         CommonGLPI::registerStandardTab($classname, DatabaseInstance::class, 150);
     }
 
-    public function onCapacityDisabled(string $classname): void
+    public function onCapacityDisabled(string $classname, CapacityConfig $config): void
     {
         /** @var \DBmysql $DB */
         global $DB;

--- a/src/Glpi/Asset/Capacity/HasDevicesCapacity.php
+++ b/src/Glpi/Asset/Capacity/HasDevicesCapacity.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2025 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -37,6 +36,7 @@ namespace Glpi\Asset\Capacity;
 
 use CommonDevice;
 use CommonGLPI;
+use Glpi\Asset\CapacityConfig;
 use Item_Devices;
 use Override;
 use Session;
@@ -151,7 +151,7 @@ class HasDevicesCapacity extends AbstractCapacity
         CommonGLPI::registerStandardTab($classname, Item_Devices::class, 15);
     }
 
-    public function onCapacityDisabled(string $classname): void
+    public function onCapacityDisabled(string $classname, CapacityConfig $config): void
     {
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;

--- a/src/Glpi/Asset/Capacity/HasDocumentsCapacity.php
+++ b/src/Glpi/Asset/Capacity/HasDocumentsCapacity.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2025 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -38,6 +37,7 @@ namespace Glpi\Asset\Capacity;
 use CommonGLPI;
 use Document;
 use Document_Item;
+use Glpi\Asset\CapacityConfig;
 use Override;
 use Session;
 
@@ -88,7 +88,7 @@ class HasDocumentsCapacity extends AbstractCapacity
         CommonGLPI::registerStandardTab($classname, Document_Item::class, 55);
     }
 
-    public function onCapacityDisabled(string $classname): void
+    public function onCapacityDisabled(string $classname, CapacityConfig $config): void
     {
         // Unregister from document types
         $this->unregisterFromTypeConfig('document_types', $classname);

--- a/src/Glpi/Asset/Capacity/HasDomainsCapacity.php
+++ b/src/Glpi/Asset/Capacity/HasDomainsCapacity.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2025 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -38,6 +37,7 @@ namespace Glpi\Asset\Capacity;
 use CommonGLPI;
 use Domain;
 use Domain_Item;
+use Glpi\Asset\CapacityConfig;
 use Override;
 use Session;
 
@@ -92,7 +92,7 @@ class HasDomainsCapacity extends AbstractCapacity
         );
     }
 
-    public function onCapacityDisabled(string $classname): void
+    public function onCapacityDisabled(string $classname, CapacityConfig $config): void
     {
         // Unregister from domain types
         $this->unregisterFromTypeConfig('domain_types', $classname);

--- a/src/Glpi/Asset/Capacity/HasHistoryCapacity.php
+++ b/src/Glpi/Asset/Capacity/HasHistoryCapacity.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2025 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -37,6 +36,7 @@ namespace Glpi\Asset\Capacity;
 
 use CommonGLPI;
 use Glpi\Asset\Asset;
+use Glpi\Asset\CapacityConfig;
 use Log;
 use Override;
 
@@ -87,7 +87,7 @@ class HasHistoryCapacity extends AbstractCapacity
         $object->dohistory = true;
     }
 
-    public function onCapacityDisabled(string $classname): void
+    public function onCapacityDisabled(string $classname, CapacityConfig $config): void
     {
         /** @var \DBmysql $DB */
         global $DB;

--- a/src/Glpi/Asset/Capacity/HasImpactCapacity.php
+++ b/src/Glpi/Asset/Capacity/HasImpactCapacity.php
@@ -36,6 +36,7 @@ namespace Glpi\Asset\Capacity;
 
 use CommonGLPI;
 use Config;
+use Glpi\Asset\CapacityConfig;
 use Impact;
 use ImpactItem;
 use ImpactRelation;
@@ -117,7 +118,7 @@ class HasImpactCapacity extends AbstractCapacity
         CommonGLPI::registerStandardTab($classname, Impact::class, 2);
     }
 
-    public function onCapacityEnabled(string $classname): void
+    public function onCapacityEnabled(string $classname, CapacityConfig $config): void
     {
         $enabled_types = json_decode(Config::getConfigurationValue('core', Impact::CONF_ENABLED)) ?? [];
         if (!in_array($classname, $enabled_types, true)) {
@@ -126,7 +127,7 @@ class HasImpactCapacity extends AbstractCapacity
         }
     }
 
-    public function onCapacityDisabled(string $classname): void
+    public function onCapacityDisabled(string $classname, CapacityConfig $config): void
     {
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;

--- a/src/Glpi/Asset/Capacity/HasInfocomCapacity.php
+++ b/src/Glpi/Asset/Capacity/HasInfocomCapacity.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2025 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -36,6 +35,7 @@
 namespace Glpi\Asset\Capacity;
 
 use CommonGLPI;
+use Glpi\Asset\CapacityConfig;
 use Infocom;
 use Override;
 
@@ -86,7 +86,7 @@ class HasInfocomCapacity extends AbstractCapacity
         CommonGLPI::registerStandardTab($classname, Infocom::class, 50);
     }
 
-    public function onCapacityDisabled(string $classname): void
+    public function onCapacityDisabled(string $classname, CapacityConfig $config): void
     {
         // Unregister from infocom types
         $this->unregisterFromTypeConfig('infocom_types', $classname);

--- a/src/Glpi/Asset/Capacity/HasKnowbaseCapacity.php
+++ b/src/Glpi/Asset/Capacity/HasKnowbaseCapacity.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2025 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -36,6 +35,7 @@
 namespace Glpi\Asset\Capacity;
 
 use CommonGLPI;
+use Glpi\Asset\CapacityConfig;
 use Knowbase;
 use KnowbaseItem;
 use KnowbaseItem_Item;
@@ -89,7 +89,7 @@ class HasKnowbaseCapacity extends AbstractCapacity
         CommonGLPI::registerStandardTab($classname, KnowbaseItem_Item::class, 70);
     }
 
-    public function onCapacityDisabled(string $classname): void
+    public function onCapacityDisabled(string $classname, CapacityConfig $config): void
     {
         $this->unregisterFromTypeConfig('kb_types', $classname);
 

--- a/src/Glpi/Asset/Capacity/HasLinksCapacity.php
+++ b/src/Glpi/Asset/Capacity/HasLinksCapacity.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2025 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -36,6 +35,7 @@
 namespace Glpi\Asset\Capacity;
 
 use CommonGLPI;
+use Glpi\Asset\CapacityConfig;
 use Link;
 use Link_Itemtype;
 use ManualLink;
@@ -99,7 +99,7 @@ class HasLinksCapacity extends AbstractCapacity
         CommonGLPI::registerStandardTab($classname, ManualLink::class, 100);
     }
 
-    public function onCapacityDisabled(string $classname): void
+    public function onCapacityDisabled(string $classname, CapacityConfig $config): void
     {
         // Unregister from link types
         $this->unregisterFromTypeConfig('link_types', $classname);

--- a/src/Glpi/Asset/Capacity/HasNetworkPortCapacity.php
+++ b/src/Glpi/Asset/Capacity/HasNetworkPortCapacity.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2025 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -36,6 +35,7 @@
 namespace Glpi\Asset\Capacity;
 
 use CommonGLPI;
+use Glpi\Asset\CapacityConfig;
 use NetworkPort;
 use Override;
 use Session;
@@ -91,7 +91,7 @@ class HasNetworkPortCapacity extends AbstractCapacity
         );
     }
 
-    public function onCapacityDisabled(string $classname): void
+    public function onCapacityDisabled(string $classname, CapacityConfig $config): void
     {
         // Unregister from document types
         $this->unregisterFromTypeConfig('networkport_types', $classname);

--- a/src/Glpi/Asset/Capacity/HasNotepadCapacity.php
+++ b/src/Glpi/Asset/Capacity/HasNotepadCapacity.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2025 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -37,6 +36,7 @@ namespace Glpi\Asset\Capacity;
 
 use CommonGLPI;
 use Glpi\Asset\Asset;
+use Glpi\Asset\CapacityConfig;
 use Notepad;
 use Override;
 use ReflectionClass;
@@ -104,7 +104,7 @@ class HasNotepadCapacity extends AbstractCapacity
         $reflected_property->setValue($object, true);
     }
 
-    public function onCapacityDisabled(string $classname): void
+    public function onCapacityDisabled(string $classname, CapacityConfig $config): void
     {
         // Delete related infocom data
         $notepad = new Notepad();

--- a/src/Glpi/Asset/Capacity/HasOperatingSystemCapacity.php
+++ b/src/Glpi/Asset/Capacity/HasOperatingSystemCapacity.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2025 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -36,6 +35,7 @@
 namespace Glpi\Asset\Capacity;
 
 use CommonGLPI;
+use Glpi\Asset\CapacityConfig;
 use Item_OperatingSystem;
 use OperatingSystem;
 use Override;
@@ -101,7 +101,7 @@ class HasOperatingSystemCapacity extends AbstractCapacity
     }
 
     // #Override
-    public function onCapacityDisabled(string $classname): void
+    public function onCapacityDisabled(string $classname, CapacityConfig $config): void
     {
         // Unregister from operating system types
         $this->unregisterFromTypeConfig('operatingsystem_types', $classname);

--- a/src/Glpi/Asset/Capacity/HasPeripheralAssetsCapacity.php
+++ b/src/Glpi/Asset/Capacity/HasPeripheralAssetsCapacity.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2025 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -37,6 +36,7 @@ namespace Glpi\Asset\Capacity;
 
 use CommonGLPI;
 use Glpi\Asset\Asset_PeripheralAsset;
+use Glpi\Asset\CapacityConfig;
 use Override;
 use Session;
 
@@ -124,7 +124,7 @@ class HasPeripheralAssetsCapacity extends AbstractCapacity
         CommonGLPI::registerStandardTab($classname, Asset_PeripheralAsset::class, 55);
     }
 
-    public function onCapacityDisabled(string $classname): void
+    public function onCapacityDisabled(string $classname, CapacityConfig $config): void
     {
         // Unregister from peripheral hosts types
         $this->unregisterFromTypeConfig('peripheralhost_types', $classname);

--- a/src/Glpi/Asset/Capacity/HasPlugCapacity.php
+++ b/src/Glpi/Asset/Capacity/HasPlugCapacity.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2025 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -36,6 +35,7 @@
 namespace Glpi\Asset\Capacity;
 
 use CommonGLPI;
+use Glpi\Asset\CapacityConfig;
 use Item_Plug;
 use Override;
 use Plug;
@@ -88,7 +88,7 @@ class HasPlugCapacity extends AbstractCapacity
         CommonGLPI::registerStandardTab($classname, Item_Plug::class, 55);
     }
 
-    public function onCapacityDisabled(string $classname): void
+    public function onCapacityDisabled(string $classname, CapacityConfig $config): void
     {
         // Unregister from types
         $this->unregisterFromTypeConfig('plug_types', $classname);

--- a/src/Glpi/Asset/Capacity/HasRemoteManagementCapacity.php
+++ b/src/Glpi/Asset/Capacity/HasRemoteManagementCapacity.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2025 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -36,6 +35,7 @@
 namespace Glpi\Asset\Capacity;
 
 use CommonGLPI;
+use Glpi\Asset\CapacityConfig;
 use Item_RemoteManagement;
 use Override;
 use Session;
@@ -92,7 +92,7 @@ class HasRemoteManagementCapacity extends AbstractCapacity
         return Item_RemoteManagement::rawSearchOptionsToAdd($classname);
     }
 
-    public function onCapacityDisabled(string $classname): void
+    public function onCapacityDisabled(string $classname, CapacityConfig $config): void
     {
         $this->unregisterFromTypeConfig('remote_management_types', $classname);
 

--- a/src/Glpi/Asset/Capacity/HasSocketCapacity.php
+++ b/src/Glpi/Asset/Capacity/HasSocketCapacity.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2025 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -37,6 +36,7 @@ namespace Glpi\Asset\Capacity;
 
 use Cable;
 use CommonGLPI;
+use Glpi\Asset\CapacityConfig;
 use Glpi\Socket;
 use Override;
 use Session;
@@ -92,7 +92,7 @@ class HasSocketCapacity extends AbstractCapacity
         );
     }
 
-    public function onCapacityDisabled(string $classname): void
+    public function onCapacityDisabled(string $classname, CapacityConfig $config): void
     {
         /** @var \DBmysql $DB */
         global $DB;

--- a/src/Glpi/Asset/Capacity/HasSoftwaresCapacity.php
+++ b/src/Glpi/Asset/Capacity/HasSoftwaresCapacity.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2025 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -36,6 +35,7 @@
 namespace Glpi\Asset\Capacity;
 
 use CommonGLPI;
+use Glpi\Asset\CapacityConfig;
 use Item_SoftwareLicense;
 use Item_SoftwareVersion;
 use Override;
@@ -188,7 +188,7 @@ class HasSoftwaresCapacity extends AbstractCapacity
         CommonGLPI::registerStandardTab($classname, Item_SoftwareVersion::class, 85);
     }
 
-    public function onCapacityDisabled(string $classname): void
+    public function onCapacityDisabled(string $classname, CapacityConfig $config): void
     {
         // Unregister from software types
         $this->unregisterFromTypeConfig('software_types', $classname);

--- a/src/Glpi/Asset/Capacity/HasVirtualMachineCapacity.php
+++ b/src/Glpi/Asset/Capacity/HasVirtualMachineCapacity.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2025 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -36,6 +35,7 @@
 namespace Glpi\Asset\Capacity;
 
 use CommonGLPI;
+use Glpi\Asset\CapacityConfig;
 use ItemVirtualMachine;
 use Override;
 use Session;
@@ -92,7 +92,7 @@ class HasVirtualMachineCapacity extends AbstractCapacity
         CommonGLPI::registerStandardTab($classname, ItemVirtualMachine::class, 55);
     }
 
-    public function onCapacityDisabled(string $classname): void
+    public function onCapacityDisabled(string $classname, CapacityConfig $config): void
     {
         // Unregister from types
         $this->unregisterFromTypeConfig('itemvirtualmachines_types', $classname);

--- a/src/Glpi/Asset/Capacity/HasVolumesCapacity.php
+++ b/src/Glpi/Asset/Capacity/HasVolumesCapacity.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2025 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -36,6 +35,7 @@
 namespace Glpi\Asset\Capacity;
 
 use CommonGLPI;
+use Glpi\Asset\CapacityConfig;
 use Item_Disk;
 use Override;
 use Session;
@@ -92,7 +92,7 @@ class HasVolumesCapacity extends AbstractCapacity
         CommonGLPI::registerStandardTab($classname, Item_Disk::class, 55);
     }
 
-    public function onCapacityDisabled(string $classname): void
+    public function onCapacityDisabled(string $classname, CapacityConfig $config): void
     {
         // Unregister from disk types
         $this->unregisterFromTypeConfig('disk_types', $classname);

--- a/src/Glpi/Asset/Capacity/IsInventoriableCapacity.php
+++ b/src/Glpi/Asset/Capacity/IsInventoriableCapacity.php
@@ -35,6 +35,7 @@
 namespace Glpi\Asset\Capacity;
 
 use CommonGLPI;
+use Glpi\Application\View\TemplateRenderer;
 use Glpi\Asset\CapacityConfig;
 use Glpi\Inventory\Inventory;
 use Item_Environment;
@@ -58,6 +59,23 @@ class IsInventoriableCapacity extends AbstractCapacity
     public function getDescription(): string
     {
         return __("The GLPI agent can report inventory data for these assets.");
+    }
+
+    #[Override]
+    public function getConfigurationForm(string $fieldname_prefix, ?CapacityConfig $current_config): ?string
+    {
+        return TemplateRenderer::getInstance()->render(
+            'pages/admin/assetdefinition/capacity/is_inventoriable_capacity_configuration_form.html.twig',
+            [
+                'fieldname_prefix'    => $fieldname_prefix,
+                'current_config'      => $current_config,
+                'itemtype_choices'    => [
+                    \Glpi\Inventory\MainAsset\GenericAsset::class        => __('Generic'),
+                    \Glpi\Inventory\MainAsset\GenericNetworkAsset::class => \NetworkEquipment::getTypeName(1),
+                    \Glpi\Inventory\MainAsset\GenericPrinterAsset::class => \Printer::getTypeName(1),
+                ]
+            ]
+        );
     }
 
     public function getSearchOptions(string $classname): array
@@ -172,14 +190,5 @@ class IsInventoriableCapacity extends AbstractCapacity
             $rules = new \RuleImportAsset();
             $rules->initRules(true, $classname);
         }
-    }
-
-    public function getConfigurationTypes(): array
-    {
-        return [
-            \Glpi\Inventory\MainAsset\GenericAsset::class => __('Generic'),
-            \Glpi\Inventory\MainAsset\GenericNetworkAsset::class => \NetworkEquipment::getTypeName(1),
-            \Glpi\Inventory\MainAsset\GenericPrinterAsset::class => \Printer::getTypeName(1),
-        ];
     }
 }

--- a/src/Glpi/Asset/Capacity/IsInventoriableCapacity.php
+++ b/src/Glpi/Asset/Capacity/IsInventoriableCapacity.php
@@ -36,6 +36,7 @@
 namespace Glpi\Asset\Capacity;
 
 use CommonGLPI;
+use Glpi\Asset\CapacityConfig;
 use Glpi\Inventory\Inventory;
 use Item_Environment;
 use Item_Process;
@@ -57,7 +58,7 @@ class IsInventoriableCapacity extends AbstractCapacity
     #[Override]
     public function getDescription(): string
     {
-        return __("The GLPI agent can report inventory data for these assets");
+        return __("The GLPI agent can report inventory data for these assets.");
     }
 
     public function getSearchOptions(string $classname): array
@@ -164,5 +165,22 @@ class IsInventoriableCapacity extends AbstractCapacity
             'pattern' => $classname
         ];
         $DB->delete(\RuleImportAsset::getTable(), $where, $joins);
+    }
+
+    public function onCapacityUpdated(string $classname, ?CapacityConfig $original_config, ?CapacityConfig $updated_config): void
+    {
+        if ($original_config->getConfig('inventory_mainasset') != $updated_config->getConfig('inventory_mainasset')) {
+            $rules = new \RuleImportAsset();
+            $rules->initRules(true, $classname);
+        }
+    }
+
+    public function getConfigurationTypes(): array
+    {
+        return [
+            \Glpi\Inventory\MainAsset\GenericAsset::class => __('Generic'),
+            \Glpi\Inventory\MainAsset\GenericNetworkAsset::class => \NetworkEquipment::getTypeName(1),
+            \Glpi\Inventory\MainAsset\GenericPrinterAsset::class => \Printer::getTypeName(1),
+        ];
     }
 }

--- a/src/Glpi/Asset/Capacity/IsInventoriableCapacity.php
+++ b/src/Glpi/Asset/Capacity/IsInventoriableCapacity.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2025 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -118,14 +117,14 @@ class IsInventoriableCapacity extends AbstractCapacity
         CommonGLPI::registerStandardTab($classname, Item_Process::class, 85);
     }
 
-    public function onCapacityEnabled(string $classname): void
+    public function onCapacityEnabled(string $classname, CapacityConfig $config): void
     {
         //create rules
         $rules = new \RuleImportAsset();
         $rules->initRules(true, $classname);
     }
 
-    public function onCapacityDisabled(string $classname): void
+    public function onCapacityDisabled(string $classname, CapacityConfig $config): void
     {
         /** @var \DBmysql $DB */
         global $DB;
@@ -167,9 +166,9 @@ class IsInventoriableCapacity extends AbstractCapacity
         $DB->delete(\RuleImportAsset::getTable(), $where, $joins);
     }
 
-    public function onCapacityUpdated(string $classname, ?CapacityConfig $original_config, ?CapacityConfig $updated_config): void
+    public function onCapacityUpdated(string $classname, CapacityConfig $original_config, CapacityConfig $updated_config): void
     {
-        if ($original_config->getConfig('inventory_mainasset') != $updated_config->getConfig('inventory_mainasset')) {
+        if ($original_config->getValue('inventory_mainasset') != $updated_config->getValue('inventory_mainasset')) {
             $rules = new \RuleImportAsset();
             $rules->initRules(true, $classname);
         }

--- a/src/Glpi/Asset/Capacity/IsProjectAssetCapacity.php
+++ b/src/Glpi/Asset/Capacity/IsProjectAssetCapacity.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2025 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -37,6 +36,7 @@ namespace Glpi\Asset\Capacity;
 
 use CommonGLPI;
 use Project;
+use Glpi\Asset\CapacityConfig;
 use Item_Project;
 use Override;
 
@@ -88,7 +88,7 @@ class IsProjectAssetCapacity extends AbstractCapacity
         CommonGLPI::registerStandardTab($classname, Item_Project::class, 95);
     }
 
-    public function onCapacityDisabled(string $classname): void
+    public function onCapacityDisabled(string $classname, CapacityConfig $config): void
     {
         // Unregister from project assets types
         $this->unregisterFromTypeConfig('project_asset_types', $classname);

--- a/src/Glpi/Asset/Capacity/IsRackableCapacity.php
+++ b/src/Glpi/Asset/Capacity/IsRackableCapacity.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2025 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -35,6 +34,7 @@
 
 namespace Glpi\Asset\Capacity;
 
+use Glpi\Asset\CapacityConfig;
 use Item_Rack;
 use Override;
 use Rack;
@@ -83,7 +83,7 @@ class IsRackableCapacity extends AbstractCapacity
         $this->registerToTypeConfig('rackable_types', $classname);
     }
 
-    public function onCapacityDisabled(string $classname): void
+    public function onCapacityDisabled(string $classname, CapacityConfig $config): void
     {
         $this->unregisterFromTypeConfig('rackable_types', $classname);
 

--- a/src/Glpi/Asset/Capacity/IsReservableCapacity.php
+++ b/src/Glpi/Asset/Capacity/IsReservableCapacity.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2025 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -36,6 +35,7 @@
 namespace Glpi\Asset\Capacity;
 
 use CommonGLPI;
+use Glpi\Asset\CapacityConfig;
 use Override;
 use Reservation;
 use ReservationItem;
@@ -81,7 +81,7 @@ class IsReservableCapacity extends AbstractCapacity
         CommonGLPI::registerStandardTab($classname, Reservation::class, 85);
     }
 
-    public function onCapacityDisabled(string $classname): void
+    public function onCapacityDisabled(string $classname, CapacityConfig $config): void
     {
         // Unregister from reservable types
         $this->unregisterFromTypeConfig('reservation_types', $classname);

--- a/src/Glpi/Asset/CapacityConfig.php
+++ b/src/Glpi/Asset/CapacityConfig.php
@@ -33,25 +33,30 @@
  * ---------------------------------------------------------------------
  */
 
-namespace Glpi\Inventory\MainAsset;
+namespace Glpi\Asset;
 
-class GenericAsset extends Computer
+use JsonSerializable;
+
+class CapacityConfig implements JsonSerializable
 {
-    protected function getModelsFieldName(): string
-    {
-        /** @var \Glpi\Asset\Asset $item */
-        $item = $this->item;
-        $model_classname = $item->getDefinition()->getAssetModelClassName();
-
-        return getForeignKeyFieldForItemType($model_classname);
+    public function __construct(
+        private array $config = []
+    ) {
     }
 
-    protected function getTypesFieldName(): string
+    public function setConfig(string $name, mixed $value): self
     {
-        /** @var \Glpi\Asset\Asset $item */
-        $item = $this->item;
-        $type_classname = $item->getDefinition()->getAssetTypeClassName();
+        $this->config[$name] = $value;
+        return $this;
+    }
 
-        return getForeignKeyFieldForItemType($type_classname);
+    public function getConfig(string $entry): mixed
+    {
+        return $this->config[$entry];
+    }
+
+    public function jsonSerialize(): array
+    {
+        return $this->config;
     }
 }

--- a/src/Glpi/Asset/CapacityConfig.php
+++ b/src/Glpi/Asset/CapacityConfig.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2025 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -40,23 +39,23 @@ use JsonSerializable;
 class CapacityConfig implements JsonSerializable
 {
     public function __construct(
-        private array $config = []
+        private array $values = []
     ) {
     }
 
-    public function setConfig(string $name, mixed $value): self
+    public function setValue(string $key, mixed $value): self
     {
-        $this->config[$name] = $value;
+        $this->values[$key] = $value;
         return $this;
     }
 
-    public function getConfig(string $entry): mixed
+    public function getValue(string $key, mixed $default = null): mixed
     {
-        return $this->config[$entry];
+        return \array_key_exists($key, $this->values) ? $this->values[$key] : $default;
     }
 
     public function jsonSerialize(): array
     {
-        return $this->config;
+        return $this->values;
     }
 }

--- a/src/Glpi/Inventory/Asset/NetworkPort.php
+++ b/src/Glpi/Inventory/Asset/NetworkPort.php
@@ -68,7 +68,7 @@ class NetworkPort extends InventoryAsset
         $this->aggregates = [];
         $this->vlans = [];
 
-        $this->extra_data['\Glpi\Inventory\MainAsset\\' . $this->item->getType()] = null;
+        $this->extra_data['\\' . $this->main_asset::class] = null;
         $mapping = [
             'ifname'       => 'name',
             'ifnumber'     => 'logical_number',
@@ -624,7 +624,7 @@ class NetworkPort extends InventoryAsset
 
     public function handle()
     {
-        $this->ports += $this->extra_data['\Glpi\Inventory\MainAsset\\' . $this->item->getType()]->getManagementPorts();
+        $this->ports += $this->extra_data['\\' . $this->main_asset::class]->getManagementPorts();
         $this->handlePorts();
     }
 
@@ -791,12 +791,12 @@ class NetworkPort extends InventoryAsset
 
     public function handlePorts($itemtype = null, $items_id = null)
     {
-        $mainasset = $this->extra_data['\Glpi\Inventory\MainAsset\\' . $this->item->getType()];
+        $mainasset = $this->extra_data['\\' . $this->main_asset::class];
 
         //remove management port for Printer on netinventory
         //to prevent twice IP (NetworkPortAggregate / NetworkPortEthernet)
         if ($mainasset instanceof Printer && !$this->item->isNewItem()) {
-            if (empty($this->extra_data['\Glpi\Inventory\MainAsset\\' . $this->item->getType()]->getManagementPorts())) {
+            if (empty($this->extra_data['\\' . $this->main_asset::class]->getManagementPorts())) {
                 //remove all port management ports
                 $networkport = new GlobalNetworkPort();
                 $networkport->deleteByCriteria([

--- a/src/Glpi/Inventory/Inventory.php
+++ b/src/Glpi/Inventory/Inventory.php
@@ -598,10 +598,10 @@ class Inventory
 
         //not found, so we have a generic asset. Let's retrieve its MainAsset class
         if ($this->item instanceof \Glpi\Asset\Asset) {
-            $main_class = $this->item->getDefinition()->getCapacityConfigurationValue(
-                \Glpi\Asset\Capacity\IsInventoriableCapacity::class,
-                'inventory_mainasset'
-            );
+            $main_class = $this->item
+                ->getDefinition()
+                ->getCapacityConfiguration(\Glpi\Asset\Capacity\IsInventoriableCapacity::class)
+                ->getValue('inventory_mainasset');
         }
         if ($main_class === null || !class_exists($main_class)) {
             $main_class = $class_ns . 'GenericAsset';

--- a/src/Glpi/Inventory/Inventory.php
+++ b/src/Glpi/Inventory/Inventory.php
@@ -598,8 +598,10 @@ class Inventory
 
         //not found, so we have a generic asset. Let's retrieve its MainAsset class
         if ($this->item instanceof \Glpi\Asset\Asset) {
-            $inventoriable_capacity = $this->item->getCapacity(\Glpi\Asset\Capacity\IsInventoriableCapacity::class);
-            $main_class = $inventoriable_capacity->getConfigurationValue('inventory_mainasset');
+            $main_class = $this->item->getDefinition()->getCapacityConfigurationValue(
+                \Glpi\Asset\Capacity\IsInventoriableCapacity::class,
+                'inventory_mainasset'
+            );
         }
         if ($main_class === null || !class_exists($main_class)) {
             $main_class = $class_ns . 'GenericAsset';

--- a/src/Glpi/Inventory/Inventory.php
+++ b/src/Glpi/Inventory/Inventory.php
@@ -595,7 +595,16 @@ class Inventory
         if (class_exists($main_class)) {
             return $main_class;
         }
-        return $class_ns . 'GenericAsset';
+
+        //not found, so we have a generic asset. Let's retrieve its MainAsset class
+        if ($this->item instanceof \Glpi\Asset\Asset) {
+            $inventoriable_capacity = $this->item->getCapacity(\Glpi\Asset\Capacity\IsInventoriableCapacity::class);
+            $main_class = $inventoriable_capacity->getConfigurationValue('inventory_mainasset');
+        }
+        if ($main_class === null || !class_exists($main_class)) {
+            $main_class = $class_ns . 'GenericAsset';
+        }
+        return $main_class;
     }
 
     /**

--- a/src/Glpi/Inventory/MainAsset/GenericNetworkAsset.php
+++ b/src/Glpi/Inventory/MainAsset/GenericNetworkAsset.php
@@ -35,7 +35,7 @@
 
 namespace Glpi\Inventory\MainAsset;
 
-class GenericAsset extends Computer
+class GenericNetworkAsset extends NetworkEquipment
 {
     protected function getModelsFieldName(): string
     {

--- a/src/Glpi/Inventory/MainAsset/GenericPrinterAsset.php
+++ b/src/Glpi/Inventory/MainAsset/GenericPrinterAsset.php
@@ -35,7 +35,7 @@
 
 namespace Glpi\Inventory\MainAsset;
 
-class GenericAsset extends Computer
+class GenericPrinterAsset extends Printer
 {
     protected function getModelsFieldName(): string
     {

--- a/src/Glpi/Inventory/MainAsset/NetworkEquipment.php
+++ b/src/Glpi/Inventory/MainAsset/NetworkEquipment.php
@@ -203,8 +203,11 @@ class NetworkEquipment extends MainAsset
             $np = new NetworkPort($this->item, [$this->data[$this->current_key]]);
 
             if ($np->checkConf($this->conf)) {
-                $np->setAgent($this->getAgent());
-                $np->setEntityID($this->getEntityID());
+                $np
+                    ->setMainAsset($this)
+                    ->setAgent($this->getAgent())
+                    ->setEntityID($this->getEntityID())
+                ;
                 $np->prepare();
                 $np->handleLinks();
                 $this->assets = ['\Glpi\Inventory\Asset\NetworkPort' => [$np]];
@@ -215,8 +218,11 @@ class NetworkEquipment extends MainAsset
             $mports = $this->getManagementPorts();
             $np = new NetworkPort($this->item, $mports);
             if ($np->checkConf($this->conf)) {
-                $np->setAgent($this->getAgent());
-                $np->setEntityID($this->getEntityID());
+                $np
+                    ->setMainAsset($this)
+                    ->setAgent($this->getAgent())
+                    ->setEntityID($this->getEntityID())
+                ;
                 $np->prepare();
                 $np->handleLinks();
                 if (!isset($this->assets['\Glpi\Inventory\Asset\NetworkPort'])) {

--- a/src/Glpi/Migration/GenericobjectPluginMigration.php
+++ b/src/Glpi/Migration/GenericobjectPluginMigration.php
@@ -932,7 +932,7 @@ class GenericobjectPluginMigration extends AbstractPluginMigration
      * Return the list of capacities for the given GenericObject type.
      *
      * @param array<string, mixed> $type_data A row from the `glpi_plugin_genericobject_types` table.
-     * @return array<int, class-string<\Glpi\Asset\Capacity\AbstractCapacity>>
+     * @return array<int, array{name: class-string<\Glpi\Asset\Capacity\AbstractCapacity>}>
      */
     private function getCapacities(array $type_data): array
     {
@@ -954,7 +954,7 @@ class GenericobjectPluginMigration extends AbstractPluginMigration
         $capacities = [];
         foreach ($mapping as $fieldname => $capacity) {
             if ($type_data[$fieldname]) {
-                $capacities[] = $capacity;
+                $capacities[] = ['name' => $capacity];
             }
         }
 

--- a/src/RuleImportAsset.php
+++ b/src/RuleImportAsset.php
@@ -36,6 +36,7 @@
 
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\Asset\AssetDefinitionManager;
+use Glpi\Asset\Capacity\IsInventoriableCapacity;
 
 class RuleImportAsset extends Rule
 {
@@ -1209,9 +1210,9 @@ TWIG, $twig_params);
         //add extra rules for active generic assets
         $definitions = AssetDefinitionManager::getInstance()->getDefinitions(true);
         foreach ($definitions as $definition) {
-            if ($capacity = $definition->getCapacity(\Glpi\Asset\Capacity\IsInventoriableCapacity::class)) {
+            if ($definition->hasCapacityEnabled(new IsInventoriableCapacity())) {
                 $asset_classname = $definition->getAssetClassName();
-                $main_asset = $definition->getCapacityConfigurationValue($capacity, 'inventory_mainasset');
+                $main_asset = $definition->getCapacityConfigurationValue(IsInventoriableCapacity::class, 'inventory_mainasset');
 
                 $origin_rule_itemtype = \Computer::class;
                 switch ($main_asset) {

--- a/src/RuleImportAsset.php
+++ b/src/RuleImportAsset.php
@@ -1209,8 +1209,20 @@ TWIG, $twig_params);
         //add extra rules for active generic assets
         $definitions = AssetDefinitionManager::getInstance()->getDefinitions(true);
         foreach ($definitions as $definition) {
-            if ($definition->hasCapacityEnabled(new \Glpi\Asset\Capacity\IsInventoriableCapacity())) {
-                $this->addGenericAssetRules($rules, $definition->getAssetClassName());
+            if ($capacity = $definition->getCapacity(\Glpi\Asset\Capacity\IsInventoriableCapacity::class)) {
+                $asset_classname = $definition->getAssetClassName();
+                $main_asset = $definition->getCapacityConfigurationValue($capacity, 'inventory_mainasset');
+
+                $origin_rule_itemtype = \Computer::class;
+                switch ($main_asset) {
+                    case \Glpi\Inventory\MainAsset\GenericNetworkAsset::class:
+                        $origin_rule_itemtype = \NetworkEquipment::class;
+                        break;
+                    case \Glpi\Inventory\MainAsset\GenericPrinterAsset::class:
+                        $origin_rule_itemtype = \Printer::class;
+                        break;
+                }
+                $this->addGenericAssetRules($rules, $asset_classname, $origin_rule_itemtype);
             }
         }
 
@@ -1220,7 +1232,7 @@ TWIG, $twig_params);
     public function addGenericAssetRules(
         SimpleXMLElement $rules,
         string $itemtype_to,
-        string $itemtype_from = \Computer::class
+        string $itemtype_from
     ): void {
         $extra_rules = $rules->xpath(
             sprintf(

--- a/src/RuleImportAsset.php
+++ b/src/RuleImportAsset.php
@@ -1212,7 +1212,7 @@ TWIG, $twig_params);
         foreach ($definitions as $definition) {
             if ($definition->hasCapacityEnabled(new IsInventoriableCapacity())) {
                 $asset_classname = $definition->getAssetClassName();
-                $main_asset = $definition->getCapacityConfigurationValue(IsInventoriableCapacity::class, 'inventory_mainasset');
+                $main_asset = $definition->getCapacityConfiguration(IsInventoriableCapacity::class)->getValue('inventory_mainasset');
 
                 $origin_rule_itemtype = \Computer::class;
                 switch ($main_asset) {

--- a/templates/pages/admin/assetdefinition/capacities.html.twig
+++ b/templates/pages/admin/assetdefinition/capacities.html.twig
@@ -37,6 +37,7 @@
 {% set params = params|merge({'candel': false}) %}
 {# do not display footer with dates #}
 {% set params = params|merge({'formfooter': false}) %}
+{% import 'components/form/fields_macros.html.twig' as fields %}
 
 {% block form_fields %}
     <input type="hidden" name="_update_capacities" value="1" />
@@ -67,8 +68,16 @@
                             <i class="{{ capacity.getIcon() }} fa-2x text-secondary"></i>
                         </span>
                         <div class="text-start">
-                            <div class="fw-bold">
-                                {{ capacity.getLabel() }}
+                            <div class="d-flex align-items-center">
+                                <div class="fw-bold">
+                                    {{ capacity.getLabel() }}
+                                </div>
+
+                                {% if get_class(capacity) == 'Glpi\\Asset\\Capacity\\IsInventoriableCapacity' %}
+                                    <button type="button" data-bs-toggle="modal" data-bs-target="#itemtype-modal" class="ms-1 btn btn-icon btn-sm btn-ghost-secondary">
+                                        <i class="ti ti-settings"></i>
+                                    </button>
+                                {% endif %}
                             </div>
                             {% if capacity.getDescription() is not empty %}
                             <small class="form-hint">
@@ -87,6 +96,47 @@
                         </div>
                     </div>
                 </label>
+
+                {% if get_class(capacity) == 'Glpi\\Asset\\Capacity\\IsInventoriableCapacity' %}
+                    <div class="modal fade" id="itemtype-modal" tabindex="-1" aria-labelledby="itemtype-modal-label" aria-hidden="true">
+                        <div class="modal-dialog modal-lg">
+                            <div class="modal-content">
+                                <div class="modal-header">
+                                    <h5 class="modal-title" id="itemtype-modal-label">
+                                        {{ __('Capacity options') }}
+                                    </h5>
+                                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ __("Close") }}"></button>
+                                </div>
+                                <div class="modal-body">
+                                    <div class="alert alert-info alert-important d-flex align-items-center" role="alert">
+                                        <i class="ti ti-info-circle me-3 fa-2x"></i>
+                                        <div>
+                                            <h4 class="alert-title">{{ __("Please select the type that represents the best the asset.") }}</h4>
+                                            {{ __("We need this information to send the inventory file in the correct inventory engine of the GLPI framework.") }}
+                                        </div>
+
+                                    </div>
+
+                                    {{ fields.dropdownArrayField(
+                                        'inventory_mainasset',
+                                        item.getCapacityConfigurationValue(capacity, 'inventory_mainasset'),
+                                        capacity.getConfigurationTypes(),
+                                        '',
+                                        {
+                                            'no_label': true,
+                                        }
+                                    ) }}
+                                </div>
+                                <div class="modal-footer">
+                                    <button type="button" class="btn btn-primary" data-bs-dismiss="modal">
+                                        <i class="ti ti-device-floppy"></i>
+                                        <span>{{ _x('button', 'OK') }}</span>
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                {% endif %}
             </div>
         {% endfor %}
     </div>

--- a/templates/pages/admin/assetdefinition/capacities.html.twig
+++ b/templates/pages/admin/assetdefinition/capacities.html.twig
@@ -52,13 +52,17 @@
         </div>
 
         {% for capacity in capacities %}
+            {% set index = loop.index0 %}
             <div class="col-12 col-lg-6 col-xxl-4 mb-2 capacity-box">
+                <input type="hidden" name="capacities[{{ index }}][name]" value="{{ get_class(capacity) }}" />
                 <label class="form-selectgroup-boxes flex-fill w-100 h-100" style="min-height: 70px;">
+                    <input type="hidden" name="capacities[{{ index }}][is_active]" value="0">
                     <input type="checkbox"
-                            name="capacities[]"
-                            value="{{ get_class(capacity) }}"
+                            name="capacities[{{ index }}][is_active]"
+                            value="1"
                             class="form-selectgroup-input"
                             id="{{ get_class(capacity) }}"
+                            data-capacity-checkbox="1"
                             data-capacity="{{ get_class(capacity) }}"
                             data-capacity-search="{{ capacity.getLabel() ~ ' ' ~ capacity.getDescription() }}"
                             data-is-used="{{ capacity.isUsed(classname) ? 1 : 0 }}"
@@ -118,8 +122,8 @@
                                     </div>
 
                                     {{ fields.dropdownArrayField(
-                                        'inventory_mainasset',
-                                        item.getCapacityConfigurationValue(capacity, 'inventory_mainasset'),
+                                        'capacities[' ~ index ~ '][config][inventory_mainasset]',
+                                        item.getDefinition().getCapacityConfigurationValue(get_class(capacity), 'inventory_mainasset'),
                                         capacity.getConfigurationTypes(),
                                         '',
                                         {
@@ -197,7 +201,7 @@
 
                 if (
                     data.is_from_modal !== true
-                    && $('input[name="capacities[]"][data-is-used="1"]:not(:checked)').length > 0
+                    && $('input[data-capacity-checkbox="1"][data-is-used="1"]:not(:checked)').length > 0
                 ) {
                     event.preventDefault();
                     $('#capacityWarningModal').modal('show');
@@ -215,7 +219,7 @@
             });
 
             // warn user about the consequences of disabling a capacity
-            $('input[name="capacities[]"][data-is-used=1]').on('change', function() {
+            $('input[data-capacity-checkbox="1"][data-is-used=1]').on('change', function() {
                 $(this).toggleClass('red-toggle-switch-bg');
                 $('.alert-capacity[data-capacity="' + $.escapeSelector($(this).data('capacity')) + '"]').toggleClass('d-none', $(this).is(':checked'));
             });
@@ -228,7 +232,7 @@
                 // delay the search to avoid flickering
                 clearTimeout(delay_timer);
                 delay_timer = setTimeout(function() {
-                    $('input[name="capacities[]"]').each(function() {
+                    $('input[data-capacity-checkbox="1"]').each(function() {
                         const capacity_search = $(this).data('capacity-search').toLowerCase();
                         if (capacity_search.indexOf(search) === -1) {
                             $(this).closest('.capacity-box').addClass('d-none');
@@ -241,7 +245,7 @@
 
             // (un)toggle all capacities button
             $('#select-all-capacities').on('click', function() {
-                var $checkboxes = $('input[name="capacities[]"]');
+                var $checkboxes = $('input[data-capacity-checkbox="1"]');
                 var $checkedCheckboxes = $checkboxes.filter(':checked');
 
                 if ($checkedCheckboxes.length === $checkboxes.length) {

--- a/templates/pages/admin/assetdefinition/capacities.html.twig
+++ b/templates/pages/admin/assetdefinition/capacities.html.twig
@@ -37,7 +37,6 @@
 {% set params = params|merge({'candel': false}) %}
 {# do not display footer with dates #}
 {% set params = params|merge({'formfooter': false}) %}
-{% import 'components/form/fields_macros.html.twig' as fields %}
 
 {% block form_fields %}
     <input type="hidden" name="_update_capacities" value="1" />
@@ -53,6 +52,7 @@
 
         {% for capacity in capacities %}
             {% set index = loop.index0 %}
+            {% set configuration_form = capacity.getConfigurationForm('capacities[' ~ index ~ '][config]', item.getCapacityConfiguration(get_class(capacity))) %}
             <div class="col-12 col-lg-6 col-xxl-4 mb-2 capacity-box">
                 <input type="hidden" name="capacities[{{ index }}][name]" value="{{ get_class(capacity) }}" />
                 <label class="form-selectgroup-boxes flex-fill w-100 h-100" style="min-height: 70px;">
@@ -61,7 +61,6 @@
                             name="capacities[{{ index }}][is_active]"
                             value="1"
                             class="form-selectgroup-input"
-                            id="{{ get_class(capacity) }}"
                             data-capacity-checkbox="1"
                             data-capacity="{{ get_class(capacity) }}"
                             data-capacity-search="{{ capacity.getLabel() ~ ' ' ~ capacity.getDescription() }}"
@@ -77,8 +76,8 @@
                                     {{ capacity.getLabel() }}
                                 </div>
 
-                                {% if get_class(capacity) == 'Glpi\\Asset\\Capacity\\IsInventoriableCapacity' %}
-                                    <button type="button" data-bs-toggle="modal" data-bs-target="#itemtype-modal" class="ms-1 btn btn-icon btn-sm btn-ghost-secondary">
+                                {% if configuration_form is not null %}
+                                    <button type="button" data-bs-toggle="modal" data-bs-target="#{{ get_class(capacity)|slug }}-modal" class="ms-1 btn btn-icon btn-sm btn-ghost-secondary">
                                         <i class="ti ti-settings"></i>
                                     </button>
                                 {% endif %}
@@ -101,36 +100,17 @@
                     </div>
                 </label>
 
-                {% if get_class(capacity) == 'Glpi\\Asset\\Capacity\\IsInventoriableCapacity' %}
-                    <div class="modal fade" id="itemtype-modal" tabindex="-1" aria-labelledby="itemtype-modal-label" aria-hidden="true">
+                {% if configuration_form is not null %}
+                    <div class="modal fade" id="{{ get_class(capacity)|slug }}-modal" tabindex="-1" aria-labelledby="{{ get_class(capacity)|slug }}-modal-label" aria-hidden="true">
                         <div class="modal-dialog modal-lg">
                             <div class="modal-content">
                                 <div class="modal-header">
-                                    <h5 class="modal-title" id="itemtype-modal-label">
+                                    <h5 class="modal-title" id="{{ get_class(capacity)|slug }}-modal-label">
                                         {{ __('Capacity options') }}
                                     </h5>
                                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ __("Close") }}"></button>
                                 </div>
-                                <div class="modal-body">
-                                    <div class="alert alert-info alert-important d-flex align-items-center" role="alert">
-                                        <i class="ti ti-info-circle me-3 fa-2x"></i>
-                                        <div>
-                                            <h4 class="alert-title">{{ __("Please select the type that represents the best the asset.") }}</h4>
-                                            {{ __("We need this information to send the inventory file in the correct inventory engine of the GLPI framework.") }}
-                                        </div>
-
-                                    </div>
-
-                                    {{ fields.dropdownArrayField(
-                                        'capacities[' ~ index ~ '][config][inventory_mainasset]',
-                                        item.getDefinition().getCapacityConfigurationValue(get_class(capacity), 'inventory_mainasset'),
-                                        capacity.getConfigurationTypes(),
-                                        '',
-                                        {
-                                            'no_label': true,
-                                        }
-                                    ) }}
-                                </div>
+                                <div class="modal-body">{{ configuration_form|raw }}</div>
                                 <div class="modal-footer">
                                     <button type="button" class="btn btn-primary" data-bs-dismiss="modal">
                                         <i class="ti ti-device-floppy"></i>

--- a/templates/pages/admin/assetdefinition/capacity/is_inventoriable_capacity_configuration_form.html.twig
+++ b/templates/pages/admin/assetdefinition/capacity/is_inventoriable_capacity_configuration_form.html.twig
@@ -1,0 +1,52 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2025 Teclib' and contributors.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+{% import 'components/form/fields_macros.html.twig' as fields %}
+
+<div class="alert alert-info alert-important d-flex align-items-center" role="alert">
+    <i class="ti ti-info-circle me-3 fa-2x"></i>
+    <div>
+        <h4 class="alert-title">{{ __("Please select the type that represents the best the asset.") }}</h4>
+        {{ __("We need this information to send the inventory file in the correct inventory engine of the GLPI framework.") }}
+    </div>
+
+</div>
+
+{{ fields.dropdownArrayField(
+    fieldname_prefix ~ '[inventory_mainasset]',
+    current_config.getValue('inventory_mainasset'),
+    itemtype_choices,
+    '',
+    {
+        'no_label': true,
+    }
+) }}


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

It adds the ability to configure the type of asset used for the inventory capacity (Generic, Network Device or Printer).

## Screenshots
![image](https://github.com/user-attachments/assets/030f131c-ccbc-46ab-9a5d-445428d6df5c)
