### PR TITLE
Do not show existing locked field forms

### DIFF
--- a/front/lockedfield.form.php
+++ b/front/lockedfield.form.php
@@ -56,12 +56,8 @@ if (isset($_POST["add"])) {
             "inventory",
             sprintf(__('%1$s adds global lock on %2$s'), $_SESSION["glpiname"], $_POST["item"])
         );
-
-        if ($_SESSION['glpibackcreated']) {
-            Html::redirect($lockedfield->getLinkURL());
-        }
     }
-    Html::back();
+    $lockedfield->redirectToList();
 } else if (isset($_POST["purge"])) {
     $lockedfield->check($_POST['id'], UPDATE);
     if ($lockedfield->delete($_POST, 1)) {
@@ -75,20 +71,6 @@ if (isset($_POST["add"])) {
         );
     }
     $lockedfield->redirectToList();
-
-   //update a locked field
-} else if (isset($_POST["update"])) {
-    $lockedfield->check($_POST['id'], UPDATE);
-    $lockedfield->update($_POST);
-    Event::log(
-        $_POST["id"],
-        "lockedfield",
-        4,
-        "inventory",
-        //TRANS: %s is the user login
-        sprintf(__('%s updates an item'), $_SESSION["glpiname"])
-    );
-    Html::back();
 } else {//print locked field information
     $menus = ["admin", "glpi\inventory\inventory", "lockedfield"];
     $lockedfield->displayFullPageForItem($_GET['id'], $menus, [


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

While testing global locks, I found that if you have GLPI go to an item after creation you are directed to a locked field form which:
1. Isn't accessible in any other way except directly via URL.
2. Shows the incorrect field as the dropdown only shows fields which are left to be locked rather than using all lockable fields and a 'used' parameter.
3. Only shows the "Field" field and lets you change it here which probably isn't intended. I think it is intended that you need to delete/add locked fields rather than reassign existing ones.

The safest solution is to just redirect to the list.