### PR TITLE
Reduce custom asset definition deletion time

### DIFF
--- a/src/Glpi/Asset/AssetDefinition.php
+++ b/src/Glpi/Asset/AssetDefinition.php
@@ -385,10 +385,9 @@ TWIG, $twig_params);
             $this->onCapacityDisabled($capacity_classname);
         }
 
+        $this->purgeConcreteClassFromDb($this->getCustomObjectClassName());
         $this->purgeConcreteClassFromDb($this->getAssetModelClassName());
         $this->purgeConcreteClassFromDb($this->getAssetTypeClassName());
-
-        parent::cleanDBonPurge();
     }
 
     /**


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

When deleting a custom asset definition, it is preferable to first remove the custom assets themselves and then remove the custom models and types. Indeed, if types or models are removed first, GLPI will, for each of them, check if they are used and update each custom asset that use them to remove the relation. As long as the custom assets are going to be removed, updating them is useless.