### PR TITLE
fix(forms-migration): Add null handling for mapped items and update horizontal rank

### DIFF
--- a/phpunit/functional/Glpi/Form/Migration/FormMigrationTest.php
+++ b/phpunit/functional/Glpi/Form/Migration/FormMigrationTest.php
@@ -278,7 +278,7 @@ final class FormMigrationTest extends DbTestCase
                 'type'                        => QuestionTypeRequester::class,
                 'is_mandatory'                => 0,
                 'vertical_rank'               => 0,
-                'horizontal_rank'             => 2,
+                'horizontal_rank'             => 1,
                 'description'                 => null,
                 'default_value'               => json_encode($default_value->jsonSerialize()),
                 'extra_data'                  => json_encode($extra_data->jsonSerialize())
@@ -948,5 +948,85 @@ final class FormMigrationTest extends DbTestCase
             current($errors)['message'],
             'Question "Orphan question" has no section. It will not be migrated.'
         );
+    }
+
+    public function testFormMigrationUpdateHorizontalRanks(): void
+    {
+        /**
+         * @var \DBmysql $DB
+         */
+        global $DB;
+
+        // Insert a new form
+        $this->assertTrue($DB->insert(
+            'glpi_plugin_formcreator_forms',
+            [
+                'name' => 'Test form migration for update horizontal ranks',
+            ]
+        ));
+
+        // Insert a new section
+        $this->assertTrue($DB->insert(
+            'glpi_plugin_formcreator_sections',
+            [
+                'name'                        => 'Test form migration for update horizontal ranks - Section',
+                'plugin_formcreator_forms_id' => $DB->insertId()
+            ]
+        ));
+
+        // Insert three questions with same vertical rank
+        $section_id = $DB->insertId();
+        $this->assertTrue($DB->insert(
+            'glpi_plugin_formcreator_questions',
+            [
+                'plugin_formcreator_sections_id' => $section_id,
+                'name'                           => 'Test form migration for update horizontal ranks - Question 1',
+                'row'                            => 0,
+                'col'                            => 0,
+                'width'                          => 1,
+            ]
+        ));
+        $this->assertTrue($DB->insert(
+            'glpi_plugin_formcreator_questions',
+            [
+                'plugin_formcreator_sections_id' => $section_id,
+                'name'                           => 'Test form migration for update horizontal ranks - Comment 1',
+                'fieldtype'                      => 'description',
+                'row'                            => 0,
+                'col'                            => 2,
+                'width'                          => 1,
+            ]
+        ));
+        $this->assertTrue($DB->insert(
+            'glpi_plugin_formcreator_questions',
+            [
+                'plugin_formcreator_sections_id' => $section_id,
+                'name'                           => 'Test form migration for update horizontal ranks - Question 2',
+                'row'                            => 0,
+                'col'                            => 4,
+                'width'                          => 1,
+            ]
+        ));
+
+        $migration = new FormMigration($DB, FormAccessControlManager::getInstance());
+        $this->setPrivateProperty($migration, 'result', new PluginMigrationResult());
+        $this->assertTrue($this->callPrivateMethod($migration, 'processMigration'));
+
+        // Check that the horizontal ranks have been updated
+        $section = getItemByTypeName(Section::class, 'Test form migration for update horizontal ranks - Section');
+        if (!($section instanceof Section)) {
+            $this->fail('Section not found');
+        }
+        $blocks = $section->getBlocks();
+
+        // Blocks are grouped by vertical rank
+        $this->assertCount(1, $blocks);
+        $this->assertCount(3, current($blocks));
+
+        // Check ranks
+        foreach (current($blocks) as $index => $block) {
+            $this->assertEquals(0, $block->fields['vertical_rank']);
+            $this->assertEquals($index, $block->fields['horizontal_rank']);
+        }
     }
 }

