### PR TITLE
Hide project task search option if no right to read

### DIFF
--- a/phpunit/functional/TicketTest.php
+++ b/phpunit/functional/TicketTest.php
@@ -40,6 +40,7 @@ use Computer;
 use CronTask;
 use DbTestCase;
 use Entity;
+use Glpi\Search\SearchOption;
 use Glpi\Team\Team;
 use Group;
 use Group_Ticket;
@@ -8674,5 +8675,15 @@ HTML
 
         // Assert: only the non closed tickets should be found.
         $this->assertEquals(5, $results['data']['totalcount']);
+    }
+
+    public function testConditionalSearchOptions()
+    {
+        $this->login();
+        $this->assertArrayHasKey('111', SearchOption::getCleanedOptions(Ticket::class));
+
+        $this->login('post-only', 'postonly');
+        SearchOption::clearSearchOptionCache(Ticket::class);
+        $this->assertArrayNotHasKey('111', SearchOption::getCleanedOptions(Ticket::class));
     }
 }

--- a/src/Glpi/Search/SearchOption.php
+++ b/src/Glpi/Search/SearchOption.php
@@ -134,7 +134,7 @@ final class SearchOption implements \ArrayAccess
 
         $search = [];
 
-        $cache_key = $itemtype . '_' . $withplugins;
+        $cache_key = $itemtype . '_' . ($withplugins ? 1 : 0);
         if (isset(self::$search_options_cache[$cache_key])) {
             return self::$search_options_cache[$cache_key];
         }
@@ -783,8 +783,26 @@ final class SearchOption implements \ArrayAccess
         return $generated_id;
     }
 
-    public static function clearSearchOptionCache(): void
+    /**
+     * Clear the {@link $search_options_cache search option cache} for a specific itemtype or all itemtypes.
+     *
+     * If an itemtype is specified, the itemtype class-level search option cache will also be cleared.
+     * If no itemtype is specified, you may need to clear the needed class-level caches manually.
+     * @param string|null $itemtype The itemtype to clear the cache for, or null to clear all caches.
+     * @return void
+     * @see \CommonDBTM::clearSearchOptionCache()
+     */
+    public static function clearSearchOptionCache(?string $itemtype = null): void
     {
-        self::$search_options_cache = [];
+        if ($itemtype === null) {
+            self::$search_options_cache = [];
+            return;
+        }
+        // Clear only the cache for the specified itemtype both with and without plugins
+        unset(self::$search_options_cache["{$itemtype}_1"], self::$search_options_cache["{$itemtype}_0"]);
+        // Clear itemtype-level cache if it is CommonDBTM
+        if (is_subclass_of($itemtype, CommonDBTM::class)) {
+            $itemtype::clearSearchOptionCache();
+        }
     }
 }

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -3140,23 +3140,25 @@ JAVASCRIPT;
             }
         }
 
-        $tab[] = [
-            'id'                 => '111',
-            'table'              => ProjectTask::getTable(),
-            'field'              => 'name',
-            'name'               => ProjectTask::getTypeName(1),
-            'datatype'           => 'dropdown',
-            'massiveaction'      => false,
-            'forcegroupby'       => true,
-            'joinparams'         => [
-                'beforejoin'         => [
-                    'table'              => ProjectTask_Ticket::getTable(),
-                    'joinparams'         => [
-                        'jointype'           => 'child',
+        if (Session::haveRight(ProjectTask::$rightname, READ)) {
+            $tab[] = [
+                'id' => '111',
+                'table' => ProjectTask::getTable(),
+                'field' => 'name',
+                'name' => ProjectTask::getTypeName(1),
+                'datatype' => 'dropdown',
+                'massiveaction' => false,
+                'forcegroupby' => true,
+                'joinparams' => [
+                    'beforejoin' => [
+                        'table' => ProjectTask_Ticket::getTable(),
+                        'joinparams' => [
+                            'jointype' => 'child',
+                        ]
                     ]
                 ]
-            ]
-        ];
+            ];
+        }
 
         return $tab;
     }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

The "Project task" search option should not be shown if the user doesn't have permission to read project tasks.