### PR TITLE
Fix(Actors): Do not send 'content'

### DIFF
--- a/templates/components/itilobject/actors/field.html.twig
+++ b/templates/components/itilobject/actors/field.html.twig
@@ -74,6 +74,7 @@
       {{ include('components/itilobject/actors/assign_to_me.html.twig') }}
    {% endif %}
 
+   {% set safe_item_fields = item.fields|filter((value, key) => key != 'content') %}
    <script type="text/javascript">
 
    // Do not use jquery ready wrapper here as it behave unexpectedly with ajax
@@ -275,7 +276,7 @@
                   itiltemplates_id: {{ itiltemplate.fields['id'] ?? 0 }},
                   itemtype: '{{ item.getType() }}',
                   items_id: {{ item.isNewItem() ? -1 : item.fields['id'] }},
-                  item: {{ item.fields|json_encode|raw }},
+                  item: {{ safe_item_fields|json_encode|raw }},
                   returned_itemtypes: {{ (returned_itemtypes ?? ['User', 'Group', 'Supplier'])|json_encode()|raw }},
                   page: params.page || 1
                };


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !37416

Since the following PR https://github.com/glpi-project/glpi/pull/10300 
**the entire ticket data is sent through the AJAX call to `actors.php`.**

This allows access to the ticket’s content within the `HOOK::FILTER_ACTORS` hook.

For example, the `itilcategorygroups` plugin uses only the **ticket type** to filter applicable groups:

```php
$type = $params['params']['item']['type'] ?? Ticket::INCIDENT_TYPE;
```

---

### Reported issue

A support request reported that the **WAF (Web Application Firewall)** is blocking the request due to the `content` field:

```
Signature ID: 010000092
```

This rule is designed to prevent **XSS (Cross-Site Scripting)** attacks by detecting potentially dangerous HTML content, such as `href` attributes.

In this case, however, the `item[content]` field contains **legitimate encoded HTML**, which is wrongly interpreted as malicious — a **false positive**.

---

### Possible solutions

1. **Avoid sending the full `item` object** unless strictly required  
   > ⚠️ Needs careful consideration, as some plugins depend on ticket data within hooks.

2. **Explicitly remove the `content` field before the AJAX call** (preferred solution)  
   > Prevents the WAF false positive without affecting functionality.

3. **Encode the `content` field in Base64**  
   > Technically possible, but less readable and requires server-side decoding — **not recommended**.

4. **Whitelist the `/ajax/actors.php` endpoint in the WAF for this signature**  
   > Viable, but not advisable unless you have full control over the security stack.