--- a/src/Glpi/Form/Destination/CommonITILField/AssociatedItemsField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/AssociatedItemsField.php
@@ -279,16 +279,12 @@ class AssociatedItemsField extends AbstractConfigField implements DestinationFie
                     );
 
                     if ($mapped_item === null) {
-                        $migration->result->addMessage(MessageType::Error, sprintf(
-                            "Question %d not found in a target form (%s)",
-                            $rawData['associate_question'],
-                            $form->getName()
-                        ));
+                        throw new InvalidArgumentException("Question not found in a target form");
                     }
 
                     return new AssociatedItemsFieldConfig(
                         strategies: [AssociatedItemsFieldStrategy::SPECIFIC_ANSWERS],
-                        specific_question_ids: [$mapped_item['items_id'] ?? 0]
+                        specific_question_ids: [$mapped_item['items_id']]
                     );
                 case 4: // PluginFormcreatorAbstractItilTarget::ASSOCIATE_RULE_LAST_ANSWER
                     return new AssociatedItemsFieldConfig(

--- a/src/Glpi/Form/Destination/CommonITILField/AssociatedItemsField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/AssociatedItemsField.php
@@ -45,7 +45,6 @@ use Glpi\Form\Migration\DestinationFieldConverterInterface;
 use Glpi\Form\Migration\FormMigration;
 use Glpi\Form\QuestionType\QuestionTypeItem;
 use Glpi\Form\QuestionType\QuestionTypeUserDevice;
-use Glpi\Message\MessageType;
 use InvalidArgumentException;
 use Override;
 

--- a/src/Glpi/Form/Destination/CommonITILField/EntityField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/EntityField.php
@@ -44,6 +44,7 @@ use Glpi\Form\Form;
 use Glpi\Form\Migration\DestinationFieldConverterInterface;
 use Glpi\Form\Migration\FormMigration;
 use Glpi\Form\QuestionType\QuestionTypeItem;
+use Glpi\Message\MessageType;
 use InvalidArgumentException;
 use Override;
 
@@ -217,12 +218,22 @@ class EntityField extends AbstractConfigField implements DestinationFieldConvert
                     specific_entity_id: $rawData['destination_entity_value']
                 );
             case 9: // PluginFormcreatorAbstractTarget::DESTINATION_ENTITY_ENTITY_FROM_OBJECT
+                $mapped_item = $migration->getMappedItemTarget(
+                    'PluginFormcreatorQuestion',
+                    $rawData['destination_entity_value']
+                );
+
+                if ($mapped_item === null) {
+                    $migration->result->addMessage(MessageType::Error, sprintf(
+                        "Question %d not found in a target form (%s)",
+                        $rawData['destination_entity_value'],
+                        $form->getName()
+                    ));
+                }
+
                 return new EntityFieldConfig(
                     strategy: EntityFieldStrategy::SPECIFIC_ANSWER,
-                    specific_question_id: $migration->getMappedItemTarget(
-                        'PluginFormcreatorQuestion',
-                        $rawData['destination_entity_value']
-                    )['items_id']
+                    specific_question_id: $mapped_item['items_id'] ?? 0
                 );
         }
 

--- a/src/Glpi/Form/Destination/CommonITILField/EntityField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/EntityField.php
@@ -44,7 +44,6 @@ use Glpi\Form\Form;
 use Glpi\Form\Migration\DestinationFieldConverterInterface;
 use Glpi\Form\Migration\FormMigration;
 use Glpi\Form\QuestionType\QuestionTypeItem;
-use Glpi\Message\MessageType;
 use InvalidArgumentException;
 use Override;
 

--- a/src/Glpi/Form/Destination/CommonITILField/EntityField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/EntityField.php
@@ -224,16 +224,12 @@ class EntityField extends AbstractConfigField implements DestinationFieldConvert
                 );
 
                 if ($mapped_item === null) {
-                    $migration->result->addMessage(MessageType::Error, sprintf(
-                        "Question %d not found in a target form (%s)",
-                        $rawData['destination_entity_value'],
-                        $form->getName()
-                    ));
+                    throw new InvalidArgumentException("Question not found in a target form");
                 }
 
                 return new EntityFieldConfig(
                     strategy: EntityFieldStrategy::SPECIFIC_ANSWER,
-                    specific_question_id: $mapped_item['items_id'] ?? 0
+                    specific_question_id: $mapped_item['items_id']
                 );
         }
 

--- a/src/Glpi/Form/Destination/CommonITILField/ITILActorField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ITILActorField.php
@@ -43,7 +43,6 @@ use Glpi\Form\Form;
 use Glpi\Form\QuestionType\QuestionTypeItem;
 use Glpi\Form\Migration\DestinationFieldConverterInterface;
 use Glpi\Form\Migration\FormMigration;
-use Glpi\Message\MessageType;
 use Group;
 use InvalidArgumentException;
 use Override;

--- a/src/Glpi/Form/Destination/CommonITILField/ITILActorField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ITILActorField.php
@@ -239,14 +239,10 @@ abstract class ITILActorField extends AbstractConfigField implements Destination
                             );
 
                             if ($mapped_item === null) {
-                                $migration->result->addMessage(MessageType::Error, sprintf(
-                                    "Question %d not found in a target form (%s)",
-                                    $id,
-                                    $form->getName()
-                                ));
+                                throw new InvalidArgumentException("Question not found in a target form");
                             }
 
-                            $specific_question_ids[] = $mapped_item['items_id'] ?? 0;
+                            $specific_question_ids[] = $mapped_item['items_id'];
                         }
                     }
                 }

