### PR TITLE
fix(ITILSolution): document not visible

### DIFF
--- a/src/ITILSolution.php
+++ b/src/ITILSolution.php
@@ -80,9 +80,9 @@ class ITILSolution extends CommonDBChild
 
     public static function canView()
     {
-        return Session::haveRight('ticket', READ)
-             || Session::haveRight('change', READ)
-             || Session::haveRight('problem', READ);
+        return Session::haveRightsOr('ticket', [Ticket::READMY, Ticket::READALL, Ticket::READGROUP, Ticket::READASSIGN])
+            || Session::haveRightsOr('change', [Change::READMY, Change::READALL])
+            || Session::haveRightsOr('problem', [Problem::READMY, Problem::READALL]);
     }
 
     public static function canUpdate()

--- a/src/ITILSolution.php
+++ b/src/ITILSolution.php
@@ -80,9 +80,7 @@ class ITILSolution extends CommonDBChild
 
     public static function canView()
     {
-        return Session::haveRightsOr('ticket', [Ticket::READMY, Ticket::READALL, Ticket::READGROUP, Ticket::READASSIGN])
-            || Session::haveRightsOr('change', [Change::READMY, Change::READALL])
-            || Session::haveRightsOr('problem', [Problem::READMY, Problem::READALL]);
+        return Ticket::canView() || Problem::canView() || Change::canView();
     }
 
     public static function canUpdate()


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !36494

A technician could see the solution of a ticket but not the documents attached to that solution if they did not have the "See my ticket" permission.

## Screenshots (if appropriate):


