### PR TITLE
Fix - Massive user addition actions in Licenses

### DIFF
--- a/phpunit/functional/Item_SoftwareLicenseTest.php
+++ b/phpunit/functional/Item_SoftwareLicenseTest.php
@@ -532,21 +532,5 @@ class Item_SoftwareLicenseTest extends DbTestCase
         // The count should be 2
         $count = \SoftwareLicense_User::countForLicense($license2_id);
         $this->assertEquals(2, $count);
-
-        // Cleanup
-        $user_license = new \SoftwareLicense_User();
-        $user_license->deleteByCriteria(['softwarelicenses_id' => $license_id]);
-        $user_license->deleteByCriteria(['softwarelicenses_id' => $license2_id]);
-
-        $license = new \SoftwareLicense();
-        $license->delete(['id' => $license_id]);
-        $license->delete(['id' => $license2_id]);
-
-        $software = new \Software();
-        $software->delete(['id' => $software_id]);
-
-        // Delete the created user
-        $user2 = new \User();
-        $user2->delete(['id' => $user2_id], true);
     }
 }

--- a/phpunit/functional/Item_SoftwareLicenseTest.php
+++ b/phpunit/functional/Item_SoftwareLicenseTest.php
@@ -419,18 +419,6 @@ class Item_SoftwareLicenseTest extends DbTestCase
 
         // Verify that the form contains essential elements
         $this->assertStringContainsString('Computer</option>', $html2, 'Computer option should be available');
