### PR TITLE
Fix password history with empty previous password

### DIFF
--- a/phpunit/functional/PasswordHistoryTest.php
+++ b/phpunit/functional/PasswordHistoryTest.php
@@ -167,7 +167,6 @@ final class PasswordHistoryTest extends DbTestCase
             'user' => $user,
             'password' => "",
             'expected' => [],
-            'warning' => 'Unexpected empty password has not been added to passwords history.',
         ];
 
         // Update password with history disabled

--- a/src/PasswordHistory.php
+++ b/src/PasswordHistory.php
@@ -119,16 +119,16 @@ final class PasswordHistory
      * Must be called after a user password is updated
      *
      * @param User   $user
-     * @param string $password Previous user's password, which has just been replaced
+     * @param string|null $password Previous user's password, which has just been replaced
      *
      * @return bool
      */
-    public function updatePasswordHistory(User $user, string $password): bool
+    public function updatePasswordHistory(User $user, ?string $password): bool
     {
-        // No password change
         if (empty($password)) {
-            trigger_error("Unexpected empty password has not been added to passwords history.", E_USER_WARNING);
-            return false;
+            // There is no previous password to store. This is a normal case if a user is created without setting the password.
+            // Login attempts with an empty password are not accepted by Auth::validateLogin()
+            return true;
         }
 
         // Here $password should always be a hash and not a "real" password


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

Fix calls to `PasswordHistory::updatePasswordHistory` with an empty value for the password. Having a missing password is normal for local users if the user is created without setting a password. As far as I can tell, it has never been required to set a password for a new user and although the checkbox to send an email to the user to set their password forces a random password, it doesn't seem to have any use because login attempts with an empty password are blocked in `Auth::validateLogin` anyways.