### PR TITLE
First buch of Twig templates fixes

### DIFF
--- a/templates/components/datatable.html.twig
+++ b/templates/components/datatable.html.twig
@@ -33,13 +33,21 @@
 {% import 'components/alerts_macros.html.twig' as alerts %}
 
 {% set datatable_id = datatable_id|default('datatable' ~ random()) %}
+{% set filters = filters|default([]) %}
+{% set additional_params = additional_params|default('') %}
+{% set sort = sort|default(null) %}
+{% set nosort = nosort|default(false) %}
+{% set order = order|default('ASC') %}
+{% set csv_url = csv_url|default('') %}
+{% set footers = footers|default([]) %}
+
 {% if total_number < 1 and filters|length == 0 %}
     <table id="{{ datatable_id }}" class="table">
         <thead>
         {% if super_header is defined and super_header is not empty %}
             {% set super_header_label = super_header is array ? super_header['label'] : super_header %}
             {% if super_header_label is not empty %}
-                {% set super_header_raw = super_header is array ? super_header['is_raw'] : false %}
+                {% set super_header_raw = super_header is array ? (super_header['is_raw'] ?? false) : false %}
                 <tr>
                     <th colspan="1">
                         {{ super_header_raw ? super_header_label|raw : super_header_label }}
@@ -60,7 +68,7 @@
     </table>
 {% else %}
     {% set total_cols = columns|length + (showmassiveactions ? 1 : 0) + (nofilter ? 0 : 1) %}
-    {% if not nopager %}
+    {% if nopager is not defined or not nopager %}
         {{ include('components/pager.html.twig', {
             'count': filtered_number,
             'additional_params': additional_params ~ '&sort=' ~ sort ~ '&order=' ~ order
@@ -77,7 +85,7 @@
             <thead>
                 {% if super_header is defined and super_header is not empty %}
                     {% set super_header_label = super_header is array ? super_header['label'] : super_header %}
-                    {% set super_header_raw = super_header is array ? super_header['is_raw'] : false %}
+                    {% set super_header_raw = super_header is array ? (super_header['is_raw'] ?? false) : false %}
                     <tr>
                         {% if super_header_raw is not same as 'th_elements' %}<th colspan="{{ total_cols }}">{% endif %}
                             {{ super_header_raw ? super_header_label|raw : super_header_label }}
@@ -225,7 +233,7 @@
                                     {% set aria_label = entry[colkey ~ '_aria_label']|default('') %}
                                     <td colspan="{{ colspan }}" aria-label="{{ aria_label }}">
 
-                                        {% set formatter = formatters[colkey] %}
+                                        {% set formatter = formatters[colkey] ?? '' %}
 
                                         {% if formatter == "maintext" %}
                                             <span class="d-inline-block bg-blue-lt p-1 text-truncate"
@@ -328,7 +336,7 @@
         </table>
     </div>
 
-    {% if not nopager %}
+    {% if nopager is defined and not nopager %}
         <div class="ms-auto d-inline-flex align-items-center d-none d-md-block my-2">
             {{ __('Entries to show:') }}
             {% include 'components/dropdown/limit.html.twig' %}

--- a/templates/components/datatable.html.twig
+++ b/templates/components/datatable.html.twig
@@ -336,7 +336,7 @@
         </table>
     </div>
 
-    {% if nopager is defined and not nopager %}
+    {% if nopager is not defined or not nopager %}
         <div class="ms-auto d-inline-flex align-items-center d-none d-md-block my-2">
             {{ __('Entries to show:') }}
             {% include 'components/dropdown/limit.html.twig' %}

--- a/templates/components/dropdown/limit.html.twig
+++ b/templates/components/dropdown/limit.html.twig
@@ -30,6 +30,7 @@
  # ---------------------------------------------------------------------
  #}
 
+{% set additional_attributes = additional_attributes|default([]) %}
 {% if additional_params is not defined %}
    {% set additional_params = '' %}
 {% else %}
@@ -38,7 +39,7 @@
    {% endif %}
 {% endif %}
 
-{% if not no_onchange %}
+{% if no_onchange is not defined or not no_onchange %}
    {% set href_separator = '?' in href ? '&' : '?' %}
    {% set href = "location.href='" ~ href ~ href_separator ~ "glpilist_limit='+this.value+'" ~ additional_params ~ "'" %}
    {% if is_tab is defined and is_tab == true %}

--- a/templates/components/form/basic_inputs_macros.html.twig
+++ b/templates/components/form/basic_inputs_macros.html.twig
@@ -40,16 +40,17 @@
         'disabled': false,
         'multiple': false,
         'required': false,
+        'maxlength': null,
         'is_disclosable': false,
         'is_copyable': false,
         'clearable': false,
     }|merge(options) %}
 
-    {% if options.fields_template.isMandatoryField(name) %}
+    {% if options.fields_template.isMandatoryField(name)|default(false) %}
         {% set options = options|merge({'required': true}) %}
     {% endif %}
 
-    {% if options.fields_template.isReadonlyField(name) %}
+    {% if options.fields_template.isReadonlyField(name)|default(false) %}
         {% set options = options|merge({'readonly': true}) %}
     {% endif %}
 
@@ -117,6 +118,10 @@
 
 
 {% macro text(name, value, options = {}) %}
+    {% set options = {
+        'copyable': false,
+    }|merge(options) %}
+
     {% if options.copyable %}
         <div class="copy_to_clipboard_wrapper">
     {% endif %}
@@ -320,9 +325,10 @@
         'aria_label': "",
         'statusbar': true,
         'content_style': "",
+        'input_addclass': '',
     }|merge(options) %}
 