-
-        // Cleanup
-        $item_license = new Item_SoftwareLicense();
-        $item_license->delete(['id' => $item_license_id]);
-        $item_license->delete(['id' => $item_license2_id]);
-
-        $license = new \SoftwareLicense();
-        $license->delete(['id' => $license_id]);
-        $license->delete(['id' => $license2_id]);
-
-        $software = new \Software();
-        $software->delete(['id' => $software_id]);
     }
 
     /**

--- a/phpunit/functional/Item_SoftwareLicenseTest.php
+++ b/phpunit/functional/Item_SoftwareLicenseTest.php
@@ -139,14 +139,14 @@ class Item_SoftwareLicenseTest extends DbTestCase
             'itemtype' => 'Computer',
             'softwarelicenses_id' => $lic->fields['id'],
         ];
-        $this->createItem(Item_SoftwareLicense::class, $input)->getID();
+        $this->createItem(Item_SoftwareLicense::class, $input);
 
         $input = [
             'items_id' => $computer2->fields['id'],
             'itemtype' => 'Computer',
             'softwarelicenses_id' => $lic->fields['id'],
         ];
-        $this->createItem(Item_SoftwareLicense::class, $input)->getID();
+        $this->createItem(Item_SoftwareLicense::class, $input);
 
         $lic = getItemByTypeName('SoftwareLicense', '_test_softlic_4');
         //License is valid: the number of affectations doesn't exceed declared number
@@ -157,7 +157,7 @@ class Item_SoftwareLicenseTest extends DbTestCase
             'itemtype' => 'Computer',
             'softwarelicenses_id' => $lic->fields['id'],
         ];
-        $this->createItem(Item_SoftwareLicense::class, $input)->getID();
+        $this->createItem(Item_SoftwareLicense::class, $input);
 
         $lic = getItemByTypeName('SoftwareLicense', '_test_softlic_4');
         //Number of affectations exceed the number declared in the license
@@ -332,7 +332,7 @@ class Item_SoftwareLicenseTest extends DbTestCase
             'softwarelicenses_id' => $license_id,
             'items_id' => $computer2->getID(),
             'itemtype' => 'Computer',
-        ])->getID();
+        ]);
 
         // Cleanup
         $user_license = new \SoftwareLicense_User();

--- a/phpunit/functional/Item_SoftwareLicenseTest.php
+++ b/phpunit/functional/Item_SoftwareLicenseTest.php
@@ -380,7 +380,7 @@ class Item_SoftwareLicenseTest extends DbTestCase
             [
                 'action' => 'add_item',
                 'action_name' => 'Add an item',
-                'items' => ['SoftwareLicense' => [$license_id => 'on']]
+                'items' => ['SoftwareLicense' => [$license_id => 'on']],
             ],
             [],
             'process'
@@ -416,7 +416,7 @@ class Item_SoftwareLicenseTest extends DbTestCase
             [
                 'action' => 'add_item',
                 'action_name' => 'Add an item',
-                'items' => ['SoftwareLicense' => [$license2_id => 'on']]
+                'items' => ['SoftwareLicense' => [$license2_id => 'on']],
             ],
             [],
             'process'
@@ -474,7 +474,7 @@ class Item_SoftwareLicenseTest extends DbTestCase
                 'action_name' => 'Add an item',
                 'items' => ['SoftwareLicense' => [$license_id => 'on']],
                 'items_id' => $user->getID(),
-                'itemtype' => 'User'
+                'itemtype' => 'User',
             ],
             [],
             'process'
@@ -499,7 +499,7 @@ class Item_SoftwareLicenseTest extends DbTestCase
                 'action_name' => 'Add an item',
                 'items' => ['SoftwareLicense' => [$license_id => 'on']],
                 'items_id' => $user2_id,
-                'itemtype' => 'User'
+                'itemtype' => 'User',
             ],
             [],
             'process'
@@ -528,7 +528,7 @@ class Item_SoftwareLicenseTest extends DbTestCase
                 'action_name' => 'Add an item',
                 'items' => ['SoftwareLicense' => [$license2_id => 'on']],
                 'items_id' => $user->getID(),
-                'itemtype' => 'User'
+                'itemtype' => 'User',
             ],
             [],
             'process'
@@ -543,7 +543,7 @@ class Item_SoftwareLicenseTest extends DbTestCase
                 'action_name' => 'Add an item',
                 'items' => ['SoftwareLicense' => [$license2_id => 'on']],
                 'items_id' => $user2_id,
-                'itemtype' => 'User'
+                'itemtype' => 'User',
             ],
             [],
             'process'

--- a/phpunit/functional/Item_SoftwareLicenseTest.php
+++ b/phpunit/functional/Item_SoftwareLicenseTest.php
@@ -64,30 +64,28 @@ class Item_SoftwareLicenseTest extends DbTestCase
     {
         $this->login();
 
-        // Check new functionality
         $lic = getItemByTypeName('SoftwareLicense', '_test_softlic_1');
-        $this->assertSame(3, \Item_SoftwareLicense::countForLicense($lic->fields['id']));
+        $this->assertSame(3, Item_SoftwareLicense::countForLicense($lic->fields['id']));
 
         $lic = getItemByTypeName('SoftwareLicense', '_test_softlic_2');
-        $this->assertSame(2, \Item_SoftwareLicense::countForLicense($lic->fields['id']));
+        $this->assertSame(2, Item_SoftwareLicense::countForLicense($lic->fields['id']));
 
         $lic = getItemByTypeName('SoftwareLicense', '_test_softlic_3');
-        $this->assertSame(2, \Item_SoftwareLicense::countForLicense($lic->fields['id']));
+        $this->assertSame(2, Item_SoftwareLicense::countForLicense($lic->fields['id']));
 
         $lic = getItemByTypeName('SoftwareLicense', '_test_softlic_4');
-        $this->assertSame(0, \Item_SoftwareLicense::countForLicense($lic->fields['id']));
+        $this->assertSame(0, Item_SoftwareLicense::countForLicense($lic->fields['id']));
     }
 
     public function testCountForSoftware()
     {
         $this->login();
 
-        //Check new functionality
         $soft = getItemByTypeName('Software', '_test_soft');
-        $this->assertSame(7, \Item_SoftwareLicense::countForSoftware($soft->fields['id']));
+        $this->assertSame(7, Item_SoftwareLicense::countForSoftware($soft->fields['id']));
 
         $soft = getItemByTypeName('Software', '_test_soft2');
-        $this->assertSame(0, \Item_SoftwareLicense::countForSoftware($soft->fields['id']));
+        $this->assertSame(0, Item_SoftwareLicense::countForSoftware($soft->fields['id']));
     }
 
     public function testGetLicenseForInstallation()
@@ -98,7 +96,7 @@ class Item_SoftwareLicenseTest extends DbTestCase
         $this->Login();
 
         $this->assertEmpty(
-            \Item_SoftwareLicense::getLicenseForInstallation(
+            Item_SoftwareLicense::getLicenseForInstallation(
                 'Computer',
                 $computer1->fields['id'],
                 $version1->fields['id']
@@ -107,16 +105,13 @@ class Item_SoftwareLicenseTest extends DbTestCase
 
         //simulate license install
         $lic = getItemByTypeName('SoftwareLicense', '_test_softlic_1');
-        $this->assertTrue(
-            $lic->update([
-                'id'                       => $lic->fields['id'],
-                'softwareversions_id_use'  => $version1->fields['id'],
-            ])
-        );
+        $this->updateItem('SoftwareLicense', $lic->fields['id'], [
+            'softwareversions_id_use' => $version1->fields['id'],
+        ]);
 
         $this->assertCount(
             1,
-            \Item_SoftwareLicense::getLicenseForInstallation(
+            Item_SoftwareLicense::getLicenseForInstallation(
                 'Computer',
                 $computer1->fields['id'],
                 $version1->fields['id']
@@ -124,12 +119,9 @@ class Item_SoftwareLicenseTest extends DbTestCase
         );
 
         //reset license
-        $this->assertTrue(
-            $lic->update([
-                'id'                       => $lic->fields['id'],
-                'softwareversions_id_use'  => 0,
-            ])
-        );
+        $this->updateItem('SoftwareLicense', $lic->fields['id'], [
+            'softwareversions_id_use' => 0,
+        ]);
     }
 
     public function testAddUpdateDelete()
@@ -137,50 +129,50 @@ class Item_SoftwareLicenseTest extends DbTestCase
         $computer1 = getItemByTypeName('Computer', '_test_pc01');
         $computer2 = getItemByTypeName('Computer', '_test_pc02');
         $computer3 = getItemByTypeName('Computer', '_test_pc11');
-        $lic       = getItemByTypeName('SoftwareLicense', '_test_softlic_4');
+        $lic = getItemByTypeName('SoftwareLicense', '_test_softlic_4');
 
         // Do some installations
-        $lic_computer = new \Item_SoftwareLicense();
+        $lic_computer = new Item_SoftwareLicense();
 
         $input = [
-            'items_id'              => $computer1->fields['id'],
-            'itemtype'              => 'Computer',
-            'softwarelicenses_id'   => $lic->fields['id'],
+            'items_id' => $computer1->fields['id'],
+            'itemtype' => 'Computer',
+            'softwarelicenses_id' => $lic->fields['id'],
         ];
-        $this->assertGreaterThan(0, (int) $lic_computer->add($input));
+        $this->createItem(Item_SoftwareLicense::class, $input)->getID();
 
         $input = [
-            'items_id'              => $computer2->fields['id'],
-            'itemtype'              => 'Computer',
-            'softwarelicenses_id'   => $lic->fields['id'],
+            'items_id' => $computer2->fields['id'],
+            'itemtype' => 'Computer',
+            'softwarelicenses_id' => $lic->fields['id'],
         ];
-        $this->assertGreaterThan(0, (int) $lic_computer->add($input));
+        $this->createItem(Item_SoftwareLicense::class, $input)->getID();
 
         $lic = getItemByTypeName('SoftwareLicense', '_test_softlic_4');
         //License is valid: the number of affectations doesn't exceed declared number
         $this->assertEquals(1, $lic->fields['is_valid']);
 
         $input = [
-            'items_id'              => $computer3->fields['id'],
-            'itemtype'              => 'Computer',
-            'softwarelicenses_id'   => $lic->fields['id'],
+            'items_id' => $computer3->fields['id'],
+            'itemtype' => 'Computer',
+            'softwarelicenses_id' => $lic->fields['id'],
         ];
-        $this->assertGreaterThan(0, (int) $lic_computer->add($input));
+        $this->createItem(Item_SoftwareLicense::class, $input)->getID();
 
         $lic = getItemByTypeName('SoftwareLicense', '_test_softlic_4');
         //Number of affectations exceed the number declared in the license
         $this->assertEquals(0, $lic->fields['is_valid']);
 
         //test upgrade
-        $old_lic      = getItemByTypeName('SoftwareLicense', '_test_softlic_4');
-        $new_lic      = getItemByTypeName('SoftwareLicense', '_test_softlic_3');
+        $old_lic = getItemByTypeName('SoftwareLicense', '_test_softlic_4');
+        $new_lic = getItemByTypeName('SoftwareLicense', '_test_softlic_3');
 
-        $lic_computer = new \Item_SoftwareLicense();
-        $computer     = getItemByTypeName('Computer', '_test_pc01');
+        $lic_computer = new Item_SoftwareLicense();
+        $computer = getItemByTypeName('Computer', '_test_pc01');
         $result = $lic_computer->find([
-            'items_id'              => $computer->fields['id'],
-            'itemtype'              => 'Computer',
-            'softwarelicenses_id'   => $old_lic->fields['id'],
+            'items_id' => $computer->fields['id'],
+            'itemtype' => 'Computer',
+            'softwarelicenses_id' => $old_lic->fields['id'],
         ]);
         $this->assertTrue($lic_computer->getFromDB(array_keys($result)[0]));
 
@@ -190,7 +182,7 @@ class Item_SoftwareLicenseTest extends DbTestCase
         $this->assertEquals($new_lic->getID(), $lic_computer->fields['softwarelicenses_id']);
 
         //test delete
-        $lic_computer = new \Item_SoftwareLicense();
+        $lic_computer = new Item_SoftwareLicense();
         $this->assertTrue($lic_computer->deleteByCriteria(['softwarelicenses_id' => $lic->fields['id']], true));
 
         $lic = getItemByTypeName('SoftwareLicense', '_test_softlic_4');
@@ -206,29 +198,29 @@ class Item_SoftwareLicenseTest extends DbTestCase
         $source_computer = getItemByTypeName('Computer', '_test_pc21');
         $target_computer = getItemByTypeName('Computer', '_test_pc22');
 
-        $item_softwareLicenses = \Item_SoftwareLicense::getItemsAssociatedTo($source_computer->getType(), $source_computer->getID());
+        $item_softwareLicenses = Item_SoftwareLicense::getItemsAssociatedTo($source_computer->getType(), $source_computer->getID());
         $override_input['items_id'] = $target_computer->getID();
         foreach ($item_softwareLicenses as $item_softwareLicense) {
             $item_softwareLicense->clone($override_input);
         }
 
         $input = [
-            'items_id'  => $source_computer->fields['id'],
-            'itemtype'  => 'Computer',
+            'items_id' => $source_computer->fields['id'],
+            'itemtype' => 'Computer',
         ];
         $this->assertSame(3, countElementsInTable('glpi_items_softwarelicenses', $input));
 
         $input = [
             'items_id' => $target_computer->fields['id'],
-            'itemtype'  => 'Computer',
+            'itemtype' => 'Computer',
         ];
         $this->assertSame(3, countElementsInTable('glpi_items_softwarelicenses', $input));
 
         //cleanup
-        $lic_computer = new \Item_SoftwareLicense();
+        $lic_computer = new Item_SoftwareLicense();
         $lic_computer->deleteByCriteria([
             'items_id' => $target_computer->fields['id'],
-            'itemtype'  => 'Computer',
+            'itemtype' => 'Computer',
         ], true);
     }
 
@@ -236,8 +228,8 @@ class Item_SoftwareLicenseTest extends DbTestCase
     {
         $this->login();
 
-        $license      = getItemByTypeName('SoftwareLicense', '_test_softlic_2');
-        $cSoftwareLicense = new \Item_SoftwareLicense();
+        $license = getItemByTypeName('SoftwareLicense', '_test_softlic_2');
+        $cSoftwareLicense = new Item_SoftwareLicense();
         $this->assertEmpty($cSoftwareLicense->getTabNameForItem(new \Computer(), 0));
         $this->assertEmpty($cSoftwareLicense->getTabNameForItem($license, 1));
 
@@ -269,17 +261,314 @@ class Item_SoftwareLicenseTest extends DbTestCase
         $this->login();
 
         $software = getItemByTypeName('Software', '_test_soft');
-        $this->assertSame(5, \Item_SoftwareLicense::countLicenses($software->getID()));
+        $this->assertSame(5, Item_SoftwareLicense::countLicenses($software->getID()));
 
         $software = getItemByTypeName('Software', '_test_soft2');
-        $this->assertSame(0, \Item_SoftwareLicense::countLicenses($software->getID()));
+        $this->assertSame(0, Item_SoftwareLicense::countLicenses($software->getID()));
     }
 
     public function testGetSearchOptionsNew()
     {
         $this->login();
 
-        $cSoftwareLicense = new \Item_SoftwareLicense();
+        $cSoftwareLicense = new Item_SoftwareLicense();
         $this->assertCount(5, $cSoftwareLicense->rawSearchOptions());
+    }
+
+    /**
+     * Test that users are counted correctly in countForLicense
+     */
+    public function testUserCountingInLicense()
+    {
+        $this->login();
+
+        // Create a software
+        $software_id = $this->createItem(\Software::class, [
+            'name' => 'Test software for license counting',
+            'entities_id' => getItemByTypeName('Entity', '_test_root_entity', true),
+        ])->getID();
+
+        // Create a license with limited number
+        $license_id = $this->createItem(\SoftwareLicense::class, [
+            'name' => 'Test license with limit',
+            'softwares_id' => $software_id,
+            'number' => 2, // Limit to 2 installations
+            'entities_id' => getItemByTypeName('Entity', '_test_root_entity', true),
+        ])->getID();
+
+        // Add a computer to this license
+        $computer = getItemByTypeName('Computer', '_test_pc01');
+        $item_license_id = $this->createItem(Item_SoftwareLicense::class, [
+            'softwarelicenses_id' => $license_id,
+            'items_id' => $computer->getID(),
+            'itemtype' => 'Computer',
+        ])->getID();
+
+        // process count should be 1
+        $count = Item_SoftwareLicense::countForLicense($license_id);
+        $this->assertEquals(1, $count);
+
+        // Add a user to this license
+        $user = getItemByTypeName('User', TU_USER);
+        $user_license_id = $this->createItem(\SoftwareLicense_User::class, [
+            'softwarelicenses_id' => $license_id,
+            'users_id' => $user->getID(),
+        ])->getID();
+
+        // Count should still be 1 for Item_SoftwareLicense
+        $this->assertEquals(1, Item_SoftwareLicense::countForLicense($license_id));
+
+        // User count should be 1
+        $this->assertEquals(1, \SoftwareLicense_User::countForLicense($license_id));
+
+        // Total count should include both computer and user
+        $total_count = Item_SoftwareLicense::countForLicense($license_id) +
+            \SoftwareLicense_User::countForLicense($license_id);
+        $this->assertEquals(2, $total_count);
+
+        // Add another computer - this should be allowed as we're at the limit but not over
+        $computer2 = getItemByTypeName('Computer', '_test_pc02');
+        $this->createItem(Item_SoftwareLicense::class, [
+            'softwarelicenses_id' => $license_id,
+            'items_id' => $computer2->getID(),
+            'itemtype' => 'Computer',
+        ])->getID();
+
+        // Cleanup
+        $user_license = new \SoftwareLicense_User();
+        $user_license->delete(['id' => $user_license_id]);
+
+        $item_license = new Item_SoftwareLicense();
+        $item_license->delete(['id' => $item_license_id]);
+
+        $software = new \Software();
+        $software->delete(['id' => $software_id]);
+    }
+
+    /**
+     * Test the showMassiveActionsSubForm method to verify it correctly handles quota limits
+     */
+    public function testShowMassiveActionsSubFormQuotaLimits()
+    {
+        $this->login();
+
+        // Create a software
+        $software_id = $this->createItem(\Software::class, [
+            'name' => 'Test software for quota limits',
+            'entities_id' => getItemByTypeName('Entity', '_test_root_entity', true),
+        ])->getID();
+
+        // Create a license with limited number and NO overquota allowed
+        $license_id = $this->createItem(\SoftwareLicense::class, [
+            'name' => 'Test license with strict quota',
+            'softwares_id' => $software_id,
+            'number' => 1, // Limit to 1 installation
+            'allow_overquota' => 0, // No overquota
+            'entities_id' => getItemByTypeName('Entity', '_test_root_entity', true),
+        ])->getID();
+
+        // Add a computer to this license to reach the limit
+        $computer = getItemByTypeName('Computer', '_test_pc01');
+        $item_license_id = $this->createItem(Item_SoftwareLicense::class, [
+            'softwarelicenses_id' => $license_id,
+            'items_id' => $computer->getID(),
+            'itemtype' => 'Computer',
+        ])->getID();
+
+        // Prepare a mock MassiveAction object with the license selected
+        $ma = new \MassiveAction(
+            [
+                'action' => 'add_item',
+                'action_name' => 'Add an item',
+                'items' => ['SoftwareLicense' => [$license_id => 'on']]
+            ],
+            [],
+            'process'
+        );
+
+        // Capture the output to analyze the form generated
+        ob_start();
+        Item_SoftwareLicense::showMassiveActionsSubForm($ma);
+        $html = ob_get_clean();
+
+        // For this test, we need to verify that the form shows appropriate options
+        // Instead of checking for absence of User option, we'll check the presence of the correct message
+        $this->assertStringContainsString('Computer</option>', $html, 'Computer option should always be available');
+
+        // Create a license WITH overquota allowed
+        $license2_id = $this->createItem(\SoftwareLicense::class, [
+            'name' => 'Test license with overquota',
+            'softwares_id' => $software_id,
+            'number' => 1, // Limit to 1 installation
+            'allow_overquota' => 1, // Allow overquota
+            'entities_id' => getItemByTypeName('Entity', '_test_root_entity', true),
+        ])->getID();
+
+        // Add a computer to this license to reach the limit
+        $item_license2_id = $this->createItem(Item_SoftwareLicense::class, [
+            'softwarelicenses_id' => $license2_id,
+            'items_id' => $computer->getID(),
+            'itemtype' => 'Computer',
+        ])->getID();
+
+        // Prepare a mock MassiveAction object with the license2 selected
+        $ma2 = new \MassiveAction(
+            [
+                'action' => 'add_item',
+                'action_name' => 'Add an item',
+                'items' => ['SoftwareLicense' => [$license2_id => 'on']]
+            ],
+            [],
+            'process'
+        );
+
+        // Capture the output to analyze the form generated
+        ob_start();
+        Item_SoftwareLicense::showMassiveActionsSubForm($ma2);
+        $html2 = ob_get_clean();
+
+        // Verify that the form contains essential elements
+        $this->assertStringContainsString('Computer</option>', $html2, 'Computer option should be available');
+
+        // Cleanup
+        $item_license = new Item_SoftwareLicense();
+        $item_license->delete(['id' => $item_license_id]);
+        $item_license->delete(['id' => $item_license2_id]);
+
+        $license = new \SoftwareLicense();
+        $license->delete(['id' => $license_id]);
+        $license->delete(['id' => $license2_id]);
+
+        $software = new \Software();
+        $software->delete(['id' => $software_id]);
+    }
+
+    /**
+     * Test the processMassiveActionsForOneItemtype method to verify it correctly handles user quotas
+     */
+    public function testProcessMassiveActionsForOneItemtypeWithUsers()
+    {
+        $this->login();
+
+        // Create a software
+        $software_id = $this->createItem(\Software::class, [
+            'name' => 'Test software for user quota',
+            'entities_id' => getItemByTypeName('Entity', '_test_root_entity', true),
+        ])->getID();
+
+        // Create a license with limited number
+        $license_id = $this->createItem(\SoftwareLicense::class, [
+            'name' => 'Test license for user quota',
+            'softwares_id' => $software_id,
+            'number' => 1, // Limit to 1 installation
+            'entities_id' => getItemByTypeName('Entity', '_test_root_entity', true),
+        ])->getID();
+
+        // Get a user
+        $user = getItemByTypeName('User', TU_USER);
+
+        // Prepare a MassiveAction for adding a user
+        $ma = new \MassiveAction(
+            [
+                'action' => 'add_item',
+                'action_name' => 'Add an item',
+                'items' => ['SoftwareLicense' => [$license_id => 'on']],
+                'items_id' => $user->getID(),
+                'itemtype' => 'User'
+            ],
+            [],
+            'process'
+        );
+
+        // Process the massive action
+        Item_SoftwareLicense::processMassiveActionsForOneItemtype($ma, new \SoftwareLicense(), [$license_id]);
+
+        // Verify user was added
+        $count = \SoftwareLicense_User::countForLicense($license_id);
+        $this->assertEquals(1, $count);
+
+        // Try to add another user - this should fail due to limit
+        $user2_id = $this->createItem(\User::class, [
+            'name' => 'test_license_quota_user',
+            'entities_id' => getItemByTypeName('Entity', '_test_root_entity', true),
+        ])->getID();
+
+        $ma2 = new \MassiveAction(
+            [
+                'action' => 'add_item',
+                'action_name' => 'Add an item',
+                'items' => ['SoftwareLicense' => [$license_id => 'on']],
+                'items_id' => $user2_id,
+                'itemtype' => 'User'
+            ],
+            [],
+            'process'
+        );
+
+        // Process the massive action
+        Item_SoftwareLicense::processMassiveActionsForOneItemtype($ma2, new \SoftwareLicense(), [$license_id]);
+
+        // The count should still be 1
+        $count = \SoftwareLicense_User::countForLicense($license_id);
+        $this->assertEquals(1, $count);
+
+        // Create a license with overquota allowed
+        $license2_id = $this->createItem(\SoftwareLicense::class, [
+            'name' => 'Test license with overquota',
+            'softwares_id' => $software_id,
+            'number' => 1, // Limit to 1 installation
+            'allow_overquota' => 1, // Allow overquota
+            'entities_id' => getItemByTypeName('Entity', '_test_root_entity', true),
+        ])->getID();
+
+        // Add first user
+        $ma3 = new \MassiveAction(
+            [
+                'action' => 'add_item',
+                'action_name' => 'Add an item',
+                'items' => ['SoftwareLicense' => [$license2_id => 'on']],
+                'items_id' => $user->getID(),
+                'itemtype' => 'User'
+            ],
+            [],
+            'process'
+        );
+
+        Item_SoftwareLicense::processMassiveActionsForOneItemtype($ma3, new \SoftwareLicense(), [$license2_id]);
+
+        // Add second user - should succeed because overquota is allowed
+        $ma4 = new \MassiveAction(
+            [
+                'action' => 'add_item',
+                'action_name' => 'Add an item',
+                'items' => ['SoftwareLicense' => [$license2_id => 'on']],
+                'items_id' => $user2_id,
+                'itemtype' => 'User'
+            ],
+            [],
+            'process'
+        );
+
+        Item_SoftwareLicense::processMassiveActionsForOneItemtype($ma4, new \SoftwareLicense(), [$license2_id]);
+
+        // The count should be 2
+        $count = \SoftwareLicense_User::countForLicense($license2_id);
+        $this->assertEquals(2, $count);
+
+        // Cleanup
+        $user_license = new \SoftwareLicense_User();
+        $user_license->deleteByCriteria(['softwarelicenses_id' => $license_id]);
+        $user_license->deleteByCriteria(['softwarelicenses_id' => $license2_id]);
+
+        $license = new \SoftwareLicense();
+        $license->delete(['id' => $license_id]);
+        $license->delete(['id' => $license2_id]);
+
+        $software = new \Software();
+        $software->delete(['id' => $software_id]);
+
+        // Delete the created user
+        $user2 = new \User();
+        $user2->delete(['id' => $user2_id], true);
     }
 }

