### PR TITLE
Remove mandatory destinations; show warning instead

### DIFF
--- a/install/migrations/update_10.0.x_to_11.0.0/form.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/form.php
@@ -201,7 +201,6 @@ if (!$DB->tableExists('glpi_forms_destinations_formdestinations')) {
             `itemtype` varchar(255) NOT NULL,
             `name` varchar(255) NOT NULL,
             `config` JSON NOT NULL COMMENT 'Extra configuration field(s) depending on the destination type',
-            `is_mandatory` tinyint NOT NULL DEFAULT '0',
             `creation_strategy` varchar(30) NOT NULL DEFAULT '',
             `conditions` JSON NOT NULL,
             PRIMARY KEY (`id`),

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -9603,7 +9603,6 @@ CREATE TABLE `glpi_forms_destinations_formdestinations` (
     `itemtype` varchar(255) NOT NULL,
     `name` varchar(255) NOT NULL,
     `config` JSON NOT NULL COMMENT 'Extra configuration field(s) depending on the destination type',
-    `is_mandatory` tinyint NOT NULL DEFAULT '0',
     `creation_strategy` varchar(30) NOT NULL DEFAULT '',
     `conditions` JSON NOT NULL,
     PRIMARY KEY (`id`),

--- a/phpunit/functional/Glpi/Form/Destination/FormDestinationTest.php
+++ b/phpunit/functional/Glpi/Form/Destination/FormDestinationTest.php
@@ -100,6 +100,28 @@ final class FormDestinationTest extends DbTestCase
         $this->assertTrue($return);
     }
 
+    public function testWarningsAreRendereredInTabContent()
+    {
+        // Arrange: create a form and remove its default destination
+        $form = $this->createForm(new FormBuilder());
+        $destinations = $form->getDestinations();
+        foreach ($destinations as $destination) {
+            $this->deleteItem($destination::class, $destination->getId(), true);
+        }
+
+        // Act: display the destination tab
+        $destination = new FormDestination();
+        ob_start();
+        $destination->displayTabContentForItem($form);
+        $content = ob_get_clean();
+
+        // Assert: the content should contain the warning
+        $this->assertStringContainsString(
+            "This form is invalid, it must create at least one item.",
+            $content
+        );
+    }
+
     private function createAndGetFormWithFourDestinations(): Form
     {
         $builder = new FormBuilder();
@@ -110,51 +132,5 @@ final class FormDestinationTest extends DbTestCase
             ->addDestination(FormDestinationTicket::class, 'destination 4')
         ;
         return $this->createForm($builder);
-    }
-
-    public function testOneMandatoryTicketDestinationIsAlwaysAdded(): void
-    {
-        // Act: create a form
-        $form = $this->createItem(Form::class, ['name' => 'My test form']);
-
-        // Assert: the form should have one ticket destination
-        $destinations = $form->getDestinations();
-        $this->assertCount(1, $destinations);
-        $this->assertEquals(
-            FormDestinationTicket::class,
-            current($destinations)->fields['itemtype']
-        );
-    }
-
-    public function testMandatoryDestinationCantBeDeleted(): void
-    {
-        // Arrange: create a form and get its default destination
-        $form = $this->createItem(Form::class, ['name' => 'My test form']);
-        $destinations = $form->getDestinations();
-        $mandatory_destination = current($destinations);
-
-        // Act: check if the destination can be deleted
-        $this->login();
-        $can_delete = $mandatory_destination->canPurgeItem();
-
-        // Assert: the mandatory destination should not be able to be deleted
-        $this->assertFalse($can_delete);
-    }
-
-    public function testNonMandatoryDestinationCanBeDeleted(): void
-    {
-        // Arrange: create a form with a non mandatory destination
-        $builder = new FormBuilder("My test form");
-        $builder->addDestination(FormDestinationTicket::class, 'My destination');
-        $form = $this->createForm($builder);
-        $destinations = $form->getDestinations();
-        $non_mandatory_destination = end($destinations);
-
-        // Act: check if the destination can be deleted
-        $this->login();
-        $can_delete = $non_mandatory_destination->canPurgeItem();
-
-        // Assert: the non mandatory destination should be able to be deleted
-        $this->assertTrue($can_delete);
     }
 }

