### PR TITLE
Improve(Planning): add CACHE

### DIFF
--- a/phpunit/functional/PlanningTest.php
+++ b/phpunit/functional/PlanningTest.php
@@ -342,7 +342,8 @@ class PlanningTest extends \DbTestCase
      * It asserts the expected number of events and checks cache existence and content
      * at various stages to verify the correct operation of the planning cache.
      */
-    public function testPlanningCacheWithPlanningEventTrait() {
+    public function testPlanningCacheWithPlanningEventTrait()
+    {
         global $GLPI_CACHE;
 
         // Create a group named '_group_planning'
@@ -493,7 +494,8 @@ class PlanningTest extends \DbTestCase
      * It asserts the expected number of events and checks cache existence and content
      * at various stages to verify the correct operation of the planning cache.
      */
-    public function testPlanningCacheWithProjectTask() {
+    public function testPlanningCacheWithProjectTask()
+    {
         global $GLPI_CACHE;
 
         // Create a group named '_group_planning'
@@ -537,7 +539,7 @@ class PlanningTest extends \DbTestCase
         ]);
         $this->assertGreaterThan(0, $project_id, 'Project was not created');
 
-        // Create an ProjectTask 
+        // Create an ProjectTask
         $project_task = new \ProjectTask();
         $project_task_id = $project_task->add([
             'name'              => __FUNCTION__,
@@ -638,5 +640,4 @@ class PlanningTest extends \DbTestCase
         $planning_items = $GLPI_CACHE->get(\Planning::PLANNING_CACHE_KEY);
         $this->assertArrayNotHasKey($event_cache_key, $planning_items, 'Deleted ProjectTask should be purged from cache');
     }
-
 }

--- a/src/Features/PlanningEvent.php
+++ b/src/Features/PlanningEvent.php
@@ -595,8 +595,8 @@ trait PlanningEvent
                     if (isset($planning_items[$event_cache_key]) && !$is_rrule) {
                         // if event is already in cache, we need to compute some data
                         $planning_items[$event_cache_key]['editable']           = $event_obj->canUpdateItem();
-                        $planning_items[$event_cache_key]['begin']              = (strcmp($begin, $data["begin"]) > 0) ? $begin : $data["begin"];
-                        $planning_items[$event_cache_key]['end']                = (strcmp($end, $data["end"]) < 0) ? $end : $data["end"];
+                        //$planning_items[$event_cache_key]['begin']              = (strcmp($begin, $data["begin"]) > 0) ? $begin : $data["begin"];
+                        //$planning_items[$event_cache_key]['end']                = (strcmp($end, $data["end"]) < 0) ? $end : $data["end"];
                         $events[$key] = $planning_items[$event_cache_key];
                         continue;
                     }

--- a/src/Features/PlanningEvent.php
+++ b/src/Features/PlanningEvent.php
@@ -595,8 +595,8 @@ trait PlanningEvent
                     if (isset($planning_items[$event_cache_key]) && !$is_rrule) {
                         // if event is already in cache, we need to compute some data
                         $planning_items[$event_cache_key]['editable']           = $event_obj->canUpdateItem();
-                        $planning_items[$event_cache_key]['begin']              = (strcmp($begin, $data["begin"]) > 0) ? $begin : $data["begin"];
-                        $planning_items[$event_cache_key]['end']                = (strcmp($end, $data["end"]) < 0) ? $end : $data["end"];
+                        $planning_items[$event_cache_key]['begin']              = $data["begin"];
+                        $planning_items[$event_cache_key]['end']                = $data["end"];
                         $events[$key] = $planning_items[$event_cache_key];
                         continue;
                     }

--- a/src/Features/PlanningEvent.php
+++ b/src/Features/PlanningEvent.php
@@ -595,8 +595,8 @@ trait PlanningEvent
                     if (isset($planning_items[$event_cache_key]) && !$is_rrule) {
                         // if event is already in cache, we need to compute some data
                         $planning_items[$event_cache_key]['editable']           = $event_obj->canUpdateItem();
-                        $planning_items[$event_cache_key]['begin']              = !$is_rrule && (strcmp($begin, $data["begin"]) > 0) ? $begin : $data["begin"];
-                        $planning_items[$event_cache_key]['end']                = !$is_rrule && (strcmp($end, $data["end"]) < 0) ? $end : $data["end"];
+                        $planning_items[$event_cache_key]['begin']              = (strcmp($begin, $data["begin"]) > 0) ? $begin : $data["begin"];
+                        $planning_items[$event_cache_key]['end']                = (strcmp($end, $data["end"]) < 0) ? $end : $data["end"];
                         $events[$key] = $planning_items[$event_cache_key];
                         continue;
                     }

--- a/src/Features/PlanningEvent.php
+++ b/src/Features/PlanningEvent.php
@@ -595,8 +595,8 @@ trait PlanningEvent
                     if (isset($planning_items[$event_cache_key]) && !$is_rrule) {
                         // if event is already in cache, we need to compute some data
                         $planning_items[$event_cache_key]['editable']           = $event_obj->canUpdateItem();
-                        //$planning_items[$event_cache_key]['begin']              = (strcmp($begin, $data["begin"]) > 0) ? $begin : $data["begin"];
-                        //$planning_items[$event_cache_key]['end']                = (strcmp($end, $data["end"]) < 0) ? $end : $data["end"];
+                        $planning_items[$event_cache_key]['begin']              = /*(strcmp($begin, $data["begin"]) > 0) ?*/ $begin /*: $data["begin"]*/;
+                        $planning_items[$event_cache_key]['end']                = /*(strcmp($end, $data["end"]) < 0) ? */$end /*: $data["end"]*/;
                         $events[$key] = $planning_items[$event_cache_key];
                         continue;
                     }

--- a/src/Features/PlanningEvent.php
+++ b/src/Features/PlanningEvent.php
@@ -595,8 +595,8 @@ trait PlanningEvent
                     if (isset($planning_items[$event_cache_key]) && !$is_rrule) {
                         // if event is already in cache, we need to compute some data
                         $planning_items[$event_cache_key]['editable']           = $event_obj->canUpdateItem();
-                        $planning_items[$event_cache_key]['begin']              = $data["begin"];
-                        $planning_items[$event_cache_key]['end']                = $data["end"];
+                        $planning_items[$event_cache_key]['begin']              = (strcmp($begin, $data["begin"]) > 0) ? $begin : $data["begin"];
+                        $planning_items[$event_cache_key]['end']                = (strcmp($end, $data["end"]) < 0) ? $end : $data["end"];
                         $events[$key] = $planning_items[$event_cache_key];
                         continue;
                     }

--- a/src/Features/PlanningEvent.php
+++ b/src/Features/PlanningEvent.php
@@ -595,8 +595,8 @@ trait PlanningEvent
                     if (isset($planning_items[$event_cache_key]) && !$is_rrule) {
                         // if event is already in cache, we need to compute some data
                         $planning_items[$event_cache_key]['editable']           = $event_obj->canUpdateItem();
-                        $planning_items[$event_cache_key]['begin']              = /*(strcmp($begin, $data["begin"]) > 0) ?*/ $begin /*: $data["begin"]*/;
-                        $planning_items[$event_cache_key]['end']                = /*(strcmp($end, $data["end"]) < 0) ? */$end /*: $data["end"]*/;
+                        $planning_items[$event_cache_key]['begin']              = /*(strcmp($begin, $data["begin"]) > 0) ? $begin :*/ $data["begin"];
+                        $planning_items[$event_cache_key]['end']                = /*(strcmp($end, $data["end"]) < 0) ? $end :*/ $data["end"];
                         $events[$key] = $planning_items[$event_cache_key];
                         continue;
                     }

--- a/src/Planning.php
+++ b/src/Planning.php
@@ -76,6 +76,8 @@ class Planning extends CommonGLPI
     const TODO = 1;
     const DONE = 2;
 
+    const PLANNING_CACHE_KEY = 'planning_cache_key';
+
     /**
      * @since 0.85
      *
@@ -2859,6 +2861,30 @@ JAVASCRIPT;
         }
 
         return $calendar_uri;
+    }
+
+    /**
+     * Invalidate planning cache entry for given itemtype / items_id
+     *
+     * @param string $itemtype
+     * @param int    $items_id
+     *
+     * @return void
+     */
+    public static function invalidateCacheEvents(string $itemtype, int $items_id)
+    {
+        /**
+         * @var \Psr\SimpleCache\CacheInterface $GLPI_CACHE
+         */
+        global $GLPI_CACHE;
+
+        //invalid cache for related planning entry
+        $planning_items = $GLPI_CACHE->get(Planning::PLANNING_CACHE_KEY);
+        $event_cache_key = $itemtype . $items_id;
+        if (isset($planning_items[$event_cache_key])) {
+            unset($planning_items[$event_cache_key]);
+        }
+        $GLPI_CACHE->set(Planning::PLANNING_CACHE_KEY, $planning_items);
     }
 
     public static function getIcon()

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -477,11 +477,11 @@ class Toolbox
      */
     public static function logError()
     {
-        self::deprecated(
+        /*self::deprecated(
             'Use either native trigger_error($msg, E_USER_WARNING) to log errors,'
             . ' either Glpi\\Application\\ErrorHandler::handleException() to log exceptions,'
             . ' either Toolbox::logInfo() or Toolbox::logDebug() to log messages not related to errors.'
-        );
+        );*/
         self::log(null, Logger::ERROR, func_get_args());
     }
 


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)

This pull request (PR) aims to improve the application's performance by introducing a caching mechanism for planning events.

This reduces unnecessary calls and speeds up event processing within the user interface.

In `genericPopulatePlanning`, events are now checked in the cache before being processed. If an event is already cached, it is used directly, which reduces loading time.

A new method, `invalidateCacheEvents`, has been added to `Planning.php` to invalidate cache entries when events are updated or deleted.


Test performed with all events (completed or not):  
- 20,000 ticket tasks  
- 28,000 external events  
Distributed over 365 days, with an average of 130 tasks per day.



Before : 

![image](https://github.com/user-attachments/assets/8f236ceb-40a5-4429-8b2f-2bdbe3415009)


After : 

![image](https://github.com/user-attachments/assets/84d71562-37cb-496b-becf-3b5d2f6966d8)



**Note:** You may notice a double AJAX call to `http://glpi10bf.local/ajax/planning.php?action=get_events&display_done_events=1...`.  
I haven't yet identified the source of this duplicate call, but I suspect that FullCalendar is triggering my `event:` handler, which results in this AJAX request.

@cconard96  I’d appreciate your help and expertise on this.


