### PR TITLE
Prevent conflicts in capacity configurations between asset definitions

### DIFF
--- a/src/Glpi/Asset/Asset.php
+++ b/src/Glpi/Asset/Asset.php
@@ -73,7 +73,7 @@ abstract class Asset extends CommonDBTM
     final public function __construct()
     {
         foreach (static::getDefinition()->getEnabledCapacities() as $capacity) {
-            $capacity->onObjectInstanciation($this);
+            $capacity->onObjectInstanciation($this, static::getDefinition()->getCapacityConfiguration($capacity));
         }
     }
 

--- a/src/Glpi/Asset/AssetDefinitionManager.php
+++ b/src/Glpi/Asset/AssetDefinitionManager.php
@@ -213,8 +213,7 @@ final class AssetDefinitionManager extends AbstractDefinitionManager
         foreach ($capacities as $capacity) {
             if ($definition->hasCapacityEnabled($capacity)) {
                 Profiler::getInstance()->start('Bootstrap ' . $capacity::class . ' on ' . $asset_class_name, Profiler::CATEGORY_CUSTOMOBJECTS);
-                $capacity->setConfiguration($definition->getCapacityConfiguration($capacity::class));
-                $capacity->onClassBootstrap($asset_class_name);
+                $capacity->onClassBootstrap($asset_class_name, $definition->getCapacityConfiguration($capacity::class));
                 Profiler::getInstance()->stop('Bootstrap ' . $capacity::class . ' on ' . $asset_class_name);
             }
         }

--- a/src/Glpi/Asset/Capacity/AbstractCapacity.php
+++ b/src/Glpi/Asset/Capacity/AbstractCapacity.php
@@ -48,8 +48,6 @@ use Log;
  */
 abstract class AbstractCapacity implements CapacityInterface
 {
-    protected CapacityConfig $config;
-
     /**
      * Constructor.
      *
@@ -185,11 +183,11 @@ abstract class AbstractCapacity implements CapacityInterface
         );
     }
 
-    public function onClassBootstrap(string $classname): void
+    public function onClassBootstrap(string $classname, CapacityConfig $config): void
     {
     }
 
-    public function onObjectInstanciation(Asset $object): void
+    public function onObjectInstanciation(Asset $object, CapacityConfig $config): void
     {
     }
 
@@ -355,16 +353,5 @@ abstract class AbstractCapacity implements CapacityInterface
                 [$itemtype]
             )
         );
-    }
-
-    public function setConfiguration(CapacityConfig $config): self
-    {
-        $this->config = $config;
-        return $this;
-    }
-
-    public function getConfiguration(): CapacityConfig
-    {
-        return $this->config ?? new CapacityConfig();
     }
 }

--- a/src/Glpi/Asset/Capacity/AllowedInGlobalSearchCapacity.php
+++ b/src/Glpi/Asset/Capacity/AllowedInGlobalSearchCapacity.php
@@ -65,7 +65,7 @@ class AllowedInGlobalSearchCapacity extends AbstractCapacity
         return '';
     }
 
-    public function onClassBootstrap(string $classname): void
+    public function onClassBootstrap(string $classname, CapacityConfig $config): void
     {
         $this->registerToTypeConfig('globalsearch_types', $classname);
     }

--- a/src/Glpi/Asset/Capacity/CapacityInterface.php
+++ b/src/Glpi/Asset/Capacity/CapacityInterface.php
@@ -114,14 +114,17 @@ interface CapacityInterface
      * Method executed during asset classes bootstraping.
      *
      * @param class-string<\Glpi\Asset\Asset> $classname
+     * @param CapacityConfig $config
      * @return void
      */
-    public function onClassBootstrap(string $classname): void;
+    public function onClassBootstrap(string $classname, CapacityConfig $config): void;
 
     /**
      * Method executed when capacity is enabled on given asset class.
      *
      * @param class-string<\Glpi\Asset\Asset> $classname
+     * @param CapacityConfig $config
+     * @return void
      */
     public function onCapacityEnabled(string $classname, CapacityConfig $config): void;
 
@@ -129,6 +132,8 @@ interface CapacityInterface
      * Method executed when capacity is disabled on given asset class.
      *
      * @param class-string<\Glpi\Asset\Asset> $classname
+     * @param CapacityConfig $config
+     * @return void
      */
     public function onCapacityDisabled(string $classname, CapacityConfig $config): void;
 
@@ -138,6 +143,7 @@ interface CapacityInterface
      * @param class-string<\Glpi\Asset\Asset> $classname
      * @param CapacityConfig $old_config
      * @param CapacityConfig $new_config
+     * @return void
      */
     public function onCapacityUpdated(string $classname, CapacityConfig $old_config, CapacityConfig $new_config): void;
 
@@ -145,23 +151,8 @@ interface CapacityInterface
      * Method executed during creation of an object instance (i.e. during `__construct()` method execution).
      *
      * @param Asset $object
+     * @param CapacityConfig $config
      * @return void
      */
-    public function onObjectInstanciation(Asset $object): void;
-
-    /**
-     * Set configuration
-     *
-     * @param CapacityConfig $config
-     *
-     * @return self
-     */
-    public function setConfiguration(CapacityConfig $config): self;
-
-    /**
-     * Get configuration
-     *
-     * @return CapacityConfig
-     */
-    public function getConfiguration(): CapacityConfig;
+    public function onObjectInstanciation(Asset $object, CapacityConfig $config): void;
 }

