### PR TITLE
Allow undescores and numbers in custom objects system names

### DIFF
--- a/phpunit/functional/Glpi/Asset/AssetDefinitionManagerTest.php
+++ b/phpunit/functional/Glpi/Asset/AssetDefinitionManagerTest.php
@@ -60,15 +60,15 @@ class AssetDefinitionManagerTest extends DbTestCase
 
     public function testAutoloader(): void
     {
-        $this->initAssetDefinition('Test123'); // use a name with numbers, to validate it works as expected
+        $this->initAssetDefinition('Test_Item123'); // use a name with numbers and underscore, to validate it works as expected
 
-        $this->assertTrue(\class_exists('Glpi\CustomAsset\Test123'));
-        $this->assertTrue(\class_exists('Glpi\CustomAsset\Test123Model'));
-        $this->assertTrue(\class_exists('Glpi\CustomAsset\Test123Type'));
-        $this->assertTrue(\class_exists('Glpi\CustomAsset\RuleDictionaryTest123ModelCollection'));
-        $this->assertTrue(\class_exists('Glpi\CustomAsset\RuleDictionaryTest123Model'));
-        $this->assertTrue(\class_exists('Glpi\CustomAsset\RuleDictionaryTest123TypeCollection'));
-        $this->assertTrue(\class_exists('Glpi\CustomAsset\RuleDictionaryTest123Type'));
+        $this->assertTrue(\class_exists('Glpi\CustomAsset\Test_Item123'));
+        $this->assertTrue(\class_exists('Glpi\CustomAsset\Test_Item123Model'));
+        $this->assertTrue(\class_exists('Glpi\CustomAsset\Test_Item123Type'));
+        $this->assertTrue(\class_exists('Glpi\CustomAsset\RuleDictionaryTest_Item123ModelCollection'));
+        $this->assertTrue(\class_exists('Glpi\CustomAsset\RuleDictionaryTest_Item123Model'));
+        $this->assertTrue(\class_exists('Glpi\CustomAsset\RuleDictionaryTest_Item123TypeCollection'));
+        $this->assertTrue(\class_exists('Glpi\CustomAsset\RuleDictionaryTest_Item123Type'));
     }
 
     /**

--- a/phpunit/functional/Glpi/Asset/AssetDefinitionTest.php
+++ b/phpunit/functional/Glpi/Asset/AssetDefinitionTest.php
@@ -349,6 +349,35 @@ class AssetDefinitionTest extends DbTestCase
             ],
         ];
 
+        // System name can contain an underscore
+        yield [
+            'input'    => [
+                'system_name' => 'Custom_Item',
+            ],
+            'output'   => [
+                'system_name'  => 'Custom_Item',
+                'label'        => 'Custom_Item',
+                'capacities'   => '[]',
+                'profiles'     => '[]',
+                'translations' => '[]',
+                'fields_display' => '[]',
+            ],
+            'messages' => [],
+        ];
+
+        // System name must not end with an underscore
+        yield [
+            'input'    => [
+                'system_name' => 'CustomItem_',
+            ],
+            'output'   => false,
+            'messages' => [
+                ERROR => [
+                    'The following field has an incorrect value: &quot;System name&quot;.',
+                ],
+            ],
+        ];
+
         // System name must not end with `Model` suffix
         yield [
             'input'    => [

--- a/phpunit/functional/Glpi/Dropdown/DropdownDefinitionManagerTest.php
+++ b/phpunit/functional/Glpi/Dropdown/DropdownDefinitionManagerTest.php
@@ -57,9 +57,9 @@ class DropdownDefinitionManagerTest extends DbTestCase
 
     public function testAutoloader(): void
     {
-        $this->initDropdownDefinition('Iso3CountryCode'); // use a name with numbers, to validate it works as expected
+        $this->initDropdownDefinition('Iso3Country_Code'); // use a name with numbers and underscore, to validate it works as expected
 
-        $this->assertTrue(\class_exists('Glpi\CustomDropdown\Iso3CountryCode'));
+        $this->assertTrue(\class_exists('Glpi\CustomDropdown\Iso3Country_Code'));
     }
 
     /**

--- a/phpunit/functional/Glpi/Dropdown/DropdownDefinitionTest.php
+++ b/phpunit/functional/Glpi/Dropdown/DropdownDefinitionTest.php
@@ -294,6 +294,33 @@ class DropdownDefinitionTest extends DbTestCase
             ],
         ];
 
+        // System name can contain an underscore
+        yield [
+            'input'    => [
+                'system_name' => 'Custom_Dropdown',
+            ],
+            'output'   => [
+                'system_name'  => 'Custom_Dropdown',
+                'label'        => 'Custom_Dropdown',
+                'profiles'     => '[]',
+                'translations' => '[]',
+            ],
+            'messages' => [],
+        ];
+
+        // System name must not end with an underscore
+        yield [
+            'input'    => [
+                'system_name' => 'CustomDropdown_',
+            ],
+            'output'   => false,
+            'messages' => [
+                ERROR => [
+                    'The following field has an incorrect value: &quot;System name&quot;.',
+                ],
+            ],
+        ];
+
         // System name must not end with `Model` suffix
         yield [
             'input'    => [

--- a/src/Glpi/Asset/CustomFieldDefinition.php
+++ b/src/Glpi/Asset/CustomFieldDefinition.php
@@ -162,7 +162,7 @@ final class CustomFieldDefinition extends CommonDBChild
         /** @var \DBmysql $DB */
         global $DB;
 