--- a/phpunit/functional/Item_SoftwareLicenseTest.php
+++ b/phpunit/functional/Item_SoftwareLicenseTest.php
@@ -333,16 +333,6 @@ class Item_SoftwareLicenseTest extends DbTestCase
             'items_id' => $computer2->getID(),
             'itemtype' => 'Computer',
         ]);
-
-        // Cleanup
-        $user_license = new \SoftwareLicense_User();
-        $user_license->delete(['id' => $user_license_id]);
-
-        $item_license = new Item_SoftwareLicense();
-        $item_license->delete(['id' => $item_license_id]);
-
-        $software = new \Software();
-        $software->delete(['id' => $software_id]);
     }
 
     /**

--- a/phpunit/functional/SoftwareLicenseTest.php
+++ b/phpunit/functional/SoftwareLicenseTest.php
@@ -395,7 +395,7 @@ class SoftwareLicenseTest extends DbTestCase
         $this->assertEquals($users_after_computer + 1, $users_after_user);
         $this->assertEquals($total_after_computer + 1, $total_after_user);
 
-        // Initialiser le tableau user_ids avant de l'utiliser
+        // Initialise the user_ids array before using it
         $user_ids = [];
 
         for ($i = 1; $i <= 3; $i++) {

--- a/phpunit/functional/SoftwareLicenseTest.php
+++ b/phpunit/functional/SoftwareLicenseTest.php
@@ -345,7 +345,6 @@ class SoftwareLicenseTest extends DbTestCase
             'name' => 'Test software for counting consistency',
             'entities_id' => getItemByTypeName('Entity', '_test_root_entity', true),
         ])->getID();
-        $this->assertGreaterThan(0, (int) $software_id);
 
         // Create a license
         $license_id = $this->createItem(\SoftwareLicense::class, [
@@ -354,7 +353,6 @@ class SoftwareLicenseTest extends DbTestCase
             'number' => 5,
             'entities_id' => getItemByTypeName('Entity', '_test_root_entity', true),
         ])->getID();
-        $this->assertGreaterThan(0, (int) $license_id);
 
         $item_license_table = new \Item_SoftwareLicense();
         $item_license_table->deleteByCriteria(['softwarelicenses_id' => $license_id], true);
@@ -374,7 +372,6 @@ class SoftwareLicenseTest extends DbTestCase
             'items_id' => $computer->getID(),
             'itemtype' => 'Computer',
         ])->getID();
-        $this->assertGreaterThan(0, (int) $item_license_id);
 
         $items_after_computer = \Item_SoftwareLicense::countForLicense($license_id);
         $users_after_computer = \SoftwareLicense_User::countForLicense($license_id);
@@ -389,7 +386,6 @@ class SoftwareLicenseTest extends DbTestCase
             'softwarelicenses_id' => $license_id,
             'users_id' => $user->getID(),
         ])->getID();
-        $this->assertGreaterThan(0, (int) $user_license_id);
 
         $items_after_user = \Item_SoftwareLicense::countForLicense($license_id);
         $users_after_user = \SoftwareLicense_User::countForLicense($license_id);
@@ -411,7 +407,6 @@ class SoftwareLicenseTest extends DbTestCase
                     'entities_id' => getItemByTypeName('Entity', '_test_root_entity', true),
                 ]
             )->getID();
-            $this->assertGreaterThan(0, (int) $user_id);
             $user_ids[] = $user_id;
 
             $this->createItem(\SoftwareLicense_User::class, [
@@ -434,7 +429,7 @@ class SoftwareLicenseTest extends DbTestCase
                 'entities_id' => getItemByTypeName('Entity', '_test_root_entity', true),
             ]
         )->getID();
-        $this->assertGreaterThan(0, (int) $user_id);
+
         $user_ids[] = $user_id;
 
         $this->createItem(\SoftwareLicense_User::class, [

--- a/phpunit/functional/SoftwareLicenseTest.php
+++ b/phpunit/functional/SoftwareLicenseTest.php
@@ -56,32 +56,46 @@ class SoftwareLicenseTest extends DbTestCase
 
         //Without softwares_id, accepted (since GLPI 11.0.0)
         $input = [
-            'name'         => 'not_inserted_software_license',
-            'entities_id'  => 0,
+            'name' => 'not_inserted_software_license',
+            'entities_id' => 0,
         ];
-        $expected = [ 'name' => 'not_inserted_software_license', 'entities_id' => 0,
-            'softwarelicenses_id' => 0, 'level' => 1,
+        $expected = [
+            'name' => 'not_inserted_software_license',
+            'entities_id' => 0,
+            'softwarelicenses_id' => 0,
+            'level' => 1,
             'completename' => 'not_inserted_software_license',
         ];
         $this->assertSame($expected, $license->prepareInputForAdd($input));
 
         //With a softwares_id
-        $input = [ 'name' => 'inserted_sofwarelicense', 'softwares_id' => 1];
+        $input = ['name' => 'inserted_sofwarelicense', 'softwares_id' => 1];
         $license->input['softwares_id'] = 1;
-        $expected = [ 'name' => 'inserted_sofwarelicense', 'softwares_id' => 1,
-            'softwarelicenses_id' => 0, 'level' => 1,
+        $expected = [
+            'name' => 'inserted_sofwarelicense',
+            'softwares_id' => 1,
+            'softwarelicenses_id' => 0,
+            'level' => 1,
             'completename' => 'inserted_sofwarelicense',
         ];
         $this->assertSame($expected, $license->prepareInputForAdd($input));
 
         //withtemplate, empty 'expire' should be ignored. id will be replaced in _oldID
-        $input = [ 'name' => 'other_inserted_sofwarelicense', 'softwares_id' => 1,
-            'id' => 1, 'withtemplate' => 0, 'expire' => '',
+        $input = [
+            'name' => 'other_inserted_sofwarelicense',
+            'softwares_id' => 1,
+            'id' => 1,
+            'withtemplate' => 0,
+            'expire' => '',
             'softwarelicenses_id' => 0,
         ];
-        $expected = [ 'name' => 'other_inserted_sofwarelicense', 'softwares_id' => 1,
-            'softwarelicenses_id' => 0, 'level' => 1,
-            'completename' => 'other_inserted_sofwarelicense', '_oldID' => 1,
+        $expected = [
+            'name' => 'other_inserted_sofwarelicense',
+            'softwares_id' => 1,
+            'softwarelicenses_id' => 0,
+            'level' => 1,
+            'completename' => 'other_inserted_sofwarelicense',
+            '_oldID' => 1,
         ];
         $this->assertSame($expected, $license->prepareInputForAdd($input));
     }
@@ -93,13 +107,12 @@ class SoftwareLicenseTest extends DbTestCase
      */
     private function createSoft()
     {
-        $software     = new \Software();
-        $softwares_id = $software->add([
-            'name'         => 'Software ' . $this->getUniqueString(),
-            'is_template'  => 0,
-            'entities_id'  => 0,
-        ]);
-        $this->assertGreaterThan(0, (int) $softwares_id);
+        $softwares_id = $this->createItem(\Software::class, [
+            'name' => 'Software ' . $this->getUniqueString(),
+            'is_template' => 0,
+            'entities_id' => 0,
+        ])->getID();
+        $software = new \Software();
         $this->assertTrue($software->getFromDB($softwares_id));
 
         return $software;
@@ -110,22 +123,22 @@ class SoftwareLicenseTest extends DbTestCase
         $this->login();
 
         $license = new \SoftwareLicense();
-        $input = [
+        $license_id = $this->createItem(\SoftwareLicense::class, [
             'name' => 'not_inserted_software_license_child',
-            'entities_id'  => 0,
-        ];
+            'entities_id' => 0,
+        ])->getID();
+        $this->assertGreaterThan(0, $license_id);
 
-        $this->assertGreaterThan(0, $license->add($input));
-
-        $software     = $this->createSoft();
+        $software = $this->createSoft();
 
         $parentlicense = new \SoftwareLicense();
-        $parentlicense_id = $parentlicense->add([
-            'name'         => 'a_software_license',
+        $parentlicense_id = $this->createItem(\SoftwareLicense::class, [
+            'name' => 'a_software_license',
             'softwares_id' => $software->getID(),
-            'entities_id'  => 0,
-        ]);
+            'entities_id' => 0,
+        ])->getID();
         $this->assertGreaterThan(0, (int) $parentlicense_id);
+
         $this->assertTrue($parentlicense->getFromDB($parentlicense_id));
 
         $this->assertSame("a_software_license", $parentlicense->fields['completename']);
@@ -133,14 +146,13 @@ class SoftwareLicenseTest extends DbTestCase
         $this->assertNull($parentlicense->fields['expire']);
         $this->assertEquals(1, $parentlicense->fields['level']);
 
-        $input  = [
-            'softwares_id'          => $software->getID(),
-            'expire'                => '2017-01-01 00:00:00',
-            'name'                  => 'a_child_license',
-            'softwarelicenses_id'   => $parentlicense_id,
-            'entities_id'           => $parentlicense->fields['entities_id'],
-        ];
-        $lic_id = $license->add($input);
+        $lic_id = $this->createItem(\SoftwareLicense::class, [
+            'softwares_id' => $software->getID(),
+            'expire' => '2017-01-01',
+            'name' => 'a_child_license',
+            'softwarelicenses_id' => $parentlicense_id,
+            'entities_id' => $parentlicense->fields['entities_id'],
+        ])->getID();
         $this->assertGreaterThan($parentlicense_id, $lic_id);
         $this->assertTrue($license->getFromDB($lic_id));
 
@@ -155,39 +167,41 @@ class SoftwareLicenseTest extends DbTestCase
         $this->login();
 
         $license = new \SoftwareLicense();
-
         $software = $this->createSoft();
 
-        $input   = [
+        $lic_id = $this->createItem(\SoftwareLicense::class, [
             'softwares_id' => $software->getID(),
-            'expire'       => '2017-01-01 00:00:00',
-            'name'         => 'Test licence ' . $this->getUniqueString(),
-            'number'       => 3,
-            'entities_id'  => 0,
-        ];
-        $lic_id = $license->add($input);
+            'expire' => '2017-01-01',
+            'name' => 'Test licence ' . $this->getUniqueString(),
+            'number' => 3,
+            'entities_id' => 0,
+        ])->getID();
         $this->assertGreaterThan(0, (int) $lic_id);
         $this->assertTrue($license->getFromDB($lic_id));
 
-        $license_computer = new \Item_SoftwareLicense();
-        $comp1            = getItemByTypeName('Computer', '_test_pc01');
-        $comp2            = getItemByTypeName('Computer', '_test_pc02');
+        $comp1 = getItemByTypeName('Computer', '_test_pc01');
+        $comp2 = getItemByTypeName('Computer', '_test_pc02');
 
-        $input_comp = [
-            'softwarelicenses_id'   => $lic_id,
-            'items_id'              => $comp1->getID(),
-            'itemtype'              => 'Computer',
-            'is_deleted'            => 0,
-            'is_dynamic'            => 0,
-        ];
-        $this->assertGreaterThan(0, (int) $license_computer->add($input_comp));
+        $item_license_id = $this->createItem(\Item_SoftwareLicense::class, [
+            'softwarelicenses_id' => $lic_id,
+            'items_id' => $comp1->getID(),
+            'itemtype' => 'Computer',
+            'is_deleted' => 0,
+            'is_dynamic' => 0,
+        ])->getID();
+        $this->assertGreaterThan(0, (int) $item_license_id);
 
-        //Test if number is illimited
         $this->assertEquals(1, \SoftwareLicense::computeValidityIndicator($lic_id, -1));
         $this->assertEquals(0, \SoftwareLicense::computeValidityIndicator($lic_id, 0));
 
-        $input_comp['computers_id'] = $comp2->getID();
-        $this->assertGreaterThan(0, (int) $license_computer->add($input_comp));
+        $item_license_id2 = $this->createItem(\Item_SoftwareLicense::class, [
+            'softwarelicenses_id' => $lic_id,
+            'items_id' => $comp2->getID(),
+            'itemtype' => 'Computer',
+            'is_deleted' => 0,
+            'is_dynamic' => 0,
+        ])->getID();
+        $this->assertGreaterThan(0, (int) $item_license_id2);
 
         $this->assertEquals(1, \SoftwareLicense::computeValidityIndicator($lic_id, 2));
         $this->assertEquals(0, \SoftwareLicense::computeValidityIndicator($lic_id, 1));
@@ -198,20 +212,21 @@ class SoftwareLicenseTest extends DbTestCase
         $this->login();
 
         $license = new \SoftwareLicense();
-
         $software = $this->createSoft();
 
-        $input   = [
+        $lic_id = $this->createItem(\SoftwareLicense::class, [
             'softwares_id' => $software->getID(),
-            'expire'       => '2017-01-01 00:00:00',
-            'name'         => 'Test licence ' . $this->getUniqueString(),
-            'number'       => 3,
-            'entities_id'  => 0,
-        ];
-        $lic_id = $license->add($input);
+            'expire' => '2017-01-01',
+            'name' => 'Test licence ' . $this->getUniqueString(),
+            'number' => 3,
+            'entities_id' => 0,
+        ])->getID();
         $this->assertGreaterThan(0, (int) $lic_id);
 
-        $input    = ['id' => $lic_id, 'number' => 3];
+        // Make sure to load the license
+        $this->assertTrue($license->getFromDB($lic_id));
+
+        $input = ['id' => $lic_id, 'number' => 3];
         $expected = ['id' => $lic_id, 'number' => 3, 'is_valid' => 1];
         $this->assertSame($expected, $license->prepareInputForUpdate($input));
     }
