### PR TITLE
Fetch filename from plugins/ or marketplace/ directory

### DIFF
--- a/phpunit/bootstrap.php
+++ b/phpunit/bootstrap.php
@@ -49,7 +49,7 @@ define('GLPI_URI', getenv('GLPI_URI') ?: 'http://localhost:8088');
 define('GLPI_STRICT_DEPRECATED', true); //enable strict depreciations
 
 define('FIXTURE_DIR', __DIR__ . "/../tests/fixtures");
-define('MARKETPLACE_DIR',  __DIR__ . "/../tests/marketplace");
+define('MARKETPLACE_DIR', __DIR__ . "/../tests/marketplace");
 define(
     'PLUGINS_DIRECTORIES',
     [

--- a/phpunit/bootstrap.php
+++ b/phpunit/bootstrap.php
@@ -49,6 +49,7 @@ define('GLPI_URI', getenv('GLPI_URI') ?: 'http://localhost:8088');
 define('GLPI_STRICT_DEPRECATED', true); //enable strict depreciations
 
 define('FIXTURE_DIR', __DIR__ . "/../tests/fixtures");
+define('MARKETPLACE_DIR',  __DIR__ . "/../tests/marketplace");
 define(
     'PLUGINS_DIRECTORIES',
     [

--- a/phpunit/functional/DbUtilsTest.php
+++ b/phpunit/functional/DbUtilsTest.php
@@ -141,6 +141,7 @@ class DbUtilsTest extends DbTestCase
         require_once FIXTURE_DIR . '/pluginfoo_search_item_filter.php';
         require_once FIXTURE_DIR . '/pluginfoo_search_a_b_c_d_e_f_g_bar.php';
         require_once FIXTURE_DIR . '/test_a_b.php';
+        require_once MARKETPLACE_DIR . '/myplugin/src/BarFooState.php';
 
         return [
             ['glpi_dbmysqls', 'DBmysql', false], // not a CommonGLPI, should not be valid
@@ -158,6 +159,7 @@ class DbUtilsTest extends DbTestCase
             ['glpi_anothers_tests', 'Glpi\Another_Test', true], // Single level namespace + CommonDBRelation
             ['glpi_tests_as_bs', 'Glpi\Test\A_B', true], // Multi-level namespace + CommonDBRelation
             ['glpi_plugin_foo_as_bs_cs_ds_es_fs_gs_bars', 'GlpiPlugin\Foo\A\B\C\D\E\F\G\Bar', true], // Long namespace
+            ['glpi_plugin_myplugin_barfoostates', 'GlpiPlugin\Myplugin\BarFooState', true],
         ];
     }
 

--- a/src/DbUtils.php
+++ b/src/DbUtils.php
@@ -418,8 +418,9 @@ final class DbUtils
         if ($context === 'glpi-core') {
             $src_dirs[] = $root_dir . '/src';
         } else {
-            $src_dirs[] = $root_dir . '/marketplace/' . $context . '/src';
-            $src_dirs[] = $root_dir . '/plugins/' . $context . '/src';
+            foreach (PLUGINS_DIRECTORIES as $plugins_dir) {
+                $srcdirs[] = $plugins_dir . '/' . $context . '/src';
+            }
         }
 
         foreach ($src_dirs as $srcdir) {

--- a/src/DbUtils.php
+++ b/src/DbUtils.php
@@ -413,8 +413,19 @@ final class DbUtils
 
         // Fetch filenames from "src" directory of context (GLPI core or given plugin).
         $mapping[$context] = [];
-        $srcdir = $root_dir . ($context === 'glpi-core' ? '' : '/plugins/' . $context) . '/src';
-        if (is_dir($srcdir)) {
+
+        $src_dirs = [];
+        if ($context === 'glpi-core') {
+            $src_dirs[] = $root_dir . '/src';
+        } else {
+            $src_dirs[] = $root_dir . '/marketplace/' . $context . '/src';
+            $src_dirs[] = $root_dir . '/plugins/' . $context . '/src';
+        }
+
+        foreach ($src_dirs as $srcdir) {
+            if (!is_dir($srcdir)) {
+                continue;
+            }
             $files_iterator = new RecursiveIteratorIterator(
                 new RecursiveDirectoryIterator($srcdir),
                 RecursiveIteratorIterator::SELF_FIRST
@@ -428,7 +439,7 @@ final class DbUtils
 
                 // Store entry into mapping:
                 // - key is the lowercased filepath;
-                // - value is the classname with correct case.
+                // - value is the classname with correct case
                 $mapping[$context][strtolower($relative_path)] = str_replace(
                     [DIRECTORY_SEPARATOR, '.php'],
                     ['\\',                ''],

--- a/tests/marketplace/myplugin/setup.php
+++ b/tests/marketplace/myplugin/setup.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+function plugin_version_myplugin()
+{
+    return [
+        'name'           => 'myplugin',
+        'version'        => '1.0.0',
+        'author'         => 'GLPI Test suite',
+        'license'        => 'GPL v2+',
+        'requirements'   => [
+            'glpi' => [
+                'min' => '9.5.0',
+            ]
+        ]
+    ];
+}

--- a/tests/marketplace/myplugin/src/BarFooState.php
+++ b/tests/marketplace/myplugin/src/BarFooState.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace GlpiPlugin\Myplugin;
+
+class BarFooState extends \CommonDBTM
+{
+}


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

During plugin dev : 
I encountered a class loading issue related to the `DBUtils->getItemTypeForTable` function, specifically within `DBUtils->fixItemtypeCase`. The problem only occurs when the plugin is located in the `marketplace` directory. Everything works fine when it is placed in the `plugins` directory.

Here is the folder structure and the file in question

![image](https://github.com/user-attachments/assets/49c83a1d-bfc5-4968-bb13-421a75f70230)

![image](https://github.com/user-attachments/assets/b438f59d-256c-4c0e-8d2d-fc621b492a2c)



The fix made to `src/DbUtils.php` works locally (it correctly handles the `/marketplace/` directory in addition to `/plugins/`). However, I’m unable to reproduce the issue in unit tests: with or without the fix, `DBUtils->getItemTypeForTable` correctly returns the class.

I'm submitting the PR here without being sure if I’ll manage to get the tests to work. Either way, I’ll adapt the plugin to be properly recognized by GLPI. The goal is to ensure the plugin works with GLPI 10, regardless of whether it’s placed in the plugins/ or marketplace/ directory.



## Screenshots (if appropriate):


