### PR TITLE
Fix(Device): add missing 'serial' and 'otherserial' for  search option to add

### DIFF
--- a/src/DeviceGraphicCard.php
+++ b/src/DeviceGraphicCard.php
@@ -224,6 +224,30 @@ class DeviceGraphicCard extends CommonDevice
             ]
         ];
 
+        $tab[] = [
+            'id'                 => '1322',
+            'table'              => 'glpi_items_devicegraphiccards',
+            'field'              => 'serial',
+            'name'               => sprintf(__('%1$s: %2$s'), self::getTypeName(1), __('Serial Number')),
+            'forcegroupby'       => true,
+            'usehaving'          => true,
+            'datatype'           => 'string',
+            'massiveaction'      => false,
+            'joinparams'         => $main_joinparams,
+        ];
+
+        $tab[] = [
+            'id'                 => '1323',
+            'table'              => 'glpi_items_devicegraphiccards',
+            'field'              => 'otherserial',
+            'name'               => sprintf(__('%1$s: %2$s'), self::getTypeName(1), __('Inventory number')),
+            'forcegroupby'       => true,
+            'usehaving'          => true,
+            'datatype'           => 'string',
+            'massiveaction'      => false,
+            'joinparams'         => $main_joinparams,
+        ];
+
         return $tab;
     }
 }

--- a/src/DeviceHardDrive.php
+++ b/src/DeviceHardDrive.php
@@ -303,6 +303,30 @@ class DeviceHardDrive extends CommonDevice
             ]
         ];
 
+        $tab[] = [
+            'id'                 => '1324',
+            'table'              => 'glpi_items_deviceharddrives',
+            'field'              => 'serial',
+            'name'               => sprintf(__('%1$s: %2$s'), self::getTypeName(1), __('Serial Number')),
+            'forcegroupby'       => true,
+            'usehaving'          => true,
+            'datatype'           => 'string',
+            'massiveaction'      => false,
+            'joinparams'         => $main_joinparams,
+        ];
+
+        $tab[] = [
+            'id'                 => '1325',
+            'table'              => 'glpi_items_deviceharddrives',
+            'field'              => 'otherserial',
+            'name'               => sprintf(__('%1$s: %2$s'), self::getTypeName(1), __('Inventory number')),
+            'forcegroupby'       => true,
+            'usehaving'          => true,
+            'datatype'           => 'string',
+            'massiveaction'      => false,
+            'joinparams'         => $main_joinparams,
+        ];
+
         return $tab;
     }
 

--- a/src/DeviceMemory.php
+++ b/src/DeviceMemory.php
@@ -254,6 +254,30 @@ class DeviceMemory extends CommonDevice
             'nometa'             => true, // cannot GROUP_CONCAT a SUM
         ];
 
+        $tab[] = [
+            'id'                 => '1326',
+            'table'              => 'glpi_items_devicememories',
+            'field'              => 'serial',
+            'name'               => sprintf(__('%1$s: %2$s'), self::getTypeName(1), __('Serial Number')),
+            'forcegroupby'       => true,
+            'usehaving'          => true,
+            'datatype'           => 'string',
+            'massiveaction'      => false,
+            'joinparams'         => $main_joinparams,
+        ];
+
+        $tab[] = [
+            'id'                 => '1327',
+            'table'              => 'glpi_items_devicememories',
+            'field'              => 'otherserial',
+            'name'               => sprintf(__('%1$s: %2$s'), self::getTypeName(1), __('Inventory number')),
+            'forcegroupby'       => true,
+            'usehaving'          => true,
+            'datatype'           => 'string',
+            'massiveaction'      => false,
+            'joinparams'         => $main_joinparams,
+        ];
+
         return $tab;
     }
 

--- a/src/DeviceMotherboard.php
+++ b/src/DeviceMotherboard.php
@@ -153,6 +153,30 @@ class DeviceMotherboard extends CommonDevice
             ]
         ];
 
+        $tab[] = [
+            'id'                 => '1328',
+            'table'              => 'glpi_items_devicemotherboards',
+            'field'              => 'serial',
+            'name'               => sprintf(__('%1$s: %2$s'), self::getTypeName(1), __('Serial Number')),
+            'forcegroupby'       => true,
+            'usehaving'          => true,
+            'datatype'           => 'string',
+            'massiveaction'      => false,
+            'joinparams'         => $main_joinparams,
+        ];
+
+        $tab[] = [
+            'id'                 => '1329',
+            'table'              => 'glpi_items_devicemotherboards',
+            'field'              => 'otherserial',
+            'name'               => sprintf(__('%1$s: %2$s'), self::getTypeName(1), __('Inventory number')),
+            'forcegroupby'       => true,
+            'usehaving'          => true,
+            'datatype'           => 'string',
+            'massiveaction'      => false,
+            'joinparams'         => $main_joinparams,
+        ];
+
         return $tab;
     }
 }

--- a/src/DeviceNetworkCard.php
+++ b/src/DeviceNetworkCard.php
@@ -234,6 +234,30 @@ class DeviceNetworkCard extends CommonDevice
             'joinparams'         => $main_joinparams
         ];
 
