### PR TITLE
Scopes is expected to be an array

### DIFF
--- a/src/OAuthClient.php
+++ b/src/OAuthClient.php
@@ -126,7 +126,7 @@ final class OAuthClient extends CommonDBTM
         $input['secret'] = $key->encrypt(self::getNewIDOrSecret());
 
         $input['grants'] = json_encode($input['grants'] ?? []);
-        $input['scopes'] = json_encode($input['scopes'] ?? []);
+        $input['scopes'] = json_encode(empty($input['scopes']) ? [] : $input['scopes']);
 
         if (empty($input['redirect_uri'])) {
             $input['redirect_uri'] = ['/api.php/oauth2/redirection'];
@@ -153,7 +153,7 @@ final class OAuthClient extends CommonDBTM
             $input['grants'] = json_encode($input['grants']);
         }
         if (isset($input['scopes'])) {
-            $input['scopes'] = json_encode($input['scopes']);
+            $input['scopes'] = json_encode(empty($input['scopes']) ? [] : $input['scopes']);
         }
         $input['redirect_uri'] = json_encode($input['redirect_uri'] ?? []);
 

--- a/templates/pages/setup/oauthclient.html.twig
+++ b/templates/pages/setup/oauthclient.html.twig
@@ -32,7 +32,7 @@
 
 {% import 'components/form/fields_macros.html.twig' as fields %}
 
-<div class="asset {{ bg }}">
+<div class="asset">
     {{ include('components/form/header.html.twig') }}
 
     {% set rand = random() %}
@@ -40,7 +40,7 @@
     {% set field_options = {} %}
 
     <div class="card-body d-flex flex-wrap">
-        <div class="col-12 col-xxl-{{ item_has_pictures ? '9' : '12' }} flex-column">
+        <div class="col-12 col-xxl-12 flex-column">
             <div class="d-flex flex-row flex-wrap flex-xl-nowrap">
                 <div class="row flex-row align-items-start flex-grow-1">
                     <div class="row flex-row">


### PR DESCRIPTION
Fix probably copy/pasted variables

Following error is displayed when no scope is provided (`""` stored in database):
![image](https://github.com/user-attachments/assets/9a057fbd-724c-44c1-8feb-bdf1fdf048c1)

