### PR TITLE
fix plugin cleanup icon

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -2635,7 +2635,7 @@ TWIG;
                         ['action' => 'clean'],
                         _x('button', 'Clean'),
                         ['id' => $ID],
-                        'fas fa-broom fs-2x'
+                        'fa-broom fs-2x'
                     );
                 }
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Fixes #19491

Function only recognizes a Font-Awesome icon if the parameter starts with 'fa-'. The 'fas' part gets added automatically by `Html::getSimpleForm`.