+        $tab[] = [
+            'id'                 => '1330',
+            'table'              => 'glpi_items_devicenetworkcards',
+            'field'              => 'serial',
+            'name'               => sprintf(__('%1$s: %2$s'), self::getTypeName(1), __('Serial Number')),
+            'forcegroupby'       => true,
+            'usehaving'          => true,
+            'datatype'           => 'string',
+            'massiveaction'      => false,
+            'joinparams'         => $main_joinparams,
+        ];
+
+        $tab[] = [
+            'id'                 => '1331',
+            'table'              => 'glpi_items_devicemotherboards',
+            'field'              => 'otherserial',
+            'name'               => sprintf(__('%1$s: %2$s'), self::getTypeName(1), __('Inventory number')),
+            'forcegroupby'       => true,
+            'usehaving'          => true,
+            'datatype'           => 'string',
+            'massiveaction'      => false,
+            'joinparams'         => $main_joinparams,
+        ];
+
         return $tab;
     }
 

--- a/src/DevicePci.php
+++ b/src/DevicePci.php
@@ -100,6 +100,30 @@ class DevicePci extends CommonDevice
             ]
         ];
 
+        $tab[] = [
+            'id'                 => '1332',
+            'table'              => 'glpi_items_devicepcis',
+            'field'              => 'serial',
+            'name'               => sprintf(__('%1$s: %2$s'), self::getTypeName(1), __('Serial Number')),
+            'forcegroupby'       => true,
+            'usehaving'          => true,
+            'datatype'           => 'string',
+            'massiveaction'      => false,
+            'joinparams'         => $main_joinparams,
+        ];
+
+        $tab[] = [
+            'id'                 => '1333',
+            'table'              => 'glpi_items_devicepcis',
+            'field'              => 'otherserial',
+            'name'               => sprintf(__('%1$s: %2$s'), self::getTypeName(1), __('Inventory number')),
+            'forcegroupby'       => true,
+            'usehaving'          => true,
+            'datatype'           => 'string',
+            'massiveaction'      => false,
+            'joinparams'         => $main_joinparams,
+        ];
+
         return $tab;
     }
 }

--- a/src/DevicePowerSupply.php
+++ b/src/DevicePowerSupply.php
@@ -159,6 +159,30 @@ class DevicePowerSupply extends CommonDevice
             ]
         ];
 
+        $tab[] = [
+            'id'                 => '1334',
+            'table'              => 'glpi_items_devicepowersupplies',
+            'field'              => 'serial',
+            'name'               => sprintf(__('%1$s: %2$s'), self::getTypeName(1), __('Serial Number')),
+            'forcegroupby'       => true,
+            'usehaving'          => true,
+            'datatype'           => 'string',
+            'massiveaction'      => false,
+            'joinparams'         => $main_joinparams,
+        ];
+
+        $tab[] = [
+            'id'                 => '1335',
+            'table'              => 'glpi_items_devicepowersupplies',
+            'field'              => 'otherserial',
+            'name'               => sprintf(__('%1$s: %2$s'), self::getTypeName(1), __('Inventory number')),
+            'forcegroupby'       => true,
+            'usehaving'          => true,
+            'datatype'           => 'string',
+            'massiveaction'      => false,
+            'joinparams'         => $main_joinparams,
+        ];
+
         return $tab;
     }
 

--- a/src/DeviceProcessor.php
+++ b/src/DeviceProcessor.php
@@ -303,6 +303,30 @@ class DeviceProcessor extends CommonDevice
             'nometa'             => true, // cannot GROUP_CONCAT a SUM
         ];
 
+        $tab[] = [
+            'id'                 => '1336',
+            'table'              => 'glpi_items_deviceprocessors',
+            'field'              => 'serial',
+            'name'               => sprintf(__('%1$s: %2$s'), self::getTypeName(1), __('Serial Number')),
+            'forcegroupby'       => true,
+            'usehaving'          => true,
+            'datatype'           => 'string',
+            'massiveaction'      => false,
+            'joinparams'         => $main_joinparams,
+        ];
+
+        $tab[] = [
+            'id'                 => '1337',
+            'table'              => 'glpi_items_deviceprocessors',
+            'field'              => 'otherserial',
+            'name'               => sprintf(__('%1$s: %2$s'), self::getTypeName(1), __('Inventory number')),
+            'forcegroupby'       => true,
+            'usehaving'          => true,
+            'datatype'           => 'string',
+            'massiveaction'      => false,
+            'joinparams'         => $main_joinparams,
+        ];
+
         return $tab;
     }
 

--- a/src/DeviceSoundCard.php
+++ b/src/DeviceSoundCard.php
@@ -161,6 +161,30 @@ class DeviceSoundCard extends CommonDevice
             ]
         ];
 
+        $tab[] = [
+            'id'                 => '1338',
+            'table'              => 'glpi_items_devicesoundcards',
+            'field'              => 'serial',
+            'name'               => sprintf(__('%1$s: %2$s'), self::getTypeName(1), __('Serial Number')),
+            'forcegroupby'       => true,
+            'usehaving'          => true,
+            'datatype'           => 'string',
+            'massiveaction'      => false,
+            'joinparams'         => $main_joinparams,
+        ];
+
+        $tab[] = [
+            'id'                 => '1339',
+            'table'              => 'glpi_items_devicesoundcards',
+            'field'              => 'otherserial',
+            'name'               => sprintf(__('%1$s: %2$s'), self::getTypeName(1), __('Inventory number')),
+            'forcegroupby'       => true,
+            'usehaving'          => true,
+            'datatype'           => 'string',
+            'massiveaction'      => false,
+            'joinparams'         => $main_joinparams,
+        ];
+
         return $tab;
     }
 


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !37442

add mising 'serial' and 'otherserial' for  `rawSearchOptionsToAdd()` function when available from relation table


## Screenshots (if appropriate):


