### PR TITLE
Forms: allow plugins to define their own destinations types

### DIFF
--- a/phpunit/functional/Glpi/Form/Destination/FormDestinationManagerTest.php
+++ b/phpunit/functional/Glpi/Form/Destination/FormDestinationManagerTest.php
@@ -40,6 +40,7 @@ use Glpi\Form\Destination\FormDestinationInterface;
 use Glpi\Form\Destination\FormDestinationManager;
 use Glpi\Tests\FormBuilder;
 use Glpi\Tests\FormTesterTrait;
+use GlpiPlugin\Tester\Form\ComputerDestination;
 
 final class FormDestinationManagerTest extends DbTestCase
 {
@@ -83,6 +84,9 @@ final class FormDestinationManagerTest extends DbTestCase
             $this->assertInstanceOf(FormDestinationInterface::class, $item);
             $this->assertNotEmpty($label);
         }
+
+        // Make sure plugin types are found
+        $this->assertArrayHasKey(ComputerDestination::class, $values);
     }
 
     /**

--- a/src/Glpi/Form/Destination/AbstractCommonITILFormDestination.php
+++ b/src/Glpi/Form/Destination/AbstractCommonITILFormDestination.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2025 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -85,6 +84,12 @@ abstract class AbstractCommonITILFormDestination implements FormDestinationInter
                 'can_update'  => FormDestination::canUpdate(),
             ]
         );
+    }
+
+    #[Override]
+    public function useDefaultConfigLayout(): bool
+    {
+        return false;
     }
 
     #[Override]

--- a/src/Glpi/Form/Destination/FormDestinationChange.php
+++ b/src/Glpi/Form/Destination/FormDestinationChange.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2025 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------

--- a/src/Glpi/Form/Destination/FormDestinationManager.php
+++ b/src/Glpi/Form/Destination/FormDestinationManager.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2025 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -46,6 +45,9 @@ final class FormDestinationManager
      */
     private static ?FormDestinationManager $instance = null;
 
+    /** @var FormDestinationInterface[] */
+    private array $plugins_destinations_types = [];
+
     /**
      * Private constructor (singleton)
      */
@@ -74,11 +76,11 @@ final class FormDestinationManager
      */
     public function getDestinationTypes(): array
     {
-        // TODO: support plugin types
         return [
             new FormDestinationTicket(),
             new FormDestinationProblem(),
             new FormDestinationChange(),
+            ...$this->plugins_destinations_types,
         ];
     }
 
@@ -108,6 +110,8 @@ final class FormDestinationManager
 
     /**
      * Default (most common) type.
+     *
+     * @return FormDestinationInterface
      */
     public function getDefaultType(): FormDestinationInterface
     {
@@ -136,5 +140,11 @@ final class FormDestinationManager
         }
 
         return $warnings;
+    }
+
+    public function registerPluginDestinationType(
+        FormDestinationInterface $type
+    ): void {
+        $this->plugins_destinations_types[] = $type;
     }
 }

--- a/src/Glpi/Form/Destination/FormDestinationProblem.php
+++ b/src/Glpi/Form/Destination/FormDestinationProblem.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2025 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------

--- a/src/Glpi/Form/Destination/FormDestinationTicket.php
+++ b/src/Glpi/Form/Destination/FormDestinationTicket.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2025 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------

--- a/templates/pages/admin/form/form_destination.html.twig
+++ b/templates/pages/admin/form/form_destination.html.twig
@@ -143,12 +143,20 @@
                     >
                         <div class="accordion-body p-0">
                             <form id="form-destination-{{ destination.getID() }}">
-                                <div class="overflow-x-hidden">
+                                <div class="overflow-x-hidden px-4">
                                     {{ concrete_destination.renderConfigForm(
                                         form,
                                         destination,
                                         destination.getConfig(),
                                     )|raw }}