--- a/src/Glpi/Form/Destination/CommonITILField/ITILActorField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ITILActorField.php
@@ -43,6 +43,7 @@ use Glpi\Form\Form;
 use Glpi\Form\QuestionType\QuestionTypeItem;
 use Glpi\Form\Migration\DestinationFieldConverterInterface;
 use Glpi\Form\Migration\FormMigration;
+use Glpi\Message\MessageType;
 use Group;
 use InvalidArgumentException;
 use Override;
@@ -232,10 +233,20 @@ abstract class ITILActorField extends AbstractConfigField implements Destination
 
                     if ($strategy === ITILActorFieldStrategy::SPECIFIC_ANSWERS) {
                         foreach ($ids as $id) {
-                            $specific_question_ids[] = $migration->getMappedItemTarget(
+                            $mapped_item = $migration->getMappedItemTarget(
                                 'PluginFormcreatorQuestion',
                                 $id
-                            )['items_id'];
+                            );
+
+                            if ($mapped_item === null) {
+                                $migration->result->addMessage(MessageType::Error, sprintf(
+                                    "Question %d not found in a target form (%s)",
+                                    $id,
+                                    $form->getName()
+                                ));
+                            }
+
+                            $specific_question_ids[] = $mapped_item['items_id'] ?? 0;
                         }
                     }
                 }

--- a/src/Glpi/Form/Destination/CommonITILField/ITILCategoryField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ITILCategoryField.php
@@ -43,7 +43,6 @@ use Glpi\Form\Form;
 use Glpi\Form\Migration\DestinationFieldConverterInterface;
 use Glpi\Form\Migration\FormMigration;
 use Glpi\Form\QuestionType\QuestionTypeItemDropdown;
-use Glpi\Message\MessageType;
 use InvalidArgumentException;
 use ITILCategory;
 use Override;

--- a/src/Glpi/Form/Destination/CommonITILField/ITILCategoryField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ITILCategoryField.php
@@ -149,16 +149,12 @@ class ITILCategoryField extends AbstractConfigField implements DestinationFieldC
                 );
 
                 if ($mapped_item === null) {
-                    $migration->result->addMessage(MessageType::Error, sprintf(
-                        "Question %d not found in a target form (%s)",
-                        $rawData['category_question'],
-                        $form->getName()
-                    ));
+                    throw new InvalidArgumentException("Question not found in a target form");
                 }
 
                 return new ITILCategoryFieldConfig(
                     strategy: ITILCategoryFieldStrategy::SPECIFIC_ANSWER,
-                    specific_question_id: $mapped_item['items_id'] ?? 0
+                    specific_question_id: $mapped_item['items_id']
                 );
             case 4: // PluginFormcreatorAbstractItilTarget::CATEGORY_RULE_LAST_ANSWER
                 return new ITILCategoryFieldConfig(

--- a/src/Glpi/Form/Destination/CommonITILField/ITILCategoryField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ITILCategoryField.php
@@ -147,7 +147,7 @@ class ITILCategoryField extends AbstractConfigField implements DestinationFieldC
                     specific_question_id: $migration->getMappedItemTarget(
                         'PluginFormcreatorQuestion',
                         $rawData['category_question']
-                    )['items_id'],
+                    )['items_id'] ?? 0
                 );
             case 4: // PluginFormcreatorAbstractItilTarget::CATEGORY_RULE_LAST_ANSWER
                 return new ITILCategoryFieldConfig(

--- a/src/Glpi/Form/Destination/CommonITILField/ITILCategoryField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ITILCategoryField.php
@@ -43,6 +43,7 @@ use Glpi\Form\Form;
 use Glpi\Form\Migration\DestinationFieldConverterInterface;
 use Glpi\Form\Migration\FormMigration;
 use Glpi\Form\QuestionType\QuestionTypeItemDropdown;
+use Glpi\Message\MessageType;
 use InvalidArgumentException;
 use ITILCategory;
 use Override;
@@ -142,12 +143,22 @@ class ITILCategoryField extends AbstractConfigField implements DestinationFieldC
                     specific_itilcategory_id: $rawData['category_question']
                 );
             case 3: // PluginFormcreatorAbstractItilTarget::CATEGORY_RULE_ANSWER