-        if (!is_string($input['system_name']) || preg_match('/^[a-z_]+$/', $input['system_name']) !== 1) {
+        if (!is_string($input['system_name']) || preg_match('/^[a-z0-9_]+$/', $input['system_name']) !== 1) {
             Session::addMessageAfterRedirect(
                 htmlescape(sprintf(
                     __('The following field has an incorrect value: "%s".'),

--- a/src/Glpi/CustomObject/AbstractDefinition.php
+++ b/src/Glpi/CustomObject/AbstractDefinition.php
@@ -55,9 +55,10 @@ abstract class AbstractDefinition extends CommonDBTM
      * System name regex pattern.
      *
      * 1. Must start with a letter.
-     * 2. Must contain only letters or numbers.
+     * 2. Must contain only letters, numbers, or underscores.
+     * 3. Must not end with an underscore.
      */
-    public const SYSTEM_NAME_PATTERN = '[A-Za-z][A-Za-z0-9]*';
+    public const SYSTEM_NAME_PATTERN = '[A-Za-z][A-Za-z0-9_]*[A-Za-z0-9]';
 
     public static $rightname = 'config';
 

--- a/templates/pages/admin/customobjects/main.html.twig
+++ b/templates/pages/admin/customobjects/main.html.twig
@@ -158,7 +158,7 @@
             }
 
             $('#mainformtable input[name="system_name"]').val(
-                $('#mainformtable input[name="label"]').val().normalize('NFD').replace(/[^a-z0-9]/gi, '')
+                $('#mainformtable input[name="label"]').val().normalize('NFD').replace(/[^a-z0-9_]/gi, '')
             );
             $('#mainformtable input[name="system_name"]').trigger('input');
         };

--- a/templates/pages/assets/customfield.html.twig
+++ b/templates/pages/assets/customfield.html.twig
@@ -102,7 +102,7 @@
                 }
                 // label is made lowercase and spaces are replaced with underscores. All other characters are removed
                 $('#customfield_form_container input[name="system_name"]')
-                    .val($('#customfield_form_container input[name="label"]').val().normalize('NFD').toLowerCase().replace(/ /g, '_').replace(/[^a-z_]/g, ''));
+                    .val($('#customfield_form_container input[name="label"]').val().normalize('NFD').toLowerCase().replace(/ /g, '_').replace(/[^a-z0-9_]/g, ''));
             };
             const updateDefaultValueField = () => {
                 // get all inputs with name starting with field_options and create an object with the values

--- a/tests/cypress/e2e/Asset/asset_definition.cy.js
+++ b/tests/cypress/e2e/Asset/asset_definition.cy.js
@@ -65,7 +65,7 @@ describe("Custom Assets - Definitions", () => {
     });
 
     it('Profiles tab', () => {
-        const system_name = `test${Math.random().toString(36).replace(/[^a-z]+/g, '')}`;
+        const system_name = `test${Math.random().toString(36).replace(/[^a-z0-9_]+/g, '')}`;
         cy.createWithAPI('Glpi\\Asset\\AssetDefinition', {
             system_name: system_name,
             is_active: true,


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

It seems that generic object dropdown may contains underscore in their name, and custom fields names may contain numbers. To ease their migration in GLPI, we could allow underscores in the custom assets/dropdowns system names and numbers in custom fields system names.