### PR TITLE
Fix styles for forms after tabler update

### DIFF
--- a/css/includes/components/_select2.scss
+++ b/css/includes/components/_select2.scss
@@ -153,7 +153,6 @@
     }
 
     &.select2-container--disabled .select2-selection {
-        background-color: var(--tblr-disabled-color);
         border-color: var(--tblr-border-color);
         box-shadow: none;
         cursor: not-allowed;

--- a/css/includes/components/form/_form-editor.scss
+++ b/css/includes/components/form/_form-editor.scss
@@ -370,6 +370,12 @@
     border-bottom-right-radius: var(--tblr-border-radius) !important;
 }
 
+input.value-selector {
+    // Use extra padding to match height of dropdowns on the same line.
+    padding-top: 10px;
+    padding-bottom: 10px;
+}
+
 .value-selector {
     border: 0 !important;
     background-color: var(--tblr-yellow-lt) !important;


### PR DESCRIPTION
## Description

Fix two small UI issues following tabler update.

1\) Disable state on dropdowns:

Before:
![image](https://github.com/user-attachments/assets/d778f2b2-b53e-443b-8f56-c47b079c080f)

After:
![image](https://github.com/user-attachments/assets/d54ebdde-70f4-4ed0-89c4-a629dec23382)

2\) Conditions input height:

Before:
![image](https://github.com/user-attachments/assets/dc2df04e-2d26-404f-8779-463112f38d90)

After:
![image](https://github.com/user-attachments/assets/74bfddbd-b77a-47d0-bfc1-d23ff5a1d709)

