### PR TITLE
Fix some broken cards when missing read my and read all ticket rights

### DIFF
--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -6080,9 +6080,9 @@ JAVASCRIPT;
             ];
         }
         if ($valid) {
-            $join_profile['glpi_ticketvalidations as tv'] = [
+            $join_profile['glpi_ticketvalidations'] = [
                 'ON' => [
-                    'tv'           => 'tickets_id',
+                    'glpi_ticketvalidations' => 'tickets_id',
                     'glpi_tickets' => 'id'
                 ]
             ];


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

When missing See My and See All permissions (very unlikely but I saw this a while ago while working on another issue when these permissions were missing), some dashboard cards showed an error state.

`Ticket::getCriteriaFromProfile` was adding the join for validations with an alias, but using criteria from `TicketValidation::getTargetCriteriaForUser` which uses the table name directly, not the alias.

