### PR TITLE
Fix - getFriendlyNameFields() query to return only first name if only one is defined

### DIFF
--- a/src/User.php
+++ b/src/User.php
@@ -6565,11 +6565,12 @@ HTML;
         $alias  = DBmysql::quoteName($alias);
         $name   = DBmysql::quoteName($table . '.' . self::getNameField());
 
-        return new QueryExpression("IF(
-            $first <> '' && $second <> '',
-            CONCAT($first, ' ', $second),
-            $name
-         ) AS $alias");
+        return new QueryExpression("CASE
+            WHEN $first <> '' AND $second <> '' THEN CONCAT($first, ' ', $second)
+            WHEN $first <> '' THEN $first
+            WHEN $second <> '' THEN $second
+            ELSE $name
+        END AS $alias");
     }
 
     public static function getIcon()


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !37139 linked to !34567
- Here is a brief description of what this PR does

The getFriendlyNameFields() function takes care of constructing a query expression to retrieve a user's name.
It works as follows: 
- If name and surname are filled in, a concatenation of the two is returned.
- If neither is filled in, the login is returned.
- If only one of the two is filled in, we return the login.

But we should return the first name if it's the only one filled in, and the same for the last name.

IMHO i consider this to be a bug fix, rather because :

- The current behavior is not intuitive and does not correspond to what one would expect from a user interface.
- The aim is to adjust existing conditional logic, not to add new functionality.
- The aim is to display the available information in a consistent way.


