### PR TITLE
Fix(TicketRule): do not compute takeintoaccount if needed

### DIFF
--- a/phpunit/functional/RuleTicketTest.php
+++ b/phpunit/functional/RuleTicketTest.php
@@ -3751,4 +3751,103 @@ class RuleTicketTest extends DbTestCase
 
         $this->assertEquals(\CommonITILObject::ASSIGNED, $ticket->fields['status']);
     }
+
+
+    /**
+     * Test action of a rule ticket that add a followup to a ticket
+     * and do not compute take into account delay.
+     */
+    public function testDoNotComputeTakeIntoAccountWithFollowupTemplateWithRule()
+    {
+        $this->login('glpi', 'glpi');
+
+        // Create followup template
+        $followuptemplate = new \ITILFollowupTemplate();
+        $templateid = $followuptemplate->add($templateinput = [
+            'name' => 'followuptemplate_' . __FUNCTION__,
+            'content' => 'Test',
+        ]);
+        $this->checkInput($followuptemplate, $templateid, $templateinput);
+
+        // Create the rule to add a followup template and to not compute takeintoaccount delay
+        $ruleticket = new \RuleTicket();
+        $rulecrit   = new \RuleCriteria();
+        $ruleaction = new \RuleAction();
+
+        // create rule
+        $ruletid = $ruleticket->add($ruletinput = [
+            'name'         => 'test do not compute takeintoaccount with followup template',
+            'match'        => 'AND',
+            'is_active'    => 1,
+            'sub_type'     => 'RuleTicket',
+            'condition'    => \RuleTicket::ONADD,
+            'is_recursive' => 1,
+        ]);
+        $this->checkInput($ruleticket, $ruletid, $ruletinput);
+
+        // create criteria to check if title contain 'test' key word
+        $crit_id = $rulecrit->add($crit_input = [
+            'rules_id'  => $ruletid,
+            'criteria'  => 'name',
+            'condition' => \Rule::PATTERN_CONTAIN,
+            'pattern'   => 'test',
+        ]);
+        $this->checkInput($rulecrit, $crit_id, $crit_input);
+
+        // add action to assign followup templates
+        $act2_id = $ruleaction->add($act2_input = [
+            'rules_id'    => $ruletid,
+            'action_type' => 'append',
+            'field'       => 'itilfollowup_template',
+            'value'       => $templateid,
+        ]);
+        $this->checkInput($ruleaction, $act2_id, $act2_input);
+
+        // add action to not compute takeintoaccount delay
+        $act3_id = $ruleaction->add($act3_input = [
+            'rules_id'    => $ruletid,
+            'action_type' => 'takeintoaccount_delay_stat',
+            'field'       => 'do_not_compute',
+            'value'       => true,
+        ]);
+        $this->checkInput($ruleaction, $act3_id, $act3_input);
+
+        // Load user glpi
+        $user1 = new \User();
+        $user1->getFromDBbyName('glpi');
+        $this->assertGreaterThan(0, $user1->getID());
+
+        // Create ticket
+        $ticket = new \Ticket();
+        $tickets_id = $ticket->add([
+            'name' => 'test ticket ' . __FUNCTION__,
+            'content' => __FUNCTION__,
+            '_actors' => [
+                'requester' => [
+                    [
+                        'items_id' => $user1->getID(),
+                        'itemtype' => 'User'
+                    ]
+                ],
+            ]
+        ]);
+        $this->assertGreaterThan(0, $tickets_id);
+
+        // reload ticket
+        $ticket = new \Ticket();
+        $ticket->getFromDB($tickets_id);
+
+        // check that ticket status is always new
+        $this->assertEquals(\CommonITILObject::INCOMING, $ticket->fields['status']);
+        // check that ticket takeintoaccount delay is not computed
+        $this->assertEquals(0, $ticket->fields['takeintoaccount_delay_stat']);
+        // followup well added
+        $this->assertEquals(
+            1,
+            countElementsInTable(
+                \ITILFollowup::getTable(),
+                ['itemtype' => \Ticket::getType(), 'items_id' => $tickets_id]
+            )
+        );
+    }
 }

