### PR TITLE
Project tasks sublist massive action button class changed to secondary - fix #19008

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -2327,6 +2327,7 @@ TWIG,
      *    - confirm          : string of confirm message before massive action
      *    - item             : CommonDBTM object that has to be passed to the actions
      *    - tag_to_send      : the tag of the elements to send to the ajax window (default: common)
+     *    - action_button_classes : string of classes to add to the action button
      *    - display          : display or return the generated html (default true)
      *
      * @return bool|string     the html if display parameter is false, or true
@@ -2338,25 +2339,26 @@ TWIG,
 
        /// TODO : permit to pass several itemtypes to show possible actions of all types : need to clean visibility management after
 
-        $p['ontop']             = true;
-        $p['num_displayed']     = -1;
-        $p['forcecreate']       = false;
-        $p['check_itemtype']    = '';
-        $p['check_items_id']    = '';
-        $p['is_deleted']        = false;
-        $p['extraparams']       = [];
-        $p['width']             = 800;
-        $p['height']            = 400;
-        $p['specific_actions']  = [];
-        $p['add_actions']       = [];
-        $p['confirm']           = '';
-        $p['rand']              = '';
-        $p['container']         = '';
-        $p['display_arrow']     = true;
-        $p['title']             = _n('Action', 'Actions', Session::getPluralNumber());
-        $p['item']              = false;
-        $p['tag_to_send']       = 'common';
-        $p['display']           = true;
+        $p['ontop']                 = true;
+        $p['num_displayed']         = -1;
+        $p['forcecreate']           = false;
+        $p['check_itemtype']        = '';
+        $p['check_items_id']        = '';
+        $p['is_deleted']            = false;
+        $p['extraparams']           = [];
+        $p['width']                 = 800;
+        $p['height']                = 400;
+        $p['specific_actions']      = [];
+        $p['add_actions']           = [];
+        $p['confirm']               = '';
+        $p['rand']                  = '';
+        $p['container']             = '';
+        $p['display_arrow']         = true;
+        $p['title']                 = _n('Action', 'Actions', Session::getPluralNumber());
+        $p['item']                  = false;
+        $p['tag_to_send']           = 'common';
+        $p['action_button_classes'] = 'btn btn-sm btn-primary me-2';
+        $p['display']               = true;
 
         foreach ($options as $key => $val) {
             if (isset($p[$key])) {
@@ -2454,7 +2456,7 @@ TWIG,
             }
             $out .= "<a role=\"button\" title='" . __s('Massive actions') . "'
                      data-bs-toggle='tooltip' data-bs-placement='" . ($p['ontop'] ? "bottom" : "top") . "'
-                     class='btn btn-sm btn-primary me-2' ";
+                     class='{$p['action_button_classes']}' ";
             if (is_array($p['confirm'] || strlen($p['confirm']))) {
                 $out .= self::addConfirmationOnAction($p['confirm'], "modal_massiveaction_window$identifier.show();");
             } else {

--- a/src/ProjectTask.php
+++ b/src/ProjectTask.php
@@ -1407,8 +1407,8 @@ TWIG, $twig_params);
                     'delete' => _x('button', 'Put in trashbin'),
                     'restore' => _x('button', 'Restore'),
                     'purge' => _x('button', 'Delete permanently')
-                ]
-            ]
+                ],
+            ],
         ]);
     }
 

--- a/src/ProjectTask.php
+++ b/src/ProjectTask.php
@@ -1407,8 +1407,8 @@ TWIG, $twig_params);
                     'delete' => _x('button', 'Put in trashbin'),
                     'restore' => _x('button', 'Restore'),
                     'purge' => _x('button', 'Delete permanently')
-                ],
-            ],
+                ]
+            ]
         ]);
     }
 

--- a/templates/components/datatable.html.twig
+++ b/templates/components/datatable.html.twig
@@ -70,7 +70,7 @@
     <div class="table-responsive" {% if showmassiveactions %} id="{{ massiveactionparams['container'] }}" {% endif %}>
         {% if showmassiveactions %}
             <div class="mb-2">
-                {% do call('Html::showMassiveActions', [massiveactionparams|default([])]) %}
+                {% do call('Html::showMassiveActions', [{action_button_classes: 'btn btn-sm btn-outline-secondary me-2'}|merge(massiveactionparams|default({}))]) %}
             </div>
         {% endif %}
         <table id="{{ datatable_id }}" class="table {{ table_class_style|default('table-hover') }}" aria-label="{{ datatable_aria_label|default('') }}">


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

- Project tasks sublist massive action button class changed to secondary - fix #19008

