### PR TITLE
Add error message when trying to copy to clipboard in insecure context

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -1503,8 +1503,18 @@ $(() => {
     // TODO: refactorate existing code to use this unique handler.
     $(document).on('click', '[data-glpi-clipboard-text]', function() {
         const text = $(this).data('glpi-clipboard-text');
-        navigator.clipboard.writeText(text);
-        glpi_toast_info(__("Copied to clipboard"));
+        if (navigator.clipboard === undefined) {
+            // The clipboard is not available in non secure environements.
+            // See: https://developer.mozilla.org/en-US/docs/Web/API/Clipboard
+            // See: https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts
+            // This rarely happens in production but we can still add a specific
+            // error message to identify this issue in our support and/or help
+            // system administrator fix it themselves.
+            glpi_toast_error(__("Unable to copy to clipboard (insecure context)."));
+        } else {
+            navigator.clipboard.writeText(text);
+            glpi_toast_info(__("Copied to clipboard"));
+        }
     });
 });
 


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.

## Description

Navigator.clipboard is not available in insecure contexts (bad https cert or http on anything else than localhost).

By adding a clear error message, it may avoid issues like #19449.