--- a/phpunit/functional/SlaLevel_TicketTest.php
+++ b/phpunit/functional/SlaLevel_TicketTest.php
@@ -167,4 +167,139 @@ class SlaLevel_TicketTest extends DbTestCase
         $this->assertTrue($ticket->getFromDB($tickets_id));
         $this->assertEquals($category_id, $ticket->fields['itilcategories_id']);
     }
+
+
+    /**
+     * Test action of a sla level that add a followup to a ticket
+     * and do not compute take into account delay.
+     */
+    public function testTakeIntoAccoutAndFollupAction()
+    {
+        $this->login();
+
+         // Create followup template
+         $followuptemplate = new \ITILFollowupTemplate();
+         $templateid = $followuptemplate->add($templateinput = [
+             'name' => 'followuptemplate_' . __FUNCTION__,
+             'content' => 'Test',
+         ]);
+         $this->checkInput($followuptemplate, $templateid, $templateinput);
+
+        // create SLM
+        $slm    = new \SLM();
+        $slm_id = $slm->add($slm_in = [
+            'name'         => __METHOD__,
+            'comment'      => $this->getUniqueString(),
+            'calendars_id' => 0, //24:24 7j/7j
+        ]);
+        $this->checkInput($slm, $slm_id, $slm_in);
+
+        // prepare sla/ola inputs
+        $sla1_in = [
+            'slms_id'         => $slm_id,
+            'name'            => "SLA TTO",
+            'comment'         => $this->getUniqueString(),
+            'type'            => \SLM::TTO,
+            'number_time'     => 1,
+            'definition_time' => 'hour',
+        ];
+
+        // add sla (TTO)
+        $sla    = new \SLA();
+        $sla1_id = $sla->add($sla1_in);
+        $this->checkInput($sla, $sla1_id, $sla1_in);
+
+        // prepare levels input for sla
+        $slal1_in = [
+            'name'           => __METHOD__,
+            'execution_time' => 0, //TIME TO OWN
+            'is_active'      => 1,
+            'match'          => 'AND',
+            'slas_id'        => $sla1_id
+        ];
+
+        // add levels
+        $slal = new \SlaLevel();
+        $slal1_id = $slal->add($slal1_in);
+        $this->checkInput($slal, $slal1_id, $slal1_in);
+
+
+        // add criteria/actions
+        $scrit_in = [
+            'slalevels_id' => $slal1_id,
+            'criteria'  => 'name',
+            'condition' => \Rule::PATTERN_CONTAIN,
+            'pattern'   => 'test',
+        ];
+
+        $saction1_in = [
+            'slalevels_id' => $slal1_id,
+            'action_type' => 'append',
+            'field'       => 'itilfollowup_template',
+            'value'       => $templateid,
+        ];
+
+        $saction2_in = [
+            'slalevels_id' => $slal1_id,
+            'action_type' => 'takeintoaccount_delay_stat',
+            'field'       => 'do_not_compute',
+            'value'       => true,
+        ];
+
+        $scrit    = new \SlaLevelCriteria();
+        $saction  = new \SlaLevelAction();
+
+        $scrit_id   = $scrit->add($scrit_in);
+        $saction_id_1 = $saction->add($saction1_in);
+        $saction_id_2 = $saction->add($saction2_in);
+
+        $this->checkInput($scrit, $scrit_id, $scrit_in);
+        $this->checkInput($saction, $saction_id_1, $saction1_in);
+        $this->checkInput($saction, $saction_id_2, $saction2_in);
+
+        // create ticket
+        $ticket = new \Ticket();
+        $tickets_id = $ticket->add($ticket_input = [
+            'name'    => 'test ticket ' . __FUNCTION__,
+            'content' => __METHOD__,
+            'slas_id_tto' => $sla1_id,
+        ]);
+
+        // check ticket data
+        $this->checkInput($ticket, $tickets_id, $ticket_input);
+        $this->assertEquals($sla1_id, (int)$ticket->getField('slas_id_tto'));
+        $this->assertEquals(0, (int)$ticket->getField('takeintoaccount_delay_stat'));
+        $this->assertEquals(\CommonITILObject::INCOMING, (int)$ticket->getField('status'));
+
+        //get SlaLevel_Ticket related to this ticket and SLM
+        $slalevels_tickets = new \SlaLevel_Ticket();
+        $this->assertTrue($slalevels_tickets->getFromDBByCrit([
+            'tickets_id' => $tickets_id, 'slalevels_id' => $slal1_id
+        ]));
+
+        //fake glpi_slalevels_tickets.date to run crontask
+        $this->assertTrue($slalevels_tickets->update([
+            'id' => $slalevels_tickets->fields['id'], 'date' => date("Y-m-d H:i:s", time() - 2 * HOUR_TIMESTAMP)
+        ]));
+
+        //run automatic action
+        //run crontask
+        $task = new \CronTask();
+        $this->assertSame(1, \SlaLevel_Ticket::cronSlaTicket($task));
+
+        //reload ticket
+        $this->assertTrue($ticket->getFromDB($tickets_id)); // reload ticket
+        $this->assertEquals($sla1_id, (int)$ticket->getField('slas_id_tto')); // check SLA
+        $this->assertEquals(0, (int)$ticket->getField('takeintoaccount_delay_stat')); // check takeintoaccount_delay_stat always 0
+        $this->assertEquals(\CommonITILObject::INCOMING, (int)$ticket->getField('status')); // check status always incoming
+
+        // followup well added
+        $this->assertEquals(
+            1,
+            countElementsInTable(
+                \ITILFollowup::getTable(),
+                ['itemtype' => \Ticket::getType(), 'items_id' => $tickets_id]
+            )
+        );
+    }
 }

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -8225,6 +8225,7 @@ abstract class CommonITILObject extends CommonDBTM
                 'items_id'                  => $this->getID(),
                 '_disablenotif'             => true,
                 '_do_not_compute_status' => $this->input['_do_not_compute_status'] ?? 0,