+                                    {% if concrete_destination.useDefaultConfigLayout() and can_update %}
+                                        <div class="mt-3 mb-3">
+                                            {{ include('pages/admin/form/form_destination_actions.html.twig', {
+                                                form: form,
+                                                destination: destination
+                                            }, with_context = false) }}
+                                        </div>
+                                    {% endif %}
                                 </div>
 
                                 {# Hidden values #}

--- a/templates/pages/admin/form/form_destination_actions.html.twig
+++ b/templates/pages/admin/form/form_destination_actions.html.twig
@@ -1,0 +1,102 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2025 Teclib' and contributors.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+<div class="d-flex flex-row-reverse align-items-center justify-content-between">
+    <div class="d-flex flex-row-reverse">
+        <button
+            class="btn btn-primary ms-2"
+            name="update"
+            type="submit"
+            formaction="{{ '/Form/%d/Destination/%d/Update'|format(form.getID(), destination.getID()) }}"
+            formmethod="post"
+        >
+            <i class="ti ti-device-floppy me-2"></i>
+            {{ __("Update item") }}
+        </button>
+        {% if destination.canPurgeItem() %}
+            <button
+                class="btn btn-ghost-danger"
+                name="purge"
+                type="submit"
+                formaction="{{ '/Form/%d/Destination/%d/Purge'|format(form.getID(), destination.getID()) }}"
+                formmethod="post"
+            >
+                <i class="ti ti-trash me-2"></i>
+                {{ __("Delete") }}
+            </button>
+        {% endif %}
+    </div>
+    <div>
+        <button
+            title="{{ __('Configure creation conditions') }}"
+            data-bs-toggle="dropdown"
+            data-bs-auto-close="outside"
+            class="dropdown-toggle btn btn-outline-secondary btn-sm px-2"
+            data-bs-placement="top"
+            type="button"
+        >
+            {% set selected_strategy = destination.getConfiguredCreationStrategy() %}
+            {% for strategy in enum_cases('Glpi\\Form\\Condition\\CreationStrategy') %}
+                {% set is_visible = selected_strategy == strategy %}
+                {% set display_class = is_visible ? 'd-flex' : 'd-none' %}
+                <div
+                    class="{{ display_class }} align-items-center"
+                    data-glpi-editor-condition-badge="{{ strategy.value }}"
+                >
+                    <i class="{{ strategy.getIcon() }} me-1"></i>
+                    <span>{{ strategy.getLabel() }}</span>
+                </div>
+            {% endfor %}
+        </button>
+        <div
+            class="dropdown-menu dropdown-menu-end dropdown-menu-card animate__animated animate__zoomIn"
+        >
+            <div class="card visibility-dropdown-card">
+                <div class="card-body">
+                    <h3 class="card-title d-flex align-items-center">
+                        <i class="ti ti-circuit-changeover me-2"></i>
+                        {{ __('Conditions') }}
+                    </h3>
+
+                    {{ include(
+                        "pages/admin/form/destination_visibility_conditions_configuration.html.twig",
+                        {
+                            destination: destination,
+                            form: form,
+                        },
+                        with_context: false
+                    ) }}
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/templates/pages/admin/form/form_destination_commonitil_config.html.twig
+++ b/templates/pages/admin/form/form_destination_commonitil_config.html.twig
@@ -245,7 +245,7 @@
     </script>
 {% endmacro %}
 
-<div class="overflow-x-hidden row d-flex mx-0 border-top">
+<div class="overflow-x-hidden row d-flex mx-n4 border-top">
     <div class="col-12 col-lg-8 order-last order-lg-first pt-2 pe-2 pe-lg-4 d-flex flex-column">
         <div class="timeline-item mb-3 ITILContent ps-4">
             <div class="row">
@@ -358,90 +358,12 @@
             {% endfor %}
         </section>
     </div>
-    <div class="itil-footer card-footer p-0 border-top">
-        <div class="d-flex flex-row-reverse align-items-center justify-content-between m-2">
-            {% if can_update %}
-                <div class="d-flex flex-row-reverse">
-                    <button
-                        class="btn btn-primary ms-2"
-                        name="update"
-                        type="submit"
-                        formaction="{{ '/Form/%d/Destination/%d/Update'|format(form.getID(), destination.getID()) }}"
-                        formmethod="post"
-                    >
-                        <i class="ti ti-device-floppy me-2"></i>
-                        {{ __("Update item") }}
-                    </button>
-                    {% if destination.canPurgeItem() %}
-                        <button
-                            class="btn btn-ghost-danger"
-                            name="purge"
-                            type="submit"
-                            formaction="{{ '/Form/%d/Destination/%d/Purge'|format(form.getID(), destination.getID()) }}"
-                            formmethod="post"
-                        >
-                            <i class="ti ti-trash me-2"></i>
-                            {{ __("Delete") }}
-                        </button>
-                    {% endif %}
-                </div>
-            {% endif %}
-            {% if destination.fields.is_mandatory %}
-                <span class="badge bg-secondary-lt ms-2">
-                    {{ __("Mandatory") }}
-                    <span
-                        class="form-help"
-                        data-bs-toggle="popover"
-                        data-bs-placement="right"
-                        data-bs-content="{{ __("This is the main item that will be created by this form. It can't be deleted.") }}"
-                    >?</span>
-                </span>
-            {% else %}
-                <div>
-                    <button
-                        title="{{ __('Configure creation conditions') }}"
-                        data-bs-toggle="dropdown"
-                        data-bs-auto-close="outside"
-                        class="dropdown-toggle btn btn-outline-secondary btn-sm px-2"
-                        data-bs-placement="top"
-                        type="button"
-                    >
-                        {% set selected_strategy = destination.getConfiguredCreationStrategy() %}
-                        {% for strategy in enum_cases('Glpi\\Form\\Condition\\CreationStrategy') %}
-                            {% set is_visible = selected_strategy == strategy %}
-                            {% set display_class = is_visible ? 'd-flex' : 'd-none' %}
-                            <div
-                                class="{{ display_class }} align-items-center"
-                                data-glpi-editor-condition-badge="{{ strategy.value }}"
-                            >
-                                <i class="{{ strategy.getIcon() }} me-1"></i>
-                                <span>{{ strategy.getLabel() }}</span>
-                            </div>
-                        {% endfor %}
-                    </button>
-                    <div
-                        class="dropdown-menu dropdown-menu-end dropdown-menu-card animate__animated animate__zoomIn"
-                    >
-                        <div class="card visibility-dropdown-card">
-                            <div class="card-body">
-                                <h3 class="card-title d-flex align-items-center">
-                                    <i class="ti ti-circuit-changeover me-2"></i>
-                                    {{ __('Conditions') }}
-                                </h3>
-
-                                {{ include(
-                                    "pages/admin/form/destination_visibility_conditions_configuration.html.twig",
-                                    {
-                                        destination: destination,
-                                        form: form,
-                                    },
-                                    with_context: false
-                                ) }}
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            {% endif %}
-        </div>
+    <div class="itil-footer card-footer p-0 border-top p-2 ps-4 pe-4">
+        {% if can_update %}
+            {{ include('pages/admin/form/form_destination_actions.html.twig', {
+                form: form,
+                destination: destination
+            }, with_context = false) }}
+        {% endif %}
     </div>
 </div>

--- a/tests/cypress/e2e/form/form_plugins.cy.js
+++ b/tests/cypress/e2e/form/form_plugins.cy.js
@@ -95,4 +95,26 @@ describe('Form plugins', () => {
             cy.getDropdownByLabelText('Day').should('have.text', "Thursday");
         });
     });
