### PR TITLE
Fix pending reason display (unclosed html property)

### DIFF
--- a/templates/components/itilobject/timeline/pending_reasons_messages.html.twig
+++ b/templates/components/itilobject/timeline/pending_reasons_messages.html.twig
@@ -36,7 +36,7 @@
 {% set pending_reason_contexts = {
    'pending': {
       'className' : 'badge bg-blue-lt',
-      'icon' : '<i class="ti ti-player-pause-filled me-1></i>',
+      'icon' : '<i class="ti ti-player-pause-filled me-1"></i>',
       'text': __('Pending'),
    },
    'done': {


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.

## Description

An unclosed `class` property was breaking the UI.

Introduced in 708bc3ab9f1ced877134c6bcc4b9025227639d6b, seems like a manual error during the merge to main (code in 10.0 is fine).

