### PR TITLE
Fix(Inventory): do not reconcile templates

### DIFF
--- a/phpunit/functional/RuleImportAssetTest.php
+++ b/phpunit/functional/RuleImportAssetTest.php
@@ -36,6 +36,8 @@ namespace tests\units;
 
 use DbTestCase;
 
+use function PHPUnit\Framework\assertTrue;
+
 /* Test for inc/ruleimportcomputer.class.php */
 
 class RuleImportAssetTest extends DbTestCase
@@ -1227,5 +1229,43 @@ class RuleImportAssetTest extends DbTestCase
         $this->assertSame("Computer update (by name and tag)", $rule->fields['name']);
         $this->assertSame($computers_id, $this->items_id);
         $this->assertSame('Computer', $this->itemtype);
+    }
+
+    public function testReconciliateWithAssetTemplate()
+    {
+
+        $computer = new \Computer();
+        $ruleCollection = new \RuleImportAssetCollection();
+
+        //create 'legacy' computer
+        $computers_id = (int)$computer->add([
+            'entities_id' => 0,
+            'name'        => 'pc-11',
+            'serial'      => '12345-65487-98765-45645',
+        ]);
+        $this->assertGreaterThan(0, $computers_id);
+
+        $input = [
+            'itemtype'      => 'Computer',
+            'name'          => 'pc-11',
+            'serial'        => '12345-65487-98765-45645',
+            'entities_id'   => 0
+        ];
+
+        // execute rule engine
+        $data = $ruleCollection->processAllRules($input, [], ['class' => $this]);
+        // check tha rule engine found the computer
+        $this->assertSame((string) $computers_id, $data["found_inventories"][0]);
+
+        // update computer to mark as template
+        $this->assertTrue($computer->update([
+            'id'            => $computers_id,
+            'is_template'   => 1,
+        ]));
+
+        // execute rule engine
+        $data = $ruleCollection->processAllRules($input, [], ['class' => $this]);
+        // check tha rule engine not found any computer
+        $this->assertSame("0", $data["found_inventories"][0]);
     }
 }

--- a/src/RuleImportAsset.php
+++ b/src/RuleImportAsset.php
@@ -506,6 +506,13 @@ class RuleImportAsset extends Rule
                 'WHERE'  => [] //to fill
             ];
 
+            // do not reconcile if it's a template
+            if (is_a($item, CommonDBTM::class, true)) {
+                if ($item->maybeTemplate()){
+                    $it_criteria['WHERE'][] = ['is_template' =>  0];
+                }
+            }
+
             if ($this->link_criteria_port) {
                 $this->handleLinkCriteriaPort($item, $it_criteria);
             } else {


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !37274

Currently, the import and material linking rule engine attempts to reconcile equipment based on various criteria (`name`, `serial number`, `UUID`, etc.), but it does not generally exclude certain criteria, particularly the `is_template` criterion.

I have encountered a case where a computer template is created with a name and serial number identical to those reported by an agent. Although the use of this template is incorrect, GLPI currently retrieves this template and subsequently attaches an agent and inventory to it.

This PR aims to exclude items marked as `is_template` from the reconciliation scope.

## Screenshots (if appropriate):


