### PR TITLE
Fix save and preview

### DIFF
--- a/js/modules/Forms/EditorController.js
+++ b/js/modules/Forms/EditorController.js
@@ -31,7 +31,7 @@
  * ---------------------------------------------------------------------
  */
 
-/* global _, tinymce_editor_configs, getUUID, getRealInputWidth, sortable, tinymce, glpi_toast_info, glpi_toast_error, bootstrap, setupAjaxDropdown, setupAdaptDropdown */
+/* global _, tinymce_editor_configs, getUUID, getRealInputWidth, sortable, tinymce, glpi_toast_info, glpi_toast_error, bootstrap, setupAjaxDropdown, setupAdaptDropdown, setHasUnsavedChanges, hasUnsavedChanges */
 
 import { GlpiFormConditionEditorController } from './ConditionEditorController.js';
 
@@ -241,14 +241,9 @@ export class GlpiFormEditorController
             }
         });
 
-        let last_form_changes = window.glpiUnsavedFormChanges;
-        setInterval(() => {
-            if (last_form_changes !== window.glpiUnsavedFormChanges) {
-                this.#updatePreviewButton();
-            }
-            last_form_changes = window.glpiUnsavedFormChanges;
-        }, 500);
-
+        $(document).on('glpiFormChangeEvent', () => {
+            this.#updatePreviewButton();
+        });
 
         // Handle conditions strategy changes
         document.addEventListener('updated_strategy', (e) => {
@@ -466,7 +461,7 @@ export class GlpiFormEditorController
 
             // No specific instructions for these events.
             // They must still be kept here as they benefits from the common code
-            // like refreshUX() and glpiUnsavedFormChanges.
+            // like refreshUX().
             case "question-sort-update":
                 break;
 
@@ -543,7 +538,7 @@ export class GlpiFormEditorController
         }
 
         if (unsaved_changes) {
-            window.glpiUnsavedFormChanges = true;
+            setHasUnsavedChanges(true);
         }
 
         // Refresh all dynamic UX components after every action.
@@ -2207,7 +2202,7 @@ export class GlpiFormEditorController
     }
 
     #updatePreviewButton() {
-        if (window.glpiUnsavedFormChanges) {
+        if (hasUnsavedChanges()) {
             $(this.#target).find('[data-glpi-form-editor-preview-actions]')
                 .find('[data-glpi-form-editor-preview-action]').addClass('d-none');
             $(this.#target).find('[data-glpi-form-editor-preview-actions]')

--- a/js/modules/Forms/EditorController.js
+++ b/js/modules/Forms/EditorController.js
@@ -82,6 +82,11 @@ export class GlpiFormEditorController
     #conditions_editors_controllers;
 
     /**
+     * @type {boolean}
+     */
+    #do_preview_after_save = false;
+
+    /**
      * Create a new GlpiFormEditorController instance for the given target.
      * The target must be a valid form.
      *
@@ -218,13 +223,21 @@ export class GlpiFormEditorController
 
         // Handle form submit success event
         $(this.#target).on('glpi-ajax-controller-submit-success', () => {
+            const save_and_preview_button = $(this.#target).find(
+                '[data-glpi-form-editor-save-and-preview-action]'
+            );
+
             // Reset unsaved changes
             this.#updatePreviewButton();
 
-            const save_and_preview_button = $(this.#target).find('[data-glpi-form-editor-save-and-preview-action]');
-            if (save_and_preview_button.get(0) === $(document.activeElement).get(0)) {
+            // Check if a preview action was queued
+            if (this.#do_preview_after_save) {
                 // Open the preview page in a new tab
-                window.open(save_and_preview_button.data('glpi-form-editor-preview-url'), '_blank');
+                window.open(
+                    save_and_preview_button.data('glpi-form-editor-preview-url'),
+                    '_blank'
+                );
+                this.#do_preview_after_save = false;
             }
         });
 
@@ -518,6 +531,10 @@ export class GlpiFormEditorController
                 this.#copyQuestionUuidToClipboard(
                     target.closest('[data-glpi-form-editor-question')
                 );
+                break;
+
+            case "queue-preview":
+                this.#do_preview_after_save = true;
                 break;
 
             // Unknown action

--- a/templates/components/itilobject/timeline/pending_reasons.html.twig
+++ b/templates/components/itilobject/timeline/pending_reasons.html.twig
@@ -107,7 +107,7 @@
             // Mark the dropdown as initialized and reset the form modification flag to avoid triggering the unsaved changes warning
             if (!pendingReasonsInitalized{{ rand }}) {
                pendingReasonsInitalized{{ rand }} = true;
-               window.glpiUnsavedFormChanges = false;
+               setHasUnsavedChanges(false);
             }
 
             $('#dropdown_pendingreasons_id{{ rand }}').change(handlePendingReasonsChange{{ rand }});

--- a/templates/pages/admin/form/access_control/allow_list.html.twig
+++ b/templates/pages/admin/form/access_control/allow_list.html.twig
@@ -73,9 +73,9 @@
 
     // Make sure this doens't trigger the "unsaved changes" detection if the form
     // was not actually changed when this code is reached.
-    let restore_unsaved_form_status = window.glpiUnsavedFormChanges == false;
+    let restore_unsaved_form_status = hasUnsavedChanges() == false;
     $select.trigger('change');
     if (restore_unsaved_form_status) {
-        window.glpiUnsavedFormChanges = false;
+        setHasUnsavedChanges(false);
     }
 </script>

--- a/templates/pages/admin/form/form_editor.html.twig
+++ b/templates/pages/admin/form/form_editor.html.twig
@@ -198,6 +198,7 @@
                 name="update"
                 form="main-form"
                 title="{{ __("Save and preview") }}"
+                data-glpi-form-editor-on-click="queue-preview"
                 data-glpi-form-editor-save-and-preview-action
                 data-glpi-form-editor-preview-url="{{ path('/Form/Render/' ~ item.fields.id) }}"
             >


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.

## Description

First commit fix the #19370 issue ("Save and preview" button didn't save the changes).
Note that there is no E2E tests on this feature as the preview open inside a new browser tab and cypress can't deal with that (will be possible with playwright tho).

Second commit improve the unsaved form state detection (which changes the "Preview" button into the "Save and preview" button).

This is done by watching for a specific custom event that we trigger when `window.glpiUnsavedFormChanges` is changed, instead of the original code which was watching for changes every 0.5s.

To make it possible `window.glpiUnsavedFormChanges` must no longer be interacted with directly, instead you should use the new `setHasUnsavedChanges()` method.

