### PR TITLE
fix(contact): restore 'Clone' MA for contact

### DIFF
--- a/phpunit/functional/ContactTest.php
+++ b/phpunit/functional/ContactTest.php
@@ -48,35 +48,35 @@ class ContactTest extends \DbTestCase
         $this->setEntity('_test_root_entity', true);
 
         // Create ContactType
-        $contact_type = $this->createItem('ContactType', [
+        $contact_type_id = $this->createItem('ContactType', [
             'name' => 'Supplier Type'
-        ]);
+        ])->getID();
 
         // Create UserTitle
-        $user_title = $this->createItem('UserTitle', [
+        $user_title_id = $this->createItem('UserTitle', [
             'name' => 'User Title'
-        ]);
+        ])->getID();
 
         // Create supplier
         $contact = $this->createItem('Contact', [
-            'name'                => 'contatc name',
+            'name'                => 'contact name',
             'entities_id'         => 0,
             'is_recursive'        => 0,
             'firstname'           => 'contact firstname',
-            'registration_number'             => '0123456789',
-            'phone'            => '123',
-            'phone2'                => '456',
-            'mobile'               => '789',
-            'fax'             => '951',
-            'email'             => 'contact email',
-            'contacttypes_id'         => $contact_type->fields['id'],
+            'registration_number' => '0123456789',
+            'phone'               => '123',
+            'phone2'              => '456',
+            'mobile'              => '789',
+            'fax'                 => '951',
+            'email'               => 'contact@email',
+            'contacttypes_id'     => $contact_type_id,
             'comment'             => 'comment',
-            'usertitles_id' => $user_title->fields['id'],
-            'postcode' => 'contact postcode',
-            'town' => 'contact town',
-            'state' => 'contact state',
-            'country' => 'contact country',
-            'pictures' => 'contact pictures',
+            'usertitles_id'       => $user_title_id,
+            'postcode'            => 'contact postcode',
+            'town'                => 'contact town',
+            'state'               => 'contact state',
+            'country'             => 'contact country',
+            'pictures'            => 'contact pictures',
         ]);
 
         // Test item cloning

--- a/phpunit/functional/ContactTest.php
+++ b/phpunit/functional/ContactTest.php
@@ -83,15 +83,15 @@ class ContactTest extends \DbTestCase
         $added = $contact->clone();
         $this->assertGreaterThan(0, (int)$added);
 
-        $clonedConact = new \Contact();
-        $this->assertTrue($clonedConact->getFromDB($added));
+        $clonedContact = new \Contact();
+        $this->assertTrue($clonedContact->getFromDB($added));
 
         // Check the values. Id and dates must be different, everything else must be equal
         $expected = $contact->fields;
-        $expected['id'] = $clonedConact->getID();
+        $expected['id'] = $clonedContact->getID();
         $expected['date_creation'] = $date;
         $expected['date_mod'] = $date;
-        $expected['name'] = "contatc name (copy)";
-        $this->assertEquals($expected, $clonedConact->fields);
+        $expected['name'] = "contact name (copy)";
+        $this->assertEquals($expected, $clonedContact->fields);
     }
 }

--- a/phpunit/functional/ContactTest.php
+++ b/phpunit/functional/ContactTest.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units;
+
+/* Test for src/Contact.php */
+
+class ContactTest extends \DbTestCase
+{
+    public function testClone()
+    {
+        $this->login();
+
+        $date = date('Y-m-d H:i:s');
+        $_SESSION['glpi_currenttime'] = $date;
+
+        $this->setEntity('_test_root_entity', true);
+
+        // Create ContactType
+        $contact_type = $this->createItem('ContactType', [
+            'name' => 'Supplier Type'
+        ]);
+
+        // Create UserTitle
+        $user_title = $this->createItem('UserTitle', [
+            'name' => 'User Title'
+        ]);
+
+        // Create supplier
+        $contact = $this->createItem('Contact', [
+            'name'                => 'contatc name',
+            'entities_id'         => 0,
+            'is_recursive'        => 0,
+            'firstname'           => 'contact firstname',
+            'registration_number'             => '0123456789',
+            'phone'            => '123',
+            'phone2'                => '456',
+            'mobile'               => '789',
+            'fax'             => '951',
+            'email'             => 'contact email',
+            'contacttypes_id'         => $contact_type->fields['id'],
+            'comment'             => 'comment',
+            'usertitles_id' => $user_title->fields['id'],
+            'postcode' => 'contact postcode',
+            'town' => 'contact town',
+            'state' => 'contact state',
+            'country' => 'contact country',
+            'pictures' => 'contact pictures',
+        ]);
+
+        // Test item cloning
+        $added = $contact->clone();
+        $this->assertGreaterThan(0, (int)$added);
+
+        $clonedConact = new \Contact();
+        $this->assertTrue($clonedConact->getFromDB($added));
+
+        // Check the values. Id and dates must be different, everything else must be equal
+        $expected = $contact->fields;
+        $expected['id'] = $clonedConact->getID();
+        $expected['date_creation'] = $date;
+        $expected['date_mod'] = $date;
+        $expected['name'] = "contatc name (copy)";
+        $this->assertEquals($expected, $clonedConact->fields);
+    }
+}

--- a/src/Contact.php
+++ b/src/Contact.php
@@ -44,6 +44,7 @@ use Sabre\VObject;
 class Contact extends CommonDBTM
 {
     use AssetImage;
+    use Glpi\Features\Clonable;
 
    // From CommonDBTM
     public $dohistory           = true;
@@ -80,6 +81,11 @@ class Contact extends CommonDBTM
                 ProjectTeam::class,
             ]
         );
+    }
+
+    public function getCloneRelations(): array
+    {
+        return [];
     }
 
 


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

It fixes !37406
In GLPI version 9.5, it was possible to clone contact. This RP re-implements this functionality.

Complete : https://github.com/glpi-project/glpi/pull/19484

## Screenshots (if appropriate):

![Capture d’écran du 2025-04-28 11-10-10](https://github.com/user-attachments/assets/a8326c7e-4b4d-4f0f-9d6e-25b0cd43ff6c)

![Capture d’écran du 2025-04-28 11-10-45](https://github.com/user-attachments/assets/eb31a886-443c-4954-91db-4f867ad0b5e9)



