### PR TITLE
Do not use withtemplate 2 when creating from no template

### DIFF
--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -5403,7 +5403,7 @@ class CommonDBTM extends CommonGLPI
         }
 
         $iterator = $DB->request($request);
-        $blank_params = (strpos($target, '?') ? '&' : '?') . "id=-1&withtemplate=2";
+        $blank_params = (strpos($target, '?') ? '&' : '?') . "id=-1";
         $target_blank = $target . $blank_params;
 
         if ($add && count($iterator) === 0) {


### PR DESCRIPTION
## Checklist before requesting a review

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

For some reason the "blank" template option or creating an item that could have templates but have none configured, always put a `withtemplate` value of 2 (creating item from template) in the URL.

A "blank" template is not a template.