### PR TITLE
fix(supplier): restore 'Clone' MA for supplier

### DIFF
--- a/phpunit/functional/SupplierTest.php
+++ b/phpunit/functional/SupplierTest.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units;
+
+/* Test for src/Supplier.php */
+
+class SupplierTest extends \DbTestCase
+{
+    public function testClone()
+    {
+        $this->login();
+
+        $date = date('Y-m-d H:i:s');
+        $_SESSION['glpi_currenttime'] = $date;
+
+        $this->setEntity('_test_root_entity', true);
+
+        // Create trype
+        $supplier_type = new \SupplierType();
+        $supplier__type_id = $supplier_type->add([
+            'name' => 'Supplier Type',
+        ]);
+        $this->assertGreaterThan(0, $supplier__type_id);
+
+        // Create supplier
+        $supplier = new \Supplier();
+        $supplier_id = $supplier->add([
+            'name'                => 'create_supplier',
+            'entities_id'         => 0,
+            'suppliertype_id'     => $supplier__type_id,
+            'registration_number' => '123',
+            'adress'              => 'supplier adress',
+            'postcode'            => 'supplier postcode',
+            'town'                => 'supplier town',
+            'state'               => 'supplier state',
+            'country'             => 'supplier country',
+            'website'             => 'supplier website',
+            'phonenumber'         => '456',
+            'comment'             => 'comment',
+            'fax'                 => '789',
+            'email'               => 'supplier@supplier.com',
+            'pictures'            => 'pictures'
+        ]);
+        $this->assertGreaterThan(0, $supplier_id);
+
+        // Test item cloning
+        $added = $supplier->clone();
+        $this->assertGreaterThan(0, (int)$added);
+
+        $clonedSupplier = new \Supplier();
+        $this->assertTrue($clonedSupplier->getFromDB($added));
+
+        $fields = $supplier->fields;
+
+        // Check the values. Id and dates must be different, everything else must be equal
+        foreach ($fields as $k => $v) {
+            switch ($k) {
+                case 'id':
+                    $this->assertNotEquals($supplier->getField($k), $clonedSupplier->getField($k));
+                    break;
+                case 'date_mod':
+                case 'date_creation':
+                    $dateClone = new \DateTime($clonedSupplier->getField($k));
+                    $expectedDate = new \DateTime($date);
+                    $this->assertEquals($expectedDate, $dateClone);
+                    break;
+                case 'name':
+                    $this->assertSame("create_supplier (copy)", $clonedSupplier->getField($k));
+                    break;
+                default:
+                    $this->assertEquals($supplier->getField($k), $clonedSupplier->getField($k));
+            }
+        }
+    }
+}

--- a/phpunit/functional/SupplierTest.php
+++ b/phpunit/functional/SupplierTest.php
@@ -81,23 +81,11 @@ class SupplierTest extends \DbTestCase
         $fields = $supplier->fields;
 
         // Check the values. Id and dates must be different, everything else must be equal
-        foreach ($fields as $k => $v) {
-            switch ($k) {
-                case 'id':
-                    $this->assertNotEquals($supplier->getField($k), $clonedSupplier->getField($k));
-                    break;
-                case 'date_mod':
-                case 'date_creation':
-                    $dateClone = new \DateTime($clonedSupplier->getField($k));
-                    $expectedDate = new \DateTime($date);
-                    $this->assertEquals($expectedDate, $dateClone);
-                    break;
-                case 'name':
-                    $this->assertSame("create_supplier (copy)", $clonedSupplier->getField($k));
-                    break;
-                default:
-                    $this->assertEquals($supplier->getField($k), $clonedSupplier->getField($k));
-            }
-        }
+        $expected = $supplier->fields;
+        $expected['id'] = $clonedSupplier->getID();
+        $expected['date_creation'] = $date;
+        $expected['date_mod'] = $date;
+        $expected['name'] = "create_supplier (copy)";
+        $this->assertEquals($expected, $clonedSupplier->fields);
     }
 }

--- a/phpunit/functional/SupplierTest.php
+++ b/phpunit/functional/SupplierTest.php
@@ -48,20 +48,17 @@ class SupplierTest extends \DbTestCase
         $this->setEntity('_test_root_entity', true);
 
         // Create trype
-        $supplier_type = new \SupplierType();
-        $supplier__type_id = $supplier_type->add([
-            'name' => 'Supplier Type',
+        $supplier_type = $this->createItem('SupplierType', [
+            'name' => 'Supplier Type'
         ]);
-        $this->assertGreaterThan(0, $supplier__type_id);
 
         // Create supplier
-        $supplier = new \Supplier();
-        $supplier_id = $supplier->add([
+        $supplier = $this->createItem('Supplier', [
             'name'                => 'create_supplier',
             'entities_id'         => 0,
-            'suppliertype_id'     => $supplier__type_id,
+            'suppliertypes_id'     => $supplier_type->fields['id'],
             'registration_number' => '123',
-            'adress'              => 'supplier adress',
+            'address'              => 'supplier address',
             'postcode'            => 'supplier postcode',
             'town'                => 'supplier town',
             'state'               => 'supplier state',
@@ -73,7 +70,6 @@ class SupplierTest extends \DbTestCase
             'email'               => 'supplier@supplier.com',
             'pictures'            => 'pictures'
         ]);
-        $this->assertGreaterThan(0, $supplier_id);
 
         // Test item cloning
         $added = $supplier->clone();

--- a/src/Supplier.php
+++ b/src/Supplier.php
@@ -41,6 +41,7 @@ use Glpi\Features\AssetImage;
 class Supplier extends CommonDBTM
 {
     use AssetImage;
+    use Glpi\Features\Clonable;
 
    // From CommonDBTM
     public $dohistory           = true;
@@ -94,6 +95,13 @@ class Supplier extends CommonDBTM
 
        // Ticket rules use suppliers_id_assign
         Rule::cleanForItemAction($this, 'suppliers_id%');
+    }
+
+    public function getCloneRelations(): array
+    {
+        return [
+            Contact_Supplier::class,
+        ];
     }
 
 

--- a/src/Supplier.php
+++ b/src/Supplier.php
@@ -99,9 +99,7 @@ class Supplier extends CommonDBTM
 
     public function getCloneRelations(): array
     {
-        return [
-            Contact_Supplier::class,
-        ];
+        return [];
     }
 
 


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !37406
- In GLPI version 9.5, it was possible to clone suppliers. This RP re-implements this functionality.

## Screenshots (if appropriate):

![Capture d’écran du 2025-04-16 16-53-24](https://github.com/user-attachments/assets/84bebf27-71b0-4a88-aa21-5b77e82e5c5e)

![Capture d’écran du 2025-04-16 16-52-52](https://github.com/user-attachments/assets/f5eea1df-4fc8-4e85-a767-9cb1e9f07814)