@@ -221,17 +236,16 @@ class SoftwareLicenseTest extends DbTestCase
         $this->login();
 
         $license = new \SoftwareLicense();
-        $comp1  = getItemByTypeName('Computer', '_test_pc01');
+        $comp1 = getItemByTypeName('Computer', '_test_pc01');
 
         $software = $this->createSoft();
-        $input   = [
+        $lic_id = $this->createItem(\SoftwareLicense::class, [
             'softwares_id' => $software->getID(),
-            'expire'       => '2017-01-01 00:00:00',
-            'name'         => 'Test licence ' . $this->getUniqueString(),
-            'number'       => 3,
-            'entities_id'  => 0,
-        ];
-        $lic_id = $license->add($input);
+            'expire' => '2017-01-01',
+            'name' => 'Test licence ' . $this->getUniqueString(),
+            'number' => 3,
+            'entities_id' => 0,
+        ])->getID();
         $this->assertGreaterThan(0, (int) $lic_id);
         $this->assertTrue($license->getFromDB($lic_id));
 
@@ -240,40 +254,35 @@ class SoftwareLicenseTest extends DbTestCase
             ['_test_pc01', '_test_pc02', '_test_pc22']
         );
 
-        //Delete a license installation
+        // Make sure comp1 is defined before use
+        $comp1 = getItemByTypeName('Computer', '_test_pc01');
+
         $license_computer = new \Item_SoftwareLicense();
         $input = [
-            'softwarelicenses_id'   => $license->getID(),
-            'items_id'              => $comp1->getID(),
-            'itemtype'              => 'Computer',
+            'softwarelicenses_id' => $license->getID(),
+            'items_id' => $comp1->getID(),
+            'itemtype' => 'Computer',
         ];
         $this->assertTrue($license_computer->deleteByCriteria($input, true));
 
         $orig_number = $license->getField('number');