+                $mapped_item = $migration->getMappedItemTarget(
+                    'PluginFormcreatorQuestion',
+                    $rawData['category_question']
+                );
+
+                if ($mapped_item === null) {
+                    $migration->result->addMessage(MessageType::Error, sprintf(
+                        "Question %d not found in a target form (%s)",
+                        $rawData['category_question'],
+                        $form->getName()
+                    ));
+                }
+
                 return new ITILCategoryFieldConfig(
                     strategy: ITILCategoryFieldStrategy::SPECIFIC_ANSWER,
-                    specific_question_id: $migration->getMappedItemTarget(
-                        'PluginFormcreatorQuestion',
-                        $rawData['category_question']
-                    )['items_id'] ?? 0
+                    specific_question_id: $mapped_item['items_id'] ?? 0
                 );
             case 4: // PluginFormcreatorAbstractItilTarget::CATEGORY_RULE_LAST_ANSWER
                 return new ITILCategoryFieldConfig(

--- a/src/Glpi/Form/Destination/CommonITILField/LocationField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/LocationField.php
@@ -43,7 +43,6 @@ use Glpi\Form\Form;
 use Glpi\Form\Migration\DestinationFieldConverterInterface;
 use Glpi\Form\Migration\FormMigration;
 use Glpi\Form\QuestionType\QuestionTypeItemDropdown;
-use Glpi\Message\MessageType;
 use InvalidArgumentException;
 use Location;
 use Override;

--- a/src/Glpi/Form/Destination/CommonITILField/LocationField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/LocationField.php
@@ -43,6 +43,7 @@ use Glpi\Form\Form;
 use Glpi\Form\Migration\DestinationFieldConverterInterface;
 use Glpi\Form\Migration\FormMigration;
 use Glpi\Form\QuestionType\QuestionTypeItemDropdown;
+use Glpi\Message\MessageType;
 use InvalidArgumentException;
 use Location;
 use Override;
@@ -185,12 +186,22 @@ class LocationField extends AbstractConfigField implements DestinationFieldConve
                         specific_location_id: $rawData['location_question']
                     );
                 case 3: // PluginFormcreatorAbstractItilTarget::LOCATION_RULE_ANSWER
+                    $mapped_item = $migration->getMappedItemTarget(
+                        'PluginFormcreatorQuestion',
+                        $rawData['location_question']
+                    );
+
+                    if ($mapped_item === null) {
+                        $migration->result->addMessage(MessageType::Error, sprintf(
+                            "Question %d not found in a target form (%s)",
+                            $rawData['location_question'],
+                            $form->getName()
+                        ));
+                    }
+
                     return new LocationFieldConfig(
                         strategy: LocationFieldStrategy::SPECIFIC_ANSWER,
-                        specific_question_id: $migration->getMappedItemTarget(
-                            'PluginFormcreatorQuestion',
-                            $rawData['location_question']
-                        )['items_id'] ?? 0
+                        specific_question_id: $mapped_item['items_id'] ?? 0
                     );
                 case 4: // PluginFormcreatorAbstractItilTarget::LOCATION_RULE_LAST_ANSWER
                     return new LocationFieldConfig(

--- a/src/Glpi/Form/Destination/CommonITILField/LocationField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/LocationField.php
@@ -192,16 +192,12 @@ class LocationField extends AbstractConfigField implements DestinationFieldConve
                     );
 
                     if ($mapped_item === null) {
-                        $migration->result->addMessage(MessageType::Error, sprintf(
-                            "Question %d not found in a target form (%s)",
-                            $rawData['location_question'],
-                            $form->getName()
-                        ));
+                        throw new InvalidArgumentException("Question not found in a target form");
                     }
 
                     return new LocationFieldConfig(
                         strategy: LocationFieldStrategy::SPECIFIC_ANSWER,
-                        specific_question_id: $mapped_item['items_id'] ?? 0
+                        specific_question_id: $mapped_item['items_id']
                     );
                 case 4: // PluginFormcreatorAbstractItilTarget::LOCATION_RULE_LAST_ANSWER
                     return new LocationFieldConfig(

--- a/src/Glpi/Form/Destination/CommonITILField/LocationField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/LocationField.php
@@ -190,7 +190,7 @@ class LocationField extends AbstractConfigField implements DestinationFieldConve
                         specific_question_id: $migration->getMappedItemTarget(
                             'PluginFormcreatorQuestion',
                             $rawData['location_question']
-                        )['items_id'],
+                        )['items_id'] ?? 0
                     );
                 case 4: // PluginFormcreatorAbstractItilTarget::LOCATION_RULE_LAST_ANSWER
                     return new LocationFieldConfig(

--- a/src/Glpi/Form/Destination/CommonITILField/RequestTypeField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/RequestTypeField.php
@@ -43,7 +43,6 @@ use Glpi\Form\Form;
 use Glpi\Form\Migration\DestinationFieldConverterInterface;
 use Glpi\Form\Migration\FormMigration;
 use Glpi\Form\QuestionType\QuestionTypeRequestType;
-use Glpi\Message\MessageType;
 use InvalidArgumentException;
 use Override;
 use Ticket;

--- a/src/Glpi/Form/Destination/CommonITILField/RequestTypeField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/RequestTypeField.php
@@ -155,16 +155,12 @@ class RequestTypeField extends AbstractConfigField implements DestinationFieldCo
                 );
 
                 if ($mapped_item === null) {
-                    $migration->result->addMessage(MessageType::Error, sprintf(
-                        "Question %d not found in a target form (%s)",
-                        $rawData['type_question'],
-                        $form->getName()
-                    ));
+                    throw new InvalidArgumentException("Question not found in a target form");
                 }
 
                 return new RequestTypeFieldConfig(
                     strategy: RequestTypeFieldStrategy::SPECIFIC_ANSWER,
-                    specific_question_id: $mapped_item['items_id'] ?? 0
+                    specific_question_id: $mapped_item['items_id']
                 );
         }
 

