### PR TITLE
Fix associated_items.cy.js

### DIFF
--- a/js/modules/Forms/FieldDestinationAssociatedItem.js
+++ b/js/modules/Forms/FieldDestinationAssociatedItem.js
@@ -59,6 +59,11 @@ export class GlpiFormFieldDestinationAssociatedItem {
     #specific_values_template;
 
     /**
+     * @type {number}
+     */
+    #last_used_dropdown_index = 0;
+
+    /**
      * @param {jQuery<HTMLElement>} specific_values_extra_field
      */
     constructor(
@@ -151,8 +156,7 @@ export class GlpiFormFieldDestinationAssociatedItem {
             }
         });
 
-
-        const id = getUUID();
+        const id = this.#last_used_dropdown_index++;
         const itemtype_select_id = field.find(`select[name="${itemtype_name}"]`).attr('id');
 
         // Replace the old id by the new one

--- a/src/Glpi/Form/Destination/CommonITILField/AssociatedItemsField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/AssociatedItemsField.php
@@ -78,6 +78,9 @@ final class AssociatedItemsField extends AbstractConfigField implements Destinat
         }
 
         $twig = TemplateRenderer::getInstance();
+        $associated_items = $config->getSpecificAssociatedItems();
+        ksort($associated_items);
+
         return $twig->render('pages/admin/form/itil_config_fields/associated_items.html.twig', [
             // Possible configuration constant that will be used to to hide/show additional fields
             'CONFIG_SPECIFIC_VALUES'  => AssociatedItemsFieldStrategy::SPECIFIC_VALUES->value,
@@ -93,7 +96,7 @@ final class AssociatedItemsField extends AbstractConfigField implements Destinat
                 'items_id_aria_label' => __("Select the item to associate..."),
                 'input_name'          => $input_name . "[" . AssociatedItemsFieldConfig::SPECIFIC_ASSOCIATED_ITEMS . "]",
                 'itemtypes'           => array_keys(CommonITILObject::getAllTypesForHelpdesk()),
-                'associated_items'    => $config->getSpecificAssociatedItems(),
+                'associated_items'    => $associated_items,
             ],
 
             // Specific additional config for SPECIFIC_ANSWERS strategy


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
   -> Covered by existing tests.

## Description

The `associated_items.cy.js` is the most common test that randomly fails on the CI so I decided to take a look at it.
It turns out it is actually not the test that is flaky, but dropdowns inside GLPI that are not correctly initialized.

This is caused by some JS cause that use an UUID as a `rand` value:

![image](https://github.com/user-attachments/assets/88b85485-d153-402a-bead-f909a9d653a3)

The ajax response truncate it because `rand` is supposed to be an integer:

![image](https://github.com/user-attachments/assets/1ef4fba7-a37f-4ec1-aa42-fe5e23e71d9b)

So `1a181201-df8c-4ae2-bfd2-d6e92a9d18dc` becomes `1` and as you can imagine this can quickly lead to conflicts as we add more and more dropdowns on the associated items config page.

This is fixed by my second commit.

The first commit fix a sorting issue that didn't affect the CI but was causing error locally if you were on MySQL (the CI is on MariaDB) due to some differences in how JSON keys are sorted when stored in the DB.

