### PR TITLE
Simplify login field names

### DIFF
--- a/front/login.php
+++ b/front/login.php
@@ -71,14 +71,7 @@ if (!empty($_POST['totp_code'])) {
 } else if (!empty($_POST['backup_code'])) {
     $mfa_params['backup_code'] = $_POST['backup_code'];
 }
-if ($auth->login(
-    login_name: $_POST['login_name'],
-    login_password: $_POST['login_password'],
-    noauto: ($_REQUEST["noAUTO"] ?? false),
-    remember_me: $remember,
-    login_auth: $_POST['auth'] ?? '',
-    mfa_params: $mfa_params)
-) {
+if ($auth->login($_POST['login_name'], $_POST['login_password'], ($_REQUEST["noAUTO"] ?? false), $remember, $_POST['auth'] ?? '', $mfa_params)) {
     Auth::redirectIfAuthenticated();
 } else {
     throw new AuthenticationFailedException(authentication_errors: $auth->getErrors());

--- a/front/login.php
+++ b/front/login.php
@@ -56,28 +56,9 @@ if (isset($_POST['totp_code']) && is_array($_POST['totp_code'])) {
     $_POST['totp_code'] = implode('', $_POST['totp_code']);
 }
 
-//Do login and checks
-if (isset($_SESSION['namfield']) && isset($_POST[$_SESSION['namfield']])) {
-    $login = $_POST[$_SESSION['namfield']];
-} else {
-    $login = '';
-}
-if (isset($_SESSION['pwdfield']) && isset($_POST[$_SESSION['pwdfield']])) {
-    $password = $_POST[$_SESSION['pwdfield']];
-} else {
-    $password = '';
-}
-// Manage the selection of the auth source (local, LDAP id, MAIL id)
-if (isset($_POST['auth'])) {
-    $login_auth = $_POST['auth'];
-} else {
-    $login_auth = '';
-}
-
-$remember = isset($_SESSION['rmbfield']) && isset($_POST[$_SESSION['rmbfield']]) && $CFG_GLPI["login_remember_time"];
+$remember = ($_POST['login_remember'] ?? 0) && $CFG_GLPI["login_remember_time"];
 
 $auth = new Auth();
-
 
 // now we can continue with the process...
 if (isset($_REQUEST['totp_cancel'])) {
@@ -90,7 +71,14 @@ if (!empty($_POST['totp_code'])) {
 } else if (!empty($_POST['backup_code'])) {
     $mfa_params['backup_code'] = $_POST['backup_code'];
 }
-if ($auth->login($login, $password, (isset($_REQUEST["noAUTO"]) ? $_REQUEST["noAUTO"] : false), $remember, $login_auth, $mfa_params)) {
+if ($auth->login(
+    login_name: $_POST['login_name'],
+    login_password: $_POST['login_password'],
+    noauto: ($_REQUEST["noAUTO"] ?? false),
+    remember_me: $remember,
+    login_auth: $_POST['auth'] ?? '',
+    mfa_params: $mfa_params)
+) {
     Auth::redirectIfAuthenticated();
 } else {
     throw new AuthenticationFailedException(authentication_errors: $auth->getErrors());

--- a/front/login.php
+++ b/front/login.php
@@ -71,7 +71,7 @@ if (!empty($_POST['totp_code'])) {
 } else if (!empty($_POST['backup_code'])) {
     $mfa_params['backup_code'] = $_POST['backup_code'];
 }
-if ($auth->login($_POST['login_name'], $_POST['login_password'], ($_REQUEST["noAUTO"] ?? false), $remember, $_POST['auth'] ?? '', $mfa_params)) {
+if ($auth->login($_POST['login_name'] ?? '', $_POST['login_password'] ?? '', ($_REQUEST["noAUTO"] ?? false), $remember, $_POST['auth'] ?? '', $mfa_params)) {
     Auth::redirectIfAuthenticated();
 } else {
     throw new AuthenticationFailedException(authentication_errors: $auth->getErrors());

--- a/src/Glpi/Controller/IndexController.php
+++ b/src/Glpi/Controller/IndexController.php
@@ -153,9 +153,6 @@ final class IndexController extends AbstractController
             'noAuto'              => $_GET["noAUTO"] ?? 0,
             'redirect'            => $redirect,
             'text_login'          => $CFG_GLPI['text_login'],
-            'namfield'            => ($_SESSION['namfield'] = \uniqid('fielda')),
-            'pwdfield'            => ($_SESSION['pwdfield'] = \uniqid('fieldb')),
-            'rmbfield'            => ($_SESSION['rmbfield'] = \uniqid('fieldc')),
             'show_lost_password'  => $CFG_GLPI["notifications_mailing"]
                 && countElementsInTable('glpi_notifications', [
                     'itemtype' => 'User',

--- a/templates/pages/login.html.twig
+++ b/templates/pages/login.html.twig
@@ -49,7 +49,7 @@
                 </div>
                 <div class="mb-3">
                     <label class="form-label" for="login_name">{{ __('Login') }}</label>
-                    <input type="text" class="form-control" id="login_name" name="{{ namfield }}" placeholder="" tabindex="1"/>
+                    <input type="text" class="form-control" id="login_name" name="login_name" placeholder="" tabindex="1"/>
                 </div>
                 <div class="mb-4">
                     <div class="d-flex">
@@ -81,7 +81,7 @@
                             {% endif %}
                         {% endif %}
                     </div>
-                    <input type="password" class="form-control" id="login_password" name="{{ pwdfield }}" placeholder="" autocomplete="off" tabindex="2"/>
+                    <input type="password" class="form-control" id="login_password" name="login_password" placeholder="" autocomplete="off" tabindex="2"/>
                 </div>
 
                 {% if config('display_login_source') %}
@@ -94,7 +94,7 @@
                 {% if config('login_remember_time') %}
                     <div class="mb-2">
                         <label class="form-check" for="login_remember">
-                            <input type="checkbox" class="form-check-input" id="login_remember" name="{{ rmbfield }}" {{ config('login_remember_default') ? 'checked' : '' }}/>
+                            <input type="checkbox" class="form-check-input" id="login_remember" name="login_remember" {{ config('login_remember_default') ? 'checked' : '' }}/>
                             <span class="form-check-label">{{ __('Remember me') }}</span>
                         </label>
                     </div>


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Many years ago, the login field names were randomized for "security". This doesn't make any sense to me and I don't know of any security recommendations that say this should be done. Also, the login field IDs were always the same and so are the labels so this doesn't even obscure the fields (which isn't real security anyways). Anyone with competence (or AI for people with none) could figure out how to parse the HTML to get the field names.

Even if the original intention was valid for security, we have used CSRF tokens for a while now which probably cover whatever the original concern was.