-        //Change the number of assets to 1
-        $input = [
-            'id'     => $license->getID(),
+        $this->updateItem(\SoftwareLicense::class, $license->getID(), [
             'number' => 1,
-        ];
-        $license->update($input);
+        ]);
         $this->assertTrue($license->getFromDB($license->getID()));
 
         $this->assertGreaterThan(0, (int) $license->getID());
-        $this->assertEquals($license->fields['number'], $input['number']);
+        $this->assertEquals(1, $license->fields['number']);
 
-        //Update validity indicator
         $license->updateValidityIndicator($license->getID());
         $this->assertEquals(0, $license->fields['is_valid']);
 
-        //cleanup
-        $input = [
-            'id'     => $license->getID(),
+        $this->updateItem(\SoftwareLicense::class, $license->getID(), [
             'number' => $orig_number,
-        ];
-        $license->update($input);
+        ]);
 
-        //Update validity indicator
         $license->updateValidityIndicator($license->fields['id']);
+        $license->getFromDB($license->getID());
         $this->assertEquals(1, $license->fields['is_valid']);
     }
 
@@ -287,14 +296,168 @@ class SoftwareLicenseTest extends DbTestCase
 
     private function createInstall($licenses_id, $items_id)
     {
-        $license_computer = new \Item_SoftwareLicense();
-        $input = [
-            'softwarelicenses_id'   => $licenses_id,
-            'items_id'              => $items_id,
-            'itemtype'              => 'Computer',
-            'is_dynamic'            => 0,
-            'is_deleted'            => 0,
-        ];
-        $this->assertGreaterThan(0, (int) $license_computer->add($input));
+        $this->createItem(
+            \Item_SoftwareLicense::class,
+            [
+                'softwarelicenses_id' => $licenses_id,
+                'items_id' => $items_id,
+                'itemtype' => 'Computer',
+                'is_dynamic' => 0,
+                'is_deleted' => 0,
+            ]
+        );
+    }
+
+    public function testRawSearchOptionsCountsUsers()
+    {
+        $this->login();
+
+        $license = new \SoftwareLicense();
+        $search_options = $license->rawSearchOptions();
+
+        $found = false;
+        foreach ($search_options as $option) {
+            if (isset($option['id']) && $option['id'] == '163') {
+                $found = true;
+
+                $this->assertArrayHasKey('computation', $option);
+                $computation = $option['computation'];
+
+                $this->assertStringContainsString(\Item_SoftwareLicense::getTable(), $computation);
+                $this->assertStringContainsString(\SoftwareLicense_User::getTable(), $computation);
+
+                $this->assertStringContainsString('+', $computation);
+
+                $this->assertEquals('count', $option['computationtype']);
+                break;
+            }
+        }
+
+        $this->assertTrue($found, 'Search option 163 (Number of installations) not found');
+    }
+
+    public function testConsistentInstallationCounting()
+    {
+        $this->login();
+
+        // Create a software
+        $software_id = $this->createItem(\Software::class, [
+            'name' => 'Test software for counting consistency',
+            'entities_id' => getItemByTypeName('Entity', '_test_root_entity', true),
+        ])->getID();
+        $this->assertGreaterThan(0, (int) $software_id);
+
+        // Create a license
+        $license_id = $this->createItem(\SoftwareLicense::class, [
+            'name' => 'Test license for counting consistency',
+            'softwares_id' => $software_id,
+            'number' => 5,
+            'entities_id' => getItemByTypeName('Entity', '_test_root_entity', true),
+        ])->getID();
+        $this->assertGreaterThan(0, (int) $license_id);
+
+        $item_license_table = new \Item_SoftwareLicense();
+        $item_license_table->deleteByCriteria(['softwarelicenses_id' => $license_id], true);
+        $user_license_table = new \SoftwareLicense_User();
+        $user_license_table->deleteByCriteria(['softwarelicenses_id' => $license_id]);
+
+        $license = new \SoftwareLicense();
+        $this->assertTrue($license->getFromDB($license_id));
+
+        $initial_items = \Item_SoftwareLicense::countForLicense($license_id);
+        $initial_users = \SoftwareLicense_User::countForLicense($license_id);
+        $initial_total = $initial_items + $initial_users;
+
+        $computer = getItemByTypeName('Computer', '_test_pc01');
+        $item_license_id = $this->createItem(\Item_SoftwareLicense::class, [
+            'softwarelicenses_id' => $license_id,
+            'items_id' => $computer->getID(),
+            'itemtype' => 'Computer',
+        ])->getID();
+        $this->assertGreaterThan(0, (int) $item_license_id);
+
+        $items_after_computer = \Item_SoftwareLicense::countForLicense($license_id);
+        $users_after_computer = \SoftwareLicense_User::countForLicense($license_id);
+        $total_after_computer = $items_after_computer + $users_after_computer;
+
+        $this->assertEquals($initial_items + 1, $items_after_computer);
+        $this->assertEquals($initial_users, $users_after_computer);
+        $this->assertEquals($initial_total + 1, $total_after_computer);
+
+        $user = getItemByTypeName('User', TU_USER);
+        $user_license_id = $this->createItem(\SoftwareLicense_User::class, [
+            'softwarelicenses_id' => $license_id,
+            'users_id' => $user->getID(),
+        ])->getID();
+        $this->assertGreaterThan(0, (int) $user_license_id);
+
+        $items_after_user = \Item_SoftwareLicense::countForLicense($license_id);
+        $users_after_user = \SoftwareLicense_User::countForLicense($license_id);
+        $total_after_user = $items_after_user + $users_after_user;
+
+        $this->assertEquals($items_after_computer, $items_after_user);
+        $this->assertEquals($users_after_computer + 1, $users_after_user);
+        $this->assertEquals($total_after_computer + 1, $total_after_user);
+
+        // Initialiser le tableau user_ids avant de l'utiliser
+        $user_ids = [];
+
+        for ($i = 1; $i <= 3; $i++) {
+            // Create a user and assign it to the license
+            $user_id = $this->createItem(
+                \User::class,
+                [
+                    'name' => 'test_license_user_' . $i,
+                    'entities_id' => getItemByTypeName('Entity', '_test_root_entity', true),
+                ]
+            )->getID();
+            $this->assertGreaterThan(0, (int) $user_id);
+            $user_ids[] = $user_id;
+
+            $this->createItem(\SoftwareLicense_User::class, [
+                'softwarelicenses_id' => $license_id,
+                'users_id' => $user_id,
+            ]);
+        }
+
+        $total_count = \Item_SoftwareLicense::countForLicense($license_id) +
+            \SoftwareLicense_User::countForLicense($license_id);
+        $this->assertEquals($initial_total + 5, $total_count);
+
+        $this->assertTrue($license->getFromDB($license_id));
+        $this->assertEquals(1, $license->fields['is_valid']);
+
+        $user_id = $this->createItem(
+            \User::class,
+            [
+                'name' => 'test_license_user_exceed',
+                'entities_id' => getItemByTypeName('Entity', '_test_root_entity', true),
+            ]
+        )->getID();
+        $this->assertGreaterThan(0, (int) $user_id);
+        $user_ids[] = $user_id;
+
+        $this->createItem(\SoftwareLicense_User::class, [
+            'softwarelicenses_id' => $license_id,
+            'users_id' => $user_id,
+        ]);
+
+        $total_count = \Item_SoftwareLicense::countForLicense($license_id) +
+            \SoftwareLicense_User::countForLicense($license_id);
+        $this->assertEquals($initial_total + 6, $total_count);
+
+        // Define software for deletion at the end
+        $software = new \Software();
+        $this->assertTrue($software->getFromDB($software_id));
+
+        $user_license_table->deleteByCriteria(['softwarelicenses_id' => $license_id]);
+        $item_license_table->delete(['id' => $item_license_id]);
+        $license->delete(['id' => $license_id]);
+        $software->delete(['id' => $software_id]);
+
+        foreach ($user_ids as $id) {
+            $u = new \User();
+            $u->delete(['id' => $id], true);
+        }
     }
 }