--- a/phpunit/functional/Glpi/Form/Export/FormSerializerDestinationTest.php
+++ b/phpunit/functional/Glpi/Form/Export/FormSerializerDestinationTest.php
@@ -88,7 +88,7 @@ use Glpi\Form\Destination\CommonITILField\ValidationField;
 use Glpi\Form\Destination\CommonITILField\ValidationFieldConfig;
 use Glpi\Form\Destination\CommonITILField\ValidationFieldStrategy;
 use Glpi\Form\Destination\FormDestinationTicket;
-use Glpi\Form\Destination\FormDestinationTypeManager;
+use Glpi\Form\Destination\FormDestinationManager;
 use Glpi\Form\Export\Context\ConfigWithForeignKeysInterface;
 use Glpi\Form\Export\Serializer\FormSerializer;
 use Glpi\Form\Form;
@@ -846,7 +846,7 @@ final class FormSerializerDestinationTest extends \DbTestCase
 
         /** @var AbstractCommonITILFormDestination[] $destination_types */
         $destination_types = array_filter(
-            FormDestinationTypeManager::getInstance()->getDestinationTypes(),
+            FormDestinationManager::getInstance()->getDestinationTypes(),
             fn($destination_type) => $destination_type instanceof AbstractCommonITILFormDestination
         );
         $destination_fields = array_merge(...array_map(

--- a/phpunit/functional/Glpi/Form/Export/FormSerializerTest.php
+++ b/phpunit/functional/Glpi/Form/Export/FormSerializerTest.php
@@ -657,16 +657,14 @@ final class FormSerializerTest extends \DbTestCase
 
         $this->assertCount(2, $imported_destinations);
 
-        // Check the mandatory destination
+        // Check the default destination
         $imported_destination_1 = current($imported_destinations);
         $this->assertEquals('Ticket', $imported_destination_1->fields['name']);
-        $this->assertTrue((bool) $imported_destination_1->fields['is_mandatory']);
 
         // Check the second destination
         $imported_destination_2 = next($imported_destinations);
         $imported_configs = end($imported_destinations)->getConfig();
         $this->assertEquals('My ticket destination', $imported_destination_2->fields['name']);
-        $this->assertFalse((bool) $imported_destination_2->fields['is_mandatory']);
 
         // Check that the imported form has the same destination
         $this->assertEquals($title_field_config->jsonSerialize(), $imported_configs[TitleField::getKey()]);

--- a/src/Glpi/Form/AnswersHandler/AnswersHandler.php
+++ b/src/Glpi/Form/AnswersHandler/AnswersHandler.php
@@ -266,12 +266,8 @@ final class AnswersHandler
                 continue;
             }
 
-            // Skip if the destination is not mandatory and it failed its
-            // required conditions.
-            if (
-                !$destination->fields['is_mandatory']
-                && !$engine_output->itemMustBeCreated($destination)
-            ) {
+            // Skip if the destination failed its required conditions.
+            if (!$engine_output->itemMustBeCreated($destination)) {
                 continue;
             }
 

--- a/src/Glpi/Form/Destination/FormDestination.php
+++ b/src/Glpi/Form/Destination/FormDestination.php
@@ -108,7 +108,7 @@ final class FormDestination extends CommonDBChild implements ConditionableCreati
             $active = null;
         }
 
-        $manager = FormDestinationTypeManager::getInstance();
+        $manager = FormDestinationManager::getInstance();
 
         $renderer = TemplateRenderer::getInstance();
         $renderer->display('pages/admin/form/form_destination.html.twig', [
@@ -119,6 +119,7 @@ final class FormDestination extends CommonDBChild implements ConditionableCreati
             'available_destinations_types' => $manager->getDestinationTypesDropdownValues(),
             'active_destination'           => $active,
             'can_update'                   => self::canUpdate(),
+            'warnings'                     => $manager->getWarnings($item),
         ]);
 
         return true;
@@ -160,10 +161,6 @@ final class FormDestination extends CommonDBChild implements ConditionableCreati
     #[Override]
     public function canPurgeItem(): bool
     {
-        if ($this->fields['is_mandatory']) {
-            return false;
-        }
-
         $form = Form::getByID($this->fields['forms_forms_id']);
         if (!$form) {
             return false;

--- a/src/Glpi/Form/Export/Serializer/FormSerializer.php
+++ b/src/Glpi/Form/Export/Serializer/FormSerializer.php
@@ -748,7 +748,6 @@ final class FormSerializer extends AbstractFormSerializer
             $destination_spec->itemtype     = $destination->fields['itemtype'];
             $destination_spec->name         = $destination->fields['name'];
             $destination_spec->config       = $destination->getConfig();
-            $destination_spec->is_mandatory = $destination->fields['is_mandatory'];
 
             $config = $destination->getConfig();
             foreach ($config as $field_key => $field_config_data) {
@@ -809,7 +808,6 @@ final class FormSerializer extends AbstractFormSerializer
                 'itemtype'                 => $destination_spec->itemtype,
                 'name'                     => $destination_spec->name,
                 'config'                   => $config,
-                'is_mandatory'             => $destination_spec->is_mandatory,
                 Form::getForeignKeyField() => $form->getID(),
             ]);
 

--- a/src/Glpi/Form/Export/Specification/DestinationContentSpecification.php
+++ b/src/Glpi/Form/Export/Specification/DestinationContentSpecification.php
@@ -40,5 +40,4 @@ final class DestinationContentSpecification implements ContentSpecificationInter
     public string $itemtype;
     public string $name;
     public array $config;
-    public bool $is_mandatory;
 }

--- a/src/Glpi/Form/Form.php
+++ b/src/Glpi/Form/Form.php
@@ -275,8 +275,11 @@ final class Form extends CommonDBTM implements ServiceCatalogLeafInterface, Prov
             $this->createFirstSection();
         }
 
