### PR TITLE
Prevent triggering cloning feature when adding new user

### DIFF
--- a/templates/pages/admin/user/user.html.twig
+++ b/templates/pages/admin/user/user.html.twig
@@ -55,7 +55,9 @@
                 <div class="d-flex flex-row flex-wrap flex-xl-nowrap">
                     <div class="row flex-row align-items-start flex-grow-1">
                         <div class="row flex-row">
-                            <input type="hidden" name="id" value="{{ is_preference_form ? session('glpiID') : item.getID() }}" />
+                            {% if not item.isNewItem() %}
+                                <input type="hidden" name="id" value="{{ item.getID() }}" />
+                            {% endif %}
                             {% if (item.isNewItem() or internal_auth) and not is_preference_form %}
                                 {{ fields.textField('name', item.fields['name'], __('Login')) }}
                             {% else %}

--- a/templates/pages/admin/user/user.html.twig
+++ b/templates/pages/admin/user/user.html.twig
@@ -55,7 +55,7 @@
                 <div class="d-flex flex-row flex-wrap flex-xl-nowrap">
                     <div class="row flex-row align-items-start flex-grow-1">
                         <div class="row flex-row">
-                            <input type="hidden" name="id" value="{{ session('glpiID') }}" />
+                            <input type="hidden" name="id" value="{{ is_preference_form ? session('glpiID') : item.getID() }}" />
                             {% if (item.isNewItem() or internal_auth) and not is_preference_form %}
                                 {{ fields.textField('name', item.fields['name'], __('Login')) }}
                             {% else %}


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Fixes #19234
Fix ID set in the user form. Previously it was always set to the current user's ID even when the form wasn't the "My Settings" one which resulted in the wrong ID being used. For adding users, having the ID set would trigger the cloning feature and clone any data not specified in the form submission from the current user including profile assignments.