### PR TITLE
fix(ticket): location of closed ticket isn't updated when replaced

### DIFF
--- a/phpunit/functional/TicketTest.php
+++ b/phpunit/functional/TicketTest.php
@@ -2805,19 +2805,31 @@ class TicketTest extends DbTestCase
     public function testClosedTicketTransfer()
     {
 
-       // 1- create a category
+       // 1- create a category and location
         $itilcat      = new \ITILCategory();
         $first_cat_id = $itilcat->add([
             'name' => 'my first cat',
         ]);
         $this->assertFalse($itilcat->isNewItem());
 
-       // 2- create a category
+        $itilloc      = new \Location();
+        $first_loc_id = $itilloc->add([
+            'name' => 'my first loc',
+        ]);
+        $this->assertFalse($itilloc->isNewItem());
+
+       // 2- create a category and location
         $second_cat    = new \ITILCategory();
         $second_cat_id = $second_cat->add([
             'name' => 'my second cat',
         ]);
         $this->assertFalse($second_cat->isNewItem());
+
+        $second_loc    = new \Location();
+        $second_loc_id = $second_loc->add([
+            'name' => 'my second loc',
+        ]);
+        $this->assertFalse($second_loc->isNewItem());
 
         // 3- create ticket
         $ticket    = new \Ticket();
@@ -2825,19 +2837,25 @@ class TicketTest extends DbTestCase
             'name'              => 'A ticket to check the category change when using the "transfer" function.',
             'content'           => 'A ticket to check the category change when using the "transfer" function.',
             'itilcategories_id' => $first_cat_id,
-            'status'            => \CommonITILObject::CLOSED
+            'status'            => \CommonITILObject::CLOSED,
+            'locations_id'       => $first_loc_id,
         ]);
 
         $this->assertFalse($ticket->isNewItem());
 
-        // 4 - delete category with replacement
+        // 4 - delete category and location with replacement
         $itilcat->delete(['id'          => $first_cat_id,
             '_replace_by' => $second_cat_id
         ], 1);
 
-        // 5 - check that the category has been replaced in the ticket
+        $itilloc->delete(['id'          => $first_loc_id,
+            '_replace_by' => $second_loc_id
+        ], 1);
+
+        // 5 - check that the category and the location has been replaced in the ticket
         $ticket->getFromDB($ticket_id);
         $this->assertEquals($second_cat_id, (int)$ticket->fields['itilcategories_id']);
+        $this->assertEquals($second_loc_id, (int)$ticket->fields['locations_id']);
     }
 
     public static function computePriorityProvider()

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -1681,6 +1681,7 @@ abstract class CommonITILObject extends CommonDBTM
                // probably transfer
                 $allowed_fields[] = 'entities_id';
                 $allowed_fields[] = 'itilcategories_id';
+                $allowed_fields[] = 'locations_id';
             } else {
                 if (
                     $this->canApprove()


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !37145
- When a location is deleted and the user chooses to replace all objects assigned to that location with another one, the change takes place for tickets, except closed tickets.

## Screenshots (if appropriate):

Before replacement:
![Capture d’écran du 2025-04-01 13-45-52](https://github.com/user-attachments/assets/ef7d36f6-bc98-4db7-9c62-7c5f5bbf328c)

During replacement:
![Capture d’écran du 2025-04-01 13-46-51](https://github.com/user-attachments/assets/ebac9e55-528d-4ae3-a0cd-4a597bf1101b)

After replacement:
![Capture d’écran du 2025-04-01 13-47-48](https://github.com/user-attachments/assets/a2163558-fbc4-45b6-8373-b021c884a930)




