### PR TITLE
Use synchronous queries when renaming an itemtype

### DIFF
--- a/src/Migration.php
+++ b/src/Migration.php
@@ -1734,12 +1734,10 @@ class Migration
             ]
         );
         foreach ($itemtype_column_iterator as $itemtype_column) {
-            $this->addPostQuery(
-                $DB->buildUpdate(
-                    $itemtype_column['TABLE_NAME'],
-                    [$itemtype_column['COLUMN_NAME'] => $new_itemtype],
-                    [$itemtype_column['COLUMN_NAME'] => $old_itemtype]
-                )
+            $DB->update(
+                $itemtype_column['TABLE_NAME'],
+                [$itemtype_column['COLUMN_NAME'] => $new_itemtype],
+                [$itemtype_column['COLUMN_NAME'] => $old_itemtype]
             );
         }
     }

--- a/tests/functional/Migration.php
+++ b/tests/functional/Migration.php
@@ -1057,13 +1057,13 @@ class Migration extends \GLPITestCase
 
         $this->array($this->queries)->isIdenticalTo([
             "RENAME TABLE `glpi_someoldtypes` TO `glpi_newnames`",
-            "ALTER TABLE `glpi_oneitem_with_fkey` CHANGE `someoldtypes_id` `newnames_id` int unsigned NOT NULL DEFAULT '0'   ",
-            "ALTER TABLE `glpi_anotheritem_with_fkey` CHANGE `someoldtypes_id` `newnames_id` int unsigned NOT NULL DEFAULT '0'   ,\n"
-         . "CHANGE `someoldtypes_id_tech` `newnames_id_tech` int unsigned NOT NULL DEFAULT '0'   ",
             "UPDATE `glpi_computers` SET `itemtype` = 'NewName' WHERE `itemtype` = 'SomeOldType'",
             "UPDATE `glpi_users` SET `itemtype` = 'NewName' WHERE `itemtype` = 'SomeOldType'",
             "UPDATE `glpi_stuffs` SET `itemtype_source` = 'NewName' WHERE `itemtype_source` = 'SomeOldType'",
             "UPDATE `glpi_stuffs` SET `itemtype_dest` = 'NewName' WHERE `itemtype_dest` = 'SomeOldType'",
+            "ALTER TABLE `glpi_oneitem_with_fkey` CHANGE `someoldtypes_id` `newnames_id` int unsigned NOT NULL DEFAULT '0'   ",
+            "ALTER TABLE `glpi_anotheritem_with_fkey` CHANGE `someoldtypes_id` `newnames_id` int unsigned NOT NULL DEFAULT '0'   ,\n"
+                . "CHANGE `someoldtypes_id_tech` `newnames_id_tech` int unsigned NOT NULL DEFAULT '0'   ",
         ]);
 
        // Test renaming without DB structure update


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

During a GLPI 10.0 -> 11.0 migration, I had the following issue:
```
An error occurred during the update. The error was: MySQL query error: Table 'glpi.glpi_networkportmigrations' doesn't exist (1146) in SQL query "UPDATE `glpi_networkportmigrations` SET `itemtype` = 'Glpi\\Event' WHERE `itemtype` = 'Event'".
```

This is due to the fact that the `$migration->renameItemtype('Event', Event::class);` is executed before the removal of the `glpi_networkportmigrations` table. Using synchronous queries instead of queued queries for the itemtype renaming fixes this issue.