### PR TITLE
fix path used by icon dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -235,6 +235,7 @@ The present file will list all changes made to the project; according to the
 - `GLPI_STRICT_DEPRECATED` constant is now know as `GLPI_STRICT_ENV`
 - `Software::merge()` method is now private.
 - The refusal of the collected emails corresponding to a GLPI notification will now be made based on a default rule.
+- The `$store_path` parameter has been removed from the `Dropdown::dropdownIcons()` method.
 
 #### Deprecated
 - Usage of the `/marketplace` path for plugins URLs. All plugins URLs should now start with `/plugins`.

--- a/src/DocumentType.php
+++ b/src/DocumentType.php
@@ -154,12 +154,7 @@ class DocumentType extends CommonDropdown
         $options['display'] = false;
         switch ($field) {
             case 'icon':
-                return Dropdown::dropdownIcons(
-                    $name,
-                    $values[$field],
-                    GLPI_ROOT . "/pics/icones",
-                    false
-                );
+                return Dropdown::dropdownIcons($name, $values[$field], '', false);
         }
         return parent::getSpecificValueToSelect($field, $name, $values, $options);
     }

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -1037,7 +1037,7 @@ JAVASCRIPT;
             </div>
 HTML;
 
-            trigger_error(sprintf(__('Error reading directory %s'), $icon_path), E_USER_WARNING);
+            trigger_error(sprintf('Error reading directory %s', $icon_path), E_USER_WARNING);
         }
     }
 

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -967,8 +967,11 @@ class Dropdown
      *    void if param display=true
      *    string if param display=false (HTML code)
      **/
-    public static function dropdownIcons($myname, $value, $store_path, $display = true, $options = [])
+    public static function dropdownIcons($myname, $value, $store_path = '', $display = true, $options = [])
     {
+        if (!empty($store_path)) {
+            Toolbox::deprecated('The store_path parameter is no longer used.');
+        }
         $icon_path = GLPI_ROOT . '/public/pics/icones';
         if ($dh = @opendir($icon_path)) {
             $files = [];

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -959,7 +959,7 @@ class Dropdown
      *
      * @param string  $myname      the name of the HTML select
      * @param mixed   $value       the preselected value we want
-     * @param string  $store_path  path where icons are stored
+     * @param string  $store_path  path where icons are stored (No longer used)
      * @param boolean $display     display of get string ? (true by default)
      *
      *
@@ -969,69 +969,72 @@ class Dropdown
      **/
     public static function dropdownIcons($myname, $value, $store_path, $display = true, $options = [])
     {
+        $icon_path = GLPI_ROOT . '/public/pics/icones';
+        if ($dh = @opendir($icon_path)) {
+            $files = [];
 
-        if (is_dir($store_path)) {
-            if ($dh = opendir($store_path)) {
-                $files = [];
-
-                while (($file = readdir($dh)) !== false) {
-                    $files[] = $file;
-                }
-
-                closedir($dh);
-                sort($files);
-
-                $values = [];
-                foreach ($files as $file) {
-                    if (preg_match("/\.png$/i", $file)) {
-                        $values[$file] = $file;
-                    }
-                }
-                $rand = mt_rand();
-                self::showFromArray(
-                    $myname,
-                    $values,
-                    array_merge(
-                        [
-                            'value'                 => $value,
-                            'display_emptychoice'   => true,
-                            'display'               => $display,
-                            'noselect2'             => true, // we will instanciate it later
-                            'rand'                  => $rand,
-                        ],
-                        $options
-                    )
-                );
-
-                /** @var array $CFG_GLPI */
-                global $CFG_GLPI;
-
-                // templates for select2 dropdown
-                $js = <<<JAVASCRIPT
-                $(function() {
-                    const formatFormIcon = function(icon) {
-                        if (!icon.id || icon.id == '0') {
-                            return icon.text;
-                        }
-                        var img = '<span><img alt="" src="{$CFG_GLPI['typedoc_icon_dir']}/'+icon.id+'" />';
-                        var label = '<span>'+icon.text+'</span>';
-                        return $(img+'&nbsp;'+label);
-                    };
-                    $("#dropdown_{$myname}{$rand}").select2({
-                        width: '60%',
-                        templateSelection: formatFormIcon,
-                        templateResult: formatFormIcon
-                    });
-                });
-JAVASCRIPT;
-                echo Html::scriptBlock($js);
-            } else {
-               //TRANS: %s is the store path
-                printf(__('Error reading directory %s'), $store_path);
+            while (($file = readdir($dh)) !== false) {
+                $files[] = $file;
             }
+
+            closedir($dh);
+            sort($files);
+
+            $values = [];
+            foreach ($files as $file) {
+                if (preg_match("/\.png$/i", $file)) {
+                    $values[$file] = $file;
+                }
+            }
+            $rand = mt_rand();
+            self::showFromArray(
+                $myname,
+                $values,
+                array_merge(
+                    [
+                        'value'                 => $value,
+                        'display_emptychoice'   => true,
+                        'display'               => $display,
+                        'noselect2'             => true, // we will instanciate it later
+                        'rand'                  => $rand,
+                    ],
+                    $options
+                )
+            );
+
+            /** @var array $CFG_GLPI */
+            global $CFG_GLPI;
+
+            // templates for select2 dropdown
+            $js = <<<JAVASCRIPT
+            $(function() {
+                const formatFormIcon = function(icon) {
+                    if (!icon.id || icon.id == '0') {
+                        return icon.text;
+                    }
+                    var img = '<span><img alt="" src="{$CFG_GLPI['typedoc_icon_dir']}/'+icon.id+'" />';
+                    var label = '<span>'+icon.text+'</span>';
+                    return $(img+'&nbsp;'+label);
+                };
+                $("#dropdown_{$myname}{$rand}").select2({
+                    width: '60%',
+                    templateSelection: formatFormIcon,
+                    templateResult: formatFormIcon
+                });
+            });
+JAVASCRIPT;
+            echo Html::scriptBlock($js);
         } else {
-           //TRANS: %s is the store path
-            printf(__('Error: %s is not a directory'), $store_path);
+            $error_msg = __('Error reading icon directory');
+            echo <<<HTML
+            <div class="alert alert-danger">
+                <span class="fs-4 alert-title">
+                    $error_msg
+                </span>
+            </div>
+HTML;
+
+            trigger_error(sprintf(__('Error reading directory %s'), $icon_path), E_USER_WARNING);
         }
     }
 

--- a/templates/components/form/fields_macros.html.twig
+++ b/templates/components/form/fields_macros.html.twig
@@ -596,7 +596,7 @@
    {% endif %}
 
    {% set field %}
-      {% do call('Dropdown::dropdownIcons', [name, value, constant('GLPI_ROOT') ~ '/pics/icones', options]) %}
+      {% do call('Dropdown::dropdownIcons', [name, value, '', options]) %}
    {% endset %}
 
    {{ _self.field(name, field, label, options|merge({'id': 'dropdown_' ~ name|replace({'[': '_', ']': '_'}) ~ options.rand})) }}


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Fixes #19585

This specific icon dropdown is only used to show icons from `/pics/icones` and even if another location was specified, the actual images always assumed to be served from the '/pics/icones` web URL. I changed the dropdown method to not have a configurable store path, fixed the path to point to the new location in the public folder, and cleaned up the error reporting.