--- a/src/Glpi/Asset/Capacity/HasAntivirusCapacity.php
+++ b/src/Glpi/Asset/Capacity/HasAntivirusCapacity.php
@@ -85,7 +85,7 @@ class HasAntivirusCapacity extends AbstractCapacity
         );
     }
 
-    public function onClassBootstrap(string $classname): void
+    public function onClassBootstrap(string $classname, CapacityConfig $config): void
     {
         $this->registerToTypeConfig('itemantivirus_types', $classname);
 

--- a/src/Glpi/Asset/Capacity/HasAppliancesCapacity.php
+++ b/src/Glpi/Asset/Capacity/HasAppliancesCapacity.php
@@ -81,7 +81,7 @@ class HasAppliancesCapacity extends AbstractCapacity
         );
     }
 
-    public function onClassBootstrap(string $classname): void
+    public function onClassBootstrap(string $classname, CapacityConfig $config): void
     {
         $this->registerToTypeConfig('appliance_types', $classname);
         CommonGLPI::registerStandardTab($classname, Appliance_Item::class, 85);

--- a/src/Glpi/Asset/Capacity/HasCertificatesCapacity.php
+++ b/src/Glpi/Asset/Capacity/HasCertificatesCapacity.php
@@ -86,7 +86,7 @@ class HasCertificatesCapacity extends AbstractCapacity
         );
     }
 
-    public function onClassBootstrap(string $classname): void
+    public function onClassBootstrap(string $classname, CapacityConfig $config): void
     {
         $this->registerToTypeConfig('certificate_types', $classname);
 

--- a/src/Glpi/Asset/Capacity/HasContractsCapacity.php
+++ b/src/Glpi/Asset/Capacity/HasContractsCapacity.php
@@ -82,7 +82,7 @@ class HasContractsCapacity extends AbstractCapacity
     }
 
     // #Override
-    public function onClassBootstrap(string $classname): void
+    public function onClassBootstrap(string $classname, CapacityConfig $config): void
     {
         // Allow our item to be linked to contracts
         $this->registerToTypeConfig('contract_types', $classname);

--- a/src/Glpi/Asset/Capacity/HasDatabaseInstanceCapacity.php
+++ b/src/Glpi/Asset/Capacity/HasDatabaseInstanceCapacity.php
@@ -82,7 +82,7 @@ class HasDatabaseInstanceCapacity extends AbstractCapacity
         );
     }
 
-    public function onClassBootstrap(string $classname): void
+    public function onClassBootstrap(string $classname, CapacityConfig $config): void
     {
         $this->registerToTypeConfig('databaseinstance_types', $classname);
 

--- a/src/Glpi/Asset/Capacity/HasDevicesCapacity.php
+++ b/src/Glpi/Asset/Capacity/HasDevicesCapacity.php
@@ -128,7 +128,7 @@ class HasDevicesCapacity extends AbstractCapacity
         return $count;
     }
 
