### PR TITLE
Test CSV export with a carriage return; closes #11406

### DIFF
--- a/phpunit/functional/Glpi/Csv/PlanningCsvTest.php
+++ b/phpunit/functional/Glpi/Csv/PlanningCsvTest.php
@@ -66,7 +66,7 @@ class PlanningCsvTest extends CsvTestCase
 
         $ticket = new \Ticket();
         $tid = (int)$ticket->add([
-            'name'         => 'ticket title',
+            'name'         => 'ticket \d\rtitle',
             'description'  => 'a description',
             'content'      => '',
             'entities_id'  => getItemByTypeName('Entity', '_test_root_entity', true)
@@ -132,7 +132,7 @@ class PlanningCsvTest extends CsvTestCase
         foreach ($tasks as $input) {
             $expected_content[] = [
                 'actor'     => $user->getFriendlyName(),
-                'title'     => 'ticket title',
+                'title'     => 'ticket \d\rtitle',
                 'itemtype'  => 'Ticket task',
                 'items_id'  => $input['id'],
                 'begindate' => $input['begin'],


### PR DESCRIPTION
Just a quick test for #11406. Success on main branch, and fail on 10.0 with the following:
```
GLPI dataset version 4.11 already loaded

PHPUnit 9.6.22 by Sebastian Bergmann and contributors.

..F                                                                 3 / 3 (100%)

Time: 00:00.847, Memory: 50.00 MB

There was 1 failure:

1) tests\units\Glpi\Csv\PlanningCsvTest::testGetFileContent
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
     0 => Array (...)
     1 => Array (
         'actor' => '_test_user'
-        'title' => 'ticket \d\rtitle'
+        'title' => 'ticket d\r
+        title'
         'itemtype' => 'Ticket task'
         'items_id' => 17
         'begindate' => '2024-10-09 06:37:36'
@@ @@
     )
     2 => Array (
         'actor' => '_test_user'
-        'title' => 'ticket \d\rtitle'
+        'title' => 'ticket d\r
+        title'
         'itemtype' => 'Ticket task'
         'items_id' => 18
         'begindate' => '2025-10-09 06:37:36'

glpi/phpunit/CsvTestCase.php:108
```