### PR TITLE
Enhance error traces in log

### DIFF
--- a/phpunit/functional/Glpi/Log/ErrorLogLineFormatterTest.php
+++ b/phpunit/functional/Glpi/Log/ErrorLogLineFormatterTest.php
@@ -141,7 +141,7 @@ class ErrorLogLineFormatterTest extends TestCase
             datetime: new DateTimeImmutable('2024-08-12 21:45:32'),
             channel: 'glpiphplog',
             level: Level::Critical,
-            message: 'Uncaught PHP Exception RuntimeException: "Operation failed!" at Central.php line 123',
+            message: 'Uncaught PHP Exception RuntimeException: "Operation failed!"',
             context: ['exception' => new \RuntimeException()],
             extra: [],
         );
@@ -151,16 +151,20 @@ class ErrorLogLineFormatterTest extends TestCase
         $lines = explode("\n", $formatted);
 
         $this->assertSame(
-            '[2024-08-12 21:45:32] glpiphplog.CRITICAL:   *** Uncaught PHP Exception RuntimeException: "Operation failed!" at Central.php line 123',
+            '[2024-08-12 21:45:32] glpiphplog.CRITICAL:   *** Uncaught PHP Exception RuntimeException: "Operation failed!"',
             $lines[0]
         );
         $this->assertSame(
             '  Backtrace :',
             $lines[1]
         );
+        $this->assertSame(
+            '  ...onal/Glpi/Log/ErrorLogLineFormatterTest.php:145 ',
+            $lines[2]
+        );
         $this->assertMatchesRegularExpression(
             '#.*phpunit/src/Framework/TestCase\.php:\d+ tests\\\units\\\Glpi\\\Log\\\ErrorLogLineFormatterTest->testFormatExceptionTrace\(\)#',
-            $lines[2]
+            $lines[3]
         );
         // Testing the following lines in the trace would produce an unstable test.
         // Unfortunately, it is imposssible to mock an exception, as all its methods are final.

--- a/src/Glpi/Log/AbstractLogLineFormatter.php
+++ b/src/Glpi/Log/AbstractLogLineFormatter.php
@@ -44,7 +44,17 @@ abstract class AbstractLogLineFormatter extends LineFormatter
     {
         $message = \sprintf(
             "\n  Backtrace :\n%s",
-            $this->getTraceAsString($e->getTrace())
+            $this->getTraceAsString(
+                array_merge(
+                    [
+                        [
+                            'file' => $e->getFile(),
+                            'line' => $e->getLine(),
+                        ]
+                    ],
+                    $e->getTrace()
+                )
+            )
         );
 
         if (($previous = $e->getPrevious()) instanceof \Throwable) {
@@ -53,7 +63,17 @@ abstract class AbstractLogLineFormatter extends LineFormatter
                 $message .= sprintf(
                     "  Previous: %s\n%s",
                     $previous->getMessage(),
-                    $this->getTraceAsString($previous->getTrace()),
+                    $this->getTraceAsString(
+                        array_merge(
+                            [
+                                [
+                                    'file' => $previous->getFile(),
+                                    'line' => $previous->getLine(),
+                                ]
+                            ],
+                            $previous->getTrace()
+                        )
+                    ),
                 );
                 if ($depth > $this->maxNormalizeDepth) {
                     break;


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

The symfony exception handling logic automatically formats the message sent to the logger by appending the location of the error. However, it just contains the basename of the file, and it can be ambiguous. Also, If we want to manually log a caught error, we will have to manually append the error location to the message to be able to have it written in the log file.

I propose to preprend a line to the backtrace in the logs to be sure to always have the full location of the error.

```diff
[2025-03-13 07:30:34] glpi.CRITICAL:   *** Uncaught PHP Exception Twig\Error\RuntimeError: "An exception has been thrown during the rendering of a template ("")." at index.html.twig line 39
  Backtrace :
+  ./templates/pages/central/index.html.twig:39       
  ...ates/8f/8f5188fccfe958e9025a2fef77fee719.php:62 Twig\Template->yieldBlock()
  ./vendor/twig/twig/src/Template.php:388            __TwigTemplate_3426c0627bf12e347bd778137f8a1fd5->doDisplay()
  ...ates/3f/3ffe9a2d07ea0abffe193d0b3395b312.php:52 Twig\Template->yield()
  ./vendor/twig/twig/src/Template.php:388            __TwigTemplate_a22b9022f37a458b999a9028d25f8b0c->doDisplay()
  ./vendor/twig/twig/src/Template.php:344            Twig\Template->yield()
  ./vendor/twig/twig/src/TemplateWrapper.php:61      Twig\Template->display()
  .../Glpi/Application/View/TemplateRenderer.php:183 Twig\TemplateWrapper->display()
  ./src/Glpi/Controller/AbstractController.php:72    Glpi\Application\View\TemplateRenderer->display()
  ./src/Glpi/Controller/CentralController.php:72     Glpi\Controller\AbstractController->render()
  ./vendor/symfony/http-kernel/HttpKernel.php:181    Glpi\Controller\CentralController->__invoke()
  ./vendor/symfony/http-kernel/HttpKernel.php:76     Symfony\Component\HttpKernel\HttpKernel->handleRaw()
  ./vendor/symfony/http-kernel/Kernel.php:197        Symfony\Component\HttpKernel\HttpKernel->handle()
  ./public/index.php:56                              Symfony\Component\HttpKernel\Kernel->handle()
  Previous: 
+  ./src/Central.php:68                               
  ./src/CommonGLPI.php:362                           Central->getTabNameForItem()
  ./src/Central.php:60                               CommonGLPI->addStandardTab()
```