--- a/src/Glpi/Form/Destination/CommonITILField/RequestTypeField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/RequestTypeField.php
@@ -43,6 +43,7 @@ use Glpi\Form\Form;
 use Glpi\Form\Migration\DestinationFieldConverterInterface;
 use Glpi\Form\Migration\FormMigration;
 use Glpi\Form\QuestionType\QuestionTypeRequestType;
+use Glpi\Message\MessageType;
 use InvalidArgumentException;
 use Override;
 use Ticket;
@@ -148,12 +149,22 @@ class RequestTypeField extends AbstractConfigField implements DestinationFieldCo
                     specific_request_type: $rawData['type_question']
                 );
             case 2: // PluginFormcreatorAbstractItilTarget::REQUESTTYPE_ANSWER
+                $mapped_item = $migration->getMappedItemTarget(
+                    'PluginFormcreatorQuestion',
+                    $rawData['type_question']
+                );
+
+                if ($mapped_item === null) {
+                    $migration->result->addMessage(MessageType::Error, sprintf(
+                        "Question %d not found in a target form (%s)",
+                        $rawData['type_question'],
+                        $form->getName()
+                    ));
+                }
+
                 return new RequestTypeFieldConfig(
                     strategy: RequestTypeFieldStrategy::SPECIFIC_ANSWER,
-                    specific_question_id: $migration->getMappedItemTarget(
-                        'PluginFormcreatorQuestion',
-                        $rawData['type_question']
-                    )['items_id'],
+                    specific_question_id: $mapped_item['items_id'] ?? 0
                 );
         }
 

--- a/src/Glpi/Form/Destination/CommonITILField/UrgencyField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/UrgencyField.php
@@ -44,7 +44,6 @@ use Glpi\Form\Form;
 use Glpi\Form\Migration\DestinationFieldConverterInterface;
 use Glpi\Form\Migration\FormMigration;
 use Glpi\Form\QuestionType\QuestionTypeUrgency;
-use Glpi\Message\MessageType;
 use InvalidArgumentException;
 use Override;
 

--- a/src/Glpi/Form/Destination/CommonITILField/UrgencyField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/UrgencyField.php
@@ -157,7 +157,7 @@ class UrgencyField extends AbstractConfigField implements DestinationFieldConver
                     specific_question_id: $migration->getMappedItemTarget(
                         'PluginFormcreatorQuestion',
                         $rawData['urgency_question']
-                    )['items_id']
+                    )['items_id'] ?? 0
                 );
         }
 

--- a/src/Glpi/Form/Destination/CommonITILField/UrgencyField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/UrgencyField.php
@@ -159,16 +159,12 @@ class UrgencyField extends AbstractConfigField implements DestinationFieldConver
                 );
 
                 if ($mapped_item === null) {
-                    $migration->result->addMessage(MessageType::Error, sprintf(
-                        "Question %d not found in a target form (%s)",
-                        $rawData['urgency_question'],
-                        $form->getName()
-                    ));
+                    throw new InvalidArgumentException("Question not found in a target form");
                 }
 
                 return new UrgencyFieldConfig(
                     strategy: UrgencyFieldStrategy::SPECIFIC_ANSWER,
-                    specific_question_id: $mapped_item['items_id'] ?? 0
+                    specific_question_id: $mapped_item['items_id']
                 );
         }
 

--- a/src/Glpi/Form/Destination/CommonITILField/UrgencyField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/UrgencyField.php
@@ -44,6 +44,7 @@ use Glpi\Form\Form;
 use Glpi\Form\Migration\DestinationFieldConverterInterface;
 use Glpi\Form\Migration\FormMigration;
 use Glpi\Form\QuestionType\QuestionTypeUrgency;
