### PR TITLE
remove z-index on error alerts

### DIFF
--- a/src/Glpi/Error/ErrorDisplayHandler/HtmlErrorDisplayHandler.php
+++ b/src/Glpi/Error/ErrorDisplayHandler/HtmlErrorDisplayHandler.php
@@ -69,7 +69,7 @@ final class HtmlErrorDisplayHandler implements ErrorDisplayHandler
     public function displayErrorMessage(string $error_label, string $message, string $log_level): void
     {
         echo \sprintf(
-            '<div class="alert alert-important alert-danger glpi-debug-alert" style="z-index:10000"><span class="fw-bold">%s: </span>%s</div>',
+            '<div class="alert alert-important alert-danger glpi-debug-alert"><span class="fw-bold">%s: </span>%s</div>',
             \htmlescape($error_label),
             \htmlescape($message)
         );


### PR DESCRIPTION
## Description

fix 
![image](https://github.com/user-attachments/assets/c5a2ffa9-8b7a-4a00-9d2f-2165489d0704)

An alternative could be to set the z-index to 1000 according to the Bootstrap doc:

```
$zindex-dropdown:                   1000;
$zindex-sticky:                     1020;
$zindex-fixed:                      1030;
$zindex-modal-backdrop:             1040;
$zindex-offcanvas:                  1050;
$zindex-modal:                      1060;
$zindex-popover:                    1070;
$zindex-tooltip:                    1080;
```


