### PR TITLE
Fix(Ruleright): fix test engine

### DIFF
--- a/src/RuleRightCollection.php
+++ b/src/RuleRightCollection.php
@@ -248,7 +248,7 @@ class RuleRightCollection extends RuleCollection
             $rule_fields = $this->getFieldsToLookFor();
 
             //Get all the data we need from ldap to process the rules
-            if (isset($params_lower["connection"]) && $params_lower["connection"] !== null) {
+            if (!empty($params_lower["connection"])) {
                 $sz = @ldap_read(
                     $params_lower["connection"],
                     $params_lower["userdn"],
@@ -258,7 +258,7 @@ class RuleRightCollection extends RuleCollection
 
                 if ($sz === false) {
                     // 32 = LDAP_NO_SUCH_OBJECT => This error can be silented as it just means that search produces no result.
-                    if (isset($params_lower["connection"]) && ldap_errno($params_lower["connection"]) !== 32) {
+                    if (ldap_errno($params_lower["connection"]) !== 32) {
                         trigger_error(
                             AuthLDAP::buildError(
                                 $params_lower["connection"],

--- a/src/RuleRightCollection.php
+++ b/src/RuleRightCollection.php
@@ -247,11 +247,11 @@ class RuleRightCollection extends RuleCollection
            //Get all the field to retrieve to be able to process rule matching
             $rule_fields = $this->getFieldsToLookFor();
 
-           //Get all the data we need from ldap to process the rules
-           if (isset($params_lower["connection"]) && $params_lower["connection"] !== null) {
+            //Get all the data we need from ldap to process the rules
+            if (isset($params_lower["connection"]) && $params_lower["connection"] !== null) {
                 $sz = @ldap_read(
                     $params_lower["connection"],
-                    $params_lower["userdn"] ?? '',
+                    $params_lower["userdn"],
                     "objectClass=*",
                     $rule_fields
                 );

--- a/src/RuleRightCollection.php
+++ b/src/RuleRightCollection.php
@@ -247,29 +247,30 @@ class RuleRightCollection extends RuleCollection
            //Get all the field to retrieve to be able to process rule matching
             $rule_fields = $this->getFieldsToLookFor();
 
-            //Get all the data we need from ldap to process the rules
-            if (!empty($params_lower["connection"])) {
-                $sz = @ldap_read(
-                    $params_lower["connection"],
-                    $params_lower["userdn"],
-                    "objectClass=*",
-                    $rule_fields
-                );
+            //If we are oustide authentication process, $params_lower["connection"] is not set
+            if (empty($params_lower["connection"])) {
+                return $rule_parameters;
+            }
 
-                if ($sz === false) {
-                    // 32 = LDAP_NO_SUCH_OBJECT => This error can be silented as it just means that search produces no result.
-                    if (ldap_errno($params_lower["connection"]) !== 32) {
-                        trigger_error(
-                            AuthLDAP::buildError(
-                                $params_lower["connection"],
-                                sprintf('Unable to get LDAP user having DN `%s` with filter `%s`', $params_lower["userdn"], 'objectClass=*')
-                            ),
-                            E_USER_WARNING
-                        );
-                    }
-                    return $rule_parameters;
+            //Get all the data we need from ldap to process the rules
+            $sz = @ldap_read(
+                $params_lower["connection"],
+                $params_lower["userdn"],
+                "objectClass=*",
+                $rule_fields
+            );
+
+            if ($sz === false) {
+                // 32 = LDAP_NO_SUCH_OBJECT => This error can be silented as it just means that search produces no result.
+                if (ldap_errno($params_lower["connection"]) !== 32) {
+                    trigger_error(
+                        AuthLDAP::buildError(
+                            $params_lower["connection"],
+                            sprintf('Unable to get LDAP user having DN `%s` with filter `%s`', $params_lower["userdn"], 'objectClass=*')
+                        ),
+                        E_USER_WARNING
+                    );
                 }
-            } else {
                 return $rule_parameters;
             }
 


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !37278

When attempting to test the GLPI rule engine for the criterion `authentication type is AD directory`, an error is displayed. 

![image](https://github.com/user-attachments/assets/df64d2df-8e7d-4931-8e82-60c29ac351a8)


This error occurs because, at this point, we simply do not have the LDAP directory data to perform an `ldap_read` (although this data is correctly provided during the authentication phase). 

During engine tests, we merely want to test in the "context" of LDAP authentication, without the need to initiate an `ldap_read`.

After correcting this part, I encountered the following error,

![image](https://github.com/user-attachments/assets/7f972b1d-290a-4e65-a337-8e0a4b1ac65d)


stemming from two issues: an extra foreach loop relative to the data provided by the engine, 


``` 
Array
  (
      [0] => Array
          (
              [0] => 0 //entities_id
              [1] => 1 //is_recursive
          )
  
  )
```

and incorrect display regarding recursivity, as the function `$this->displayActionByName` expects 'is_recursive' as the key instead of 'recursive'.

```php
    public function displayActionByName($name, $value)
    {

        echo "<tr class='tab_bg_2'>";
        switch ($name) {
            case "entity":
                echo "<td class='center'>" . Entity::getTypeName(1) . " </td>\n";
                echo "<td class='center'>" . Dropdown::getDropdownName("glpi_entities", $value) . "</td>";
                break;

            case "profile":
                echo "<td class='center'>" . _n('Profile', 'Profiles', Session::getPluralNumber()) . " </td>\n";
                echo "<td class='center'>" . Dropdown::getDropdownName("glpi_profiles", $value) . "</td>";
                break;

            case "is_recursive":
                echo "<td class='center'>" . __('Recursive') . " </td>\n";
                echo "<td class='center'>" . Dropdown::getYesNo($value) . "</td>";
                break;
        }
        echo "</tr>";
    }
```

After : 

![image](https://github.com/user-attachments/assets/bd76d91a-5f29-4b30-95e2-7b7c1fe47780)


## Screenshots (if appropriate):


