### PR TITLE
feat(forms): add a badge that displays the number of elements in a section when it is collapsed

### DIFF
--- a/css/includes/components/form/_form-editor.scss
+++ b/css/includes/components/form/_form-editor.scss
@@ -303,6 +303,13 @@
     margin-bottom: 1rem !important;
 }
 
+// Hide question badge in section when section is not collapsed
+[data-glpi-form-editor-section]:not(.section-collapsed) {
+    [data-glpi-form-editor-section-block-badge] {
+        display: none;
+    }
+}
+
 [data-glpi-form-editor-question] {
     &[data-glpi-form-editor-active-question] {
         .dropdown-border {

--- a/js/modules/Forms/EditorController.js
+++ b/js/modules/Forms/EditorController.js
@@ -2029,6 +2029,23 @@ export class GlpiFormEditorController
     #collaspeSection(section) {
         // Simple class toggle, hiding the correct parts is handled by CSS rules
         section.toggleClass("section-collapsed");
+
+        // Update the block count
+        this.#updateSectionBlockCount(section);
+    }
+
+    /**
+     * Update the number of blocks for the given section
+     * @param {jQuery} section
+     */
+    #updateSectionBlockCount(section) {
+        const blocks = section
+            .find("[data-glpi-form-editor-block]")
+            .length;
+
+        // Update the badge with the new block count
+        const badge = section.find('span[data-glpi-form-editor-section-block-badge]');
+        badge.html(badge.html().trim().replace(/^\d+\s/, `${blocks} `));
     }
 
     /**

--- a/templates/pages/admin/form/form_section.html.twig
+++ b/templates/pages/admin/form/form_section.html.twig
@@ -98,6 +98,14 @@
                         'type': "Glpi\\Form\\Section",
                     }, with_context = false) }}
 
+                    {# Question count #}
+                    <span
+                        class="badge bg-secondary-lt"
+                        data-glpi-form-editor-section-block-badge
+                    >
+                        {{ _n('%d element', '%d elements', section.getBlocks()|length)|format(section.getBlocks()|length) }}
+                    </span>
+
                     {# Collapse section #}
                     <i
                         role="button"

--- a/tests/cypress/e2e/form/editor/editor.cy.js
+++ b/tests/cypress/e2e/form/editor/editor.cy.js
@@ -522,6 +522,95 @@ describe ('Form editor', () => {
         cy.findByRole('region', {'name': 'Question details'}).should('exist');
     });
 
+    it('can display correct element count in section badge', () => {
+        cy.createFormWithAPI().visitFormTab('Form');
+
+        // Add first question
+        cy.addQuestion("First question");
+
+        // Add a section
+        cy.addSection("Form section");
+
+        // Check badge is not visible when section is not collapsed
+        cy.findAllByRole('region', {'name': 'Form section'}).as('sections');
+        cy.get('@sections').each((section) => {
+            cy.wrap(section).find('[data-glpi-form-editor-section-block-badge]').should('not.be.visible');
+        });
+
+        // Collapse the section
+        cy.get('@sections').eq(0)
+            .findByRole('button', {'name': "Collapse section"})
+            .click();
+
+        // Check that the badge shows "1 element"
+        cy.get('@sections').eq(0)
+            .find('[data-glpi-form-editor-section-block-badge]')
+            .should('be.visible')
+            .and('contain.text', '1 element');
+
+        // Uncollapse the section
+        cy.get('@sections').eq(0)
+            .findByRole('button', {'name': "Collapse section"})
+            .click();
+
+        // Focus the first question to display hidden actions
+        cy.get('@sections').eq(0)
+            .findByRole('option', {'name': 'New question'})
+            .click();
+
+        // Add a second question
+        cy.addQuestion("Second question");
+
+        // Add a comment
+        cy.findByRole('button', {'name': "Add a new comment"}).click();
+        cy.focused().type("My comment");
+
+        // Collapse the section again
+        cy.get('@sections').eq(0)
+            .findByRole('button', {'name': "Collapse section"})
+            .click();
+
+        // Check that the badge shows "3 elements" (2 questions + 1 comment)
+        cy.get('@sections').eq(0)
+            .find('[data-glpi-form-editor-section-block-badge]')
+            .should('be.visible')
+            .and('contain.text', '3 elements');
+
+        // Delete one of the questions
+        cy.get('@sections').eq(0)
+            .findByRole('button', {'name': "Collapse section"})
+            .click();
+        cy.findAllByRole('region', {'name': 'Question details'}).eq(1).click(); // Focus question to display hidden actions
+        cy.findAllByRole('region', {'name': 'Question details'}).eq(1).within(() => {
+            cy.findByRole('button', {'name': 'Delete'}).click();
+        });
+
+        // Collapse the section again
+        cy.get('@sections').eq(0)
+            .findByRole('button', {'name': "Collapse section"})
+            .click();
+
+        // Check that the badge shows "2 elements" (1 question + 1 comment)
+        cy.get('@sections').eq(0)
+            .find('[data-glpi-form-editor-section-block-badge]')
+            .should('be.visible')
+            .and('contain.text', '2 elements');
+
+        // Save and reload
+        cy.saveFormEditorAndReload();
+
+        // Collapse the section again
+        cy.get('@sections').eq(0)
+            .findByRole('button', {'name': "Collapse section"})
+            .click();
+
+        // Check that the badge shows "2 elements" (1 question + 1 comment)
+        cy.get('@sections').eq(0)
+            .find('[data-glpi-form-editor-section-block-badge]')
+            .should('be.visible')
+            .and('contain.text', '2 elements');
+    });
+
     it('can reorder sections', () => {
         cy.createFormWithAPI().visitFormTab('Form');
 


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

This pull request introduces changes to the form editor to display the number of elements in a section badge and updates the corresponding tests. The most important changes include adding CSS rules to hide the badge when the section is not collapsed, updating the section block count in the JS controller, and adding the badge to the template. Additionally, a new test case is added to verify the correct element count in the section badge.

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/d5de56e3-1ae9-40a7-849c-d57fe26bdd30)