+
+    it('can configure destinations from plugins', () => {
+        // Create and go to form
+        cy.createFormWithAPI().visitFormTab('Destinations');
+
+        // Add computer destination
+        cy.findByRole('button', {name: "Add Computer"}).click();
+
+        // Set name and save
+        cy.findByRole('textbox', {name: 'Name'}).should(
+            'not.have.value',
+            "My computer name"
+        );
+        cy.findByRole('textbox', {name: 'Name'}).type("My computer name");
+        cy.findByRole('button', {name: 'Update item'}).click();
+
+        // Validate value was saved
+        cy.findByRole('textbox', {name: 'Name'}).should(
+            'have.value',
+            "My computer name"
+        );
+    });
 });

--- a/tests/fixtures/plugins/tester/setup.php
+++ b/tests/fixtures/plugins/tester/setup.php
@@ -33,7 +33,9 @@
  */
 
 use Glpi\Form\AccessControl\FormAccessControlManager;
+use Glpi\Form\Destination\FormDestinationManager;
 use Glpi\Form\QuestionType\QuestionTypesManager;
+use GlpiPlugin\Tester\Form\ComputerDestination;
 use GlpiPlugin\Tester\Form\DayOfTheWeekPolicy;
 use GlpiPlugin\Tester\Form\QuestionTypeRange;
 use GlpiPlugin\Tester\Form\QuestionTypeColor;
@@ -91,4 +93,8 @@ function plugin_init_tester(): void
     // Register access control policies
     $access_manager = FormAccessControlManager::getInstance();
     $access_manager->registerPluginAccessControlPolicy(new DayOfTheWeekPolicy());
+
+    // Register destination type
+    $destination_manager = FormDestinationManager::getInstance();
+    $destination_manager->registerPluginDestinationType(new ComputerDestination());
 }

--- a/tests/fixtures/plugins/tester/src/Form/ComputerDestination.php
+++ b/tests/fixtures/plugins/tester/src/Form/ComputerDestination.php
@@ -32,72 +32,82 @@
  * ---------------------------------------------------------------------
  */
 
-namespace Glpi\Form\Destination;
+namespace GlpiPlugin\Tester\Form;
 
+use Computer;
+use Glpi\Application\View\TemplateRenderer;
 use Glpi\Form\AnswersSet;
+use Glpi\Form\Destination\FormDestination;
+use Glpi\Form\Destination\FormDestinationInterface;
 use Glpi\Form\Export\Context\DatabaseMapper;
 use Glpi\Form\Export\Serializer\DynamicExportDataField;
 use Glpi\Form\Form;
+use Override;
 