-    {% if options.fields_template.isMandatoryField(name) %}
+    {% if options.fields_template.isMandatoryField(name)|default(false) %}
         {% set options = {'required': true}|merge(options) %}
     {% endif %}
     {% set options = options|merge({
@@ -438,13 +444,14 @@
 
 {% macro label(label, id, options = {}, class = 'form-label') %}
     {% set options = {
-        locked: false,
-        locked_value: null,
-        tpl_mark: null
+        'locked': false,
+        'locked_value': null,
+        'tpl_mark': null,
+        'helper': false
     }|merge(options) %}
 
     {% set required_mark = '' %}
-    {% if options.fields_template.isMandatoryField(options.name) or options.required %}
+    {% if options.fields_template.isMandatoryField(options.name)|default(false) or options.required ?? false %}
         {% set required_mark = '<span class="required">*</span>' %}
     {% endif %}
 

--- a/templates/components/form/buttons.html.twig
+++ b/templates/components/form/buttons.html.twig
@@ -132,7 +132,7 @@
             <input type="hidden" name="id" value="{{ id }}" />
          {% endif %}
 
-         {% if canedit and params['addbuttons']|length > 0 %}
+         {% if canedit and (params['addbuttons'] ?? [])|length > 0 %}
             {% for key, val in params['addbuttons'] %}
                 {% if val.add_attribs is not empty %}
                     {% set extra_attribs = call('Html::parseAttributes', {options: val.add_attribs}) %}

--- a/templates/components/form/fields_macros.html.twig
+++ b/templates/components/form/fields_macros.html.twig
@@ -77,7 +77,7 @@
 {% endmacro %}
 
 {% macro autoNameField(name, item, label = '', withtemplate, options = {}) %}
-   {% set tpl_value = options.value|length > 0 ? options.value : item.fields[name] %}
+   {% set tpl_value = (options.value ?? '')|length > 0 ? options.value : item.fields[name] %}
    {% if item.isTemplate() %} {# TODO exluded types #}
        {% set options = options|merge({
            tpl_mark: item.getAutofillMark(name, {'withtemplate': withtemplate}, tpl_value)
@@ -137,17 +137,22 @@
 
 
 {% macro sliderField(name, value, label = '', options = {}) %}
-   {% if options.fields_template.isMandatoryField(name) %}
+   {% if options.fields_template.isMandatoryField(name)|default(false) %}
       {% set options = {
          'required': true
       }|merge(options) %}
    {% endif %}
-   {% if options.fields_template.isReadonlyField(name) %}
+   {% if options.fields_template.isReadonlyField(name)|default(false) %}
       {% set options = options|merge({'readonly': true}) %}
    {% endif %}
    {% set options = {
       'no_value': 0,
       'yes_value': 1,
+      'readonly': false,
+      'required': false,
+      'disabled': false,
+      'additional_attributes': [],
+      'label2': '',
    }|merge(options) %}
 
    {% set field %}
@@ -214,6 +219,7 @@
       'entities_id': session('glpiactive_entity'),
       'uploads': [],
       'rows': 3,
+      'readonly': false,
    }|merge(options) %}
 
    {% if options.id is not defined %}
@@ -233,7 +239,7 @@
              'editor_id': options.id,
              'multiple': true,
              'uploads': options.uploads,
-             'required': options.fields_template.isMandatoryField('_documents_id')
+             'required': options.fields_template.isMandatoryField('_documents_id')|default(false)
          }]) %}
       {% endset %}
    {% elseif not options.readonly and not options.enable_fileupload and options.enable_richtext and options.enable_images %}
@@ -243,7 +249,7 @@
              'name': name,
              'only_uploaded_files': true,
              'uploads': options.uploads,
-             'required': options.fields_template.isMandatoryField('_documents_id')
+             'required': options.fields_template.isMandatoryField('_documents_id')|default(false)
          }]) %}
       {% endset %}
    {% endif %}