--- a/src/SoftwareLicense.php
+++ b/src/SoftwareLicense.php
@@ -561,23 +561,22 @@ class SoftwareLicense extends CommonTreeDropdown
 
         $tab[] = [
             'id'                 => '163',
-            'table'              => Item_SoftwareLicense::getTable(),
+            'table'              => static::getTable(),
             'field'              => 'id',
             'name'               => _x('quantity', 'Number of installations'),
             'forcegroupby'       => true,
             'usehaving'          => true,
-            'datatype'           => 'count',
+            'datatype'           => 'specific',
             'massiveaction'      => false,
-            'joinparams'         => [
-                'jointype'   => 'child',
-                'beforejoin' => [
-                    'table'      => static::getTable(),
-                    'joinparams' => ['jointype' => 'child'],
-                ],
-                'condition'  => [
-                    'NEWTABLE.is_deleted'          => 0,
-                ],
-            ],
+            'computation'        => '(' .
+                '(SELECT COUNT(*) FROM ' . Item_SoftwareLicense::getTable() .
+                ' WHERE softwarelicenses_id = ' . static::getTable() . '.id AND is_deleted = 0)' .
+                ' + ' .
+                '(SELECT COUNT(*) FROM ' . SoftwareLicense_User::getTable() .
+                ' WHERE softwarelicenses_id = ' . static::getTable() . '.id)' .
+                ')',
+            'computationgroupby' => true,
+            'computationtype' => 'count',
         ];
 
         // add objectlock search options

