### PR TITLE
Allow acces to /front/initpassword.php page without session

### DIFF
--- a/phpunit/functional/Glpi/Http/FirewallTest.php
+++ b/phpunit/functional/Glpi/Http/FirewallTest.php
@@ -191,6 +191,7 @@ class FirewallTest extends \DbTestCase
                 '/front/locale.php',
                 '/front/login.php',
                 '/front/logout.php',
+                '/front/initpassword.php',
                 '/front/lostpassword.php',
                 '/front/updatepassword.php',
             ];

--- a/phpunit/functional/Glpi/Http/FirewallTest.php
+++ b/phpunit/functional/Glpi/Http/FirewallTest.php
@@ -76,6 +76,7 @@ class FirewallTest extends \DbTestCase
                     'lostpassword.php' => '',
                     'planning.php' => '',
                     'tracking.injector.php' => '',
+                    'initpassword.php' => '',
                     'updatepassword.php' => '',
                 ],
                 'marketplace' => [

--- a/src/Glpi/Http/Firewall.php
+++ b/src/Glpi/Http/Firewall.php
@@ -231,6 +231,7 @@ final class Firewall
             '/front/locale.php' => self::STRATEGY_NO_CHECK, // locales must be accessible also on public pages
             '/front/login.php' => self::STRATEGY_NO_CHECK,
             '/front/logout.php' => self::STRATEGY_NO_CHECK,
+            '/front/initpassword.php' => self::STRATEGY_NO_CHECK,
             '/front/lostpassword.php' => self::STRATEGY_NO_CHECK,
             '/front/updatepassword.php' => self::STRATEGY_NO_CHECK,
             '/install/' => self::STRATEGY_NO_CHECK, // No check during install/update


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Fix #19625.

The /front/initsession page was not available for users without sessions.

Note:  not sure why we have two different endpoints /front/initsession and /front/lostpassword when the do the exact same operation.


