### PR TITLE
Remove redundant aria label for JS toast messages

### DIFF
--- a/js/glpi_dialog.js
+++ b/js/glpi_dialog.js
@@ -356,7 +356,7 @@ const glpi_toast = (title, message, css_class, options = {}) => {
         location = 'bottom-right';
     }
     const html = `<div class='toast-container ${location} p-3 messages_after_redirect'>
-      <div id='toast_js_${toast_id}' class='toast ${animation_classes}' role='alert' aria-live='assertive' aria-atomic='true' aria-label="${message}">
+      <div id='toast_js_${toast_id}' class='toast ${animation_classes}' role='alert' aria-live='assertive' aria-atomic='true'>
          <div class='toast-header ${css_class}'>
             <strong class='me-auto'>${title}</strong>
             <button type='button' class='btn-close' data-bs-dismiss='toast' aria-label='${__('Close')}'></button>

--- a/tests/cypress/e2e/self-service/home_config.cy.js
+++ b/tests/cypress/e2e/self-service/home_config.cy.js
@@ -142,7 +142,7 @@ for (const test of tests) {
 
             // Save new order
             cy.findByRole('button', {'name': "Save tiles order"}).click();
-            cy.findByRole('alert')
+            cy.findAllByRole('alert')
                 .contains("Configuration updated successfully.")
                 .should('be.visible')
             ;
@@ -161,7 +161,7 @@ for (const test of tests) {
 
             // Validate deletion
             cy.findByRole("region", {'name': "Request a service"}).should('not.exist');
-            cy.findByRole('alert')
+            cy.findAllByRole('alert')
                 .contains("Configuration updated successfully.")
                 .should('be.visible')
             ;
@@ -190,7 +190,7 @@ for (const test of tests) {
 
             // Submit
             cy.findByRole('dialog').findByRole('button', {'name': 'Save changes'}).click();
-            cy.findByRole('alert')
+            cy.findAllByRole('alert')
                 .contains("Configuration updated successfully.")
                 .should('be.visible')
             ;
@@ -219,7 +219,7 @@ for (const test of tests) {
 
             // Submit
             cy.findByRole('dialog').findByRole('button', {'name': 'Add tile'}).click();
-            cy.findByRole('alert')
+            cy.findAllByRole('alert')
                 .contains("Configuration updated successfully.")
                 .should('be.visible')
             ;
@@ -250,7 +250,7 @@ for (const test of tests) {
 
             // Submit
             cy.findByRole('dialog').findByRole('button', {'name': 'Add tile'}).click();
-            cy.findByRole('alert')
+            cy.findAllByRole('alert')
                 .contains("Configuration updated successfully.")
                 .should('be.visible')
             ;
@@ -274,7 +274,7 @@ for (const test of tests) {
 
             // Submit
             cy.findByRole('dialog').findByRole('button', {'name': 'Add tile'}).click();
-            cy.findByRole('alert')
+            cy.findAllByRole('alert')
                 .contains("Configuration updated successfully.")
                 .should('be.visible')
             ;

--- a/tests/cypress/e2e/self-service/home_config.cy.js
+++ b/tests/cypress/e2e/self-service/home_config.cy.js
@@ -142,7 +142,8 @@ for (const test of tests) {
 
             // Save new order
             cy.findByRole('button', {'name': "Save tiles order"}).click();
-            cy.findByRole('alert', {name: "Configuration updated successfully."})
+            cy.findByRole('alert')
+                .contains("Configuration updated successfully.")
                 .should('be.visible')
             ;
             validateTilesOrder([
@@ -160,7 +161,8 @@ for (const test of tests) {
 
             // Validate deletion
             cy.findByRole("region", {'name': "Request a service"}).should('not.exist');
-            cy.findByRole('alert', {name: "Configuration updated successfully."})
+            cy.findByRole('alert')
+                .contains("Configuration updated successfully.")
                 .should('be.visible')
             ;
             validateTilesOrder([
@@ -188,7 +190,8 @@ for (const test of tests) {
 
             // Submit
             cy.findByRole('dialog').findByRole('button', {'name': 'Save changes'}).click();
-            cy.findByRole('alert', {name: "Configuration updated successfully."})
+            cy.findByRole('alert')
+                .contains("Configuration updated successfully.")
                 .should('be.visible')
             ;
             validateTilesOrder([
@@ -216,7 +219,8 @@ for (const test of tests) {
 
             // Submit
             cy.findByRole('dialog').findByRole('button', {'name': 'Add tile'}).click();
-            cy.findByRole('alert', {name: "Configuration updated successfully."})
+            cy.findByRole('alert')
+                .contains("Configuration updated successfully.")
                 .should('be.visible')
             ;
             validateTilesOrder([
@@ -246,7 +250,8 @@ for (const test of tests) {
 
             // Submit
             cy.findByRole('dialog').findByRole('button', {'name': 'Add tile'}).click();
-            cy.findByRole('alert', {name: "Configuration updated successfully."})
+            cy.findByRole('alert')
+                .contains("Configuration updated successfully.")
                 .should('be.visible')
             ;
             validateTilesOrder([
@@ -269,7 +274,8 @@ for (const test of tests) {
 
             // Submit
             cy.findByRole('dialog').findByRole('button', {'name': 'Add tile'}).click();
-            cy.findByRole('alert', {name: "Configuration updated successfully."})
+            cy.findByRole('alert')
+                .contains("Configuration updated successfully.")
                 .should('be.visible')
             ;
             validateTilesOrder([


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Noticed with Forms that HTML content wasn't handled properly for JS toast messages when using it in an aria-label attribute. It wasn't escaped, but also the label is completely redundant and would be annoying for screen reader users. Change was added in #19355.

The way it was, as soon as the message appeared the screen reader would announce:
1. The message content
2. The message title
3. The close button
4. The message content

## Screenshots (if appropriate):

![Selection_463](https://github.com/user-attachments/assets/23f569e4-4c4c-44bc-af8a-ca9ca6ab0d14)