+use Glpi\Message\MessageType;
 use InvalidArgumentException;
 use Override;
 
@@ -152,12 +153,22 @@ class UrgencyField extends AbstractConfigField implements DestinationFieldConver
                     specific_urgency_value: $rawData['urgency_question']
                 );
             case 3: // PluginFormcreatorAbstractItilTarget::URGENCY_RULE_ANSWER
+                $mapped_item = $migration->getMappedItemTarget(
+                    'PluginFormcreatorQuestion',
+                    $rawData['urgency_question']
+                );
+
+                if ($mapped_item === null) {
+                    $migration->result->addMessage(MessageType::Error, sprintf(
+                        "Question %d not found in a target form (%s)",
+                        $rawData['urgency_question'],
+                        $form->getName()
+                    ));
+                }
+
                 return new UrgencyFieldConfig(
                     strategy: UrgencyFieldStrategy::SPECIFIC_ANSWER,
-                    specific_question_id: $migration->getMappedItemTarget(
-                        'PluginFormcreatorQuestion',
-                        $rawData['urgency_question']
-                    )['items_id'] ?? 0
+                    specific_question_id: $mapped_item['items_id'] ?? 0
                 );
         }
 

--- a/src/Glpi/Form/Destination/CommonITILField/ValidationField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ValidationField.php
@@ -46,7 +46,6 @@ use Glpi\Form\QuestionType\AbstractQuestionTypeActors;
 use Glpi\Form\QuestionType\QuestionTypeAssignee;
 use Glpi\Form\QuestionType\QuestionTypeItem;
 use Glpi\Form\QuestionType\QuestionTypeObserver;
-use Glpi\Message\MessageType;
 use Group;
 use InvalidArgumentException;
 use Override;

--- a/src/Glpi/Form/Destination/CommonITILField/ValidationField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ValidationField.php
@@ -277,14 +277,17 @@ class ValidationField extends AbstractConfigField implements DestinationFieldCon
                     );
                 case 3: // PluginFormcreatorAbstractItilTarget::VALIDATION_ANSWER_USER
                 case 4: // PluginFormcreatorAbstractItilTarget::VALIDATION_ANSWER_GROUP
+                    $question_ids = [];
+                    if (is_numeric($rawData['commonitil_validation_question'] ?? null)) {
+                        $question_ids[] = $migration->getMappedItemTarget(
+                            'PluginFormcreatorQuestion',
+                            $rawData['commonitil_validation_question']
+                        )['items_id'] ?? 0;
+                    }
+
                     return new ValidationFieldConfig(
                         strategies: [ValidationFieldStrategy::SPECIFIC_ANSWERS],
-                        specific_question_ids: [
-                            $migration->getMappedItemTarget(
-                                'PluginFormcreatorQuestion',
-                                $rawData['commonitil_validation_question']
-                            )['items_id']
-                        ]
+                        specific_question_ids: $question_ids
                     );
             }
         }

--- a/src/Glpi/Form/Destination/CommonITILField/ValidationField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ValidationField.php
@@ -46,6 +46,7 @@ use Glpi\Form\QuestionType\AbstractQuestionTypeActors;
 use Glpi\Form\QuestionType\QuestionTypeAssignee;
 use Glpi\Form\QuestionType\QuestionTypeItem;
 use Glpi\Form\QuestionType\QuestionTypeObserver;
+use Glpi\Message\MessageType;
 use Group;
 use InvalidArgumentException;
 use Override;
@@ -279,10 +280,20 @@ class ValidationField extends AbstractConfigField implements DestinationFieldCon
                 case 4: // PluginFormcreatorAbstractItilTarget::VALIDATION_ANSWER_GROUP
                     $question_ids = [];
                     if (is_numeric($rawData['commonitil_validation_question'] ?? null)) {
-                        $question_ids[] = $migration->getMappedItemTarget(
+                        $mapped_item = $migration->getMappedItemTarget(
                             'PluginFormcreatorQuestion',
                             $rawData['commonitil_validation_question']
-                        )['items_id'] ?? 0;
+                        );
+
+                        if ($mapped_item === null) {
+                            $migration->result->addMessage(MessageType::Error, sprintf(
+                                "Question %d not found in a target form (%s)",
+                                $rawData['commonitil_validation_question'],
+                                $form->getName()
+                            ));
+                        }
+
+                        $question_ids[] = $mapped_item['items_id'] ?? 0;
                     }
 
                     return new ValidationFieldConfig(

--- a/src/Glpi/Form/Destination/CommonITILField/ValidationField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ValidationField.php
@@ -286,14 +286,10 @@ class ValidationField extends AbstractConfigField implements DestinationFieldCon
                         );
 
                         if ($mapped_item === null) {
-                            $migration->result->addMessage(MessageType::Error, sprintf(
-                                "Question %d not found in a target form (%s)",
-                                $rawData['commonitil_validation_question'],
-                                $form->getName()
-                            ));
+                            throw new InvalidArgumentException("Question not found in a target form");
                         }
 
