### PR TITLE
fix(business rule): first group of user without group

### DIFF
--- a/phpunit/functional/RuleAssetTest.php
+++ b/phpunit/functional/RuleAssetTest.php
@@ -560,6 +560,17 @@ class RuleAssetTest extends DbTestCase
         //Load user tech
         $user = getItemByTypeName('User', 'tech');
 
+        // Check case where user is not in any group
+        $computer = $this->createItem(
+            'Computer',
+            [
+                'name'        => 'test no groups',
+                'entities_id' => 0,
+                'users_id'    => $user->getID(),
+            ]
+        );
+        $this->assertEquals(0, $computer->getField('groups_id'));
+
         //add user to group
         $group_user    = new \Group_User();
         $group_user_id = $group_user->add($group_user_input = [

--- a/src/RuleAsset.php
+++ b/src/RuleAsset.php
@@ -295,7 +295,7 @@ class RuleAsset extends Rule
                             ($action->fields['field'] == 'groups_id')
                             && isset($input['_groups_id_of_user'])
                         ) {
-                            $output['groups_id'] = reset($input['_groups_id_of_user']);
+                            $output['groups_id'] = (int) reset($input['_groups_id_of_user']);
                         }
                         break;
 


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !37215

With this rule:
![image_paste](https://github.com/user-attachments/assets/0c6f99c9-a5f4-4a10-a3a4-340532c0556a)

Prevent this SQL error where user is not in any group:
![image_paste](https://github.com/user-attachments/assets/4b4cd016-1862-409b-8343-a5bf42db2307)

