### PR TITLE
Try to re-enable all log levels in tests

### DIFF
--- a/src/Glpi/Error/ErrorHandler.php
+++ b/src/Glpi/Error/ErrorHandler.php
@@ -226,25 +226,12 @@ final class ErrorHandler extends BaseErrorHandler
         $reporting_level = E_ALL;
         foreach (self::ERROR_LEVEL_MAP as $value => $log_level) {
             if (
-                $this->env !== GLPI::ENV_DEVELOPMENT
-                && \in_array($log_level, [LogLevel::DEBUG, LogLevel::INFO], true)
-            ) {
-                // Do not report debug and info messages unless in development env.
-                // Suppressing the INFO level will prevent deprecations to be pushed in other environments logs.
-                //
-                // Suppressing the deprecations in the testing environment is mandatory to prevent deprecations
-                // triggered in vendor code to make our test suite fail.
-                // We may review this part once we will have migrate all our test suite on PHPUnit.
-                // For now, we rely on PHPStan to detect usages of deprecated code.
-                $reporting_level &= ~$value;
-            }
-
-            if (
-                $log_level === LogLevel::NOTICE
+                \in_array($log_level, [LogLevel::DEBUG, LogLevel::INFO, LogLevel::NOTICE], true)
                 && !\in_array($this->env, [GLPI::ENV_DEVELOPMENT, GLPI::ENV_TESTING], true)
             ) {
-                // Do not report notice messages unless in development/testing env.
+                // Do not report debug, info, and notice messages unless in development/testing env.
                 // Notices are errors with no functional impact, so we do not want people to report them as issues.
+                // Suppressing the INFO level will prevent deprecations to be pushed in other environments logs.
                 $reporting_level &= ~$value;
             }
         }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

PHPStan deprecations detection is only based on the `@deprecated` tag presence. If we want to detect all deprecated usages in our code, we need to report them in the `testing` environment.