### PR TITLE
Fix viewing unattached domain records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The present file will list all changes made to the project; according to the
 
 ### Changed
 - Only unsolved/unclosed tickets will be shown in the dropdown when performing the "Merge as Followup" action.
+- Domain records must be attached to a domain. Existing unattached records will remain but will require a domain if edited.
 
 ### Deprecated
 

--- a/phpunit/functional/DomainRecordTest.php
+++ b/phpunit/functional/DomainRecordTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units;
+
+use DbTestCase;
+
+/* Test for inc/software.class.php */
+
+class DomainRecordTest extends DbTestCase
+{
+    public function testCanViewUnattached()
+    {
+        $this->login();
+        $record = $this->createItem('DomainRecord', ['name' => 'unattached']);
+        $this->assertTrue($record->canViewItem());
+    }
+}

--- a/src/DomainRecord.php
+++ b/src/DomainRecord.php
@@ -42,6 +42,7 @@ class DomainRecord extends CommonDBChild
     public static $itemtype        = 'Domain';
     public static $items_id        = 'domains_id';
     public $dohistory              = true;
+    public static $mustBeAttached  = false;
 
     public static function getTypeName($nb = 0)
     {

--- a/src/DomainRecord.php
+++ b/src/DomainRecord.php
@@ -259,6 +259,14 @@ class DomainRecord extends CommonDBChild
      */
     private function prepareInput($input, $add = false)
     {
+        if (($add && empty($input['domains_id'])) || (isset($input['domains_id']) && empty($input['domains_id']))) {
+            Session::addMessageAfterRedirect(
+                __('A domain is required'),
+                true,
+                ERROR
+            );
+            return false;
+        }
 
         if ($add) {
             if (isset($input['date_creation']) && empty($input['date_creation'])) {
@@ -362,6 +370,7 @@ class DomainRecord extends CommonDBChild
                     'value'  => $this->fields["domains_id"],
                     'entity' => $this->fields["entities_id"],
                     'rand'   => $rand,
+                    'display_emptychoice' => false,
                 ]
             );
         }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

It seems like having domain records not linked to a domain was an intentional design since there is even a UI feature to link unattached records to domains. However, domain records use a `CommonDBChild` class which by default requires they be attached to a parent item (domain). While you could create records without a domain (probably another bug, but I don't want to dive into that right now), you would not be able to view them because it would fail a permission check. When `canChildItem` can't find a parent item, it will return false if it must be attached.