-    public function onClassBootstrap(string $classname): void
+    public function onClassBootstrap(string $classname, CapacityConfig $config): void
     {
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;

--- a/src/Glpi/Asset/Capacity/HasDocumentsCapacity.php
+++ b/src/Glpi/Asset/Capacity/HasDocumentsCapacity.php
@@ -81,7 +81,7 @@ class HasDocumentsCapacity extends AbstractCapacity
         );
     }
 
-    public function onClassBootstrap(string $classname): void
+    public function onClassBootstrap(string $classname, CapacityConfig $config): void
     {
         $this->registerToTypeConfig('document_types', $classname);
 

--- a/src/Glpi/Asset/Capacity/HasDomainsCapacity.php
+++ b/src/Glpi/Asset/Capacity/HasDomainsCapacity.php
@@ -81,7 +81,7 @@ class HasDomainsCapacity extends AbstractCapacity
         );
     }
 
-    public function onClassBootstrap(string $classname): void
+    public function onClassBootstrap(string $classname, CapacityConfig $config): void
     {
         $this->registerToTypeConfig('domain_types', $classname);
 

--- a/src/Glpi/Asset/Capacity/HasHistoryCapacity.php
+++ b/src/Glpi/Asset/Capacity/HasHistoryCapacity.php
@@ -73,7 +73,7 @@ class HasHistoryCapacity extends AbstractCapacity
         );
     }
 
-    public function onClassBootstrap(string $classname): void
+    public function onClassBootstrap(string $classname, CapacityConfig $config): void
     {
         CommonGLPI::registerStandardTab(
             $classname,
@@ -82,7 +82,7 @@ class HasHistoryCapacity extends AbstractCapacity
         );
     }
 
-    public function onObjectInstanciation(Asset $object): void
+    public function onObjectInstanciation(Asset $object, CapacityConfig $config): void
     {
         $object->dohistory = true;
     }

--- a/src/Glpi/Asset/Capacity/HasImpactCapacity.php
+++ b/src/Glpi/Asset/Capacity/HasImpactCapacity.php
@@ -105,7 +105,7 @@ class HasImpactCapacity extends AbstractCapacity
         return sprintf(__('%1$s impact relations involving %2$s assets'), $impact_count, $asset_count);
     }
 
-    public function onClassBootstrap(string $classname): void
+    public function onClassBootstrap(string $classname, CapacityConfig $config): void
     {
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;

--- a/src/Glpi/Asset/Capacity/HasInfocomCapacity.php
+++ b/src/Glpi/Asset/Capacity/HasInfocomCapacity.php
@@ -79,7 +79,7 @@ class HasInfocomCapacity extends AbstractCapacity
         );
     }
 
-    public function onClassBootstrap(string $classname): void
+    public function onClassBootstrap(string $classname, CapacityConfig $config): void
     {
         $this->registerToTypeConfig('infocom_types', $classname);
 

--- a/src/Glpi/Asset/Capacity/HasKnowbaseCapacity.php
+++ b/src/Glpi/Asset/Capacity/HasKnowbaseCapacity.php
@@ -82,7 +82,7 @@ class HasKnowbaseCapacity extends AbstractCapacity
         );
     }
 
-    public function onClassBootstrap(string $classname): void
+    public function onClassBootstrap(string $classname, CapacityConfig $config): void
     {
         $this->registerToTypeConfig('kb_types', $classname);
 

--- a/src/Glpi/Asset/Capacity/HasLinksCapacity.php
+++ b/src/Glpi/Asset/Capacity/HasLinksCapacity.php
@@ -92,7 +92,7 @@ class HasLinksCapacity extends AbstractCapacity
         return sprintf(__('%1$s links attached to %2$s assets'), $manualLinkCount + $externalLinkCount, $max);
     }
 
-    public function onClassBootstrap(string $classname): void
+    public function onClassBootstrap(string $classname, CapacityConfig $config): void
     {
         $this->registerToTypeConfig('link_types', $classname);
 

--- a/src/Glpi/Asset/Capacity/HasNetworkPortCapacity.php
+++ b/src/Glpi/Asset/Capacity/HasNetworkPortCapacity.php
@@ -80,7 +80,7 @@ class HasNetworkPortCapacity extends AbstractCapacity
         );
     }
 
