### PR TITLE
fix(forms): Fixed how translation handlers are retrieved to work with horizontal layout

### DIFF
--- a/phpunit/functional/Glpi/Form/Translation/FormTranslationTest.php
+++ b/phpunit/functional/Glpi/Form/Translation/FormTranslationTest.php
@@ -126,6 +126,31 @@ class FormTranslationTest extends \DbTestCase
         }
     }
 
+    public function testListTranslationHandlersFromFormWithHorizontalLayout(): void
+    {
+        $form_builder = (new FormBuilder())
+            ->addQuestion(
+                name: 'First question in first section',
+                type: QuestionTypeShortText::class,
+                horizontal_rank: 0,
+            )
+            ->addQuestion(
+                name: 'Second question in first section',
+                type: QuestionTypeShortText::class,
+                horizontal_rank: 1,
+            )
+            ->addQuestion(
+                name: 'Third question in first section',
+                type: QuestionTypeShortText::class,
+                horizontal_rank: 2,
+            );
+        $form = $this->createForm($form_builder);
+        $this->assertCount(
+            4, // Form name + 3 question titles
+            $form->listTranslationsHandlers()
+        );
+    }
+
     public function createFormWithTranslations(): Form
     {
         $form_builder = (new FormBuilder())

--- a/src/Glpi/Form/Section.php
+++ b/src/Glpi/Form/Section.php
@@ -157,10 +157,13 @@ final class Section extends CommonDBChild implements ConditionableVisibilityInte
             }
         }
 
-        $blocks_handlers = array_map(
-            fn(ProvideTranslationsInterface $block) => $block->listTranslationsHandlers(),
-            $this->getBlocks()
-        );
+        $blocks_handlers = [];
+        foreach ($this->getBlocks() as $block) {
+            $blocks_to_process = is_array($block) ? $block : [$block];
+            foreach ($blocks_to_process as $b) {
+                $blocks_handlers[] = $b->listTranslationsHandlers();
+            }
+        }
 
         return array_merge($handlers, ...$blocks_handlers);
     }
@@ -170,7 +173,7 @@ final class Section extends CommonDBChild implements ConditionableVisibilityInte
      * Block can be a question or a comment
      * Each block implements BlockInterface and extends CommonDBChild
      *
-     * @return array<int, (BlockInterface & CommonDBChild)[]>
+     * @return array<int, (BlockInterface & CommonDBChild)|(BlockInterface & CommonDBChild)[]>
      */
     public function getBlocks(): array
     {

--- a/tests/src/FormBuilder.php
+++ b/tests/src/FormBuilder.php
@@ -389,6 +389,7 @@ class FormBuilder
         ?string $extra_data = "",
         string $description = "",
         bool $is_mandatory = false,
+        ?int $horizontal_rank = null,
     ): self {
         // Add first section if missing
         if (empty($this->sections)) {
@@ -397,12 +398,13 @@ class FormBuilder
 
         // Add question into last section
         $this->sections[count($this->sections) - 1]['questions'][] = [
-            'name'          => $name,
-            'type'          => $type,
-            'default_value' => $default_value,
-            'extra_data'    => $extra_data,
-            'description'   => $description,
-            'is_mandatory'  => $is_mandatory,
+            'name'            => $name,
+            'type'            => $type,
+            'default_value'   => $default_value,
+            'extra_data'      => $extra_data,
+            'description'     => $description,
+            'is_mandatory'    => $is_mandatory,
+            'horizontal_rank' => $horizontal_rank,
         ];
 
         return $this;

--- a/tests/src/FormTesterTrait.php
+++ b/tests/src/FormTesterTrait.php
@@ -108,6 +108,7 @@ trait FormTesterTrait
                     'description'       => $question_data['description'],
                     'default_value'     => $question_data['default_value'],
                     'extra_data'        => $question_data['extra_data'],
+                    'horizontal_rank'   => $question_data['horizontal_rank'],
                     'vertical_rank'     => $question_rank++,
                 ], [
                     'default_value', // The default value can be formatted by the question type


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

It fixes #19369
Since it is now possible to define a horizontal layout for questions and comments on a form, the method used to retrieve elements has changed signature.
The method that retrieves elements for translation has not been modified accordingly.