### PR TITLE
Fix custom object autoloader cache in testing context

### DIFF
--- a/phpunit/GLPITestCase.php
+++ b/phpunit/GLPITestCase.php
@@ -34,6 +34,7 @@
  */
 
 use Glpi\Asset\AssetDefinitionManager;
+use Glpi\Dropdown\DropdownDefinitionManager;
 use Glpi\Tests\Log\TestHandler;
 use Monolog\Level;
 use org\bovigo\vfs\vfsStreamWrapper;
@@ -450,6 +451,7 @@ class GLPITestCase extends TestCase
         CommonDBTM::clearSearchOptionCache();
         \Glpi\Search\SearchOption::clearSearchOptionCache();
         AssetDefinitionManager::unsetInstance();
+        DropdownDefinitionManager::unsetInstance();
         Dropdown::resetItemtypesStaticCache();
     }
 

--- a/src/Glpi/Dropdown/DropdownDefinitionManager.php
+++ b/src/Glpi/Dropdown/DropdownDefinitionManager.php
@@ -49,12 +49,6 @@ final class DropdownDefinitionManager extends AbstractDefinitionManager
     private static ?DropdownDefinitionManager $instance = null;
 
     /**
-     * Definitions cache.
-     * @var DropdownDefinition[]|null
-     */
-    protected ?array $definitions_data;
-
-    /**
      * Get singleton instance
      *
      * @return DropdownDefinitionManager
@@ -66,6 +60,16 @@ final class DropdownDefinitionManager extends AbstractDefinitionManager
         }
 
         return self::$instance;
+    }
+
+    /**
+     * Unset the singleton instance
+     *
+     * @return void
+     */
+    public static function unsetInstance(): void
+    {
+        self::$instance = null;
     }
 
     public static function getDefinitionClass(): string


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

In #19033 , I had issues with the custom objects autoloader that was not able to find the created custom classes. I figured out that the registered autoloader was the one instanciated during the GLPI boot, due to the usage of `$this` (`spl_autoload_register([$this, 'autoloadClass']);`). Due to this, the `AssetDefinitionManager::unsetInstance();` had no effect on the cached definitions used by the autoloader.

I fixed it by always using the current instance in the custom objects autoloader.

I also simplified how the cache is handled, by removing a useless nesting level in the `$definitions_data` property.