### PR TITLE
Try to make the display_preferences e2e test less flaky

### DIFF
--- a/tests/cypress/e2e/search/display_preferences.cy.js
+++ b/tests/cypress/e2e/search/display_preferences.cy.js
@@ -143,6 +143,9 @@ describe('Display preferences', () => {
             // an arbitrary amount of time.
             // eslint-disable-next-line cypress/no-unnecessary-waiting
             cy.wait(800);
+
+            // Reseting the alias here seems to make the test less flaky
+            createIframeBodyAlias();
         }
 
         cy.get('@iframeBody').find('#tabspanel-select').select(name);


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.

## Description

Try to make the display_preferences e2e test less flaky

Also, please note that this test does not really benefits from the retries because once it fail the state is not recoverable for the next retry.
Having a way to reset the display preferences using the API would helps a lot here.
