### PR TITLE
fix: Adding missing CSRF tokens for users preferences page + enhance accessibility

### DIFF
--- a/src/CommonDBChild.php
+++ b/src/CommonDBChild.php
@@ -865,11 +865,12 @@ abstract class CommonDBChild extends CommonDBConnexity
             $lower_name         = strtolower(get_called_class());
             $child_count_js_var = htmlescape('nb' . $lower_name . 's');
             $div_id             = htmlescape("add_" . $lower_name . "_to_" . $item->getType() . "_" . $items_id);
+            $add_label          = sprintf(__('Add a new %s'), call_user_func([get_called_class(), 'getTypeName']));
 
             // Beware : -1 is for the first element added ...
             $result = "&nbsp;<script type='text/javascript'>var $child_count_js_var=2; </script>";
             $result .= "<span id='add" . $lower_name . "button' class='ti ti-plus cursor-pointer'" .
-              " title=\"" . __s('Add') . "\"" .
+              " title=\"" . __s('Add') . "\"" . "aria-label=\"" . $add_label . "\"" .
                 "\" onClick=\"var row = $('#" . $div_id . "');
                              row.append('" .
                static::getJSCodeToAddForItemChild($field_name, $child_count_js_var) . "');

--- a/src/CommonDBChild.php
+++ b/src/CommonDBChild.php
@@ -865,7 +865,7 @@ abstract class CommonDBChild extends CommonDBConnexity
             $lower_name         = strtolower(get_called_class());
             $child_count_js_var = htmlescape('nb' . $lower_name . 's');
             $div_id             = htmlescape("add_" . $lower_name . "_to_" . $item->getType() . "_" . $items_id);
-            $add_label          = sprintf(__('Add a new %s'), call_user_func([get_called_class(), 'getTypeName']));
+            $add_label          = sprintf(__s('Add a new %s'), static::getTypeName());
 
             // Beware : -1 is for the first element added ...
             $result = "&nbsp;<script type='text/javascript'>var $child_count_js_var=2; </script>";

--- a/src/CommonDBChild.php
+++ b/src/CommonDBChild.php
@@ -865,7 +865,7 @@ abstract class CommonDBChild extends CommonDBConnexity
             $lower_name         = strtolower(get_called_class());
             $child_count_js_var = htmlescape('nb' . $lower_name . 's');
             $div_id             = htmlescape("add_" . $lower_name . "_to_" . $item->getType() . "_" . $items_id);
-            $add_label          = sprintf(__s('Add a new %s'), static::getTypeName());
+            $add_label          = htmlescape(sprintf(__('Add a new %s'), static::getTypeName()));
 
             // Beware : -1 is for the first element added ...
             $result = "&nbsp;<script type='text/javascript'>var $child_count_js_var=2; </script>";

--- a/src/UserEmail.php
+++ b/src/UserEmail.php
@@ -188,9 +188,9 @@ class UserEmail extends CommonDBChild
     {
 
         return "<div class=\'d-flex\'><input title=\'" . __s('Default email') . "\' type=\'radio\' name=\'_default_email\'" .
-             " value=\'-'+" . htmlescape($child_count_js_var) . "+'\'>&nbsp;" .
+             " value=\'-'+" . htmlescape($child_count_js_var) . "+'\' aria-label=\'" . __s('Set as default email') . "\'>&nbsp;" .
              "<input type=\'text\' size=\'30\' class=\'form-control\' " . "name=\'" . htmlescape($field_name) .
-             "[-'+" . htmlescape($child_count_js_var) . "+']\'></div>";
+             "[-'+" . htmlescape($child_count_js_var) . "+']\'  aria-label=\'" . __s('Email address') . "\'></div>";
     }
 
 
@@ -220,12 +220,12 @@ class UserEmail extends CommonDBChild
         if ($this->fields['is_default']) {
             $result .= " checked";
         }
-        $result .= ">&nbsp;";
+        $result .= " aria-label='" . __s('Set as default email') . "'>&nbsp;";
         if (!$canedit || $this->fields['is_dynamic']) {
             $result .= "<input type='hidden' name='$field_name' value='$value'>";
             $result .= sprintf('%s <span class="b">(%s)</span>', $value, __s('D'));
         } else {
-            $result .= "<input type='text' size=30 class='form-control' name='$field_name' value='$value' >";
+            $result .= "<input type='text' size=30 class='form-control' name='$field_name' value='$value' aria-label='" . __s('Email address') . "'>";
         }
         $result .= "</div>";
 

--- a/src/UserEmail.php
+++ b/src/UserEmail.php
@@ -215,7 +215,7 @@ class UserEmail extends CommonDBChild
         $result .= "<input title='" . __s('Default email') . "' type='radio' name='_default_email'
              value='" . htmlescape($this->getID()) . "'";
         if (!$canedit) {
-            $result .= " disabled";
+            $result .= " disabled aria-disabled='true'";
         }
         if ($this->fields['is_default']) {
             $result .= " checked";

--- a/templates/pages/admin/user/user.html.twig
+++ b/templates/pages/admin/user/user.html.twig
@@ -50,6 +50,8 @@
 
 <div class="asset {{ bg }}">
     <form id="main-form" name="asset_form" method="post" action="{{ target }}" enctype="multipart/form-data" data-submit-once>
+        <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}" />
+
         <div class="card-body d-flex flex-wrap">
             <div class="col-12 col-xxl-12 flex-column">
                 <div class="d-flex flex-row flex-wrap flex-xl-nowrap">

--- a/tests/cypress/e2e/Admin/user.cy.js
+++ b/tests/cypress/e2e/Admin/user.cy.js
@@ -68,4 +68,27 @@ describe('User form', () => {
             cy.get('[data-preview-avatar]').should('not.be.visible');
         });
     });
