### PR TITLE
row_massiveactions used before its declaration

### DIFF
--- a/templates/components/datatable.html.twig
+++ b/templates/components/datatable.html.twig
@@ -216,8 +216,8 @@
             <tbody>
                 {% if entries|length > 0 %}
                     {% for entry in entries %}
+                        {% set row_massiveactions = entry['showmassiveactions']|default(showmassiveactions) %}
                         <tr class="{{ row_class|default('') }} {{ entry['row_class']|default('') }}"{% if row_massiveactions %} data-itemtype="{{ entry['itemtype'] }}" data-id="{{ entry['id'] }}"{% endif %}>
-                            {% set row_massiveactions = entry['showmassiveactions']|default(showmassiveactions) %}
                             {% if row_massiveactions %}
                                 <td style="width: 10px">
                                     {% if entry['skip_ma'] is not defined or entry['skip_ma'] == false %}


### PR DESCRIPTION
Introduced by change to revert `Rule` class changes while working on #19495