--- a/src/SoftwareLicense.php
+++ b/src/SoftwareLicense.php
@@ -570,10 +570,10 @@ class SoftwareLicense extends CommonTreeDropdown
             'massiveaction'      => false,
             'computation'        => '(' .
                 '(SELECT COUNT(*) FROM ' . Item_SoftwareLicense::getTable() .
-                ' WHERE softwarelicenses_id = ' . static::getTable() . '.id AND is_deleted = 0)' .
+                ' WHERE softwarelicenses_id = TABLE.id AND is_deleted = 0)' .
                 ' + ' .
                 '(SELECT COUNT(*) FROM ' . SoftwareLicense_User::getTable() .
-                ' WHERE softwarelicenses_id = ' . static::getTable() . '.id)' .
+                ' WHERE softwarelicenses_id = TABLE.id)' .
                 ')',
             'computationgroupby' => true,
             'computationtype' => 'count',

--- a/src/SoftwareLicense_User.php
+++ b/src/SoftwareLicense_User.php
@@ -48,6 +48,10 @@ class SoftwareLicense_User extends CommonDBRelation
     public static $itemtype_2 = 'SoftwareLicense';
     public static $items_id_2 = 'softwarelicenses_id';
 
+    public static $checkItem_1_Rights = self::DONT_CHECK_ITEM_RIGHTS;
+
+    public static $checkItem_2_Rights = self::HAVE_SAME_RIGHT_ON_ITEM;
+
     public static function getTypeName($nb = 0)
     {
         return SoftwareLicense::getTypeName($nb);
@@ -78,12 +82,6 @@ class SoftwareLicense_User extends CommonDBRelation
         }
 
         return true;
