### PR TITLE
Add PHPStan rules to forbid some PHP functions

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -1556,6 +1556,18 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Api/API.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^You should not use the `exit` function\\. It prevents the execution of post\\-request/post\\-command routines\\.$#',
+	'identifier' => 'glpi.forbidExit',
+	'count' => 3,
+	'path' => __DIR__ . '/src/Glpi/Api/API.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^You should not use the `http_response_code` function to change the response code\\. Due to a PHP bug, it may not provide the expected result \\(see https\\://bugs\\.php\\.net/bug\\.php\\?id\\=81451\\)\\.$#',
+	'identifier' => 'glpi.forbidHttpResponseCode',
+	'count' => 1,
+	'path' => __DIR__ . '/src/Glpi/Api/API.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Method Glpi\\\\Api\\\\APIRest\\:\\:parseIncomingParams\\(\\) with return type void returns string but should not return anything\\.$#',
 	'identifier' => 'return.void',
 	'count' => 1,
@@ -1576,6 +1588,18 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Strict comparison using \\!\\=\\= between false and array will always evaluate to true\\.$#',
 	'identifier' => 'notIdentical.alwaysTrue',
+	'count' => 1,
+	'path' => __DIR__ . '/src/Glpi/Api/APIRest.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^You should not use the `exit` function\\. It prevents the execution of post\\-request/post\\-command routines\\.$#',
+	'identifier' => 'glpi.forbidExit',
+	'count' => 3,
+	'path' => __DIR__ . '/src/Glpi/Api/APIRest.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^You should not use the `http_response_code` function to change the response code\\. Due to a PHP bug, it may not provide the expected result \\(see https\\://bugs\\.php\\.net/bug\\.php\\?id\\=81451\\)\\.$#',
+	'identifier' => 'glpi.forbidHttpResponseCode',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Glpi/Api/APIRest.php',
 ];
