### PR TITLE
Hide license validity when creating new license

### DIFF
--- a/templates/pages/management/softwarelicense.html.twig
+++ b/templates/pages/management/softwarelicense.html.twig
@@ -121,9 +121,8 @@
       'min': 1,
       'max': 10000,
       'step': 1,
-      'toadd': {'-1': __('Unlimited')},
-      'add_field_html': validity_msg
-   }) }}
+      'toadd': {'-1': __('Unlimited')}
+   }|merge(item.isNewItem() ? {} : {'add_field_html': validity_msg})) }}
 
    {{ fields.dropdownYesNo('allow_overquota', item.fields['allow_overquota'], __('Allow Over-Quota')) }}
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Related to #19237 but not clear yet if it refers to additional issues.

Hide validity message when creating a new license. This is not needed and it was also incorrect since an empty license object would have `is_valid` set to an empty string which makes the license seem invalid/over quota.