### PR TITLE
feat(forms): add translation support for default values of short answer questions

### DIFF
--- a/src/Glpi/Form/QuestionType/AbstractQuestionTypeShortAnswer.php
+++ b/src/Glpi/Form/QuestionType/AbstractQuestionTypeShortAnswer.php
@@ -135,9 +135,9 @@ TWIG;
     public function renderEndUserTemplate(
         Question $question,
     ): string {
-        $defaul_value = $question->fields['default_value'] ?? '';
+        $default_value = $question->fields['default_value'] ?? '';
         if ($this instanceof TranslationAwareQuestionType) {
-            $defaul_value = ItemTranslation::translate(
+            $default_value = ItemTranslation::translate(
                 $question,
                 Question::TRANSLATION_KEY_DEFAULT_VALUE,
                 1
@@ -149,7 +149,7 @@ TWIG;
                 type="{{ input_type }}"
                 class="form-control"
                 name="{{ question.getEndUserInputName() }}"
-                value="{{ defaul_value }}"
+                value="{{ default_value }}"
                 aria-label="{{ label }}"
                 {{ question.fields.is_mandatory ? 'required' : '' }}
                 {% for key, value in attributes %}
@@ -160,11 +160,11 @@ TWIG;
 
         $twig = TemplateRenderer::getInstance();
         return $twig->renderFromStringTemplate($template, [
-            'question'     => $question,
-            'defaul_value' => $defaul_value,
-            'input_type'   => $this->getInputType(),
-            'label'        => $question->fields['name'],
-            'attributes'   => $this->getInputAttributes(),
+            'question'      => $question,
+            'default_value' => $default_value,
+            'input_type'    => $this->getInputType(),
+            'label'         => $question->fields['name'],
+            'attributes'    => $this->getInputAttributes(),
         ]);
     }
 

--- a/src/Glpi/Form/QuestionType/AbstractQuestionTypeShortAnswer.php
+++ b/src/Glpi/Form/QuestionType/AbstractQuestionTypeShortAnswer.php
@@ -38,6 +38,7 @@ namespace Glpi\Form\QuestionType;
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\Form\Migration\FormQuestionDataConverterInterface;
 use Glpi\Form\Question;
+use Glpi\ItemTranslation\ItemTranslation;
 use Override;
 
 /**
@@ -134,12 +135,21 @@ TWIG;
     public function renderEndUserTemplate(
         Question $question,
     ): string {
+        $defaul_value = $question->fields['default_value'] ?? '';
+        if ($this instanceof TranslationAwareQuestionType) {
+            $defaul_value = ItemTranslation::translate(
+                $question,
+                Question::TRANSLATION_KEY_DEFAULT_VALUE,
+                1
+            );
+        }
+
         $template = <<<TWIG
             <input
                 type="{{ input_type }}"
                 class="form-control"
                 name="{{ question.getEndUserInputName() }}"
-                value="{{ question.fields.default_value }}"
+                value="{{ defaul_value }}"
                 aria-label="{{ label }}"
                 {{ question.fields.is_mandatory ? 'required' : '' }}
                 {% for key, value in attributes %}
@@ -150,10 +160,11 @@ TWIG;
 
         $twig = TemplateRenderer::getInstance();
         return $twig->renderFromStringTemplate($template, [
-            'question'   => $question,
-            'input_type' => $this->getInputType(),
-            'label'      => $question->fields['name'],
-            'attributes' => $this->getInputAttributes(),
+            'question'     => $question,
+            'defaul_value' => $defaul_value,
+            'input_type'   => $this->getInputType(),
+            'label'        => $question->fields['name'],
+            'attributes'   => $this->getInputAttributes(),
         ]);
     }
 

--- a/src/Glpi/Form/QuestionType/QuestionTypeShortText.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeShortText.php
@@ -39,9 +39,13 @@ use Glpi\DBAL\JsonFieldInterface;
 use Glpi\Form\Condition\ConditionHandler\ConditionHandlerInterface;
 use Glpi\Form\Condition\ConditionHandler\StringConditionHandler;
 use Glpi\Form\Condition\UsedAsCriteriaInterface;
+use Glpi\Form\Question;
+use Glpi\ItemTranslation\Context\TranslationHandler;
 use Override;
 
-final class QuestionTypeShortText extends AbstractQuestionTypeShortAnswer implements UsedAsCriteriaInterface
+final class QuestionTypeShortText extends AbstractQuestionTypeShortAnswer implements
+    UsedAsCriteriaInterface,
+    TranslationAwareQuestionType
 {
     #[Override]
     public function getInputType(): string
@@ -72,5 +76,18 @@ final class QuestionTypeShortText extends AbstractQuestionTypeShortAnswer implem
         ?JsonFieldInterface $question_config
     ): ConditionHandlerInterface {
         return new StringConditionHandler();
+    }
+
+    #[Override]
+    public function listTranslationsHandlers(Question $question): array
+    {
+        return [
+            new TranslationHandler(
+                item: $question,
+                key: Question::TRANSLATION_KEY_DEFAULT_VALUE,
+                name: __('Default value'),
+                value: $question->fields['default_value'] ?? '',
+            )
+        ];
     }
 }

--- a/tests/cypress/e2e/form/form_translation.cy.js
+++ b/tests/cypress/e2e/form/form_translation.cy.js
@@ -463,4 +463,65 @@ describe('Edit form translations', () => {
         cy.findByRole('heading', { name: 'Long answer question' }).should('exist');
         cy.findAllByLabelText('Long answer question').awaitTinyMCE().should('have.text', 'Ceci est une question de texte long');
     });
+
+    it('can translate default value of a short answer question', () => {
+        // Go to the form editor
+        cy.findByRole('tab', { name: 'Form' }).click();
+
+        // Add a new short answer question
+        cy.findByRole('button', { name: 'Add a new question' }).click();
+        cy.findByRole('textbox', { name: 'Question name' }).type('Short answer question');
+        cy.getDropdownByLabelText('Question type').selectDropdownValue('Short answer');
+
+        // Set default value
+        cy.findByRole('textbox', { name: 'Default value' }).type('This is a short answer question');
+
+        // Save the form
+        cy.findByRole('button', { name: 'Save' }).click();
+        cy.checkAndCloseAlert('Item successfully updated');
+
+        // Go to the form translations page
+        cy.findByRole('tab', { name: 'Form translations' }).click();
+
+        // Add a new language translation
+        cy.findByRole('button', { name: 'Add language' }).click();
+        cy.getDropdownByLabelText('Select language to translate').selectDropdownValue('Français');
+        cy.findByRole('button', { name: 'Add' }).click();
+        cy.findByRole('dialog').should('have.attr', 'data-cy-shown', 'true');
+
+        // Add translations for the short answer question
+        cy.findByRole('table', { name: 'Form translations' }).as('formTranslationsTable');
+        cy.get('@formTranslationsTable').findAllByRole('row').as('formTranslationsRows');
+        cy.get('@formTranslationsRows').eq(-1).within(() => {
+            cy.findByRole('cell', { name: 'Translation name' }).contains('Default value');
+            cy.findByRole('cell', { name: 'Default value' }).contains('This is a short answer question');
+            cy.findByRole('cell', { name: 'Translated value' }).findByRole('textbox', { name: 'Enter translation' })
+                .type('Ceci est une question de réponse courte');
+        });
+
+        // Save the translations
+        cy.findByRole('button', { name: 'Save translation' }).click();
+        cy.checkAndCloseAlert('Item successfully updated');
+
+        // Go to the form preview
+        cy.get('@form_id').then((form_id) => {
+            cy.visit(`/Form/Render/${form_id}`);
+        });
+
+        // Check default translations
+        cy.findByRole('heading', { name: 'Form title' }).should('exist').contains('Tests form translations');
+        cy.findByRole('note', { name: 'Form description' }).should('exist').contains('This form is used to test form translations');
+        cy.findByRole('heading', { name: 'Short answer question' }).should('exist');
+        cy.findByRole('textbox', { name: 'Short answer question' }).should('exist').should('have.value', 'This is a short answer question');
+
+        // Change the user language to French
+        changeUserLanguage('fr_FR');
+        cy.reload();
+
+        // Check the translations for the short answer question
+        cy.findByRole('heading', { name: 'Form title' }).should('exist').contains('Tests form translations');
+        cy.findByRole('note', { name: 'Form description' }).should('exist').contains('This form is used to test form translations');
+        cy.findByRole('heading', { name: 'Short answer question' }).should('exist');
+        cy.findByRole('textbox', { name: 'Short answer question' }).should('exist').should('have.value', 'Ceci est une question de réponse courte');
+    });
 });


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Adding translation support for default values of short answer questions.