-    public function onClassBootstrap(string $classname): void
+    public function onClassBootstrap(string $classname, CapacityConfig $config): void
     {
         $this->registerToTypeConfig('networkport_types', $classname);
 

--- a/src/Glpi/Asset/Capacity/HasNotepadCapacity.php
+++ b/src/Glpi/Asset/Capacity/HasNotepadCapacity.php
@@ -92,12 +92,12 @@ class HasNotepadCapacity extends AbstractCapacity
         );
     }
 
-    public function onClassBootstrap(string $classname): void
+    public function onClassBootstrap(string $classname, CapacityConfig $config): void
     {
         CommonGLPI::registerStandardTab($classname, Notepad::class, 80);
     }
 
-    public function onObjectInstanciation(Asset $object): void
+    public function onObjectInstanciation(Asset $object, CapacityConfig $config): void
     {
         $reflected_class = new ReflectionClass($object);
         $reflected_property = $reflected_class->getProperty('usenotepad');

--- a/src/Glpi/Asset/Capacity/HasOperatingSystemCapacity.php
+++ b/src/Glpi/Asset/Capacity/HasOperatingSystemCapacity.php
@@ -75,7 +75,7 @@ class HasOperatingSystemCapacity extends AbstractCapacity
     }
 
     // #Override
-    public function onClassBootstrap(string $classname): void
+    public function onClassBootstrap(string $classname, CapacityConfig $config): void
     {
         $this->registerToTypeConfig('operatingsystem_types', $classname);
 

--- a/src/Glpi/Asset/Capacity/HasPeripheralAssetsCapacity.php
+++ b/src/Glpi/Asset/Capacity/HasPeripheralAssetsCapacity.php
@@ -116,7 +116,7 @@ class HasPeripheralAssetsCapacity extends AbstractCapacity
         );
     }
 
-    public function onClassBootstrap(string $classname): void
+    public function onClassBootstrap(string $classname, CapacityConfig $config): void
     {
         // Allow the asset to be linked to peripheral asset
         $this->registerToTypeConfig('peripheralhost_types', $classname);

--- a/src/Glpi/Asset/Capacity/HasPlugCapacity.php
+++ b/src/Glpi/Asset/Capacity/HasPlugCapacity.php
@@ -81,7 +81,7 @@ class HasPlugCapacity extends AbstractCapacity
         );
     }
 
-    public function onClassBootstrap(string $classname): void
+    public function onClassBootstrap(string $classname, CapacityConfig $config): void
     {
         $this->registerToTypeConfig('plug_types', $classname);
 

--- a/src/Glpi/Asset/Capacity/HasRemoteManagementCapacity.php
+++ b/src/Glpi/Asset/Capacity/HasRemoteManagementCapacity.php
@@ -80,7 +80,7 @@ class HasRemoteManagementCapacity extends AbstractCapacity
         );
     }
 
-    public function onClassBootstrap(string $classname): void
+    public function onClassBootstrap(string $classname, CapacityConfig $config): void
     {
         $this->registerToTypeConfig('remote_management_types', $classname);
 

--- a/src/Glpi/Asset/Capacity/HasSocketCapacity.php
+++ b/src/Glpi/Asset/Capacity/HasSocketCapacity.php
@@ -81,7 +81,7 @@ class HasSocketCapacity extends AbstractCapacity
         );
     }
 
-    public function onClassBootstrap(string $classname): void
+    public function onClassBootstrap(string $classname, CapacityConfig $config): void
     {
         $this->registerToTypeConfig('socket_types', $classname);
 

--- a/src/Glpi/Asset/Capacity/HasSoftwaresCapacity.php
+++ b/src/Glpi/Asset/Capacity/HasSoftwaresCapacity.php
@@ -181,7 +181,7 @@ class HasSoftwaresCapacity extends AbstractCapacity
         );
     }
 
