### PR TITLE
Add a proper "install required" page

### DIFF
--- a/src/Glpi/Controller/InstallController.php
+++ b/src/Glpi/Controller/InstallController.php
@@ -137,6 +137,15 @@ class InstallController extends AbstractController
     }
 
     /**
+     * Internal route that displays the "install required" page.
+     */
+    #[SecurityStrategy(Firewall::STRATEGY_NO_CHECK)]
+    public function installRequired(): Response
+    {
+        return $this->render('install/install.install_required.html.twig');
+    }
+
+    /**
      * Internal route that displays the "update required" page.
      */
     #[SecurityStrategy(Firewall::STRATEGY_NO_CHECK)]

--- a/templates/install/install.install_required.html.twig
+++ b/templates/install/install.install_required.html.twig
@@ -1,0 +1,56 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2025 Teclib' and contributors.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+{% set title = __('GLPI setup') %}
+
+{% extends 'layout/page_card_notlogged.html.twig' %}
+
+{% block content_block %}
+<div class="flex-fill d-flex align-items-center justify-content-center">
+    <div class="empty p-0">
+        <i class="fas fa-tools fa-3x mb-3"></i>
+
+        <p class="empty-title">{{ __('GLPI setup') }}</p>
+
+        <p class="empty-subtitle">
+            {{ __('The GLPI database must be configured and installed.') }}
+        </p>
+        <div class="empty-action">
+            <a href="{{ path('/install/install.php') }}" class="btn btn-primary">{{ __('Go to install page') }}</a>
+        </div>
+
+        <div class="alert alert-warning mt-4">
+            {{ __('If you see this page when the installation has already been done, it means that the GLPI database configuration file has been removed or corrupted.') }}
+        </div>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

In GLPI < 11.0, when the configuration file was missing, the following behaviours were applied:
 - if the user go to the root URL (`/` or `/index.php`), it is redirected to the installation page;
 - if the user go to any other URL, the `GLPI seems to not be configured properly.` error message is displayed.

In GLPI 11.0, the redirection from the root URL is no longer present, as we decided to remove it to have a common behaviour for all pages. Having an error page does not seems normal if the administrator is trying to start the installation process as [documented](https://glpi-install.readthedocs.io/en/latest/install/wizard.html), but it may be important to indicate that there is an issue with the installation file if GLPI is supposed to be already installed.

I propose to replace this error page by a proper "install required" page, that does not look like an error page, but still display a warning to hint about a potential issue.

The displayed messages may be improved.

It closes #19423.

## Screenshots:

After:
![image](https://github.com/user-attachments/assets/688aa4f2-c80e-4ed0-be65-a50f0541e088)

Before:
![image](https://github.com/user-attachments/assets/a59473e7-002b-4f75-8bd3-92d608c3ae34)
