### PR TITLE
Fix filtering on anonymous users in changes

### DIFF
--- a/src/Search.php
+++ b/src/Search.php
@@ -6775,7 +6775,7 @@ JAVASCRIPT;
 
                            // Manage alternative_email for tickets_users
                                 if (
-                                    ($itemtype == 'Ticket')
+                                    is_subclass_of($itemtype, CommonITILObject::class)
                                     && isset($data[$ID][$k][2])
                                 ) {
                                         $split = explode(self::LONGSEP, $data[$ID][$k][2]);
@@ -6797,7 +6797,7 @@ JAVASCRIPT;
                     if ($itemtype != 'User') {
                         $toadd = '';
                         if (
-                            ($itemtype == 'Ticket')
+                            is_subclass_of($itemtype, CommonITILObject::class)
                             && ($data[$ID][0]['id'] > 0)
                         ) {
                             $userdata = getUserName($data[$ID][0]['id'], 2);

--- a/src/Search.php
+++ b/src/Search.php
@@ -6738,7 +6738,7 @@ JAVASCRIPT;
                                     $out .= self::LBBR;
                                 }
 
-                                if ($itemtype == 'Ticket') {
+                                if (is_subclass_of($itemtype, CommonITILObject::class)) {
                                     if (
                                         isset($data[$ID][$k]['name'])
                                         && $data[$ID][$k]['name'] > 0


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !36707
- Here is a brief description of what this PR does

If a `Change` or `Problem` contains **anonymous actors** and you try to filter the list on them, an error appears and they don't appear in the search option results.
The problem stems from the fact that the search processing only targeted `Tickets` and not `Changes` and `Problems`.

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/e03aa1f5-1791-4217-8d2a-a04dc8200fe7)

### Before:
![image](https://github.com/user-attachments/assets/c4e360e0-ebb7-4f89-8c04-6e04211ef7a2)

### After : 
![image](https://github.com/user-attachments/assets/80c87cae-042a-4766-8311-dd06888fd712)