@@ -2172,6 +2196,12 @@ $ignoreErrors[] = [
 	'identifier' => 'return.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Glpi/Dropdown/Dropdown.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^You should not use the `http_response_code` function to change the response code\\. Due to a PHP bug, it may not provide the expected result \\(see https\\://bugs\\.php\\.net/bug\\.php\\?id\\=81451\\)\\.$#',
+	'identifier' => 'glpi.forbidHttpResponseCode',
+	'count' => 1,
+	'path' => __DIR__ . '/src/Glpi/Http/Response.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Negated boolean expression is always false\\.$#',

--- a/composer.json
+++ b/composer.json
@@ -108,6 +108,7 @@
         "friendsoftwig/twigcs": "^6.4",
         "glpi-project/tools": "^0.7",
         "mikey179/vfsstream": "^1.6",
+        "nikic/php-parser": "^5.4",
         "php-parallel-lint/php-parallel-lint": "^1.4",
         "phpstan/extension-installer": "^1.4",
         "phpstan/phpstan": "^2.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a37d68bd366ad1ec5ff38377678492b3",
+    "content-hash": "5f20fe84913c193f5cb2f435b4ba3011",
     "packages": [
         {
             "name": "apereo/phpcas",

--- a/front/_check_webserver_config.php
+++ b/front/_check_webserver_config.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2025 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -36,7 +35,7 @@
 if (!class_exists('Glpi\\Kernel\\Kernel', autoload: false)) {
     // `Glpi\Kernel\Kernel` class will exists if the request was processed by the `/public/index.php` file,
     // and will not be found otherwise.
-    http_response_code(404);
+    header('HTTP/1.1 404 Not Found');
     readfile(__DIR__ . '/../index.html');
-    exit();
+    exit(); // @phpstan-ignore glpi.forbidExit (Script execution should be stopped to prevent further errors)
 }

--- a/front/cron.php
+++ b/front/cron.php
@@ -53,7 +53,7 @@ if (PHP_SAPI === 'cli') {
         echo "\t" . 'You should run the script as the same user that your web server runs as to avoid file permissions being ruined.' . "\n";
         if (!in_array('--allow-superuser', $_SERVER['argv'], true)) {
             echo "\t" . 'Use --allow-superuser option to bypass this limitation.' . "\n";
-            exit(1);
+            exit(1); // @phpstan-ignore glpi.forbidExit (CLI context)
         }
     }
 
@@ -79,7 +79,7 @@ if (PHP_SAPI === 'cli') {
 
     if ($CFG_GLPI['maintenance_mode'] ?? false) {
         echo 'Service is down for maintenance. It will be back shortly.' . PHP_EOL;
-        exit(1);
+        exit(1); // @phpstan-ignore glpi.forbidExit (CLI context)
     }
 
     if (!($DB instanceof DBmysql)) {
@@ -87,28 +87,28 @@ if (PHP_SAPI === 'cli') {
             'ERROR: The database configuration file "%s" is missing or is corrupted. You have to either restart the install process, or restore this file.',
             GLPI_CONFIG_DIR . '/config_db.php'
         ) . PHP_EOL;
-        exit(1);
+        exit(1); // @phpstan-ignore glpi.forbidExit (CLI context)
     }
 
     if (!$DB->connected) {
         echo 'ERROR: The connection to the SQL server could not be established. Please check your configuration.' . PHP_EOL;
-        exit(1);
+        exit(1); // @phpstan-ignore glpi.forbidExit (CLI context)
     }
 
     if (!Config::isLegacyConfigurationLoaded()) {
         echo 'ERROR: Unable to load the GLPI configuration from the database.' . PHP_EOL;
-        exit(1);
+        exit(1); // @phpstan-ignore glpi.forbidExit (CLI context)
     }
 
     if (Update::isUpdateMandatory()) {
         echo 'The GLPI codebase has been updated. The update of the GLPI database is necessary.' . PHP_EOL;
-        exit(1);
+        exit(1); // @phpstan-ignore glpi.forbidExit (CLI context)
     }
 
     if (!is_writable(GLPI_LOCK_DIR)) {
         echo "\t" . sprintf('ERROR: %s is not writable.' . "\n", GLPI_LOCK_DIR);
         echo "\t" . 'Run the script as the same user that your web server runs as.' . "\n";
-        exit(1);
+        exit(1); // @phpstan-ignore glpi.forbidExit (CLI context)
     }
 
     if (isset($_SERVER['argc']) && ($_SERVER['argc'] > 1)) {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -68,6 +68,8 @@ parameters:
             message: '~/(downstream\.php|config_db\.php|config_db_slave\.php)" is not a file or it does not exist.~'
             reportUnmatched: false
 rules:
+    - Glpi\Tools\PHPStan\ForbidExitRule
+    - Glpi\Tools\PHPStan\ForbidHttpResponseCodeRule
     - GlpiProject\Tools\PHPStan\Rules\GlobalVarTypeRule
 
 # Copy and uncomment this content into a "phpstan.neon" file to add your own config values

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -4167,7 +4167,16 @@ abstract class CommonITILObject extends CommonDBTM
 
         switch ($ma->getAction()) {
             case 'add_task':
-                $itemtype = $ma->getItemtype(true);
+                $itemtype_or_selector = $ma->getItemtype(true);
+
+                if (is_bool($itemtype_or_selector)) {
+                    // MassiveAction::getItemtype() will return a boolean if the itemtype selector needs to be displayed.
+                    return $itemtype_or_selector;
+                }
+
+                // MassiveAction::getItemtype() will return a classname if the selector does not need to be displayed.
+                $itemtype = $itemtype_or_selector;
+
                 $tasktype = $itemtype . 'Task';
                 if ($ttype = getItemForItemtype($tasktype)) {
                     /** @var CommonITILTask $ttype */

--- a/src/CronTask.php
+++ b/src/CronTask.php
@@ -213,7 +213,7 @@ class CronTask extends CommonDBTM
             $_SESSION["glpicronuserrunning"] = '';
             self::release_lock();
             Toolbox::logInFile('cron', __('Action aborted') . "\n");
-            exit();
+            exit(); // @phpstan-ignore glpi.forbidExit (CLI context)
         }
     }
 

--- a/src/Glpi/Application/ResourcesChecker.php
+++ b/src/Glpi/Application/ResourcesChecker.php
@@ -53,12 +53,12 @@ final class ResourcesChecker
         if (!$this->areDependenciesUpToDate()) {
             echo 'Application dependencies are not up to date.' . PHP_EOL;
             echo 'Run "php bin/console dependencies install" in the glpi tree to fix this.' . PHP_EOL;
-            exit(1);
+            exit(1); // @phpstan-ignore glpi.forbidExit (Script execution should be stopped to prevent further errors)
         }
         if (!$this->areLocalesUpToDate()) {
             echo 'Application locales have to be compiled.' . PHP_EOL;
             echo 'Run "php bin/console locales:compile" in the glpi tree to fix this.' . PHP_EOL;
-            exit(1);
+            exit(1); // @phpstan-ignore glpi.forbidExit (Script execution should be stopped to prevent further errors)
         }
     }
 

--- a/src/Glpi/Http/Response.php
+++ b/src/Glpi/Http/Response.php
@@ -88,7 +88,7 @@ class Response extends \GuzzleHttp\Psr7\Response
         Toolbox::logDebug($message);
 
         echo($output);
-        exit(1);
+        exit(1); // @phpstan-ignore glpi.forbidExit (Deprecated scope)
     }
 
     public function sendHeaders(): Response

--- a/src/Glpi/Kernel/Kernel.php
+++ b/src/Glpi/Kernel/Kernel.php
@@ -161,7 +161,7 @@ final class Kernel extends BaseKernel
 
                 echo sprintf('Unable to write in the `%s` directory.', $relative_path) . PHP_EOL;
                 echo 'Files ACL must be fixed.' . PHP_EOL;
-                exit(1);
+                exit(1); // @phpstan-ignore glpi.forbidExit (Script execution should be stopped to prevent further errors)
             }
         }
 

--- a/src/MassiveAction.php
+++ b/src/MassiveAction.php
@@ -246,8 +246,8 @@ class MassiveAction
                             throw new \Exception(__('Implementation error!'));
                         }
                         if ($POST['action'] == -1) {
-                       // Case when no action is choosen
-                            exit();
+                            // Case when no action is choosen
+                            throw new \RuntimeException();
                         }
                         if (isset($POST['actions'])) {
                             // First, get the name of current action !
@@ -550,11 +550,11 @@ class MassiveAction
 
         if ($this->check_item === null && isset($POST['check_itemtype'])) {
             if (!($this->check_item = getItemForItemtype($POST['check_itemtype']))) {
-                exit();
+                throw new \RuntimeException();
             }
             if (isset($POST['check_items_id'])) {
                 if (!$this->check_item->getFromDB($POST['check_items_id'])) {
-                    exit();
+                    throw new \RuntimeException();
                 } else {
                     $this->check_item->getEmpty();
                 }
@@ -595,7 +595,7 @@ class MassiveAction
      *
      * @param boolean $display_selector  can we display the itemtype selector ?
      *
-     * @return string|boolean  the itemtype or false if we cannot define it (and we cannot display the selector)
+     * @return string|boolean  the itemtype, or true if the selector is displayed, or false if we cannot define the itemtype nor display the selector
      **/
     public function getItemtype($display_selector)
     {
@@ -629,7 +629,7 @@ class MassiveAction
             );
 
             echo "<span id='show_itemtype$rand'>&nbsp;</span>";
-            exit();
+            return true;
         }
 
         return false;
@@ -1083,15 +1083,11 @@ class MassiveAction
                         );
                     }
                     // Only display the form for this stage
