### PR TITLE
Add old_id and new_id col in glpi_logs table

### DIFF
--- a/install/migrations/update_10.0.x_to_11.0.0/logs.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/logs.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * @var DB $DB
+ * @var Migration $migration
+ */
+
+$default_key_sign = DBConnection::getDefaultPrimaryKeySignOption();
+
+$migration->addField(
+    "glpi_logs",
+    "new_id",
+    "int {$default_key_sign}",
+    [
+        "null" => true,
+    ]
+);
+
+$migration->addField(
+    "glpi_logs",
+    "old_id",
+    "int {$default_key_sign}",
+    [
+        "null" => true,
+    ]
+);
+
+$migration->addKey("glpi_logs", "new_id");
+$migration->addKey("glpi_logs", "old_id");

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -4295,11 +4295,15 @@ CREATE TABLE `glpi_logs` (
   `id_search_option` int NOT NULL DEFAULT '0',
   `old_value` varchar(255) DEFAULT NULL,
   `new_value` varchar(255) DEFAULT NULL,
+  `old_id` int unsigned DEFAULT NULL,
+  `new_id` int unsigned DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `date_mod` (`date_mod`),
   KEY `itemtype_link` (`itemtype_link`),
   KEY `item` (`itemtype`,`items_id`),
-  KEY `id_search_option` (`id_search_option`)
+  KEY `id_search_option` (`id_search_option`),
+  KEY `old_id` (`old_id`),
+  KEY `new_id` (`new_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 

--- a/phpunit/functional/ConfigTest.php
+++ b/phpunit/functional/ConfigTest.php
@@ -798,6 +798,8 @@ class ConfigTest extends DbTestCase
             'user_name'        => Session::getLoginUserID(false),
             'date_mod'         => $_SESSION['glpi_currenttime'],
             'id_search_option' => 1,
+            'old_id' => null,
+            'new_id' => null
         ];
 
         $clean_ids = function (&$value, $key) {

--- a/src/Log.php
+++ b/src/Log.php
@@ -198,7 +198,9 @@ class Log extends CommonDBTM
                                     $values[$key]
                                 ),
                                 $values[$key]
-                            )
+                            ),
+                            $oldval,
+                            (int)$values[$key]
                         ];
                     }
                     break;
@@ -237,6 +239,8 @@ class Log extends CommonDBTM
         $id_search_option = $changes[0];
         $old_value        = $changes[1] ?? '';
         $new_value        = $changes[2] ?? '';
+        $old_id           = $changes[3] ?? null;
+        $new_id           = $changes[4] ?? null;
 
         // Remove json values
         $decoded_old_value = json_decode($old_value);
@@ -287,7 +291,9 @@ class Log extends CommonDBTM
             'date_mod'          => $date_mod,
             'id_search_option'  => $id_search_option,
             'old_value'         => $old_value,
-            'new_value'         => $new_value
+            'old_id'            => $old_id,
+            'new_value'         => $new_value,
+            'new_id'            => $new_id,
         ];
 
         if (static::$use_queue) {


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes https://github.com/glpi-project/glpi/pull/19140
- Here is a brief description of what this PR does

Add two `new_id` and `old_id` columns to the `glpi_logs` table to optimize table searches

