### PR TITLE
Fix `SKIP_UPDATES` handling during GLPI boot

### DIFF
--- a/front/cron.php
+++ b/front/cron.php
@@ -83,7 +83,7 @@ if (PHP_SAPI === 'cli') {
         exit();
     }
 
-    if (!defined('SKIP_UPDATES') && !Update::isDbUpToDate()) {
+    if (Update::isUpdateMandatory()) {
         echo 'The GLPI codebase has been updated. The update of the GLPI database is necessary.' . PHP_EOL;
         exit();
     }

--- a/phpunit/bootstrap.php
+++ b/phpunit/bootstrap.php
@@ -56,7 +56,7 @@ if (!file_exists(GLPI_CONFIG_DIR . '/config_db.php')) {
     echo("\nConfiguration file for tests not found\n\nrun: php bin/console database:install --env=testing ...\n\n");
     exit(1);
 }
-if (!defined('SKIP_UPDATES') && !Update::isDbUpToDate()) {
+if (Update::isUpdateMandatory()) {
     echo 'The GLPI codebase has been updated. The update of the GLPI database is necessary.' . PHP_EOL;
     exit(1);
 }

--- a/phpunit/functional/Glpi/Toolbox/VersionParserTest.php
+++ b/phpunit/functional/Glpi/Toolbox/VersionParserTest.php
@@ -48,6 +48,8 @@ class VersionParserTest extends \GLPITestCase
                 'version'             => '',
                 'keep_stability_flag' => false,
                 'normalized'          => '',
+                'major'               => '',
+                'intermediate'        => '',
                 'stable'              => true,
                 'dev'                 => false,
             ],
@@ -55,6 +57,8 @@ class VersionParserTest extends \GLPITestCase
                 'version'             => '9.5+2.0',
                 'keep_stability_flag' => false,
                 'normalized'          => '9.5+2.0', // not semver compatible, cannot be normalized
+                'major'               => '9',
+                'intermediate'        => '9.5',
                 'stable'              => true,
                 'dev'                 => false,
             ],
@@ -62,6 +66,8 @@ class VersionParserTest extends \GLPITestCase
                 'version'             => '0.89',
                 'keep_stability_flag' => false,
                 'normalized'          => '0.89.0',
+                'major'               => '0',
+                'intermediate'        => '0.89',
                 'stable'              => true,
                 'dev'                 => false,
             ],
@@ -69,6 +75,8 @@ class VersionParserTest extends \GLPITestCase
                 'version'             => '9.2',
                 'keep_stability_flag' => false,
                 'normalized'          => '9.2.0',
+                'major'               => '9',
+                'intermediate'        => '9.2',
                 'stable'              => true,
                 'dev'                 => false,
             ],
@@ -76,6 +84,8 @@ class VersionParserTest extends \GLPITestCase
                 'version'             => '9.2',
                 'keep_stability_flag' => true, // should have no effect
                 'normalized'          => '9.2.0',
+                'major'               => '9',
+                'intermediate'        => '9.2',
                 'stable'              => true,
                 'dev'                 => false,
             ],
@@ -83,6 +93,8 @@ class VersionParserTest extends \GLPITestCase
                 'version'             => '9.4.1.1',
                 'keep_stability_flag' => false,
                 'normalized'          => '9.4.1',
+                'major'               => '9',
+                'intermediate'        => '9.4',
                 'stable'              => true,
                 'dev'                 => false,
             ],
@@ -90,6 +102,8 @@ class VersionParserTest extends \GLPITestCase
                 'version'             => '10.0.0-dev',
                 'keep_stability_flag' => false,
                 'normalized'          => '10.0.0',
+                'major'               => '10',
+                'intermediate'        => '10.0',
                 'stable'              => false,
                 'dev'                 => true,
             ],
@@ -97,6 +111,8 @@ class VersionParserTest extends \GLPITestCase
                 'version'             => '10.0.0-dev',
                 'keep_stability_flag' => true,
                 'normalized'          => '10.0.0-dev',
+                'major'               => '10',
+                'intermediate'        => '10.0',
                 'stable'              => false,
                 'dev'                 => true,
             ],
@@ -104,6 +120,8 @@ class VersionParserTest extends \GLPITestCase
                 'version'             => '10.0.0-alpha',
                 'keep_stability_flag' => false,
                 'normalized'          => '10.0.0',
+                'major'               => '10',
+                'intermediate'        => '10.0',
                 'stable'              => false,
                 'dev'                 => false,
             ],