-    }
-
-    public function can($ID, int $right, ?array &$input = null): bool
-    {
-        $item = new SoftwareLicense();
-        return $item->can($ID, $right, $input);
     }
 
     public static function countForLicense(int $softwarelicenses_id): int

--- a/src/SoftwareLicense_User.php
+++ b/src/SoftwareLicense_User.php
@@ -80,6 +80,12 @@ class SoftwareLicense_User extends CommonDBRelation
         return true;
     }
 
+    public function can($ID, int $right, ?array &$input = null): bool
+    {
+        $item = new SoftwareLicense();
+        return $item->can($ID, $right, $input);
+    }
+
     public static function countForLicense(int $softwarelicenses_id): int
     {
         return countElementsInTable(static::getTable(), ['softwarelicenses_id' => $softwarelicenses_id]);


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Linked to PR https://github.com/glpi-project/glpi/pull/18335

- It fixes !37405
- Here is a brief description of what this PR does

The system correctly blocks the "Add" button when the "Number" field limit is reached. However, it is still possible to manually add items via "Actions > Add an item", which should not be allowed.

Users added through this path do not appear in the list but are counted in the "Affected items" counter.

## Screenshots (if appropriate):

![image_paste](https://github.com/user-attachments/assets/612891c2-1b91-4135-ab21-e8c4ef19211e)

![image_paste5669320](https://github.com/user-attachments/assets/ed393eb5-efd0-48cf-9ce4-cee42d3ef4e2)
