### PR TITLE
fix: Missing attachments in entity notes

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -5181,7 +5181,7 @@ HTML;
                       . ($p['onlyimages'] ? " accept='.gif,.png,.jpg,.jpeg'" : "") . ">";
 
         $display .= "<div id='progress{$rand_id}' style='display:none'>" .
-                "<div class='uploadbar' style='width: 0%;'></div></div>";
+                "<div role='progressbar' class='uploadbar' style='width: 0%;'></div></div>";
         $progressall_js = "
         progressall: function(event, data) {
             var progress = parseInt(data.loaded / data.total * 100, 10);

--- a/templates/components/itilobject/fields_panel.html.twig
+++ b/templates/components/itilobject/fields_panel.html.twig
@@ -303,7 +303,14 @@
              <div id="notes" class="accordion-collapse collapse {{ notes_show ? "show" : "" }}" aria-labelledby="notes-heading">
                 <div class="accordion-body row m-0 mt-n2">
                   {% for note in notes %}
-                     <div class="alert alert-info entitynote rich_text_container" role="alert">{{ note['content']|safe_html }}</div>
+                     <div class="alert alert-info entitynote rich_text_container" role="alert">
+                        {{ note['content']|safe_html }}
+
+                        {{ include('components/itilobject/timeline/sub_documents.html.twig', {
+                           'item': note,
+                           'entry': note
+                        }) }}
+                     </div>
                   {% endfor %}
                 </div>
              </div>

--- a/templates/components/notepad/form.html.twig
+++ b/templates/components/notepad/form.html.twig
@@ -148,10 +148,15 @@
                             'entry': note
                         }) }}
 
-                        <div id="edit-{{ id }}" class="modal fade">
+                    </form>
 
-                            <div class="modal-dialog modal-xl">
-                                <div class="modal-content">
+                    <div id="edit-{{ id }}" class="modal fade">
+                        <div class="modal-dialog modal-xl">
+                            <div class="modal-content">
+                                <form action="{{ url }}" method="post" autocomplete="off" data-submit-once>
+                                    <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}" />
+                                    <input type="hidden" name="id" value="{{ note['id'] }}" />
+
                                     <div class="modal-header">
                                         <h3 class="modal-title">
                                             <i class="ti ti-notes"></i>
@@ -195,11 +200,10 @@
                                             <span>{{ __('Update') }}</span>
                                         </button>
                                     </div>
-                                </div>
+                                </form>
                             </div>
                         </div>
-
-                    </form>
+                    </div>
                 </div>
             </div>
         </div>

