### PR TITLE
Use the progress indicator in the update process

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -131,54 +131,6 @@ $ignoreErrors[] = [
 	'message' => '#^Empty array passed to foreach\\.$#',
 	'identifier' => 'foreach.emptyArray',
 	'count' => 2,
-	'path' => __DIR__ . '/install/migrations/update_0.85.x_to_0.90.0.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^If condition is always false\\.$#',
-	'identifier' => 'if.alwaysFalse',
-	'count' => 1,
-	'path' => __DIR__ . '/install/migrations/update_0.85.x_to_0.90.0.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Empty array passed to foreach\\.$#',
-	'identifier' => 'foreach.emptyArray',
-	'count' => 1,
-	'path' => __DIR__ . '/install/migrations/update_0.90.0_to_0.90.1.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^If condition is always false\\.$#',
-	'identifier' => 'if.alwaysFalse',
-	'count' => 1,
-	'path' => __DIR__ . '/install/migrations/update_0.90.0_to_0.90.1.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Empty array passed to foreach\\.$#',
-	'identifier' => 'foreach.emptyArray',
-	'count' => 1,
-	'path' => __DIR__ . '/install/migrations/update_0.90.1_to_0.90.5.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^If condition is always false\\.$#',
-	'identifier' => 'if.alwaysFalse',
-	'count' => 1,
-	'path' => __DIR__ . '/install/migrations/update_0.90.1_to_0.90.5.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Empty array passed to foreach\\.$#',
-	'identifier' => 'foreach.emptyArray',
-	'count' => 1,
-	'path' => __DIR__ . '/install/migrations/update_0.90.x_to_9.1.0.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^If condition is always false\\.$#',
-	'identifier' => 'if.alwaysFalse',
-	'count' => 1,
-	'path' => __DIR__ . '/install/migrations/update_0.90.x_to_9.1.0.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Empty array passed to foreach\\.$#',
-	'identifier' => 'foreach.emptyArray',
-	'count' => 2,
 	'path' => __DIR__ . '/install/migrations/update_10.0.0_to_10.0.1.php',
 ];
 $ignoreErrors[] = [
@@ -210,30 +162,6 @@ $ignoreErrors[] = [
 	'identifier' => 'foreach.emptyArray',
 	'count' => 3,
 	'path' => __DIR__ . '/install/migrations/update_10.0.x_to_11.0.0.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Empty array passed to foreach\\.$#',
-	'identifier' => 'foreach.emptyArray',
-	'count' => 1,
-	'path' => __DIR__ . '/install/migrations/update_9.1.0_to_9.1.1.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^If condition is always false\\.$#',
-	'identifier' => 'if.alwaysFalse',
-	'count' => 1,
-	'path' => __DIR__ . '/install/migrations/update_9.1.0_to_9.1.1.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Empty array passed to foreach\\.$#',
-	'identifier' => 'foreach.emptyArray',
-	'count' => 1,
-	'path' => __DIR__ . '/install/migrations/update_9.1.1_to_9.1.3.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^If condition is always false\\.$#',
-	'identifier' => 'if.alwaysFalse',
-	'count' => 1,
-	'path' => __DIR__ . '/install/migrations/update_9.1.1_to_9.1.3.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Method Migration\\:\\:addPostQuery\\(\\) invoked with 4 parameters, 1\\-2 required\\.$#',
@@ -3719,18 +3647,6 @@ $ignoreErrors[] = [
 	'message' => '#^Call to function is_null\\(\\) with string will always evaluate to false\\.$#',
 	'identifier' => 'function.impossibleType',
 	'count' => 8,
-	'path' => __DIR__ . '/src/Migration.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Instanceof between Glpi\\\\Console\\\\Application and Glpi\\\\Console\\\\Application will always evaluate to true\\.$#',
-	'identifier' => 'instanceof.alwaysTrue',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Migration.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Strict comparison using \\!\\=\\= between null and \'comment\'\\|\'error\'\\|\'info\' will always evaluate to true\\.$#',
-	'identifier' => 'notIdentical.alwaysTrue',
-	'count' => 1,
 	'path' => __DIR__ . '/src/Migration.php',
 ];
 $ignoreErrors[] = [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -293,6 +293,11 @@ The present file will list all changes made to the project; according to the
 - `ITILFollowup::ADDMYTICKET` constant. Use `ITILFollowup::ADDMY`.
 - `ITILFollowup::ADDGROUPTICKET` constant. Use `ITILFollowup::ADD_AS_GROUP`.
 - `ITILFollowup::ADDALLTICKET` constant. Use `ITILFollowup::ADDALLITEM`.
+- `Migration::addNewMessageArea()`
+- `Migration::displayError()`
+- `Migration::displayTitle()`
+- `Migration::displayWarning()`
+- `Migration::setOutputHandler()`
 - `Pdu_Plug` has been deprecated and replaced by `Item_Plug`
 - `Plugin::getWebDir()`
 - `Search::joinDropdownTranslations()`

--- a/composer-dependency-analyser.php
+++ b/composer-dependency-analyser.php
@@ -47,7 +47,7 @@ return $config
         // 'src' Loaded from the autoloader
     ], false)
 
-    ->ignoreUnknownClasses(['DbTestCase'])
+    ->ignoreUnknownClasses(['DB', 'DbTestCase'])
 
     // Ignore errors on extensions that are suggested but not required
     ->ignoreErrorsOnExtensionAndPaths('ext-exif', [

--- a/install/migrations/update_0.85.x_to_0.90.0.php
+++ b/install/migrations/update_0.85.x_to_0.90.0.php
@@ -47,31 +47,8 @@ function update085xto0900()
     global $DB, $migration;
 
     $updateresult     = true;
-    $ADDTODISPLAYPREF = [];
 
-   //TRANS: %s is the number of new version
-    $migration->displayTitle(sprintf(__('Update to %s'), '0.90'));
     $migration->setVersion('0.90');
-
-    $backup_tables = false;
-    $newtables     = [];
-
-    foreach ($newtables as $new_table) {
-       // rename new tables if exists ?
-        if ($DB->tableExists($new_table)) {
-            $migration->dropTable("backup_$new_table");
-            $migration->displayWarning("$new_table table already exists. " .
-                                    "A backup have been done to backup_$new_table.");
-            $backup_tables = true;
-            $migration->renameTable("$new_table", "backup_$new_table");
-        }
-    }
-    if ($backup_tables) {
-        $migration->displayWarning(
-            "You can delete backup tables if you have no need of them.",
-            true
-        );
-    }
 
    // Add Color selector
     Config::setConfigurationValues('core', ['palette' => 'auror']);
@@ -91,54 +68,6 @@ function update085xto0900()
     $migration->dropField("glpi_users", "dropdown_chars_limit");
     Config::deleteConfigurationValues('core', ['name' => 'dropdown_chars_limit']);
 
-   // ************ Keep it at the end **************
-   //TRANS: %s is the table or item to migrate
-    $migration->displayMessage(sprintf(__('Data migration - %s'), 'glpi_displaypreferences'));
-
-    foreach ($ADDTODISPLAYPREF as $type => $tab) {
-        $query = "SELECT DISTINCT `users_id`
-                FROM `glpi_displaypreferences`
-                WHERE `itemtype` = '$type'";
-
-        if ($result = $DB->doQuery($query)) {
-            if ($DB->numrows($result) > 0) {
-                while ($data = $DB->fetchAssoc($result)) {
-                    $query = "SELECT MAX(`rank`)
-                         FROM `glpi_displaypreferences`
-                         WHERE `users_id` = '" . $data['users_id'] . "'
-                               AND `itemtype` = '$type'";
-                    $result = $DB->doQuery($query);
-                    $rank   = $DB->result($result, 0, 0);
-                    $rank++;
-
-                    foreach ($tab as $newval) {
-                        $query = "SELECT *
-                            FROM `glpi_displaypreferences`
-                            WHERE `users_id` = '" . $data['users_id'] . "'
-                                  AND `num` = '$newval'
-                                  AND `itemtype` = '$type'";
-                        if ($result2 = $DB->doQuery($query)) {
-                            if ($DB->numrows($result2) == 0) {
-                                 $query = "INSERT INTO `glpi_displaypreferences`
-                                         (`itemtype` ,`num` ,`rank` ,`users_id`)
-                                  VALUES ('$type', '$newval', '" . $rank++ . "',
-                                          '" . $data['users_id'] . "')";
-                                 $DB->doQuery($query);
-                            }
-                        }
-                    }
-                }
-            } else { // Add for default user
-                $rank = 1;
-                foreach ($tab as $newval) {
-                    $query = "INSERT INTO `glpi_displaypreferences`
-                                (`itemtype` ,`num` ,`rank` ,`users_id`)
-                         VALUES ('$type', '$newval', '" . $rank++ . "', '0')";
-                    $DB->doQuery($query);
-                }
-            }
-        }
-    }
    // change type of field solution in ticket.change and problem
     $migration->changeField('glpi_tickets', 'solution', 'solution', 'longtext');
     $migration->changeField('glpi_changes', 'solution', 'solution', 'longtext');

--- a/install/migrations/update_0.90.0_to_0.90.1.php
+++ b/install/migrations/update_0.90.0_to_0.90.1.php
@@ -49,29 +49,7 @@ function update0900to0901()
     $updateresult     = true;
     $ADDTODISPLAYPREF = [];
 
-   //TRANS: %s is the number of new version
-    $migration->displayTitle(sprintf(__('Update to %s'), '0.90.1'));
     $migration->setVersion('0.90.1');
-
-    $backup_tables = false;
-    $newtables     = [];
-
-    foreach ($newtables as $new_table) {
-       // rename new tables if exists ?
-        if ($DB->tableExists($new_table)) {
-            $migration->dropTable("backup_$new_table");
-            $migration->displayWarning("$new_table table already exists. " .
-                                    "A backup have been done to backup_$new_table.");
-            $backup_tables = true;
-            $migration->renameTable("$new_table", "backup_$new_table");
-        }
-    }
-    if ($backup_tables) {
-        $migration->displayWarning(
-            "You can delete backup tables if you have no need of them.",
-            true
-        );
-    }
 
    // Add missing fill in 0.90 empty version
     $migration->addField("glpi_entities", 'inquest_duration', "integer", ['value' => 0]);

--- a/install/migrations/update_0.90.1_to_0.90.5.php
+++ b/install/migrations/update_0.90.1_to_0.90.5.php
@@ -49,29 +49,7 @@ function update0901to0905()
     $updateresult     = true;
     $ADDTODISPLAYPREF = [];
 
-   //TRANS: %s is the number of new version
-    $migration->displayTitle(sprintf(__('Update to %s'), '0.90.5'));
     $migration->setVersion('0.90.5');
-
-    $backup_tables = false;
-    $newtables     = [];
-
-    foreach ($newtables as $new_table) {
-       // rename new tables if exists ?
-        if ($DB->tableExists($new_table)) {
-            $migration->dropTable("backup_$new_table");
-            $migration->displayWarning("$new_table table already exists. " .
-                                    "A backup have been done to backup_$new_table.");
-            $backup_tables = true;
-            $migration->renameTable("$new_table", "backup_$new_table");
-        }
-    }
-    if ($backup_tables) {
-        $migration->displayWarning(
-            "You can delete backup tables if you have no need of them.",
-            true
-        );
-    }
 
    // fix https://github.com/glpi-project/glpi/issues/820
    // remove empty suppliers in tickets

--- a/install/migrations/update_0.90.x_to_9.1.0.php
+++ b/install/migrations/update_0.90.x_to_9.1.0.php
@@ -54,31 +54,7 @@ function update090xto910()
     $updateresult     = true;
     $ADDTODISPLAYPREF = [];
 
-   //TRANS: %s is the number of new version
-    $migration->displayTitle(sprintf(__('Update to %s'), '9.1'));
     $migration->setVersion('9.1');
-
-    $backup_tables = false;
-   // table already exist but deleted during the migration
-   // not table created during the migration
-    $newtables     = [];
-
-    foreach ($newtables as $new_table) {
-       // rename new tables if exists ?
-        if ($DB->tableExists($new_table)) {
-            $migration->dropTable("backup_$new_table");
-            $migration->displayWarning("$new_table table already exists. " .
-                                    "A backup have been done to backup_$new_table.");
-            $backup_tables = true;
-            $migration->renameTable("$new_table", "backup_$new_table");
-        }
-    }
-    if ($backup_tables) {
-        $migration->displayWarning(
-            "You can delete backup tables if you have no need of them.",
-            true
-        );
-    }
 
     $migration->displayMessage(sprintf(__('Add of - %s to database'), 'Object Locks'));
 

--- a/install/migrations/update_10.0.0_to_10.0.1.php
+++ b/install/migrations/update_10.0.0_to_10.0.1.php
@@ -50,8 +50,6 @@ function update1000to1001()
     $DELFROMDISPLAYPREF = [];
     $update_dir = __DIR__ . '/update_10.0.0_to_10.0.1/';
 
-    //TRANS: %s is the number of new version
-    $migration->displayTitle(sprintf(__('Update to %s'), '10.0.1'));
     $migration->setVersion('10.0.1');
 
     $update_scripts = scandir($update_dir);

--- a/install/migrations/update_10.0.0_to_10.0.1/configs.php
+++ b/install/migrations/update_10.0.0_to_10.0.1/configs.php
@@ -39,7 +39,6 @@
 
 use Glpi\Agent\Communication\AbstractRequest;
 
-$migration->displayMessage('Add new configurations / user preferences');
 $migration->addPreQuery(
     $DB->buildUpdate(
         Config::getTable(),

--- a/install/migrations/update_10.0.10_to_10.0.11.php
+++ b/install/migrations/update_10.0.10_to_10.0.11.php
@@ -50,8 +50,6 @@ function update10010to10011()
     $DELFROMDISPLAYPREF = [];
     $update_dir = __DIR__ . '/update_10.0.10_to_10.0.11/';
 
-    //TRANS: %s is the number of new version
-    $migration->displayTitle(sprintf(__('Update to %s'), '10.0.11'));
     $migration->setVersion('10.0.11');
 
     $update_scripts = scandir($update_dir);

--- a/install/migrations/update_10.0.11_to_10.0.12.php
+++ b/install/migrations/update_10.0.11_to_10.0.12.php
@@ -50,8 +50,6 @@ function update10011to10012()
     $DELFROMDISPLAYPREF = [];
     $update_dir = __DIR__ . '/update_10.0.11_to_10.0.12/';
 
-    //TRANS: %s is the number of new version
-    $migration->displayTitle(sprintf(__('Update to %s'), '10.0.12'));
     $migration->setVersion('10.0.12');
 
     $update_scripts = scandir($update_dir);

--- a/install/migrations/update_10.0.12_to_10.0.13.php
+++ b/install/migrations/update_10.0.12_to_10.0.13.php
@@ -50,8 +50,6 @@ function update10012to10013()
     $DELFROMDISPLAYPREF = [];
     $update_dir = __DIR__ . '/update_10.0.12_to_10.0.13/';
 
-    //TRANS: %s is the number of new version
-    $migration->displayTitle(sprintf(__('Update to %s'), '10.0.13'));
     $migration->setVersion('10.0.13');
 
     $update_scripts = scandir($update_dir);

--- a/install/migrations/update_10.0.14_to_10.0.15.php
+++ b/install/migrations/update_10.0.14_to_10.0.15.php
@@ -50,8 +50,6 @@ function update10014to10015()
     $DELFROMDISPLAYPREF = [];
     $update_dir = __DIR__ . '/update_10.0.14_to_10.0.15/';
 
-    //TRANS: %s is the number of new version
-    $migration->displayTitle(sprintf(__('Update to %s'), '10.0.15'));
     $migration->setVersion('10.0.15');
 
     $update_scripts = scandir($update_dir);

--- a/install/migrations/update_10.0.15_to_10.0.16.php
+++ b/install/migrations/update_10.0.15_to_10.0.16.php
@@ -50,8 +50,6 @@ function update10015to10016()
     $DELFROMDISPLAYPREF = [];
     $update_dir = __DIR__ . '/update_10.0.15_to_10.0.16/';
 
-    //TRANS: %s is the number of new version
-    $migration->displayTitle(sprintf(__('Update to %s'), '10.0.16'));
     $migration->setVersion('10.0.16');
 
     $update_scripts = scandir($update_dir);

--- a/install/migrations/update_10.0.16_to_10.0.17.php
+++ b/install/migrations/update_10.0.16_to_10.0.17.php
@@ -50,8 +50,6 @@ function update10016to10017()
     $DELFROMDISPLAYPREF = [];
     $update_dir = __DIR__ . '/update_10.0.16_to_10.0.17/';
 
-    //TRANS: %s is the number of new version
-    $migration->displayTitle(sprintf(__('Update to %s'), '10.0.17'));
     $migration->setVersion('10.0.17');
 
     $update_scripts = scandir($update_dir);

--- a/install/migrations/update_10.0.17_to_10.0.18.php
+++ b/install/migrations/update_10.0.17_to_10.0.18.php
@@ -50,8 +50,6 @@ function update10017to10018()
     $DELFROMDISPLAYPREF = [];
     $update_dir = __DIR__ . '/update_10.0.17_to_10.0.18/';
 
-    //TRANS: %s is the number of new version
-    $migration->displayTitle(sprintf(__('Update to %s'), '10.0.18'));
     $migration->setVersion('10.0.18');
 
     $update_scripts = scandir($update_dir);

--- a/install/migrations/update_10.0.1_to_10.0.2.php
+++ b/install/migrations/update_10.0.1_to_10.0.2.php
@@ -50,8 +50,6 @@ function update1001to1002()
     $DELFROMDISPLAYPREF = [];
     $update_dir = __DIR__ . '/update_10.0.1_to_10.0.2/';
 
-    //TRANS: %s is the number of new version
-    $migration->displayTitle(sprintf(__('Update to %s'), '10.0.2'));
     $migration->setVersion('10.0.2');
 
     $update_scripts = scandir($update_dir);

--- a/install/migrations/update_10.0.1_to_10.0.2/configs.php
+++ b/install/migrations/update_10.0.1_to_10.0.2/configs.php
@@ -36,7 +36,6 @@
  * @var \Migration $migration
  */
 
-$migration->displayMessage('Add new configurations / user preferences');
 $migration->addConfig(
     [
         'import_monitor' => 1,

--- a/install/migrations/update_10.0.2_to_10.0.3.php
+++ b/install/migrations/update_10.0.2_to_10.0.3.php
@@ -50,8 +50,6 @@ function update1002to1003()
     $DELFROMDISPLAYPREF = [];
     $update_dir = __DIR__ . '/update_10.0.2_to_10.0.3/';
 
-    //TRANS: %s is the number of new version
-    $migration->displayTitle(sprintf(__('Update to %s'), '10.0.3'));
     $migration->setVersion('10.0.3');
 
     $update_scripts = scandir($update_dir);

--- a/install/migrations/update_10.0.3_to_10.0.4.php
+++ b/install/migrations/update_10.0.3_to_10.0.4.php
@@ -50,8 +50,6 @@ function update1003to1004()
     $DELFROMDISPLAYPREF = [];
     $update_dir = __DIR__ . '/update_10.0.3_to_10.0.4/';
 
-    //TRANS: %s is the number of new version
-    $migration->displayTitle(sprintf(__('Update to %s'), '10.0.4'));
     $migration->setVersion('10.0.4');
 
     $update_scripts = scandir($update_dir);

--- a/install/migrations/update_10.0.4_to_10.0.5.php
+++ b/install/migrations/update_10.0.4_to_10.0.5.php
@@ -50,8 +50,6 @@ function update1004to1005()
     $DELFROMDISPLAYPREF = [];
     $update_dir = __DIR__ . '/update_10.0.4_to_10.0.5/';
 
-    //TRANS: %s is the number of new version
-    $migration->displayTitle(sprintf(__('Update to %s'), '10.0.5'));
     $migration->setVersion('10.0.5');
 
     $update_scripts = scandir($update_dir);

--- a/install/migrations/update_10.0.5_to_10.0.6.php
+++ b/install/migrations/update_10.0.5_to_10.0.6.php
@@ -50,8 +50,6 @@ function update1005to1006()
     $DELFROMDISPLAYPREF = [];
     $update_dir = __DIR__ . '/update_10.0.5_to_10.0.6/';
 
-    //TRANS: %s is the number of new version
-    $migration->displayTitle(sprintf(__('Update to %s'), '10.0.6'));
     $migration->setVersion('10.0.6');
 
     $update_scripts = scandir($update_dir);

--- a/install/migrations/update_10.0.5_to_10.0.6/configs.php
+++ b/install/migrations/update_10.0.5_to_10.0.6/configs.php
@@ -36,7 +36,6 @@
  * @var \Migration $migration
  */
 
-$migration->displayMessage('Add new configurations / user preferences');
 $migration->addConfig([
     'timeline_action_btn_layout'   => 0,
     'timeline_date_format'   => 0,

--- a/install/migrations/update_10.0.6_to_10.0.7.php
+++ b/install/migrations/update_10.0.6_to_10.0.7.php
@@ -50,8 +50,6 @@ function update1006to1007()
     $DELFROMDISPLAYPREF = [];
     $update_dir = __DIR__ . '/update_10.0.6_to_10.0.7/';
 
-    //TRANS: %s is the number of new version
-    $migration->displayTitle(sprintf(__('Update to %s'), '10.0.7'));
     $migration->setVersion('10.0.7');
 
     $update_scripts = scandir($update_dir);

--- a/install/migrations/update_10.0.7_to_10.0.8.php
+++ b/install/migrations/update_10.0.7_to_10.0.8.php
@@ -50,8 +50,6 @@ function update1007to1008()
     $DELFROMDISPLAYPREF = [];
     $update_dir = __DIR__ . '/update_10.0.7_to_10.0.8/';
 
-    //TRANS: %s is the number of new version
-    $migration->displayTitle(sprintf(__('Update to %s'), '10.0.8'));
     $migration->setVersion('10.0.8');
 
     $update_scripts = scandir($update_dir);

--- a/install/migrations/update_10.0.7_to_10.0.8/configs.php
+++ b/install/migrations/update_10.0.7_to_10.0.8/configs.php
@@ -36,7 +36,6 @@
  * @var \Migration $migration
  */
 
-$migration->displayMessage('Add new configurations / user preferences');
 $migration->addConfig([
     'use_flat_dropdowntree_on_search_result'   => 1,
 ]);

--- a/install/migrations/update_10.0.8_to_10.0.9.php
+++ b/install/migrations/update_10.0.8_to_10.0.9.php
@@ -50,8 +50,6 @@ function update1008to1009()
     $DELFROMDISPLAYPREF = [];
     $update_dir = __DIR__ . '/update_10.0.8_to_10.0.9/';
 
-    //TRANS: %s is the number of new version
-    $migration->displayTitle(sprintf(__('Update to %s'), '10.0.9'));
     $migration->setVersion('10.0.9');
 
     $update_scripts = scandir($update_dir);

--- a/install/migrations/update_10.0.9_to_10.0.10.php
+++ b/install/migrations/update_10.0.9_to_10.0.10.php
@@ -50,8 +50,6 @@ function update1009to10010()
     $DELFROMDISPLAYPREF = [];
     $update_dir = __DIR__ . '/update_10.0.9_to_10.0.10/';
 
-    //TRANS: %s is the number of new version
-    $migration->displayTitle(sprintf(__('Update to %s'), '10.0.10'));
     $migration->setVersion('10.0.10');
 
     $update_scripts = scandir($update_dir);

--- a/install/migrations/update_10.0.x_to_11.0.0.php
+++ b/install/migrations/update_10.0.x_to_11.0.0.php
@@ -51,8 +51,6 @@ function update100xto1100()
     $DELFROMDISPLAYPREF        = [];
     $update_dir                = __DIR__ . '/update_10.0.x_to_11.0.0/';
 
-    //TRANS: %s is the number of new version
-    $migration->displayTitle(sprintf(__('Update to %s'), '11.0.0'));
     $migration->setVersion('11.0.0');
 
     $update_scripts = scandir($update_dir);

--- a/install/migrations/update_10.0.x_to_11.0.0/configs.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/configs.php
@@ -36,7 +36,6 @@
  * @var \Migration $migration
  */
 
-$migration->displayMessage('Add new configurations / user preferences');
 $migration->addConfig([
     'password_init_token_delay' => '86400',
     'toast_location'    => 'bottom-right',

--- a/install/migrations/update_10.0.x_to_11.0.0/states.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/states.php
@@ -99,7 +99,7 @@ if (!$DB->tableExists('glpi_dropdownvisibilities')) {
         }
     }
 }
-$migration->displayWarning(
+$migration->addInfoMessage(
     'States dropdown in devices items forms are now filtered, and, by default, existing states are not visible.'
 );
 

--- a/install/migrations/update_9.1.0_to_9.1.1.php
+++ b/install/migrations/update_9.1.0_to_9.1.1.php
@@ -49,32 +49,7 @@ function update910to911()
     $updateresult     = true;
     $ADDTODISPLAYPREF = [];
 
-   //TRANS: %s is the number of new version
-    $migration->displayTitle(sprintf(__('Update to %s'), '9.1.1'));
     $migration->setVersion('9.1.1');
-
-    $backup_tables = false;
-   // table already exist but deleted during the migration
-   // not table created during the migration
-   // not table created during the migration
-    $newtables     = [];
-
-    foreach ($newtables as $new_table) {
-       // rename new tables if exists ?
-        if ($DB->tableExists($new_table)) {
-            $migration->dropTable("backup_$new_table");
-            $migration->displayWarning("$new_table table already exists. " .
-                                    "A backup have been done to backup_$new_table.");
-            $backup_tables = true;
-            $migration->renameTable("$new_table", "backup_$new_table");
-        }
-    }
-    if ($backup_tables) {
-        $migration->displayWarning(
-            "You can delete backup tables if you have no need of them.",
-            true
-        );
-    }
 
    // rectify missing right in 9.1 update
     if (countElementsInTable("glpi_profilerights", ['name' => 'license']) == 0) {

--- a/install/migrations/update_9.1.1_to_9.1.3.php
+++ b/install/migrations/update_9.1.1_to_9.1.3.php
@@ -49,31 +49,7 @@ function update911to913()
     $updateresult     = true;
     $ADDTODISPLAYPREF = [];
 
-   //TRANS: %s is the number of new version
-    $migration->displayTitle(sprintf(__('Update to %s'), '9.1.3'));
     $migration->setVersion('9.1.3');
-
-    $backup_tables = false;
-   // table already exist but deleted during the migration
-   // not table created during the migration
-    $newtables     = [];
-
-    foreach ($newtables as $new_table) {
-       // rename new tables if exists ?
-        if ($DB->tableExists($new_table)) {
-            $migration->dropTable("backup_$new_table");
-            $migration->displayWarning("$new_table table already exists. " .
-                                    "A backup have been done to backup_$new_table.");
-            $backup_tables = true;
-            $migration->renameTable("$new_table", "backup_$new_table");
-        }
-    }
-    if ($backup_tables) {
-        $migration->displayWarning(
-            "You can delete backup tables if you have no need of them.",
-            true
-        );
-    }
 
    //Fix duplicated search options
     if (countElementsInTable("glpi_displaypreferences", ['itemtype' => 'IPNetwork', 'num' => '17']) == 0) {

--- a/install/migrations/update_9.1.x_to_9.2.0.php
+++ b/install/migrations/update_9.1.x_to_9.2.0.php
@@ -51,8 +51,6 @@ function update91xto920()
     $updateresult     = true;
     $ADDTODISPLAYPREF = [];
 
-   //TRANS: %s is the number of new version
-    $migration->displayTitle(sprintf(__('Update to %s'), '9.2'));
     $migration->setVersion('9.2');
 
    // add business criticity
@@ -1219,7 +1217,7 @@ function update91xto920()
         $migration->addKey("glpi_logs", "id_search_option");
     } else {
        //Just display a Warning to the user.
-        $migration->displayWarning("An index must be added in the 'id_search_option' field " .
+        $migration->addWarningMessage("An index must be added in the 'id_search_option' field " .
          "of the 'glpi_logs table'; but your glpi_logs table is " .
          "too huge. You'll have to add it on your database " .
          "with the following query:\n" .
@@ -1370,9 +1368,8 @@ Regards,',
     if (!$DB->fieldExists('glpi_users', 'api_token')) {
         $migration->addField('glpi_users', 'api_token', 'string', ['after' => 'personal_token_date']);
         $migration->addField('glpi_users', 'api_token_date', 'datetime', ['after' => 'api_token']);
-        $migration->displayWarning(
-            "Api users tokens has been reset, if you use REST/XMLRPC api with personal token for authentication, please reset your user's token.",
-            true
+        $migration->addWarningMessage(
+            "Api users tokens has been reset, if you use REST/XMLRPC api with personal token for authentication, please reset your user's token."
         );
     }
 

--- a/install/migrations/update_9.2.0_to_9.2.1.php
+++ b/install/migrations/update_9.2.0_to_9.2.1.php
@@ -49,8 +49,6 @@ function update920to921()
     $updateresult     = true;
     $ADDTODISPLAYPREF = [];
 
-   //TRANS: %s is the number of new version
-    $migration->displayTitle(sprintf(__('Update to %s'), '9.2.1'));
     $migration->setVersion('9.2.1');
 
    //fix migration parts that may not been ran from 9.1.x update

--- a/install/migrations/update_9.2.1_to_9.2.2.php
+++ b/install/migrations/update_9.2.1_to_9.2.2.php
@@ -53,8 +53,6 @@ function update921to922()
     $updateresult     = true;
     $ADDTODISPLAYPREF = [];
 
-   //TRANS: %s is the number of new version
-    $migration->displayTitle(sprintf(__('Update to %s'), '9.2.2'));
     $migration->setVersion('9.2.2');
 
     $migration->addConfig([

--- a/install/migrations/update_9.2.2_to_9.2.3.php
+++ b/install/migrations/update_9.2.2_to_9.2.3.php
@@ -53,8 +53,6 @@ function update922to923()
     $updateresult     = true;
     $ADDTODISPLAYPREF = [];
 
-   //TRANS: %s is the number of new version
-    $migration->displayTitle(sprintf(__('Update to %s'), '9.2.3'));
     $migration->setVersion('9.2.3');
 
    //add a column for the model

--- a/install/migrations/update_9.2.x_to_9.3.0.php
+++ b/install/migrations/update_9.2.x_to_9.3.0.php
@@ -50,8 +50,6 @@ function update92xto930()
     $updateresult     = true;
     $ADDTODISPLAYPREF = [];
 
-   //TRANS: %s is the number of new version
-    $migration->displayTitle(sprintf(__('Update to %s'), '9.3'));
     $migration->setVersion('9.3');
 
    //Create solutions table
@@ -839,7 +837,7 @@ function update92xto930()
     }
 
     if (isset($configs_toadd['purge_plugins']) && count($purge_plugin_values)) {
-        $migration->displayWarning(
+        $migration->addWarningMessage(
             'There are changes on plugins logs purge between core and the old plugin. Please review your configuration.'
         );
     }

--- a/install/migrations/update_9.3.0_to_9.3.1.php
+++ b/install/migrations/update_9.3.0_to_9.3.1.php
@@ -52,8 +52,6 @@ function update930to931()
     $updateresult     = true;
     $ADDTODISPLAYPREF = [];
 
-   //TRANS: %s is the number of new version
-    $migration->displayTitle(sprintf(__('Update to %s'), '9.3.1'));
     $migration->setVersion('9.3.1');
 
     /** Change field type */

--- a/install/migrations/update_9.3.1_to_9.3.2.php
+++ b/install/migrations/update_9.3.1_to_9.3.2.php
@@ -53,8 +53,6 @@ function update931to932()
     $updateresult     = true;
     $ADDTODISPLAYPREF = [];
 
-   //TRANS: %s is the number of new version
-    $migration->displayTitle(sprintf(__('Update to %s'), '9.3.2'));
     $migration->setVersion('9.3.2');
 
     /** Clean rack/enclosure items corrupted relations */

--- a/install/migrations/update_9.3.x_to_9.4.0.php
+++ b/install/migrations/update_9.3.x_to_9.4.0.php
@@ -51,8 +51,6 @@ function update93xto940()
     $ADDTODISPLAYPREF = [];
     $config_to_drop = [];
 
-   //TRANS: %s is the number of new version
-    $migration->displayTitle(sprintf(__('Update to %s'), '9.4.0'));
     $migration->setVersion('9.4.0');
 
     /** Add otherserial field on ConsumableItem */

--- a/install/migrations/update_9.4.0_to_9.4.1.php
+++ b/install/migrations/update_9.4.0_to_9.4.1.php
@@ -47,8 +47,6 @@ function update940to941()
 
     $updateresult     = true;
 
-   //TRANS: %s is the number of new version
-    $migration->displayTitle(sprintf(__('Update to %s'), '9.4.1'));
     $migration->setVersion('9.4.1');
 
     /** Add a search option for profile id */

--- a/install/migrations/update_9.4.1_to_9.4.2.php
+++ b/install/migrations/update_9.4.1_to_9.4.2.php
@@ -49,8 +49,6 @@ function update941to942()
 
     $updateresult     = true;
 
-   //TRANS: %s is the number of new version
-    $migration->displayTitle(sprintf(__('Update to %s'), '9.4.2'));
     $migration->setVersion('9.4.2');
 
    /* Remove trailing slash from 'url_base' config */

--- a/install/migrations/update_9.4.2_to_9.4.3.php
+++ b/install/migrations/update_9.4.2_to_9.4.3.php
@@ -47,8 +47,6 @@ function update942to943()
 
     $updateresult     = true;
 
-   //TRANS: %s is the number of new version
-    $migration->displayTitle(sprintf(__('Update to %s'), '9.4.3'));
     $migration->setVersion('9.4.3');
 
     /** Fix URL of images inside ITIL objects contents */

--- a/install/migrations/update_9.4.3_to_9.4.5.php
+++ b/install/migrations/update_9.4.3_to_9.4.5.php
@@ -47,8 +47,6 @@ function update943to945()
 
     $updateresult     = true;
 
-   //TRANS: %s is the number of new version
-    $migration->displayTitle(sprintf(__('Update to %s'), '9.4.5'));
     $migration->setVersion('9.4.5');
 
     /** Add OLA TTR begin date field to Tickets */

--- a/install/migrations/update_9.4.5_to_9.4.6.php
+++ b/install/migrations/update_9.4.5_to_9.4.6.php
@@ -45,8 +45,6 @@ function update945to946()
      */
     global $DB, $migration;
     $updateresult     = true;
-   //TRANS: %s is the number of new version
-    $migration->displayTitle(sprintf(__('Update to %s'), '9.4.6'));
     $migration->setVersion('9.4.6');
     $DB->delete(
         'glpi_profilerights',

--- a/install/migrations/update_9.4.6_to_9.4.7.php
+++ b/install/migrations/update_9.4.6_to_9.4.7.php
@@ -47,8 +47,6 @@ function update946to947()
 
     $updateresult     = true;
 
-   //TRANS: %s is the number of new version
-    $migration->displayTitle(sprintf(__('Update to %s'), '9.4.7'));
     $migration->setVersion('9.4.7');
 
     $DB->update('glpi_events', ['type'   => 'dcrooms'], ['type' => 'serverroms']);

--- a/install/migrations/update_9.4.x_to_9.5.0.php
+++ b/install/migrations/update_9.4.x_to_9.5.0.php
@@ -52,8 +52,6 @@ function update94xto950()
     $updateresult     = true;
     $ADDTODISPLAYPREF = [];
 
-   //TRANS: %s is the number of new version
-    $migration->displayTitle(sprintf(__('Update to %s'), '9.5.0'));
     $migration->setVersion('9.5.0');
 
     /** Encrypted FS support  */
@@ -107,7 +105,7 @@ function update94xto950()
     if (!$DB->fieldExists('glpi_users', 'timezone')) {
         $migration->addField("glpi_users", "timezone", "varchar(50) DEFAULT NULL");
     }
-    $migration->displayWarning("DATETIME fields must be converted to TIMESTAMP for timezones to work. Run bin/console migration:timestamps");
+    $migration->addInfoMessage("DATETIME fields must be converted to TIMESTAMP for timezones to work. Run bin/console migration:timestamps");
 
    // Add a config entry for app timezone setting
     $migration->addConfig(['timezone' => null]);
@@ -636,7 +634,7 @@ function update94xto950()
     }
 
     /** Make software linkable to other itemtypes besides Computers */
-    $migration->displayWarning('Updating software tables. This may take several minutes.');
+    $migration->displayMessage('Updating software tables. This may take several minutes.');
     if (!$DB->tableExists('glpi_items_softwareversions')) {
         $migration->renameTable('glpi_computers_softwareversions', 'glpi_items_softwareversions');
         $migration->changeField(

--- a/install/migrations/update_9.5.1_to_9.5.2.php
+++ b/install/migrations/update_9.5.1_to_9.5.2.php
@@ -47,12 +47,10 @@ function update951to952()
 
     $updateresult     = true;
 
-   //TRANS: %s is the number of new version
-    $migration->displayTitle(sprintf(__('Update to %s'), '9.5.2'));
     $migration->setVersion('9.5.2');
 
     /* Fix document_item migration */
-    $migration->displayTitle("Building inline images data in " . Document_Item::getTable());
+    $migration->displayMessage("Building inline images data in " . Document_Item::getTable());
 
     $now = date('Y-m-d H:i:s');
 

--- a/install/migrations/update_9.5.2_to_9.5.3.php
+++ b/install/migrations/update_9.5.2_to_9.5.3.php
@@ -47,8 +47,6 @@ function update952to953()
 
     $updateresult     = true;
 
-   //TRANS: %s is the number of new version
-    $migration->displayTitle(sprintf(__('Update to %s'), '9.5.3'));
     $migration->setVersion('9.5.3');
 
    /* Fix rule criteria names */

--- a/install/migrations/update_9.5.3_to_9.5.4.php
+++ b/install/migrations/update_9.5.3_to_9.5.4.php
@@ -47,8 +47,6 @@ function update953to954()
 
     $updateresult = true;
 
-   //TRANS: %s is the number of new version
-    $migration->displayTitle(sprintf(__('Update to %s'), '9.5.4'));
     $migration->setVersion('9.5.4');
 
    /* Remove invalid Profile SO */

--- a/install/migrations/update_9.5.4_to_9.5.5.php
+++ b/install/migrations/update_9.5.4_to_9.5.5.php
@@ -47,8 +47,6 @@ function update954to955()
 
     $updateresult = true;
 
-   //TRANS: %s is the number of new version
-    $migration->displayTitle(sprintf(__('Update to %s'), '9.5.5'));
     $migration->setVersion('9.5.5');
 
    /* Add `DEFAULT CURRENT_TIMESTAMP` to some date fields */

--- a/install/migrations/update_9.5.5_to_9.5.6.php
+++ b/install/migrations/update_9.5.5_to_9.5.6.php
@@ -53,8 +53,6 @@ function update955to956()
     $updateresult     = true;
     $ADDTODISPLAYPREF = [];
 
-   //TRANS: %s is the number of new version
-    $migration->displayTitle(sprintf(__('Update to %s'), '9.5.6'));
     $migration->setVersion('9.5.6');
 
    // Change DC itemtype template_name search option ID from 50 to 61 to prevent duplicate IDs now that those itemtypes have Infocom search options.

--- a/install/migrations/update_9.5.6_to_9.5.7.php
+++ b/install/migrations/update_9.5.6_to_9.5.7.php
@@ -52,8 +52,6 @@ function update956to957()
     $updateresult     = true;
     $ADDTODISPLAYPREF = [];
 
-   //TRANS: %s is the number of new version
-    $migration->displayTitle(sprintf(__('Update to %s'), '9.5.7'));
     $migration->setVersion('9.5.7');
 
    /* Fix null `date` in ITIL tables */

--- a/install/migrations/update_9.5.x_to_10.0.0.php
+++ b/install/migrations/update_9.5.x_to_10.0.0.php
@@ -50,8 +50,6 @@ function update95xto1000()
     $DELFROMDISPLAYPREF = [];
     $update_dir = __DIR__ . '/update_9.5.x_to_10.0.0/';
 
-   //TRANS: %s is the number of new version
-    $migration->displayTitle(sprintf(__('Update to %s'), '10.0.0'));
     $migration->setVersion('10.0.0');
 
     $update_scripts = scandir($update_dir);
@@ -91,7 +89,7 @@ function update95xto1000()
 
     $migration->executeMigration();
 
-    $migration->displayWarning(
+    $migration->addWarningMessage(
         '"utf8mb4" support requires additional migration which can be performed via the "php bin/console migration:utf8mb4" command.'
     );
 

--- a/install/migrations/update_9.5.x_to_10.0.0/cache.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/cache.php
@@ -47,7 +47,7 @@ if (countElementsInTable('glpi_configs', ['name' => 'cache_trans', 'context' => 
     $had_custom_config = true;
 }
 
-$migration->displayWarning(
+$migration->addInfoMessage(
     'GLPI cache has been changed and will not use anymore APCu or Wincache extensions. '
     . ($had_custom_config ? 'Existing cache configuration will not be reused. ' : '')
     . 'Use "php bin/console cache:configure" command to configure cache system.'

--- a/install/migrations/update_9.5.x_to_10.0.0/configs.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/configs.php
@@ -36,7 +36,6 @@
  * @var \Migration $migration
  */
 
-$migration->displayMessage('Add new configurations / user preferences');
 $migration->addConfig([
     'default_central_tab'   => 0,
     'page_layout'           => 'vertical',
@@ -64,7 +63,6 @@ $migration->addField('glpi_users', 'richtext_layout', 'char(20) DEFAULT NULL', [
 $migration->addField("glpi_users", "timeline_order", "char(20) DEFAULT NULL", ['after' => 'savedsearches_pinned']);
 $migration->addField('glpi_users', 'itil_layout', 'text', ['after' => 'timeline_order']);
 
-$migration->displayMessage('Drop old configurations / user preferences');
 $migration->dropField('glpi_users', 'layout');
 Config::deleteConfigurationValues('core', ['layout']);
 Config::deleteConfigurationValues('core', ['use_ajax_autocompletion']);

--- a/install/migrations/update_9.5.x_to_10.0.0/recurrentchange.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/recurrentchange.php
@@ -37,8 +37,6 @@
  * @var \Migration $migration
  */
 
-$migration->displayMessage("Adding recurrent changes");
-
 $default_charset = DBConnection::getDefaultCharset();
 $default_collation = DBConnection::getDefaultCollation();
 $default_key_sign = DBConnection::getDefaultPrimaryKeySignOption();

--- a/install/migrations/update_9.5.x_to_10.0.0/reservationitem.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/reservationitem.php
@@ -37,7 +37,6 @@
  * @var \Migration $migration
  */
 
-$migration->displayMessage("Adding unicity key to reservationitem");
 $table = 'glpi_reservationitems';
 
 // Copy table

--- a/js/modules/GlpiInstall.js
+++ b/js/modules/GlpiInstall.js
@@ -41,7 +41,7 @@ export function init_database(progress_key)
     const back_button_container = document.getElementById('glpi_install_back');
 
     const request = new Request(
-        `${CFG_GLPI.root_doc}/install/init_database`,
+        `${CFG_GLPI.root_doc}/Install/InitDatabase`,
         {
             method: 'POST',
             headers: {
@@ -64,6 +64,37 @@ export function init_database(progress_key)
         error_callback: () => {
             back_button_container.querySelector('button[type="submit"]').removeAttribute('disabled');
             back_button_container.setAttribute('class', 'd-inline');
+        },
+    });
+
+    progress_indicator.start();
+}
+
+export async function update_database(progress_key)
+{
+    const messages_container = document.getElementById('glpi_update_messages_container');
+    const success_container = document.getElementById('glpi_update_success');
+
+    const request = new Request(
+        `${CFG_GLPI.root_doc}/Install/UpdateDatabase`,
+        {
+            method: 'POST',
+            headers: {
+                'Accept': 'application/json',
+                'Content-Type': 'application/x-www-form-urlencoded;',
+                'X-Requested-With': 'XMLHttpRequest',
+                'X-Glpi-Csrf-Token': getAjaxCsrfToken(),
+            },
+        },
+    );
+
+    const progress_indicator = new ProgressIndicator({
+        key: progress_key,
+        container: messages_container,
+        request: request,
+        success_callback: () => {
+            success_container.querySelector('button[type="submit"]').removeAttribute('disabled');
+            success_container.setAttribute('class', 'd-inline');
         },
     });
 

--- a/js/modules/ProgressIndicator.js
+++ b/js/modules/ProgressIndicator.js
@@ -214,7 +214,7 @@ export class ProgressIndicator
             const now = new Date().getTime();
             const updated_at = new Date(json['updated_at']).getTime();
             const diff = now - updated_at;
-            const max_diff = 1000 * 20; // 20 seconds timeout
+            const max_diff = 1000 * 60; // 60 seconds timeout
             if (diff > max_diff) {
                 this.#display_message(
                     'error',

--- a/src/Glpi/Controller/InstallController.php
+++ b/src/Glpi/Controller/InstallController.php
@@ -34,32 +34,42 @@
 
 namespace Glpi\Controller;
 
+use Config;
+use DB;
+use Glpi\Cache\CacheManager;
 use Glpi\Exception\Http\AccessDeniedHttpException;
 use Glpi\Http\Firewall;
 use Glpi\Progress\ProgressStorage;
 use Glpi\Progress\StoredProgressIndicator;
 use Glpi\Security\Attribute\SecurityStrategy;
+use Migration;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\Routing\Attribute\Route;
 use Toolbox;
+use Update;
 
 class InstallController extends AbstractController
 {
     public const PROGRESS_KEY_INIT_DATABASE = 'init_database';
+    public const PROGRESS_KEY_UPDATE_DATABASE = 'update_database';
 
     public function __construct(
         private readonly ProgressStorage $progress_storage,
+        private readonly LoggerInterface $logger
     ) {
     }
 
-    #[Route("/install/init_database", methods: 'POST')]
+    #[Route("/Install/InitDatabase", methods: 'POST')]
     #[SecurityStrategy(Firewall::STRATEGY_NO_CHECK)]
-    public function start_inserts(): Response
+    public function initDatabase(): Response
     {
         if (!isset($_SESSION['can_process_install'])) {
             throw new AccessDeniedHttpException();
         }
+
+        ini_set('max_execution_time', '300'); // Allow up to 5 minutes to prevent unexpected timeout
 
         $progress_indicator = new StoredProgressIndicator($this->progress_storage, self::PROGRESS_KEY_INIT_DATABASE);
 
@@ -70,6 +80,55 @@ class InstallController extends AbstractController
                 $progress_indicator->fail();
                 // Try to remove the config file, to be able to restart the process.
                 @unlink(GLPI_CONFIG_DIR . '/config_db.php');
+            }
+        });
+    }
+
+    #[Route("/Install/UpdateDatabase", methods: 'POST')]
+    #[SecurityStrategy(Firewall::STRATEGY_NO_CHECK)]
+    public function updateDatabase(): Response
+    {
+        if (!isset($_SESSION['can_process_update'])) {
+            throw new AccessDeniedHttpException();
+        }
+
+        ini_set('max_execution_time', '300'); // Allow up to 5 minutes to prevent unexpected timeout
+
+        if (!file_exists(GLPI_CONFIG_DIR . '/config_db.php')) {
+            throw new \RuntimeException('Missing database configuration file.');
+        } else {
+            include_once(GLPI_CONFIG_DIR . '/config_db.php');
+            if (!\class_exists(DB::class)) {
+                throw new \RuntimeException('Invalid database configuration file.');
+            }
+        }
+
+        /** @var \DBmysql $DB */
+        global $DB;
+        $DB = new DB();
+        $DB->disableTableCaching(); // Prevents issues on fieldExists upgrading from old versions
+
+        // Required, at least, by usage of `Plugin::unactivateAll()`
+        // FIXME: We should not have to load the configuration before running the update process.
+        Config::loadLegacyConfiguration();
+
+        $progress_indicator = new StoredProgressIndicator($this->progress_storage, self::PROGRESS_KEY_UPDATE_DATABASE);
+
+        $update = new Update($DB);
+        $update->setMigration(new Migration(GLPI_VERSION, $progress_indicator));
+        $update->setLogger($this->logger);
+
+        return new StreamedResponse(function () use ($update, $progress_indicator) {
+            try {
+                $update->doUpdates(
+                    current_version: $update->getCurrents()['version'],
+                    progress_indicator: $progress_indicator
+                );
+
+                // Force cache cleaning to ensure it will not contain stale data
+                (new CacheManager())->resetAllCaches();
+            } catch (\Throwable $e) {
+                $progress_indicator->fail();
             }
         });
     }

--- a/src/Glpi/Http/RequestPoliciesTrait.php
+++ b/src/Glpi/Http/RequestPoliciesTrait.php
@@ -76,6 +76,7 @@ trait RequestPoliciesTrait
         if (
             \str_starts_with($path, '/install/')
             || ($_SESSION['is_installing'] ?? false)
+            || ($_SESSION['is_updating'] ?? false)
         ) {
             // DB status should never be checked when the requested endpoint is part of the install process.
             return false;

--- a/src/Update.php
+++ b/src/Update.php
@@ -37,17 +37,18 @@ use Glpi\Helpdesk\DefaultDataManager;
 use Glpi\Rules\RulesManager;
 use Glpi\System\Diagnostic\DatabaseSchemaIntegrityChecker;
 use Glpi\Toolbox\VersionParser;
+use Glpi\Progress\AbstractProgressIndicator;
+use Glpi\Message\MessageType;
+use Psr\Log\LoggerAwareTrait;
 
 /**
  *  Update class
  **/
 class Update
 {
+    use LoggerAwareTrait;
+
     private $DB;
-    /**
-     * @var Migration
-     */
-    private $migration;
     private $version;
     private $dbversion;
     private $language;
@@ -64,6 +65,8 @@ class Update
      *
      * @param object $DB   Database instance
      * @param string $migrations_directory
+     *
+     * @since 11.0.0 The `$args` parameter has been removed.
      */
     public function __construct($DB, string $migrations_directory = GLPI_ROOT . '/install/migrations/')
     {
@@ -166,8 +169,11 @@ class Update
      *
      * @return void
      */
-    public function doUpdates($current_version = null, bool $force_latest = false)
-    {
+    public function doUpdates(
+        $current_version = null,
+        bool $force_latest = false,
+        ?AbstractProgressIndicator $progress_indicator = null
+    ) {
         if ($current_version === null) {
             if ($this->version === null) {
                 throw new \RuntimeException('Cannot process updates without any version specified!');
@@ -176,8 +182,20 @@ class Update
         }
 
         if (version_compare($current_version, '0.85.5', 'lt')) {
-            echo('Upgrade from version < 0.85.5 is not supported!');
-            exit(1);
+            $progress_indicator?->addMessage(
+                MessageType::Error,
+                sprintf(__('Upgrade from version lower than %s is not supported.'), '0.85.5')
+            );
+            $progress_indicator?->fail();
+            return;
+        }
+        if (version_compare($current_version, GLPI_VERSION, '>')) {
+            $progress_indicator?->addMessage(
+                MessageType::Error,
+                sprintf(__('Downgrading to version %s is not supported.'), GLPI_VERSION)
+            );
+            $progress_indicator?->fail();
+            return;
         }
 
         $DB = $this->DB;
@@ -209,39 +227,49 @@ class Update
             $DB->doQuery(sprintf('SET SESSION sql_mode = %s', $DB->quote(implode(',', $sql_mode_flags))));
         }
 
-       // To prevent problem of execution time
-        ini_set("max_execution_time", "0");
-
-       // Update process desactivate all plugins
+        // Update process desactivate all plugins
         $plugin = new Plugin();
         $plugin->unactivateAll();
 
-        if (version_compare($current_version, GLPI_VERSION, '>')) {
-            $message = sprintf(
-                __('Unsupported version (%1$s)'),
-                $current_version
-            );
-            if (isCommandLine()) {
-                echo "$message\n";
-                exit(1);
-            } else {
-                $this->migration->displayWarning($message, true);
-                exit(1);
-            }
+        $migrations = $this->getMigrationsToDo($current_version, $force_latest);
+
+        $number_of_steps = count($migrations);
+        $init_form_weight = round($number_of_steps * 0.1); // 10 % of the update process
+        $init_rules_weight = round($number_of_steps * 0.1); // 10 % of the update process
+        $structure_check_weight = round($number_of_steps * 0.02); // 2 % of the update process
+        $post_update_weight = 1;
+        $cron_config_weight = 1;
+        $generate_keys_weight = round($number_of_steps * 0.02); // 2 % of the update process
+        $number_of_steps = count($migrations)
+            + $init_form_weight
+            + $init_rules_weight
+            + $structure_check_weight
+            + $post_update_weight
+            + $generate_keys_weight;
+        if (defined('GLPI_SYSTEM_CRON')) {
+            $number_of_steps += $cron_config_weight;
         }
 
-        $migrations = $this->getMigrationsToDo($current_version, $force_latest);
+        $progress_indicator?->setMaxSteps($number_of_steps);
+
         foreach ($migrations as $key => $migration_specs) {
+            $progress_indicator?->setProgressBarMessage(sprintf(__('Upgrading to %s…'), $migration_specs['target_version']));
+
             include_once($migration_specs['file']);
 
             try {
                 $migration_specs['function']();
             } catch (\Throwable $e) {
-                $this->migration->displayError(sprintf(
-                    __('An error occurred during the update. The error was: %s'),
-                    $e->getMessage()
-                ));
-                exit(1);
+                $progress_indicator?->addMessage(
+                    MessageType::Error,
+                    sprintf(
+                        __('An error occurred during the update. The error was: %s'),
+                        $e->getMessage()
+                    )
+                );
+                $progress_indicator?->fail();
+                $this->logger?->error($e->getMessage(), context: ['exception' => $e]);
+                return;
             }
 
             if ($key !== array_key_last($migrations)) {
@@ -258,50 +286,62 @@ class Update
                     ]
                 );
             }
+
+            $progress_indicator?->advance();
         }
 
         // Create default forms
+        $progress_indicator?->setProgressBarMessage(__('Creating default forms…'));
         $helpdesk_data_manager = new DefaultDataManager();
         $helpdesk_data_manager->initializeDataIfNeeded();
+        $progress_indicator?->advance($init_form_weight);
+        $progress_indicator?->addMessage(MessageType::Success, __('Default forms created.'));
 
         // Initalize rules
-        $this->migration->displayTitle(__('Initializing rules...'));
+        $progress_indicator?->setProgressBarMessage(__('Initalizing default rules…'));
         RulesManager::initializeRules();
+        $progress_indicator?->advance($init_rules_weight);
+        $progress_indicator?->addMessage(MessageType::Success, __('Default rules initialized.'));
 
+        $progress_indicator?->setProgressBarMessage(__('Checking the database structure…'));
         if (($myisam_count = $DB->getMyIsamTables()->count()) > 0) {
-            $message = sprintf(__('%d tables are using the deprecated MyISAM storage engine.'), $myisam_count)
-                . ' '
-                . sprintf(__('Run the "%1$s" command to migrate them.'), 'php bin/console migration:myisam_to_innodb');
-            $this->migration->displayError($message);
+            $progress_indicator?->addMessage(
+                MessageType::Warning,
+                sprintf(__('%d tables are using the deprecated MyISAM storage engine.'), $myisam_count)
+                    . ' '
+                    . sprintf(__('Run the "%1$s" command to migrate them.'), 'php bin/console migration:myisam_to_innodb')
+            );
         }
         if (($datetime_count = $DB->getTzIncompatibleTables()->count()) > 0) {
-            $message = sprintf(__('%1$s columns are using the deprecated datetime storage field type.'), $datetime_count)
-                . ' '
-                . sprintf(__('Run the "%1$s" command to migrate them.'), 'php bin/console migration:timestamps');
-            $this->migration->displayError($message);
+            $progress_indicator?->addMessage(
+                MessageType::Warning,
+                sprintf(__('%1$s columns are using the deprecated datetime storage field type.'), $datetime_count)
+                    . ' '
+                    . sprintf(__('Run the "%1$s" command to migrate them.'), 'php bin/console migration:timestamps')
+            );
         }
         if (($non_utf8mb4_count = $DB->getNonUtf8mb4Tables()->count()) > 0) {
-            $message = sprintf(__('%1$s tables are using the deprecated utf8mb3 storage charset.'), $non_utf8mb4_count)
-                . ' '
-                . sprintf(__('Run the "%1$s" command to migrate them.'), 'php bin/console migration:utf8mb4');
-            $this->migration->displayError($message);
+            $progress_indicator?->addMessage(
+                MessageType::Warning,
+                sprintf(__('%1$s tables are using the deprecated utf8mb3 storage charset.'), $non_utf8mb4_count)
+                    . ' '
+                    . sprintf(__('Run the "%1$s" command to migrate them.'), 'php bin/console migration:utf8mb4')
+            );
         }
         if (($signed_keys_col_count = $DB->getSignedKeysColumns()->count()) > 0) {
-            $message = sprintf(__('%d primary or foreign keys columns are using signed integers.'), $signed_keys_col_count)
-                . ' '
-                . sprintf(__('Run the "%1$s" command to migrate them.'), 'php bin/console migration:unsigned_keys');
-            $this->migration->displayError($message);
+            $progress_indicator?->addMessage(
+                MessageType::Warning,
+                sprintf(__('%d primary or foreign keys columns are using signed integers.'), $signed_keys_col_count)
+                    . ' '
+                    . sprintf(__('Run the "%1$s" command to migrate them.'), 'php bin/console migration:unsigned_keys')
+            );
         }
+        $progress_indicator?->advance($structure_check_weight);
 
-        // Update version number and default langage and new version_founded ---- LEAVE AT THE END
-        Config::setConfigurationValues('core', ['version'             => GLPI_VERSION,
-            'dbversion'           => GLPI_SCHEMA_VERSION,
-            'language'            => $this->language,
-            'founded_new_version' => ''
-        ]);
+        $progress_indicator?->setProgressBarMessage(__('Finalizing the update…'));
 
         if (defined('GLPI_SYSTEM_CRON')) {
-           // Downstream packages may provide a good system cron
+            // Downstream packages may provide a good system cron
             $DB->update(
                 'glpi_crontasks',
                 [
@@ -312,7 +352,16 @@ class Update
                     'allowmode' => ['&', 2]
                 ]
             );
+            $progress_indicator?->advance($cron_config_weight);
         }
+
+        // Update version number and default langage and new version_founded ---- LEAVE AT THE END
+        Config::setConfigurationValues('core', [
+            'version'             => GLPI_VERSION,
+            'dbversion'           => GLPI_SCHEMA_VERSION,
+            'language'            => $this->language,
+            'founded_new_version' => ''
+        ]);
 
        // Reset telemetry if its state is running, assuming it remained stuck due to telemetry service issue (see #7492).
         $crontask_telemetry = new CronTask();
@@ -322,36 +371,48 @@ class Update
             $crontask_telemetry->resetState();
         }
 
-       //generate security key if missing, and update db
+        $progress_indicator?->advance($post_update_weight);
+
+        $progress_indicator?->setProgressBarMessage(__('Generating security keys…'));
+
+        //generate security key if missing, and update db
         $glpikey = new GLPIKey();
         if (!$glpikey->keyExists() && !$glpikey->generate()) {
-            $this->migration->displayWarning(
+            $progress_indicator?->addMessage(
+                MessageType::Error,
                 sprintf(
                     __('Unable to create security key file! You have to run the "%s" command to manually create this file.'),
                     'php bin/console security:change_key'
-                ),
-                true
+                )
             );
         }
 
         $private_key_path = GLPI_CONFIG_DIR . '/oauth.pem';
         $public_key_path = GLPI_CONFIG_DIR . '/oauth.pub';
         if (!file_exists($private_key_path) && !file_exists($public_key_path)) {
-            $this->migration->displayMessage("Generating OAuth keys");
             \Glpi\OAuth\Server::generateKeys();
         }
+        $progress_indicator?->advance($generate_keys_weight);
+        $progress_indicator?->addMessage(MessageType::Success, __('Security keys generated.'));
+
+        $progress_indicator?->setProgressBarMessage('');
+        $progress_indicator?->addMessage(MessageType::Success, __('Update done.'));
+        $progress_indicator?->finish();
     }
 
     /**
      * Set migration
      *
-     * @param Migration $migration Migration instance
+     * @param Migration $migration_instance Migration instance
      *
      * @return Update
      */
-    public function setMigration(Migration $migration)
+    public function setMigration(Migration $migration_instance)
     {
-        $this->migration = $migration;
+        /** @var \Migration $migration */
+        global $migration; // Migration scripts are using global `$migration`
+        $migration = $migration_instance;
+
         return $this;
     }
 

--- a/templates/install/post_update_step.html.twig
+++ b/templates/install/post_update_step.html.twig
@@ -30,7 +30,13 @@
  # ---------------------------------------------------------------------
  #}
 
-<hr>
+{% if not is_db_consistent %}
+    <div class="alert alert-important alert-danger my-2 mx-4" role="alert">
+        <i class="fas fa-2x fa-exclamation-triangle align-middle"></i>
+        {{ __('The database schema is not consistent with the current GLPI version.') }}<br />
+        {{ __('It is recommended to run the "%s" command to see the differences.')|format('php bin/console database:check_schema_integrity') }}
+    </div>
+{% endif %}
 
 <h2>{{ __("One last thing before starting") }}</h2>
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Since we use the Symfony kernel, the `flush()` operations are not working as expected and, depending on the web server configuration, one may encounter timeout issues on long lasting operations. To prevent this kind of issue in the update process, I implemented the progress indicator system introduced in #18296 and used in the install process for the same reasons.

I had to review a bit the migration code to assign the correct type to migration messages. I also remove some of them that were not relevant IMHO.

The UI is not perfect, but can be improved in a later PR, especially for the updates that generates too many messages. In the web UI, the `continue` button is pushed outside the visible scope of the page, and, in contrary, first messages dissapear in the CLI because the area is limited to 25 lines.

## Screenshots

Video of the update from a 0.85.5 version (web UI):
[Capture vidéo du 2025-03-26 15-39-14.webm](https://github.com/user-attachments/assets/797e2e72-ca9a-4268-92b6-1a6cb598abc5)


Video of the update from a 0.85.5 version (CLI):
[Capture vidéo du 2025-03-26 15-24-28.webm](https://github.com/user-attachments/assets/680da23e-970f-4ed0-9095-113a58509e66)



