### PR TITLE
Fix icon for plugin to enable

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -2526,7 +2526,7 @@ class Plugin extends CommonDBTM
                             ['action' => 'activate'],
                             _x('button', 'Enable'),
                             ['id' => $ID],
-                            'ti-toggle-right-filled fs-2x disabled'
+                            'ti-toggle-left-filled fs-2x disabled'
                         ) . '&nbsp;';
                     }
                 }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Wrong icon used since changing from FA icon to Tabler


