### PR TITLE
Allow dependabot to upgrade dev dependencies on `main` branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,6 +40,40 @@ updates:
           - "*"
 
 
+  # Update development dependencies on future release branch (main).
+  # The future branch may permit to use higher versions than the current release branch
+  # due to changes in PHP/node version support.
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    allow:
+      - dependency-type: "development"
+    open-pull-requests-limit: 100
+    target-branch: "main"
+    versioning-strategy: "increase"
+    rebase-strategy: "disabled"
+    groups:
+      dev-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    allow:
+      - dependency-type: "development"
+    open-pull-requests-limit: 100
+    target-branch: "main"
+    versioning-strategy: "increase"
+    rebase-strategy: "disabled"
+    groups:
+      dev-dependencies:
+        patterns:
+          - "*"
+
+
   # Update production dependencies on future release branch (main).
   - package-ecosystem: "npm"
     directory: "/"


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Some of our dev dependencies are outdated because they are currently upgraded using the `10.0/bugfixes` branch constraints (PHP 7.4 support).
I propose to have 2 parallel upgrade configurations:
- one for the current bugfixes branch, to get, at least, as most as bug fixes as possible on our dev dependencies;
- one for the `main` branch, to get the latest major versions.

Each configuration will not generate more than 2 PRs, as all the dev dependencies are in the same group.

There are already some minor conflicts in the dependencies lock files to solve everytime our dev dependencies are updated, so it will not be worse on this point.