### PR TITLE
update illustrations to 0.5.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
                 "@fullcalendar/rrule": "^4.4.2",
                 "@fullcalendar/timegrid": "^4.4.2",
                 "@fullcalendar/timeline": "^4.4.3",
-                "@glpi-project/illustrations": "^0.5.1",
+                "@glpi-project/illustrations": "^0.5.3",
                 "@tabler/core": "^1.0.0",
                 "@tabler/icons-webfont": "^3.31.0",
                 "animate.css": "^4.1.1",
@@ -2396,9 +2396,9 @@
             }
         },
         "node_modules/@glpi-project/illustrations": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/@glpi-project/illustrations/-/illustrations-0.5.1.tgz",
-            "integrity": "sha512-pmX2Ck0kmPXCrVtay30lOHsfefC0UYAFpy1tw5CNP9QLfhUFwES1rZmYshRMxmz+jx3wofkga6R7eqwq3l8k/g==",
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/@glpi-project/illustrations/-/illustrations-0.5.3.tgz",
+            "integrity": "sha512-w7Znw1KWxsA43a7B+yrBWh9LLHqFnrCdHKkWvmkrEFoEYQhWfLPJ3iY60dR2GSIacFYSP5+DJPLhPeB7U/BxBg==",
             "license": "CC-BY-SA-4.0"
         },
         "node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "@fullcalendar/rrule": "^4.4.2",
         "@fullcalendar/timegrid": "^4.4.2",
         "@fullcalendar/timeline": "^4.4.3",
-        "@glpi-project/illustrations": "^0.5.1",
+        "@glpi-project/illustrations": "^0.5.3",
         "@tabler/core": "^1.0.0",
         "@tabler/icons-webfont": "^3.31.0",
         "animate.css": "^4.1.1",

--- a/phpunit/functional/Glpi/UI/IllustrationManagerTest.php
+++ b/phpunit/functional/Glpi/UI/IllustrationManagerTest.php
@@ -73,7 +73,7 @@ final class IllustrationManagerTest extends GLPITestCase
             'expected' => [
                 'antivirus',
                 'application',
-                'approve-requests',
+                'application-altenative',
             ],
         ];
 
@@ -81,9 +81,9 @@ final class IllustrationManagerTest extends GLPITestCase
             'page' => 2,
             'page_size' => 3,
             'expected' => [
+                'application-edit',
+                'approve-requests',
                 'asset-cartridge',
-                'asset-desktop-1',
-                'asset-desktop-2',
             ],
         ];
 
@@ -93,14 +93,14 @@ final class IllustrationManagerTest extends GLPITestCase
             'expected' => [
                 'antivirus',
                 'application',
+                'application-altenative',
+                'application-edit',
                 'approve-requests',
                 'asset-cartridge',
                 'asset-desktop-1',
                 'asset-desktop-2',
                 'asset-laptop',
                 'asset-lost',
-                'asset-network-equipment',
-                'asset-peripheral',
             ],
         ];
     }


### PR DESCRIPTION
## Description

- Last (and probably final for this release) batch of icons
- extracted from the new website and adapted to our colors.

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/4b7e98cb-86de-4018-b842-23f22e36f6e9)