@@ -366,7 +372,7 @@
          {% endif %}
       </div>
    {% endset %}
-   {% if options.fields_template.isReadonlyField(name) %}
+   {% if options.fields_template.isReadonlyField(name)|default(false) %}
       {% set options = options|merge({'readonly': true}) %}
    {% endif %}
    {{ _self.field(name, field, label, options) }}
@@ -392,7 +398,7 @@
       }) }}
    {% endset %}
 
-   {% if options.fields_template.isReadonlyField(name) %}
+   {% if options.fields_template.isReadonlyField(name)|default(false) %}
       {% set options = options|merge({'readonly': true}) %}
    {% endif %}
 
@@ -406,7 +412,7 @@
 {% endmacro %}
 
 {% macro hiddenField(name, value, label = '', options = {}) %}
-   {% if options.no_label %}
+   {% if options.no_label ?? false %}
       {% set options = {
          mb: 'mb-0'
       }|merge(options) %}
@@ -422,23 +428,24 @@
     {% set options = {
         'rand': random(),
         'width': '100%',
+        'disabled': false,
     }|merge(options) %}
 
-   {% if options.fields_template.isReadonlyField(name) %}
+   {% if options.fields_template.isReadonlyField(name)|default(false) %}
       {% set options = options|merge({'readonly': true}) %}
    {% endif %}
 
    {% if options.disabled %}
       {% set options = options|merge({specific_tags: {'disabled': 'disabled'}}) %}
    {% endif %}
-   {% if options.fields_template.isMandatoryField(name) %}
+   {% if options.fields_template.isMandatoryField(name)|default(false) %}
       {% set options = {'specific_tags': {'required': true}}|merge(options) %}
    {% endif %}
 
    {% set field %}
       {% do call('Dropdown::showNumber', [name, {
          'value': value,
-         'rand': rand
+         'rand': options.rand
       }|merge(options)]) %}
    {% endset %}
 
@@ -448,10 +455,11 @@
 {% macro dropdownArrayField(name, value, elements, label = '', options = {}) %}
     {% set options = {
         'rand': random(),
+        'disabled': false,
         'width': '100%',
     }|merge(options) %}
 
-   {% if options.fields_template.isReadonlyField(name) %}
+   {% if options.fields_template.isReadonlyField(name)|default(false) %}
       {% set options = options|merge({'readonly': true}) %}
    {% endif %}
 
