### PR TITLE
fix: Fix rights verification for updating saved searches via massive action

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -4622,12 +4622,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/SavedSearch.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Unreachable statement \\- code above always terminates\\.$#',
-	'identifier' => 'deadCode.unreachable',
-	'count' => 1,
-	'path' => __DIR__ . '/src/SavedSearch.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method SavedSearch_Alert\\:\\:showForSavedSearch\\(\\) with return type void returns false but should not return anything\\.$#',
 	'identifier' => 'return.void',
 	'count' => 1,

--- a/phpunit/functional/MassiveActionTest.php
+++ b/phpunit/functional/MassiveActionTest.php
@@ -632,6 +632,7 @@ class MassiveActionTest extends DbTestCase
         $entity = getItemByTypeName('Entity', '_test_root_entity', true);
         $uid = getItemByTypeName('User', TU_USER, true);
         $bk = new \SavedSearch();
+        $bku = new \SavedSearch_User();
         $this->assertTrue(
             (bool)$bk->add([
                 'name'         => 'public root recursive',
@@ -642,6 +643,14 @@ class MassiveActionTest extends DbTestCase
                 'entities_id'  => $entity,
                 'is_recursive' => 1,
                 'url'          => 'front/ticket.php?itemtype=Ticket&sort=2&order=DESC&start=0&criteria[0][field]=5&criteria[0][searchtype]=equals&criteria[0][value]=' . $uid
+            ])
+        );
+
+        $this->assertTrue(
+            (bool)$bku->add([
+                'users_id'          => $uid,
+                'itemtype'          => 'Ticket',
+                'savedsearches_id'  => $bk->getID(),
             ])
         );
 

--- a/src/SavedSearch.php
+++ b/src/SavedSearch.php
@@ -70,6 +70,11 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
         return _n('Saved search', 'Saved searches', $nb);
     }
 
+    public function canUpdateItem()
+    {
+        return Session::haveRight(self::$rightname, UPDATE) ||
+            $this->fields["users_id"] === Session::getLoginUserID();
+    }
 
     public function getForbiddenStandardMassiveAction()
     {
@@ -132,6 +137,7 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
         }
         return parent::showMassiveActionsSubForm($ma);
     }
+
 
     public static function processMassiveActionsForOneItemtype(
         MassiveAction $ma,
@@ -832,6 +838,7 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
         }
     }
 
+
     /**
      * Unmark savedsearch as default view for the current user
      *
@@ -867,6 +874,7 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
             }
         }
     }
+
 
     /**
      * Unmark savedsearch as default view
@@ -1121,12 +1129,6 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
             $types[] = $data['itemtype'];
         }
         return $types;
-    }
-
-    public function canUpdateItem()
-    {
-        return Session::haveRight(self::$rightname, UPDATE) ||
-            $this->fields["users_id"] === Session::getLoginUserID();
     }
 
 

--- a/src/SavedSearch.php
+++ b/src/SavedSearch.php
@@ -1080,7 +1080,7 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
 
     public function canUpdateItem()
     {
-        return Session::haveRight('bookmark_public', UPDATE) ||
+        return Session::haveRight(self::$rightname, UPDATE) ||
             $this->fields["users_id"] === Session::getLoginUserID();
     }
 
@@ -1191,7 +1191,7 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
     /**
      * Set do_count from massive actions
      *
-     * @param integer   $ids     Items ID
+     * @param integer $id     Item ID
      * @param integer $do_count One of self::COUNT_*
      *
      * @return boolean

--- a/src/SavedSearch.php
+++ b/src/SavedSearch.php
@@ -824,7 +824,7 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
         /** @var \DBmysql $DB */
         global $DB;
 
-        if (Session::haveRight('config', UPDATE)) {
+        if (Session::haveRight('bookmark_public', UPDATE)) {
             return $DB->delete(
                 'glpi_savedsearches_users',
                 [

--- a/src/SavedSearch.php
+++ b/src/SavedSearch.php
@@ -860,7 +860,7 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
     }
 
     /**
-     * Unmark savedsearch as default view for the current user
+     * Unmark savedsearch as default view for all users
      *
      * @param integer $ID ID of the saved search
      *

--- a/src/SavedSearch.php
+++ b/src/SavedSearch.php
@@ -908,12 +908,14 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
         /** @var \DBmysql $DB */
         global $DB;
 
-        return $DB->delete(
-            'glpi_savedsearches_users',
-            [
-                'savedsearches_id'   => $ids
-            ]
-        );
+        if (Session::haveRight('config', UPDATE)) {
+            return $DB->delete(
+                'glpi_savedsearches_users',
+                [
+                    'savedsearches_id'   => $ids
+                ]
+            );
+        }
 
         return false;
     }
@@ -1262,7 +1264,7 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
     /**
      * Set do_count from massive actions
      *
-     * @param array   $ids     Items IDs
+     * @param array   $ids      Items IDs
      * @param integer $do_count One of self::COUNT_*
      *
      * @return boolean


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !36776
-  To use the massive action "Unset default" to delete a saved default search, you had to have the right to update the GLPI configuration. However, choosing a saved search by default is an individual choice ( visible only to the user ). Checking for update permission on the configuration is not necessary in this case.

![Capture d’écran du 2025-03-11 14-05-03](https://github.com/user-attachments/assets/bae1e68b-6936-4d86-a69c-64217abd1972)



