### PR TITLE
fix(dashboard): increases widget limit from 50 to 99999

### DIFF
--- a/src/Dashboard/Provider.php
+++ b/src/Dashboard/Provider.php
@@ -801,7 +801,6 @@ class Provider
             'label'           => "",
             'searchoption_id' => $found_so_id,
             'icon'            => $fk_item::getIcon() ?? $item::getIcon(),
-            'limit'           => 99999,
             'join_key'        => 'LEFT JOIN',
             'apply_filters'   => [],
         ];
@@ -844,7 +843,6 @@ class Provider
                 ],
                 'GROUPBY'   => "$fk_table.$name",
                 'ORDERBY'   => "cpt DESC",
-                'LIMIT'     => $params['limit'],
             ],
             count($where) ? ['WHERE' => $where] : [],
             self::getFiltersCriteria($c_table, $params['apply_filters']),

--- a/src/Dashboard/Provider.php
+++ b/src/Dashboard/Provider.php
@@ -801,7 +801,7 @@ class Provider
             'label'           => "",
             'searchoption_id' => $found_so_id,
             'icon'            => $fk_item::getIcon() ?? $item::getIcon(),
-            'limit'           => 50,
+            'limit'           => 99999,
             'join_key'        => 'LEFT JOIN',
             'apply_filters'   => [],
         ];


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !36817
-Increased the limit of the maximum number of line lines displayed in dashboard widgets.

## Screenshots (if appropriate):

![Capture d’écran du 2025-03-14 10-32-37](https://github.com/user-attachments/assets/f863e5db-7d67-4425-adf7-c014cd831d25)



