### PR TITLE
Enhance plugin hooks

### DIFF
--- a/src/Glpi/Plugin/Hooks.php
+++ b/src/Glpi/Plugin/Hooks.php
@@ -40,148 +40,160 @@ use Glpi\Api\HL as HL_API;
 class Hooks
 {
     // Boolean hooks
-    const CSRF_COMPLIANT = 'csrf_compliant';
+    /**
+     * @var string
+     * @deprecated 11.0.0 Plugins are expected to always be CSRF compliant.
+     */
+    public const CSRF_COMPLIANT = 'csrf_compliant';
 
     // File hooks
-    const ADD_CSS               = 'add_css';
-    const ADD_JAVASCRIPT        = 'add_javascript';
-    const ADD_JAVASCRIPT_MODULE = 'add_javascript_module';
-    const ADD_HEADER_TAG        = 'add_header_tag';
+    public const ADD_CSS               = 'add_css';
+    public const ADD_JAVASCRIPT        = 'add_javascript';
+    public const ADD_JAVASCRIPT_MODULE = 'add_javascript_module';
+    public const ADD_HEADER_TAG        = 'add_header_tag';
+    /**
+     * Register one or more on-demand JavaScript files.
+     *
+     * On-demand JS files are loaded based on the `$CFG_GLPI['javascript']` array.
+     * Example: `$PLUGIN_HOOKS[Hooks::JAVASCRIPT]['your_js_name'] = ['path/to/your/file.js'];`
+     */
+    public const JAVASCRIPT            = 'javascript';
 
     // File hooks for anonymous pages
-    const ADD_CSS_ANONYMOUS_PAGE               = 'add_css_anonymous_page';
-    const ADD_JAVASCRIPT_ANONYMOUS_PAGE        = 'add_javascript_anonymous_page';
-    const ADD_JAVASCRIPT_MODULE_ANONYMOUS_PAGE = 'add_javascript_module_anonymous_page';
-    const ADD_HEADER_TAG_ANONYMOUS_PAGE        = 'add_header_tag_anonymous_page';
+    public const ADD_CSS_ANONYMOUS_PAGE               = 'add_css_anonymous_page';
+    public const ADD_JAVASCRIPT_ANONYMOUS_PAGE        = 'add_javascript_anonymous_page';
+    public const ADD_JAVASCRIPT_MODULE_ANONYMOUS_PAGE = 'add_javascript_module_anonymous_page';
+    public const ADD_HEADER_TAG_ANONYMOUS_PAGE        = 'add_header_tag_anonymous_page';
 
     // Function hooks with no parameters
-    const CHANGE_ENTITY               = 'change_entity';
-    const CHANGE_PROFILE              = 'change_profile';
-    const DISPLAY_LOGIN               = 'display_login';
-    const DISPLAY_CENTRAL             = 'display_central';
-    const DISPLAY_NETPORT_LIST_BEFORE = 'display_netport_list_before';
-    const INIT_SESSION                = 'init_session';
-    const POST_INIT                   = 'post_init';
-    const CONFIG_PAGE                 = 'config_page';
-    const USE_MASSIVE_ACTION          = 'use_massive_action';
-    const IMPORT_ITEM                 = 'import_item';
+    public const CHANGE_ENTITY               = 'change_entity';
+    public const CHANGE_PROFILE              = 'change_profile';
+    public const DISPLAY_LOGIN               = 'display_login';
+    public const DISPLAY_CENTRAL             = 'display_central';
+    public const DISPLAY_NETPORT_LIST_BEFORE = 'display_netport_list_before';
+    public const INIT_SESSION                = 'init_session';
+    public const POST_INIT                   = 'post_init';
+    public const CONFIG_PAGE                 = 'config_page';
+    public const USE_MASSIVE_ACTION          = 'use_massive_action';
+    public const IMPORT_ITEM                 = 'import_item';
 
     // Specific function hooks with parameters
-    const RULE_MATCHED          = 'rule_matched';
-    const VCARD_DATA            = 'vcard_data';
-    const POST_PLUGIN_DISABLE   = 'post_plugin_disable';
-    const POST_PLUGIN_CLEAN     = 'post_plugin_clean';
-    const POST_PLUGIN_INSTALL   = 'post_plugin_install';
-    const POST_PLUGIN_UNINSTALL = 'post_plugin_uninstall';
-    const POST_PLUGIN_ENABLE    = 'post_plugin_enable' ;
+    public const RULE_MATCHED          = 'rule_matched';
+    public const VCARD_DATA            = 'vcard_data';
+    public const POST_PLUGIN_DISABLE   = 'post_plugin_disable';
+    public const POST_PLUGIN_CLEAN     = 'post_plugin_clean';
+    public const POST_PLUGIN_INSTALL   = 'post_plugin_install';
+    public const POST_PLUGIN_UNINSTALL = 'post_plugin_uninstall';
+    public const POST_PLUGIN_ENABLE    = 'post_plugin_enable' ;
 
     // Function hooks with parameters and output
-    const DISPLAY_LOCKED_FIELDS         = 'display_locked_fields';
-    const POST_KANBAN_CONTENT           = 'post_kanban_content';
-    const PRE_KANBAN_CONTENT            = 'pre_kanban_content';
-    const KANBAN_ITEM_METADATA          = 'kanban_item_metadata';
-    const KANBAN_FILTERS                = 'kanban_filters';
-    const REDEFINE_MENUS                = 'redefine_menus';
-    const RETRIEVE_MORE_DATA_FROM_LDAP  = 'retrieve_more_data_from_ldap';
-    const RETRIEVE_MORE_FIELD_FROM_LDAP = 'retrieve_more_field_from_ldap';
-    const RESTRICT_LDAP_AUTH            = 'restrict_ldap_auth';
-    const UNLOCK_FIELDS                 = 'unlock_fields';
-    const UNDISCLOSED_CONFIG_VALUE      = 'undiscloseConfigValue';
-    const FILTER_ACTORS                 = 'filter_actors';
-    const DEFAULT_DISPLAY_PREFS         = 'default_display_prefs';
+    public const DISPLAY_LOCKED_FIELDS         = 'display_locked_fields';
+    public const POST_KANBAN_CONTENT           = 'post_kanban_content';
+    public const PRE_KANBAN_CONTENT            = 'pre_kanban_content';
+    public const KANBAN_ITEM_METADATA          = 'kanban_item_metadata';
+    public const KANBAN_FILTERS                = 'kanban_filters';
+    public const REDEFINE_MENUS                = 'redefine_menus';
+    public const RETRIEVE_MORE_DATA_FROM_LDAP  = 'retrieve_more_data_from_ldap';
+    public const RETRIEVE_MORE_FIELD_FROM_LDAP = 'retrieve_more_field_from_ldap';
+    public const RESTRICT_LDAP_AUTH            = 'restrict_ldap_auth';
+    public const UNLOCK_FIELDS                 = 'unlock_fields';
+    public const UNDISCLOSED_CONFIG_VALUE      = 'undiscloseConfigValue';
+    public const FILTER_ACTORS                 = 'filter_actors';
+    public const DEFAULT_DISPLAY_PREFS         = 'default_display_prefs';
+    public const USE_RULES                     = 'use_rules';
 
     // Item hooks expecting an 'item' parameter
-    const ADD_RECIPIENT_TO_TARGET   = 'add_recipient_to_target';
-    const AUTOINVENTORY_INFORMATION = 'autoinventory_information';
-    const INFOCOM                   = 'infocom';
-    const ITEM_ACTION_TARGETS       = 'item_action_targets';
-    const ITEM_ADD                  = 'item_add';
-    const ITEM_ADD_TARGETS          = 'item_add_targets';
-    const ITEM_CAN                  = 'item_can';
-    const ITEM_EMPTY                = 'item_empty';
-    const ITEM_DELETE               = 'item_delete';
-    const ITEM_GET_DATA             = 'item_get_datas';
-    const ITEM_GET_EVENTS           = 'item_get_events';
-    const ITEM_UPDATE               = 'item_update';
-    const ITEM_PURGE                = 'item_purge';
-    const ITEM_RESTORE              = 'item_restore';
-    const POST_PREPAREADD           = 'post_prepareadd';
-    const PRE_ITEM_ADD              = 'pre_item_add';
-    const PRE_ITEM_UPDATE           = 'pre_item_update';
-    const PRE_ITEM_DELETE           = 'pre_item_delete';
-    const PRE_ITEM_PURGE            = 'pre_item_purge';
-    const PRE_ITEM_RESTORE          = 'pre_item_restore';
-    const SHOW_ITEM_STATS           = 'show_item_stats';
+    public const ADD_RECIPIENT_TO_TARGET   = 'add_recipient_to_target';
+    public const AUTOINVENTORY_INFORMATION = 'autoinventory_information';
+    public const INFOCOM                   = 'infocom';
+    public const ITEM_ACTION_TARGETS       = 'item_action_targets';
+    public const ITEM_ADD                  = 'item_add';
+    public const ITEM_ADD_TARGETS          = 'item_add_targets';
+    public const ITEM_CAN                  = 'item_can';
+    public const ITEM_EMPTY                = 'item_empty';
+    public const ITEM_DELETE               = 'item_delete';
+    public const ITEM_GET_DATA             = 'item_get_datas';
+    public const ITEM_GET_EVENTS           = 'item_get_events';
+    public const ITEM_UPDATE               = 'item_update';
+    public const ITEM_PURGE                = 'item_purge';
+    public const ITEM_RESTORE              = 'item_restore';
+    public const POST_PREPAREADD           = 'post_prepareadd';
+    public const PRE_ITEM_ADD              = 'pre_item_add';
+    public const PRE_ITEM_UPDATE           = 'pre_item_update';
+    public const PRE_ITEM_DELETE           = 'pre_item_delete';
+    public const PRE_ITEM_PURGE            = 'pre_item_purge';
+    public const PRE_ITEM_RESTORE          = 'pre_item_restore';
+    public const SHOW_ITEM_STATS           = 'show_item_stats';
 
     // Item hooks expecting an array parameter (available keys: item, options)
-    const PRE_ITIL_INFO_SECTION   = 'pre_itil_info_section';
-    const POST_ITIL_INFO_SECTION  = 'post_itil_info_section';
-    const ITEM_TRANSFER           = 'item_transfer';
-    const POST_ITEM_FORM          = 'post_item_form';
-    const POST_SHOW_ITEM          = 'post_show_item';
-    const POST_SHOW_TAB           = 'post_show_tab';
-    const POST_ITEM_LIST          = 'post_item_list';
-    const PRE_ITEM_FORM           = 'pre_item_form';
-    const PRE_SHOW_ITEM           = 'pre_show_item';
-    const PRE_SHOW_TAB            = 'pre_show_tab';
-    const PRE_ITEM_LIST           = 'pre_item_list';
-    const TIMELINE_ACTIONS        = 'timeline_actions';  // (keys: item, rand)
-    const TIMELINE_ANSWER_ACTIONS = 'timeline_answer_actions';  // (keys: item)
+    public const PRE_ITIL_INFO_SECTION   = 'pre_itil_info_section';
+    public const POST_ITIL_INFO_SECTION  = 'post_itil_info_section';
+    public const ITEM_TRANSFER           = 'item_transfer';
+    public const POST_ITEM_FORM          = 'post_item_form';
+    public const POST_SHOW_ITEM          = 'post_show_item';
+    public const POST_SHOW_TAB           = 'post_show_tab';
+    public const POST_ITEM_LIST          = 'post_item_list';
+    public const PRE_ITEM_FORM           = 'pre_item_form';
+    public const PRE_SHOW_ITEM           = 'pre_show_item';
+    public const PRE_SHOW_TAB            = 'pre_show_tab';
+    public const PRE_ITEM_LIST           = 'pre_item_list';
+    public const TIMELINE_ACTIONS        = 'timeline_actions';  // (keys: item, rand)
+    public const TIMELINE_ANSWER_ACTIONS = 'timeline_answer_actions';  // (keys: item)
     /**
      * @deprecated 11.0.0 Use `TIMELINE_ITEMS` instead.
      */
-    const SHOW_IN_TIMELINE        = 'show_in_timeline';
-    const TIMELINE_ITEMS          = 'timeline_items';  // (keys: item)
-    const SET_ITEM_IMPACT_ICON    = 'set_item_impact_icon'; // (keys: itemtype, items_id)
+    public const SHOW_IN_TIMELINE        = 'show_in_timeline';
+    public const TIMELINE_ITEMS          = 'timeline_items';  // (keys: item)
+    public const SET_ITEM_IMPACT_ICON    = 'set_item_impact_icon'; // (keys: itemtype, items_id)
 
     // Security hooks (data to encypt)
-    const SECURED_FIELDS  = 'secured_fields';
-    const SECURED_CONFIGS = 'secured_configs';
+    public const SECURED_FIELDS  = 'secured_fields';
+    public const SECURED_CONFIGS = 'secured_configs';
 
     // Inventory hooks
-    const PROLOG_RESPONSE = 'prolog_response';
-    const NETWORK_DISCOVERY = 'network_discovery';
-    const NETWORK_INVENTORY = 'network_inventory';
-    const INVENTORY_GET_PARAMS = 'inventory_get_params';
+    public const PROLOG_RESPONSE = 'prolog_response';
+    public const NETWORK_DISCOVERY = 'network_discovery';
+    public const NETWORK_INVENTORY = 'network_inventory';
+    public const INVENTORY_GET_PARAMS = 'inventory_get_params';
     /** @var string Hook called before the inventory submission is handled.
      *              You may modify the inventory data which is passed as a parameter (stdClass) and return the modified data.
      *              Returning null will cancel the inventory submission with no specific reason.
      *              Throwing an Exception will cancel the inventory submission with the exception message as the reason.
      *              To avoid unrelated exception messages from being sent to the agent, you must handle all exceptions (except the one you would throw to cancel the inventory) within the hook function.
      */
-    const PRE_INVENTORY = 'pre_inventory';
+    public const PRE_INVENTORY = 'pre_inventory';
     /** @var string Hook called after the inventory submission is handled.
      *              You may view the inventory data which is passed as a parameter (stdClass).
      *              Nothing is expected to be returned.
      *              This hook is only called if the inventory submission was successful.
      */
-    const POST_INVENTORY = 'post_inventory';
+    public const POST_INVENTORY = 'post_inventory';
 
     // Agent contact request related hooks
-    const HANDLE_INVENTORY_TASK    = 'handle_inventory_task';
-    const HANDLE_NETDISCOVERY_TASK = 'handle_netdiscovery_task';
-    const HANDLE_NETINVENTORY_TASK = 'handle_netinventory_task';
-    const HANDLE_ESX_TASK          = 'handle_esx_task';
-    const HANDLE_COLLECT_TASK      = 'handle_collect_task';
-    const HANDLE_DEPLOY_TASK       = 'handle_deploy_task';
-    const HANDLE_WAKEONLAN_TASK    = 'handle_wakeonlan_task';
-    const HANDLE_REMOTEINV_TASK    = 'handle_remoteinventory_task';
+    public const HANDLE_INVENTORY_TASK    = 'handle_inventory_task';
+    public const HANDLE_NETDISCOVERY_TASK = 'handle_netdiscovery_task';
+    public const HANDLE_NETINVENTORY_TASK = 'handle_netinventory_task';
+    public const HANDLE_ESX_TASK          = 'handle_esx_task';
+    public const HANDLE_COLLECT_TASK      = 'handle_collect_task';
+    public const HANDLE_DEPLOY_TASK       = 'handle_deploy_task';
+    public const HANDLE_WAKEONLAN_TASK    = 'handle_wakeonlan_task';
+    public const HANDLE_REMOTEINV_TASK    = 'handle_remoteinventory_task';
 
-    const STALE_AGENT_CONFIG = 'stale_agent_config';
+    public const STALE_AGENT_CONFIG = 'stale_agent_config';
 
     // Debug / Development hooks
     const DEBUG_TABS = 'debug_tabs';
 
     // Menu Hooks
-    const MENU_TOADD = 'menu_toadd';
-    const HELPDESK_MENU_ENTRY = 'helpdesk_menu_entry';
-    const HELPDESK_MENU_ENTRY_ICON = 'helpdesk_menu_entry_icon';
+    public const MENU_TOADD = 'menu_toadd';
+    public const HELPDESK_MENU_ENTRY = 'helpdesk_menu_entry';
+    public const HELPDESK_MENU_ENTRY_ICON = 'helpdesk_menu_entry_icon';
 
     // Dashboard hooks
-    const DASHBOARD_CARDS    = 'dashboard_cards';
-    const DASHBOARD_FILTERS  = 'dashboard_filters';
-    const DASHBOARD_PALETTES = 'dashboard_palettes';
-    const DASHBOARD_TYPES    = 'dashboard_types';
+    public const DASHBOARD_CARDS    = 'dashboard_cards';
+    public const DASHBOARD_FILTERS  = 'dashboard_filters';
+    public const DASHBOARD_PALETTES = 'dashboard_palettes';
+    public const DASHBOARD_TYPES    = 'dashboard_types';
 
     // HL API hooks
     /**
@@ -191,11 +203,11 @@ class Hooks
      * The function should return the modified $data array.
      * The controller value should not be changed as it would result in undefined behavior.
      */
-    const REDEFINE_API_SCHEMAS          = 'redefine_api_schemas';
+    public const REDEFINE_API_SCHEMAS          = 'redefine_api_schemas';
     /**
      * This hook should provide an array of the plugin's API controller class names.
      */
-    const API_CONTROLLERS               = 'api_controllers';
+    public const API_CONTROLLERS               = 'api_controllers';
     /**
      * This hook should provide an array of arrays containing a 'middlware' value that is the class name.
      * The middleware classes should extend {@link HL_API\Middleware\AbstractMiddleware} and
@@ -203,7 +215,9 @@ class Hooks
      * The arrays may also contain values for 'priority' and 'condition' where priority is an integer (higher is more important) and condition is a callable.
      * If a condition is provided, that callable will be called with the current controller as a parameter and it must return true for the middleware to be used, or false to not be.
      */
-    const API_MIDDLEWARE                = 'api_middleware';
+    public const API_MIDDLEWARE                = 'api_middleware';
+
+    public const STATS = 'stats';
 
     /**
      * Get file hooks

--- a/src/Glpi/Plugin/Hooks.php
+++ b/src/Glpi/Plugin/Hooks.php
@@ -181,9 +181,6 @@ class Hooks
 
     public const STALE_AGENT_CONFIG = 'stale_agent_config';
 
-    // Debug / Development hooks
-    const DEBUG_TABS = 'debug_tabs';
-
     // Menu Hooks
     public const MENU_TOADD = 'menu_toadd';
     public const HELPDESK_MENU_ENTRY = 'helpdesk_menu_entry';
@@ -229,6 +226,13 @@ class Hooks
         return [
             self::ADD_CSS,
             self::ADD_JAVASCRIPT,
+            self::ADD_JAVASCRIPT_MODULE,
+            self::JAVASCRIPT,
+            self::ADD_CSS_ANONYMOUS_PAGE,
+            self::ADD_JAVASCRIPT_ANONYMOUS_PAGE,
+            self::ADD_JAVASCRIPT_MODULE_ANONYMOUS_PAGE,
+            self::ADD_HEADER_TAG,
+            self::ADD_HEADER_TAG_ANONYMOUS_PAGE,
         ];
     }
 
@@ -257,7 +261,6 @@ class Hooks
             self::UNDISCLOSED_CONFIG_VALUE,
             self::UNLOCK_FIELDS,
             self::VCARD_DATA,
-            self::ADD_HEADER_TAG
         ];
     }
 

--- a/src/Html.php
+++ b/src/Html.php
@@ -1473,23 +1473,23 @@ TWIG,
         }
 
         if (
-            isset($PLUGIN_HOOKS["helpdesk_menu_entry"])
-            && count($PLUGIN_HOOKS["helpdesk_menu_entry"])
+            isset($PLUGIN_HOOKS[Hooks::HELPDESK_MENU_ENTRY])
+            && count($PLUGIN_HOOKS[Hooks::HELPDESK_MENU_ENTRY])
         ) {
             $menu['plugins'] = [
                 'title' => __("Plugins"),
                 'icon'  => Plugin::getIcon(),
             ];
 
-            foreach ($PLUGIN_HOOKS["helpdesk_menu_entry"] as $plugin => $active) {
+            foreach ($PLUGIN_HOOKS[Hooks::HELPDESK_MENU_ENTRY] as $plugin => $active) {
                 if (!Plugin::isPluginActive($plugin)) {
                     continue;
                 }
                 if ($active) {
                     $infos = Plugin::getInfo($plugin);
                     $link = "";
-                    if (is_string($PLUGIN_HOOKS["helpdesk_menu_entry"][$plugin])) {
-                        $link = $PLUGIN_HOOKS["helpdesk_menu_entry"][$plugin];
+                    if (is_string($PLUGIN_HOOKS[Hooks::HELPDESK_MENU_ENTRY][$plugin])) {
+                        $link = $PLUGIN_HOOKS[Hooks::HELPDESK_MENU_ENTRY][$plugin];
 
                         // Ensure menu entries have all a starting `/`
                         if (!str_starts_with($link, '/')) {
@@ -1503,8 +1503,8 @@ TWIG,
                     }
                     $infos['page'] = $link;
                     $infos['title'] = $infos['name'];
-                    if (isset($PLUGIN_HOOKS["helpdesk_menu_entry_icon"][$plugin])) {
-                        $infos['icon'] = $PLUGIN_HOOKS["helpdesk_menu_entry_icon"][$plugin];
+                    if (isset($PLUGIN_HOOKS[Hooks::HELPDESK_MENU_ENTRY_ICON][$plugin])) {
+                        $infos['icon'] = $PLUGIN_HOOKS[Hooks::HELPDESK_MENU_ENTRY_ICON][$plugin];
                     }
                     $menu['plugins']['content'][$plugin] = $infos;
                 }
@@ -5895,9 +5895,9 @@ HTML;
                 break;
             default:
                 $found = false;
-                if (isset($PLUGIN_HOOKS['javascript']) && isset($PLUGIN_HOOKS['javascript'][$name])) {
+                if (isset($PLUGIN_HOOKS[Hooks::JAVASCRIPT][$name])) {
                     $found = true;
-                    $jslibs = $PLUGIN_HOOKS['javascript'][$name];
+                    $jslibs = $PLUGIN_HOOKS[Hooks::JAVASCRIPT][$name];
                     if (!is_array($jslibs)) {
                         $jslibs = [$jslibs];
                     }
@@ -5989,8 +5989,8 @@ HTML;
             }
         }
 
-        if (isset($PLUGIN_HOOKS['add_javascript_module']) && count($PLUGIN_HOOKS['add_javascript_module'])) {
-            foreach ($PLUGIN_HOOKS["add_javascript_module"] as $plugin => $files) {
+        if (isset($PLUGIN_HOOKS[Hooks::ADD_JAVASCRIPT_MODULE]) && count($PLUGIN_HOOKS[Hooks::ADD_JAVASCRIPT_MODULE])) {
+            foreach ($PLUGIN_HOOKS[Hooks::ADD_JAVASCRIPT_MODULE] as $plugin => $files) {
                 if (!Plugin::isPluginActive($plugin)) {
                     continue;
                 }

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -1742,8 +1742,8 @@ JS
         global $PLUGIN_HOOKS;
 
         $input = $this->prepareInputDataForProcess($input, $params);
-        if (isset($PLUGIN_HOOKS['use_rules'])) {
-            foreach ($PLUGIN_HOOKS['use_rules'] as $plugin => $val) {
+        if (isset($PLUGIN_HOOKS[Hooks::USE_RULES])) {
+            foreach ($PLUGIN_HOOKS[Hooks::USE_RULES] as $plugin => $val) {
                 if (!Plugin::isPluginActive($plugin)) {
                     continue;
                 }
@@ -1784,10 +1784,10 @@ JS
         /** @var array $PLUGIN_HOOKS */
         global $PLUGIN_HOOKS;
 
-        if (isset($PLUGIN_HOOKS['use_rules'])) {
+        if (isset($PLUGIN_HOOKS[Hooks::USE_RULES])) {
             $params['criterias_results'] = $this->criterias_results;
             $params['rule_itemtype']     = static::class;
-            foreach ($PLUGIN_HOOKS['use_rules'] as $plugin => $val) {
+            foreach ($PLUGIN_HOOKS[Hooks::USE_RULES] as $plugin => $val) {
                 if (!Plugin::isPluginActive($plugin)) {
                     continue;
                 }
@@ -2758,10 +2758,10 @@ JS
         /** @var array $PLUGIN_HOOKS */
         global $PLUGIN_HOOKS;
 
-        if (isset($PLUGIN_HOOKS['use_rules'])) {
+        if (isset($PLUGIN_HOOKS[Hooks::USE_RULES])) {
             $params['criterias_results'] = $this->criterias_results;
             $params['rule_itemtype']     = static::class;
-            foreach ($PLUGIN_HOOKS['use_rules'] as $plugin => $val) {
+            foreach ($PLUGIN_HOOKS[Hooks::USE_RULES] as $plugin => $val) {
                 if (!Plugin::isPluginActive($plugin)) {
                     continue;
                 }
@@ -2873,8 +2873,8 @@ JS
 
        //Agregate all plugins criteria for this rules engine
         $toreturn = $params;
-        if (isset($PLUGIN_HOOKS['use_rules'])) {
-            foreach ($PLUGIN_HOOKS['use_rules'] as $plugin => $val) {
+        if (isset($PLUGIN_HOOKS[Hooks::USE_RULES])) {
+            foreach ($PLUGIN_HOOKS[Hooks::USE_RULES] as $plugin => $val) {
                 if (!Plugin::isPluginActive($plugin)) {
                     continue;
                 }

--- a/src/RuleCollection.php
+++ b/src/RuleCollection.php
@@ -36,6 +36,7 @@
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\QueryExpression;
 use Glpi\Event;
+use Glpi\Plugin\Hooks;
 
 class RuleCollection extends CommonDBTM
 {
@@ -1619,8 +1620,8 @@ TWIG, $twig_params);
         global $PLUGIN_HOOKS;
 
         $input = $this->prepareInputDataForProcess($input, $params);
-        if (isset($PLUGIN_HOOKS['use_rules'])) {
-            foreach ($PLUGIN_HOOKS['use_rules'] as $plugin => $val) {
+        if (isset($PLUGIN_HOOKS[Hooks::USE_RULES])) {
+            foreach ($PLUGIN_HOOKS[Hooks::USE_RULES] as $plugin => $val) {
                 if (!Plugin::isPluginActive($plugin)) {
                     continue;
                 }
@@ -1792,9 +1793,9 @@ TWIG, $twig_params);
         /** @var array $PLUGIN_HOOKS */
         global $PLUGIN_HOOKS;
 
-        if (isset($PLUGIN_HOOKS['use_rules'])) {
+        if (isset($PLUGIN_HOOKS[Hooks::USE_RULES])) {
             $params['rule_itemtype'] = static::class;
-            foreach ($PLUGIN_HOOKS['use_rules'] as $plugin => $val) {
+            foreach ($PLUGIN_HOOKS[Hooks::USE_RULES] as $plugin => $val) {
                 if (!Plugin::isPluginActive($plugin)) {
                     continue;
                 }

--- a/src/RuleImportAsset.php
+++ b/src/RuleImportAsset.php
@@ -37,6 +37,7 @@
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\Asset\AssetDefinitionManager;
 use Glpi\Asset\Capacity\IsInventoriableCapacity;
+use Glpi\Plugin\Hooks;
 
 class RuleImportAsset extends Rule
 {
@@ -515,8 +516,8 @@ class RuleImportAsset extends Rule
 
             $this->handleFieldsCriteria($item, $it_criteria, $input);
 
-            if (isset($PLUGIN_HOOKS['use_rules'])) {
-                foreach ($PLUGIN_HOOKS['use_rules'] as $plugin => $val) {
+            if (isset($PLUGIN_HOOKS[Hooks::USE_RULES])) {
+                foreach ($PLUGIN_HOOKS[Hooks::USE_RULES] as $plugin => $val) {
                     if (!Plugin::isPluginActive($plugin)) {
                         continue;
                     }

--- a/src/Stat.php
+++ b/src/Stat.php
@@ -35,6 +35,7 @@
 
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
+use Glpi\Plugin\Hooks;
 use Glpi\Search\Output\Csv;
 use Glpi\Search\Output\HTMLSearchOutput;
 use Glpi\Search\Output\Pdf;
@@ -1771,8 +1772,8 @@ class Stat extends CommonGLPI
         // Manage plugins
         $names    = [];
         $optgroup = [];
-        if (isset($PLUGIN_HOOKS["stats"]) && is_array($PLUGIN_HOOKS["stats"])) {
-            foreach ($PLUGIN_HOOKS["stats"] as $plug => $pages) {
+        if (isset($PLUGIN_HOOKS[Hooks::STATS]) && is_array($PLUGIN_HOOKS[Hooks::STATS])) {
+            foreach ($PLUGIN_HOOKS[Hooks::STATS] as $plug => $pages) {
                 if (!Plugin::isPluginActive($plug)) {
                     continue;
                 }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Creating GLPI plugins is getting more complicated, and some of the existing plugin functionality suffers from inconsistent design decisions and outdated/missing documentation.
- Some hooks are **still** missing from the `Hooks` class.
- Recently I noticed that adding a plugin itemtype to `CFG_GLPI['ticket_types']` is the *wrong* way to allow a plugin itemtype to be added to a ticket because `CommonITILObject::getAllTypesForHelpdesk` explicitly ignores plugin itemtypes in this array and instead uses an undocumented hook even though we handle plugin itemtypes in the other `CFG_GLPI` arrays anywhere else. Worse yet, this hook is actually 2 hooks in a seemingly unnecessarily complicated design. A plugin must not only add a hook function like `plugin_databases_AssignToTicket`, but they also need to add `$PLUGIN_HOOKS['assign_to_ticket']['databases'] = true;` in their init function.
- Some hooks still lack documentation in the developer documentation
- The functions in `Hooks` seem to return incomplete lists
- The `HookManager` is undocumented and not its use is not recommended or mentioned anywhere in the documentation or example plugin.