### PR TITLE
Fix group not deleted for LDAP user

### DIFF
--- a/phpunit/LDAP/AuthLdapTest.php
+++ b/phpunit/LDAP/AuthLdapTest.php
@@ -2256,6 +2256,7 @@ class AuthLDAPTest extends DbTestCase
         $this->assertGreaterThan(0, $users_id);
 
         // Check the dynamic group is deleted without losing the manual groups
+        $this->assertFalse(\Group_User::isUserInGroup($users_id, $group_id));
         $this->assertTrue(\Group_User::isUserInGroup($users_id, $group2_id));
 
         // Create 2 manual groups

--- a/phpunit/LDAP/AuthLdapTest.php
+++ b/phpunit/LDAP/AuthLdapTest.php
@@ -2217,10 +2217,10 @@ class AuthLDAPTest extends DbTestCase
         ]);
 
         // Create 2 dynamic group
-        $group_id = $this->createItem(Group::class, ["name" => "testgroup1"]);
+        $group_id = $this->createItem(Group::class, ["name" => "testgroup1"])->getID();
         $this->assertGreaterThan(0, $group_id);
 
-        $group2_id = $this->createItem(Group::class, ["name" => "testgroup2"]);
+        $group2_id = $this->createItem(Group::class, ["name" => "testgroup2"])->getID();
         $this->assertGreaterThan(0, $group2_id);
 
         // Add groups with a rule
@@ -2229,7 +2229,7 @@ class AuthLDAPTest extends DbTestCase
             'action_type' => 'assign',
             'field'       => 'specific_groups_id',
             'value'       => $group_id,
-        ]);
+        ])->getID();
 
         // login the user to force a real synchronisation and get it's glpi id
         $this->login('brazil6', 'password', false);
@@ -2259,9 +2259,9 @@ class AuthLDAPTest extends DbTestCase
         $this->assertTrue(\Group_User::isUserInGroup($users_id, $group2_id));
 
         // Create 2 manual groups
-        $mgroup_id = $this->createItem(Group::class, ["name" => "manualgroup1"]);
+        $mgroup_id = $this->createItem(Group::class, ["name" => "manualgroup1"])->getID();
         $this->assertGreaterThan(0, $mgroup_id);
-        $mgroup2_id = $this->createItem(Group::class, ["name" => "manualgroup2"]);
+        $mgroup2_id = $this->createItem(Group::class, ["name" => "manualgroup2"])->getID();
         $this->assertGreaterThan(0, $mgroup2_id);
 
         // Add 2 groups manualy
@@ -2269,12 +2269,12 @@ class AuthLDAPTest extends DbTestCase
         $gu_id = $this->createItem(Group_User::class, [
             'users_id' => $users_id,
             'groups_id' => $mgroup_id,
-        ]);
+        ])->getID();
         $this->assertGreaterThan(0, $gu_id);
         $gu_id = $this->createItem(Group_User::class, [
             'users_id' => $users_id,
             'groups_id' => $mgroup2_id,
-        ]);
+        ])->getID();
         $this->assertGreaterThan(0, $gu_id);
 
         // Check group

--- a/phpunit/LDAP/AuthLdapTest.php
+++ b/phpunit/LDAP/AuthLdapTest.php
@@ -2186,7 +2186,7 @@ class AuthLDAPTest extends DbTestCase
         //prepare rules
         $rules = new \RuleRight();
         $rules_id = $rules->add([
-            'sub_type'     => 'GroupRuleRight',
+            'sub_type'     => 'RuleRight',
             'name'         => 'test ldap groupruleright',
             'match'        => 'AND',
             'is_active'    => 1,

--- a/phpunit/LDAP/AuthLdapTest.php
+++ b/phpunit/LDAP/AuthLdapTest.php
@@ -2273,7 +2273,7 @@ class AuthLDAPTest extends DbTestCase
         $gu = new Group_User();
         $gus = $gu->find([
             'users_id' => $users_id,
-            'is_dynamic' => 0,
+            'is_dynamic' => false,
         ]);
         $this->assertCount(2, $gus);
 

--- a/phpunit/LDAP/AuthLdapTest.php
+++ b/phpunit/LDAP/AuthLdapTest.php
@@ -2176,7 +2176,8 @@ class AuthLDAPTest extends DbTestCase
         $this->assertCount(1, $gus);
     }
 
-    * Test if rules targeting ldap criteria are working
+    /**
+     * Test if rules targeting ldap criteria are working
      *
      * @return void
      */

--- a/phpunit/LDAP/AuthLdapTest.php
+++ b/phpunit/LDAP/AuthLdapTest.php
@@ -2207,6 +2207,20 @@ class AuthLDAPTest extends DbTestCase
             'pattern'   => 'brazil6',
         ]);
         $actions = new \RuleAction();
