### PR TITLE
Display plugin local logo files in the marketplace

### DIFF
--- a/phpunit/functional/Glpi/Http/FirewallTest.php
+++ b/phpunit/functional/Glpi/Http/FirewallTest.php
@@ -270,6 +270,7 @@ class FirewallTest extends \DbTestCase
     public static function provideStrategy(): iterable
     {
         yield ['strategy' => Firewall::STRATEGY_AUTHENTICATED];
+        yield ['strategy' => Firewall::STRATEGY_ADMIN_ACCESS];
         yield ['strategy' => Firewall::STRATEGY_CENTRAL_ACCESS];
         yield ['strategy' => Firewall::STRATEGY_FAQ_ACCESS];
         yield ['strategy' => Firewall::STRATEGY_HELPDESK_ACCESS];
@@ -299,11 +300,42 @@ class FirewallTest extends \DbTestCase
 
     public static function provideStrategyResults(): iterable
     {
+        $admin_users = [
+            TU_USER => TU_PASS,
+            'glpi'  => 'glpi',
+        ];
+
+        foreach ($admin_users as $login => $pass) {
+            yield [
+                'strategy'      => Firewall::STRATEGY_AUTHENTICATED,
+                'credentials'   => [$login, $pass],
+                'exception'     => null,
+            ];
+            yield [
+                'strategy'      => Firewall::STRATEGY_ADMIN_ACCESS,
+                'credentials'   => [$login, $pass],
+                'exception'     => null,
+            ];
+            yield [
+                'strategy'      => Firewall::STRATEGY_CENTRAL_ACCESS,
+                'credentials'   => [$login, $pass],
+                'exception'     => null,
+            ];
+            yield [
+                'strategy'      => Firewall::STRATEGY_FAQ_ACCESS,
+                'credentials'   => [$login, $pass],
+                'exception'     => null,
+            ];
+            yield [
+                'strategy'      => Firewall::STRATEGY_HELPDESK_ACCESS,
+                'credentials'   => [$login, $pass],
+                'exception'     => new AccessDeniedHttpException('The current profile does not use the simplified interface'),
+            ];
+        }
+
         $central_users = [
-            TU_USER     => TU_PASS,
-            'glpi'      => 'glpi',
-            'tech'      => 'tech',
-            'normal'    => 'normal',
+            'tech'   => 'tech',
+            'normal' => 'normal',
         ];
 
         foreach ($central_users as $login => $pass) {
@@ -311,6 +343,11 @@ class FirewallTest extends \DbTestCase
                 'strategy'      => Firewall::STRATEGY_AUTHENTICATED,
                 'credentials'   => [$login, $pass],
                 'exception'     => null,
+            ];
+            yield [
+                'strategy'      => Firewall::STRATEGY_ADMIN_ACCESS,
+                'credentials'   => [$login, $pass],
+                'exception'     => new AccessDeniedHttpException('Missing administration rights.'),
             ];
             yield [
                 'strategy'      => Firewall::STRATEGY_CENTRAL_ACCESS,
@@ -337,6 +374,11 @@ class FirewallTest extends \DbTestCase
                 'strategy'      => Firewall::STRATEGY_AUTHENTICATED,
                 'credentials'   => [$login, $pass],
                 'exception'     => null,
+            ];
+            yield [
+                'strategy'      => Firewall::STRATEGY_ADMIN_ACCESS,
+                'credentials'   => [$login, $pass],
+                'exception'     => new AccessDeniedHttpException('Missing administration rights.'),
             ];
             yield [
                 'strategy'      => Firewall::STRATEGY_CENTRAL_ACCESS,

--- a/src/Glpi/Controller/Plugin/LogoController.php
+++ b/src/Glpi/Controller/Plugin/LogoController.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Controller\Plugin;
+
+use Document;
+use Glpi\Controller\AbstractController;
+use Glpi\Http\Firewall;
+use Glpi\Security\Attribute\SecurityStrategy;
+use Plugin;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+final class LogoController extends AbstractController
+{
+    /**
+     * Base64 encoded transparent 1x1 PNG.
+     */
+    private const EMPTY_PNG = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAAAl21bKAAAAA1BMVEUAAACnej3aAAAAAXRSTlMAQObYZgAAAApJREFUCNdjYAAAAAIAAeIhvDMAAAAASUVORK5CYII=';
+
+    #[SecurityStrategy(Firewall::STRATEGY_ADMIN_ACCESS)]
+    #[Route(
+        "/Plugin/{plugin_key}/Logo",
+        name: "glpi_plugin_logo",
+        methods: "GET"
+    )]
+    public function __invoke(string $plugin_key): Response
+    {
+        // Try to serve local logo file.
+        $plugin_path = Plugin::getPhpDir($plugin_key);
+        $logo = \sprintf('%s/logo.png', $plugin_path);
+
+        if (Document::isImage($logo)) {
+            return new BinaryFileResponse($logo);
+        }
+
+        // Fallback to an empty PNG to prevent 500 error that would pollute logs.
+        $empty_png = \base64_decode(self::EMPTY_PNG);
+        return new Response(
+            $empty_png,
+            status: 404,
+            headers: [
+                'Content-Type' => 'image/png',
+            ]
+        );
+    }
+}

--- a/src/Glpi/Http/Firewall.php
+++ b/src/Glpi/Http/Firewall.php
@@ -34,6 +34,8 @@
 
 namespace Glpi\Http;
 
+use Config;
+use Glpi\Exception\Http\AccessDeniedHttpException;
 use Session;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -51,6 +53,11 @@ final class Firewall
      * Check that user is authenticated.
      */
     public const STRATEGY_AUTHENTICATED = 'authenticated';
+
+    /**
+     * Check that user is authenticated and has administration rights.
+     */
+    public const STRATEGY_ADMIN_ACCESS = 'admin_access';
 
     /**
      * Check that user is authenticated and is using a profile based on central interface.
@@ -140,6 +147,12 @@ final class Firewall
         switch ($strategy) {
             case self::STRATEGY_AUTHENTICATED:
                 Session::checkLoginUser();
+                break;
+            case self::STRATEGY_ADMIN_ACCESS:
+                Session::checkLoginUser();
+                if (!Session::haveRight(Config::$rightname, UPDATE)) {
+                    throw new AccessDeniedHttpException('Missing administration rights.');
+                }
                 break;
             case self::STRATEGY_CENTRAL_ACCESS:
                 Session::checkCentralAccess();

--- a/src/Glpi/Marketplace/View.php
+++ b/src/Glpi/Marketplace/View.php
@@ -37,6 +37,7 @@ namespace Glpi\Marketplace;
 
 use CommonGLPI;
 use Config;
+use Document;
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\Marketplace\Api\Plugins as PluginsApi;
 use GLPINetwork;
@@ -224,6 +225,10 @@ class View extends CommonGLPI
         bool $only_lis = false,
         string $string_filter = ""
     ) {
+        /**
+         * @var array $CFG_GLPI
+         */
+        global $CFG_GLPI;
 
         $plugin_inst = new Plugin();
         $plugin_inst->init(true); // reload plugins
@@ -247,10 +252,16 @@ class View extends CommonGLPI
                 continue;
             }
 
