### PR TITLE
fix(ticket template): sub tables not cleaned when ticket template is …

### DIFF
--- a/src/ChangeTemplate.php
+++ b/src/ChangeTemplate.php
@@ -59,6 +59,17 @@ class ChangeTemplate extends ITILTemplate
         ];
     }
 
+    public function cleanDBonPurge()
+    {
+        $this->deleteChildrenAndRelationsFromDb(
+            [
+                ChangeTemplateHiddenField::class,
+                ChangeTemplateMandatoryField::class,
+                ChangeTemplatePredefinedField::class,
+            ]
+        );
+    }
+
     public static function getExtraAllowedFields($withtypeandcategory = false, $withitemtype = false)
     {
         $change = new Change();

--- a/src/ProblemTemplate.php
+++ b/src/ProblemTemplate.php
@@ -59,6 +59,17 @@ class ProblemTemplate extends ITILTemplate
         ];
     }
 
+    public function cleanDBonPurge()
+    {
+        $this->deleteChildrenAndRelationsFromDb(
+            [
+                ProblemTemplateHiddenField::class,
+                ProblemTemplateMandatoryField::class,
+                ProblemTemplatePredefinedField::class,
+            ]
+        );
+    }
+
     public static function getExtraAllowedFields($withtypeandcategory = false, $withitemtype = false)
     {
         $problem = new Problem();

--- a/src/TicketTemplate.php
+++ b/src/TicketTemplate.php
@@ -59,6 +59,17 @@ class TicketTemplate extends ITILTemplate
         ];
     }
 
+    public function cleanDBonPurge()
+    {
+        $this->deleteChildrenAndRelationsFromDb(
+            [
+                TicketTemplateHiddenField::class,
+                TicketTemplateMandatoryField::class,
+                TicketTemplatePredefinedField::class,
+            ]
+        );
+    }
+
     public static function getExtraAllowedFields($withtypeandcategory = false, $withitemtype = false)
     {
         $itil_object = new Ticket();


### PR DESCRIPTION
…deleted

<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !36831

When a ticket template is deleted, the tables `glpi_tickettemplatemandatoryfields`, `glpi_tickettemplatepredefinedfields`, `glpi_tickettemplatehiddenfields` were not cleaned up.

## Screenshots (if appropriate):


