### PR TITLE
Init form access policies on creation

### DIFF
--- a/phpunit/functional/Glpi/Form/AccessControl/ControlType/AllowListTest.php
+++ b/phpunit/functional/Glpi/Form/AccessControl/ControlType/AllowListTest.php
@@ -90,14 +90,15 @@ class AllowListTest extends \DbTestCase
         // The rendered content should be validated by an E2E test.
         $form = $this->createForm(
             (new FormBuilder())
+                ->setUseDefaultAccessPolicies(false)
                 ->addAccessControl(
-                    \Glpi\Form\AccessControl\ControlType\AllowList::class,
+                    AllowList::class,
                     $this->getFullyConfiguredAllowListConfig()
                 )
         );
         $access_control = $this->getAccessControl(
             $form,
-            \Glpi\Form\AccessControl\ControlType\AllowList::class
+            AllowList::class
         );
         $this->assertNotEmpty($allow_list->renderConfigForm($access_control));
     }

--- a/phpunit/functional/Glpi/Form/AccessControl/ControlType/DirectAccessTest.php
+++ b/phpunit/functional/Glpi/Form/AccessControl/ControlType/DirectAccessTest.php
@@ -96,6 +96,7 @@ class DirectAccessTest extends \DBTestCase
         // The rendered content should be validated by an E2E test.
         $form = $this->createForm(
             (new FormBuilder())
+                ->setUseDefaultAccessPolicies(false)
                 ->addAccessControl(
                     DirectAccess::class,
                     new DirectAccessConfig(
@@ -259,6 +260,7 @@ class DirectAccessTest extends \DBTestCase
     {
         yield 'form without blacklisted question types' => [
             (new FormBuilder())
+                ->setUseDefaultAccessPolicies(false)
                 ->addAccessControl(DirectAccess::class, new DirectAccessConfig(
                     token: 'my_token',
                     allow_unauthenticated: true,
@@ -269,6 +271,7 @@ class DirectAccessTest extends \DBTestCase
         yield 'form with blacklisted question types' => [
             (new FormBuilder())
                 ->addQuestion('My observer question', QuestionTypeObserver::class)
+                ->setUseDefaultAccessPolicies(false)
                 ->addAccessControl(DirectAccess::class, new DirectAccessConfig(
                     token: 'my_token',
                     allow_unauthenticated: true,
@@ -282,6 +285,7 @@ class DirectAccessTest extends \DBTestCase
             (new FormBuilder())
                 ->setIsActive(false)
                 ->addQuestion('My observer question', QuestionTypeObserver::class)
+                ->setUseDefaultAccessPolicies(false)
                 ->addAccessControl(DirectAccess::class, new DirectAccessConfig(
                     token: 'my_token',
                     allow_unauthenticated: true,

--- a/phpunit/functional/Glpi/Form/AccessControl/FormAccessControlManagerTest.php
+++ b/phpunit/functional/Glpi/Form/AccessControl/FormAccessControlManagerTest.php
@@ -188,7 +188,9 @@ final class FormAccessControlManagerTest extends DbTestCase
 
     public function testFormWithoutRestrictionCantBeAnswered(): void
     {
-        $form = $this->createForm(new FormBuilder());
+        $builder = new FormBuilder();
+        $builder->setUseDefaultAccessPolicies(false);
+        $form = $this->createForm($builder);
         $access_parameters = $this->getEmptyParameters();
 
         $this->assertFalse(
@@ -274,7 +276,10 @@ final class FormAccessControlManagerTest extends DbTestCase
 
     public function testGetWarningForInactiveFormWithoutAccessControlPolicies(): void
     {
-        $form = $this->createForm((new FormBuilder())->setIsActive(false));
+        $builder = new FormBuilder();
+        $builder->setIsActive(false);
+        $builder->setUseDefaultAccessPolicies(false);
+        $form = $this->createForm($builder);
         $this->checkGetWarnings($form, [
             'This form is not visible to anyone because it is not active.',
             'This form will not be visible to any users as there are currently no active access policies.',
@@ -283,7 +288,10 @@ final class FormAccessControlManagerTest extends DbTestCase
 
     public function testGetWarningForActiveFormWithoutAccessControlPolicies(): void
     {
-        $form = $this->createForm((new FormBuilder())->setIsActive(true));
+        $builder = new FormBuilder();
+        $builder->setIsActive(true);
+        $builder->setUseDefaultAccessPolicies(false);
+        $form = $this->createForm($builder);
         $this->checkGetWarnings($form, [
             'This form will not be visible to any users as there are currently no active access policies.',
         ]);
@@ -330,6 +338,7 @@ final class FormAccessControlManagerTest extends DbTestCase
     {
         return $this->createForm(
             (new FormBuilder())
+                ->setUseDefaultAccessPolicies(false)
                 ->addAccessControl(AllowList::class, new AllowListConfig(
                     user_ids: [
                         getItemByTypeName(User::class, "tech", true),
@@ -343,6 +352,7 @@ final class FormAccessControlManagerTest extends DbTestCase
         return $this->createForm(
             (new FormBuilder())
                 ->setIsActive(true)
+                ->setUseDefaultAccessPolicies(false)
                 ->addAccessControl(DirectAccess::class, new DirectAccessConfig(
                     token: 'my_token',
                 ))
@@ -354,6 +364,7 @@ final class FormAccessControlManagerTest extends DbTestCase
         return $this->createForm(
             (new FormBuilder())
                 ->setIsActive(false)
+                ->setUseDefaultAccessPolicies(false)
                 ->addAccessControl(DirectAccess::class, new DirectAccessConfig(
                     token: 'my_token',
                 ))
@@ -365,6 +376,7 @@ final class FormAccessControlManagerTest extends DbTestCase
         $form = $this->createForm(
             (new FormBuilder())
                 ->setIsActive(true)
+                ->setUseDefaultAccessPolicies(false)
                 ->addAccessControl(DirectAccess::class, new DirectAccessConfig(
                     token: 'my_token',
                 ))
@@ -382,6 +394,7 @@ final class FormAccessControlManagerTest extends DbTestCase
         $form = $this->createForm(
             (new FormBuilder())
                 ->setIsActive(false)
+                ->setUseDefaultAccessPolicies(false)
                 ->addAccessControl(DirectAccess::class, new DirectAccessConfig(
                     token: 'my_token',
                 ))
@@ -396,13 +409,16 @@ final class FormAccessControlManagerTest extends DbTestCase
 
     private function createAndGetFormWithoutAccessControls(): Form
     {
-        return $this->createForm(new FormBuilder());
+        $builder = new FormBuilder();
+        $builder->setUseDefaultAccessPolicies(false);
+        return $this->createForm($builder);
     }
 
     private function createAndGetFormWithActiveAccessControls(): Form
     {
         return $this->createForm(
             (new FormBuilder())
+                ->setUseDefaultAccessPolicies(false)
                 ->addAccessControl(AllowList::class, new AllowListConfig(
                     user_ids: [
                         getItemByTypeName(User::class, "tech", true),
@@ -418,6 +434,7 @@ final class FormAccessControlManagerTest extends DbTestCase
     {
         $form = $this->createForm(
             (new FormBuilder())
+                ->setUseDefaultAccessPolicies(false)
                 ->addAccessControl(AllowList::class, new AllowListConfig(
                     user_ids: [
                         getItemByTypeName(User::class, "tech", true),
@@ -439,6 +456,7 @@ final class FormAccessControlManagerTest extends DbTestCase
     {
         return $this->createForm(
             (new FormBuilder())
+                ->setUseDefaultAccessPolicies(false)
                 ->addAccessControl(AllowList::class, new AllowListConfig(
                     user_ids: [
                         getItemByTypeName(User::class, "tech", true),

--- a/phpunit/functional/Glpi/Form/AccessControl/FormAccessControlTest.php
+++ b/phpunit/functional/Glpi/Form/AccessControl/FormAccessControlTest.php
@@ -241,7 +241,7 @@ class FormAccessControlTest extends DbTestCase
     public function testGetTabNameForEmptyForm(): void
     {
         $form = $this->createAndGetSimpleForm();
-        $this->checkGetTabNameForItem($form, "Access control");
+        $this->checkGetTabNameForItem($form, "Access control 1"); // 1 for default policy
     }
 
     public function testGetTabNameWithActivePolicies(): void
@@ -392,6 +392,7 @@ class FormAccessControlTest extends DbTestCase
         $form = $this->createForm(
             (new FormBuilder())
                 ->addQuestion("Name", QuestionTypeShortText::class)
+                ->setUseDefaultAccessPolicies(false)
                 ->addAccessControl(DirectAccess::class, new DirectAccessConfig(
                     token: 'my_token',
                     allow_unauthenticated: true,
@@ -453,6 +454,7 @@ class FormAccessControlTest extends DbTestCase
         $form = $this->createForm(
             (new FormBuilder())
                 ->addQuestion("Name", QuestionTypeShortText::class)
+                ->setUseDefaultAccessPolicies(false)
                 ->addAccessControl(DirectAccess::class, new DirectAccessConfig())
         );
         return $this->getAccessControl($form, DirectAccess::class);
@@ -471,6 +473,7 @@ class FormAccessControlTest extends DbTestCase
         return $this->createForm(
             (new FormBuilder())
                 ->addQuestion("Name", QuestionTypeShortText::class)
+                ->setUseDefaultAccessPolicies(false)
                 ->addAccessControl(DirectAccess::class, new DirectAccessConfig(
                     token: 'my_token',
                     allow_unauthenticated: true,

--- a/phpunit/functional/Glpi/Form/Export/FormSerializerAccessPoliciesTest.php
+++ b/phpunit/functional/Glpi/Form/Export/FormSerializerAccessPoliciesTest.php
@@ -89,6 +89,7 @@ final class FormSerializerAccessPoliciesTest extends \DbTestCase
     ): void {
         // Arrange: create a form with a direct access policy
         $builder = new FormBuilder("My test form");
+        $builder->setUseDefaultAccessPolicies(false);
         $builder->addAccessControl(
             strategy: DirectAccess::class,
             config: new DirectAccessConfig(
@@ -176,6 +177,7 @@ final class FormSerializerAccessPoliciesTest extends \DbTestCase
     ): void {
         // Arrange: Create a form with an allow list policy
         $builder = new FormBuilder("My test form");
+        $builder->setUseDefaultAccessPolicies(false);
         $builder->addAccessControl(
             strategy: AllowList::class,
             config: new AllowListConfig(
@@ -224,6 +226,7 @@ final class FormSerializerAccessPoliciesTest extends \DbTestCase
         );
 
         $builder = new FormBuilder("My test form");
+        $builder->setUseDefaultAccessPolicies(false);
         $builder->addAccessControl(AllowList::class, new AllowListConfig(
             user_ids: [$user_1->getID(), $user_2->getID(), AbstractRightsDropdown::ALL_USERS],
             group_ids: [$group_1->getID(), $group_2->getID()],
@@ -283,6 +286,7 @@ final class FormSerializerAccessPoliciesTest extends \DbTestCase
         );
 
         $builder = new FormBuilder("My test form");
+        $builder->setUseDefaultAccessPolicies(false);
         $builder->addAccessControl(AllowList::class, new AllowListConfig(
             user_ids: [$user_1->getID(), $user_2->getID(), AbstractRightsDropdown::ALL_USERS],
             group_ids: [$group_1->getID(), $group_2->getID()],

--- a/phpunit/functional/Glpi/Form/FormTest.php
+++ b/phpunit/functional/Glpi/Form/FormTest.php
@@ -215,9 +215,9 @@ class FormTest extends DbTestCase
         $this->assertCount(1, $form_with_section->getSections());
 
         $form_without_section = $this->createItem(Form::class, [
-            'name'                  => 'Form without first section',
-            'entities_id'           => $entity->getID(),
-            '_do_not_init_sections' => true,
+            'name'           => 'Form without first section',
+            'entities_id'    => $entity->getID(),
+            '_init_sections' => false,
         ]);
         $this->assertCount(0, $form_without_section->getSections());
     }
@@ -384,37 +384,37 @@ class FormTest extends DbTestCase
         $this->login();
 
         $form = $this->createForm(new FormBuilder());
-        $this->checkTestLogs($form, 2); // Created + mandatory target added
+        $this->checkTestLogs($form, 3); // Created + mandatory target + default policy
 
         $this->addSectionToForm($form, "Section 1");
         $this->addSectionToForm($form, "Section 2");
         $this->addSectionToForm($form, "Section 3");
-        $this->checkTestLogs($form, 5); // + 3 sections added
+        $this->checkTestLogs($form, 6); // + 3 sections added
 
         $q1 = $this->addQuestionToForm($form, "Question 1");
         $this->addQuestionToForm($form, "Question 2");
-        $this->checkTestLogs($form, 7); // + 2 questions added
+        $this->checkTestLogs($form, 8); // + 2 questions added
 
         $c1 = $this->addCommentBlockToForm($form, "Title 1", "Content 1");
         $this->addCommentBlockToForm($form, "Title 2", "Content 2");
-        $this->checkTestLogs($form, 9); // + 2 comments added
+        $this->checkTestLogs($form, 10); // + 2 comments added
 
         $this->updateItem(Question::class, $q1->getId(), [
             'name' => 'Question 1 (updated)',
             'type' => QuestionTypeEmail::class,
         ]);
-        $this->checkTestLogs($form, 11); // + 2 question fields updated
+        $this->checkTestLogs($form, 12); // + 2 question fields updated
 
         $this->deleteItem(Question::class, $q1->getId());
-        $this->checkTestLogs($form, 12); // + 1 question deleted
+        $this->checkTestLogs($form, 13); // + 1 question deleted
 
         $this->updateItem(Comment::class, $c1->getId(), [
             'name' => 'Title 1 (updated)',
         ]);
-        $this->checkTestLogs($form, 13); // + 1 comment updated
+        $this->checkTestLogs($form, 14); // + 1 comment updated
 
         $this->deleteItem(Comment::class, $c1->getId());
-        $this->checkTestLogs($form, 14); // + 1 comment deleted
+        $this->checkTestLogs($form, 15); // + 1 comment deleted
     }
 
     private function checkTestLogs(
@@ -458,6 +458,7 @@ class FormTest extends DbTestCase
                 ->addQuestion('Question 2', QuestionTypeShortText::class)
                 ->addQuestion('Question 3', QuestionTypeShortText::class)
                 ->addDestination(FormDestinationTicket::class, 'Destination 1')
+                ->setUseDefaultAccessPolicies(false)
                 ->addAccessControl(AllowList::class, new AllowListConfig())
                 ->addAccessControl(DirectAccess::class, new DirectAccessConfig())
         );
@@ -469,6 +470,7 @@ class FormTest extends DbTestCase
                 ->addQuestion('Question 1', QuestionTypeShortText::class)
                 ->addComment('Comment 1', 'Comment 1 description')
                 ->addDestination(FormDestinationTicket::class, 'Destination 1')
+                ->setUseDefaultAccessPolicies(false)
                 ->addAccessControl(DirectAccess::class, new DirectAccessConfig())
         );
 
@@ -526,6 +528,7 @@ class FormTest extends DbTestCase
                 ->addSection('Section 1')
                 ->addQuestion('Question 1', QuestionTypeShortText::class)
                 ->addDestination(FormDestinationTicket::class, 'Destination 1')
+                ->setUseDefaultAccessPolicies(false)
                 ->addAccessControl(DirectAccess::class, new DirectAccessConfig())
         );
         $DB->update(
@@ -556,7 +559,7 @@ class FormTest extends DbTestCase
             'expected_tabs' => [
                 'Form',
                 'Service catalog',
-                'Access control',
+                'Access control 1',
                 'Items to create 1',
                 'Form translations',
             ],
@@ -568,7 +571,7 @@ class FormTest extends DbTestCase
                 'Form',
                 'Service catalog',
                 'Tickets 1',
-                'Access control',
+                'Access control 1',
                 'Items to create 1',
                 'Form translations',
             ],
@@ -580,7 +583,7 @@ class FormTest extends DbTestCase
                 'Form',
                 'Service catalog',
                 'Tickets 5',
-                'Access control',
+                'Access control 1',
                 'Items to create 1',
                 'Form translations',
             ],
@@ -600,7 +603,7 @@ class FormTest extends DbTestCase
             'expected_tabs' => [
                 'Form',
                 'Service catalog',
-                'Access control',
+                'Access control 1',
                 'Items to create 4',
                 'Form translations',
             ],
@@ -612,7 +615,7 @@ class FormTest extends DbTestCase
                 'Form',
                 'Service catalog',
                 'Tickets 4', // (1 (default) + 3) destinations * 1 answer
-                'Access control',
+                'Access control 1',
                 'Items to create 4',
                 'Form translations',
             ],
@@ -624,7 +627,7 @@ class FormTest extends DbTestCase
                 'Form',
                 'Service catalog',
                 'Tickets 20', // (1 (default) + 3) destinations 5 answers
-                'Access control',
+                'Access control 1',
                 'Items to create 4',
                 'Form translations',
             ],
@@ -644,7 +647,7 @@ class FormTest extends DbTestCase
             'expected_tabs' => [
                 'Form',
                 'Service catalog',
-                'Access control',
+                'Access control 1',
                 'Items to create 4',
                 'Form translations',
             ],
@@ -657,7 +660,7 @@ class FormTest extends DbTestCase
                 'Service catalog',
                 'Tickets 1',
                 'Changes 3', // 3 destinations * 1 answer
-                'Access control',
+                'Access control 1',
                 'Items to create 4',
                 'Form translations',
             ],
@@ -670,7 +673,7 @@ class FormTest extends DbTestCase
                 'Service catalog',
                 'Tickets 5',
                 'Changes 15', // 3 destinations * 5 answers
-                'Access control',
+                'Access control 1',
                 'Items to create 4',
                 'Form translations',
             ],
@@ -690,7 +693,7 @@ class FormTest extends DbTestCase
             'expected_tabs' => [
                 'Form',
                 'Service catalog',
-                'Access control',
+                'Access control 1',
                 'Items to create 4',
                 'Form translations',
             ],
@@ -703,7 +706,7 @@ class FormTest extends DbTestCase
                 'Service catalog',
                 'Tickets 1',
                 'Problems 3', // 3 destinations * 1 answer
-                'Access control',
+                'Access control 1',
                 'Items to create 4',
                 'Form translations',
             ],
@@ -716,7 +719,7 @@ class FormTest extends DbTestCase
                 'Service catalog',
                 'Tickets 5',
                 'Problems 15', // 3 destinations * 5 answers
-                'Access control',
+                'Access control 1',
                 'Items to create 4',
                 'Form translations',
             ],

--- a/phpunit/functional/Glpi/Form/ServiceCatalog/ServiceCatalogManagerTest.php
+++ b/phpunit/functional/Glpi/Form/ServiceCatalog/ServiceCatalogManagerTest.php
@@ -83,7 +83,6 @@ final class ServiceCatalogManagerTest extends \DbTestCase
             (new FormBuilder("Inactive form 3"))->setIsActive(false),
         ];
         foreach ($builders as $builder) {
-            $builder->allowAllUsers();
             $this->createForm($builder);
         }
 
@@ -110,7 +109,6 @@ final class ServiceCatalogManagerTest extends \DbTestCase
             (new FormBuilder("Not pinned form 2"))->setIsPinned(false),
         ];
         foreach ($builders as $builder) {
-            $builder->allowAllUsers();
             $builder->setIsActive(true);
             $this->createForm($builder);
         }
@@ -145,7 +143,6 @@ final class ServiceCatalogManagerTest extends \DbTestCase
             (new FormBuilder("child 2"))->setCategory($category_2->getID()),
         ];
         foreach ($builders as $builder) {
-            $builder->allowAllUsers();
             $builder->setIsActive(true);
             $this->createForm($builder);
         }
@@ -179,7 +176,6 @@ final class ServiceCatalogManagerTest extends \DbTestCase
             (new FormBuilder("A Not pinned form"))->setIsPinned(false),
         ];
         foreach ($builders as $builder) {
-            $builder->allowAllUsers();
             $builder->setIsActive(true);
             $this->createForm($builder);
         }
@@ -205,6 +201,8 @@ final class ServiceCatalogManagerTest extends \DbTestCase
     {
         // Arrange: create a form with an active policy
         $builder = new FormBuilder("Form with active policy");
+        $builder->setUseDefaultAccessPolicies(false);
+        $builder->setUseDefaultAccessPolicies(false);
         $builder->addAccessControl(
             strategy: AllowList::class,
             config: new AllowListConfig(
@@ -230,6 +228,7 @@ final class ServiceCatalogManagerTest extends \DbTestCase
         // Arrange: create a form without any policies
         $builder = new FormBuilder("Form without policies");
         $builder->setIsActive(true);
+        $builder->setUseDefaultAccessPolicies(false);
         $this->createForm($builder);
 
         // Act: get the forms from the catalog manager and extract their names
@@ -246,6 +245,7 @@ final class ServiceCatalogManagerTest extends \DbTestCase
     {
         // Arrange: create a form with an inactive policy
         $builder = new FormBuilder("Form with inactive policy");
+        $builder->setUseDefaultAccessPolicies(false);
         $builder->addAccessControl(
             strategy: AllowList::class,
             config: new AllowListConfig(
@@ -304,6 +304,7 @@ final class ServiceCatalogManagerTest extends \DbTestCase
     ): void {
         // Arrange: create a form with an allow list
         $builder = new FormBuilder();
+        $builder->setUseDefaultAccessPolicies(false);
         $builder->addAccessControl(
             strategy: AllowList::class,
             config: $config,
@@ -406,7 +407,6 @@ final class ServiceCatalogManagerTest extends \DbTestCase
         foreach ($forms_data as $form_data) {
             $builder = new FormBuilder($form_data['name']);
             $builder->setDescription($form_data['description']);
-            $builder->allowAllUsers();
             $builder->setIsActive(true);
             $this->createForm($builder);
         }
@@ -439,7 +439,6 @@ final class ServiceCatalogManagerTest extends \DbTestCase
             (new FormBuilder("Form from category B"))->setCategory($category_b->getID()),
         ];
         foreach ($builders as $builder) {
-            $builder->allowAllUsers();
             $builder->setIsActive(true);
             $this->createForm($builder);
         }
@@ -476,7 +475,6 @@ final class ServiceCatalogManagerTest extends \DbTestCase
             (new FormBuilder("Form from category B"))->setCategory($category_b->getID()),
         ];
         foreach ($builders as $builder) {
-            $builder->allowAllUsers();
             $builder->setIsActive(true);
             $this->createForm($builder);
         }
@@ -514,7 +512,6 @@ final class ServiceCatalogManagerTest extends \DbTestCase
             (new FormBuilder("Form from category C2"))->setCategory($category_c2->getID()),
         ];
         foreach ($builders as $builder) {
-            $builder->allowAllUsers();
             $builder->setIsActive(true);
             $this->createForm($builder);
         }
@@ -562,7 +559,6 @@ final class ServiceCatalogManagerTest extends \DbTestCase
             (new FormBuilder("Form from category D1"))->setCategory($category_d1->getID()),
         ];
         foreach ($builders as $builder) {
-            $builder->allowAllUsers();
             $builder->setIsActive(true);
             $this->createForm($builder);
         }
@@ -806,7 +802,6 @@ final class ServiceCatalogManagerTest extends \DbTestCase
 
         // Create a form
         $builder = new FormBuilder("Test Form");
-        $builder->allowAllUsers();
         $builder->setIsActive(true);
         $builder->setIsPinned(true);
         $this->createForm($builder);

--- a/phpunit/functional/Glpi/Helpdesk/Tile/TilesManagerTest.php
+++ b/phpunit/functional/Glpi/Helpdesk/Tile/TilesManagerTest.php
@@ -134,13 +134,11 @@ final class TilesManagerTest extends DbTestCase
         $builder = new FormBuilder("Inactive form");
         $builder->setIsActive(false);
         $builder->setEntitiesId($test_entity_id);
-        $builder->allowAllUsers();
         $forms[] = $this->createForm($builder);
 
         $builder = new FormBuilder("Active form");
         $builder->setIsActive(true);
         $builder->setEntitiesId($test_entity_id);
-        $builder->allowAllUsers();
         $forms[] = $this->createForm($builder);
 
         foreach ($forms as $form) {
@@ -175,13 +173,13 @@ final class TilesManagerTest extends DbTestCase
 
         $builder = new FormBuilder("Form without access policies");
         $builder->setIsActive(true);
+        $builder->setUseDefaultAccessPolicies(false);
         $builder->setEntitiesId($test_entity_id);
         $forms[] = $this->createForm($builder);
 
         $builder = new FormBuilder("Form with access policies");
         $builder->setIsActive(true);
         $builder->setEntitiesId($test_entity_id);
-        $builder->allowAllUsers();
         $forms[] = $this->createForm($builder);
 
         foreach ($forms as $form) {
@@ -217,21 +215,18 @@ final class TilesManagerTest extends DbTestCase
         $builder = new FormBuilder("Form inside current entity");
         $builder->setIsActive(true);
         $builder->setEntitiesId($test_entity_id);
-        $builder->allowAllUsers();
         $forms[] = $this->createForm($builder);
 
         $builder = new FormBuilder("Form outside current entity");
         $builder->setIsActive(true);
         $builder->setEntitiesId(0);
         $builder->setIsRecursive(false);
-        $builder->allowAllUsers();
         $forms[] = $this->createForm($builder);
 
         $builder = new FormBuilder("Form inside recursive parent entity");
         $builder->setIsActive(true);
         $builder->setEntitiesId(0);
         $builder->setIsRecursive(true);
-        $builder->allowAllUsers();
         $forms[] = $this->createForm($builder);
 
         foreach ($forms as $form) {

--- a/phpunit/functional/LogTest.php
+++ b/phpunit/functional/LogTest.php
@@ -837,6 +837,7 @@ class LogTest extends DbTestCase
     {
         // Arrange: create a form with a linked item that contains JSON values
         $builder = new FormBuilder();
+        $builder->setUseDefaultAccessPolicies(false);
         $builder->addAccessControl(
             DirectAccess::class,
             new DirectAccessConfig(token: 'my_token')

--- a/src/Glpi/Form/Export/Serializer/FormSerializer.php
+++ b/src/Glpi/Form/Export/Serializer/FormSerializer.php
@@ -351,7 +351,7 @@ final class FormSerializer extends AbstractFormSerializer
             'entities_id'           => $entities_id,
             'is_recursive'          => $spec->is_recursive,
             'is_active'             => $spec->is_active,
-            '_do_not_init_sections' => true,
+            '_init_sections'        => false,
         ]);
         if (!$form->getFromDB($id)) {
             throw new RuntimeException("Failed to create form");

--- a/src/Glpi/Form/Migration/FormMigration.php
+++ b/src/Glpi/Form/Migration/FormMigration.php
@@ -318,7 +318,7 @@ final class FormMigration extends AbstractPluginMigration
                     'entities_id'           => $raw_form['entities_id'],
                     'is_recursive'          => $raw_form['is_recursive'],
                     'is_active'             => $raw_form['is_active'],
-                    '_do_not_init_sections' => true
+                    '_from_migration'       =>  true
                 ],
                 [
                     'name'                => $raw_form['name'],

--- a/src/Glpi/Helpdesk/DefaultDataManager.php
+++ b/src/Glpi/Helpdesk/DefaultDataManager.php
@@ -35,10 +35,6 @@
 
 namespace Glpi\Helpdesk;
 
-use AbstractRightsDropdown;
-use Glpi\Form\AccessControl\ControlType\AllowList;
-use Glpi\Form\AccessControl\ControlType\AllowListConfig;
-use Glpi\Form\AccessControl\FormAccessControl;
 use Glpi\Form\Destination\CommonITILField\ContentField;
 use Glpi\Form\Destination\CommonITILField\ITILActorFieldStrategy;
 use Glpi\Form\Destination\CommonITILField\ObserverField;
@@ -48,8 +44,6 @@ use Glpi\Form\Destination\CommonITILField\RequestTypeFieldConfig;
 use Glpi\Form\Destination\CommonITILField\RequestTypeFieldStrategy;
 use Glpi\Form\Destination\CommonITILField\SimpleValueConfig;
 use Glpi\Form\Destination\CommonITILField\TitleField;
-use Glpi\Form\Destination\FormDestination;
-use Glpi\Form\Destination\FormDestinationTicket;
 use Glpi\Form\Form;
 use Glpi\Form\Question;
 use Glpi\Form\QuestionType\QuestionTypeItemDropdown;
@@ -207,9 +201,6 @@ final class DefaultDataManager
         // Add ticket destination
         $this->setMandatoryTicketDestination($form, $config);
 
-        // Allow all users
-        $this->allowAllUsers($form);
-
         return $form;
     }
 
@@ -269,9 +260,6 @@ final class DefaultDataManager
 
         // Add ticket destination
         $this->setMandatoryTicketDestination($form, $config);
-
-        // Allow all users
-        $this->allowAllUsers($form);
     }
 
     private function createForm(
@@ -395,23 +383,6 @@ final class DefaultDataManager
 
         if (!$success) {
             throw new \RuntimeException("Failed configure destination");
-        }
-    }
-
-    private function allowAllUsers(Form $form): void
-    {
-        $form_access_control = new FormAccessControl();
-        $id = $form_access_control->add([
-            Form::getForeignKeyField() => $form->getID(),
-            'strategy' => AllowList::class,
-            '_config'   => new AllowListConfig(
-                user_ids: [AbstractRightsDropdown::ALL_USERS]
-            ),
-            'is_active' => 1,
-        ]);
-
-        if (!$id) {
-            throw new \RuntimeException("Failed to create access policy");
         }
     }
 }

--- a/tests/cypress/e2e/ajax_controller.cy.js
+++ b/tests/cypress/e2e/ajax_controller.cy.js
@@ -44,8 +44,8 @@ describe('Ajax Controller', () => {
             cy.visit(`/front/form/form.form.php?id=${form_id}&forcetab=${tab}`);
 
             // Load the history tab
-            cy.findByRole('tab', {'name': "Historical 3"}).click();
-            cy.findAllByRole('row').should('have.length', 4); // 3 entries + header
+            cy.findByRole('tab', {'name': "Historical 4"}).click();
+            cy.findAllByRole('row').should('have.length', 5); // 4 entries + header
             cy.findByRole('tab', {'name': "Form"}).click();
 
             // Modify and save form
@@ -57,8 +57,8 @@ describe('Ajax Controller', () => {
             );
 
             // Go to history tab, it must be updated with a new entry
-            cy.findByRole('tab', {'name': "Historical 3"}).click();
-            cy.findAllByRole('row').should('have.length', 5); // 4 entries + header
+            cy.findByRole('tab', {'name': "Historical 4"}).click();
+            cy.findAllByRole('row').should('have.length', 6); // 5 entries + header
         });
     });
 });

--- a/tests/cypress/e2e/form/access_policies/access_control.cy.js
+++ b/tests/cypress/e2e/form/access_policies/access_control.cy.js
@@ -37,6 +37,7 @@ describe('Access Control', () => {
 
         cy.createWithAPI('Glpi\\Form\\Form', {
             'name': '[Tests] Access Control',
+            '_init_access_policies': false,
         }).then((form_id) => {
             const tab = 'Glpi\\Form\\AccessControl\\FormAccessControl$1';
             cy.visit(`/front/form/form.form.php?id=${form_id}&forcetab=${tab}`);

--- a/tests/cypress/e2e/form/access_policies/direct_access.cy.js
+++ b/tests/cypress/e2e/form/access_policies/direct_access.cy.js
@@ -35,6 +35,7 @@ describe('Form access policy', () => {
         cy.createWithAPI('Glpi\\Form\\Form', {
             'name': 'Test form for the access policy form suite',
             'is_active': true,
+            '_init_access_policies': false,
         }).as('form_id');
 
         cy.login();

--- a/tests/cypress/e2e/form/service_catalog/service_catalog_page.cy.js
+++ b/tests/cypress/e2e/form/service_catalog/service_catalog_page.cy.js
@@ -39,19 +39,6 @@ describe('Service catalog page', () => {
             'is_active': true,
             'forms_categories_id': category,
         }).as('form_id');
-
-        cy.get('@form_id').then(form_id => {
-            cy.createWithAPI('Glpi\\Form\\AccessControl\\FormAccessControl', {
-                'forms_forms_id': form_id,
-                'strategy'      : 'Glpi\\Form\\AccessControl\\ControlType\\AllowList',
-                '_config'        : {
-                    'user_ids': ['all'],
-                    'groups_ids': [],
-                    'profiles_ids': [],
-                },
-                'is_active'     : true,
-            });
-        });
     }
 
     function createKnowledgeBaseItem(name, options = {}) {
@@ -357,6 +344,9 @@ describe('Service catalog page', () => {
         // Go to the service catalog
         cy.changeProfile('Self-Service', true);
         cy.visit('/ServiceCatalog');
+
+        // Filter forms to show only the ones created in this test
+        cy.findByPlaceholderText('Search for forms...').type(time);
 
         // Check breadcrumb
         cy.findByRole('navigation', {'name': 'Service catalog categories'}).within(() => {

--- a/tests/src/FormBuilder.php
+++ b/tests/src/FormBuilder.php
@@ -126,6 +126,7 @@ class FormBuilder
      */
     protected array $destinations_conditions;
 
+    protected bool $use_default_access_policies;
 
     /**
      * Constructor
@@ -150,6 +151,7 @@ class FormBuilder
         $this->comments_visibilities = [];
         $this->sections_visibilities = [];
         $this->destinations_conditions = [];
+        $this->use_default_access_policies = true;
     }
 
     /**
@@ -490,23 +492,6 @@ class FormBuilder
     }
 
     /**
-     * Shorthand to add an allow list without restrictions to the form.
-     *
-     * @return self
-     */
-    public function allowAllUsers(): self
-    {
-        $this->addAccessControl(
-            strategy: AllowList::class,
-            config: new AllowListConfig(
-                user_ids: [AbstractRightsDropdown::ALL_USERS]
-            ),
-            is_active: true,
-        );
-        return $this;
-    }
-
-    /**
      * Get form category
      *
      * @return int Form category
@@ -591,5 +576,16 @@ class FormBuilder
     public function getDestinationCondition(): array
     {
         return $this->destinations_conditions;
+    }
+
+    public function setUseDefaultAccessPolicies(bool $use_default_access_policies): self
+    {
+        $this->use_default_access_policies = $use_default_access_policies;
+        return $this;
+    }
+
+    public function getUseDefaultAccessPolicies(): bool
+    {
+        return $this->use_default_access_policies;
     }
 }

--- a/tests/src/FormTesterTrait.php
+++ b/tests/src/FormTesterTrait.php
@@ -82,7 +82,8 @@ trait FormTesterTrait
             'is_draft'              => $builder->getIsDraft(),
             'is_pinned'             => $builder->getIsPinned(),
             'forms_categories_id'   => $builder->getCategory(),
-            '_do_not_init_sections' => true, // We will handle sections ourselves
+            '_init_sections'        => false,  // We will handle sections ourselves
+            '_init_access_policies' => $builder->getUseDefaultAccessPolicies(),
         ]);
 
         $section_rank = 0;


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
   -> Existing tests have been updated.

## Description

Forms are now created with the following default access policies:

![image](https://github.com/user-attachments/assets/4135b5a3-3714-4d41-aacc-02c18392f9e6)

It is possible to prevent this initialization using a special `_init_access_policies = false` input value.
This is mainly used for tests, and may be used by future plugins or API calls if needed.

The existing `_do_not_init_sections` input value was renamed to `_init_sections` to be consistant with this new parameter.

