### PR TITLE
Fix deletion of a used asset model/type

### DIFF
--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -979,7 +979,7 @@ class CommonDBTM extends CommonGLPI
                         ]
                     );
                     foreach ($result as $data) {
-                        $item = new $itemtype();
+                        $item = $itemtype::getById($data[$id_field]);
                         $input =  [
                             $id_field       => $data[$id_field],
                             '_disablenotif' => true,

--- a/src/CommonDropdown.php
+++ b/src/CommonDropdown.php
@@ -659,7 +659,7 @@ abstract class CommonDropdown extends CommonDBTM
             $replacement_options['used'] = [$ID];
         }
         Dropdown::show(
-            getItemTypeForTable($this->getTable()),
+            static::class,
             $replacement_options
         );
         echo "<input type='hidden' name='id' value='$ID' />";


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

This fixes 2 errors preventing the deletion of an asset model/type used in at least one asset.


First, an error preventing the replacement dropdown to be shown.

```
glpi.WARNING:   *** User Warning: Cannot instanciate "Glpi\Asset\AssetModel" as it is an abstract class. at DbUtils.php line 536
  Backtrace :
  ./src/DbUtils.php:536                              
  ./src/autoload/dbutils-aliases.php:147             DbUtils->getItemForItemtype()
  ./src/Dropdown.php:113                             getItemForItemtype()
  ./src/CommonDropdown.php:660                       Dropdown::show()
  .../Glpi/Controller/DropdownFormController.php:128 CommonDropdown->showDeleteConfirmForm()
  ...c/Glpi/Controller/DropdownFormController.php:67 Glpi\Controller\DropdownFormController::loadDropdownForm()
  ./vendor/symfony/http-kernel/HttpKernel.php:101    Glpi\Controller\DropdownFormController->{closure:Glpi\Controller\DropdownFormController::__invoke():65}()
  ...ymfony/http-foundation/StreamedResponse.php:106 Symfony\Component\HttpKernel\HttpKernel::{closure:Symfony\Component\HttpKernel\HttpKernel::handle():98}()
  ./vendor/symfony/http-foundation/Response.php:423  Symfony\Component\HttpFoundation\StreamedResponse->sendContent()
  ./src/Glpi/Kernel/Kernel.php:234                   Symfony\Component\HttpFoundation\Response->send()
  ./public/index.php:58                              Glpi\Kernel\Kernel->sendResponse()
```

Second, and error preventing to correctly update the linked assets.
```
glpi.CRITICAL:   *** Uncaught PHP Exception Error: "Cannot instantiate abstract class Glpi\Asset\Asset" at CommonDBTM.php line 986
  Backtrace :
  ./src/CommonDBTM.php:986                           
  ./src/CommonDBTM.php:843                           CommonDBTM->cleanRelationData()
  ./src/CommonDBTM.php:2213                          CommonDBTM->deleteFromDB()
  ./src/CommonDBTM.php:4825                          CommonDBTM->delete()
  ./src/Glpi/CustomObject/AbstractDefinition.php:584 CommonDBTM->deleteByCriteria()
  ./src/Glpi/Asset/AssetDefinition.php:389           Glpi\CustomObject\AbstractDefinition->purgeConcreteClassFromDb()
  ./src/CommonDBTM.php:838                           Glpi\Asset\AssetDefinition->cleanDBonPurge()
  ./src/CommonDBTM.php:2213                          CommonDBTM->deleteFromDB()
  ./front/asset/assetdefinition.form.php:104         CommonDBTM->delete()
  ...Glpi/Controller/LegacyFileLoadController.php:59 require()
  ./vendor/symfony/http-kernel/HttpKernel.php:101    Glpi\Controller\LegacyFileLoadController->{closure:Glpi\Controller\LegacyFileLoadController::__invoke():58}()
  ...ymfony/http-foundation/StreamedResponse.php:106 Symfony\Component\HttpKernel\HttpKernel::{closure:Symfony\Component\HttpKernel\HttpKernel::handle():98}()
  ./vendor/symfony/http-foundation/Response.php:423  Symfony\Component\HttpFoundation\StreamedResponse->sendContent()
  ./src/Glpi/Kernel/Kernel.php:234                   Symfony\Component\HttpFoundation\Response->send()
  ./public/index.php:58                              Glpi\Kernel\Kernel->sendResponse()
```

