### PR TITLE
Fix enter key in requester field form submission

### DIFF
--- a/templates/components/itilobject/actors/field.html.twig
+++ b/templates/components/itilobject/actors/field.html.twig
@@ -46,7 +46,7 @@
 {% set onchange = '' %}
 {% set allow_auto_submit = allow_auto_submit ?? true %}
 {% if allow_auto_submit and item.isNewItem() and actortype == "requester" %}
-   {% set onchange = 'this.form.submit();' %}
+   {% set onchange = 'e.target.form.submit();' %}
 {% endif %}
 
 {% if not is_actor_hidden %}
@@ -356,11 +356,11 @@
             saveActorsToDom();
         }
 
-        $("#actor_{{ rand }}").on('select2:select', () => {
+        $("#actor_{{ rand }}").on('select2:select', (e) => {
             updateActors();
             {{ onchange }}
         });
-        $("#actor_{{ rand }}").on('select2:unselect', () => {
+        $("#actor_{{ rand }}").on('select2:unselect', (e) => {
             updateActors();
             {{ onchange }}
         });

--- a/tests/cypress/e2e/ITILObject/ticket_form.cy.js
+++ b/tests/cypress/e2e/ITILObject/ticket_form.cy.js
@@ -139,4 +139,24 @@ describe("Ticket Form", () => {
             });
         });
     });
+
+    it('Enter key in requester field reloads new ticket form', () => {
+        cy.visit(`/front/ticket.form.php`);
+
+        // intercept form submit
+        cy.intercept('POST', '/front/ticket.form.php').as('submit');
+
+        // Need to manually trigger the enter key event as 'typing' {enter} is not matching real-life behavior
+        cy.findByLabelText('Requester').next().find('.select2-search__field').type('tec');
+        cy.get('.select2-results__option--highlighted').contains('tech');
+        cy.findByLabelText('Requester').next().find('.select2-search__field').trigger('keydown', {
+            key: 'Enter',
+            code: 'Enter',
+            which: 13,
+        });
+
+        // We should still be creating a new ticket, but the form should have been 'submitted'
+        cy.wait('@submit').its('response.statusCode').should('eq', 200);
+        cy.url().should('match', /\/front\/ticket\.form\.php$/);
+    });
 });


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

Fixes #19529

The select2 select and unselect event handler functions were changed to be arrow functions but the `onchange` code was still using `this`. This caused the generic form submission to never be called and instead, the default functionality of the browser was used which is to submit the form using the first submit button when the enter key is pressed.