@@ -459,14 +467,14 @@
       {% set options = options|merge({specific_tags: {'disabled': 'disabled'}}) %}
    {% endif %}
 
-   {% if options.fields_template.isMandatoryField(name) %}
+   {% if options.fields_template.isMandatoryField(name)|default(false) %}
       {% set options = {'required': true}|merge(options) %}
    {% endif %}
 
    {% set field %}
       {% do call('Dropdown::showFromArray', [name, elements, {
          'value': value,
-         'rand': rand,
+         'rand': options.rand,
       }|merge(options)]) %}
    {% endset %}
 
@@ -478,11 +486,11 @@
         'rand': random(),
         'width': '100%',
     }|merge(options) %}
-   {% if options.fields_template.isMandatoryField(name) %}
+   {% if options.fields_template.isMandatoryField(name)|default(false) %}
       {% set options = {'required': true}|merge(options) %}
    {% endif %}
 
-   {% if options.fields_template.isReadonlyField(name) %}
+   {% if options.fields_template.isReadonlyField(name)|default(false) %}
       {% set options = options|merge({'readonly': true}) %}
    {% endif %}
 
@@ -505,11 +513,11 @@
         'rand': random(),
         'width': '100%',
     }|merge(options) %}
-   {% if options.fields_template.isMandatoryField(name) %}
+   {% if options.fields_template.isMandatoryField(name)|default(false) %}
       {% set options = {'required': true}|merge(options) %}
    {% endif %}
 
-   {% if options.fields_template.isReadonlyField(name) %}
+   {% if options.fields_template.isReadonlyField(name)|default(false) %}
       {% set options = options|merge({'readonly': true}) %}
    {% endif %}
 
@@ -530,12 +538,13 @@
     {% set options = {
         'rand': random(),
         'width': '100%',
+        'disabled': false,
     }|merge(options) %}
-   {% if options.fields_template.isMandatoryField(name) %}
+   {% if options.fields_template.isMandatoryField(name)|default(false) %}
       {% set options = {'required': true}|merge(options) %}
    {% endif %}
 
-   {% if options.fields_template.isReadonlyField(name) %}
+   {% if options.fields_template.isReadonlyField(name)|default(false) %}
       {% set options = options|merge({'readonly': true}) %}
    {% endif %}
 
@@ -547,7 +556,7 @@
 
    {% set field %}
       {% do call('Dropdown::showItemTypes', [name, types, {
-         'rand': rand,
+         'rand': options.rand,
          'value': value
       }|merge(options)]) %}
    {% endset %}
@@ -560,7 +569,7 @@
       'rand': random()
    }|merge(options) %}
 
-   {% if options.fields_template.isReadonlyField(name) %}
+   {% if options.fields_template.isReadonlyField(name)|default(false) %}
       {% set options = options|merge({'readonly': true}) %}
    {% endif %}
 
@@ -575,11 +584,11 @@
         'rand': random(),
         'width': '100%',
     }|merge(options) %}
-   {% if options.fields_template.isMandatoryField(name) %}
+   {% if options.fields_template.isMandatoryField(name)|default(false) %}
       {% set options = {'required': true}|merge(options) %}
    {% endif %}
 
-   {% if options.fields_template.isReadonlyField(name) %}
+   {% if options.fields_template.isReadonlyField(name)|default(false) %}
       {% set options = options|merge({'readonly': true}) %}
    {% endif %}
 
@@ -620,11 +629,11 @@
         'rand': random(),
         'width': '100%',
     }|merge(options) %}
-   {% if options.fields_template.isMandatoryField(name) %}
+   {% if options.fields_template.isMandatoryField(name)|default(false) %}
       {% set options = {'required': true}|merge(options) %}
    {% endif %}
 
-   {% if options.fields_template.isReadonlyField(name) %}
+   {% if options.fields_template.isReadonlyField(name)|default(false) %}
       {% set options = options|merge({'readonly': true}) %}
    {% endif %}
 