-                        $question_ids[] = $mapped_item['items_id'] ?? 0;
+                        $question_ids[] = $mapped_item['items_id'];
                     }
 
                     return new ValidationFieldConfig(

--- a/src/Glpi/Form/Migration/FormMigration.php
+++ b/src/Glpi/Form/Migration/FormMigration.php
@@ -246,7 +246,8 @@ class FormMigration extends AbstractPluginMigration
         $this->processMigrationOfSections();
         $this->processMigrationOfQuestions();
         $this->processMigrationOfComments();
-        $this->updateBlockHorizontalRank();
+        $this->removeUselessHorizontalRanks();
+        $this->updateHorizontalRanks();
         $this->processMigrationOfAccessControls();
         $this->processMigrationOfFormTargets();
         $this->processMigrationOfTranslations();
@@ -534,13 +535,14 @@ class FormMigration extends AbstractPluginMigration
     }
 
     /**
-     * Update horizontal rank of questions and comments to be consistent with the new form system
+     * Sets horizontal_rank to null for blocks that are contained in a horizontal layout
+     * and have only one element.
      *
      * @return void
      */
-    private function updateBlockHorizontalRank(): void
+    private function removeUselessHorizontalRanks(): void
     {
-        $this->progress_indicator?->setProgressBarMessage(__('Updating horizontal rank...'));
+        $this->progress_indicator?->setProgressBarMessage(__('Removing useless horizontal ranks...'));
 
         $tables = [Question::getTable(), Comment::getTable()];
 
@@ -589,6 +591,59 @@ class FormMigration extends AbstractPluginMigration
                     ['OR' => $sections_ranks]
                 );
             }
+        }
+    }
+
+    /**
+     * The new form system no longer allows defining a precise width for a block
+     * The width of each block is now determined by the number of elements contained in the horizontal layout
+     */
+    private function updateHorizontalRanks(): void
+    {
+        $this->progress_indicator?->setProgressBarMessage(__('Updating horizontal ranks...'));
+
+        // Retrieve all blocks with horizontal ranks and their new horizontal ranks
+        $blocks = $this->db->request([
+            'SELECT' => [
+                'id',
+                'table',
+                new QueryExpression(
+                    'ROW_NUMBER() OVER ( PARTITION BY forms_sections_id, vertical_rank ORDER BY horizontal_rank ) - 1',
+                    'new_horizontal_rank'
+                )
+            ],
+            'FROM' => new QueryUnion([
+                [
+                    'SELECT' => [
+                        'id',
+                        'forms_sections_id',
+                        'vertical_rank',
+                        'horizontal_rank',
+                        new QueryExpression("'" . Question::getTable() . "'", 'table')
+                    ],
+                    'FROM'   => Question::getTable(),
+                    'WHERE'  => ['NOT' => ['horizontal_rank' => null]]
+                ],
+                [
+                    'SELECT' => [
+                        'id',
+                        'forms_sections_id',
+                        'vertical_rank',
+                        'horizontal_rank',
+                        new QueryExpression("'" . Comment::getTable() . "'", 'table')
+                    ],
+                    'FROM'   => Comment::getTable(),
+                    'WHERE'  => ['NOT' => ['horizontal_rank' => null]]
+                ]
+            ]),
+        ]);
+
+        foreach ($blocks as $block) {
+            $this->db->update(
+                $block['table'],
+                ['horizontal_rank' => $block['new_horizontal_rank']],
+                ['id' => $block['id']]
+            );
         }
     }
 

