### PR TITLE
Make sure the tester plugin is loaded in our phpunit tests

### DIFF
--- a/phpunit/GLPITestCase.php
+++ b/phpunit/GLPITestCase.php
@@ -79,6 +79,10 @@ class GLPITestCase extends TestCase
         $PHPLOGGER->setHandlers([$this->log_handler]);
 
         vfsStreamWrapper::register();
+
+        // Make sure the tester plugin is never deactived by a test as it would
+        // impact others tests that depend on it.
+        $this->assertTrue(Plugin::isPluginActive('tester'));
     }
 
     public function tearDown(): void
@@ -86,6 +90,10 @@ class GLPITestCase extends TestCase
         $this->resetGlobalsAndStaticValues();
 
         vfsStreamWrapper::unregister();
+
+        // Make sure the tester plugin is never deactived by a test as it would
+        // impact others tests that depend on it.
+        $this->assertTrue(Plugin::isPluginActive('tester'));
 
         if (isset($_SESSION['MESSAGE_AFTER_REDIRECT']) && !$this->has_failed) {
             unset($_SESSION['MESSAGE_AFTER_REDIRECT'][INFO]);

--- a/phpunit/functional/CronTaskTest.php
+++ b/phpunit/functional/CronTaskTest.php
@@ -227,34 +227,27 @@ class CronTaskTest extends DbTestCase
     {
         global $DB;
 
-        $plugins = new \Plugin();
-        $plugins->init();
+        // Deactivate all registered tasks
+        $crontask = new \CronTask();
+        $this->assertTrue($DB->update(\CronTask::getTable(), ['state' => \CronTask::STATE_DISABLE], [1]));
+        $this->assertFalse($crontask->getNeedToRun());
 
-        try {
-            // Deactivate all registered tasks
-            $crontask = new \CronTask();
-            $this->assertTrue($DB->update(\CronTask::getTable(), ['state' => \CronTask::STATE_DISABLE], [1]));
-            $this->assertFalse($crontask->getNeedToRun());
-
-            // Register task for active plugin.
-            $plugin_task = \CronTask::register(
-                $itemtype,
-                $name,
-                30,
-                [
-                    'state'   => \CronTask::STATE_WAITING,
-                    'hourmin' => 0,
-                    'hourmax' => 24,
-                ]
-            );
-            $this->assertNotFalse($plugin_task);
-            $this->assertEquals($should_run, $crontask->getNeedToRun());
-            if ($should_run) {
-                $this->assertEquals($itemtype, $crontask->fields['itemtype']);
-                $this->assertEquals($name, $crontask->fields['name']);
-            }
-        } finally {
-            $plugins->unactivateAll();
+        // Register task for active plugin.
+        $plugin_task = \CronTask::register(
+            $itemtype,
+            $name,
+            30,
+            [
+                'state'   => \CronTask::STATE_WAITING,
+                'hourmin' => 0,
+                'hourmax' => 24,
+            ]
+        );
+        $this->assertNotFalse($plugin_task);
+        $this->assertEquals($should_run, $crontask->getNeedToRun());
+        if ($should_run) {
+            $this->assertEquals($itemtype, $crontask->fields['itemtype']);
+            $this->assertEquals($name, $crontask->fields['name']);
         }
     }
 

--- a/phpunit/functional/InfocomTest.php
+++ b/phpunit/functional/InfocomTest.php
@@ -311,7 +311,7 @@ class InfocomTest extends DbTestCase
         $alerts = array_values(getAllDataFromTable(\Alert::getTable(), [
             'itemtype' => 'Infocom',
             'items_id' => [$deleted_infocom_id, $deleted_expired_infocom_id, $not_deleted_infocom_id],
-        ]));
+        ], order: 'id'));
 
         $this->assertCount(2, $alerts);
         $this->assertSame($not_deleted_infocom_id, $alerts[0]['items_id']);

--- a/tests/src/autoload/functions.php
+++ b/tests/src/autoload/functions.php
@@ -654,13 +654,6 @@ function loadDataset()
                 'itemtype'                 => 'Profile',
                 'items_id'                 => 3,
             ]
-        ], 'Plugin' => [
-            [
-                'directory'    => 'tester',
-                'name'         => 'tester',
-                'version'      => '1.0.0',
-                'state'        => 1,
-            ]
         ], 'Change' => [
             [
                 'name'           => '_change01',


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.

## Description

The current workaround of installing the tester plugin through the `loadDataset()` method is not good because it is done after the kernel is booted.
Thus, the call to `$Plugin::init()` was already make and the plugin is not taken into account by GLPI.

This is fixed by installing the plugin directly during the `InitializePlugins` process.


