### PR TITLE
Make the logger instance optional for plugins migrations

### DIFF
--- a/phpunit/abstracts/AbstractDestinationFieldTest.php
+++ b/phpunit/abstracts/AbstractDestinationFieldTest.php
@@ -84,9 +84,8 @@ abstract class AbstractDestinationFieldTest extends DbTestCase
     ): void {
         /**
          * @var \DBmysql $DB
-         * LoggerInterface $PHPLOGGER
          */
-        global $DB, $PHPLOGGER;
+        global $DB;
 
         if (!empty($fields_to_set)) {
             // Compute some values
@@ -115,7 +114,7 @@ abstract class AbstractDestinationFieldTest extends DbTestCase
         }
 
         // Run migration
-        $migration = new FormMigration($DB, $PHPLOGGER, FormAccessControlManager::getInstance());
+        $migration = new FormMigration($DB, FormAccessControlManager::getInstance());
         $this->setPrivateProperty($migration, 'result', new PluginMigrationResult());
         $this->assertTrue($this->callPrivateMethod($migration, 'processMigration'));
 

--- a/phpunit/functional/Glpi/Form/Migration/FormMigrationTest.php
+++ b/phpunit/functional/Glpi/Form/Migration/FormMigrationTest.php
@@ -141,10 +141,10 @@ final class FormMigrationTest extends DbTestCase
     {
         /**
          * @var \DBmysql $DB
-         * LoggerInterface $PHPLOGGER
          */
-        global $DB, $PHPLOGGER;
-        $migration = new FormMigration($DB, $PHPLOGGER, FormAccessControlManager::getInstance());
+        global $DB;
+
+        $migration = new FormMigration($DB, FormAccessControlManager::getInstance());
         $this->setPrivateProperty($migration, 'result', new PluginMigrationResult());
         $this->assertTrue($this->callPrivateMethod($migration, 'processMigration'));
 
@@ -196,10 +196,10 @@ final class FormMigrationTest extends DbTestCase
     {
         /**
          * @var \DBmysql $DB
-         * LoggerInterface $PHPLOGGER
          */
-        global $DB, $PHPLOGGER;
-        $migration = new FormMigration($DB, $PHPLOGGER, FormAccessControlManager::getInstance());
+        global $DB;
+
+        $migration = new FormMigration($DB, FormAccessControlManager::getInstance());
         $this->setPrivateProperty($migration, 'result', new PluginMigrationResult());
         $this->assertTrue($this->callPrivateMethod($migration, 'processMigration'));
 
@@ -239,10 +239,10 @@ final class FormMigrationTest extends DbTestCase
     {
         /**
          * @var \DBmysql $DB
-         * LoggerInterface $PHPLOGGER
          */
-        global $DB, $PHPLOGGER;
-        $migration = new FormMigration($DB, $PHPLOGGER, FormAccessControlManager::getInstance());
+        global $DB;
+
+        $migration = new FormMigration($DB, FormAccessControlManager::getInstance());
         $this->setPrivateProperty($migration, 'result', new PluginMigrationResult());
         $this->assertTrue($this->callPrivateMethod($migration, 'processMigration'));
 
@@ -534,10 +534,10 @@ final class FormMigrationTest extends DbTestCase
     {
         /**
          * @var \DBmysql $DB
-         * LoggerInterface $PHPLOGGER
          */
-        global $DB, $PHPLOGGER;
-        $migration = new FormMigration($DB, $PHPLOGGER, FormAccessControlManager::getInstance());
+        global $DB;
+
+        $migration = new FormMigration($DB, FormAccessControlManager::getInstance());
         $this->setPrivateProperty($migration, 'result', new PluginMigrationResult());
         $this->assertTrue($this->callPrivateMethod($migration, 'processMigration'));
 
@@ -555,10 +555,10 @@ final class FormMigrationTest extends DbTestCase
     {
         /**
          * @var \DBmysql $DB
-         * LoggerInterface $PHPLOGGER
          */
-        global $DB, $PHPLOGGER;
-        $migration = new FormMigration($DB, $PHPLOGGER, FormAccessControlManager::getInstance());
+        global $DB;
+
+        $migration = new FormMigration($DB, FormAccessControlManager::getInstance());
         $this->setPrivateProperty($migration, 'result', new PluginMigrationResult());
         $this->assertTrue($this->callPrivateMethod($migration, 'processMigration'));
 
@@ -584,10 +584,10 @@ final class FormMigrationTest extends DbTestCase
     {
         /**
          * @var \DBmysql $DB
-         * LoggerInterface $PHPLOGGER
          */
-        global $DB, $PHPLOGGER;
-        $migration = new FormMigration($DB, $PHPLOGGER, FormAccessControlManager::getInstance());
+        global $DB;
+
+        $migration = new FormMigration($DB, FormAccessControlManager::getInstance());
         $this->setPrivateProperty($migration, 'result', new PluginMigrationResult());
         $this->assertTrue($this->callPrivateMethod($migration, 'processMigration'));
 
@@ -674,10 +674,10 @@ final class FormMigrationTest extends DbTestCase
     {
         /**
          * @var \DBmysql $DB
-         * LoggerInterface $PHPLOGGER
          */
-        global $DB, $PHPLOGGER;
-        $migration = new FormMigration($DB, $PHPLOGGER, FormAccessControlManager::getInstance());
+        global $DB;
+
+        $migration = new FormMigration($DB, FormAccessControlManager::getInstance());
         $this->setPrivateProperty($migration, 'result', new PluginMigrationResult());
         $this->assertTrue($this->callPrivateMethod($migration, 'processMigration'));
 

--- a/phpunit/functional/Glpi/Form/Migration/TargetsMigrationTest.php
+++ b/phpunit/functional/Glpi/Form/Migration/TargetsMigrationTest.php
@@ -327,10 +327,10 @@ final class TargetsMigrationTest extends DbTestCase
     {
         /**
          * @var \DBmysql $DB
-         * LoggerInterface $PHPLOGGER
          */
-        global $DB, $PHPLOGGER;
-        $migration = new FormMigration($DB, $PHPLOGGER, FormAccessControlManager::getInstance());
+        global $DB;
+
+        $migration = new FormMigration($DB, FormAccessControlManager::getInstance());
         $this->setPrivateProperty($migration, 'result', new PluginMigrationResult());
         $this->assertTrue($this->callPrivateMethod($migration, 'processMigration'));
 

--- a/phpunit/functional/Glpi/Migration/AbstractPluginMigrationTest.php
+++ b/phpunit/functional/Glpi/Migration/AbstractPluginMigrationTest.php
@@ -43,7 +43,6 @@ use Glpi\Message\MessageType;
 use Glpi\Migration\AbstractPluginMigration;
 use Glpi\Migration\PluginMigrationResult;
 use Monitor;
-use Psr\Log\LoggerInterface;
 use ReflectionClass;
 
 class AbstractPluginMigrationTest extends DbTestCase
@@ -52,9 +51,8 @@ class AbstractPluginMigrationTest extends DbTestCase
     {
         // Arrange
         $db = $this->createMock(DBmysql::class);
-        $logger = $this->createMock(LoggerInterface::class);
 
-        $instance = new class ($db, $logger) extends AbstractPluginMigration {
+        $instance = new class ($db) extends AbstractPluginMigration {
             protected function validatePrerequisites(): bool
             {
                 $this->result->addMessage(MessageType::Error, 'Appliances plugin table "glpi_plugins_myplugin_items" is missing.');
@@ -91,9 +89,8 @@ class AbstractPluginMigrationTest extends DbTestCase
     {
         // Arrange
         $db = $this->createMock(DBmysql::class);
-        $logger = $this->createMock(LoggerInterface::class);
 
-        $instance = new class ($db, $logger) extends AbstractPluginMigration {
+        $instance = new class ($db) extends AbstractPluginMigration {
             protected function validatePrerequisites(): bool
             {
                 throw new \RuntimeException('Something went wrong during prerequisites validation.');
@@ -128,9 +125,7 @@ class AbstractPluginMigrationTest extends DbTestCase
         $db->expects($this->once())->method('beginTransaction'); // A transtation will be started ...
         $db->expects($this->once())->method('commit'); // ... and commited.
 
-        $logger = $this->createMock(LoggerInterface::class);
-
-        $instance = new class ($db, $logger) extends AbstractPluginMigration {
+        $instance = new class ($db) extends AbstractPluginMigration {
             protected function validatePrerequisites(): bool
             {
                 return true;
@@ -168,9 +163,7 @@ class AbstractPluginMigrationTest extends DbTestCase
         $db->expects($this->once())->method('rollBack'); // ... but a roll-back will be done.
         $db->expects($this->never())->method('commit');
 
-        $logger = $this->createMock(LoggerInterface::class);
-
-        $instance = new class ($db, $logger) extends AbstractPluginMigration {
+        $instance = new class ($db) extends AbstractPluginMigration {
             protected function validatePrerequisites(): bool
             {
                 $this->result->addMessage(MessageType::Notice, 'Plugin\'s data can be imported.');
@@ -211,9 +204,7 @@ class AbstractPluginMigrationTest extends DbTestCase
         $db->expects($this->once())->method('rollBack'); // ... but a roll-back will be done.
         $db->expects($this->never())->method('commit');
 
-        $logger = $this->createMock(LoggerInterface::class);
-
-        $instance = new class ($db, $logger) extends AbstractPluginMigration {
+        $instance = new class ($db) extends AbstractPluginMigration {
             protected function validatePrerequisites(): bool
             {
                 return true;
@@ -251,9 +242,7 @@ class AbstractPluginMigrationTest extends DbTestCase
         $db->expects($this->once())->method('rollBack'); // ... but a roll-back will be done.
         $db->expects($this->never())->method('commit');
 
-        $logger = $this->createMock(LoggerInterface::class);
-
-        $instance = new class ($db, $logger) extends AbstractPluginMigration {
+        $instance = new class ($db) extends AbstractPluginMigration {
             protected function validatePrerequisites(): bool
             {
                 $this->result->addMessage(MessageType::Notice, 'Plugin\'s data can be imported.');
@@ -311,7 +300,7 @@ class AbstractPluginMigrationTest extends DbTestCase
         });
 
         $instance = $this->getMockBuilder(AbstractPluginMigration::class)
-            ->setConstructorArgs([$db, $this->createMock(LoggerInterface::class)])
+            ->setConstructorArgs([$db])
             ->onlyMethods(['execute', 'validatePrerequisites', 'processMigration'])
             ->getMock();
 
@@ -369,9 +358,8 @@ class AbstractPluginMigrationTest extends DbTestCase
     {
         // Arrange
         $db = $this->createMock(DBmysql::class);
-        $logger = $this->createMock(LoggerInterface::class);
 
-        $instance = new class ($db, $logger) extends AbstractPluginMigration {
+        $instance = new class ($db) extends AbstractPluginMigration {
             protected function validatePrerequisites(): bool
             {
                 return true;
@@ -496,9 +484,8 @@ class AbstractPluginMigrationTest extends DbTestCase
     {
         // Arrange
         $db = $this->createMock(DBmysql::class);
-        $logger = $this->createMock(LoggerInterface::class);
 
-        $instance = new class ($db, $logger) extends AbstractPluginMigration {
+        $instance = new class ($db) extends AbstractPluginMigration {
             protected function validatePrerequisites(): bool
             {
                 return true;
@@ -611,10 +598,8 @@ class AbstractPluginMigrationTest extends DbTestCase
             ]);
         });
 
-        $logger = $this->createMock(LoggerInterface::class);
-
         $instance = $this->getMockBuilder(AbstractPluginMigration::class)
-            ->setConstructorArgs([$db, $logger])
+            ->setConstructorArgs([$db])
             ->onlyMethods(['validatePrerequisites', 'processMigration'])
             ->getMock();
 

--- a/src/Glpi/Console/Migration/AbstractPluginMigrationCommand.php
+++ b/src/Glpi/Console/Migration/AbstractPluginMigrationCommand.php
@@ -79,6 +79,7 @@ abstract class AbstractPluginMigrationCommand extends AbstractCommand
         global $PHPLOGGER;
 
         $migration = $this->getMigration();
+        $migration->setLogger($PHPLOGGER);
         $migration->setProgressIndicator(new ConsoleProgressIndicator($output));
         $result = $migration->execute((bool) $input->getOption('dry-run'));
 

--- a/src/Glpi/Console/Migration/FormCreatorPluginToCoreCommand.php
+++ b/src/Glpi/Console/Migration/FormCreatorPluginToCoreCommand.php
@@ -38,7 +38,6 @@ use Glpi\Form\AccessControl\FormAccessControlManager;
 use Glpi\Form\Migration\FormMigration;
 use Glpi\Migration\AbstractPluginMigration;
 use Override;
-use Psr\Log\LoggerInterface;
 
 class FormCreatorPluginToCoreCommand extends AbstractPluginMigrationCommand
 {
@@ -57,9 +56,6 @@ class FormCreatorPluginToCoreCommand extends AbstractPluginMigrationCommand
     #[Override]
     public function getMigration(): AbstractPluginMigration
     {
-        /** @var LoggerInterface $PHPLOGGER */
-        global $PHPLOGGER;
-
-        return new FormMigration($this->db, $PHPLOGGER, FormAccessControlManager::getInstance());
+        return new FormMigration($this->db, FormAccessControlManager::getInstance());
     }
 }

--- a/src/Glpi/Form/Migration/FormMigration.php
+++ b/src/Glpi/Form/Migration/FormMigration.php
@@ -73,7 +73,6 @@ use Glpi\Form\QuestionType\QuestionTypeUrgency;
 use Glpi\Form\Section;
 use Glpi\Migration\AbstractPluginMigration;
 use LogicException;
-use Psr\Log\LoggerInterface;
 
 final class FormMigration extends AbstractPluginMigration
 {
@@ -87,10 +86,9 @@ final class FormMigration extends AbstractPluginMigration
 
     public function __construct(
         DBmysql $db,
-        LoggerInterface $logger,
         FormAccessControlManager $formAccessControlManager
     ) {
-        parent::__construct($db, $logger);
+        parent::__construct($db);
 
         $this->formAccessControlManager = $formAccessControlManager;
     }

--- a/src/Glpi/Migration/AbstractPluginMigration.php
+++ b/src/Glpi/Migration/AbstractPluginMigration.php
@@ -37,20 +37,17 @@ namespace Glpi\Migration;
 use CommonDBTM;
 use DBmysql;
 use Glpi\Progress\AbstractProgressIndicator;
-use Psr\Log\LoggerInterface;
+use Psr\Log\LoggerAwareTrait;
 use Glpi\Message\MessageType;
 
 abstract class AbstractPluginMigration
 {
+    use LoggerAwareTrait;
+
     /**
      * Progress indicator.
      */
     protected DBmysql $db;
-
-    /**
-     * Logger.
-     */
-    protected LoggerInterface $logger;
 
     /**
      * Progress indicator.
@@ -69,10 +66,9 @@ abstract class AbstractPluginMigration
      */
     private array $target_items_mapping = [];
 
-    public function __construct(DBmysql $db, LoggerInterface $logger)
+    public function __construct(DBmysql $db)
     {
         $this->db = $db;
-        $this->logger = $logger;
     }
 
     /**
@@ -114,7 +110,7 @@ abstract class AbstractPluginMigration
                 $e instanceof MigrationException ? $e->getLocalizedMessage() : __('An unexpected error occured.')
             );
 
-            $this->logger->error($e->getMessage(), context: ['exception' => $e]);
+            $this->logger?->error($e->getMessage(), context: ['exception' => $e]);
 
             if ($this->db->inTransaction()) {
                 $this->db->rollBack();


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

This simplify the migration concrete class constructors.