### PR TITLE
Improve(Planning): add option to display or not done event

### DIFF
--- a/js/planning.js
+++ b/js/planning.js
@@ -463,7 +463,9 @@ var GLPIPlanning  = {
                         ? GLPIPlanning.calendar.state.viewType
                         : options.default_view;
                     var display_done_events = 1;
-                    if (view_name.indexOf('list') >= 0) {
+
+                    // if we are in a list view or user doesn't want to see done events
+                    if (view_name.indexOf('list') >= 0 || !$('#WithDoneEvents').is(':checked')) {
                         display_done_events = 0;
                     }
                     return {

--- a/src/Planning.php
+++ b/src/Planning.php
@@ -904,7 +904,7 @@ JAVASCRIPT;
 
         return array_merge(
             $CFG_GLPI['planning_types'],
-            ['NotPlanned', 'OnlyBgEvents']
+            ['NotPlanned', 'OnlyBgEvents', 'WithDoneEvents']
         );
     }
 
@@ -936,11 +936,11 @@ JAVASCRIPT;
         $filters = &$_SESSION['glpi_plannings']['filters'];
         $index_color = 0;
         foreach (self::getPlanningTypes() as $planning_type) {
-            if (in_array($planning_type, ['NotPlanned', 'OnlyBgEvents']) || $planning_type::canView()) {
+            if (in_array($planning_type, ['NotPlanned', 'OnlyBgEvents', 'WithDoneEvents']) || $planning_type::canView()) {
                 if (!isset($filters[$planning_type])) {
                     $filters[$planning_type] = [
                         'color'   => self::getPaletteColor('ev', $index_color),
-                        'display' => !in_array($planning_type, ['NotPlanned', 'OnlyBgEvents']),
+                        'display' => !in_array($planning_type, ['NotPlanned', 'WithDoneEvents']),
                         'type'    => 'event_filter'
                     ];
                 }
@@ -1092,6 +1092,8 @@ JAVASCRIPT;
                 $title = __('Not planned tasks');
             } else if ($filter_key == 'OnlyBgEvents') {
                 $title = __('Only background events');
+            }  else if ($filter_key == 'WithDoneEvents') {
+                $title = __('with done events');
             } else {
                 if (!getItemForItemtype($filter_key)) {
                     return false;


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes  !37230

First PR in a series aimed at improving the performance of the planning feature in cases of intensive use.

This aims to add a filtering option to display or not (default is not) `done` events when : 

- `ExternalEvent` => state `done`
- `CommonITILTask`  => state `done`, or `CommonITILObject` linked with state => `closed`


Before "with 'done' event : 

![image](https://github.com/user-attachments/assets/193c781c-36e9-447b-822e-0dedd104757d)


After without 'done' event : 

![image](https://github.com/user-attachments/assets/477d2e6c-5d57-4451-a3aa-4bef122cb2fc)



## Screenshots (if appropriate):


