### PR TITLE
Prevent false positive "unsaved changed" warning on access control tab

### DIFF
--- a/templates/pages/admin/form/access_control/allow_list.html.twig
+++ b/templates/pages/admin/form/access_control/allow_list.html.twig
@@ -70,5 +70,12 @@
             .replace("%d", response.count))
         ;
     });
+
+    // Make sure this doens't trigger the "unsaved changes" detection if the form
+    // was not actually changed when this code is reached.
+    let restore_unsaved_form_status = window.glpiUnsavedFormChanges == false;
     $select.trigger('change');
+    if (restore_unsaved_form_status) {
+        window.glpiUnsavedFormChanges = false;
+    }
 </script>


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.

## Description

There was a warning on this tab even if no modification were made due to a script triggering a change event on a dropdown when the tab is loaded.

![image](https://github.com/user-attachments/assets/02face7a-246c-4f66-895d-500c2ead5f68)



