### PR TITLE
Fix(ItemDevice): add missing declaration from define.php

### DIFF
--- a/inc/define.php
+++ b/inc/define.php
@@ -373,6 +373,10 @@ $CFG_GLPI['itemdevicemotherboard_types']  = ['Computer', 'Phone'];
 
 $CFG_GLPI['itemdevicecamera_types']  = ['Computer', 'Phone'];
 
+$CFG_GLPI['itemdevicedrive_types']  = ['Computer', 'Peripheral'];
+
+$CFG_GLPI['itemdevicecontrol_types']  = ['Computer', 'Peripheral', 'Phone', 'NetworkEquipment', 'Printer'];
+
 $CFG_GLPI["notificationtemplates_types"]  = ['CartridgeItem', 'Change', 'ConsumableItem',
     'Contract', 'CronTask', 'DBConnection',
     'FieldUnicity', 'Infocom', 'MailCollector',


### PR DESCRIPTION

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !

by working on https://github.com/pluginsGLPI/genericobject/pull/420

and missing related components
- `itemdevicedrive_types`
- `itemdevicecontrol_types`

I realised that the appropriate declarations were missing for registering a class (from `genericobject` in my case)  on these components

## Screenshots (if appropriate):


