### PR TITLE
Fix(url) force /plugins/ instead of /marketplace/ for plugin internurl

### DIFF
--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -1084,8 +1084,7 @@ class Toolbox
         $dir = ($full ? $CFG_GLPI['root_doc'] : '');
 
         if ($plug = isPluginItemType($itemtype)) {
-            /* PluginFooBar => /plugins/foo/front/bar */
-            $dir .= Plugin::getPhpDir(strtolower($plug['plugin']), false);
+            $dir .= "/plugins/" . strtolower($plug['plugin']);
             $item = str_replace('\\', '/', strtolower($plug['class']));
         } else { // Standard case
             $item = strtolower($itemtype);
@@ -1114,7 +1113,7 @@ class Toolbox
         $dir = ($full ? $CFG_GLPI['root_doc'] : '');
 
         if ($plug = isPluginItemType($itemtype)) {
-            $dir .= Plugin::getPhpDir(strtolower($plug['plugin']), false);
+            $dir .= "/plugins/" . strtolower($plug['plugin']);
             $item = str_replace('\\', '/', strtolower($plug['class']));
         } else { // Standard case
             if ($itemtype == 'Cartridge') {


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

The `getItemTypeFormUrl()` method relies on `getPhpDir()` to determine the plugin's location.

As a result, if the plugin is installed in the `marketplace` directory, all URLs generated for plugin-related item types will automatically use the `marketplace` path.

To avoid this behavior and ensure consistent URL paths, it is necessary to explicitly enforce the use of the `plugins` path for item types provided by plugins, regardless of their actual installation directory.


## Screenshots (if appropriate):


