### PR TITLE
Fix(Unicity): check unicity on template

### DIFF
--- a/phpunit/functional/CommonDBTMTest.php
+++ b/phpunit/functional/CommonDBTMTest.php
@@ -1451,6 +1451,58 @@ class CommonDBTMTest extends DbTestCase
         $this->hasSessionMessages(1, [$err_msg]);
     }
 
+    public function testCheckUnicityWithTemplate()
+    {
+        $this->login();
+
+        $field_unicity = new \FieldUnicity();
+        $this->assertGreaterThan(
+            0,
+            $field_unicity->add([
+                'name' => 'name uniqueness',
+                'itemtype' => 'Computer',
+                '_fields' => ['name'],
+                'is_active' => 1,
+                'action_refuse' => 1,
+                'entities_id' => getItemByTypeName('Entity', '_test_root_entity', true),
+            ])
+        );
+
+        $computer = new \Computer();
+        $this->assertGreaterThan(
+            0,
+            $computers_id1 = $computer->add([
+                'name' => __FUNCTION__ . '01',
+                'entities_id' => getItemByTypeName('Entity', '_test_root_entity', true),
+            ])
+        );
+
+        //create template with same name should not be possible
+        $template = new \Computer();
+        $this->assertFalse(
+            $template->add([
+                'name' => __FUNCTION__ . '01',
+                'entities_id' => getItemByTypeName('Entity', '_test_root_entity', true),
+                'is_template' => 1,
+            ])
+        );
+
+        $err_msg = "Impossible record for Name = " . __FUNCTION__ . '01' . "<br>Other item exist<br>[<a  href='/glpi/front/computer.form.php?id=" . $computers_id1 . "'  title=\"testCheckUnicityWithTemplate01\">testCheckUnicityWithTemplate01</a> - ID: {$computers_id1} - Serial number:  - Entity: Root entity &#62; _test_root_entity]";
+        $this->hasSessionMessages(1, [$err_msg]);
+
+        //create template with different name should be possible
+        $template = new \Computer();
+        $this->assertGreaterThan(
+            0,
+            $template->add([
+                'name' => __FUNCTION__ . '02',
+                'entities_id' => getItemByTypeName('Entity', '_test_root_entity', true),
+                'is_template' => 1,
+            ])
+        );
+
+    }
+
     public function testAddFilesWithNewFile()
     {
         // Simulate legit call to `addFiles()` post_addItem / post_updateItem

--- a/phpunit/functional/CommonDBTMTest.php
+++ b/phpunit/functional/CommonDBTMTest.php
@@ -1500,7 +1500,6 @@ class CommonDBTMTest extends DbTestCase
                 'is_template' => 1,
             ])
         );
-
     }
 
     public function testAddFilesWithNewFile()

--- a/phpunit/functional/ComputerTest.php
+++ b/phpunit/functional/ComputerTest.php
@@ -594,6 +594,7 @@ class ComputerTest extends DbTestCase
         $computer_template = new \Computer();
         $templates_id = $computer_template->add([
             'template_name' => __FUNCTION__ . '_template',
+            'entities_id'   => getItemByTypeName('Entity', '_test_root_entity', true),
             'is_template' => 1
         ]);
         $this->assertGreaterThan(0, $templates_id);

--- a/phpunit/functional/SoftwareTest.php
+++ b/phpunit/functional/SoftwareTest.php
@@ -230,6 +230,7 @@ class SoftwareTest extends DbTestCase
         $softwares_id = $software->add([
             'name'          => 'MyTemplate',
             'is_template'   => 1,
+            'entities_id'   => getItemByTypeName('Entity', '_test_root_entity', true),
             'template_name' => 'template'
         ]);
         $this->assertGreaterThan(0, $softwares_id);

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -4536,11 +4536,6 @@ class CommonDBTM extends CommonGLPI
             }
         }
 
-       // Do not check for template
-        if (isset($this->input['is_template']) && $this->input['is_template']) {
-            return true;
-        }
-
         $result = true;
 
        //Do not check unicity when creating infocoms or if checking is expliclty disabled


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !37274


since https://github.com/glpi-project/glpi/commit/146bea79034f9ed6487269fb580599dcc3a6c61a

(a long time ago)
![image](https://github.com/user-attachments/assets/7f406707-558c-4b80-bcb7-c950191d1645)

The uniqueness check is bypassed for templates.

For instance, if a uniqueness criterion is set on the name, GLPI does not prevent me from creating a template even if a name already exists.

Therefore, each time the template is used or when object with same name is updated, an error is displayed to alert about this uniqueness issue.



## Screenshots (if appropriate):


