### PR TITLE
Ease handling of `FieldUnicity` add/update operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -399,6 +399,7 @@ The present file will list all changes made to the project; according to the
 - `Entity::getDefaultContractValues()`
 - `Entity::cleanEntitySelectorCache()`
 - `Entity::title()`
+- `FieldUnicity::checkBeforeInsert()`
 - `FieldUnicity::showDebug()`
 - `GLPI::getErrorHandler()`
 - `GLPI::getLogLevel()`

--- a/phpunit/functional/FieldUnicityTest.php
+++ b/phpunit/functional/FieldUnicityTest.php
@@ -1,0 +1,152 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units;
+
+use Computer;
+use DbTestCase;
+use FieldUnicity;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+class FieldUnicityTest extends DbTestCase
+{
+    public static function inputProvider(): iterable
+    {
+        yield [
+            'input'  => [
+                'itemtype' => Computer::class,
+            ],
+            'result' => false,
+            'errors' => ['It&#039;s mandatory to select a type and at least one field'],
+        ];
+
+        yield [
+            'input'  => [
+                'fields'   => '',
+            ],
+            'result' => false,
+            'errors' => ['It&#039;s mandatory to select a type and at least one field'],
+        ];
+
+        yield [
+            'input'  => [
+                '_fields'  => [],
+            ],
+            'result' => false,
+            'errors' => ['It&#039;s mandatory to select a type and at least one field'],
+        ];
+
+        yield [
+            'input'  => [
+                'itemtype' => Computer::class,
+                'fields'   => '',
+            ],
+            'result' => false,
+            'errors' => ['It&#039;s mandatory to select a type and at least one field'],
+        ];
+
+        yield [
+            'input'  => [
+                'itemtype' => Computer::class,
+                'fields'   => 'name',
+            ],
+            'result' => [
+                'itemtype' => Computer::class,
+                'fields'   => 'name',
+            ],
+            'errors' => [],
+        ];
+
+        yield [
+            'input'  => [
+                'itemtype' => Computer::class,
+                '_fields'  => ['name', 'serial'],
+            ],
+            'result' => [
+                'itemtype' => Computer::class,
+                'fields'   => 'name,serial',
+            ],
+            'errors' => [],
+        ];
+    }
+
+    public static function addInputProvider(): iterable
+    {
+        yield [
+            'input'  => [],
+            'result' => false,
+            'errors' => ['It&#039;s mandatory to select a type and at least one field'],
+        ];
+
+        yield from self::inputProvider();
+    }
+
+    #[DataProvider('addInputProvider')]
+    public function testPrepareInputForAdd(
+        array $input,
+        mixed $result,
+        array $errors
+    ): void {
+        $this->login();
+
+        $fieldunicity = new FieldUnicity();
+        $this->assertEquals($result, $fieldunicity->prepareInputForAdd($input));
+
+        if (count($errors) > 0) {
+            $this->hasSessionMessages(ERROR, $errors);
+        }
+    }
+
+    public static function updateInputProvider(): iterable
+    {
+        yield from self::inputProvider();
+    }
+
+    #[DataProvider('updateInputProvider')]
+    public function testPrepareInputForUpdate(
+        array $input,
+        mixed $result,
+        array $errors
+    ): void {
+        $this->login();
+
+        $fieldunicity = new FieldUnicity();
+        $this->assertEquals($result, $fieldunicity->prepareInputForUpdate($input));
+
+        if (count($errors) > 0) {
+            $this->hasSessionMessages(ERROR, $errors);
+        }
+    }
+}


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

In #19033, I had to handle "copy" operations of `FieldUnicity` items. The `prepareInputFor*()` methods were made to handle the format sent by the web form (i.e. a `_fields` entry that contains an array of values). I added the ability to directly pass the expected value in a `fields` entry (i.e. a string containing a coma separated list of values), in order to be able to "copy" a `FieldUnicity` item easilly.