### PR TITLE
Fix false depreciation message

### DIFF
--- a/front/dropdown.common.form.php
+++ b/front/dropdown.common.form.php
@@ -55,5 +55,5 @@ if (!($this instanceof LegacyFileLoadController) || !($dropdown instanceof Commo
 DropdownFormController::loadDropdownForm(
     $this->getRequest(), // @phpstan-ignore method.private
     $dropdown,
-    $options ?? []
+    $options ?? null
 );


### PR DESCRIPTION
Calling `loadDropdownForm` with something else than null will throw a depreciation message; default was wrong.