### PR TITLE
⚠️ ⚠️💥 Fix(Search): do not compute  `$nott` from self 💥⚠️ ⚠️

### DIFF
--- a/phpunit/functional/SearchTest.php
+++ b/phpunit/functional/SearchTest.php
@@ -2468,6 +2468,26 @@ class SearchTest extends DbTestCase
             [
                 'link' => ' ',
                 'nott' => 0,
+                'itemtype' => \Ticket::class,
+                'ID' => 2, // ID
+                'searchtype' => 'notequals',
+                'val' => '5',
+                'meta' => false,
+                'expected' => "(`glpi_tickets`.`id` <> 5)",
+            ],
+            [
+                'link' => ' ',
+                'nott' => 0,
+                'itemtype' => \Ticket::class,
+                'ID' => 2, // ID
+                'searchtype' => 'notcontains',
+                'val' => '88',
+                'meta' => false,
+                'expected' => "(`glpi_tickets`.`id` <> 88)",
+            ],
+            [
+                'link' => ' ',
+                'nott' => 0,
                 'itemtype' => \User::class,
                 'ID' => 99,
                 'searchtype' => 'equals',

--- a/src/Search.php
+++ b/src/Search.php
@@ -5409,7 +5409,7 @@ JAVASCRIPT;
                         $numeric_val = floatval($val);
 
                         if (in_array($searchtype, ["notequals", "notcontains"])) {
-                            $nott = !$nott;
+                            $nott = true;
                         }
 
                         if (isset($searchopt[$ID]["width"])) {


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !36903

### 🛠️ PR: Mission Impossible – GLPI Search Edition 🔍💥  

👋 **Hey R&D team**,  

Today, I embarked on a mission worthy of **caffeinated Tom Cruise**: fixing GLPI’s search without triggering a digital apocalypse.  

🚨 **Context: The Cursed File**  
- I had to face **Search.php**, a **9000+ line beast**, written in an ancient language only the devs of old can decipher.  
- This class is **so critical** that even an extra space could cause GLPI’s search engine to collapse.  

🐛 **The Bug (or rather, the Curse)**  
- Present **since version 9.5**, but apparently **only affects one person** (shoutout to support 👋).  
- It makes the **"item ID IS NOT X" search completely useless**, because it **literally returns the ITEM with the ID I wanted to exclude**. A search engine… just a little *too* eager.  

🔧 **What I tried to do (with limited survival gear)**  
- Fix the bug **without awakening Cthulhu** inside` Search.php`.  
- Avoid breaking everything else in the search engine (fingers crossed 🤞).  
- Apply the “change, pray, test” methodology.  

🔥 **Danger level: Code Red**  
- High probability that my patch is **both a fix and a future bug**.  
- If it works, it’s probably by accident.  

📢 **Message to the team**  
I **still** have no idea what I’m doing, but if you’re feeling brave, a review would be appreciated. Otherwise, let’s merge, close our eyes, and pretend everything is fine.  

Good luck to those who dare test it… and may **Search.php be merciful to you**. 🚀💀  

PS: If support still says it doesn’t work, we officially **call it a feature, not a bug**. 😈


## Screenshots (if appropriate):