-    public function onClassBootstrap(string $classname): void
+    public function onClassBootstrap(string $classname, CapacityConfig $config): void
     {
         $this->registerToTypeConfig('software_types', $classname);
 

--- a/src/Glpi/Asset/Capacity/HasVirtualMachineCapacity.php
+++ b/src/Glpi/Asset/Capacity/HasVirtualMachineCapacity.php
@@ -85,7 +85,7 @@ class HasVirtualMachineCapacity extends AbstractCapacity
         );
     }
 
-    public function onClassBootstrap(string $classname): void
+    public function onClassBootstrap(string $classname, CapacityConfig $config): void
     {
         $this->registerToTypeConfig('itemvirtualmachines_types', $classname);
 

--- a/src/Glpi/Asset/Capacity/HasVolumesCapacity.php
+++ b/src/Glpi/Asset/Capacity/HasVolumesCapacity.php
@@ -85,7 +85,7 @@ class HasVolumesCapacity extends AbstractCapacity
         );
     }
 
-    public function onClassBootstrap(string $classname): void
+    public function onClassBootstrap(string $classname, CapacityConfig $config): void
     {
         $this->registerToTypeConfig('disk_types', $classname);
 

--- a/src/Glpi/Asset/Capacity/IsInventoriableCapacity.php
+++ b/src/Glpi/Asset/Capacity/IsInventoriableCapacity.php
@@ -121,7 +121,7 @@ class IsInventoriableCapacity extends AbstractCapacity
         );
     }
 
-    public function onClassBootstrap(string $classname): void
+    public function onClassBootstrap(string $classname, CapacityConfig $config): void
     {
         $this->registerToTypeConfig('inventory_types', $classname);
         $this->registerToTypeConfig('agent_types', $classname);
@@ -129,7 +129,7 @@ class IsInventoriableCapacity extends AbstractCapacity
         $this->registerToTypeConfig('process_types', $classname);
         $this->registerToTypeConfig('ruleimportasset_types', $classname);
 
-        if ($this->getConfiguration()->getValue('inventory_mainasset') === \Glpi\Inventory\MainAsset\GenericPrinterAsset::class) {
+        if ($config->getValue('inventory_mainasset') === \Glpi\Inventory\MainAsset\GenericPrinterAsset::class) {
             $this->registerToTypeConfig('printer_types', $classname);
         }
 

--- a/src/Glpi/Asset/Capacity/IsProjectAssetCapacity.php
+++ b/src/Glpi/Asset/Capacity/IsProjectAssetCapacity.php
@@ -80,7 +80,7 @@ class IsProjectAssetCapacity extends AbstractCapacity
         );
     }
 
-    public function onClassBootstrap(string $classname): void
+    public function onClassBootstrap(string $classname, CapacityConfig $config): void
     {
         // Allow our item to be linked to projects
         $this->registerToTypeConfig('project_asset_types', $classname);

--- a/src/Glpi/Asset/Capacity/IsRackableCapacity.php
+++ b/src/Glpi/Asset/Capacity/IsRackableCapacity.php
@@ -78,7 +78,7 @@ class IsRackableCapacity extends AbstractCapacity
         );
     }
 
-    public function onClassBootstrap(string $classname): void
+    public function onClassBootstrap(string $classname, CapacityConfig $config): void
     {
         $this->registerToTypeConfig('rackable_types', $classname);
     }

--- a/src/Glpi/Asset/Capacity/IsReservableCapacity.php
+++ b/src/Glpi/Asset/Capacity/IsReservableCapacity.php
@@ -74,7 +74,7 @@ class IsReservableCapacity extends AbstractCapacity
         );
     }
 
-    public function onClassBootstrap(string $classname): void
+    public function onClassBootstrap(string $classname, CapacityConfig $config): void
     {
         $this->registerToTypeConfig('reservation_types', $classname);
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Follows #19256.

`AbstractCapacity` instances are shared between every custom asset definition. Therefore, storing the configuration associated to a specific definition in an `AbstractCapacity` instance can result in unexpected conflicts.

To prevent this, the specific configuration can be passed to the `onClassBootstrap()` method, the same way t is done for `onCapacityEnabled()`/`onCapacityDisabled()`/...