### PR TITLE
Display a dedicated page when webserver is misconfigured

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,46 @@
+<!--
+---------------------------------------------------------------------
+
+GLPI - Gestionnaire Libre de Parc Informatique
+
+http://glpi-project.org
+
+@copyright 2015-2025 Teclib' and contributors.
+@licence   https://www.gnu.org/licenses/gpl-3.0.html
+
+---------------------------------------------------------------------
+
+LICENSE
+
+This file is part of GLPI.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+---------------------------------------------------------------------
+-->
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <title>Web server misconfigured</title>
+    </head>
+    <body>
+        <h1>The web server seems to be misconfigured.</h1>
+        <p>
+            The web root directory must correspond to the <em>/public</em> directory of GLPI
+            and all the requests should be forwarded to the <em>/public/index.php</em> file.<br />
+            See the <a href="https://glpi-install.readthedocs.io/en/">installation documentation</a> for more details.
+        </p>
+    </body>
+</html>


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

When the webserver document root is not configured properly, if someone tries to access the index path (e.g. `http://glpi.example.com/`), a default 404 error will be displayed.
I propose to add an `index.html` fallback page to be displayed in this case. This file name corresponds to a default value handled by [Apache](https://httpd.apache.org/docs/trunk/getting-started.html#content), [IIS](https://learn.microsoft.com/en-us/troubleshoot/developer/webapps/iis/www-modules-features/configure-default-document-iis) and [NGINX](https://nginx.org/en/docs/http/ngx_http_index_module.html).

If the webserver is correctly configured, accessing the `/index.html` path will result in a GLPI error page with a 404 status code.

## Screenshots
![image](https://github.com/user-attachments/assets/8b458d46-5d13-492b-bd4f-51cb4e4f58b5)
