### PR TITLE
Fix missing CSRF in update process

### DIFF
--- a/install/update.php
+++ b/install/update.php
@@ -82,6 +82,7 @@ function showSecurityKeyCheckForm()
     echo '<form action="update.php" method="post">';
     echo '<input type="hidden" name="continuer" value="1" />';
     echo '<input type="hidden" name="missing_key_warning_shown" value="1" />';
+    echo Html::hidden('_glpi_csrf_token', ['value' => Session::getNewCSRFToken()]);
     echo '<div class="text-center">';
     echo '<h3>' . __s('Missing security key file') . '</h3>';
     echo '<div class="d-flex alert alert-warning">';


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

During the update process, when the missing key file is missing, a specific page is displayed to propose ask the user what should be done (ignore and regenerate a new key, or wait for him to manually restore its key file and retry).
This form had no CSRF token, and submitting it was resulting in a 403 error.