-        // Add the mandatory destinations
-        $this->addMandatoryDestinations();
+        // Add the default destinations
+        $add_default_destinations = $this->input['_init_destinations'] ?? true;
+        if ($add_default_destinations) {
+            $this->addDefaultDestinations();
+        }
 
         // Add the default access policies unless specified otherwise
         $init_policies = $this->input['_init_access_policies'] ?? true;
@@ -1040,15 +1043,17 @@ final class Form extends CommonDBTM implements ServiceCatalogLeafInterface, Prov
         return "/Form/Render/" . $this->getID();
     }
 
-    private function addMandatoryDestinations(): void
+    private function addDefaultDestinations(): void
     {
         $destination = new FormDestination();
-        $destination->add([
+        $id = $destination->add([
             self::getForeignKeyField() => $this->getId(),
             'itemtype'                 => FormDestinationTicket::class,
             'name'                     => Ticket::getTypeName(1),
-            'is_mandatory'             => true,
         ]);
+        if (!$id) {
+            throw new RuntimeException("Failed to initialize destinations");
+        }
     }
 
     private function addDefaultAccessPolicies(): void

--- a/src/Glpi/Form/Migration/FormMigration.php
+++ b/src/Glpi/Form/Migration/FormMigration.php
@@ -248,7 +248,6 @@ class FormMigration extends AbstractPluginMigration
         $this->updateBlockHorizontalRank();
         $this->processMigrationOfAccessControls();
         $this->processMigrationOfFormTargets();
-        $this->handleMandatoryDestination();
         $this->processMigrationOfTranslations();
 
         $this->progress_indicator?->setProgressBarMessage('');
@@ -878,35 +877,6 @@ class FormMigration extends AbstractPluginMigration
                 ])
             ) {
                 throw new LogicException("Failed to update destination with id {$destination->getID()}");
-            }
-        }
-    }
-
-    private function handleMandatoryDestination(): void
-    {
-        $this->progress_indicator?->setProgressBarMessage(__('Handling mandatory destination...'));
-
-        foreach ($this->getMappedItemsForItemtype('PluginFormcreatorForm') as $form) {
-            $form_destination = new FormDestination();
-            $raw_destinations = $form_destination->find([
-                Form::getForeignKeyField() => $form['items_id'],
-                'itemtype'                 => FormDestinationTicket::class,
-                'is_mandatory'             => false
-            ]);
-
-            if (count($raw_destinations) > 0) {
-                // Delete default mandatory destination
-                $form_destination->deleteByCriteria([
-                    Form::getForeignKeyField() => $form['items_id'],
-                    'itemtype'                 => FormDestinationTicket::class,
-                    'is_mandatory'             => 1
-                ], true);
-
-                // Set the first destination as mandatory
-                $form_destination->update([
-                    'id'           => current($raw_destinations)['id'],
-                    'is_mandatory' => 1
-                ]);
             }
         }
     }

