### PR TITLE
Fix tree dropdown tabs

### DIFF
--- a/phpunit/functional/LocationTest.php
+++ b/phpunit/functional/LocationTest.php
@@ -35,6 +35,7 @@
 namespace tests\units;
 
 use DbTestCase;
+use Glpi\Socket;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 /* Test for inc/location.class.php */
@@ -413,5 +414,17 @@ class LocationTest extends DbTestCase
             $item = new $type();
             $this->assertTrue($item->maybeLocated(), $type . ' cannot be located!');
         }
+    }
+
+    public function testTabs()
+    {
+        $this->login();
+        $tabs = (new \Location())->defineTabs();
+        $this->assertArrayHasKey('Location$main', $tabs);
+        $this->assertStringContainsString('Locations', $tabs[\Location::class . '$1']);
+        $this->assertStringContainsString('Items', $tabs[\Location::class . '$2']);
+        $this->assertStringContainsString('Translations', $tabs[\DropdownTranslation::class . '$1']);
+        $this->assertStringContainsString('Sockets', $tabs[Socket::class . '$1']);
+        $this->assertStringContainsString('Documents', $tabs[\Document_Item::class . '$1']);
     }
 }

--- a/phpunit/functional/LocationTest.php
+++ b/phpunit/functional/LocationTest.php
@@ -419,7 +419,11 @@ class LocationTest extends DbTestCase
     public function testTabs()
     {
         $this->login();
-        $tabs = (new \Location())->defineTabs();
+        $location = $this->createItem(\Location::class, [
+            'name' => __FUNCTION__,
+            'entities_id' => $this->getTestRootEntity(true)
+        ]);
+        $tabs = $location->defineTabs();
         $this->assertArrayHasKey('Location$main', $tabs);
         $this->assertStringContainsString('Locations', $tabs[\Location::class . '$1']);
         $this->assertStringContainsString('Items', $tabs[\Location::class . '$2']);

--- a/src/CommonTreeDropdown.php
+++ b/src/CommonTreeDropdown.php
@@ -65,7 +65,7 @@ abstract class CommonTreeDropdown extends CommonDropdown
         $this->addDefaultFormTab($ong);
         $this->addImpactTab($ong, $options);
 
-        $this->addStandardTab(__CLASS__, $ong, $options);
+        $this->addStandardTab(static::class, $ong, $options);
 
         $ong = array_merge($ong, $this->insertTabs($options));
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

Fix small mistake from #19556. Most classes do in fact use `__CLASS__` to add their own extra tabs, but `CommonTreeDropdown` is abstract and this was causing GLPI to try to get an item for an abstract itemtype:
```
[2025-04-28 18:02:16] glpi.WARNING:   *** User Warning: Cannot instanciate "CommonTreeDropdown" as it is an abstract class. at DbUtils.php line 537
```

The safest replacement for `$this::getType()` is `static::class` as it is the exact same functionality.
`$this::getType()` -> `static::class`
`$item::getType()` -> `$item::class`