### PR TITLE
fix: infinite file upload progress bar issue with multiple textareas …

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -5506,7 +5506,7 @@ HTML;
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $randupload             = mt_rand();
+        $randupload = $options['rand'] ?? mt_rand();
 
         $p['name']                = 'filename';
         $p['onlyimages']          = false;
@@ -5699,10 +5699,13 @@ HTML;
     public static function textarea($options = [])
     {
        //default options
+
+        $rand = $options['rand'] ?? mt_rand();
+
         $p['name']              = 'text';
-        $p['filecontainer']     = 'fileupload_info';
-        $p['rand']              = mt_rand();
-        $p['editor_id']         = 'text' . $p['rand'];
+        $p['rand']              = $rand;
+        $p['filecontainer']     = 'fileupload_info' . $rand;
+        $p['editor_id']         = 'text' . $rand;
         $p['value']             = '';
         $p['enable_richtext']   = false;
         $p['enable_images']     = true;


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !36662
- Here is a brief description of what this PR does

## Screenshots (if appropriate):

This PR fixes the problem that uploading files in the wrong text box which blocked the progress bar at 100%

**Before patch**
![Capture d’écran du 2025-03-07 15-56-54](https://github.com/user-attachments/assets/6e995a31-2f75-4c4e-9d49-581ae3460555)

**With fix**
![Capture d’écran du 2025-03-07 15-55-36](https://github.com/user-attachments/assets/64980370-c0be-4467-8c56-a60b52827b2b)