-interface FormDestinationInterface
+final class ComputerDestination implements FormDestinationInterface
 {
-    /**
-     * Create one or multiple items for a given form and its answers
-     *
-     * @param Form       $form
-     * @param AnswersSet $answers_set
-     * @param array      $config
-     *
-     * @return \CommonDBTM[]
-     *
-     * @throws \Exception Must be thrown if the item can't be created
-     */
+    #[Override]
     public function createDestinationItems(
         Form $form,
         AnswersSet $answers_set,
         array $config,
-    ): array;
+    ): array {
+        $computer = new Computer();
+        $computer->add([
+            'name'         => $config['name'] ?? "",
+            'entities_id'  => $form->fields['entities_id'],
+            'is_recursive' => $form->fields['is_recursive'],
+        ]);
+        return [$computer];
+    }
 
-
-    /**
-     * Render the configuration form for this destination type.
-     *
-     * @param Form  $form
-     * @param FormDestination $destination
-     * @param array $config
-     * @return string The rendered HTML content
-     */
+    #[Override]
     public function renderConfigForm(
         Form $form,
         FormDestination $destination,
         array $config
-    ): string;
+    ): string {
+        $twig = TemplateRenderer::getInstance();
+        return $twig->render("@tester/computer_destination.html.twig", [
+            'config' => $config,
+        ]);
+    }
 
-    /**
-     * If true, the config form will be populated with a complete layout that
-     * contains the actions buttons and some preset margins.
-     *
-     * If false, the layout will be empty and renderConfigForm() will have the
-     * full responsability of including the actions buttons.
-     */
-    public function useDefaultConfigLayout(): bool;
+    #[Override]
+    public function useDefaultConfigLayout(): bool
+    {
+        return true;
+    }
 
-    /**
-     * Used to ordered items (lowest = first, highest = last)
-     */
-    public function getWeight(): int;
+    #[Override]
+    public function getWeight(): int
+    {
+        return 40;
+    }
 
-    public function getLabel(): string;
+    #[Override]
+    public function getLabel(): string
+    {
+        return Computer::getTypeName(1);
+    }
 
-    /**
-     * @return string Fully qualified tabler icon name (e.g. ti ti-user)
-     */
-    public function getIcon(): string;
+    #[Override]
+    public function getIcon(): string
+    {
+        return Computer::getIcon();
+    }
 
-    public function exportDynamicConfig(array $config): DynamicExportDataField;
+    #[Override]
+    public function exportDynamicConfig(array $config): DynamicExportDataField
+    {
+        return new DynamicExportDataField($config, []);
+    }
 
+    #[Override]
     public static function prepareDynamicConfigDataForImport(
         array $config,
         DatabaseMapper $mapper,
-    ): array;
+    ): array {
+        return $config;
+    }
 }

--- a/tests/fixtures/plugins/tester/templates/computer_destination.html.twig
+++ b/tests/fixtures/plugins/tester/templates/computer_destination.html.twig
@@ -1,0 +1,42 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2025 Teclib' and contributors.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+{% import 'components/form/fields_macros.html.twig' as fields %}
+
+{{ fields.textField(
+    'config[name]',
+    config.name ?? "",
+    __("Name"),
+    {
+        is_horizontal: false,
+    }
+) }}

--- a/tests/src/Form/Destination/AbstractCommonITILFormDestinationType.php
+++ b/tests/src/Form/Destination/AbstractCommonITILFormDestinationType.php
@@ -38,6 +38,7 @@ use CommonDBTM;
 use DbTestCase;
 use Glpi\Form\AnswersHandler\AnswersHandler;
 use Glpi\Form\AnswersSet;
+use Glpi\Form\Destination\AbstractCommonITILFormDestination;
 use Glpi\Form\Destination\CommonITILField\ContentField;
 use Glpi\Form\Destination\CommonITILField\SimpleValueConfig;
 use Glpi\Form\Destination\CommonITILField\TitleField;
@@ -55,9 +56,9 @@ abstract class AbstractCommonITILFormDestinationType extends DbTestCase
     /**
      * Get the tested instance
      *
-     * @return \Glpi\Form\Destination\AbstractCommonITILFormDestination
+     * @return AbstractCommonITILFormDestination
      */
-    abstract protected function getTestedInstance(): \Glpi\Form\Destination\AbstractCommonITILFormDestination;
+    abstract protected function getTestedInstance(): AbstractCommonITILFormDestination;
 
     final public function testCreateDestinations(): void
     {


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Allow form destinations to be defined by plugins.

## Screenshots

![image](https://github.com/user-attachments/assets/788a0ec4-cd60-4dd9-8f44-dc7ac05daa40)

![image](https://github.com/user-attachments/assets/cbb8c76f-c76e-45e2-bd7b-140030ce0644)



