### PR TITLE
Remove redundant user picture search option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ The present file will list all changes made to the project; according to the
 - `Glpi\System\Status\StatusChecker::getServiceStatus()` `as_array` parameter.
 - `Sylk` export of search results.
 - `full_width_adapt_column` option for fields macros has been removed.
+- `Picture` search option (ID 150) for Users.
 
 ### API changes
 

--- a/install/migrations/update_10.0.x_to_11.0.0/user.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/user.php
@@ -55,3 +55,6 @@ Config::deleteConfigurationValues('core', ['fold_search']);
 
 // Drop useless field
 $migration->dropField('glpi_users', 'display_options');
+
+// Drop "picture" search option
+$migration->removeSearchOption('User', 150);

--- a/src/User.php
+++ b/src/User.php
@@ -3968,16 +3968,6 @@ JAVASCRIPT;
         ];
 
         $tab[] = [
-            'id'                 => '150',
-            'table'              => $this->getTable(),
-            'field'              => 'picture',
-            'name'               => _n('Picture', 'Pictures', 1),
-            'datatype'           => 'specific',
-            'nosearch'           => true,
-            'massiveaction'      => false
-        ];
-
-        $tab[] = [
             'id'                 => '28',
             'table'              => $this->getTable(),
             'field'              => 'sync_field',


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

The "Picture" search option for users has been redundant since the initial GLPI 10 release as the user avatars are shown in the Login column. The "Picture" search option only showed the uploaded pictures, showed broken images when none existed, and used legacy CSS styles.

This PR also adds a helper to the Migration class to cleanly remove search options from various places in the database including display preferences, saved searches and ticket templates.