+
+        $actions->add([
+            'rules_id'    => $rules_id,
+            'action_type' => 'assign',
+            'field'       => 'profiles_id',
+            'value'       => 5, // 'normal' profile
+        ]);
+        $actions->add([
+            'rules_id'    => $rules_id,
+            'action_type' => 'assign',
+            'field'       => 'entities_id',
+            'value'       => 0, // '_test_child_1' entity
+        ]);
+
         // Create 2 dynamic group
         $group = new Group();
         $group_id = $group->add(["name" => "testgroup1"]);
@@ -2229,6 +2243,7 @@ class AuthLDAPTest extends DbTestCase
         $gu = new Group_User();
         $gus = $gu->find([
             'users_id' => $users_id,
+            'groups_id' => $group_id,
             'is_dynamic' => 1,
         ]);
         $this->assertCount(1, $gus);

--- a/phpunit/LDAP/AuthLdapTest.php
+++ b/phpunit/LDAP/AuthLdapTest.php
@@ -2292,7 +2292,6 @@ class AuthLDAPTest extends DbTestCase
         // Check group not assigned
         $gu = new Group_User();
         $gus = $gu->find([
-            'groups_id' => $group_id,
             'users_id' => $users_id,
         ]);
 

--- a/phpunit/LDAP/AuthLdapTest.php
+++ b/phpunit/LDAP/AuthLdapTest.php
@@ -2184,15 +2184,17 @@ class AuthLDAPTest extends DbTestCase
     public function testGroupRuleRight()
     {
         //prepare rules
-        $rules = new \RuleRight();
-        $rules_id = $rules->add([
-            'sub_type'     => 'RuleRight',
-            'name'         => 'test ldap groupruleright',
-            'match'        => 'AND',
-            'is_active'    => 1,
-            'entities_id'  => 0,
-            'is_recursive' => 1,
-        ]);
+        $rules_id = $this->createItem(
+            'RuleRight',
+            [
+                'sub_type'     => 'RuleRight',
+                'name'         => 'test ldap groupruleright',
+                'match'        => 'AND',
+                'is_active'    => 1,
+                'entities_id'  => 0,
+                'is_recursive' => 1,
+            ]
+        )->getID();
         $criteria = new \RuleCriteria();
         $criteria->add([
             'rules_id'  => $rules_id,
@@ -2231,7 +2233,7 @@ class AuthLDAPTest extends DbTestCase
             'rules_id'    => $rules_id,
             'action_type' => 'assign',
             'field'       => 'specific_groups_id',
-            'value'       => $group_id, // '_test_child_1' entity
+            'value'       => $group_id,
         ]);
 
         // login the user to force a real synchronisation and get it's glpi id
@@ -2284,12 +2286,12 @@ class AuthLDAPTest extends DbTestCase
             'pattern'   => 'brazil7',
         ]);
 
-        // Check the user got the entity/profiles unassigned
+        // Login
         $this->login('brazil6', 'password', false);
         $users_id = \User::getIdByName('brazil6');
         $this->assertGreaterThan(0, $users_id);
 
-        // Check group not assigned
+        // Check the dynamic group is deleted without losing the manual groups
         $gu = new Group_User();
         $gus = $gu->find([
             'users_id' => $users_id,

--- a/src/User.php
+++ b/src/User.php
@@ -6583,7 +6583,10 @@ HTML;
         if (!isset($this->input["_ldap_rules"]['groups_id'])) {
             if (isset($this->input["_ldap_rules"]) && isset($this->input['id'])) {
                 $group_user = new Group_User();
-                $groups = $group_user->find(['users_id' => $this->input['id'], 'is_dynamic' => 1]);
+                $groups = $group_user->find([
+                    'users_id' => $this->input['id'],
+                    'is_dynamic' => true
+                ]);
                 foreach ($groups as $group) {
                     $group_user->delete($group);
                 }
@@ -6601,7 +6604,7 @@ HTML;
             ];
 
             if (!$group_user->getFromDBByCrit($data)) {
-                $group_user->add(array_merge($data, ['is_dynamic' => 1]));
+                $group_user->add(array_merge($data, ['is_dynamic' => true]));
             }
         }
     }

--- a/src/User.php
+++ b/src/User.php
@@ -6581,6 +6581,13 @@ HTML;
     public function applyGroupsRules()
     {
         if (!isset($this->input["_ldap_rules"]['groups_id'])) {
+            if (isset($this->input["_ldap_rules"]) && isset($this->input['id'])) {
+                $group_user = new Group_User();
+                $groups = $group_user->find(['users_id' => $this->input['id'], 'is_dynamic' => 1]);
+                foreach ($groups as $group) {
+                    $group_user->delete($group);
+                }
+            }
             return;
         }
 
@@ -6594,7 +6601,7 @@ HTML;
             ];
 
             if (!$group_user->getFromDBByCrit($data)) {
-                $group_user->add($data);
+                $group_user->add(array_merge($data, ['is_dynamic' => 1]));
             }
         }
     }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !36835
- Here is a brief description of what this PR does
When a user is added to a group via an LDAP authorization rule, the group is not automatically removed if the user no longer meets the rule's criteria due to a change in LDAP attributes.

## Screenshots (if appropriate):