-                    exit();
+                    return;
                 }
 
                 if (!isset($ma->POST['common_options'])) {
-                    echo "<div class='center'><img src='" . $CFG_GLPI["root_doc"] . "/pics/warning.png' alt='" .
-                              __s('Warning') . "'><br><br>";
-                    echo "<span class='b'>" . __s('Implementation error!') . "</span><br>";
-                    echo "</div>";
-                    exit();
+                    throw new \RuntimeException('Implementation error!');
                 }
 
                 if ($ma->POST['common_options'] == 'false') {
@@ -1124,7 +1120,7 @@ class MassiveAction
 
                     $itemtype_search_options = SearchOption::getOptionsForItemtype($so_itemtype);
                     if (!isset($itemtype_search_options[$so_index])) {
-                        exit();
+                        throw new \RuntimeException();
                     }
 
                     $item   = $so_item;
@@ -1133,7 +1129,7 @@ class MassiveAction
                 }
 
                 if ($item === null) {
-                    exit();
+                    throw new \RuntimeException();
                 }
 
                 $plugdisplay = false;

--- a/tools/src/PHPStan/ForbidExitRule.php
+++ b/tools/src/PHPStan/ForbidExitRule.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Tools\PHPStan;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Exit_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+class ForbidExitRule implements Rule
+{
+    public function getNodeType(): string
+    {
+        return Exit_::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $name = match ($node->getAttribute('kind')) {
+            Exit_::KIND_DIE  => 'die',
+            Exit_::KIND_EXIT => 'exit',
+            default          => 'die/exit',
+        };
+
+        return [
+            RuleErrorBuilder::message(
+                sprintf(
+                    'You should not use the `%s` function. It prevents the execution of post-request/post-command routines.',
+                    $name
+                )
+            )
+            ->identifier('glpi.forbidExit')
+            ->build()
+        ];
+    }
+}

--- a/tools/src/PHPStan/ForbidHttpResponseCodeRule.php
+++ b/tools/src/PHPStan/ForbidHttpResponseCodeRule.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Tools\PHPStan;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PhpParser\Node\Name;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+class ForbidHttpResponseCodeRule implements Rule
+{
+    public function getNodeType(): string
+    {
+        return FuncCall::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (
+            $node instanceof FuncCall
+            && $node->name instanceof Name
+            && $node->name->toString() === 'http_response_code'
+            && count($node->getRawArgs()) > 0 // `http_response_code()` used without args is a setter and does not cause issues
+        ) {
+            return [
+                RuleErrorBuilder::message(
+                    'You should not use the `http_response_code` function to change the response code. Due to a PHP bug, it may not provide the expected result (see https://bugs.php.net/bug.php?id=81451).',
+                )
+                ->identifier('glpi.forbidHttpResponseCode')
+                ->build()
+            ];
+        }
+
+        return [];
+    }
+}


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

This provides some rules to detect usages of PHP functions that can cause issues.

- I changed a bit the `Massive` actions code to use `return` instructions of to throw exceptions.
- I marked legitimate usages with a `phpstan-ignore` comment.
- Remaining usages were added to the baseline. The corresponding code should be refactored to use a `Symfony\Component\HttpFoundation\Response`.