### PR TITLE
Show only unsolved tickets for Merge as Followup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The present file will list all changes made to the project; according to the
 ### Added
 
 ### Changed
+- Only unsolved/unclosed tickets will be shown in the dropdown when performing the "Merge as Followup" action.
 
 ### Deprecated
 

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -2707,7 +2707,12 @@ class Ticket extends CommonITILObject
                     'name'         => "_mergeticket",
                     'used'         => $ma->getItems()['Ticket'],
                     'displaywith'  => ['id'],
-                    'rand'         => $rand
+                    'rand'         => $rand,
+                    'condition'    => [
+                        'NOT' => [
+                            'status' => array_merge(self::getSolvedStatusArray(), self::getClosedStatusArray())
+                        ]
+                    ]
                 ];
                 echo "<table class='mx-auto'><tr>";
                 echo "<td><label for='dropdown__mergeticket$rand'>" . Ticket::getTypeName(1) . "</label></td><td colspan='3'>";


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Fixes #19172

Only show unsolved/unclosed tickets in the dropdown for the Merge as Followup massive action. This is both for performance reasons and also logical since followups usually cannot be added to solved/closed tickets.