### PR TITLE
Fix default notification translation selection

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -1868,8 +1868,7 @@ function setupAdaptDropdown(config)
     // to avoid issues with jQuery.
     const field_id = $.escapeSelector(config.field_id);
 
-    const select2_el = $('#' + field_id).select2({
-        placeholder: config.placeholder,
+    const options = {
         width: config.width,
         dropdownAutoWidth: true,
         dropdownCssClass: config.dropdown_css_class,
@@ -1956,10 +1955,13 @@ function setupAdaptDropdown(config)
         },
         templateResult: config.templateresult,
         templateSelection: config.templateselection,
-    })
-        .bind('setValue', function (e, value) {
-            $('#' + field_id).val(value).trigger('change');
-        });
+    };
+    if (config.placeholder !== undefined && config.placeholder !== '') {
+        options.placeholder = config.placeholder;
+    }
+    const select2_el = $('#' + field_id).select2(options).bind('setValue', (e, value) => {
+        $('#' + field_id).val(value).trigger('change');
+    });
     $('label[for=' + field_id + ']').on('click', function () {
         $('#' + field_id).select2('open');
     });

--- a/js/common.js
+++ b/js/common.js
@@ -1959,7 +1959,9 @@ function setupAdaptDropdown(config)
     if (config.placeholder !== undefined && config.placeholder !== '') {
         options.placeholder = config.placeholder;
     }
-    const select2_el = $('#' + field_id).select2(options).bind('setValue', (e, value) => {
+    const select2_el = $('#' + field_id).select2(options);
+
+    select2_el.bind('setValue', (e, value) => {
         $('#' + field_id).val(value).trigger('change');
     });
     $('label[for=' + field_id + ']').on('click', function () {

--- a/src/NotificationTemplateTranslation.php
+++ b/src/NotificationTemplateTranslation.php
@@ -104,10 +104,16 @@ class NotificationTemplateTranslation extends CommonDBChild
         $template = new NotificationTemplate();
         $template->getFromDB($notificationtemplates_id);
 
+        $used_languages = self::getAllUsedLanguages($notificationtemplates_id);
+        // Remove current language
+        if (!$this->isNewItem()) {
+            $used_languages = array_diff($used_languages, [$this->getField('language')]);
+        }
+
         TemplateRenderer::getInstance()->display('pages/setup/notification/translation.html.twig', [
             'item' => $this,
             'template' => $template,
-            'used_languages' => self::getAllUsedLanguages($notificationtemplates_id),
+            'used_languages' => $used_languages,
         ]);
         return true;
     }

--- a/src/Notification_NotificationTemplate.php
+++ b/src/Notification_NotificationTemplate.php
@@ -140,7 +140,8 @@ class Notification_NotificationTemplate extends CommonDBRelation
             // language=Twig
             echo TemplateRenderer::getInstance()->renderFromStringTemplate(<<<TWIG
                 <div class="text-center mb-3">
-                    <a class="btn btn-primary" href="{{ 'Notification_NotificationTemplate'|itemtype_form_path }}?notifications_id={{ id }}&withtemplate={{ withtemplate}}">
+                    <a class="btn btn-primary" role="button"
+                       href="{{ 'Notification_NotificationTemplate'|itemtype_form_path }}?notifications_id={{ id }}&withtemplate={{ withtemplate}}">
                         {{ add_msg }}
                     </a>
                 </div>

--- a/tests/cypress/e2e/notifications.cy.js
+++ b/tests/cypress/e2e/notifications.cy.js
@@ -69,21 +69,24 @@ describe('Notifications', () => {
             });
         });
 
-        cy.get('.tab-content .tab-pane.active[id^="tab"] .btn').contains('Add a template').click();
+        cy.findByRole('tabpanel').within(() => {
+            cy.findByRole('button', { name: /Add a template/ }).click();
+        });
+
         // Should be redirected to notification_notificationtemplate form
         cy.url().should('include', '/front/notification_notificationtemplate.form.php').and('include', 'notifications_id=2');
         cy.get('label').contains('Notification').next().find('a').invoke('attr', 'href').should('contain', '/front/notification.form.php?id=2');
 
         // Go back to the notification form
         cy.go('back');
-        cy.get('#tabspanel .nav-item').contains('Templates').click();
+        cy.findByRole('tab', { name: /Templates/ }).click();
 
         cy.get('table.table tbody td a[href*="notificationtemplate.form.php?id=4"]').click();
-        cy.get('#tabspanel .nav-item').contains('Template translations').click();
+        cy.findByRole('tab', { name: /Template translations/ }).click();
         // Click the default template translation link
         cy.get('table.table tbody td a').contains('Default translation').click();
-        cy.get('#tabspanel .nav-item').contains('Template translation').click();
-        cy.get('.tab-content .tab-pane.active[id^="tab"]').within(() => {
+        cy.findByRole('tab', { name: /Template translation/ }).click();
+        cy.findByRole('tabpanel').within(() => {
             cy.get('select[name=language]').should('have.value', '');
             cy.get('select[name=language] option:selected').should('have.text', 'Default translation');
         });

--- a/tests/cypress/e2e/notifications.cy.js
+++ b/tests/cypress/e2e/notifications.cy.js
@@ -81,10 +81,10 @@ describe('Notifications', () => {
         cy.go('back');
         cy.findByRole('tab', { name: /Templates/ }).click();
 
-        cy.get('table.table tbody td a[href*="notificationtemplate.form.php?id=4"]').click();
+        cy.findByRole('table').findByRole('link', {name: "Tickets"}).click();
         cy.findByRole('tab', { name: /Template translations/ }).click();
         // Click the default template translation link
-        cy.get('table.table tbody td a').contains('Default translation').click();
+        cy.findByRole('link', {name: "Default translation"}).click();
         cy.findByRole('tab', { name: /Template translation/ }).click();
         cy.findByRole('tabpanel').within(() => {
             cy.get('select[name=language]').should('have.value', '');

--- a/tests/cypress/e2e/notifications.cy.js
+++ b/tests/cypress/e2e/notifications.cy.js
@@ -77,9 +77,15 @@ describe('Notifications', () => {
         // Go back to the notification form
         cy.go('back');
         cy.get('#tabspanel .nav-item').contains('Templates').click();
-        // Click the first template link
-        cy.get('table.table tbody td:nth-of-type(2) a').first().click();
-        cy.url().should('include', '/front/notification_notificationtemplate.form.php').and('not.include', 'notifications_id=2');
-        cy.get('label').contains('Notification').next().find('a').invoke('attr', 'href').should('contain', '/front/notification.form.php?id=2');
+
+        cy.get('table.table tbody td a[href*="notificationtemplate.form.php?id=4"]').click();
+        cy.get('#tabspanel .nav-item').contains('Template translations').click();
+        // Click the default template translation link
+        cy.get('table.table tbody td a').contains('Default translation').click();
+        cy.get('#tabspanel .nav-item').contains('Template translation').click();
+        cy.get('.tab-content .tab-pane.active[id^="tab"]').within(() => {
+            cy.get('select[name=language]').should('have.value', '');
+            cy.get('select[name=language] option:selected').should('have.text', 'Default translation');
+        });
     });
 });


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

Fixes #19522

Two issues:
1. The current language shouldn't be in the used array
2. An empty string placeholder breaks the display of the current option if the key of the current option is also an empty string. No need to add a blank placeholder in the Select2 config.