### PR TITLE
fix(build): remove composer-dependency-analyser

### DIFF
--- a/tools/build_glpi.sh
+++ b/tools/build_glpi.sh
@@ -80,6 +80,7 @@ find $WORKING_DIR -depth -iname ".*" -exec rm -rf {} \;
 dev_nodes=(
     "composer.json"
     "composer.lock"
+    "composer-dependency-analyser.php"
     "docker-compose.yaml"
     "eslint.config.mjs"
     "js"


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

"composer-dependency-analyser.php" is not needed in the build.

