### PR TITLE
Fix(planning): Avoid double AJAX call to get_events on FullC initiazation

### DIFF
--- a/js/planning.js
+++ b/js/planning.js
@@ -627,12 +627,6 @@ var GLPIPlanning  = {
             }
         });
 
-        // Load the last known view only if it is valid (else load default view)
-        const view = this.calendar.isValidViewType(options.default_view) ?
-            options.default_view :
-            default_options.default_view;
-        this.calendar.changeView(view);
-
         $('.planning_on_central a')
             .mousedown(function() {
                 disable_qtip = true;


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !37230

During the plugin initialization, we observe two AJAX calls made to load events.

![image](https://github.com/user-attachments/assets/685be098-9590-44bb-be71-912e83997af9)

The first one results from the calendar initialization, 

![image](https://github.com/user-attachments/assets/b8c9fe57-1fa1-4b96-ac8a-1d4b5590f1c3)


while the second is triggered by the computation and loading of the last default view.

![image](https://github.com/user-attachments/assets/35e2751a-ef98-40ea-8fd7-4bf2d5999f5d)

trigger by this

```javascript

        // Load the last known view only if it is valid (else load default view)
        const view = this.calendar.isValidViewType(options.default_view) ?
            options.default_view :
            default_options.default_view;
        this.calendar.changeView(view);
```

This second call is redundant, as the default view has already been computed server-side (in PHP) and does not need to be reloaded / check on the client side.

```php
            $options = [
                'full_view'    => true,
                'default_view' => $_SESSION['glpi_plannings']['lastview'] ?? 'timeGridWeek',  // HERE
                'license_key'  => $scheduler_key,
                'resources'    => self::getTimelineResources(),
                'now'          => date("Y-m-d H:i:s"),
                'can_create'   => PlanningExternalEvent::canCreate(),
                'can_delete'   => PlanningExternalEvent::canPurge(),
            ];
```

## Screenshots (if appropriate):