@@ -644,11 +653,11 @@
 
 {% macro dropdownFrequency(name, value, label = '', options = {}) %}
    {% set options = {'rand': random()}|merge(options) %}
-   {% if options.fields_template.isMandatoryField(name) %}
+   {% if options.fields_template.isMandatoryField(name)|default(false) %}
       {% set options = {'required': true}|merge(options) %}
    {% endif %}
 
-   {% if options.fields_template.isReadonlyField(name) %}
+   {% if options.fields_template.isReadonlyField(name)|default(false) %}
       {% set options = options|merge({'readonly': true}) %}
    {% endif %}
 
@@ -668,7 +677,7 @@
 {% endmacro %}
 
 {% macro dropdownField(itemtype, name, value, label = '', options = {}) %}
-   {% if options.multiple %}
+   {% if options.multiple ?? false %}
       {# Needed for empty value as the input wont be sent in this case... we need something to know the input was displayed AND empty #}
       {% set defined_input_name = "_#{name}_defined" %}
       <input type="hidden" name="{{ defined_input_name }}" value="1"></input>
@@ -679,12 +688,13 @@
     {% set options = {
         'rand': random(),
         'width': '100%',
+        'disabled': false,
     }|merge(options) %}
-   {% if options.fields_template.isMandatoryField(name) %}
+   {% if options.fields_template.isMandatoryField(name)|default(false) %}
       {% set options = {'specific_tags': {'required': true}}|merge(options) %}
    {% endif %}
 
-   {% if options.fields_template.isReadonlyField(name) %}
+   {% if options.fields_template.isReadonlyField(name)|default(false) %}
       {% set options = options|merge({'readonly': true}) %}
    {% endif %}
 
@@ -696,7 +706,7 @@
       {{ itemtype|itemtype_dropdown({
          'name': name,
          'value': value,
-         'rand': rand,
+         'rand': options.rand,
       }|merge(options)) }}
    {% endset %}
 
@@ -718,11 +728,11 @@
         'rand': random(),
         'width': '100%',
     }|merge(options) %}
-    {% if options.fields_template.isMandatoryField(name) %}
+    {% if options.fields_template.isMandatoryField(name)|default(false) %}
         {% set options = {'specific_tags': {'required': true}}|merge(options) %}
     {% endif %}
 
-    {% if options.fields_template.isReadonlyField(name) %}
+    {% if options.fields_template.isReadonlyField(name)|default(false) %}
         {% set options = options|merge({'readonly': true}) %}
     {% endif %}
 
@@ -751,7 +761,7 @@
       wrapper_class: 'form-control-plaintext'
    }|merge(options) %}
 
-   {% if options.fields_template.isReadonlyField(name) %}
+   {% if options.fields_template.isReadonlyField(name)|default(false) %}
       {% set options = options|merge({'readonly': true}) %}
    {% endif %}
 
@@ -769,6 +779,7 @@
       'add_field_html': '',
       'locked': false,
       'locked_fields': [],
+       'no_label': false,
    }|merge(options) %}
 
    {% if options.locked_fields[name] is defined %}
@@ -777,14 +788,14 @@
       {% set options = options|merge({'locked': true}) %}
    {% endif %}
 
-   {% if options.fields_template.isReadonlyField(name) %}
+   {% if options.fields_template.isReadonlyField(name)|default(false) %}
       {% set options = options|merge({'readonly': true}) %}
    {% endif %}
 
    {% if not options.include_field %}
       {{ field }}
    {% else %}
-      {% set id    = options.id|length > 0 and options.id != '%id%' ? options.id : (name|slug ~ '_' ~ options.rand) %}
+      {% set id    = (options.id ?? '')|length > 0 and options.id != '%id%' ? options.id : (name|slug ~ '_' ~ options.rand) %}
       {% set field = field|replace({'%id%': id}) %}
       {% set add_field_html = options.add_field_html|length > 0 ? options.add_field_html : '' %}
 
@@ -863,6 +874,7 @@
       'center': false,
       'label_align': 'end',
       'inline_add_field_html': false,