+            $logo_url = $apidata['logo_url'] ?? '';
+            if (Document::isImage(\sprintf('%s/logo.png', Plugin::getPhpDir($key)))) {
+                // Use the local logo.png file if it exists.
+                $logo_url = sprintf('%s/Plugin/%s/Logo', $CFG_GLPI['root_doc'], $key);
+            }
+
             $clean_plugin = [
                 'key'           => $key,
                 'name'          => $plugin['name'],
-                'logo_url'      => $apidata['logo_url'] ?? "",
+                'logo_url'      => $logo_url,
                 'description'   => $apidata['descriptions'][0]['short_description'] ?? "",
                 'authors'       => $apidata['authors'] ?? [['id' => 'all', 'name' => $plugin['author'] ?? ""]],
                 'license'       => $apidata['license'] ?? $plugin['license'] ?? "",


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] This change requires a documentation update.

## Description

Replaces #18811.

In the marketplace view, when the plugin directory contains a `logo.png` file, it will be used to display the plugin logo instead of fetching it from the remote URL provided by the marketplace API.

1. This permit to display a logo for local plugins that are not available throught the marketplace.
2. This prevent requests to remote servers that can be an issue is securized contexts.

To prevent anyone to use the new controller to discover if a plugin is present on a GLPI instance, I introduced a new "admin access" firewall strategy. Plugins logos will be available only to GLPI administrators.


