### PR TITLE
Helpdesk forms: support regex on strings conditions

### DIFF
--- a/phpunit/functional/Glpi/Form/Condition/ConditionHandler/StringConditionHandlerTest.php
+++ b/phpunit/functional/Glpi/Form/Condition/ConditionHandler/StringConditionHandlerTest.php
@@ -198,6 +198,52 @@ final class StringConditionHandlerTest extends AbstractConditionHandler
                 'submitted_answer'   => "exact ANSWER",
                 'expected_result'    => false,
             ];
+
+            // Test string answers with the MATCH_REGEX operator
+            yield "Match regex check - case 1 for $type" => [
+                'question_type'      => $type,
+                'condition_operator' => ValueOperator::MATCH_REGEX,
+                'condition_value'    => "/[09]+/",
+                'submitted_answer'   => "Invalid format",
+                'expected_result'    => false,
+            ];
+            yield "Match regex check - case 2 for $type" => [
+                'question_type'      => $type,
+                'condition_operator' => ValueOperator::MATCH_REGEX,
+                'condition_value'    => "/[09]+/",
+                'submitted_answer'   => "0124511",
+                'expected_result'    => true,
+            ];
+            yield "Match regex check - case 3 for $type" => [
+                'question_type'      => $type,
+                'condition_operator' => ValueOperator::MATCH_REGEX,
+                'condition_value'    => "not a regex", // Invalid regex should not trigger errors
+                'submitted_answer'   => "answer",
+                'expected_result'    => false,
+            ];
+
+            // Test string answers with the NOT_MATCH_REGEX operator
+            yield "Not match regex check - case 1 for $type" => [
+                'question_type'      => $type,
+                'condition_operator' => ValueOperator::NOT_MATCH_REGEX,
+                'condition_value'    => "/[09]+/",
+                'submitted_answer'   => "Invalid format",
+                'expected_result'    => true,
+            ];
+            yield "Not match regex check - case 2 for $type" => [
+                'question_type'      => $type,
+                'condition_operator' => ValueOperator::NOT_MATCH_REGEX,
+                'condition_value'    => "/[09]+/",
+                'submitted_answer'   => "0124511",
+                'expected_result'    => false,
+            ];
+            yield "Not match regex check - case 3 for $type" => [
+                'question_type'      => $type,
+                'condition_operator' => ValueOperator::NOT_MATCH_REGEX,
+                'condition_value'    => "not a regex", // Invalid regex should not trigger errors
+                'submitted_answer'   => "answer",
+                'expected_result'    => true,
+            ];
         }
     }
 }

--- a/phpunit/functional/Glpi/Form/Condition/EditorManagerTest.php
+++ b/phpunit/functional/Glpi/Form/Condition/EditorManagerTest.php
@@ -234,6 +234,8 @@ final class EditorManagerTest extends GLPITestCase
             'not_equals'   => __("Is not equal to"),
             'contains'     => __("Contains"),
             'not_contains' => __("Do not contains"),
+            'match_regex' => __("Match regular expression"),
+            'not_match_regex' => __("Do not match regular expression"),
         ], $dropdown_values);
     }
 

--- a/src/Glpi/Form/Condition/ConditionHandler/StringConditionHandler.php
+++ b/src/Glpi/Form/Condition/ConditionHandler/StringConditionHandler.php
@@ -48,6 +48,8 @@ class StringConditionHandler implements ConditionHandlerInterface
             ValueOperator::NOT_EQUALS,
             ValueOperator::CONTAINS,
             ValueOperator::NOT_CONTAINS,
+            ValueOperator::MATCH_REGEX,
+            ValueOperator::NOT_MATCH_REGEX,
         ];
     }
 
@@ -74,10 +76,18 @@ class StringConditionHandler implements ConditionHandlerInterface
         $b = strtolower(strval($b));
 
         return match ($operator) {
-            ValueOperator::EQUALS       => $a === $b,
-            ValueOperator::NOT_EQUALS   => $a !== $b,
-            ValueOperator::CONTAINS     => str_contains($b, $a),
-            ValueOperator::NOT_CONTAINS => !str_contains($b, $a),
+            ValueOperator::EQUALS          => $a === $b,
+            ValueOperator::NOT_EQUALS      => $a !== $b,
+            ValueOperator::CONTAINS        => str_contains($b, $a),
+            ValueOperator::NOT_CONTAINS    => !str_contains($b, $a),
+
+            // Note: we do not want to throw warnings here if an invalid regex
+            // is configured by the user.
+            // There is no clean way to test that a regex is valid in PHP,
+            // therefore the simplest way to deal with that is to ignore
+            // warnings using the "@" prefix.
+            ValueOperator::MATCH_REGEX     => @preg_match($b, $a),
+            ValueOperator::NOT_MATCH_REGEX => !@preg_match($b, $a),
 
             // Unsupported operators
             default => false,

--- a/src/Glpi/Form/Condition/ValueOperator.php
+++ b/src/Glpi/Form/Condition/ValueOperator.php
@@ -44,6 +44,8 @@ enum ValueOperator: string
     case GREATER_THAN_OR_EQUALS = 'greater_than_or_equals';
     case LESS_THAN = 'less_than';
     case LESS_THAN_OR_EQUALS = 'less_than_or_equals';
+    case MATCH_REGEX = 'match_regex';
+    case NOT_MATCH_REGEX = 'not_match_regex';
 
     // Not yet implemented:
     // case VISIBLE = 'visible';
@@ -60,6 +62,8 @@ enum ValueOperator: string
             self::GREATER_THAN_OR_EQUALS => __("Is greater than or equals to"),
             self::LESS_THAN              => __("Is less than"),
             self::LESS_THAN_OR_EQUALS    => __("Is less than or equals to"),
+            self::MATCH_REGEX            => __("Match regular expression"),
+            self::NOT_MATCH_REGEX        => __("Do not match regular expression"),
         };
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

@orthagh notified us that this was a feature of formcreator so we must keep it.