--- a/src/Glpi/Form/Migration/FormMigration.php
+++ b/src/Glpi/Form/Migration/FormMigration.php
@@ -542,7 +542,7 @@ class FormMigration extends AbstractPluginMigration
      */
     private function removeUselessHorizontalRanks(): void
     {
-        $this->progress_indicator?->setProgressBarMessage(__('Removing useless horizontal ranks...'));
+        $this->progress_indicator?->setProgressBarMessage(__('Cleaning imported data...'));
 
         $tables = [Question::getTable(), Comment::getTable()];
 
@@ -600,7 +600,7 @@ class FormMigration extends AbstractPluginMigration
      */
     private function updateHorizontalRanks(): void
     {
-        $this->progress_indicator?->setProgressBarMessage(__('Updating horizontal ranks...'));
+        $this->progress_indicator?->setProgressBarMessage(__('Fixing forms layouts...'));
 
         // Retrieve all blocks with horizontal ranks and their new horizontal ranks
         $blocks = $this->db->request([

--- a/src/Glpi/Form/Migration/FormMigration.php
+++ b/src/Glpi/Form/Migration/FormMigration.php
@@ -843,11 +843,22 @@ class FormMigration extends AbstractPluginMigration
             foreach ($configurable_fields as $configurable_field) {
                 /** @var AbstractConfigField $configurable_field */
                 if ($configurable_field instanceof DestinationFieldConverterInterface) {
-                    $fields_config[$configurable_field::getKey()] = $configurable_field->convertFieldConfig(
-                        $this,
-                        $form,
-                        $raw_target
-                    )->jsonSerialize();
+                    try {
+                        $fields_config[$configurable_field::getKey()] = $configurable_field->convertFieldConfig(
+                            $this,
+                            $form,
+                            $raw_target
+                        )->jsonSerialize();
+                    } catch (\Throwable $th) {
+                        $this->result->addMessage(
+                            MessageType::Error,
+                            sprintf(
+                                __('The "%s" destination field configuration of the form "%s" cannot be imported.'),
+                                $configurable_field->getLabel(),
+                                $form->getName()
+                            )
+                        );
+                    }
                 }
 
                 if ($configurable_field instanceof ContentField) {
@@ -936,12 +947,23 @@ class FormMigration extends AbstractPluginMigration
             );
 
             foreach ($configurable_fields as $configurable_field) {
-                /** @var ITILActorField $configurable_field */
-                $fields_config[$configurable_field::getKey()] = $configurable_field->convertFieldConfig(
-                    $this,
-                    $destination->getItem(),
-                    $actors
-                )->jsonSerialize();
+                try {
+                    /** @var ITILActorField $configurable_field */
+                    $fields_config[$configurable_field::getKey()] = $configurable_field->convertFieldConfig(
+                        $this,
+                        $destination->getItem(),
+                        $actors
+                    )->jsonSerialize();
+                } catch (\Throwable $th) {
+                    $this->result->addMessage(
+                        MessageType::Error,
+                        sprintf(
+                            __('The "%s" destination field configuration of the form "%s" cannot be imported.'),
+                            $configurable_field->getLabel(),
+                            $destination->getItem()->getName()
+                        )
+                    );
+                }
             }
 
             if (

--- a/src/Glpi/Form/QuestionType/AbstractQuestionTypeSelectable.php
+++ b/src/Glpi/Form/QuestionType/AbstractQuestionTypeSelectable.php
@@ -176,10 +176,20 @@ TWIG;
     #[Override]
     public function convertDefaultValue(array $rawData): array
     {
-        $default_values = json_decode($rawData['default_values']) ?? [];
-        $options = json_decode($rawData['values']) ?? [];
+        if (
+            empty($rawData['default_values'])
+            || empty($rawData['values'])
+        ) {
+            return [];
+        }
 
-        if (empty($default_values) && !empty($rawData['default_values'])) {
+        $options = json_decode($rawData['values']);
+        if (empty($options)) {
+            return [];
+        }
+
+        $default_values = json_decode($rawData['default_values']);
+        if ($default_values === null && json_last_error() !== JSON_ERROR_NONE) {
             $default_values = [$rawData['default_values']];
         }
 

--- a/src/Glpi/Migration/AbstractPluginMigration.php
+++ b/src/Glpi/Migration/AbstractPluginMigration.php
@@ -59,7 +59,7 @@ abstract class AbstractPluginMigration
     /**
      * Current execution results.
      */
-    protected PluginMigrationResult $result;
+    public PluginMigrationResult $result;
 
     /**
      * Mapping between plugin items and GLPI core items.
@@ -512,7 +512,7 @@ abstract class AbstractPluginMigration
     /**
      * Return the GLPI core item specs corresponding to the given plugin item.
      *
-     * @return array{itemtype: class-string<\CommonDBTM>, items_id: int}
+     * @return array{itemtype: class-string<\CommonDBTM>, items_id: int}|null
      */
     final public function getMappedItemTarget(string $source_itemtype, int $source_items_id): ?array
     {

--- a/src/Glpi/Migration/AbstractPluginMigration.php
+++ b/src/Glpi/Migration/AbstractPluginMigration.php
@@ -59,7 +59,7 @@ abstract class AbstractPluginMigration
     /**
      * Current execution results.
      */
-    public PluginMigrationResult $result;
+    protected PluginMigrationResult $result;
 
     /**
      * Mapping between plugin items and GLPI core items.


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Should fix #19362 
Improve form migration by handling null values for mapping and updating horizontal rank to match the new sorting system.