### PR TITLE
Allow plugins to register generic assets capacities

### DIFF
--- a/phpunit/DbTestCase.php
+++ b/phpunit/DbTestCase.php
@@ -37,6 +37,7 @@
 use Glpi\Asset\AssetDefinition;
 use Glpi\Asset\AssetDefinitionManager;
 use Glpi\Asset\Capacity;
+use Glpi\Asset\CapacityConfig;
 use Glpi\Dropdown\DropdownDefinition;
 
 class DbTestCase extends \GLPITestCase
@@ -569,13 +570,14 @@ class DbTestCase extends \GLPITestCase
      */
     protected function enableCapacity(
         AssetDefinition $definition,
-        string $capacity_classname
+        string $capacity_classname,
+        ?CapacityConfig $config = new CapacityConfig()
     ): AssetDefinition {
         // Add new capacity
         $existing_capacities = $this->callPrivateMethod($definition, 'getDecodedCapacitiesField');
+        $existing_capacities[] = new Capacity(name: $capacity_classname, config: $config);
 
         $capacity_input = array_map(fn(Capacity $capacity) => $capacity->jsonSerialize(), $existing_capacities);
-        $capacity_input[] = ['name' => $capacity_classname];
 
         $this->updateItem(
             AssetDefinition::class,

--- a/src/Glpi/Asset/AssetDefinitionManager.php
+++ b/src/Glpi/Asset/AssetDefinitionManager.php
@@ -319,6 +319,14 @@ final class AssetDefinitionManager extends AbstractDefinitionManager
     }
 
     /**
+     * Register a capacity.
+     */
+    public function registerCapacity(CapacityInterface $capacity): void
+    {
+        $this->capacities[$capacity::class] = $capacity;
+    }
+
+    /**
      * Returns available capacities instances.
      *
      * @return CapacityInterface[]

--- a/tests/fixtures/plugins/tester/src/Asset/Capacity/HasFooCapacity.php
+++ b/tests/fixtures/plugins/tester/src/Asset/Capacity/HasFooCapacity.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace GlpiPlugin\Tester\Asset\Capacity;
+
+use Override;
+use Glpi\Asset\Capacity\AbstractCapacity;
+use GlpiPlugin\Tester\Asset\Foo;
+use Glpi\Asset\Asset;
+use Glpi\Asset\CapacityConfig;
+
+final class HasFooCapacity extends AbstractCapacity
+{
+    #[Override]
+    public function getLabel(): string
+    {
+        return Foo::getTypeName();
+    }
+
+    #[Override]
+    public function getIcon(): string
+    {
+        return Foo::getIcon();
+    }
+
+    #[Override]
+    public function getCapacityUsageDescription(string $classname): string
+    {
+        return '';
+    }
+
+    #[Override]
+    public function getSearchOptions(string $classname): array
+    {
+        return Foo::rawSearchOptionsToAdd();
+    }
+
+    #[Override]
+    public function getCloneRelations(): array
+    {
+        return [
+            Foo::class,
+        ];
+    }
+
+    #[Override]
+    public function onObjectInstanciation(Asset $object, CapacityConfig $config): void
+    {
+        $object->fields['_added_by_hasfoocapacity'] = 'abc';
+    }
+}

--- a/tests/fixtures/plugins/tester/src/Asset/Foo.php
+++ b/tests/fixtures/plugins/tester/src/Asset/Foo.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace GlpiPlugin\Tester\Asset;
+
+use CommonDBChild;
+use Override;
+
+final class Foo extends CommonDBChild
+{
+    public static $itemtype = 'itemtype';
+    public static $items_id = 'items_id';
+
+    #[Override]
+    public static function getTypeName($nb = 0)
+    {
+        return 'Foo';
+    }
+
+    #[Override]
+    public static function getIcon()
+    {
+        return 'ti ti-foo';
+    }
+
+    public static function rawSearchOptionsToAdd()
+    {
+
+        $so = [];
+
+        $so[] = [
+            'id'       => 'foo',
+            'name'     => static::getTypeName(),
+        ];
+
+        $so[] = [
+            'id'       => '123456',
+            'table'    => self::getTable(),
+            'field'    => 'name',
+            'name'     => 'Name',
+            'datatype' => 'itemlink',
+        ];
+
+        return $so;
+    }
+}


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] This change requires a documentation update.

## Description

This provides a method that can be used by plugins to register asset capacities from their setup function.
```php
AssetDefinitionManager::getInstance()->registerCapacity(new MyPluginCapacity());
```