### PR TITLE
Fix(Inventory): Do not handle lock on add

### DIFF
--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -1331,8 +1331,6 @@ class CommonDBTM extends CommonGLPI
 
             $this->pre_addInDB();
 
-            // fill array for add
-            $this->cleanLockedsOnAdd();
             foreach (array_keys($this->input) as $key) {
                 if (
                     ($key[0] != '_')
@@ -1778,6 +1776,8 @@ class CommonDBTM extends CommonGLPI
      */
     protected function cleanLockedsOnAdd()
     {
+        Toolbox::deprecated('Called method is deprecated', true, '11.0');
+
         if (isset($this->input['is_dynamic']) && $this->input['is_dynamic'] == true) {
             $lockedfield = new Lockedfield();
             $config = Config::getConfigurationValues('inventory');


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !37330

Currently,` Global Locks` on fields such as the computer `Name` incorrectly prevent agents from importing data even when creating new objects.

Real-world examples:

A `Computer` object is created by an agent, but the `Name` field remains empty because it is globally locked.


This behavior is inconsistent: `Global Locks` are meant to preserve existing manually entered data, but they should not block the initial population of fields during new object creation.

Proposed Solution
This PR adjusts the application logic so that` Global Locks`:

- Are enforced only for existing objects in GLPI.
- Do not block field values during the creation of new objects, even if a global lock is active on that field.


:information_source:  This first draft aims to observe the behavior of the unit tests and evaluate the workload involved in this change. It will help me identify any functional cases where it might be relevant to keep the current behavior.


## Screenshots (if appropriate):