+       'icon_label': false,
    }|merge(options) %}
 
    {% if options.icon_label %}
@@ -922,6 +934,8 @@
       'add_field_class': '',
       'add_field_attribs': {},
       'insert_content_after_label': '',
+      'label_class': '',
+      'input_class': '',
    }|merge(options) %}
 
    {% if options.full_width %}

--- a/templates/components/form/header.html.twig
+++ b/templates/components/form/header.html.twig
@@ -72,7 +72,6 @@
 
       {{ call_plugin_hook(constant('Glpi\\Plugin\\Hooks::PRE_ITEM_FORM'), {'item': item, 'options': params}) }}
 
-      {# todo modal message #}
-      {% if app.request.request('in_modal') == true %}
+      {% if _request['_in_modal'] is defined and _request['_in_modal'] == "1" %}
       <input type="hidden" name="_no_message_link" value="1" />
       {% endif %}

--- a/templates/components/form/item_itilobject_item_list.html.twig
+++ b/templates/components/form/item_itilobject_item_list.html.twig
@@ -60,8 +60,8 @@
     {% set entries = call(itemtype_1 ~ '::getDatatableEntries', [values]) %}
     {% set datatable_params = {
         'super_header': {
-            'label': superheader,
-            'is_raw': superheader_raw,
+            'label': superheader|default(''),
+            'is_raw': superheader_raw|default(false),
         },
         'is_tab': true,
         'nopager': true,
@@ -69,7 +69,7 @@
         'nosort': true,
         'entries': entries,
         'total_number': entries|length,
-        'showmassiveactions': canedit,
+        'showmassiveactions': canedit|default(false),
     } %}
     {% set merged_params = datatable_params|merge(common_columns) %}
 

--- a/templates/components/pager.html.twig
+++ b/templates/components/pager.html.twig
@@ -38,6 +38,9 @@
     {% endif %}
 {% endif %}
 
+{% set href = href|default('') %}
+{% set start = start|default(1) %}
+
 {% set href_separator = '?' in href ? '&' : '?' %}
 {% set href = href ~ href_separator ~ "start=%start%" ~ additional_params %}
 {% if is_tab is defined and is_tab == true %}

--- a/templates/components/search/controls.html.twig
+++ b/templates/components/search/controls.html.twig
@@ -37,15 +37,15 @@
 {% endif %}
 
 <div class="card-header search-header px-1 px-xl-3">
-    {% if not original_params.hide_controls %}
+    {% if not original_params.hide_controls ?? false %}
         <div class="search-controls d-flex justify-content-between align-items-center">
 
             {% set mainform = mainform ?? true %}
             {% set showaction = showaction ?? true %}
             {% if mainform and showaction %}
-                <form name="searchform{{ normalized_itemtype }}" class="search-form-container needs-validation" novalidate method="get" action="{{ p['target'] }}">
+                <form name="searchform{{ normalized_itemtype }}" class="search-form-container needs-validation" novalidate method="get" action="{{ href }}">
             {% endif %}
-            {% if not original_params.hide_criteria %}
+            {% if not original_params.hide_criteria ?? false %}
                 <div class="primary-controls">
                 <div class="btn-group me-1 me-xl-2">
                     {% set is_filter_active = false %}

--- a/templates/components/search/display_data.html.twig
+++ b/templates/components/search/display_data.html.twig
@@ -37,7 +37,7 @@
    <div class="ajax-container search-display-data">
 {% endif %}
 {% set push_history = push_history is defined and push_history %}
-{% set hide_controls = data['search']['hide_controls'] or (hide_controls is defined and hide_controls) %}
+{% set hide_controls = data['search']['hide_controls'] ?? hide_controls ?? false %}
 
 {# Remove namespace separators for use in HTML attributes #}
 {% set normalized_itemtype = itemtype|replace({'\\': ''}) %}

--- a/templates/components/search/query_builder/criteria.html.twig
+++ b/templates/components/search/query_builder/criteria.html.twig
@@ -33,6 +33,7 @@
 {% import 'components/form/fields_macros.html.twig' as fields %}
 
 {% set add_padding = from_meta ? 'p-0' : 'p-2' %}
+{% set add_class = add_class|default('') %}
 
 {% if meta and not from_meta %}
    {{ call("Glpi\\Search\\Input\\QueryBuilder::displayMetaCriteria", [{

--- a/templates/components/search/query_builder/search_option.html.twig
+++ b/templates/components/search/query_builder/search_option.html.twig
@@ -55,7 +55,6 @@
       itemtype: itemtype,
       _idor_token: idor_token(itemtype),
       from_meta: from_meta is defined ? from_meta : false,
-      field: field,
       prefix: prefix,
       p: p,
    } %}

--- a/templates/components/user/picture.html.twig
+++ b/templates/components/user/picture.html.twig
@@ -35,6 +35,7 @@
 {% set anonymized = enable_anonymization and entity_config('anonymize_support_agents', session('glpiactive_entity')) != constant('Entity::ANONYMIZE_DISABLED') %}
 {% set user = user_object ?? get_item('User', users_id) %}
 {% set with_link = with_link ?? true %}
+{% set force_initials = force_initials ?? false %}
 {% if not force_initials %}
     {% set user_thumbnail = user.getThumbnailPicturePath(enable_anonymization) %}
     {% if user_thumbnail == null and not entity_config('display_users_initials', session('glpiactive_entity')) %}

--- a/templates/generic_show_form.html.twig
+++ b/templates/generic_show_form.html.twig
@@ -124,7 +124,7 @@
                                   {% set conditions_met = conditions_met + 1 %}
                               {% endif %}
 
-                              {% if cluster is not null %}
+                              {% if cluster is defined and cluster is not null %}
                                   {{ fields.htmlField(
                                       '',
                                       cluster.getLink(),
@@ -578,7 +578,7 @@
       {{ include('components/form/inventory_info.html.twig') }}
    {% endif %}
 
-   {% if params['formfooter'] is null or params['formfooter'] == true %}
+   {% if params['formfooter'] ?? true %}
       <div class="card-footer mx-n2 mb-n2">
          {{ include('components/form/dates.html.twig') }}
       </div>

--- a/templates/layout/parts/menu.html.twig
+++ b/templates/layout/parts/menu.html.twig
@@ -37,8 +37,8 @@
 
 <ul class="navbar-nav" id="menu_{{ rand }}">
 {% for firstlevel in menu %}
-   {% set firstlevel_active = menu[sector]['title'] == firstlevel['title'] %}
-   {% set firstlevel_shown = (menu[sector]['title'] == firstlevel['title'] and is_vertical and is_menu_folded == false) %}
+   {% set firstlevel_active = menu[sector]['title']|default('') == firstlevel['title'] %}
+   {% set firstlevel_shown = firstlevel_active and is_vertical and is_menu_folded == false %}
    {% set has_subitems = false %}
    {% if firstlevel['content'] is defined %}
       {# Are there any items under contents with a page property? #}

--- a/templates/pages/management/document_item.html.twig
+++ b/templates/pages/management/document_item.html.twig
@@ -37,7 +37,7 @@
     <form method="post" action="{{ 'Document'|itemtype_form_path }}" enctype="multipart/form-data" data-submit-once>
 
         <div class="d-flex">
-            {{ fields.dropdownField('DocumentCategory', 'documentcategories_id', item.fields['documentcategories_id'], 'DocumentCategory'|itemtype_name, {
+            {{ fields.dropdownField('DocumentCategory', 'documentcategories_id', item.fields['documentcategories_id'] ?? '', 'DocumentCategory'|itemtype_name, {
                 field_class: 'col-12 col-sm-5 pe-2',
                 entity: entities
             }) }}


### PR DESCRIPTION
Fixes to display main dashboard, computers list, computer form and (almost) all its standard tabs.

Goal is to quick fix several generic issues detected when enabling Twig strict variables. In case of doubt on one change, it can be reverted to be reviewed later.