### PR TITLE
Fix maintenance redirection loop

### DIFF
--- a/tests/cypress/e2e/maintenance.cy.js
+++ b/tests/cypress/e2e/maintenance.cy.js
@@ -1,5 +1,3 @@
-<?php
-
 /**
  * ---------------------------------------------------------------------
  *
@@ -32,25 +30,15 @@
  * ---------------------------------------------------------------------
  */
 
-declare(strict_types=1);
-
-namespace Glpi\Controller;
-
-use Glpi\Http\Firewall;
-use Glpi\Security\Attribute\SecurityStrategy;
-use Symfony\Component\HttpFoundation\Response;
-
-class MaintenanceController extends AbstractController
-{
-    #[SecurityStrategy(Firewall::STRATEGY_NO_CHECK)]
-    public function __invoke(): Response
-    {
-        /** @var array $CFG_GLPI */
-        global $CFG_GLPI;
-
-        return $this->render('maintenance.html.twig', [
-            'title'            => "MAINTENANCE MODE",
-            'maintenance_text' => $CFG_GLPI["maintenance_text"] ?? "",
-        ]);
-    }
-}
+describe('Maintenance', () => {
+    before(() => {
+        cy.exec('php ../bin/console maintenance:enable');
+    });
+    after(() => {
+        cy.exec('php ../bin/console maintenance:disable');
+    });
+    it('GLPI is not accessible during maintenance', () => {
+        cy.visit('/');
+        cy.findByText("Temporarily down for maintenance").should('be.visible');
+    });
+});


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

The maintenance controller will handle all requests when GLPI is in maintenance mode.
However, due to the default firewall strategies changes in GLPI 11, the controller is only accessible for logged-in users.

This create a redirection loop for unauthenticated users (login page -> maintenance -> login page -> maintenance -> ...).

Fixed by adding the correct firewall strategy to the maintenance controller and adding a very small test that make sure the maintenance page is working for unauthenticated users.

