### PR TITLE
Speed up profile creation

### DIFF
--- a/src/Profile.php
+++ b/src/Profile.php
@@ -274,8 +274,7 @@ class Profile extends CommonDBTM
         /** @var \DBmysql $DB */
         global $DB;
 
-        $rights = ProfileRight::getAllPossibleRights();
-        ProfileRight::updateProfileRights($this->fields['id'], $rights);
+        ProfileRight::fillProfileRights($this->fields['id']);
         $this->profileRight = null;
 
         if (isset($this->fields['is_default']) && ((int) $this->fields["is_default"] === 1)) {
@@ -508,6 +507,8 @@ class Profile extends CommonDBTM
 
     public function prepareInputForAdd($input)
     {
+        $input['last_rights_update'] = Session::getCurrentTime();
+
         if (isset($input["helpdesk_item_type"])) {
             $input["helpdesk_item_type"] = exportArrayToDB(
                 ArrayNormalizer::normalizeValues($input["helpdesk_item_type"] ?: [], 'strval')


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
   -> Existing tests should cover it. 

## Description

I noticed that some simple phpunit cases were a bit too slow:

![image](https://github.com/user-attachments/assets/e34aa54e-6589-4008-8b50-11f4a2d7dcd8)

8s for some basics tests is way too much.

After investigations, I found that it was entirely caused by the profile creation process, which is executed like this in a few of the test cases:
```php
$profile = $this->createItem(Profile::class, [
    'name' => 'Helpdesk profile',
    'interface' => 'helpdesk',
]);
```

The `Profile::post_addItem()` process is the culprit as it triggers 1000+ SQL requests and iterate on 25000+ rows of data.

This is because this process need to initialize ~100 rows in the `glpi_profile_rights` table, which trigger a lot of "framework callback hell" as each row lead to some extra process (post_add/post_update/post_getempty callback, rights checks, cache being set and reset with the same data, triggering an update on the profile being added for each rows, ...).

I've noticed that `ProfileRight::updateProfileRights()` is a bit weird as it supports updating the rights in two ways:
* The rights that are sent to it as its `$rights` parameter are initialized with the GLPI framework (direct call to `->add()` method).
* The remaining rights that may be missing from this parameter are initialized throught a unique direct SQL query - bypassing the framework. This is done by a call to the `ProfileRight::fillProfileRights()` method at the end of `ProfileRight::updateProfileRights()`.

So it seems that by making `Profile::post_addItem()` directly call `ProfileRight::fillProfileRights()` we can bypass the framework here and gain a lot of time.
This make sense as this method seems to be made for rights initialization, the `updateProfileRights()` method being dedicated to the update of existing rights instead.

This result in the exact same data being created, the only difference being that `last_right_update` is not initialized in the profiles table (with the previous process it was being initialized 200 times with the same value as it is done on each `ProfileRight` creation or update).

This is easily fixable by setting the value in the `prepareInputForAdd()` method.

After this simple change, the tests are much faster:

![image](https://github.com/user-attachments/assets/0b1b140d-17ce-49d5-9d97-3e618342ad4d)

The speed up is noticeable when creating a new profile in the UI but it is not a very common action so not much to gain for users overall.