### PR TITLE
fix(displaypreference): add interface for reset option

### DIFF
--- a/src/DisplayPreference.php
+++ b/src/DisplayPreference.php
@@ -744,15 +744,17 @@ class DisplayPreference extends CommonDBTM
             $result = $DB->updateOrInsert(
                 self::getTable(),
                 [
-                    'itemtype' => $itemtype,
-                    'users_id' => 0,
-                    'num'      => $pref['num'],
-                    'rank'     => $pref['rank']
+                    'itemtype'  => $itemtype,
+                    'users_id'  => 0,
+                    'num'       => $pref['num'],
+                    'rank'      => $pref['rank'],
+                    'interface' => $pref['interface'],
                 ],
                 [
-                    'itemtype' => $itemtype,
-                    'users_id' => 0,
-                    'num'      => $pref['num'],
+                    'itemtype'  => $itemtype,
+                    'users_id'  => 0,
+                    'num'       => $pref['num'],
+                    'interface' => $pref['interface'],
                 ]
             );
             if (!$result) {


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] My feature works.

## Description

When using the "Reset to default" action in the new "Search result display" setup tab, 
If the selected itemtype has more than one interface, this generates an error "Update would change too many rows!".

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/623016fe-1ba1-43d0-bd06-3ac9effb0ef1)

![image](https://github.com/user-attachments/assets/f16aec90-6034-451d-8c39-7ae47a8f058b)


