### PR TITLE
Fix(change): add missing 'to_validate' list from central personal view

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -458,12 +458,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Change.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Loose comparison using \\!\\= between \'\' and \'\' will always evaluate to false\\.$#',
-	'identifier' => 'notEqual.alwaysFalse',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Change.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^PHPDoc tag @var with type CommonDBTM is not subtype of native type Group\\.$#',
 	'identifier' => 'varTag.nativeType',
 	'count' => 1,

--- a/phpunit/functional/ChangeTest.php
+++ b/phpunit/functional/ChangeTest.php
@@ -462,6 +462,6 @@ class ChangeTest extends DbTestCase
         ob_start();
         \Change::showCentralList(0, 'tovalidate', false);
         $output = ob_get_clean();
-        $this->assertStringNotContainsString("Your changes to validate <span class='primary-bg primary-fg count'>1</span>", $output);
+        $this->assertStringNotContainsString("Your changes to validate", $output);
     }
 }

--- a/phpunit/functional/ChangeTest.php
+++ b/phpunit/functional/ChangeTest.php
@@ -446,7 +446,8 @@ class ChangeTest extends DbTestCase
         // create change validation
         $this->createItem('ChangeValidation', [
             'changes_id'        => $change->getID(),
-            'users_id_validate' => $users_id,
+            'items_id_target'   => $users_id,
+            'itemtype_target'   => \User::class,
         ]);
 
         ob_start();

--- a/phpunit/functional/ChangeTest.php
+++ b/phpunit/functional/ChangeTest.php
@@ -455,5 +455,13 @@ class ChangeTest extends DbTestCase
         $output = ob_get_clean();
         $this->assertStringContainsString("Your changes to validate <span class='primary-bg primary-fg count'>1</span>", $output);
         $this->assertMatchesRegularExpression("/href='\/glpi\/front\/change.form.php\?id=" . $change->getID() . "[^']+'>/", $output);
+
+        // login as tech to check if the change validation is not shown
+        $this->login('tech', 'tech');
+
+        ob_start();
+        \Change::showCentralList(0, 'tovalidate', false);
+        $output = ob_get_clean();
+        $this->assertStringNotContainsString("Your changes to validate <span class='primary-bg primary-fg count'>1</span>", $output);
     }
 }

--- a/phpunit/functional/ChangeTest.php
+++ b/phpunit/functional/ChangeTest.php
@@ -430,4 +430,29 @@ class ChangeTest extends DbTestCase
         $this->assertTrue(array_key_exists('ITEM_Change_74', $change_with_so));
         $this->assertEquals($last_solution_date, $change_with_so['ITEM_Change_74']);
     }
+
+    public function testCentralChangeValidationList()
+    {
+        $this->login();
+        $users_id = getItemByTypeName('User', TU_USER, true);
+
+        // create change
+        $change = $this->createItem('Change', [
+            'name'         => 'test change',
+            'content'      => '<p>test content</p>',
+            'entities_id'  => getItemByTypeName('Entity', '_test_child_2', true),
+        ]);
+
+        // create change validation
+        $this->createItem('ChangeValidation', [
+            'changes_id'        => $change->getID(),
+            'users_id_validate' => $users_id,
+        ]);
+
+        ob_start();
+        \Change::showCentralList(0, 'tovalidate', false);
+        $output = ob_get_clean();
+        $this->assertStringContainsString("Your changes to validate <span class='primary-bg primary-fg count'>1</span>", $output);
+        $this->assertMatchesRegularExpression("/href='\/glpi\/front\/change.form.php\?id=" . $change->getID() . "[^']+'>/", $output);
+    }
 }

--- a/src/Central.php
+++ b/src/Central.php
@@ -243,6 +243,13 @@ class Central extends CommonGLPI
             ];
         }
 
+        if (Session::haveRightsOr('changevalidation', ChangeValidation::getValidateRights())) {
+            $lists[] = [
+                'itemtype'  => Change::class,
+                'status'    => 'tovalidate'
+            ];
+        }
+
         if ($showchanges) {
             $lists[] = [
                 'itemtype'  => Change::class,

--- a/src/Change.php
+++ b/src/Change.php
@@ -1131,7 +1131,7 @@ class Change extends CommonITILObject
                 $WHERE = array_merge(
                     $WHERE,
                     [
-                        'glpi_changevalidations.users_id_validate'              => Session::getLoginUserID(),
+                        ChangeValidation::getTargetCriteriaForUser(Session::getLoginUserID()),
                         'glpi_changevalidations.status'  => CommonITILValidation::WAITING,
                         'glpi_changes.global_validation' => CommonITILValidation::WAITING,
                         'NOT'                            => [
@@ -1262,15 +1262,27 @@ class Change extends CommonITILObject
                         $options['criteria'][0]['value']      = CommonITILValidation::WAITING;
                         $options['criteria'][0]['link']       = 'AND';
 
-                        $options['criteria'][1]['field']      = 59; // validation aprobator
-                        $options['criteria'][1]['searchtype'] = 'equals';
-                        $options['criteria'][1]['value']      = Session::getLoginUserID();
+                        $options['criteria'][1]['criteria'][0]['field']      = 59; // validation aprobator user
+                        $options['criteria'][1]['criteria'][0]['searchtype'] = 'equals';
+                        $options['criteria'][1]['criteria'][0]['value']      = 'myself'; // Resolved as current user's ID
+                        $options['criteria'][1]['criteria'][1]['field']      = 195; // validation aprobator substitute user
+                        $options['criteria'][1]['criteria'][1]['searchtype'] = 'equals';
+                        $options['criteria'][1]['criteria'][1]['value']      = 'myself'; // Resolved as current user's ID
+                        $options['criteria'][1]['criteria'][1]['link']       = 'OR';
+                        $options['criteria'][1]['criteria'][2]['field']      = 196; // validation aprobator group
+                        $options['criteria'][1]['criteria'][2]['searchtype'] = 'equals';
+                        $options['criteria'][1]['criteria'][2]['value']      = 'mygroups'; // Resolved as groups the current user belongs to
+                        $options['criteria'][1]['criteria'][2]['link']       = 'OR';
+                        $options['criteria'][1]['criteria'][3]['field']      = 197; // validation aprobator group
+                        $options['criteria'][1]['criteria'][3]['searchtype'] = 'equals';
+                        $options['criteria'][1]['criteria'][3]['value']      = 'myself'; // Resolved as groups the current user belongs to
+                        $options['criteria'][1]['criteria'][3]['link']       = 'OR';
                         $options['criteria'][1]['link']       = 'AND';
 
                         $options['criteria'][2]['field']      = 12; // validation aprobator
                         $options['criteria'][2]['searchtype'] = 'equals';
-                        $options['criteria'][2]['value']      = 'old';
-                        $options['criteria'][2]['link']       = 'AND NOT';
+                        $options['criteria'][2]['value']      = 'notold';
+                        $options['criteria'][2]['link']       = 'AND';
 
                         $options['criteria'][3]['field']      = 52; // global validation status
                         $options['criteria'][3]['searchtype'] = 'equals';


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !37495

Add missing _change to validate_ list from central personel view 

![image](https://github.com/user-attachments/assets/b910a324-69f3-425f-bfb9-b47767eec9f7)


(like _ticket to validate_)

![image](https://github.com/user-attachments/assets/cf3f3cd6-890b-4126-bfcf-97399c503d55)


## Screenshots (if appropriate):


