### PR TITLE
Do not use output buffering when rendering a page

### DIFF
--- a/src/Glpi/Controller/AbstractController.php
+++ b/src/Glpi/Controller/AbstractController.php
@@ -65,12 +65,7 @@ abstract class AbstractController implements PublicService
     ): Response {
         $twig = TemplateRenderer::getInstance();
 
-        // We must use output buffering here as Html::header() and Html::footer()
-        // output content directly.
-        // TODO: fix header() and footer() methods and remove output buffering
-        ob_start();
-        $twig->display($view, $parameters);
-        $content = ob_get_clean();
+        $content = $twig->render($view, $parameters);
 
         $response->setContent($content);
         return $response;


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

This is no longer necessary as the `flush()` operation that was present in the `Html::header()` method has been removed.