### PR TITLE
Handle `marketplace` directory in `DbUtils::fixItemtypeCase()`

### DIFF
--- a/phpunit/functional/DbUtilsTest.php
+++ b/phpunit/functional/DbUtilsTest.php
@@ -1607,7 +1607,7 @@ class DbUtilsTest extends DbTestCase
     public static function fixItemtypeCaseProvider()
     {
         return [
-         // Bad case classnames matching and existing class file
+            // Bad case classnames matching and existing class file
             [
                 'itemtype' => 'myclass',
                 'expected' => 'MyClass',
@@ -1632,7 +1632,19 @@ class DbUtilsTest extends DbTestCase
                 'itemtype' => 'glpiplugin\\foo\\models\\foo\\bar_item',
                 'expected' => 'GlpiPlugin\\Foo\\Models\\Foo\\Bar_Item',
             ],
-         // Good case (should not be altered)
+            [
+                'itemtype' => 'PluginBarFooitem',
+                'expected' => 'PluginBarFooItem',
+            ],
+            [
+                'itemtype' => 'GlpiPluGin\\Bar\\Namespacedfoo',
+                'expected' => 'GlpiPlugin\\Bar\\NamespacedFoo',
+            ],
+            [
+                'itemtype' => 'glpiplugin\\bar\\models\\bar\\foo_item',
+                'expected' => 'GlpiPlugin\\Bar\\Models\\Bar\\Foo_Item',
+            ],
+            // Good case (should not be altered)
             [
                 'itemtype' => 'MyClass',
                 'expected' => 'MyClass',
@@ -1645,7 +1657,11 @@ class DbUtilsTest extends DbTestCase
                 'itemtype' => 'GlpiPlugin\\Foo\\NamespacedBar',
                 'expected' => 'GlpiPlugin\\Foo\\NamespacedBar',
             ],
-         // Not matching any class file (should not be altered)
+            [
+                'itemtype' => 'GlpiPlugin\\Bar\\NamespacedFoo',
+                'expected' => 'GlpiPlugin\\Bar\\NamespacedFoo',
+            ],
+            // Not matching any class file (should not be altered)
             [
                 'itemtype' => 'notanitemtype',
                 'expected' => 'notanitemtype',
@@ -1691,10 +1707,23 @@ class DbUtilsTest extends DbTestCase
                         ],
                     ],
                 ],
+                'marketplace' => [
+                    'bar' => [
+                        'src' => [
+                            'Models' => [
+                                'Bar' => [
+                                    'Foo_Item.php' => '',
+                                ],
+                            ],
+                            'NamespacedFoo.php' => '',
+                            'PluginBarFooItem.php' => '',
+                        ],
+                    ],
+                ],
             ]
         );
         $instance = new \DbUtils();
-        $result = $instance->fixItemtypeCase($itemtype, vfsStream::url('glpi'));
+        $result = $instance->fixItemtypeCase($itemtype, vfsStream::url('glpi'), [vfsStream::url('glpi/plugins'), vfsStream::url('glpi/marketplace')]);
         $this->assertEquals($expected, $result);
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

Replaces #19294.

`DbUtils::fixItemtypeCase()` was not scanning the plugins in the `marketplace` directory, and it was leading to unexpected "class not found" issues.

This is a backport of some changes already implemented in the `main` branch. Whitespaces changes should be ignored during the code review.