--- a/src/Glpi/Helpdesk/DefaultDataManager.php
+++ b/src/Glpi/Helpdesk/DefaultDataManager.php
@@ -199,7 +199,7 @@ final class DefaultDataManager
         ];
 
         // Add ticket destination
-        $this->setMandatoryTicketDestination($form, $config);
+        $this->setDefaultDestinationConfig($form, $config);
 
         return $form;
     }
@@ -259,7 +259,7 @@ final class DefaultDataManager
         ];
 
         // Add ticket destination
-        $this->setMandatoryTicketDestination($form, $config);
+        $this->setDefaultDestinationConfig($form, $config);
     }
 
     private function createForm(
@@ -373,7 +373,7 @@ final class DefaultDataManager
         ];
     }
 
-    private function setMandatoryTicketDestination(Form $form, array $config): void
+    private function setDefaultDestinationConfig(Form $form, array $config): void
     {
         $destination = current($form->getDestinations());
         $success = $destination->update([

--- a/templates/pages/admin/form/form_destination.html.twig
+++ b/templates/pages/admin/form/form_destination.html.twig
@@ -43,6 +43,13 @@
         {{ __("Items to create") }}
     </h2>
 
+    {% for warning in warnings %}
+        <div class="alert alert-warning d-flex align-items-center mb-3" role="alert">
+            <i class="ti ti-alert-triangle me-2"></i>
+            {{ warning }}
+        </div>
+    {% endfor %}
+
     <div class="d-flex">
         {# Add Form #}
         {% for type, label in available_destinations_types %}
@@ -73,7 +80,7 @@
     </div>
 
     {% if destinations|length == 0 %}
-        <p class="empty-subtitle text-muted">
+        <p class="empty-subtitle text-muted mt-3 ms-1">
             {{ __("No items will be created for this form.") }}
         </p>
     {% else %}
@@ -114,30 +121,18 @@
                                 data-glpi-form-destination-name
                             />
                             <div data-glpi-editor-destination-badges-container>
-                                {% if destination.fields.is_mandatory %}
-                                    <span class="badge bg-secondary-lt ms-2">
-                                        {{ __("Mandatory") }}
-                                        <span
-                                            class="form-help"
-                                            data-bs-toggle="popover"
-                                            data-bs-placement="right"
-                                            data-bs-content="{{ __("This is the main item that will be created by this form. It can't be deleted.") }}"
-                                        >?</span>
+                                {% set selected_strategy = destination.getConfiguredCreationStrategy() %}
+                                {% for strategy in enum_cases('Glpi\\Form\\Condition\\CreationStrategy') %}
+                                    {% set is_visible = selected_strategy == strategy %}
+                                    {% set display_class = is_visible ? 'd-flex' : 'd-none' %}
+                                    <span
+                                        class="{{ display_class }} badge bg-secondary-lt d-flex align-items-center ms-2"
+                                        data-glpi-editor-condition-badge="{{ strategy.value }}"
+                                    >
+                                        <i class="{{ strategy.getIcon() }} me-1"></i>
+                                        <span>{{ strategy.getLabel() }}</span>
                                     </span>
-                                {% else %}
-                                    {% set selected_strategy = destination.getConfiguredCreationStrategy() %}
-                                    {% for strategy in enum_cases('Glpi\\Form\\Condition\\CreationStrategy') %}
-                                        {% set is_visible = selected_strategy == strategy %}
-                                        {% set display_class = is_visible ? 'd-flex' : 'd-none' %}
-                                        <span
-                                            class="{{ display_class }} badge bg-secondary-lt d-flex align-items-center ms-2"
-                                            data-glpi-editor-condition-badge="{{ strategy.value }}"
-                                        >
-                                            <i class="{{ strategy.getIcon() }} me-1"></i>
-                                            <span>{{ strategy.getLabel() }}</span>
-                                        </span>
-                                    {% endfor %}
-                                {% endif %}
+                                {% endfor %}
                             </div>
                         </button>
                     </h3>

--- a/tests/cypress/e2e/form/editor/conditions.cy.js
+++ b/tests/cypress/e2e/form/editor/conditions.cy.js
@@ -598,9 +598,8 @@ describe ('Conditions', () => {
         addQuestion('My second question');
         saveAndReload();
 
-        // Create a destination and add a few conditions to it
+        // Add a few conditions to the default destination
         goToDestinationTab();
-        addDestination('Ticket');
         openConditionEditor();
         setConditionStrategy('Created if');
         fillCondition(0, null, 'My second question', 'Is not equal to', 'I love GLPI');

--- a/tests/cypress/e2e/form/editor/conditions.cy.js
+++ b/tests/cypress/e2e/form/editor/conditions.cy.js
@@ -57,12 +57,6 @@ function addQuestion(name) {
     });
 }
 
-function addDestination(type) {
-    cy.findByRole('button', {'name': `Add ${type}`}).click();
-    cy.findByRole('alert').should('contains.text', 'Item successfully added');
-    cy.findByRole('button', {'name': 'Close'}).click();
-}
-
 function setQuestionTypeCategory(category) {
     cy.getDropdownByLabelText('Question type').selectDropdownValue(category);
 }

--- a/tests/src/FormBuilder.php
+++ b/tests/src/FormBuilder.php
@@ -34,10 +34,7 @@
 
 namespace Glpi\Tests;
 
-use AbstractRightsDropdown;
 use Glpi\DBAL\JsonFieldInterface;
-use Glpi\Form\AccessControl\ControlType\AllowList;
-use Glpi\Form\AccessControl\ControlType\AllowListConfig;
 use Glpi\Form\Condition\CreationStrategy;
 use Glpi\Form\Condition\VisibilityStrategy;
 
@@ -446,7 +443,6 @@ class FormBuilder
         string $itemtype,
         string $name,
         array $config = [],
-        bool $is_mandatory = false,
     ): self {
         // If first destination of the given itemtype, init its key
         if (!isset($this->destinations[$itemtype])) {
@@ -456,7 +452,6 @@ class FormBuilder
         $this->destinations[$itemtype][] = [
             'name'         => $name,
             'config'       => $config,
-            'is_mandatory' => $is_mandatory,
         ];
         return $this;
     }

--- a/tests/src/FormTesterTrait.php
+++ b/tests/src/FormTesterTrait.php
@@ -133,7 +133,6 @@ trait FormTesterTrait
                     'itemtype'       => $itemtype,
                     'name'           => $destination_data['name'],
                     'config'         => $destination_data['config'],
-                    'is_mandatory'   => $destination_data['is_mandatory'],
                 ], ['config']);
             }
         }


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

As discussed with @orthagh:
* A form is still initialized with one ticket to create but it can now be removed or conditioned.
* If all items to create have been removed, a warning is shown.
* If all items to create are conditioned, a warning is shown.

Fix #19292.

## Screenshot

![image](https://github.com/user-attachments/assets/01220f6a-1c94-41b0-b2c8-632eebe3f4b6)

