### PR TITLE
Forms: allow plugins to define custom access policies

### DIFF
--- a/phpunit/functional/Glpi/Form/AccessControl/FormAccessControlManagerTest.php
+++ b/phpunit/functional/Glpi/Form/AccessControl/FormAccessControlManagerTest.php
@@ -346,7 +346,6 @@ final class FormAccessControlManagerTest extends DbTestCase
     ): void {
         // Arrange: create a form with a plugin policy
         $builder = new FormBuilder();
-        $builder->allowAllUsers();
         $builder->addAccessControl(
             DayOfTheWeekPolicy::class,
             new DayOfTheWeekPolicyConfig("Friday"),

--- a/src/Glpi/Form/AccessControl/ControlType/AllowList.php
+++ b/src/Glpi/Form/AccessControl/ControlType/AllowList.php
@@ -69,9 +69,9 @@ final class AllowList implements ControlTypeInterface
     }
 
     #[Override]
-    public function getWarnings(Form $form, array $warnings): array
+    public function getWarnings(Form $form): array
     {
-        return $warnings;
+        return [];
     }
 
     #[Override]

--- a/src/Glpi/Form/AccessControl/ControlType/ControlTypeInterface.php
+++ b/src/Glpi/Form/AccessControl/ControlType/ControlTypeInterface.php
@@ -68,10 +68,9 @@ interface ControlTypeInterface
      * Get the warnings for the given form.
      *
      * @param  Form $form
-     * @param  string[] $warnings
      * @return string[]
      */
-    public function getWarnings(Form $form, array $warnings): array;
+    public function getWarnings(Form $form): array;
 
     /**
      * Render the configuration form of this control type.

--- a/src/Glpi/Form/AccessControl/ControlType/DirectAccess.php
+++ b/src/Glpi/Form/AccessControl/ControlType/DirectAccess.php
@@ -65,15 +65,16 @@ final class DirectAccess implements ControlTypeInterface
     }
 
     #[Override]
-    public function getWarnings(Form $form, array $warnings): array
+    public function getWarnings(Form $form): array
     {
-        return $this->addWarningIfFormHasBlacklistedQuestionTypes($form, $warnings);
+        return $this->addWarningIfFormHasBlacklistedQuestionTypes($form);
     }
 
     private function addWarningIfFormHasBlacklistedQuestionTypes(
         Form $form,
-        array $warnings
     ): array {
+        $warnings = [];
+
         if (
             FormAccessControlManager::getInstance()->allowUnauthenticatedAccess($form)
             && array_reduce(

--- a/src/Glpi/Form/AccessControl/ControlType/DirectAccess.php
+++ b/src/Glpi/Form/AccessControl/ControlType/DirectAccess.php
@@ -67,10 +67,10 @@ final class DirectAccess implements ControlTypeInterface
     #[Override]
     public function getWarnings(Form $form): array
     {
-        return $this->addWarningIfFormHasBlacklistedQuestionTypes($form);
+        return $this->getWarningIfFormHasBlacklistedQuestionTypes($form);
     }
 
-    private function addWarningIfFormHasBlacklistedQuestionTypes(
+    private function getWarningIfFormHasBlacklistedQuestionTypes(
         Form $form,
     ): array {
         $warnings = [];

--- a/tests/cypress/e2e/form/form_plugins.cy.js
+++ b/tests/cypress/e2e/form/form_plugins.cy.js
@@ -65,4 +65,34 @@ describe('Form plugins', () => {
             '1) My range question: 50'
         );
     });
+
+    it('can configure access policies from plugins', () => {
+        // Create and go to form
+        cy.createFormWithAPI().visitFormTab('Policies');
+
+        // Config day of the week
+        cy.findByRole('region', {
+            name: 'Restrict access to a specific day of the week'
+        }).within(() => {
+            // Validate default values
+            cy.getDropdownByLabelText('Day').should('have.text', "Monday");
+            cy.findByRole('checkbox', {name: 'Active'}).should('not.be.checked');
+
+            // Apply config
+            cy.getDropdownByLabelText('Day').selectDropdownValue('Thursday');
+            cy.findByRole('checkbox', {name: 'Active'}).should('be.checked');
+        });
+
+        // Save and reload
+        cy.findByRole('button', {name: 'Save changes'}).click();
+        cy.reload();
+
+        // Validate that the value was applied and that the policy is active.
+        cy.findByRole('region', {
+            name: 'Restrict access to a specific day of the week'
+        }).within(() => {
+            cy.findByRole('checkbox', {name: 'Active'}).should('be.checked');
+            cy.getDropdownByLabelText('Day').should('have.text', "Thursday");
+        });
+    });
 });

--- a/tests/fixtures/plugins/tester/setup.php
+++ b/tests/fixtures/plugins/tester/setup.php
@@ -32,7 +32,9 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Form\AccessControl\FormAccessControlManager;
 use Glpi\Form\QuestionType\QuestionTypesManager;
+use GlpiPlugin\Tester\Form\DayOfTheWeekPolicy;
 use GlpiPlugin\Tester\Form\QuestionTypeRange;
 use GlpiPlugin\Tester\Form\QuestionTypeColor;
 use GlpiPlugin\Tester\Form\TesterCategory;
@@ -85,4 +87,8 @@ function plugin_init_tester(): void
     $types_manager->registerPluginCategory(new TesterCategory());
     $types_manager->registerPluginQuestionType(new QuestionTypeRange());
     $types_manager->registerPluginQuestionType(new QuestionTypeColor());
+
+    // Register access control policies
+    $access_manager = FormAccessControlManager::getInstance();
+    $access_manager->registerPluginAccessControlPolicy(new DayOfTheWeekPolicy());
 }

--- a/tests/fixtures/plugins/tester/src/Form/DayOfTheWeekPolicy.php
+++ b/tests/fixtures/plugins/tester/src/Form/DayOfTheWeekPolicy.php
@@ -1,0 +1,125 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace GlpiPlugin\Tester\Form;
+
+use Glpi\Application\View\TemplateRenderer;
+use Glpi\DBAL\JsonFieldInterface;
+use Glpi\Form\AccessControl\AccessVote;
+use Glpi\Form\AccessControl\ControlType\ControlTypeInterface;
+use Glpi\Form\AccessControl\FormAccessControl;
+use Glpi\Form\AccessControl\FormAccessParameters;
+use Glpi\Form\Form;
+use InvalidArgumentException;
+use Override;
+use Session;
+
+final class DayOfTheWeekPolicy implements ControlTypeInterface
+{
+    #[Override]
+    public function getLabel(): string
+    {
+        return __("Restrict access to a specific day of the week");
+    }
+
+    #[Override]
+    public function getIcon(): string
+    {
+        return "ti ti-calendar";
+    }
+
+    #[Override]
+    public function getWeight(): int
+    {
+        return 30;
+    }
+
+    #[Override]
+    public function getConfigClass(): string
+    {
+        return DayOfTheWeekPolicyConfig::class;
+    }
+
+    #[Override]
+    public function createConfigFromUserInput(array $input): JsonFieldInterface
+    {
+        return DayOfTheWeekPolicyConfig::jsonDeserialize([
+            'day_of_the_week' => $input['_day_of_the_week'],
+        ]);
+    }
+
+    #[Override]
+    public function allowUnauthenticated(JsonFieldInterface $config): bool
+    {
+        return false;
+    }
+
+    #[Override]
+    public function canAnswer(
+        Form $form,
+        JsonFieldInterface $config,
+        FormAccessParameters $parameters
+    ): AccessVote {
+        if (!($config instanceof DayOfTheWeekPolicyConfig)) {
+            throw new InvalidArgumentException();
+        }
+
+        $date = Session::getCurrentDate();
+        $day = date('l', strtotime($date));
+
+        return $day === $config->getDay() ? AccessVote::Abstain : AccessVote::Deny;
+    }
+
+    #[Override]
+    public function getWarnings(Form $form): array
+    {
+        return [];
+    }
+
+    #[Override]
+    public function renderConfigForm(FormAccessControl $access_control): string
+    {
+        $config = $access_control->getConfig();
+        if (!$config instanceof DayOfTheWeekPolicyConfig) {
+            throw new InvalidArgumentException();
+        }
+
+        $twig = TemplateRenderer::getInstance();
+        return $twig->render("@tester/day_of_the_week_policy.html.twig", [
+            'input_name' => $access_control->getNormalizedInputName('_day_of_the_week'),
+            'value'      => $config->getDay(),
+            'label'      => __("Day"),
+        ]);
+    }
+}

--- a/tests/fixtures/plugins/tester/src/Form/DayOfTheWeekPolicyConfig.php
+++ b/tests/fixtures/plugins/tester/src/Form/DayOfTheWeekPolicyConfig.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace GlpiPlugin\Tester\Form;
+
+use Glpi\DBAL\JsonFieldInterface;
+use Override;
+
+final class DayOfTheWeekPolicyConfig implements JsonFieldInterface
+{
+    public function __construct(
+        private string $day_of_the_week = "Monday",
+    ) {
+    }
+
+    #[Override]
+    public static function jsonDeserialize(array $data): self
+    {
+        return new self(
+            day_of_the_week: $data['day_of_the_week'] ?? "Monday",
+        );
+    }
+
+    #[Override]
+    public function jsonSerialize(): array
+    {
+        return [
+            'day_of_the_week' => $this->day_of_the_week,
+        ];
+    }
+
+    public function getDay(): string
+    {
+        return $this->day_of_the_week;
+    }
+}

--- a/tests/fixtures/plugins/tester/templates/day_of_the_week_policy.html.twig
+++ b/tests/fixtures/plugins/tester/templates/day_of_the_week_policy.html.twig
@@ -1,0 +1,49 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2025 Teclib' and contributors.
+ # @copyright 2003-2014 by the INDEPNET Development Team.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+{% do call('Dropdown::showFromArray', [
+    input_name,
+    {
+        'Monday'   : __("Monday"),
+        'Tuesday'  : __("Tuesday"),
+        'Wednesday': __("Wednesday"),
+        'Thursday' : __("Thursday"),
+        'Friday'   : __("Friday"),
+        'Saturday' : __("Saturday"),
+        'Sunday'   : __("Sunday"),
+    },
+    {
+        'value': value,
+        'aria_label': label,
+    }
+]) %}


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

* Allow plugins to define their own access policies.
* Refactor the `ControlTypeInterfame::getWarnings()` method to remove the `warnings` parameter.

## Screenshots

![image](https://github.com/user-attachments/assets/1312cfee-c0f9-411e-a63a-ca81500f8fae)

![image](https://github.com/user-attachments/assets/7ec5f237-6aea-4009-a05f-b2e9057bf256)
