### PR TITLE
fix(lockfield): replace dropdown value don't replace locked fields

### DIFF
--- a/phpunit/functional/LockedfieldTest.php
+++ b/phpunit/functional/LockedfieldTest.php
@@ -35,6 +35,7 @@
 namespace tests\units;
 
 use DbTestCase;
+use Location;
 
 /* Test for inc/savedsearch.class.php */
 
@@ -867,5 +868,52 @@ class LockedfieldTest extends DbTestCase
             'items_id' => $computer->getID(),
         ];
         $this->assertEquals(false, $instance->canCreateItem());
+    }
+
+    public function testReplaceLockedField()
+    {
+        $this->login('glpi', 'glpi');
+
+        $location = new Location();
+        $location_id = (int)$location->add([
+            'entities' => 0,
+            'name' => 'Location 1',
+        ]);
+        $this->assertGreaterThan(0, $location_id);
+
+        $location2 = new Location();
+        $location_id2 = (int)$location2->add([
+            'entities' => 0,
+            'name' => 'Location 2',
+        ]);
+        $this->assertGreaterThan(0, $location_id2);
+
+        $computer = new \Computer();
+        $cid = (int)$computer->add([
+            'name'         => 'Computer',
+            'entities_id'  => 0,
+            'is_dynamic'   => 1,
+            'locations_id' => $location_id,
+        ]);
+        $this->assertGreaterThan(0, $cid);
+
+        $global_lockedfield = new \Lockedfield();
+        $global_lockedfield_id = (int)$global_lockedfield->add([
+            'item' => 'Computer - locations_id'
+        ]);
+        $this->assertGreaterThan(0, $global_lockedfield_id);
+
+        $this->assertSame(['locations_id' => null], $global_lockedfield->getLockedValues($computer->getType(), $cid));
+
+        $this->assertEquals($computer->fields['locations_id'], $location_id);
+        $location->delete([
+            'id' => $location_id,
+            '_replace_by' => $location_id2,
+            'itemtype' => Location::class,
+            'replace' => 'Replace',
+        ], 1);
+
+        $this->assertTrue($computer->getFromDB($cid));
+        $this->assertEquals($computer->fields['locations_id'], $location_id2);
     }
 }

--- a/phpunit/functional/LockedfieldTest.php
+++ b/phpunit/functional/LockedfieldTest.php
@@ -906,14 +906,22 @@ class LockedfieldTest extends DbTestCase
         $this->assertSame(['locations_id' => null], $global_lockedfield->getLockedValues($computer->getType(), $cid));
 
         $this->assertEquals($computer->fields['locations_id'], $location_id);
+
+        // Delete the location with a replacement value
         $location->delete([
             'id' => $location_id,
             '_replace_by' => $location_id2,
-            'itemtype' => Location::class,
-            'replace' => 'Replace',
-        ], 1);
+        ], true);
 
         $this->assertTrue($computer->getFromDB($cid));
         $this->assertEquals($computer->fields['locations_id'], $location_id2);
+
+        // Delete the location with no replacement value
+        $location->delete([
+            'id' => $location_id2,
+        ], true);
+
+        $this->assertTrue($computer->getFromDB($cid));
+        $this->assertEquals($computer->fields['locations_id'], 0);
     }
 }

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -940,7 +940,7 @@ class CommonDBTM extends CommonGLPI
                         $input =  [
                             $id_field       => $data[$id_field],
                             '_disablenotif' => true,
-                            '_skip_locks'   => isset($this->input['_replace_by']),
+                            '_skip_locks'   => true,
                         ] + $update;
 
                         //prevent lock if item is dynamic

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -940,6 +940,7 @@ class CommonDBTM extends CommonGLPI
                         $input =  [
                             $id_field       => $data[$id_field],
                             '_disablenotif' => true,
+                            '_replace'      => isset($this->input['_replace_by']),
                         ] + $update;
 
                         //prevent lock if item is dynamic
@@ -1819,6 +1820,7 @@ class CommonDBTM extends CommonGLPI
             && $this->isDynamic()
             && (in_array('is_dynamic', $this->updates) || isset($this->input['is_dynamic'])
             && $this->input['is_dynamic'] == true)
+            && !$this->input['_replace']
         ) {
             $lockedfield = new Lockedfield();
             $locks = $lockedfield->getFullLockedFields($this->getType(), $this->fields['id']);

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -1820,7 +1820,7 @@ class CommonDBTM extends CommonGLPI
             && $this->isDynamic()
             && (in_array('is_dynamic', $this->updates) || isset($this->input['is_dynamic'])
             && $this->input['is_dynamic'] == true)
-            && !$this->input['_replace']
+            && !isset($this->input['_replace'])
         ) {
             $lockedfield = new Lockedfield();
             $locks = $lockedfield->getFullLockedFields($this->getType(), $this->fields['id']);

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -940,7 +940,7 @@ class CommonDBTM extends CommonGLPI
                         $input =  [
                             $id_field       => $data[$id_field],
                             '_disablenotif' => true,
-                            '_replace'      => isset($this->input['_replace_by']),
+                            '_replace_by'      => isset($this->input['_replace_by']),
                         ] + $update;
 
                         //prevent lock if item is dynamic
@@ -1820,7 +1820,7 @@ class CommonDBTM extends CommonGLPI
             && $this->isDynamic()
             && (in_array('is_dynamic', $this->updates) || isset($this->input['is_dynamic'])
             && $this->input['is_dynamic'] == true)
-            && !isset($this->input['_replace'])
+            && !isset($this->input['_replace_by'])
         ) {
             $lockedfield = new Lockedfield();
             $locks = $lockedfield->getFullLockedFields($this->getType(), $this->fields['id']);

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -940,7 +940,7 @@ class CommonDBTM extends CommonGLPI
                         $input =  [
                             $id_field       => $data[$id_field],
                             '_disablenotif' => true,
-                            '_replace_by'      => isset($this->input['_replace_by']),
+                            '_skip_locks'   => isset($this->input['_replace_by']),
                         ] + $update;
 
                         //prevent lock if item is dynamic
@@ -1809,7 +1809,8 @@ class CommonDBTM extends CommonGLPI
     protected function cleanLockeds()
     {
         if (
-            (
+            ($this->input['_skip_locks'] ?? false) !== true
+            && (
                 (
                     isset($this->input['_transfer'])
                     // lock updated fields in transfer only if requested
@@ -1820,7 +1821,6 @@ class CommonDBTM extends CommonGLPI
             && $this->isDynamic()
             && (in_array('is_dynamic', $this->updates) || isset($this->input['is_dynamic'])
             && $this->input['is_dynamic'] == true)
-            && !isset($this->input['_replace_by'])
         ) {
             $lockedfield = new Lockedfield();
             $locks = $lockedfield->getFullLockedFields($this->getType(), $this->fields['id']);


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !37320
- If a field in an asset dynamic is locked and you want to replace its value, the value of the field was deleted instead of being replaced.

## Screenshots (if appropriate):

Location before replace
![Capture d’écran du 2025-04-11 11-54-27](https://github.com/user-attachments/assets/93752dfc-5383-402b-957c-00f15fe14fab)

Replace
![Capture d’écran du 2025-04-11 11-55-19](https://github.com/user-attachments/assets/e0e1f0d6-f2fe-46b1-b15d-f1ffc0c16dd8)

Location after replace
![Capture d’écran du 2025-04-11 11-56-23](https://github.com/user-attachments/assets/cbf9b172-c4cf-4457-aaf4-f34e8a78183b)