@@ -111,6 +129,8 @@ class VersionParserTest extends \GLPITestCase
                 'version'             => '10.0.0-alpha2',
                 'keep_stability_flag' => true,
                 'normalized'          => '10.0.0-alpha2',
+                'major'               => '10',
+                'intermediate'        => '10.0',
                 'stable'              => false,
                 'dev'                 => false,
             ],
@@ -118,6 +138,8 @@ class VersionParserTest extends \GLPITestCase
                 'version'             => '10.0.0-beta1',
                 'keep_stability_flag' => false,
                 'normalized'          => '10.0.0',
+                'major'               => '10',
+                'intermediate'        => '10.0',
                 'stable'              => false,
                 'dev'                 => false,
             ],
@@ -125,6 +147,8 @@ class VersionParserTest extends \GLPITestCase
                 'version'             => '10.0.0-beta1',
                 'keep_stability_flag' => true,
                 'normalized'          => '10.0.0-beta1',
+                'major'               => '10',
+                'intermediate'        => '10.0',
                 'stable'              => false,
                 'dev'                 => false,
             ],
@@ -132,6 +156,8 @@ class VersionParserTest extends \GLPITestCase
                 'version'             => '10.0.0-rc3',
                 'keep_stability_flag' => false,
                 'normalized'          => '10.0.0',
+                'major'               => '10',
+                'intermediate'        => '10.0',
                 'stable'              => false,
                 'dev'                 => false,
             ],
@@ -139,6 +165,8 @@ class VersionParserTest extends \GLPITestCase
                 'version'             => '10.0.0-rc',
                 'keep_stability_flag' => true,
                 'normalized'          => '10.0.0-rc',
+                'major'               => '10',
+                'intermediate'        => '10.0',
                 'stable'              => false,
                 'dev'                 => false,
             ],
@@ -146,6 +174,8 @@ class VersionParserTest extends \GLPITestCase
                 'version'             => '10.0.3',
                 'keep_stability_flag' => true,
                 'normalized'          => '10.0.3',
+                'major'               => '10',
+                'intermediate'        => '10.0',
                 'stable'              => true,
                 'dev'                 => false,
             ],
@@ -153,21 +183,36 @@ class VersionParserTest extends \GLPITestCase
     }
 
     #[DataProvider('versionsProvider')]
-    public function testGetNormalizeVersion(string $version, bool $keep_stability_flag, string $normalized, bool $stable, bool $dev): void
+    public function testGetNormalizeVersion(string $version, bool $keep_stability_flag, string $normalized, string $major, string $intermediate, bool $stable, bool $dev): void
     {
         $version_parser = new \Glpi\Toolbox\VersionParser();
         $this->assertEquals($normalized, $version_parser->getNormalizedVersion($version, $keep_stability_flag));
     }
 
     #[DataProvider('versionsProvider')]
-    public function testIsStableRelease(string $version, bool $keep_stability_flag, string $normalized, bool $stable, bool $dev): void
+    public function testGetMajorVersion(string $version, bool $keep_stability_flag, string $normalized, string $major, string $intermediate, bool $stable, bool $dev): void
+    {
+        $version_parser = new \Glpi\Toolbox\VersionParser();
+        $this->assertEquals($major, $version_parser->getMajorVersion($version));
+    }
+
+    #[DataProvider('versionsProvider')]
+    public function testGetIntermediateVersion(string $version, bool $keep_stability_flag, string $normalized, string $major, string $intermediate, bool $stable, bool $dev): void
+    {
+        $version_parser = new \Glpi\Toolbox\VersionParser();
+        $this->assertEquals($intermediate, $version_parser->getIntermediateVersion($version));
+    }
+
+
+    #[DataProvider('versionsProvider')]
+    public function testIsStableRelease(string $version, bool $keep_stability_flag, string $normalized, string $major, string $intermediate, bool $stable, bool $dev): void
     {
         $version_parser = new \Glpi\Toolbox\VersionParser();
         $this->assertSame($stable, $version_parser->isStableRelease($version));
     }
 
     #[DataProvider('versionsProvider')]
