### PR TITLE
Add a nested foreach around $uresult

### DIFF
--- a/src/Glpi/Api/APIRest.php
+++ b/src/Glpi/Api/APIRest.php
@@ -93,10 +93,10 @@ class APIRest extends API
                 'print_response' => false
             ]);
             foreach ($upload_result as $uresult) {
-              foreach($uresult as $file_result) {
-                $this->parameters['input']->_filename[]        = $file_result->name;
-                $this->parameters['input']->_prefix_filename[] = $file_result->prefix;
-              }
+                foreach ($uresult as $file_result) {
+                    $this->parameters['input']->_filename[]        = $file_result->name;
+                    $this->parameters['input']->_prefix_filename[] = $file_result->prefix;
+                }
             }
             $this->parameters['upload_result'][] = $upload_result;
         }

--- a/src/Glpi/Api/APIRest.php
+++ b/src/Glpi/Api/APIRest.php
@@ -93,8 +93,10 @@ class APIRest extends API
                 'print_response' => false
             ]);
             foreach ($upload_result as $uresult) {
-                 $this->parameters['input']->_filename[] = $uresult[0]->name;
-                 $this->parameters['input']->_prefix_filename[] = $uresult[0]->prefix;
+              foreach($uresult as $file_result) {
+                $this->parameters['input']->_filename[]        = $file_result->name;
+                $this->parameters['input']->_prefix_filename[] = $file_result->prefix;
+              }
             }
             $this->parameters['upload_result'][] = $upload_result;
         }


### PR DESCRIPTION
Due to the nature of multipart forms and the way that PHP handles them, during multi-part POST requests only the first uploaded file was attached to the created item. With this nested `foreach` it's possible now to upload multiple files at once and expect `manageUploadedFiles()` to handle them properly.

Tested on main and 10.0.17

## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
