### PR TITLE
Helpdesk home page config for entities

### DIFF
--- a/css/includes/_includes.scss
+++ b/css/includes/_includes.scss
@@ -50,6 +50,7 @@ $is-dark: false !default;
 @import "components/form/form-renderer";
 @import "components/form/form-destination";
 @import "components/form/form-translations";
+@import "components/form/helpdesk-home-config-for-empty-entity";
 @import "components/fuzzy";
 @import "components/global-menu";
 @import "components/illustration-picker";

--- a/css/includes/components/form/_helpdesk-home-config-for-empty-entity.scss
+++ b/css/includes/components/form/_helpdesk-home-config-for-empty-entity.scss
@@ -1,6 +1,4 @@
-<?php
-
-/**
+/*!
  * ---------------------------------------------------------------------
  *
  * GLPI - Gestionnaire Libre de Parc Informatique
@@ -8,6 +6,7 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2025 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -32,10 +31,9 @@
  * ---------------------------------------------------------------------
  */
 
-namespace Glpi\Helpdesk\Tile;
-
-interface LinkableToTilesInterface
-{
-    public function acceptTiles(): bool;
-    public function getConfigInformationText(): ?string;
+.helpdesk-home-config-for-empty-entity-wrapper {
+    // Hide the tiles and actions
+    [data-glpi-helpdesk-config-tiles], [data-glpi-helpdesk-config-actions] {
+        display: none !important;
+    }
 }

--- a/js/glpi_dialog.js
+++ b/js/glpi_dialog.js
@@ -356,7 +356,7 @@ const glpi_toast = (title, message, css_class, options = {}) => {
         location = 'bottom-right';
     }
     const html = `<div class='toast-container ${location} p-3 messages_after_redirect'>
-      <div id='toast_js_${toast_id}' class='toast ${animation_classes}' role='alert' aria-live='assertive' aria-atomic='true'>
+      <div id='toast_js_${toast_id}' class='toast ${animation_classes}' role='alert' aria-live='assertive' aria-atomic='true' aria-label="${message}">
          <div class='toast-header ${css_class}'>
             <strong class='me-auto'>${title}</strong>
             <button type='button' class='btn-close' data-bs-dismiss='toast' aria-label='${__('Close')}'></button>

--- a/js/modules/Helpdesk/HelpdeskConfigForEmptyEntityController.js
+++ b/js/modules/Helpdesk/HelpdeskConfigForEmptyEntityController.js
@@ -1,0 +1,94 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+export class GlpiHelpdeskConfigForEmptyEntityController
+{
+    /** @type {HTMLElement} */
+    #container;
+
+    constructor(container)
+    {
+        this.#container = container;
+        this.#initEventsHandlers();
+        this.#enableActions();
+    }
+
+    #initEventsHandlers()
+    {
+        // Watch for click on the "define tiles" button.
+        this.#getDefineTilesButton().addEventListener('click', () => {
+            this.#getSpecificConfigDiv().classList.add('d-none');
+            this.#getOriginalHelpdeskConfigDiv()
+                .classList
+                .remove('helpdesk-home-config-for-empty-entity-wrapper')
+            ;
+        });
+    }
+
+    #enableActions()
+    {
+        this.#getDefineTilesButton().classList.remove('pointer-events-none');
+        this.#getCopyTilesButton().classList.remove('pointer-events-none');
+    }
+
+    /** @return {HTMLElement} */
+    #getDefineTilesButton()
+    {
+        return this.#container.querySelector(
+            '[data-glpi-helpdesk-config-tiles-empty-entity-define-tiles]'
+        );
+    }
+
+    /** @return {HTMLElement} */
+    #getCopyTilesButton()
+    {
+        return this.#container.querySelector(
+            '[data-glpi-helpdesk-config-tiles-empty-entity-copy-tiles]'
+        );
+    }
+
+    /** @return {HTMLElement} */
+    #getOriginalHelpdeskConfigDiv()
+    {
+        return this.#container.querySelector(
+            '[data-glpi-helpdesk-config-tiles-empty-entity-original-content]'
+        );
+    }
+
+    /** @return {HTMLElement} */
+    #getSpecificConfigDiv()
+    {
+        return this.#container.querySelector(
+            '[data-glpi-helpdesk-config-tiles-empty-entity-specific]'
+        );
+    }
+}

--- a/phpunit/functional/Glpi/Helpdesk/DefaultDataManagerTest.php
+++ b/phpunit/functional/Glpi/Helpdesk/DefaultDataManagerTest.php
@@ -37,6 +37,7 @@ namespace test\units\Glpi\Helpdesk;
 use CommonITILActor;
 use Computer;
 use DbTestCase;
+use Entity;
 use Glpi\Form\AccessControl\FormAccessControlManager;
 use Glpi\Form\AccessControl\FormAccessParameters;
 use Glpi\Helpdesk\DefaultDataManager;
@@ -351,6 +352,13 @@ final class DefaultDataManagerTest extends DbTestCase
     public function testsTilesAreAddedAfterInstallation(): void
     {
         $this->assertEquals(5, countElementsInTable(Item_Tile::getTable()));
+
+        // Default tiles must be attached to the root entity
+        $profile_tiles = (new Item_Tile())->find([]);
+        foreach ($profile_tiles as $row) {
+            $this->assertEquals(Entity::class, $row['itemtype_item']);
+            $this->assertEquals(0, $row['items_id_item']);
+        }
     }
 
     public function testNoTilesAreCreatedWhenDatabaseIsNotEmpty(): void

--- a/src/Entity.php
+++ b/src/Entity.php
@@ -37,12 +37,14 @@ use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
 use Glpi\Event;
+use Glpi\Helpdesk\Tile\LinkableToTilesInterface;
+use Glpi\Helpdesk\Tile\TilesManager;
 use Glpi\Plugin\Hooks;
 
 /**
  * Entity class
  */
-class Entity extends CommonTreeDropdown
+class Entity extends CommonTreeDropdown implements LinkableToTilesInterface
 {
     use Glpi\Features\Clonable;
     use MapGeolocation;
@@ -528,6 +530,7 @@ class Entity extends CommonTreeDropdown
                         $ong[7] = self::createTabEntry(__('UI customization'), 0, $item::class, 'ti ti-palette');
                     }
                     $ong[8] = self::createTabEntry(__('Security'), 0, $item::class, 'ti ti-shield-lock');
+                    $ong[9] = self::createTabEntry(__('Helpdesk home'), 0, $item::class, 'ti ti-home');
 
                     return $ong;
             }
@@ -571,6 +574,9 @@ class Entity extends CommonTreeDropdown
                     break;
                 case 8:
                     self::showSecurityOptions($item);
+                    break;
+                case 9:
+                    $item->showHelpdeskHomeConfig();
                     break;
             }
         }
@@ -3119,5 +3125,51 @@ class Entity extends CommonTreeDropdown
         $select_tree($entitiestree);
 
         return $entitiestree;
+    }
+
+    public function showHelpdeskHomeConfig(): bool
+    {
+        $tiles_manager = new TilesManager();
+
+        if (
+            // Is not root entity
+            $this->getId() !== 0
+            // Editable
+            && static::canUpdate()
+            && $this->canUpdateItem()
+            // Has no tiles
+            && count($tiles_manager->getTilesForItem($this)) === 0
+        ) {
+            // Render a custom template when there are no tiles as we want the
+            // user to preview the tiles from the parent entities and to be able
+            // to copy them into the current entity if needed.
+            $twig = TemplateRenderer::getInstance();
+            $twig->display(
+                'pages/admin/helpdesk_home_config_for_empty_entity.html.twig',
+                [
+                    'tiles_manager' => $tiles_manager,
+                    'itemtype_item' => static::class,
+                    'items_id_item' => $this->getID(),
+                    'info_text'     => $this->getConfigInformationText(),
+                    'parent_tiles'  => $tiles_manager->getTilesForEntityRecursive($this)
+                ]
+            );
+        } else {
+            $tiles_manager->showConfigFormForItem($this);
+        }
+
+        return true;
+    }
+
+    #[Override]
+    public function acceptTiles(): bool
+    {
+        return true;
+    }
+
+    #[Override]
+    public function getConfigInformationText(): ?string
+    {
+        return __("Tiles may also be configured by profile.");
     }
 }

--- a/src/Entity.php
+++ b/src/Entity.php
@@ -3170,6 +3170,6 @@ class Entity extends CommonTreeDropdown implements LinkableToTilesInterface
     #[Override]
     public function getConfigInformationText(): ?string
     {
-        return __("Tiles may also be configured by profile.");
+        return __("Tiles may be overriden by profile.");
     }
 }

--- a/src/Glpi/Controller/Config/Helpdesk/CopyParentEntityController.php
+++ b/src/Glpi/Controller/Config/Helpdesk/CopyParentEntityController.php
@@ -32,10 +32,32 @@
  * ---------------------------------------------------------------------
  */
 
-namespace Glpi\Helpdesk\Tile;
+namespace Glpi\Controller\Config\Helpdesk;
 
-interface LinkableToTilesInterface
+use Entity;
+use Glpi\Exception\Http\AccessDeniedHttpException;
+use Html;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+final class CopyParentEntityController extends AbstractTileController
 {
-    public function acceptTiles(): bool;
-    public function getConfigInformationText(): ?string;
+    #[Route(
+        "/Config/Helpdesk/CopyParentEntity",
+        name: "glpi_config_helpdesk_copy_parent_entity",
+        methods: "POST"
+    )]
+    public function __invoke(Request $request): Response
+    {
+        // Validate itemtype
+        $entity = $this->getAndValidateLinkedItemFromRequest(
+            Entity::class,
+            $request->request->getInt('entities_id'),
+        );
+        $this->tiles_manager->copyTilesFromParentEntity($entity);
+
+        return new RedirectResponse(Html::getBackUrl());
+    }
 }

--- a/src/Glpi/Helpdesk/DefaultDataManager.php
+++ b/src/Glpi/Helpdesk/DefaultDataManager.php
@@ -35,6 +35,7 @@
 
 namespace Glpi\Helpdesk;
 
+use Entity;
 use Glpi\Form\Destination\CommonITILField\ContentField;
 use Glpi\Form\Destination\CommonITILField\ITILActorFieldStrategy;
 use Glpi\Form\Destination\CommonITILField\ObserverField;
@@ -59,7 +60,6 @@ use Glpi\Helpdesk\Tile\GlpiPageTile;
 use Glpi\Helpdesk\Tile\TilesManager;
 use ITILCategory;
 use Location;
-use Profile;
 use Ticket;
 
 final class DefaultDataManager
@@ -87,55 +87,39 @@ final class DefaultDataManager
         $incident_form = $this->createIncidentForm();
         $this->createRequestForm();
 
-        foreach ($this->getHelpdeskProfiles() as $profile) {
-            $this->tiles_manager->addTile($profile, GlpiPageTile::class, [
-                'title'        => __("Browse help articles"),
-                'description'  => __("See all available help articles and our FAQ."),
-                'illustration' => "browse-kb",
-                'page'         => GlpiPageTile::PAGE_FAQ,
-            ]);
+        $root_entity = Entity::getById(0);
 
-            $this->tiles_manager->addTile($profile, FormTile::class, [
-                'forms_forms_id' => $incident_form->getID(),
-            ]);
+        $this->tiles_manager->addTile($root_entity, GlpiPageTile::class, [
+            'title'        => __("Browse help articles"),
+            'description'  => __("See all available help articles and our FAQ."),
+            'illustration' => "browse-kb",
+            'page'         => GlpiPageTile::PAGE_FAQ,
+        ]);
 
-            $this->tiles_manager->addTile($profile, GlpiPageTile::class, [
-                'title'        => __("Request a service"),
-                'description'  => __("Ask for a service to be provided by our team."),
-                'illustration' => "request-service",
-                'page'         => GlpiPageTile::PAGE_SERVICE_CATALOG,
-            ]);
+        $this->tiles_manager->addTile($root_entity, FormTile::class, [
+            'forms_forms_id' => $incident_form->getID(),
+        ]);
 
-            $this->tiles_manager->addTile($profile, GlpiPageTile::class, [
-                'title'        => __("Make a reservation"),
-                'description'  => __("Pick an available asset and reserve it for a given date."),
-                'illustration' => "reservation",
-                'page'         => GlpiPageTile::PAGE_RESERVATION,
-            ]);
+        $this->tiles_manager->addTile($root_entity, GlpiPageTile::class, [
+            'title'        => __("Request a service"),
+            'description'  => __("Ask for a service to be provided by our team."),
+            'illustration' => "request-service",
+            'page'         => GlpiPageTile::PAGE_SERVICE_CATALOG,
+        ]);
 
-            $this->tiles_manager->addTile($profile, GlpiPageTile::class, [
-                'title'        => __("View approval requests"),
-                'description'  => __("View all tickets waiting for your validation."),
-                'illustration' => "approve-requests",
-                'page'         => GlpiPageTile::PAGE_APPROVAL,
-            ]);
-        }
-    }
+        $this->tiles_manager->addTile($root_entity, GlpiPageTile::class, [
+            'title'        => __("Make a reservation"),
+            'description'  => __("Pick an available asset and reserve it for a given date."),
+            'illustration' => "reservation",
+            'page'         => GlpiPageTile::PAGE_RESERVATION,
+        ]);
 
-    /** @return Profile[] */
-    private function getHelpdeskProfiles(): array
-    {
-        $profiles = [];
-        $profiles_data = (new Profile())->find(['interface' => 'helpdesk']);
-
-        foreach ($profiles_data as $row) {
-            $profile = new Profile();
-            $profile->getFromResultSet($row);
-            $profile->post_getFromDB();
-            $profiles[] = $profile;
-        }
-
-        return $profiles;
+        $this->tiles_manager->addTile($root_entity, GlpiPageTile::class, [
+            'title'        => __("View approval requests"),
+            'description'  => __("View all tickets waiting for your validation."),
+            'illustration' => "approve-requests",
+            'page'         => GlpiPageTile::PAGE_APPROVAL,
+        ]);
     }
 
     private function dataHasBeenInitialized(): bool

--- a/src/Glpi/Session/SessionInfo.php
+++ b/src/Glpi/Session/SessionInfo.php
@@ -48,6 +48,7 @@ final class SessionInfo
         private int $profile_id = 0,
         /** @var int[] $entities_ids */
         private array $active_entities_ids = [],
+        private int $current_entity_id = 0,
     ) {
     }
 
@@ -70,6 +71,11 @@ final class SessionInfo
     public function getActiveEntitiesIds(): array
     {
         return $this->active_entities_ids;
+    }
+
+    public function getCurrentEntityId(): int
+    {
+        return $this->current_entity_id;
     }
 
     public function hasRight(string $right, int $action): bool

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -4461,7 +4461,7 @@ class Profile extends CommonDBTM implements LinkableToTilesInterface
         return true;
     }
 
-    private function showHelpdeskHomeConfig(): bool
+    public function showHelpdeskHomeConfig(): bool
     {
         $tiles_manager = new TilesManager();
         $tiles_manager->showConfigFormForItem($this);
@@ -4473,5 +4473,11 @@ class Profile extends CommonDBTM implements LinkableToTilesInterface
     public function acceptTiles(): bool
     {
         return $this->fields['interface'] === 'helpdesk';
+    }
+
+    #[Override]
+    public function getConfigInformationText(): ?string
+    {
+        return __("Users with this profile will see the tiles below if defined, overriding the one found in the entities configuration.");
     }
 }

--- a/src/Session.php
+++ b/src/Session.php
@@ -2349,6 +2349,7 @@ class Session
             group_ids : $_SESSION['glpigroups'] ?? [],
             profile_id: $_SESSION['glpiactiveprofile']['id'],
             active_entities_ids: $_SESSION['glpiactiveentities'],
+            current_entity_id: self::getActiveEntity(),
         );
     }
 

--- a/templates/pages/admin/helpdesk_home_config.html.twig
+++ b/templates/pages/admin/helpdesk_home_config.html.twig
@@ -31,11 +31,25 @@
  #}
 
 {% set container_id = "glpi-helpdesk-config-container-" ~ random() %}
+{% set header_id = "config-tiles-header-" ~ random() %}
 
 <div id="{{ container_id }}">
     <div data-glpi-helpdesk-config-default-view>
-        <section class="container-xl ms-0 mt-2" aria-labelledby="config-tiles-header">
-            <h1 id="config-tiles-header" class="fs-2">
+        <section
+            class="container-xl ms-0 mt-2"
+            aria-labelledby="{{ header_id }}"
+        >
+            {% if info_text is not null %}
+                <div
+                    class="alert alert-info d-flex align-items-center mb-3"
+                    role="alert"
+                >
+                    <i class="ti ti-info-circle me-2"></i>
+                    {{ info_text }}
+                </div>
+            {% endif %}
+
+            <h1 id="{{ header_id }}" class="fs-2 mb-2">
                 {{ __("Home tiles configuration") }}
             </h1>
 
@@ -44,66 +58,71 @@
                 {{ include('pages/admin/helpdesk_home_config_tiles.html.twig', {
                     'tiles_manager': tiles_manager,
                     'tiles': tiles,
+                    'editable': editable,
                 }, with_context = false) }}
             </div>
 
-            <div class="d-flex mb-3">
-                <button
-                    class="btn btn-primary ms-2 w-auto d-flex align-items-center ms-auto"
-                    data-glpi-helpdesk-config-reorder-action-save
-                >
-                    <i class="ti ti-device-floppy me-1"></i>
-                    <span>{{ __("Save tiles order") }}<span>
-                </button>
-            </div>
-
-            <div
-                class="offcanvas offcanvas-end"
-                tabindex="-1"
-                id="tile-form-offcanvas"
-                aria-labelledby="tile-form-offcanvas-label"
-            >
-                <div class="offcanvas-header">
-                    <h3
-                        id="tile-form-offcanvas-label"
-                        class="offcanvas-title"
-                        data-glpi-helpdesk-config-tile-form-title
-                    ></h3>
+            {% if editable %}
+                <div class="d-flex mb-3" data-glpi-helpdesk-config-actions>
                     <button
-                        type="button"
-                        class="btn-close text-reset"
-                        data-bs-dismiss="offcanvas"
-                        aria-label="{{ __("Close") }}"
-                    ></button>
+                        class="btn btn-primary ms-2 w-auto d-flex align-items-center ms-auto"
+                        data-glpi-helpdesk-config-reorder-action-save
+                    >
+                        <i class="ti ti-device-floppy me-1"></i>
+                        <span>{{ __("Save tiles order") }}<span>
+                    </button>
                 </div>
+
                 <div
-                    class="offcanvas-body d-flex"
-                    data-glpi-helpdesk-config-tile-form-loading
+                    class="offcanvas offcanvas-end"
+                    tabindex="-1"
+                    id="tile-form-offcanvas"
+                    aria-labelledby="tile-form-offcanvas-label"
                 >
-                    <span
-                        class="spinner-border me-auto ms-auto mt-5 mb-5"
-                        role="status"
-                    ></span>
+                    <div class="offcanvas-header">
+                        <h3
+                            id="tile-form-offcanvas-label"
+                            class="offcanvas-title"
+                            data-glpi-helpdesk-config-tile-form-title
+                        ></h3>
+                        <button
+                            type="button"
+                            class="btn-close text-reset"
+                            data-bs-dismiss="offcanvas"
+                            aria-label="{{ __("Close") }}"
+                        ></button>
+                    </div>
+                    <div
+                        class="offcanvas-body d-flex"
+                        data-glpi-helpdesk-config-tile-form-loading
+                    >
+                        <span
+                            class="spinner-border me-auto ms-auto mt-5 mb-5"
+                            role="status"
+                        ></span>
+                    </div>
+                    <div
+                        class="offcanvas-body d-none"
+                        data-glpi-helpdesk-config-tile-form
+                    ></div>
                 </div>
-                <div
-                    class="offcanvas-body d-none"
-                    data-glpi-helpdesk-config-tile-form
-                ></div>
-            </div>
+            {% endif %}
         </section>
     </div>
 </div>
 
-{# Start js controller #}
-<script defer type="module">
-    (async () => {
-        const module = await import(
-            "{{ js_path('js/modules/Helpdesk/HelpdeskConfigController.js') }}"
-        );
-        new module.GlpiHelpdeskConfigController(
-            document.getElementById("{{ container_id }}"),
-            "{{ itemtype_item|escape('js') }}",
-            {{ items_id_item }},
-        );
-    })();
-</script>
+{% if editable %}
+    {# Start js controller #}
+    <script defer type="module">
+        (async () => {
+            const module = await import(
+                "{{ js_path('js/modules/Helpdesk/HelpdeskConfigController.js') }}"
+            );
+            new module.GlpiHelpdeskConfigController(
+                document.getElementById("{{ container_id }}"),
+                "{{ itemtype_item|escape('js') }}",
+                {{ items_id_item }},
+            );
+        })();
+    </script>
+{% endif %}

--- a/templates/pages/admin/helpdesk_home_config_for_empty_entity.html.twig
+++ b/templates/pages/admin/helpdesk_home_config_for_empty_entity.html.twig
@@ -1,0 +1,112 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2025 Teclib' and contributors.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+{% set container_id = "glpi-helpdesk-config-container-empty-entity" ~ random() %}
+{% set form_id = "copy-entity-settings-form-" ~ random() %}
+
+<div id="{{ container_id }}">
+    <div
+        data-glpi-helpdesk-config-tiles-empty-entity-original-content
+        class="helpdesk-home-config-for-empty-entity-wrapper"
+    >
+        {{ include('pages/admin/helpdesk_home_config.html.twig', {
+            tiles_manager: tiles_manager,
+            tiles        : [],
+            itemtype_item: itemtype_item,
+            items_id_item: items_id_item,
+            editable     : true,
+            info_text    : info_text,
+        }, with_context: false) }}
+    </div>
+
+    <div
+        class="container-xl ms-0 mt-2"
+        data-glpi-helpdesk-config-tiles-empty-entity-specific
+    >
+        <div class="d-flex flex-column text-muted mb-2">
+            <span>
+                {{ __("There are no tiles defined for this entity.") }}
+            </span>
+            <span>
+                {{ __("The following tiles from the parent entity will be used:") }}
+            </span>
+        </div>
+
+        <div class="row ms-n2 me-n2 mb-3">
+            {{ include('pages/admin/helpdesk_home_config_tiles.html.twig', {
+                'tiles_manager': tiles_manager,
+                'tiles': parent_tiles,
+                'editable': false,
+            }, with_context = false) }}
+        </div>
+
+        <div class="d-flex">
+            <button
+                form="{{ form_id }}"
+                class="btn ms-auto me-2 pointer-events-none"
+                data-glpi-helpdesk-config-tiles-empty-entity-copy-tiles
+            >
+                <i class="ti ti-copy me-2"></i>
+                {{ __("Copy parent entity configuration into this entity") }}
+            </button>
+            <button
+                type="button"
+                class="btn btn-primary pointer-events-none"
+                data-glpi-helpdesk-config-tiles-empty-entity-define-tiles
+            >
+                <i class="ti ti-settings me-2"></i>
+                {{ __("Define tiles for this entity from scratch") }}
+            </button>
+        </div>
+    </div>
+</div>
+
+<form
+    id="{{ form_id }}"
+    method="POST"
+    action="{{ path('/Config/Helpdesk/CopyParentEntity') }}"
+>
+    <input type="hidden" name="entities_id" value="{{ items_id_item }}">
+    <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}"/>
+</form>
+
+{# Start js controller #}
+<script defer type="module">
+    (async () => {
+        const module = await import(
+            "{{ js_path('js/modules/Helpdesk/HelpdeskConfigForEmptyEntityController.js') }}"
+        );
+        new module.GlpiHelpdeskConfigForEmptyEntityController(
+            document.getElementById("{{ container_id }}"),
+        );
+    })();
+</script>

--- a/templates/pages/admin/helpdesk_home_config_tiles.html.twig
+++ b/templates/pages/admin/helpdesk_home_config_tiles.html.twig
@@ -31,24 +31,27 @@
  #}
 
 {% for tile in tiles %}
-    {% set item_tile_id = tiles_manager.getItemTileForTile(tile).getID() %}
-
     <section
         class="col-12 col-lg-6 col-xl-4 d-flex-soft"
         aria-label="{{ tile.getTitle() }}"
-        data-glpi-draggable-item
-        data-glpi-helpdesk-config-tile-container
-        data-glpi-helpdesk-config-action-show-edit-form
-        data-bs-toggle="offcanvas"
-        data-bs-target="#tile-form-offcanvas"
+        {% if editable %}
+            data-glpi-draggable-item
+            data-glpi-helpdesk-config-tile-container
+            data-glpi-helpdesk-config-action-show-edit-form
+            data-bs-toggle="offcanvas"
+            data-bs-target="#tile-form-offcanvas"
+        {% endif %}
     >
         <div
-            data-glpi-helpdesk-config-tile
-            data-glpi-helpdesk-config-tile-id="{{ tile.getDatabaseId() }}"
-            data-glpi-helpdesk-config-tile-itemtype="{{ get_class(tile) }}"
-            data-glpi-helpdesk-config-item-tile-id="{{ item_tile_id }}"
-            data-glpi-helpdesk-config-tile-sortable
-            class="card rounded my-2 flex-grow-1 cursor-pointer"
+            {% if editable %}
+                {% set item_tile_id = tiles_manager.getItemTileForTile(tile).getID() %}
+                data-glpi-helpdesk-config-tile
+                data-glpi-helpdesk-config-tile-id="{{ tile.getDatabaseId() }}"
+                data-glpi-helpdesk-config-tile-itemtype="{{ get_class(tile) }}"
+                data-glpi-helpdesk-config-item-tile-id="{{ item_tile_id }}"
+                data-glpi-helpdesk-config-tile-sortable
+            {% endif %}
+            class="card rounded my-2 flex-grow-1 {{ editable ? "cursor-pointer" : "" }}"
         >
             <section class="card-body">
                 <div class="d-flex">
@@ -61,11 +64,13 @@
                                 {{ tile.getTitle() }}
                             </h2>
 
-                            <i
-                                class="ti ti-grip-horizontal cursor-grab ms-auto opacity-50"
-                                data-glpi-helpdesk-config-tile-handle
-                                draggable="true"
-                            ></i>
+                            {% if editable %}
+                                <i
+                                    class="ti ti-grip-horizontal cursor-grab ms-auto opacity-50"
+                                    data-glpi-helpdesk-config-tile-handle
+                                    draggable="true"
+                                ></i>
+                            {% endif %}
                         </div>
                         <div class="text-secondary remove-last-tinymce-margin">
                             {{ tile.getDescription()|safe_html }}
@@ -75,22 +80,32 @@
             </section>
         </div>
     </section>
+{% else %}
+    {# If the content is not editable and the list is empty, we need to add
+    a empty state text as the user will not see the "Add tile" button #}
+    {% if not editable %}
+        <span class="text-muted">
+            {{ __("There are no tiles defined for this item.") }}
+        </span>
+    {% endif %}
 {% endfor %}
 
-<div
-    role="button"
-    aria-label="{{ __('Add tile') }}"
-    data-bs-toggle="offcanvas"
-    data-bs-target="#tile-form-offcanvas"
-    data-glpi-helpdesk-config-action-new-tile
-    class="col-12 col-lg-6 col-xl-4 d-flex-soft opacity-80 cursor-pointer opacity-100-hover min-height-110"
->
-    <div class="card rounded my-2 flex-grow-1 border-dashed">
-        <div class="card-body d-flex justify-content-center">
-            <div class="d-flex align-items-center">
-                <i class="ti ti-plus me-1"></i>
-                <span class="fs-3">{{ __('Add tile') }}</span>
+{% if editable %}
+    <div
+        role="button"
+        aria-label="{{ __('Add tile') }}"
+        data-bs-toggle="offcanvas"
+        data-bs-target="#tile-form-offcanvas"
+        data-glpi-helpdesk-config-action-new-tile
+        class="col-12 col-lg-6 col-xl-4 d-flex-soft opacity-80 cursor-pointer opacity-100-hover min-height-110"
+    >
+        <div class="card rounded my-2 flex-grow-1 border-dashed">
+            <div class="card-body d-flex justify-content-center">
+                <div class="d-flex align-items-center">
+                    <i class="ti ti-plus me-1"></i>
+                    <span class="fs-3">{{ __('Add tile') }}</span>
+                </div>
             </div>
         </div>
     </div>
-</div>
+{% endif %}

--- a/tests/cypress/e2e/self-service/home_config.cy.js
+++ b/tests/cypress/e2e/self-service/home_config.cy.js
@@ -30,233 +30,327 @@
  * ---------------------------------------------------------------------
  */
 
-describe('Helpdesk home page configuration', () => {
-    beforeEach(() => {
-        cy.login();
+const test_tiles = [
+    {
+        title: "Browse help articles",
+        description: "See all available help articles and our FAQ.",
+        illustration: "browse-kb",
+        page: "faq",
+    },
+    {
+        title: "Request a service",
+        description: "Ask for a service to be provided by our team.",
+        illustration: "request-service",
+        page: "service_catalog ",
+    },
+    {
+        title: "Make a reservation",
+        description: "Pick an available asset and reserve it for a given date.",
+        illustration: "reservation",
+        page: "reservation",
+    },
+    {
+        title: "View approval requests",
+        description: "View all tickets waiting for your validation.",
+        illustration: "approve-requests",
+        page: "approval",
+    },
+];
 
-        // Set up a new profile with 4 tiles
-        cy.createWithAPI('Profile', {
+const tests = [
+    {
+        label: "profile",
+        itemtype: "Profile",
+        subject: {
             'name': 'Helpdesk profile for e2e tests',
             'interface': 'helpdesk',
-        }).then((profile_id) => {
-            const tiles = [
-                {
-                    title: "Browse help articles",
-                    description: "See all available help articles and our FAQ.",
-                    illustration: "browse-kb",
-                    page: "faq",
-                },
-                {
-                    title: "Request a service",
-                    description: "Ask for a service to be provided by our team.",
-                    illustration: "request-service",
-                    page: "service_catalog ",
-                },
-                {
-                    title: "Make a reservation",
-                    description: "Pick an available asset and reserve it for a given date.",
-                    illustration: "reservation",
-                    page: "reservation",
-                },
-                {
-                    title: "View approval requests",
-                    description: "View all tickets waiting for your validation.",
-                    illustration: "approve-requests",
-                    page: "approval",
-                },
-            ];
-            tiles.forEach((tile, i) => {
-                cy.createWithAPI(
-                    'Glpi\\Helpdesk\\Tile\\GlpiPageTile',
-                    tile
-                ).then((tile_id) => {
-                    cy.createWithAPI('Glpi\\Helpdesk\\Tile\\Item_Tile', {
-                        'itemtype_item': "Profile",
-                        'items_id_item': profile_id,
-                        'itemtype_tile': 'Glpi\\Helpdesk\\Tile\\GlpiPageTile',
-                        'items_id_tile': tile_id,
-                        'rank': i,
+        },
+        url: "/front/profile.form.php?id=${id}&forcetab=Profile$4",
+    },
+    {
+        label: "entity",
+        itemtype: "Entity",
+        subject: {
+            'name': 'Entity for e2e tests',
+            'entities_id': 1, // E2ETestEntity
+        },
+        url: "/front/entity.form.php?id=${id}&forcetab=Entity$9",
+    }
+];
+
+for (const test of tests) {
+    const original_name = test.subject.name;
+
+    describe(`Helpdesk home page configuration (${test.label})`, () => {
+        beforeEach(() => {
+            cy.login();
+
+            // Add random part to subject name to avoid unicity issues
+            test.subject.name = original_name + (new Date()).getTime();
+
+            // Set up a new profile with 4 tiles
+            cy.createWithAPI(test.itemtype, test.subject).then((id) => {
+                test_tiles.forEach((tile, i) => {
+                    cy.createWithAPI(
+                        'Glpi\\Helpdesk\\Tile\\GlpiPageTile',
+                        tile
+                    ).then((tile_id) => {
+                        cy.createWithAPI('Glpi\\Helpdesk\\Tile\\Item_Tile', {
+                            'itemtype_item': test.itemtype,
+                            'items_id_item': id,
+                            'itemtype_tile': 'Glpi\\Helpdesk\\Tile\\GlpiPageTile',
+                            'items_id_tile': tile_id,
+                            'rank': i,
+                        });
                     });
                 });
+
+                cy.visit(test.url.replace('${id}', id));
             });
 
-            cy.visit(`/front/profile.form.php?id=${profile_id}&forcetab=Profile$4`);
+            // Need the JS controller to be ready
+            // eslint-disable-next-line cypress/no-unnecessary-waiting
+            cy.wait(1000);
+
+            // html5sortable add the wrong "option" role, we must remove it
+            cy.window().then((win) => {
+                win.document
+                    .querySelector('[data-glpi-helpdesk-config-tiles]')
+                    .querySelectorAll('section')
+                    .forEach((node) => node.removeAttribute('role'))
+                ;
+            });
         });
 
-        // Need the JS controller to be ready
-        // eslint-disable-next-line cypress/no-unnecessary-waiting
-        cy.wait(1000);
+        it(`can reorder tiles (${test.label})`, () => {
+            // Valide default order
+            validateTilesOrder([
+                "Browse help articles",
+                "Request a service",
+                "Make a reservation",
+                "View approval requests",
+            ]);
 
-        // html5sortable add the wrong "option" role, we must remove it
-        cy.window().then((win) => {
-            win.document
-                .querySelector('[data-glpi-helpdesk-config-tiles]')
-                .querySelectorAll('section')
-                .forEach((node) => node.removeAttribute('role'))
+            // Change order
+            moveTileAfterTile("Browse help articles", "Make a reservation");
+            validateTilesOrder([
+                "Request a service",
+                "Make a reservation",
+                "Browse help articles",
+                "View approval requests",
+            ]);
+
+            // Save new order
+            cy.findByRole('button', {'name': "Save tiles order"}).click();
+            cy.findByRole('alert', {name: "Configuration updated successfully."})
+                .should('be.visible')
             ;
+            validateTilesOrder([
+                "Request a service",
+                "Make a reservation",
+                "Browse help articles",
+                "View approval requests",
+            ]);
+        });
+
+        it(`can remove tiles (${test.label})`, () => {
+            // Delete tile
+            cy.findByRole("region", {'name': "Request a service"}).click();
+            cy.findByRole('button', {'name': 'Delete tile'}).click();
+
+            // Validate deletion
+            cy.findByRole("region", {'name': "Request a service"}).should('not.exist');
+            cy.findByRole('alert', {name: "Configuration updated successfully."})
+                .should('be.visible')
+            ;
+            validateTilesOrder([
+                "Browse help articles",
+                "Make a reservation",
+                "View approval requests",
+            ]);
+
+            // Refresh page to confirm deletion
+            cy.reload();
+            validateTilesOrder([
+                "Browse help articles",
+                "Make a reservation",
+                "View approval requests",
+            ]);
+        });
+
+        it(`can edit a tile (${test.label})`, () => {
+            // Go to tile edition form
+            cy.findByRole("region", {'name': "Request a service"}).click();
+
+            // Change a field
+            cy.findByRole("textbox", {'name': 'Title'}).clear();
+            cy.findByRole("textbox", {'name': 'Title'}).type("My new tile name");
+
+            // Submit
+            cy.findByRole('dialog').findByRole('button', {'name': 'Save changes'}).click();
+            cy.findByRole('alert', {name: "Configuration updated successfully."})
+                .should('be.visible')
+            ;
+            validateTilesOrder([
+                "Browse help articles",
+                "My new tile name",
+                "Make a reservation",
+                "View approval requests",
+            ]);
+        });
+
+        it(`can add a "Glpi page" tile (${test.label})`, () => {
+            // Go to tile creation form
+            cy.findByRole('button', {'name': "Add tile"}).click();
+
+            // Set fields
+            cy.getDropdownByLabelText('Type').selectDropdownValue('GLPI page');
+            cy.findByRole("textbox", {'name': 'Title'}).type("My title");
+            cy.findByRole("dialog")
+                .find('div[data-glpi-helpdesk-config-add-tile-form-for]:visible') // impossible to target without this due to some limitations
+                .findByLabelText('Description')
+                .awaitTinyMCE()
+                .type("My description")
+            ;
+            cy.getDropdownByLabelText('Target page').selectDropdownValue('Service catalog');
+
+            // Submit
+            cy.findByRole('dialog').findByRole('button', {'name': 'Add tile'}).click();
+            cy.findByRole('alert', {name: "Configuration updated successfully."})
+                .should('be.visible')
+            ;
+            validateTilesOrder([
+                "Browse help articles",
+                "Request a service",
+                "Make a reservation",
+                "View approval requests",
+                "My title",
+            ]);
+            cy.findByText("My description").should('be.visible');
+        });
+
+        it(`can add a "External page" tile (${test.label})`, () => {
+            // Go to tile creation form
+            cy.findByRole('button', {'name': "Add tile"}).click();
+
+            // Set fields
+            cy.getDropdownByLabelText('Type').selectDropdownValue('External page');
+            cy.findByRole("textbox", {'name': 'Title'}).type("My external tile title");
+            cy.findByRole("dialog")
+                .find('div[data-glpi-helpdesk-config-add-tile-form-for]:visible') // impossible to target without this due to some limitations
+                .findByLabelText('Description')
+                .awaitTinyMCE()
+                .type("My description")
+            ;
+            cy.findByRole("textbox", {'name': 'Target url'}).type("support.teclib.com");
+
+            // Submit
+            cy.findByRole('dialog').findByRole('button', {'name': 'Add tile'}).click();
+            cy.findByRole('alert', {name: "Configuration updated successfully."})
+                .should('be.visible')
+            ;
+            validateTilesOrder([
+                "Browse help articles",
+                "Request a service",
+                "Make a reservation",
+                "View approval requests",
+                "My external tile title",
+            ]);
+            cy.findByText("My description").should('be.visible');
+        });
+
+        it(`can add a "Form" tile (${test.label})`, () => {
+            // Go to tile creation form
+            cy.findByRole('button', {'name': "Add tile"}).click();
+
+            // Set fields
+            cy.getDropdownByLabelText('Type').selectDropdownValue('Form');
+            cy.getDropdownByLabelText('Target form').selectDropdownValue('Report an issue');
+
+            // Submit
+            cy.findByRole('dialog').findByRole('button', {'name': 'Add tile'}).click();
+            cy.findByRole('alert', {name: "Configuration updated successfully."})
+                .should('be.visible')
+            ;
+            validateTilesOrder([
+                "Browse help articles",
+                "Request a service",
+                "Make a reservation",
+                "View approval requests",
+                "Report an issue",
+            ]);
+            cy.findByText("Ask for support from our helpdesk team.").should('be.visible');
+        });
+    });
+}
+
+describe(`Helpdesk home page configuration - entities specific`, () => {
+    beforeEach(() => {
+        cy.login();
+        cy.createWithAPI("Entity", {
+            'name': `Entity for e2e tests ${(new Date()).getTime()}`,
+            'entities_id': 1, // E2ETestEntity
+        }).then((id) => {
+            cy.visit(`/front/entity.form.php?id=${id}&forcetab=Entity$9`);
         });
     });
 
-    function validateTilesOrder(tiles) {
-        cy.findByRole("region", {'name': "Home tiles configuration"}).within(() => {
-            tiles.forEach((title, i) => {
-                cy.findAllByRole("region").eq(i).should('have.attr', 'aria-label', title);
-            });
-        });
-    }
-
-    function moveTileAfterTile(subject, destination) {
-        cy.findByRole("region", {'name': subject}).startToDrag();
-        cy.findByRole("region", {'name': destination}).dropDraggedItemAfter();
-    }
-
-    it('can reorder tiles', () => {
-        // Valide default order
-        validateTilesOrder([
-            "Browse help articles",
-            "Request a service",
-            "Make a reservation",
-            "View approval requests",
-        ]);
-
-        // Change order
-        moveTileAfterTile("Browse help articles", "Make a reservation");
-        validateTilesOrder([
-            "Request a service",
-            "Make a reservation",
-            "Browse help articles",
-            "View approval requests",
-        ]);
-
-        // Save new order
-        cy.findByRole('button', {'name': "Save tiles order"}).click();
-        cy.findByRole('alert').should(
-            'contain.text',
-            "Configuration updated successfully."
-        );
-        validateTilesOrder([
-            "Request a service",
-            "Make a reservation",
-            "Browse help articles",
-            "View approval requests",
-        ]);
-    });
-
-    it('can remove tiles', () => {
-        // Delete tile
-        cy.findByRole("region", {'name': "Request a service"}).click();
-        cy.findByRole('button', {'name': 'Delete tile'}).click();
-
-        // Validate deletion
-        cy.findByRole("region", {'name': "Request a service"}).should('not.exist');
-        cy.findByRole('alert').should(
-            'contain.text',
-            "Configuration updated successfully."
-        );
-        validateTilesOrder([
-            "Browse help articles",
-            "Make a reservation",
-            "View approval requests",
-        ]);
-
-        // Refresh page to confirm deletion
-        cy.reload();
-        validateTilesOrder([
-            "Browse help articles",
-            "Make a reservation",
-            "View approval requests",
-        ]);
-    });
-
-    it('can edit a tile', () => {
-        // Go to tile edition form
-        cy.findByRole("region", {'name': "Request a service"}).click();
-
-        // Change a field
-        cy.findByRole("textbox", {'name': 'Title'}).clear();
-        cy.findByRole("textbox", {'name': 'Title'}).type("My new tile name");
-
-        // Submit
-        cy.findByRole('dialog').findByRole('button', {'name': 'Save changes'}).click();
-        validateTilesOrder([
-            "Browse help articles",
-            "My new tile name",
-            "Make a reservation",
-            "View approval requests",
-        ]);
-    });
-
-    it('can add a "Glpi page" tile', () => {
-        // Go to tile creation form
-        cy.findByRole('button', {'name': "Add tile"}).click();
-
-        // Set fields
-        cy.getDropdownByLabelText('Type').selectDropdownValue('GLPI page');
-        cy.findByRole("textbox", {'name': 'Title'}).type("My title");
-        cy.findByRole("dialog")
-            .find('div[data-glpi-helpdesk-config-add-tile-form-for]:visible') // impossible to target without this due to some limitations
-            .findByLabelText('Description')
-            .awaitTinyMCE()
-            .type("My description")
+    it(`can configure an entity from scratch`, () => {
+        // When the page is loaded, the tiles from the parent entity are shown
+        cy.findByText('There are no tiles defined for this entity.')
+            .should('be.visible')
         ;
-        cy.getDropdownByLabelText('Target page').selectDropdownValue('Service catalog');
-
-        // Submit
-        cy.findByRole('dialog').findByRole('button', {'name': 'Add tile'}).click();
-        validateTilesOrder([
-            "Browse help articles",
-            "Request a service",
-            "Make a reservation",
-            "View approval requests",
-            "My title",
-        ]);
-        cy.findByText("My description").should('be.visible');
-    });
-
-    it('can add a "External page" tile', () => {
-        // Go to tile creation form
-        cy.findByRole('button', {'name': "Add tile"}).click();
-
-        // Set fields
-        cy.getDropdownByLabelText('Type').selectDropdownValue('External page');
-        cy.findByRole("textbox", {'name': 'Title'}).type("My external tile title");
-        cy.findByRole("dialog")
-            .find('div[data-glpi-helpdesk-config-add-tile-form-for]:visible') // impossible to target without this due to some limitations
-            .findByLabelText('Description')
-            .awaitTinyMCE()
-            .type("My description")
+        cy.findByRole('heading', {name: 'Browse help articles'})
+            .should('be.visible')
         ;
-        cy.findByRole("textbox", {'name': 'Target url'}).type("support.teclib.com");
+        cy.findByRole('button', {name: "Add tile"}).should('not.exist');
 
-        // Submit
-        cy.findByRole('dialog').findByRole('button', {'name': 'Add tile'}).click();
-        validateTilesOrder([
-            "Browse help articles",
-            "Request a service",
-            "Make a reservation",
-            "View approval requests",
-            "My external tile title",
-        ]);
-        cy.findByText("My description").should('be.visible');
+        // Define our own tabs
+        cy.findByRole('button', {
+            name: "Define tiles for this entity from scratch"
+        }).click();
+        cy.findByRole('button', {name: "Add tile"}).should('be.visible');
+        cy.findByText('There are no tiles defined for this entity.')
+            .should('not.be.visible')
+        ;
+        cy.findByRole('heading', {name: 'Browse help articles'})
+            .should('not.exist')
+        ;
     });
 
-    it('can add a "Form" tile', () => {
-        // Go to tile creation form
-        cy.findByRole('button', {'name': "Add tile"}).click();
+    it(`can copy an entity settings`, () => {
+        // When the page is loaded, the tiles from the parent entity are shown
+        cy.findByText('There are no tiles defined for this entity.')
+            .should('be.visible')
+        ;
+        cy.findByRole('heading', {name: 'Browse help articles'})
+            .should('be.visible')
+        ;
+        cy.findByRole('button', {name: "Add tile"}).should('not.exist');
 
-        // Set fields
-        cy.getDropdownByLabelText('Type').selectDropdownValue('Form');
-        cy.getDropdownByLabelText('Target form').selectDropdownValue('Report an issue');
-
-        // Submit
-        cy.findByRole('dialog').findByRole('button', {'name': 'Add tile'}).click();
-        validateTilesOrder([
-            "Browse help articles",
-            "Request a service",
-            "Make a reservation",
-            "View approval requests",
-            "Report an issue",
-        ]);
-        cy.findByText("Ask for support from our helpdesk team.").should('be.visible');
+        // Define our own tabs, with the parent tabs still being here
+        cy.findByRole('button', {
+            name: "Copy parent entity configuration into this entity"
+        }).click();
+        cy.findByRole('button', {name: "Add tile"}).should('be.visible');
+        cy.findByText('There are no tiles defined for this entity.')
+            .should('not.exist')
+        ;
+        cy.findByRole('heading', {name: 'Browse help articles'})
+            .should('be.visible')
+        ;
     });
 });
+
+function validateTilesOrder(tiles) {
+    cy.findByRole("region", {'name': "Home tiles configuration"}).within(() => {
+        tiles.forEach((title, i) => {
+            cy.findAllByRole("region").eq(i).should('have.attr', 'aria-label', title);
+        });
+    });
+}
+
+function moveTileAfterTile(subject, destination) {
+    cy.findByRole("region", {'name': subject}).startToDrag();
+    cy.findByRole("region", {'name': destination}).dropDraggedItemAfter();
+}

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -357,6 +357,11 @@ Cypress.Commands.add("createWithAPI", (url, values) => {
             throw new Error('Failed to create item');
         }
 
+        // Session can't be re-used as active entities will be invalid...
+        if (url == "Entity") {
+            api_token = null;
+        }
+
         return response.body.id;
     });
 });


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Allow the helpdesk home page to be configured by entity.
The first commit is from #19321, which should be merged first (wait for it to be merged before reviewing).

## Screenshots

Config on an entity;
![image](https://github.com/user-attachments/assets/1af7597a-8f08-4d23-ae70-6a09176d8ab2)

Config on a profile:
![image](https://github.com/user-attachments/assets/2f75515d-e514-41c5-b200-201042953ff0)

On an entity that does not have any values, we should the parent values instead:
![image](https://github.com/user-attachments/assets/74c8cd46-697f-4945-973b-883d23511217)

The two actions allow to define your own values for this entity (starting from an empty list of tiles or from a copy of the parent tiles).


