### PR TITLE
Trigger an error when an inline template contains a translatable string

### DIFF
--- a/src/Appliance_Item_Relation.php
+++ b/src/Appliance_Item_Relation.php
@@ -269,13 +269,15 @@ class Appliance_Item_Relation extends CommonDBRelation
 
             $crsf_token = Session::getNewCSRFToken();
 
+            $add_button = json_encode(_x('button', "Add an item"));
+
             $js = <<<JAVASCRIPT
          $(function() {
             $(document).on('click', '.add_relation', function() {
                var appliances_items_id = $(this).data('appliances-items-id');
 
                glpi_html_dialog({
-                  title: _x('button', "Add an item"),
+                  title: {$add_button},
                   body: {$modal_html},
                   id: 'add_relation_dialog',
                   show: function() {

--- a/src/Domain_Item.php
+++ b/src/Domain_Item.php
@@ -475,7 +475,8 @@ TWIG, $twig_params);
                 'entities' => $entities,
                 'is_recursive' => $is_recursive,
                 'item'   => $item,
-                'btn_msg' => __('Associate a domain')
+                'btn_msg' => __('Associate a domain'),
+                'helper' => sprintf(__('%s that are already associated are not displayed'), Domain::getTypeName(Session::getPluralNumber())),
             ];
             // language=Twig
             echo TemplateRenderer::getInstance()->renderFromStringTemplate(<<<TWIG
@@ -501,7 +502,7 @@ TWIG, $twig_params);
                                 display: false
                             }]) %}
                             {{ fields.htmlField('', domain_dropdown, 'Domain'|itemtype_name, {
-                                helper: __('%s that are already associated are not displayed')|format('Domain'|itemtype_name(get_plural_number()))
+                                helper: helper
                             }) }}
                             {{ fields.dropdownField('DomainRelation', 'domainrelations_id', constant('DomainRelation::BELONGS'), 'DomainRelation'|itemtype_name, {
                                 display_emptychoice: false

--- a/src/Glpi/Application/View/Extension/I18nExtension.php
+++ b/src/Glpi/Application/View/Extension/I18nExtension.php
@@ -50,10 +50,6 @@ class I18nExtension extends AbstractExtension
     public function getFunctions(): array
     {
         return [
-            new TwigFunction('__', '__'),
-            new TwigFunction('_n', '_n'),
-            new TwigFunction('_x', '_x'),
-            new TwigFunction('_nx', '_nx'),
             new TwigFunction('get_current_locale', [$this, 'getCurrentLocale']),
             new TwigFunction('get_plural_number', [Session::class, 'getPluralNumber']),
             new TwigFunction('translate_item_key', [$this, 'translateItemKey']),

--- a/src/Glpi/Application/View/TemplateRenderer.php
+++ b/src/Glpi/Application/View/TemplateRenderer.php
@@ -57,6 +57,8 @@ use Twig\Environment;
 use Twig\Extension\DebugExtension;
 use Twig\Extra\String\StringExtension;
 use Twig\Loader\FilesystemLoader;
+use Twig\Loader\LoaderInterface;
+use Twig\TwigFunction;
 
 /**
  * @since 10.0.0
@@ -64,64 +66,95 @@ use Twig\Loader\FilesystemLoader;
 class TemplateRenderer
 {
     /**
-     * @var Environment
+     * Templates files rendering environment.
      */
-    private $environment;
+    private ?Environment $files_environment = null;
+
+    /**
+     * Inline templates rendering environment.
+     */
+    private ?Environment $inline_environment = null;
+
+    /**
+     * Templates loader instance.
+     */
+    private LoaderInterface $templates_loader;
+
+    /**
+     * Templates environments parameters.
+     */
+    private array $environment_params;
+
+    /**
+     * Twig extensions.
+     * @var list<\Twig\Extension\ExtensionInterface>
+     */
+    private array $extensions;
+
+    /**
+     * Twig globals.
+     * @var array<string, mixed>
+     */
+    private array $globals;
 
     public function __construct(string $rootdir = GLPI_ROOT, string $cachedir = GLPI_CACHE_DIR)
     {
-        $loader = new FilesystemLoader($rootdir . '/templates', $rootdir);
+        // Initialize the loader
+        $this->templates_loader = new FilesystemLoader($rootdir . '/templates', $rootdir);
 
         $active_plugins = Plugin::getPlugins();
         foreach ($active_plugins as $plugin_key) {
            // Add a dedicated namespace for each active plugin, so templates would be loadable using
            // `@my_plugin/path/to/template.html.twig` where `my_plugin` is the plugin key and `path/to/template.html.twig`
            // is the path of the template inside the `/templates` directory of the plugin.
-            $loader->addPath(Plugin::getPhpDir($plugin_key . '/templates'), $plugin_key);
+            $this->templates_loader->addPath(Plugin::getPhpDir($plugin_key . '/templates'), $plugin_key);
         }
 
-        $env_params = [
+        // Compute environment parameters
+        $this->environment_params = [
             'debug'       => $_SESSION['glpi_use_mode'] ?? null === Session::DEBUG_MODE,
             'auto_reload' => GLPI_ENVIRONMENT_TYPE !== GLPI::ENV_PRODUCTION,
         ];
 
-        $tpl_cachedir = $cachedir . '/templates';
+        $tpl_cache_dir = $cachedir . '/templates';
         if (
-            (file_exists($tpl_cachedir) && !is_writable($tpl_cachedir))
-            || (!file_exists($tpl_cachedir) && !is_writable($cachedir))
+            (file_exists($tpl_cache_dir) && !is_writable($tpl_cache_dir))
+            || (!file_exists($tpl_cache_dir) && !is_writable($cachedir))
         ) {
-            trigger_error(sprintf('Cache directory "%s" is not writeable.', $tpl_cachedir), E_USER_WARNING);
+            trigger_error(sprintf('Cache directory "%s" is not writeable.', $tpl_cache_dir), E_USER_WARNING);
         } else {
-            $env_params['cache'] = $tpl_cachedir;
+            $this->environment_params['cache'] = $tpl_cache_dir;
         }
 
-        $this->environment = new Environment(
-            $loader,
-            $env_params
-        );
-       // Vendor extensions
-        $this->environment->addExtension(new DebugExtension());
-        $this->environment->addExtension(new StringExtension());
-       // GLPI extensions
-        $this->environment->addExtension(new ConfigExtension());
-        $this->environment->addExtension(new SecurityExtension());
-        $this->environment->addExtension(new DataHelpersExtension());
-        $this->environment->addExtension(new DocumentExtension());
-        $this->environment->addExtension(new FrontEndAssetsExtension());
-        $this->environment->addExtension(new I18nExtension());
-        $this->environment->addExtension(new IllustrationExtension());
-        $this->environment->addExtension(new ItemtypeExtension());
-        $this->environment->addExtension(new PhpExtension());
-        $this->environment->addExtension(new PluginExtension());
-        $this->environment->addExtension(new RoutingExtension());
-        $this->environment->addExtension(new SearchExtension());
-        $this->environment->addExtension(new SessionExtension());
-        $this->environment->addExtension(new TeamExtension());
+        // Initialize the extensions
+        $this->extensions = [
+            // Vendor extensions
+            new DebugExtension(),
+            new StringExtension(),
 
-       // add superglobals
-        $this->environment->addGlobal('_post', $_POST);
-        $this->environment->addGlobal('_get', $_GET);
-        $this->environment->addGlobal('_request', $_REQUEST);
+            // GLPI extensions
+            new ConfigExtension(),
+            new SecurityExtension(),
+            new DataHelpersExtension(),
+            new DocumentExtension(),
+            new FrontEndAssetsExtension(),
+            new I18nExtension(),
+            new IllustrationExtension(),
+            new ItemtypeExtension(),
+            new PhpExtension(),
+            new PluginExtension(),
+            new RoutingExtension(),
+            new SearchExtension(),
+            new SessionExtension(),
+            new TeamExtension(),
+        ];
+
+        // Initialize the global variables
+        $this->globals = [
+            '_post'    => $_POST,
+            '_get'     => $_GET,
+            '_request' => $_REQUEST,
+        ];
     }
 
     /**
@@ -141,13 +174,29 @@ class TemplateRenderer
     }
 
     /**
-     * Return Twig environment used to handle templates.
+     * Return Twig environment used to handle templates files.
      *
      * @return Environment
      */
     public function getEnvironment(): Environment
     {
-        return $this->environment;
+        if ($this->files_environment === null) {
+            $this->files_environment = $this->getNewEnvironment(with_translation_functions: true);
+        }
+        return $this->files_environment;
+    }
+
+    /**
+     * Return Twig environment used to handle inlined templates.
+     *
+     * @return Environment
+     */
+    private function getInlineEnvironment(): Environment
+    {
+        if ($this->inline_environment === null) {
+            $this->inline_environment = $this->getNewEnvironment(with_translation_functions: false);
+        }
+        return $this->inline_environment;
     }
 
     /**
@@ -162,7 +211,7 @@ class TemplateRenderer
     {
         try {
             Profiler::getInstance()->start($template, Profiler::CATEGORY_TWIG);
-            return $this->environment->load($template)->render($variables);
+            return $this->getEnvironment()->load($template)->render($variables);
         } finally {
             Profiler::getInstance()->stop($template);
         }
@@ -180,7 +229,7 @@ class TemplateRenderer
     {
         try {
             Profiler::getInstance()->start($template, Profiler::CATEGORY_TWIG);
-            $this->environment->load($template)->display($variables);
+            $this->getEnvironment()->load($template)->display($variables);
         } finally {
             Profiler::getInstance()->stop($template);
         }
@@ -196,11 +245,40 @@ class TemplateRenderer
      */
     public function renderFromStringTemplate(string $template, array $variables = []): string
     {
+
         try {
             Profiler::getInstance()->start($template, Profiler::CATEGORY_TWIG);
-            return $this->environment->createTemplate($template)->render($variables);
+            return $this->getInlineEnvironment()->createTemplate($template)->render($variables);
         } finally {
             Profiler::getInstance()->stop($template);
         }
+    }
+
+    /**
+     * Create a new template rendering environment.
+     */
+    private function getNewEnvironment(bool $with_translation_functions): Environment
+    {
+        $environment = new Environment(
+            $this->templates_loader,
+            $this->environment_params
+        );
+
+        foreach ($this->extensions as $extension) {
+            $environment->addExtension($extension);
+        }
+
+        foreach ($this->globals as $name => $value) {
+            $environment->addGlobal($name, $value);
+        }
+
+        if ($with_translation_functions) {
+            $environment->addFunction(new TwigFunction('__', '__'));
+            $environment->addFunction(new TwigFunction('_n', '_n'));
+            $environment->addFunction(new TwigFunction('_x', '_x'));
+            $environment->addFunction(new TwigFunction('_nx', '_nx'));
+        }
+
+        return $environment;
     }
 }

--- a/src/Glpi/Asset/CustomFieldOption/ProfileRestrictOption.php
+++ b/src/Glpi/Asset/CustomFieldOption/ProfileRestrictOption.php
@@ -49,6 +49,7 @@ class ProfileRestrictOption extends AbstractOption
             'key' => $this->getKey(),
             'label' => $this->getName(),
             'value' => array_filter($value),
+            'all_label' => __('All'),
         ];
         // language=Twig
         return TemplateRenderer::getInstance()->renderFromStringTemplate(<<<TWIG
@@ -56,7 +57,7 @@ class ProfileRestrictOption extends AbstractOption
             {{ fields.dropdownField('Profile', 'field_options[' ~ key ~ ']', value, label, {
                 multiple: true,
                 to_add: {
-                    '-1': __('All')
+                    '-1': all_label
                 },
                 condition: {
                     'interface': 'central'

--- a/src/Glpi/Form/QuestionType/QuestionTypeDropdown.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeDropdown.php
@@ -160,7 +160,7 @@ TWIG;
                     'display_emptychoice': true,
                     'field_class': 'single-preview-dropdown col-12' ~ (is_multiple_dropdown ? ' d-none' : ''),
                     'mb': '',
-                    'aria_label': __('Default option')
+                    'aria_label': default_option_label
                 }
             ) }}
             {{ fields.dropdownArrayField(
@@ -175,7 +175,7 @@ TWIG;
                     'values': checked_values,
                     'field_class': 'multiple-preview-dropdown col-12' ~ (not is_multiple_dropdown ? ' d-none' : ''),
                     'mb': '',
-                    'aria_label': __('Default options')
+                    'aria_label': default_options_label
                 }
             ) }}
         </div>
@@ -193,11 +193,13 @@ TWIG;
             array_filter($this->getValues($question), fn ($option) => $option['checked'])
         );
         return $twig->renderFromStringTemplate($template, [
-            'question'             => $question,
-            'init'                 => $question != null,
-            'values'               => $values,
-            'checked_values'       => $checked_values,
-            'is_multiple_dropdown' => $this->isMultipleDropdown($question),
+            'question'              => $question,
+            'init'                  => $question != null,
+            'values'                => $values,
+            'checked_values'        => $checked_values,
+            'is_multiple_dropdown'  => $this->isMultipleDropdown($question),
+            'default_option_label'  => __('Default option'),
+            'default_options_label' => __('Default options'),
         ]);
     }
 

--- a/src/Glpi/RichText/RichText.php
+++ b/src/Glpi/RichText/RichText.php
@@ -462,6 +462,13 @@ HTML;
         $items_json = json_encode($imgs);
         $close_json = json_encode($p['controls']['close'] ?? false);
         $zoom_json  = json_encode($p['controls']['zoom'] ?? false);
+
+        $next_title     = json_encode(__('Next (arrow right)'));
+        $prev_title     = json_encode(__('Previous (arrow left)'));
+        $close_title    = json_encode(__('Close (Esc)'));
+        $download_title = json_encode(__('Download'));
+        $zoom_title     = json_encode(__('Zoom in/out'));
+
         $js = <<<JAVASCRIPT
       (function($) {
          $('.pswp-img{$p['rand']}').on('click', 'figure', function(event) {
@@ -476,11 +483,11 @@ HTML;
                 close: {$close_json},
                 zoom: {$zoom_json},
 
-                arrowNextTitle: __('Next (arrow right)'),
-                arrowPrevTitle: __('Previous (arrow left)'),
-                closeTitle: __('Close (Esc)'),
-                downloadTitle: __('Download'),
-                zoomTitle: __('Zoom in/out'),
+                arrowNextTitle: {$next_title},
+                arrowPrevTitle: {$prev_title},
+                closeTitle: {$close_title},
+                downloadTitle: {$download_title},
+                zoomTitle: {$zoom_title},
             };
             const gallery = new PhotoSwipe(options);
             gallery.on(

--- a/src/Html.php
+++ b/src/Html.php
@@ -5256,8 +5256,8 @@ HTML;
                );
             },
             messages: {
-              acceptFileTypes: __('Filetype not allowed'),
-              maxFileSize: __('File is too big'),
+              acceptFileTypes: " . json_encode(__('Filetype not allowed')) . ",
+              maxFileSize: " . json_encode(__('File is too big')) . ",
             },
             $progressall_js
          });

--- a/src/Impact.php
+++ b/src/Impact.php
@@ -493,7 +493,7 @@ TWIG, $twig_params);
             echo Html::scriptBlock('
             $("#impact-list-settings").click(function() {
                glpi_html_dialog({
-                  title: __("Settings"),
+                  title: ' . json_encode(__("Settings")) . ',
                   body: ' . ($setting_dialog || '{}') . ',
                });
             });

--- a/src/Item_Disk.php
+++ b/src/Item_Disk.php
@@ -249,16 +249,20 @@ class Item_Disk extends CommonDBChild
             $encryption_label = '';
             if ($data['encryption_status'] !== self::ENCRYPTION_STATUS_NO) {
                 $twig_params = [
-                    'encryption_status' => Dropdown::getYesNo($data['encryption_status'] === self::ENCRYPTION_STATUS_YES),
-                    'encryption_tool' => $data['encryption_tool'],
-                    'encryption_algorithm' => $data['encryption_algorithm'],
-                    'encryption_type' => $data['encryption_type'],
+                    'encryption_status_label'    => __('Partial encryption'),
+                    'encryption_status_value'    => Dropdown::getYesNo($data['encryption_status'] === self::ENCRYPTION_STATUS_YES),
+                    'encryption_tool_label'      => __('Encryption tool'),
+                    'encryption_tool_value'      => $data['encryption_tool'],
+                    'encryption_algorithm_label' => __('Encryption algorithm'),
+                    'encryption_algorithm_value' => $data['encryption_algorithm'],
+                    'encryption_type_label'      => __('Encryption type'),
+                    'encryption_type_value'      => $data['encryption_type'],
                 ];
                 $encryptionTooltip = TemplateRenderer::getInstance()->renderFromStringTemplate(<<<TWIG
-                    <strong>{{ __('Partial encryption') }}</strong> : {{ encryption_status }}<br/>
-                    <strong>{{ __('Encryption tool') }}</strong> : {{ encryption_tool }}</br>
-                    <strong>{{ __('Encryption algorithm') }}</strong> : {{ encryption_algorithm }}</br>
-                    <strong>{{ __('Encryption type') }}</strong> : {{ encryption_type }}
+                    <strong>{{ encryption_status_label }}</strong> : {{ encryption_status_value }}<br/>
+                    <strong>{{ encryption_tool_label }}</strong> : {{ encryption_tool_value }}</br>
+                    <strong>{{ encryption_algorithm_label }}</strong> : {{ encryption_algorithm_value }}<br/>
+                    <strong>{{ encryption_type_label }}</strong> : {{ encryption_type_value }}
 TWIG, $twig_params);
 
                 $encryption_label = Html::showTooltip($encryptionTooltip, [

--- a/src/ObjectLock.php
+++ b/src/ObjectLock.php
@@ -367,8 +367,8 @@ class ObjectLock extends CommonDBTM
                 $templateContent = <<<TWIG
                     {% set color = is_locked ? 'bg-red-lt' : 'bg-green-lt' %}
                     {% set icon = is_locked ? 'ti-lock' : 'ti-lock-open' %}
-                    {% set text = is_locked ? __('Locked') : __('Free') %}
-                    {% set tooltip = is_locked ? __('Locked by %s at %s')|format(user_name, date) : text %}
+                    {% set text = is_locked ? locked_label : free_label %}
+                    {% set tooltip = is_locked ? locked_by_label|format(user_name, date) : text %}
 
                     <span class="badge {{ color }}" data-bs-toggle="tooltip" title="{{ tooltip }}">
                         <i class="ti {{ icon }}"></i>
@@ -377,9 +377,12 @@ class ObjectLock extends CommonDBTM
 TWIG;
 
                 return TemplateRenderer::getInstance()->renderFromStringTemplate($templateContent, [
-                    'is_locked' => $values['id'] > 0,
-                    'user_name' => getUserName($values['users_id']),
-                    'date'      => $values['date'],
+                    'is_locked'       => $values['id'] > 0,
+                    'user_name'       => getUserName($values['users_id']),
+                    'date'            => $values['date'],
+                    'locked_label'    => __('Locked'),
+                    'free_label'      => __('Free'),
+                    'locked_by_label' => __('Locked by %s at %s'),
                 ]);
         }
 

--- a/src/Planning.php
+++ b/src/Planning.php
@@ -515,20 +515,12 @@ JAVASCRIPT;
         }
 
         // language=Twig
-        echo TemplateRenderer::getInstance()->renderFromStringTemplate(<<<TWIG
-            <div {% if  options.full_view %} id="planning_container" {% endif %} class="d-flex flex-wrap flex-sm-nowrap">
-                {% if options.full_view %}
-                    {{ include('pages/assistance/planning/filters.html.twig') }}
-                {% endif %}
-                <div id="planning{{ options.rand }}" class="flex-fill"></div>
-            </div>
-            <script>
-                $(() => {
-                    GLPIPlanning.display({{ options|json_encode|raw }});
-                    GLPIPlanning.planningFilters();
-                });
-            </script>
-TWIG, ['options' => $options]);
+        echo TemplateRenderer::getInstance()->render(
+            'pages/assistance/planning/planning.html.twig',
+            [
+                'options' => $options,
+            ]
+        );
     }
 
     public static function getTimelineResources()

--- a/src/SLM.php
+++ b/src/SLM.php
@@ -166,8 +166,10 @@ class SLM extends CommonDBTM
     public function showForm($ID, array $options = [])
     {
         $twig_params = [
-            'item' => $this,
-            'params' => $options,
+            'item'        => $this,
+            'params'      => $options,
+            'empty_label' => __('24/7'),
+            'toadd_label' => __('Calendar of the ticket'),
         ];
         // language=Twig
         echo TemplateRenderer::getInstance()->renderFromStringTemplate(<<<TWIG
@@ -176,9 +178,9 @@ class SLM extends CommonDBTM
             
             {% block more_fields %}
                 {{ fields.dropdownField('Calendar', 'calendars_id', item.fields['use_ticket_calendar'] ? -1 : item.fields['calendars_id'], 'Calendar'|itemtype_name(1), {
-                    emptylabel: __('24/7'),
+                    emptylabel: empty_label,
                     toadd: {
-                        (-1): __('Calendar of the ticket')
+                        (-1): toadd_label
                     }
                 }) }}
             {% endblock %}

--- a/src/Telemetry.php
+++ b/src/Telemetry.php
@@ -377,7 +377,7 @@ class Telemetry extends CommonGLPI
             e.preventDefault();
 
             glpi_ajax_dialog({
-               title: __('Telemetry data'),
+               title: " . json_encode(__('Telemetry data')) . ",
                url: $('#view_telemetry').attr('href'),
                dialogclass: 'modal-lg'
             });

--- a/templates/pages/assistance/planning/planning.html.twig
+++ b/templates/pages/assistance/planning/planning.html.twig
@@ -1,0 +1,44 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2025 Teclib' and contributors.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+<div {% if options.full_view %} id="planning_container" {% endif %} class="d-flex flex-wrap flex-sm-nowrap">
+    {% if options.full_view %}
+        {{ include('pages/assistance/planning/filters.html.twig') }}
+    {% endif %}
+    <div id="planning{{ options.rand }}" class="flex-fill"></div>
+</div>
+<script>
+    $(() => {
+        GLPIPlanning.display({{ options|json_encode|raw }});
+        GLPIPlanning.planningFilters();
+    });
+</script>


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Usages of the translation function in inlined templates should be prohibited. Indeed, these translations will not be extracted as expected by `xgettext` and most of them will be missing in our string sources. Some of them were not detected during the code review, see https://github.com/glpi-project/glpi/blob/ab015d906c135191d2d59649fe1b1a3b0912cd01/src/Glpi/Form/QuestionType/AbstractQuestionTypeShortAnswer.php#L115

To prevent this, I propose to remove the `__()`, `_x()`, `_n()` and `_nx()` functions from the Twig environment used to render inlined templates, in order to trigger an error when some of them are used in this context.

Example of an error trace:
```
Unknown "__" function in "__string_template__c0d9752debc559c2a90bffb6ffb290b3" at line 3.
In ./vendor/twig/twig/src/ExpressionParser.php(816)
#0 ./vendor/twig/twig/src/ExpressionParser.php(533): Twig\ExpressionParser->getFunction('__', 3)
#1 ./vendor/twig/twig/src/ExpressionParser.php(322): Twig\ExpressionParser->getFunctionNode('__', 3)
#2 ./vendor/twig/twig/src/ExpressionParser.php(265): Twig\ExpressionParser->parsePrimaryExpression()
#3 ./vendor/twig/twig/src/ExpressionParser.php(102): Twig\ExpressionParser->getPrimary()
#4 ./vendor/twig/twig/src/Parser.php(158): Twig\ExpressionParser->parseExpression()
#5 ./vendor/twig/twig/src/Parser.php(95): Twig\Parser->subparse(NULL, false)
#6 ./vendor/twig/twig/src/Environment.php(559): Twig\Parser->parse(Object(Twig\TokenStream))
#7 ./vendor/twig/twig/src/Environment.php(590): Twig\Environment->parse(Object(Twig\TokenStream))
#8 ./vendor/twig/twig/src/Environment.php(409): Twig\Environment->compileSource(Object(Twig\Source))
#9 ./vendor/twig/twig/src/Environment.php(462): Twig\Environment->loadTemplate('__TwigTemplate_...', '__string_templa...')
#10 ./src/Glpi/Application/View/TemplateRenderer.php(247): Twig\Environment->createTemplate('            <di...')
#11 ./src/CronTask.php(1209): Glpi\Application\View\TemplateRenderer->renderFromStringTemplate('            <di...', Array)
#12 ./src/CronTask.php(1129): CronTask->showHistoryDetail('18')
#13 ./src/CronTaskLog.php(118): CronTask->showHistory()
#14 ./src/CommonGLPI.php(681): CronTaskLog::displayTabContentForItem(Object(CronTask), '2', 0)
#15 ./ajax/common.tabs.php(109): CommonGLPI::displayStandardTab(Object(CronTask), 'CronTaskLog$2', 0, Array)
#16 ./src/Glpi/Controller/LegacyFileLoadController.php(59): require('./a...')
#17 ./vendor/symfony/http-kernel/HttpKernel.php(101): Glpi\Controller\LegacyFileLoadController->{closure:Glpi\Controller\LegacyFileLoadController::__invoke():58}()
#18 ./vendor/symfony/http-foundation/StreamedResponse.php(106): Symfony\Component\HttpKernel\HttpKernel::{closure:Symfony\Component\HttpKernel\HttpKernel::handle():98}()
#19 ./vendor/symfony/http-foundation/Response.php(423): Symfony\Component\HttpFoundation\StreamedResponse->sendContent()
#20 ./src/Glpi/Kernel/Kernel.php(234): Symfony\Component\HttpFoundation\Response->send()
#21 ./public/index.php(58): Glpi\Kernel\Kernel->sendResponse(Object(Symfony\Component\HttpFoundation\Request), Object(Glpi\Http\HeaderlessStreamedResponse))
#22 {main}
```