+                '_do_not_compute_takeintoaccount' => $this->input['_do_not_compute_takeintoaccount'] ?? 0,
             ];
            // Insert new followup from template
             $fup = new ITILFollowup();

--- a/src/ITILFollowup.php
+++ b/src/ITILFollowup.php
@@ -365,6 +365,13 @@ class ITILFollowup extends CommonDBChild
             );
         }
 
+        // _do_not_compute_status can be passed from rule
+        // if isset it will be used to set _do_not_compute_takeintoaccount
+        // and prevent take into account delay computation
+        if (isset($input['_do_not_compute_status'])) {
+            $input['_do_not_compute_takeintoaccount'] = $input['_do_not_compute_status'];
+        }
+
         $input["_job"] = new $input['itemtype']();
 
         if (

--- a/src/ITILFollowup.php
+++ b/src/ITILFollowup.php
@@ -365,13 +365,6 @@ class ITILFollowup extends CommonDBChild
             );
         }
 
-        // _do_not_compute_status can be passed from rule
-        // if isset it will be used to set _do_not_compute_takeintoaccount
-        // and prevent take into account delay computation
-        if (isset($input['_do_not_compute_status'])) {
-            $input['_do_not_compute_takeintoaccount'] = $input['_do_not_compute_status'];
-        }
-
         $input["_job"] = new $input['itemtype']();
 
         if (


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !36815

From `Escalation Level` or from  `Ruleticket`

Although we have an action configured to disregard delay calculations `takeintoaccount_delay_stat => do_not_compute`, the 'itilfollowup_template' action still triggers the computation of the delay state.




The `post_addItem` method of the `ITILFollowup` class updates the last modification date of the parent item.

```php
// Check if stats should be computed after this change
$no_stat = isset($this->input['_do_not_compute_takeintoaccount']);

$parentitem = $this->input['_job'];
$parentitem->updateDateMod(
    $this->input["items_id"],
    $no_stat,
    $this->input["users_id"]
);
```

However, the `prepareInputForAdd()` method never retrieves the `_do_not_compute_takeintoaccount` key, even when it is present in the input data.

This pull request fixes that issue by ensuring the field is correctly handled during the input preparation process.

## Screenshots (if appropriate):