--- a/tests/cypress/e2e/entity_notes.cy.js
+++ b/tests/cypress/e2e/entity_notes.cy.js
@@ -1,0 +1,182 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+function addEntityNote(visible_on_tickets = false) {
+    cy.findByRole('button', { name: 'Add a note' }).click();
+    cy.findByLabelText('Content').awaitTinyMCE().type('This is a test note');
+
+    if (visible_on_tickets) {
+        cy.findByRole('checkbox', { name: 'Visible on tickets' }).check();
+    }
+
+    cy.findByRole('button', { name: 'Add' }).click();
+}
+
+function addEntityNoteWithAttachment(visible_on_tickets = false) {
+    cy.findByRole('button', { name: 'Add a note' }).click();
+    cy.findByLabelText('Content').awaitTinyMCE().type('This is a test note');
+
+    if (visible_on_tickets) {
+        cy.findByRole('checkbox', { name: 'Visible on tickets' }).check();
+    }
+
+    cy.get('input[type="file"]').selectFile('fixtures/uploads/bar.png');
+    cy.findByRole('progressbar').should('contain', 'Upload successful');
+    cy.get('input[type="file"]').selectFile('fixtures/uploads/bar.txt');
+    cy.findByRole('progressbar').should('contain', 'Upload successful');
+    cy.findByRole('progressbar').should('not.exist');
+
+    cy.findByRole('button', { name: 'Add' }).click();
+}
+
+describe('Entity notes', () => {
+    beforeEach(() => {
+        cy.login();
+
+        // Create entity
+        cy.createWithAPI('Entity', {
+            name: `EntityNotesTest ${Date.now()}`,
+        }).as('entity_id').then((entity_id) => {
+            cy.visit(`/front/entity.form.php?id=${entity_id}`);
+            cy.findByRole('tab', { name: 'Notes' }).click();
+        });
+    });
+
+    it('can add entity notes', () => {
+        addEntityNote();
+
+        cy.findByRole('button', { name: /^#\d+ - \d{4}-\d{2}-\d{2} \d{2}:\d{2}$/ }).click();
+        cy.findByRole('tabpanel').find('.rich_text_container').should('contain', 'This is a test note');
+    });
+
+    it('can delete entity notes', () => {
+        addEntityNote();
+
+        // Delete the note
+        cy.findByRole('button', { name: /^#\d+ - \d{4}-\d{2}-\d{2} \d{2}:\d{2}$/ }).click();
+        cy.findByRole('button', { name: 'Delete' }).click();
+
+        // Check that the note is deleted
+        cy.findByRole('button', { name: /^#\d+ - \d{4}-\d{2}-\d{2} \d{2}:\d{2}$/ }).should('not.exist');
+    });
+
+    it('can edit entity notes', () => {
+        addEntityNote();
+
+        // Edit the note
+        cy.findByRole('button', { name: /^#\d+ - \d{4}-\d{2}-\d{2} \d{2}:\d{2}$/ }).click();
+        cy.findByRole('button', { name: 'Edit' }).click();
+        cy.findByRole('dialog').within(() => {
+            cy.findByLabelText('Content').awaitTinyMCE().clear();
+            cy.findByLabelText('Content').awaitTinyMCE().type('This is an edited test note');
+            cy.findByRole('button', { name: 'Update' }).click();
+        });
+
+        // Check that the note is edited
+        cy.findByRole('tabpanel').find('.rich_text_container').should('contain', 'This is an edited test note');
+    });
+
+    it('can edit entity notes with attachments', () => {
+        addEntityNoteWithAttachment();
+
+        // Edit the note
+        cy.findByRole('button', { name: /^#\d+ - \d{4}-\d{2}-\d{2} \d{2}:\d{2}$/ }).click();
+        cy.findByRole('button', { name: 'Edit' }).click();
+
+        cy.findByRole('dialog').within(() => {
+            cy.findByLabelText('Content').awaitTinyMCE().clear();
+            cy.findByLabelText('Content').awaitTinyMCE().type('This is an edited test note');
+            cy.findByRole('button', { name: 'Update' }).click();
+        });
+
+        cy.findByRole('dialog').should('not.exist');
+    });
+
+    it('entity note can be visible on tickets', () => {
+        addEntityNote(true);
+        cy.get('@entity_id').then((entity_id) => {
+            // Create a ticket
+            cy.createWithAPI('Ticket', {
+                name: `Ticket ${Date.now()}`,
+                entities_id: entity_id,
+            }).then((ticket_id) => {
+                cy.visit(`/front/ticket.form.php?id=${ticket_id}`);
+                cy.findByRole('region', { name: 'Notes' }).should('exist').within(() => {
+                    cy.findByRole('generic', { name: 'Entity notes 1' })
+                        .find('p').should('contain', 'This is a test note');
+                });
+            });
+        });
+    });
+
+    it('entity note attachments are visible on tickets', () => {
+        addEntityNoteWithAttachment(true);
+
+        cy.get('@entity_id').then((entity_id) => {
+            // Create a ticket
+            cy.createWithAPI('Ticket', {
+                name: `Ticket ${Date.now()}`,
+                entities_id: entity_id,
+            }).then((ticket_id) => {
+                cy.visit(`/front/ticket.form.php?id=${ticket_id}`);
+                cy.findByRole('region', { name: 'Notes' }).should('exist').within(() => {
+                    cy.findByRole('alert').within(() => {
+                        cy.findByRole('figure').should('exist');
+                        cy.findByRole('link', { name: 'File extension bar.txt' }).should('exist');
+                    });
+                });
+            });
+        });
+    });
+
+    it('can add an attachment to an entity note', () => {
+        addEntityNote();
+
+        // Add an attachment
+        cy.findByRole('button', { name: /^#\d+ - \d{4}-\d{2}-\d{2} \d{2}:\d{2}$/ }).click();
+        cy.findByRole('button', { name: 'Edit' }).click();
+
+        cy.findByRole('dialog').within(() => {
+            cy.get('input[type="file"]').selectFile('fixtures/uploads/bar.png');
+            cy.findByRole('progressbar').should('contain', 'Upload successful');
+            cy.get('input[type="file"]').selectFile('fixtures/uploads/bar.txt');
+            cy.findByRole('progressbar').should('contain', 'Upload successful');
+            cy.findByRole('progressbar').should('not.exist');
+            cy.findByRole('button', { name: 'Update' }).click();
+        });
+
+        // Check that the attachment is added
+        cy.findByRole('button', { name: /^#\d+ - \d{4}-\d{2}-\d{2} \d{2}:\d{2}$/ }).click();
+        cy.findByRole('figure').should('exist');
+        cy.findByRole('link', { name: 'File extension bar.txt' }).should('exist');
+    });
+});

--- a/tests/cypress/e2e/entity_notes.cy.js
+++ b/tests/cypress/e2e/entity_notes.cy.js
@@ -102,6 +102,7 @@ describe('Entity notes', () => {
         });
 
         // Check that the note is edited
+        cy.findByRole('dialog').should('not.exist');
         cy.findByRole('tabpanel').find('.rich_text_container').should('contain', 'This is an edited test note');
     });
 
@@ -118,7 +119,9 @@ describe('Entity notes', () => {
             cy.findByRole('button', { name: 'Update' }).click();
         });
 
+        // Check that the note is edited
         cy.findByRole('dialog').should('not.exist');
+        cy.findByRole('tabpanel').find('.rich_text_container').should('contain', 'This is an edited test note');
     });
 
     it('entity note can be visible on tickets', () => {


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

- It fixes #19249

Display on tickets of linked documents to an entity's notes.

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/1b2cb7e2-09d1-4989-9dde-b0dca159d385)