+    it('can add emails and set one as default', () => {
+        cy.visit('/front/preference.php');
+        cy.get('.nav-item').contains('Main').click();
+
+        // Add a new email
+        cy.findByRole('textbox', { name: 'Email address' }).should('be.visible').type('test@test.test');
+        cy.findByRole('button', { name: /Save/ }).click();
+
+        // Check if the email is added
+        cy.findByRole('textbox', { name: 'Email address' }).should('have.value', 'test@test.test');
+        cy.findByRole('radio', { name: 'Set as default email' }).should('be.checked');
+
+        // Add another email
+        cy.findByRole('generic', { name: 'Add a new Emails' }).click();
+        cy.findAllByRole('textbox', { name: 'Email address' }).eq(1).should('be.visible').type('anothertest@test.test');
+        cy.findByRole('button', { name: /Save/ }).click();
+
+        // Check emails
+        cy.findAllByRole('textbox', { name: 'Email address' }).eq(0).should('have.value', 'test@test.test');
+        cy.findAllByRole('textbox', { name: 'Email address' }).eq(1).should('have.value', 'anothertest@test.test');
+        cy.findAllByRole('radio', { name: 'Set as default email' }).eq(0).should('be.checked');
+        cy.findAllByRole('radio', { name: 'Set as default email' }).eq(1).should('not.be.checked');
+    });
 });

--- a/tests/cypress/e2e/Admin/user.cy.js
+++ b/tests/cypress/e2e/Admin/user.cy.js
@@ -86,9 +86,9 @@ describe('User form', () => {
         cy.findByRole('button', { name: /Save/ }).click();
 
         // Check emails
-        cy.findAllByRole('textbox', { name: 'Email address' }).eq(0).should('have.value', 'test@test.test');
-        cy.findAllByRole('textbox', { name: 'Email address' }).eq(1).should('have.value', 'anothertest@test.test');
-        cy.findAllByRole('radio', { name: 'Set as default email' }).eq(0).should('be.checked');
-        cy.findAllByRole('radio', { name: 'Set as default email' }).eq(1).should('not.be.checked');
+        cy.findAllByRole('textbox', { name: 'Email address' }).eq(0).should('have.value', 'anothertest@test.test');
+        cy.findAllByRole('textbox', { name: 'Email address' }).eq(1).should('have.value', 'test@test.test');
+        cy.findAllByRole('radio', { name: 'Set as default email' }).eq(0).should('not.be.checked');
+        cy.findAllByRole('radio', { name: 'Set as default email' }).eq(1).should('be.checked');
     });
 });


### PR DESCRIPTION

<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Added missing CSRF field in user configuration and preferences.
Added an E2E test that verifies the addition of e-mails.
Improved accessibility on this point.