### PR TITLE
Fix error page display when database is corrupted

### DIFF
--- a/src/Glpi/Application/View/Extension/FrontEndAssetsExtension.php
+++ b/src/Glpi/Application/View/Extension/FrontEndAssetsExtension.php
@@ -187,7 +187,7 @@ class FrontEndAssetsExtension extends AbstractExtension
 
         $css = '';
 
-        if ($DB instanceof DBmysql && $DB->connected) {
+        if ($DB instanceof DBmysql && $DB->connected && $DB->tableExists(Entity::getTable())) {
             $entity = new Entity();
             if (isset($_SESSION['glpiactive_entity'])) {
                 // Apply active entity styles


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

If the database configuration files exists but targets an empty database (no tables at all), the error page is not correctly displayed, because it generates a subsequent error while trying to get the `custom_css` configuration from the root entity.

I propose to add a check to prevent the error page to failed to be displayed propertly.

## Screenshots (if appropriate):

After:
![image](https://github.com/user-attachments/assets/45cb09a1-8989-4fc8-bfc3-a9d3f350a890)

Before:
![image](https://github.com/user-attachments/assets/90e68b4c-5699-40e7-bbdb-35ae02064226)


