### PR TITLE
Do not disable plugins during bugfixes updates

### DIFF
--- a/phpunit/functional/Glpi/Toolbox/VersionParserTest.php
+++ b/phpunit/functional/Glpi/Toolbox/VersionParserTest.php
@@ -49,6 +49,8 @@ class VersionParserTest extends \GLPITestCase
                 'version'             => '',
                 'keep_stability_flag' => false,
                 'normalized'          => '',
+                'major'               => '',
+                'intermediate'        => '',
                 'stable'              => true,
                 'dev'                 => false,
             ],
@@ -56,6 +58,8 @@ class VersionParserTest extends \GLPITestCase
                 'version'             => '9.5+2.0',
                 'keep_stability_flag' => false,
                 'normalized'          => '9.5+2.0', // not semver compatible, cannot be normalized
+                'major'               => '9',
+                'intermediate'        => '9.5',
                 'stable'              => true,
                 'dev'                 => false,
             ],
@@ -63,6 +67,8 @@ class VersionParserTest extends \GLPITestCase
                 'version'             => '0.89',
                 'keep_stability_flag' => false,
                 'normalized'          => '0.89.0',
+                'major'               => '0',
+                'intermediate'        => '0.89',
                 'stable'              => true,
                 'dev'                 => false,
             ],
@@ -70,6 +76,8 @@ class VersionParserTest extends \GLPITestCase
                 'version'             => '9.2',
                 'keep_stability_flag' => false,
                 'normalized'          => '9.2.0',
+                'major'               => '9',
+                'intermediate'        => '9.2',
                 'stable'              => true,
                 'dev'                 => false,
             ],
@@ -77,6 +85,8 @@ class VersionParserTest extends \GLPITestCase
                 'version'             => '9.2',
                 'keep_stability_flag' => true, // should have no effect
                 'normalized'          => '9.2.0',
+                'major'               => '9',
+                'intermediate'        => '9.2',
                 'stable'              => true,
                 'dev'                 => false,
             ],
@@ -84,6 +94,8 @@ class VersionParserTest extends \GLPITestCase
                 'version'             => '9.4.1.1',
                 'keep_stability_flag' => false,
                 'normalized'          => '9.4.1',
+                'major'               => '9',
+                'intermediate'        => '9.4',
                 'stable'              => true,
                 'dev'                 => false,
             ],
@@ -91,6 +103,8 @@ class VersionParserTest extends \GLPITestCase
                 'version'             => '10.0.0-dev',
                 'keep_stability_flag' => false,
                 'normalized'          => '10.0.0',
+                'major'               => '10',
+                'intermediate'        => '10.0',
                 'stable'              => false,
                 'dev'                 => true,
             ],
@@ -98,6 +112,8 @@ class VersionParserTest extends \GLPITestCase
                 'version'             => '10.0.0-dev',
                 'keep_stability_flag' => true,
                 'normalized'          => '10.0.0-dev',
+                'major'               => '10',
+                'intermediate'        => '10.0',
                 'stable'              => false,
                 'dev'                 => true,
             ],
@@ -105,6 +121,8 @@ class VersionParserTest extends \GLPITestCase
                 'version'             => '10.0.0-alpha',
                 'keep_stability_flag' => false,
                 'normalized'          => '10.0.0',
+                'major'               => '10',
+                'intermediate'        => '10.0',
                 'stable'              => false,
                 'dev'                 => false,
             ],
@@ -112,6 +130,8 @@ class VersionParserTest extends \GLPITestCase
                 'version'             => '10.0.0-alpha2',
                 'keep_stability_flag' => true,
                 'normalized'          => '10.0.0-alpha2',
+                'major'               => '10',
+                'intermediate'        => '10.0',
                 'stable'              => false,
                 'dev'                 => false,
             ],
@@ -119,6 +139,8 @@ class VersionParserTest extends \GLPITestCase
                 'version'             => '10.0.0-beta1',
                 'keep_stability_flag' => false,
                 'normalized'          => '10.0.0',
+                'major'               => '10',
+                'intermediate'        => '10.0',
                 'stable'              => false,
                 'dev'                 => false,
             ],
@@ -126,6 +148,8 @@ class VersionParserTest extends \GLPITestCase
                 'version'             => '10.0.0-beta1',
                 'keep_stability_flag' => true,
                 'normalized'          => '10.0.0-beta1',
+                'major'               => '10',
+                'intermediate'        => '10.0',
                 'stable'              => false,
                 'dev'                 => false,
             ],
@@ -133,6 +157,8 @@ class VersionParserTest extends \GLPITestCase
                 'version'             => '10.0.0-rc3',
                 'keep_stability_flag' => false,
                 'normalized'          => '10.0.0',
+                'major'               => '10',
+                'intermediate'        => '10.0',
                 'stable'              => false,
                 'dev'                 => false,
             ],
@@ -140,6 +166,8 @@ class VersionParserTest extends \GLPITestCase
                 'version'             => '10.0.0-rc',
                 'keep_stability_flag' => true,
                 'normalized'          => '10.0.0-rc',
+                'major'               => '10',
+                'intermediate'        => '10.0',
                 'stable'              => false,
                 'dev'                 => false,
             ],
@@ -147,6 +175,8 @@ class VersionParserTest extends \GLPITestCase
                 'version'             => '10.0.3',
                 'keep_stability_flag' => true,
                 'normalized'          => '10.0.3',