-    public function testIsDevVersion(string $version, bool $keep_stability_flag, string $normalized, bool $stable, bool $dev): void
+    public function testIsDevVersion(string $version, bool $keep_stability_flag, string $normalized, string $major, string $intermediate, bool $stable, bool $dev): void
     {
         $version_parser = new \Glpi\Toolbox\VersionParser();
         $this->assertSame($dev, $version_parser->isDevVersion($version));

--- a/phpunit/functional/ImpactTest.php
+++ b/phpunit/functional/ImpactTest.php
@@ -564,8 +564,6 @@ class ImpactTest extends \DbTestCase
          */
         global $CFG_GLPI, $PLUGIN_HOOKS;
 
-        (new Plugin())->init(true); // The `tester` plugin must be considered as loaded/active.
-
         $PLUGIN_HOOKS[Hooks::SET_ITEM_IMPACT_ICON]['tester'] = function (array $params) {
             if ($params['itemtype'] === 'PluginTesterMyAsset') {
                 return $params['items_id'] > 0

--- a/phpunit/imap/MailCollectorTest.php
+++ b/phpunit/imap/MailCollectorTest.php
@@ -1345,8 +1345,6 @@ PLAINTEXT,
     ) {
         global $PLUGIN_HOOKS;
 
-        (new \Plugin())->init(true); // The `tester` plugin must be considered as loaded/active.
-
         $hooks_backup = $PLUGIN_HOOKS;
 
         $PLUGIN_HOOKS['mail_server_protocols']['tester'] = function () use ($hook_result) {

--- a/src/Glpi/Http/Listener/CheckIfUpdateNeededListener.php
+++ b/src/Glpi/Http/Listener/CheckIfUpdateNeededListener.php
@@ -62,9 +62,8 @@ final readonly class CheckIfUpdateNeededListener implements EventSubscriberInter
         }
 
         if (
-            \defined('SKIP_UPDATES')
-            || Update::isDbUpToDate()
-            || !$this->shouldCheckDbStatus($event->getRequest())
+            !$this->shouldCheckDbStatus($event->getRequest())
+            || !Update::isUpdateMandatory()
         ) {
             return;
         }

--- a/src/Glpi/Kernel/Listener/CustomObjectsAutoloaderRegistration.php
+++ b/src/Glpi/Kernel/Listener/CustomObjectsAutoloaderRegistration.php
@@ -34,17 +34,17 @@
 
 namespace Glpi\Kernel\Listener;
 
-use DBConnection;
 use Glpi\Asset\AssetDefinitionManager;
 use Glpi\Debug\Profiler;
 use Glpi\Dropdown\DropdownDefinitionManager;
 use Glpi\Kernel\ListenersPriority;
 use Glpi\Kernel\PostBootEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Update;
 
 final readonly class CustomObjectsAutoloaderRegistration implements EventSubscriberInterface
 {
+    use PostBootListenerTrait;
+
     public static function getSubscribedEvents(): array
     {
         return [
@@ -54,7 +54,7 @@ final readonly class CustomObjectsAutoloaderRegistration implements EventSubscri
 
     public function onPostBoot(): void
     {
-        if (!DBConnection::isDbAvailable() || (!defined('SKIP_UPDATES') && !Update::isDbUpToDate())) {
+        if (!$this->canUseDbToInitServices()) {
             // Requires the database to be available.
             return;
         }

--- a/src/Glpi/Kernel/Listener/InitializePlugins.php
+++ b/src/Glpi/Kernel/Listener/InitializePlugins.php
@@ -34,7 +34,6 @@
 
 namespace Glpi\Kernel\Listener;
 
-use DBConnection;
 use GLPI;
 use Glpi\Debug\Profiler;
 use Glpi\DependencyInjection\PluginContainer;
@@ -42,10 +41,11 @@ use Glpi\Kernel\ListenersPriority;
 use Glpi\Kernel\PostBootEvent;
 use Plugin;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Update;
 
 final readonly class InitializePlugins implements EventSubscriberInterface
 {
+    use PostBootListenerTrait;
+
     public function __construct(private PluginContainer $pluginContainer)
     {
     }
@@ -59,7 +59,7 @@ final readonly class InitializePlugins implements EventSubscriberInterface
 
     public function onPostBoot(): void
     {
-        if (!DBConnection::isDbAvailable() || (!defined('SKIP_UPDATES') && !Update::isDbUpToDate())) {
+        if (!$this->canUseDbToInitServices()) {
             // Requires the database to be available.
             return;
         }

--- a/src/Glpi/Toolbox/VersionParser.php
+++ b/src/Glpi/Toolbox/VersionParser.php
@@ -77,6 +77,26 @@ class VersionParser
     }
 
     /**
+     * Get major version number (e.g. '9').
+     */
+    public static function getMajorVersion(string $version): string
+    {
+        $normalized = self::getNormalizedVersion($version, false);
+
+        return \preg_replace('/^(\d+)[^d].+$/', '$1', $normalized);
+    }
+
+    /**
+     * Get intermediate version number (e.g. '9.5').
+     */
+    public static function getIntermediateVersion(string $version): string
+    {
+        $normalized = self::getNormalizedVersion($version, false);
+
+        return \preg_replace('/^(\d+\.\d+)[^d].+$/', '$1', $normalized);
+    }
+
+    /**
      * Check if given version is a stable release (i.e. does not contain a stability flag referring to unstable state).
      *
      * @param string $version

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -285,12 +285,6 @@ class Plugin extends CommonDBTM
         self::$activated_plugins = [];
         self::$loaded_plugins = [];
 
-        if (!($DB instanceof DBmysql) || !$DB->connected) {
-            // Cannot init plugins list if DB is not connected
-            self::$plugins_state_checked = true;
-            return;
-        }
-
         $this->checkStates(false);
 
         $plugins = $this->find(['state' => [self::ACTIVATED, self::TOBECONFIGURED]]);

--- a/src/Update.php
+++ b/src/Update.php
@@ -521,16 +521,36 @@ class Update
             return false; // Considered as outdated if installed version is unknown.
         }
 
-        $installed_version = trim($CFG_GLPI['dbversion']);
-        $defined_version   = GLPI_SCHEMA_VERSION;
+        $installed_db_version = trim($CFG_GLPI['dbversion']);
+        $defined_db_version   = GLPI_SCHEMA_VERSION;
 
-        if (!str_contains($installed_version, '@') || !str_contains($defined_version, '@')) {
+        if (!str_contains($installed_db_version, '@') || !str_contains($defined_db_version, '@')) {
             // Either installed or defined version is not containing schema hash.
             // Hash is removed from both to do a simple version comparison.
-            $installed_version = preg_replace('/@.+$/', '', $installed_version);
-            $defined_version   = preg_replace('/@.+$/', '', $defined_version);
+            $installed_db_version = preg_replace('/@.+$/', '', $installed_db_version);
+            $defined_db_version   = preg_replace('/@.+$/', '', $defined_db_version);
         }
 
-        return $installed_version === $defined_version;
+        return $installed_db_version === $defined_db_version;
+    }
+
+    /**
+     * Check if database update is mandatory.
+     *
+     * @return bool
+     */
+    public static function isUpdateMandatory(): bool
+    {
+        /** @var array $CFG_GLPI */
+        global $CFG_GLPI;
+
+        if (defined('SKIP_UPDATES')) {
+            // If `SKIP_UPDATES`, bugfixes update are not mandatory.
+            $installed_intermediate_version = VersionParser::getIntermediateVersion($CFG_GLPI['version'] ?? '0.0.0-dev');
+            $defined_intermediate_version   = VersionParser::getIntermediateVersion(GLPI_VERSION);
+            return $installed_intermediate_version !== $defined_intermediate_version;
+        }
+
+        return self::isDbUpToDate() === false;
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -54,7 +54,7 @@ if (!file_exists(GLPI_CONFIG_DIR . '/config_db.php')) {
     echo("\nConfiguration file for tests not found\n\nrun: php bin/console database:install --env=testing ...\n\n");
     exit(1);
 }
-if (!defined('SKIP_UPDATES') && !Update::isDbUpToDate()) {
+if (Update::isUpdateMandatory()) {
     echo 'The GLPI codebase has been updated. The update of the GLPI database is necessary.' . PHP_EOL;
     exit(1);
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

It fixes #19250.

The checks based on `SKIP_UPDATES` in the post boot listeners were wrong. Indeed, they were considering a totaly empty DB as a available and it results in errors when trying to init plugins or load custome objects definitions.

I fixed this, and I changed a bit the `SKIP_UPDATES` behaviour. Now, it will not allow to skip the update when a new intermediate/major version is available. Indeed, it is probably a bad idea to allow skipping and intermediate/major update, as it often contains structural changes in the DB.

Now the behaviour changed, I wonder if we should not replace `defined('SKIP_UPDATES')`  checks by `GLPI_ENVIRONMENT === 'development'`, to be sure to be able to use this behaviour only in dev environment, and to be sure to have the same behaviour on all developers machines.