### PR TITLE
Fix stacked switches components numbering

### DIFF
--- a/src/Inventory/Asset/NetworkEquipment.php
+++ b/src/Inventory/Asset/NetworkEquipment.php
@@ -335,6 +335,14 @@ class NetworkEquipment extends MainAsset
             switch ($component->type) {
                 case 'chassis':
                     if (property_exists($component, 'serial')) {
+                        // Chassis name permits to find the right component stack number
+                        // as it can change after a component is removed and so component
+                        // numbers can no more be ordered from 1
+                        if (
+                            preg_match('/^Unit\s(\d+)$/', $component->name, $matches)
+                        ) {
+                            $stack_number = (int) $matches[1];
+                        }
                         $component->stack_number = $stack_number;
                         $switches[$component->index] = $component;
                     }

--- a/src/Inventory/Asset/NetworkEquipment.php
+++ b/src/Inventory/Asset/NetworkEquipment.php
@@ -339,6 +339,7 @@ class NetworkEquipment extends MainAsset
                         // as it can change after a component is removed and so component
                         // numbers can no more be ordered from 1
                         if (
+                            property_exists($component, 'name') &&
                             preg_match('/^Unit\s(\d+)$/', $component->name, $matches)
                         ) {
                             $stack_number = (int) $matches[1];


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.

## Description

- It fixes an issue related to a Netgear network device inventory on which first component of the stack was removed: the stack contains 2 switches with different size, one of 24 ports and another of 16 ports. The removed switch had 16 ports and they are still listed in the stack, but with IFSTATUS set to "6" meaning they are not physically present (checked in IF-MIB RFC). Without the patch, GLPI set stack index to 1 for first found component, but it's real index is 2, and it set index 2 to the last one which has indeed index 3. In the XML, chassis name is "Unit 2" for the first and "Unit 3" for the second. The problem is the 16 ports of missing "Unit 1" are linked to "Unit 2" and the 24 ports of "Unit 2" are linked to "Unit 3".
- Here is a brief description of what this PR does: the patch check if component name matches `/^Unit (\d+)$/` regexp to find the real unit stack number so "Unit 2" is finally linked with the expected 24 ports and "Unit 3" is linked with the right 16 ports.

## Screenshots (if appropriate):
- Without the patch: "Unit 2" shown with 16 ports from 1/0/1 to 1/0/16 and "Unit 3" with 24 ports from 2/0/1 to 2/0/24
![sample-bad-ports-Unit-2](https://github.com/user-attachments/assets/fe253dd1-65e6-4463-a67c-373c23ff9116)
![sample-bad-ports-Unit-3](https://github.com/user-attachments/assets/c8bc3cdf-e5f9-4d32-898f-270c07b703e5)
- With the patch: "Unit 2" shown with expected 24 ports from 2/0/1 to 2/0/24 and "Unit 3" with expected 16 ports from 3/0/1 to 3/0/16
![sample-good-ports-Unit-2](https://github.com/user-attachments/assets/ed240d59-4f8d-4f1e-b1a5-7fb954e3cf78)
![sample-good-ports-Unit-3](https://github.com/user-attachments/assets/cf5da6dc-8033-4a59-a0ec-840f22e39076)

## Other infos
Problem identified into glpi-project/glpi-agent#873