+                'major'               => '10',
+                'intermediate'        => '10.0',
                 'stable'              => true,
                 'dev'                 => false,
             ],
@@ -154,21 +184,36 @@ class VersionParserTest extends \GLPITestCase
     }
 
     #[DataProvider('versionsProvider')]
-    public function testGetNormalizeVersion(string $version, bool $keep_stability_flag, string $normalized, bool $stable, bool $dev): void
+    public function testGetNormalizeVersion(string $version, bool $keep_stability_flag, string $normalized, string $major, string $intermediate, bool $stable, bool $dev): void
     {
         $version_parser = new \Glpi\Toolbox\VersionParser();
         $this->assertEquals($normalized, $version_parser->getNormalizedVersion($version, $keep_stability_flag));
     }
 
     #[DataProvider('versionsProvider')]
-    public function testIsStableRelease(string $version, bool $keep_stability_flag, string $normalized, bool $stable, bool $dev): void
+    public function testGetMajorVersion(string $version, bool $keep_stability_flag, string $normalized, string $major, string $intermediate, bool $stable, bool $dev): void
+    {
+        $version_parser = new \Glpi\Toolbox\VersionParser();
+        $this->assertEquals($major, $version_parser->getMajorVersion($version));
+    }
+
+    #[DataProvider('versionsProvider')]
+    public function testGetIntermediateVersion(string $version, bool $keep_stability_flag, string $normalized, string $major, string $intermediate, bool $stable, bool $dev): void
+    {
+        $version_parser = new \Glpi\Toolbox\VersionParser();
+        $this->assertEquals($intermediate, $version_parser->getIntermediateVersion($version));
+    }
+
+
+    #[DataProvider('versionsProvider')]
+    public function testIsStableRelease(string $version, bool $keep_stability_flag, string $normalized, string $major, string $intermediate, bool $stable, bool $dev): void
     {
         $version_parser = new \Glpi\Toolbox\VersionParser();
         $this->assertSame($stable, $version_parser->isStableRelease($version));
     }
 
     #[DataProvider('versionsProvider')]
-    public function testIsDevVersion(string $version, bool $keep_stability_flag, string $normalized, bool $stable, bool $dev): void
+    public function testIsDevVersion(string $version, bool $keep_stability_flag, string $normalized, string $major, string $intermediate, bool $stable, bool $dev): void
     {
         $version_parser = new \Glpi\Toolbox\VersionParser();
         $this->assertSame($dev, $version_parser->isDevVersion($version));

--- a/src/Glpi/Toolbox/VersionParser.php
+++ b/src/Glpi/Toolbox/VersionParser.php
@@ -77,6 +77,26 @@ class VersionParser
     }
 
     /**
+     * Get major version number (e.g. '9').
+     */
+    public static function getMajorVersion(string $version): string
+    {
+        $normalized = self::getNormalizedVersion($version, false);
+
+        return \preg_replace('/^(\d+)[^d].+$/', '$1', $normalized);
+    }
+
+    /**
+     * Get intermediate version number (e.g. '9.5').
+     */
+    public static function getIntermediateVersion(string $version): string
+    {
+        $normalized = self::getNormalizedVersion($version, false);
+
+        return \preg_replace('/^(\d+\.\d+)[^d].+$/', '$1', $normalized);
+    }
+
+    /**
      * Check if given version is a stable release (i.e. does not contain a stability flag referring to unstable state).
      *
      * @param string $version

--- a/src/Update.php
+++ b/src/Update.php
@@ -212,10 +212,6 @@ class Update
        // To prevent problem of execution time
         ini_set("max_execution_time", "0");
 
-       // Update process desactivate all plugins
-        $plugin = new Plugin();
-        $plugin->unactivateAll();
-
         if (version_compare($current_version, GLPI_VERSION, '>')) {
             $message = sprintf(
                 __('Unsupported version (%1$s)'),
@@ -228,6 +224,13 @@ class Update
                 $this->migration->displayWarning($message, true);
                 exit(1);
             }
+        }
+
+        // Update process deactivate all plugins when GLPI is upgraded to a new intermediate/major version,
+        // to prevent blocking the GLPI execution if a plugin is incompatible with this new version.
+        if (VersionParser::getIntermediateVersion($current_version) !== VersionParser::getIntermediateVersion(GLPI_VERSION)) {
+            $plugin = new Plugin();
+            $plugin->unactivateAll();
         }
 
         $migrations = $this->getMigrationsToDo($current_version, $force_latest);


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] This change requires a documentation update.

## Description

It make sense to disable all plugins when GLPI is upgraded to a new intermediate version (e.g. 9.4 -> 9.5) or a new major version (9.5 -> 10.0), because we can introduce BC breaks in the code that would result in a complete GLPI crash when an incompatible plugin is loaded. But it does not seems required to do it when the update  does not contains more than bugfixes. Indeed, in bugfixes version, we are not suppose to introduce BC-breaks (see https://glpi-developer-documentation.readthedocs.io/en/develop/sourcecode.html#backward-compatibility).

I therefore propose to disable the plugins only when an update is made to a new intermediate or major version.

Please note that it will also prevent the `tester` plugin to be disabled on the test database everytime an update is made to update the DB to the latest dev version.
