### PR TITLE
Fix - Missing predefined group in helpdesk ticket form

### DIFF
--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -3990,6 +3990,7 @@ JAVASCRIPT;
             '_users_id_observer_notif'  => [
                 'use_notification' => $default_use_notif,
             ],
+            '_groups_id_observer'        => 0,
             'name'                      => '',
             'content'                   => '',
             'itilcategories_id'         => 0,

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -3978,6 +3978,8 @@ JAVASCRIPT;
 
         // Set default values...
         $default_values = self::getDefaultValues();
+        $default_values['nodelegate']   = 1;
+        $default_values['_right']       = "id";
 
         $options = [];
 

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -3976,43 +3976,9 @@ JAVASCRIPT;
             $url_validate = Ticket::getSearchURL() . "?" . Toolbox::append_params($opt);
         }
 
-        $email  = UserEmail::getDefaultForUser($ID);
-        $default_use_notif = Entity::getUsedConfig('is_notif_enable_default', $_SESSION['glpiactive_entity'], '', 1);
-
         // Set default values...
-        $default_values = [
-            '_users_id_requester_notif' => [
-                'use_notification' => (($email == "") ? 0 : $default_use_notif),
-            ],
-            'nodelegate'                => 1,
-            '_users_id_requester'       => 0,
-            '_users_id_observer'        => 0,
-            '_users_id_observer_notif'  => [
-                'use_notification' => $default_use_notif,
-            ],
-            '_groups_id_observer'        => 0,
-            'name'                      => '',
-            'content'                   => '',
-            'itilcategories_id'         => 0,
-            'locations_id'              => 0,
-            'urgency'                   => 3,
-            'items_id'                  => [],
-            'entities_id'               => $_SESSION['glpiactive_entity'],
-            'plan'                      => [],
-            '_add_validation'           => 0,
-            'type'                      => Entity::getUsedConfig(
-                'tickettype',
-                $_SESSION['glpiactive_entity'],
-                '',
-                Ticket::INCIDENT_TYPE
-            ),
-            '_right'                    => "id",
-            '_content'                  => [],
-            '_tag_content'              => [],
-            '_filename'                 => [],
-            '_tag_filename'             => [],
-            '_tasktemplates_id'         => [],
-        ];
+        $default_values = self::getDefaultValues();
+
         $options = [];
 
         // Get default values from posted values on reload form


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !37384
- Here is a brief description of what this PR does

If a ticket template predefines a group as observer. In the simplified interface, the observer group is not filled in on the ticket creation form.

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/8a0d28dc-eb62-4855-a1c7-d9e2ee7914fa)

![image](https://github.com/user-attachments/assets/be51482d-9c6f-4c91-a2ae-dfde4aa00883)
