### PR TITLE
fix(forms): ensure form description translation fallback returns an empty string

### DIFF
--- a/src/Glpi/Form/Form.php
+++ b/src/Glpi/Form/Form.php
@@ -1002,7 +1002,7 @@ final class Form extends CommonDBTM implements ServiceCatalogLeafInterface, Prov
         return FormTranslation::translate(
             $this,
             static::TRANSLATION_KEY_DESCRIPTION
-        );
+        ) ?? '';
     }
 
     #[Override]

--- a/tests/cypress/e2e/form/service_catalog/service_catalog_page.cy.js
+++ b/tests/cypress/e2e/form/service_catalog/service_catalog_page.cy.js
@@ -32,10 +32,10 @@
 
 describe('Service catalog page', () => {
 
-    function createActiveForm(name, category = 0) {
+    function createActiveForm(name, category = 0, description = 'Lorem ipsum dolor sit amet, consectetur adipisicing elit.') {
         cy.createFormWithAPI({
             'name': name,
-            'description': "Lorem ipsum dolor sit amet, consectetur adipisicing elit.",
+            'description': description,
             'is_active': true,
             'forms_categories_id': category,
         }).as('form_id');
@@ -474,5 +474,28 @@ describe('Service catalog page', () => {
             cy.findByRole('region', {name: `Form ${String.fromCharCode(65 + i)} ${time}`}).should('exist');
         }
         cy.findByRole('region', {name: `Form ${String.fromCharCode(65 + forms_per_page)} ${time}`}).should('not.exist');
+    });
+
+    it('can display service catalog with form that has no description', () => {
+        const form_name = `Test form without description ${(new Date()).getTime()}`;
+
+        cy.changeProfile('Super-Admin');
+        createActiveForm(form_name, 0, null);
+
+        cy.changeProfile('Self-Service', true);
+        cy.visit('/ServiceCatalog');
+
+        // Search for the form
+        cy.findByPlaceholderText('Search for forms...').as('filter_input');
+        cy.get('@filter_input').type(form_name);
+
+        // Validate that the form is displayed correctly.
+        cy.findByRole('region', {'name': form_name}).as('forms');
+        cy.get('@forms').within(() => {
+            cy.findByRole('heading', {'name': form_name}).should('exist');
+            cy.findByRole('heading', {'name': form_name}).next('div').invoke('text').then((text) => {
+                expect(text.trim()).to.be.empty;
+            });
+        });
     });
 });


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Fixes #19279
Ensure form description translation fallback returns an empty string to avoid errors
