### PR TITLE
Change some FontAwesome icons to Tabler icons

### DIFF
--- a/ajax/comments.php
+++ b/ajax/comments.php
@@ -145,7 +145,7 @@ if (
                     ) {
                         echo Html::scriptBlock(
                             sprintf(
-                                '$("#%s").html("href", "&nbsp;<a class=\'fas fa-crosshairs\' href=\'%s\'></a>");',
+                                '$("#%s").html("href", "&nbsp;<a class=\'ti ti-crosshairs\' href=\'%s\'></a>");',
                                 htmlescape($_POST['with_dc_position']),
                                 htmlescape($rack->getLinkURL())
                             )

--- a/ajax/uemailUpdate.php
+++ b/ajax/uemailUpdate.php
@@ -78,7 +78,7 @@ if (
     $switch_name = $_POST['field'] . '[use_notification][]';
     echo "<div class='my-1 d-flex align-items-center'>
          <label  for='email_fup_check'>
-            <i class='far fa-envelope me-1'></i>
+            <i class='ti ti-mail me-1'></i>
             " . __s('Email followup') . "
          </label>
          <div class='ms-2'>

--- a/css/standalone/marketplace.scss
+++ b/css/standalone/marketplace.scss
@@ -159,8 +159,7 @@ $break_s_screen: 1400px;
                 backdrop-filter: blur(2px);
                 background-color: rgba(0, 0, 0, 50%);
 
-                i.fas,
-                i.fa-solid {
+                .spinner-border {
                     position: absolute;
                     top: 50%;
                     left: calc(50% - 1.5rem);

--- a/js/common.js
+++ b/js/common.js
@@ -922,46 +922,46 @@ var templateItilStatus = function(option) {
     var classes = "";
     switch (parseInt(status)) {
         case 1 :
-            classes = 'new fas fa-circle';
+            classes = 'new ti ti-circle-filled';
             break;
         case 2 :
-            classes = 'assigned far fa-circle';
+            classes = 'assigned ti ti-circle';
             break;
         case 3 :
-            classes = 'planned far fa-calendar';
+            classes = 'planned ti ti-calendar';
             break;
         case 4 :
-            classes = 'waiting fas fa-circle';
+            classes = 'waiting ti ti-circle-filled';
             break;
         case 5 :
-            classes = 'solved far fa-circle';
+            classes = 'solved ti ti-circle';
             break;
         case 6 :
-            classes = 'closed fas fa-circle';
+            classes = 'closed ti ti-circle-filled';
             break;
         case 7:
-            classes = 'accepted fas fa-check-circle';
+            classes = 'accepted ti ti-circle-check-filled';
             break;
         case 8 :
-            classes = 'observe fas fa-eye';
+            classes = 'observe ti ti-eye';
             break;
         case 9 :
-            classes = 'eval far fa-circle';
+            classes = 'eval ti ti-circle';
             break;
         case 10 :
-            classes = 'approval fas fa-question-circle';
+            classes = 'approval ti ti-help-circle';
             break;
         case 11 :
-            classes = 'test fas fa-question-circle';
+            classes = 'test ti ti-help-circle';
             break;
         case 12 :
-            classes = 'qualif far fa-circle';
+            classes = 'qualif ti ti-circle';
             break;
         case 13 :
-            classes = 'refused far fa-times-circle';
+            classes = 'refused ti ti-circle-x';
             break;
         case 14 :
-            classes = 'canceled fas fa-ban';
+            classes = 'canceled ti ti-ban';
             break;
     }
 
@@ -979,13 +979,13 @@ var templateValidation = function(option) {
     var classes = "";
     switch (parseInt(status)) {
         case 2 : // WAITING
-            classes = 'waiting far fa-clock';
+            classes = 'waiting ti ti-clock';
             break;
         case 3 : // ACCEPTED
-            classes = 'accepted fas fa-check';
+            classes = 'accepted ti ti-circle-check-filled';
             break;
         case 4 : // REFUSED
-            classes = 'refused fas fa-times';
+            classes = 'refused ti ti-circle-x';
             break;
     }
 
@@ -1003,7 +1003,7 @@ var templateItilPriority = function(option) {
     var color_badge = "";
 
     if (priority_color.length > 0) {
-        color_badge += `<i class='fas fa-circle' style='color: ${priority_color}'></i>`;
+        color_badge += `<i class='ti ti-circle-filled' style='color: ${priority_color}'></i>`;
     }
 
     return $(`<span>${color_badge}&nbsp;${option.text}</span>`);
@@ -1596,19 +1596,19 @@ function initSortableTable(element_id) {
         const current_sort = element.data('sort');
         element.data('sort', column_index);
         const current_order = element.data('order');
-        const new_order = current_sort === column_index && current_order === 'asc' ? 'desc' : 'asc';
+        const new_order = current_sort === column_index && current_order === 'up' ? 'down' : 'up';
         element.data('order', new_order);
         const sortable_header = element.find('thead').first();
         const col = sortable_header.find('th').eq(column_index);
         // Remove all sort icon classes
-        sortable_header.find('th i[class*="fa-sort"]').removeClass('fa-sort fa-sort-asc fa-sort-desc');
+        sortable_header.find('th i[class*="ti ti-caret"]').removeClass('ti-caret-down-filled ti-caret-up-filled');
 
         const sort_icon = col.find('i');
         if (sort_icon.length === 0) {
             // Add sort icon
-            col.eq(0).append(`<i class="fas fa-sort-${new_order}"></i>`);
+            col.eq(0).append(`<i class="ti ti-caret-${new_order}-filled"></i>`);
         } else {
-            sort_icon.addClass(new_order === 'asc' ? 'fa-sort-asc' : 'fa-sort-desc');
+            sort_icon.addClass(new_order === 'up' ? 'ti-caret-up-filled' : 'ti-caret-down-filled');
         }
 
         const rows = element.find('tbody tr');
@@ -1633,7 +1633,7 @@ function initSortableTable(element_id) {
             if (a_value === b_value) {
                 return 0;
             }
-            if (new_order === 'asc') {
+            if (new_order === 'up') {
                 return a_value < b_value ? -1 : 1;
             }
             return a_value > b_value ? -1 : 1;

--- a/js/impact.js
+++ b/js/impact.js
@@ -1371,21 +1371,21 @@ var GLPIImpact = {
         return [
             {
                 id             : 'goTo',
-                content        : '<i class="fas fa-link me-2"></i>' + __("Go to"),
+                content        : '<i class="ti ti-external-link me-2"></i>' + __("Go to"),
                 tooltipText    : _.unescape(__("Open this element in a new tab")),
                 selector       : 'node[link]',
                 onClickFunction: this.menuOnGoTo
             },
             {
                 id             : 'showOngoing',
-                content        : '<i class="fas fa-list me-2"></i>' + __("Show ongoing tickets"),
+                content        : '<i class="ti ti-alert-circle me-2"></i>' + __("Show ongoing tickets"),
                 tooltipText    : _.unescape(__("Show ongoing tickets for this item")),
                 selector       : 'node[hasITILObjects=1]',
                 onClickFunction: this.menuOnShowOngoing
             },
             {
                 id             : 'editEdge',
-                content        : '<i class="fas fa-edit me-2"></i>' + __("Edge properties..."),
+                content        : '<i class="ti ti-edit me-2"></i>' + __("Edge properties..."),
                 tooltipText    : _.unescape(__("Set name for this edge")),
                 selector       : 'edge',
                 onClickFunction: this.menuOnEditEdge,
@@ -1393,7 +1393,7 @@ var GLPIImpact = {
             },
             {
                 id             : 'editCompound',
-                content        : '<i class="fas fa-edit me-2"></i>' + __("Group properties..."),
+                content        : '<i class="ti ti-edit me-2"></i>' + __("Group properties..."),
                 tooltipText    : _.unescape(__("Set name and/or color for this group")),
                 selector       : 'node:parent',
                 onClickFunction: this.menuOnEditCompound,
@@ -1401,7 +1401,7 @@ var GLPIImpact = {
             },
             {
                 id             : 'removeFromCompound',
-                content        : '<i class="fas fa-external-link-alt me-2"></i>' + __("Remove from group"),
+                content        : '<i class="ti ti-home-move me-2"></i>' + __("Remove from group"),
                 tooltipText    : _.unescape(__("Remove this asset from the group")),
                 selector       : 'node:child',
                 onClickFunction: this.menuOnRemoveFromCompound,
@@ -1409,7 +1409,7 @@ var GLPIImpact = {
             },
             {
                 id             : 'delete',
-                content        : '<i class="fas fa-trash me-2"></i>' + __("Delete"),
+                content        : '<i class="ti ti-trash me-2"></i>' + __("Delete"),
                 tooltipText    : _.unescape(__("Delete element")),
                 selector       : 'node, edge',
                 onClickFunction: this.menuOnDelete,
@@ -3678,7 +3678,7 @@ var GLPIImpact = {
                     str += value["name"];
 
                     if (isHidden) {
-                        str += '<i class="fas fa-eye-slash impact-res-hidden"></i>';
+                        str += '<i class="ti ti-eye-off impact-res-hidden"></i>';
                     }
 
                     str += "</p>";

--- a/js/marketplace.js
+++ b/js/marketplace.js
@@ -54,7 +54,7 @@ $(document).ready(function() {
 
         icon
             .removeClass()
-            .addClass('fas fa-spinner fa-spin');
+            .addClass('spinner-border');
 
         const executeAction = function () {
             if (action === 'download_plugin'
@@ -155,7 +155,7 @@ var filterPluginList = function(page, force) {
     }
 
     plugins_list
-        .append("<div class='loading-plugins'><i class='fas fa-spinner fa-pulse'></i></div>");
+        .append("<div class='loading-plugins'><div class='spinner-border'></div></div>");
     pagination.find('li.current').removeClass('current');
 
     var jqxhr = $.get(ajax_url, {
@@ -192,13 +192,13 @@ var refreshPlugins = function(page, force) {
     var icon = $('.marketplace:visible .refresh-plugin-list');
 
     icon
-        .removeClass('fa-sync-alt')
-        .addClass('fa-spinner fa-spin');
+        .removeClass('ti ti-refresh')
+        .addClass('spinner-border spinner-border-sm');
 
     $.when(filterPluginList(page, force)).then(function() {
         icon
-            .removeClass('fa-spinner fa-spin')
-            .addClass('fa-sync-alt');
+            .removeClass('spinner-border spinner-border-sm')
+            .addClass('ti ti-refresh');
         current_page = page;
 
         addTooltips();

--- a/js/modules/Dashboard/Dashboard.js
+++ b/js/modules/Dashboard/Dashboard.js
@@ -1114,7 +1114,7 @@ class GLPIDashboard {
                     this.fitNumbers(card);
                     this.animateNumbers(card);
                 }, () => {
-                    card.html("<div class='empty-card card-error'><i class='fas fa-exclamation-triangle'></i></div>");
+                    card.html("<div class='empty-card card-error'><i class='ti ti-alert-triangle'></i></div>");
                 }));
             });
 
@@ -1154,13 +1154,13 @@ class GLPIDashboard {
                         }
                     });
                     if (!has_result) {
-                        card.html("<div class='empty-card card-error'><i class='fas fa-exclamation-triangle'></i></div>");
+                        card.html("<div class='empty-card card-error'><i class='ti ti-alert-triangle'></i></div>");
                     }
                 });
             }, () => {
                 $.each(requested_cards, (i2, crd) => {
                     const card = crd.card_el;
-                    card.html("<div class='empty-card card-error'><i class='fas fa-exclamation-triangle'></i></div>");
+                    card.html("<div class='empty-card card-error'><i class='ti ti-alert-triangle'></i></div>");
                 });
             });
         }

--- a/js/planning.js
+++ b/js/planning.js
@@ -158,7 +158,7 @@ var GLPIPlanning  = {
                 }
                 $(info.el)
                     .find('.fc-cell-text')
-                    .prepend(`<i class="fas fa-${icon}"></i>&nbsp;`);
+                    .prepend(`<i class="ti ti-${icon}"></i>&nbsp;`);
 
                 if (info.resource._resource.extendedProps.itemtype == 'Group_User') {
                     info.el.style.backgroundColor = 'lightgray';
@@ -278,10 +278,10 @@ var GLPIPlanning  = {
                     // create new one
                     var actions = '';
                     if (options.can_create) {
-                        actions += `<li class="clone-event"><i class="far fa-clone"></i>${__("Clone")}</li>`;
+                        actions += `<li class="clone-event"><i class="ti ti-copy"></i>${__("Clone")}</li>`;
                     }
                     if (options.can_delete) {
-                        actions += `<li class="delete-event"><i class="fas fa-trash"></i>${__("Delete")}</li>`;
+                        actions += `<li class="delete-event"><i class="ti ti-trash"></i>${__("Delete")}</li>`;
                     }
                     if (actions == '') {
                         return;
@@ -360,7 +360,7 @@ var GLPIPlanning  = {
                         } else {
                             glpi_html_dialog({
                                 title: __("Make a choice"),
-                                body: `${__("Delete the whole serie of the recurrent event")}<br>${ 
+                                body: `${__("Delete the whole serie of the recurrent event")}<br>${
                                     __("or just add an exception by deleting this instance?")}`,
                                 buttons: [{
                                     label: __("Serie"),
@@ -392,9 +392,9 @@ var GLPIPlanning  = {
                 // attach button (planning and refresh) in planning header
                 $(`#${GLPIPlanning.dom_id} .fc-toolbar .fc-center h2`)
                     .after(
-                        $('<i id="refresh_planning" class="fa fa-sync pointer"></i>')
+                        $('<i id="refresh_planning" class="ti ti-refresh pointer"></i>')
                     ).after(
-                        $('<div id="planning_datepicker"><a data-toggle><i class="far fa-calendar-alt fa-lg pointer"></i></a>')
+                        $('<div id="planning_datepicker"><a data-toggle><i class="ti ti-calendar pointer"></i></a>')
                     );
 
                 // specific process for full list

--- a/js/src/vue/FuzzySearch/Modal.vue
+++ b/js/src/vue/FuzzySearch/Modal.vue
@@ -107,7 +107,7 @@
                 </div>
                 <div class="modal-body">
                     <div class="alert alert-info d-flex" role="alert">
-                        <i class="fas fa-exclamation-circle fa-2x me-2"></i>
+                        <i class="ti ti-alert-circle-filled fa-2x me-2"></i>
                         <p v-html="shortcut_message"></p>
                     </div>
                     <input type="text" class="form-control" :placeholder="placeholder" v-model="input_text">

--- a/js/src/vue/Kanban/TeamBadgeProvider.js
+++ b/js/src/vue/Kanban/TeamBadgeProvider.js
@@ -46,7 +46,7 @@ export class TeamBadgeProvider {
          * The size in pixels for the team badges
          * @type {number}
          */
-        this.team_image_size = 22;
+        this.team_image_size = 26;
         this.max_team_images = max_team_images;
         this.display_initials = display_initials;
 
@@ -97,16 +97,16 @@ export class TeamBadgeProvider {
         // Pictures from groups, supplier, contact
         switch (itemtype) {
             case 'Group':
-                this.badges[itemtype][items_id] = this.generateOtherBadge(team_member, 'fa-users');
+                this.badges[itemtype][items_id] = this.generateOtherBadge(team_member, 'ti ti-users-group');
                 break;
             case 'Supplier':
-                this.badges[itemtype][items_id] = this.generateOtherBadge(team_member, 'fa-briefcase');
+                this.badges[itemtype][items_id] = this.generateOtherBadge(team_member, 'ti ti-truck-loading');
                 break;
             case 'Contact':
-                this.badges[itemtype][items_id] = this.generateOtherBadge(team_member, 'fa-user');
+                this.badges[itemtype][items_id] = this.generateOtherBadge(team_member, 'ti ti-user');
                 break;
             default:
-                this.badges[itemtype][items_id] = this.generateOtherBadge(team_member, 'fa-user');
+                this.badges[itemtype][items_id] = this.generateOtherBadge(team_member, 'ti ti-user');
         }
         return this.badges[itemtype][items_id];
     }
@@ -232,9 +232,8 @@ export class TeamBadgeProvider {
         const name = team_member['name'].replace(/"/g, '&quot;').replace(/'/g, '&#39;');
 
         return `
-            <span class='fa-stack fa-lg' style='font-size: ${(this.team_image_size / 2)}px'>
-                <i class='fas fa-circle fa-stack-2x' style="color: ${bg_color}" title="${team_member['name']}"></i>
-                <i class='fas ${icon} fa-stack-1x' title="${name}" data-bs-toggle='tooltip' data-bs-placement='top'></i>
+            <span class="badge badge-pill" style="background-color: ${bg_color}; font-size: ${(this.team_image_size / 2)}px; height: 26px">
+                <i class='${icon}' title="${name}" data-bs-toggle='tooltip' data-bs-placement='top'></i>
             </span>
         `;
     }

--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -4304,7 +4304,7 @@ TWIG, $twig_params);
 
     public static function getIcon()
     {
-        return "far fa-address-book";
+        return "ti ti-address-book";
     }
 
     /**

--- a/src/AuthMail.php
+++ b/src/AuthMail.php
@@ -403,7 +403,7 @@ TWIG, $twig_params);
 
     public static function getIcon()
     {
-        return "far fa-envelope";
+        return "ti ti-mail";
     }
 
     /**

--- a/src/Blacklist.php
+++ b/src/Blacklist.php
@@ -563,7 +563,7 @@ class Blacklist extends CommonDropdown
 
     public static function getIcon()
     {
-        return "fas fa-ban";
+        return "ti ti-ban";
     }
 
     public function getCloneRelations(): array

--- a/src/BlacklistedMailContent.php
+++ b/src/BlacklistedMailContent.php
@@ -102,7 +102,7 @@ class BlacklistedMailContent extends CommonDropdown
 
     public static function getIcon()
     {
-        return "fas fa-envelope-square";
+        return "ti ti-mail-x";
     }
 
     public function getCloneRelations(): array

--- a/src/BusinessCriticity.php
+++ b/src/BusinessCriticity.php
@@ -47,6 +47,6 @@ class BusinessCriticity extends CommonTreeDropdown
 
     public static function getIcon()
     {
-        return "fas fa-briefcase";
+        return "ti ti-briefcase";
     }
 }

--- a/src/Calendar.php
+++ b/src/Calendar.php
@@ -709,6 +709,6 @@ class Calendar extends CommonDropdown
 
     public static function getIcon()
     {
-        return "far fa-calendar-alt";
+        return "ti ti-calendar";
     }
 }

--- a/src/CommonITILObject_CommonITILObject.php
+++ b/src/CommonITILObject_CommonITILObject.php
@@ -388,20 +388,20 @@ abstract class CommonITILObject_CommonITILObject extends CommonDBRelation
         return [
             self::LINK_TO => [
                 'name' => __('Linked to'),
-                'icon' => 'fas fa-link',
+                'icon' => 'ti ti-link',
             ],
             self::DUPLICATE_WITH => [
                 'name' => __('Duplicates'),
-                'icon' => 'fas fa-clone',
+                'icon' => 'ti ti-copy-plus-filled',
             ],
             self::SON_OF => [
                 'name' => __('Son of'),
-                'icon' => 'fa-level-up-alt fa-flip-horizontal',
+                'icon' => 'ti ti-corner-left-up',
                 'inverse' => self::PARENT_OF,
             ],
             self::PARENT_OF => [
                 'name' => __('Parent of'),
-                'icon' => 'fa-level-up-alt',
+                'icon' => 'ti ti-corner-left-down',
                 'inverse' => self::SON_OF,
             ],
         ];

--- a/src/CommonTreeDropdown.php
+++ b/src/CommonTreeDropdown.php
@@ -687,7 +687,7 @@ TWIG, $twig_params);
 
         if ($isadmin) {
             $actions[__CLASS__ . MassiveAction::CLASS_ACTION_SEPARATOR . 'move_under']
-                  = "<i class='fas fa-sitemap'></i>" .
+                  = "<i class='ti ti-sitemap'></i>" .
                     _sx('button', 'Move under');
         }
 

--- a/src/Contact.php
+++ b/src/Contact.php
@@ -518,6 +518,6 @@ HTML;
 
     public static function getIcon()
     {
-        return "fas fa-user-tie";
+        return "ti ti-address-book";
     }
 }

--- a/src/DeviceDrive.php
+++ b/src/DeviceDrive.php
@@ -177,6 +177,6 @@ class DeviceDrive extends CommonDevice
 
     public static function getIcon()
     {
-        return "far fa-hdd";
+        return "ti ti-server-2";
     }
 }

--- a/src/DeviceFirmware.php
+++ b/src/DeviceFirmware.php
@@ -315,6 +315,6 @@ class DeviceFirmware extends CommonDevice
 
     public static function getIcon()
     {
-        return "fas fa-microchip";
+        return "ti ti-cpu";
     }
 }

--- a/src/DeviceHardDrive.php
+++ b/src/DeviceHardDrive.php
@@ -332,6 +332,6 @@ class DeviceHardDrive extends CommonDevice
 
     public static function getIcon()
     {
-        return "far fa-hdd";
+        return "ti ti-server-2";
     }
 }

--- a/src/DeviceNetworkCard.php
+++ b/src/DeviceNetworkCard.php
@@ -264,6 +264,6 @@ class DeviceNetworkCard extends CommonDevice
 
     public static function getIcon()
     {
-        return "fas fa-network-wired";
+        return NetworkPort::getIcon();
     }
 }

--- a/src/DocumentCategory.php
+++ b/src/DocumentCategory.php
@@ -90,6 +90,6 @@ class DocumentCategory extends CommonTreeDropdown
 
     public static function getIcon()
     {
-        return "fas fa-tags";
+        return "ti ti-tags";
     }
 }

--- a/src/DocumentType.php
+++ b/src/DocumentType.php
@@ -235,6 +235,6 @@ class DocumentType extends CommonDropdown
 
     public static function getIcon()
     {
-        return "far fa-file";
+        return "ti ti-file";
     }
 }

--- a/src/Domain.php
+++ b/src/Domain.php
@@ -893,7 +893,7 @@ class Domain extends CommonDBTM
 
     public static function getIcon()
     {
-        return "fas fa-globe-americas";
+        return "ti ti-world-www";
     }
 
     public function post_updateItem($history = true)

--- a/src/Entity.php
+++ b/src/Entity.php
@@ -2895,7 +2895,7 @@ class Entity extends CommonTreeDropdown implements LinkableToTilesInterface
         $out = "<div class='badge bg-azure-lt m-1 py-1 " . ($inline ? "inline" : "") . "'
                    title='" . __s("Value inherited from a parent entity") . "'
                    data-bs-toggle='tooltip'>
-         <i class='fas fa-level-down-alt me-1'></i>
+         <i class='ti ti-corner-right-down me-1'></i>
          $value
       </div>";
 
@@ -3020,7 +3020,7 @@ class Entity extends CommonTreeDropdown implements LinkableToTilesInterface
             $title = htmlescape(implode(' > ', $names));
         }
         $breadcrumbs = implode(
-            '<i class="fas fa-caret-right mx-1"></i>',
+            '<i class="ti ti-caret-right-filled mx-1"></i>',
             array_map(
                 static fn(string $name) => '<span class="text-nowrap">' . htmlescape($name) . '</span>',
                 $names
@@ -3061,14 +3061,14 @@ class Entity extends CommonTreeDropdown implements LinkableToTilesInterface
         $title       = htmlescape(implode(' > ', $names));
         $last_name   = array_pop($names);
         $breadcrumbs = implode(
-            '<i class="fas fa-caret-right mx-1"></i>',
+            '<i class="ti ti-caret-right-filled mx-1"></i>',
             array_map(
                 static fn(string $name) => '<span class="text-nowrap text-muted">' . htmlescape($name) . '</span>',
                 $names
             )
         );
 
-        $last_url  = '<i class="fas fa-caret-right mx-1"></i>' . '<a href="' . $entity->getLinkURL() . '" title="' . $title . '">' . htmlescape($last_name) . '</a>';
+        $last_url  = '<i class="ti ti-caret-right-filled mx-1"></i>' . '<a href="' . $entity->getLinkURL() . '" title="' . $title . '">' . htmlescape($last_name) . '</a>';
 
         return '<span class="glpi-badge" title="' . $title . '">' . $breadcrumbs . $last_url . '</span>';
     }

--- a/src/FQDN.php
+++ b/src/FQDN.php
@@ -243,6 +243,6 @@ class FQDN extends CommonDropdown
 
     public static function getIcon()
     {
-        return "fas fa-globe";
+        return "ti ti-world";
     }
 }

--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -46,6 +46,6 @@ class Filesystem extends CommonDropdown
 
     public static function getIcon()
     {
-        return "far fa-folder";
+        return "ti ti-folder";
     }
 }

--- a/src/Glpi/Features/PlanningEvent.php
+++ b/src/Glpi/Features/PlanningEvent.php
@@ -800,7 +800,7 @@ trait PlanningEvent
         $out .= "<a class='btn btn-primary'
                  title='" . __("Personalization") . "'
                  onclick='$(\"#advanced_repetition$rand\").toggle()'>
-                 <i class='fas fa-cog'></i>
+                 <i class='ti ti-settings'></i>
               </a>";
         $out .= "<div id='advanced_repetition$rand' style='display: $display_ar; max-width: 23'>";
 

--- a/src/Glpi/Form/Category.php
+++ b/src/Glpi/Form/Category.php
@@ -59,7 +59,7 @@ final class Category extends CommonTreeDropdown implements ServiceCatalogComposi
     #[Override]
     public static function getIcon(): string
     {
-        return "ti ti-folder";
+        return "ti ti-tags";
     }
 
     #[Override]

--- a/src/Glpi/Marketplace/View.php
+++ b/src/Glpi/Marketplace/View.php
@@ -748,7 +748,7 @@ HTML;
                 <button class='modify_plugin'
                         data-action='clean_plugin'
                         title='" . __s("Clean") . "'>
-                        <i class='fas fa-broom'></i>
+                        <i class='ti ti-recycle'></i>
                 </button>";
             if ($can_be_downloaded) {
                 $buttons .= "

--- a/src/Group.php
+++ b/src/Group.php
@@ -259,7 +259,7 @@ class Group extends CommonTreeDropdown
             $prefix                            = 'Group_User' . MassiveAction::CLASS_ACTION_SEPARATOR;
             $actions[$prefix . 'add']            = "<i class='ti ti-user-plus'></i>" .
                                               _sx('button', 'Add a user');
-            $actions[$prefix . 'add_supervisor'] = "<i class='fas fa-user-tie'></i>" .
+            $actions[$prefix . 'add_supervisor'] = "<i class='ti ti-user-star'></i>" .
                                               _sx('button', 'Add a manager');
             $actions[$prefix . 'remove']         = "<i class='ti ti-user-minus'></i>" .
                                               _sx('button', 'Remove a user');

--- a/src/Holiday.php
+++ b/src/Holiday.php
@@ -171,6 +171,6 @@ class Holiday extends CommonDropdown
 
     public static function getIcon()
     {
-        return "far fa-calendar-times";
+        return "ti ti-calendar-off";
     }
 }

--- a/src/ITILCategory.php
+++ b/src/ITILCategory.php
@@ -533,4 +533,9 @@ class ITILCategory extends CommonTreeDropdown
     {
         return [];
     }
+
+    public static function getIcon()
+    {
+        return "ti ti-tags";
+    }
 }

--- a/src/ITILFollowupTemplate.php
+++ b/src/ITILFollowupTemplate.php
@@ -119,7 +119,7 @@ class ITILFollowupTemplate extends AbstractITILChildTemplate
 
     public static function getIcon()
     {
-        return "fas fa-layer-group";
+        return "ti ti-stack-2-filled";
     }
 
     public function getCloneRelations(): array

--- a/src/ITILTemplate.php
+++ b/src/ITILTemplate.php
@@ -838,7 +838,7 @@ abstract class ITILTemplate extends CommonDropdown
 
     public static function getIcon()
     {
-        return "fas fa-layer-group";
+        return "ti ti-stack-2-filled";
     }
 
     public function prepareInputForAdd($input)

--- a/src/ITILValidationTemplate.php
+++ b/src/ITILValidationTemplate.php
@@ -133,7 +133,7 @@ class ITILValidationTemplate extends AbstractITILChildTemplate
 
     public static function getIcon()
     {
-        return "fas fa-layer-group";
+        return "ti ti-stack-2-filled";
     }
 
     private function postTargets(): void

--- a/src/ImageFormat.php
+++ b/src/ImageFormat.php
@@ -45,7 +45,7 @@ class ImageFormat extends CommonDropdown
 
     public static function getIcon()
     {
-        return "far fa-file-image";
+        return "ti ti-photo-cog";
     }
 
     public function cleanDBonPurge()

--- a/src/Impact.php
+++ b/src/Impact.php
@@ -1123,12 +1123,12 @@ JS);
 
         echo '<ul class="fs-1">';
         echo '<li id="save_impact" title="' . __s("Save") . '"><i class="ti ti-device-floppy"></i></li>';
-        echo '<li id="impact_undo" class="impact-disabled" title="' . __s("Undo") . '"><i class="fa-fw fas fa-undo"></i></li>';
-        echo '<li id="impact_redo" class="impact-disabled" title="' . __s("Redo") . '"><i class="fa-fw fas fa-redo"></i></li>';
+        echo '<li id="impact_undo" class="impact-disabled" title="' . __s("Undo") . '"><i class="ti ti-arrow-back-up"></i></li>';
+        echo '<li id="impact_redo" class="impact-disabled" title="' . __s("Redo") . '"><i class="ti ti-arrow-forward-up"></i></li>';
         echo '<li class="impact-separator"></li>';
         echo '<li id="add_node" title="' . __s("Add asset") . '"><i class="ti ti-plus"></i></li>';
         echo '<li id="add_edge" title="' . __s("Add relation") . '"><i class="ti ti-line"></i></li>';
-        echo '<li id="add_compound" title="' . __s("Add group") . '"><i class="far fa-object-group"></i></li>';
+        echo '<li id="add_compound" title="' . __s("Add group") . '"><i class="ti ti-augmented-reality"></i></li>';
         echo '<li id="delete_element" title="' . __s("Delete element") . '"><i class="ti ti-trash"></i></li>';
         echo '<li class="impact-separator"></li>';
         echo '<li id="export_graph" title="' . __s("Download") . '"><i class="ti ti-download"></i></li>';

--- a/src/Item_Disk.php
+++ b/src/Item_Disk.php
@@ -59,7 +59,7 @@ class Item_Disk extends CommonDBChild
 
     public static function getIcon()
     {
-        return 'far fa-hdd';
+        return 'ti ti-server-2';
     }
 
     public function post_getEmpty()
@@ -266,7 +266,7 @@ class Item_Disk extends CommonDBChild
 TWIG, $twig_params);
 
                 $encryption_label = Html::showTooltip($encryptionTooltip, [
-                    'awesome-class' => "fas fa-lock",
+                    'awesome-class' => "ti ti-lock-password",
                     'display' => false,
                 ]);
             }

--- a/src/Item_SoftwareVersion.php
+++ b/src/Item_SoftwareVersion.php
@@ -1102,7 +1102,7 @@ class Item_SoftwareVersion extends CommonDBRelation
             $header_end .= "<th>" . __s('Valid license') . "</th>";
             $header_end .= "<th>
                 <button class='btn btn-sm show_filters " . ($is_filtered ? "btn-secondary" : "btn-outline-secondary") . "'>
-                    <i class='fas fa-filter'></i>
+                    <i class='ti ti-filter'></i>
                     <span class='d-none d-xl-block'>" . __s('Filter') . "</span>
                 </button></th>";
             $header_end .= "</tr>";

--- a/src/KnowbaseItem_KnowbaseItemCategory.php
+++ b/src/KnowbaseItem_KnowbaseItemCategory.php
@@ -136,7 +136,7 @@ class KnowbaseItem_KnowbaseItemCategory extends CommonDBRelation
             $action_prefix = __CLASS__ . MassiveAction::CLASS_ACTION_SEPARATOR;
 
             $actions[$action_prefix . 'add']
-            = "<i class='ma-icon fas fa-book'></i>" .
+            = "<i class='ma-icon ti ti-book'></i>" .
               _sx('button', 'Link knowledgebase article');
         }
 

--- a/src/Lock.php
+++ b/src/Lock.php
@@ -1072,7 +1072,7 @@ TWIG, $twig_params);
             // language=Twig
             echo TemplateRenderer::getInstance()->renderFromStringTemplate(<<<TWIG
                 <div>
-                    <i class='fas fa-level-up-alt fa-flip-horizontal fs-2 mx-2'></i>
+                    <i class='ti ti-corner-left-up mx-3'></i>
                     <a onclick="if ( markCheckboxes('lock_form') ) return false;" href='#'>{{ check_all_msg }}</a>
                     <span>/</span>
                     <a onclick="if ( unMarkCheckboxes('lock_form') ) return false;" href='#'>{{ uncheck_all_msg }}</a>

--- a/src/NetworkEquipment.php
+++ b/src/NetworkEquipment.php
@@ -275,7 +275,7 @@ class NetworkEquipment extends CommonDBTM
         if ($isadmin) {
             $actions += [
                 'Item_SoftwareLicense' . MassiveAction::CLASS_ACTION_SEPARATOR . 'add'
-               => "<i class='ma-icon fas fa-key'></i>" .
+               => "<i class='ti ti-key'></i>" .
                   _sx('button', 'Add a license'),
             ];
             KnowbaseItem_Item::getMassiveActionsForItemtype($actions, __CLASS__, 0, $checkitem);

--- a/src/NetworkPort.php
+++ b/src/NetworkPort.php
@@ -1832,6 +1832,6 @@ class NetworkPort extends CommonDBChild
 
     public static function getIcon()
     {
-        return "fas fa-ethernet";
+        return "ti ti-network";
     }
 }

--- a/src/NotificationSetting.php
+++ b/src/NotificationSetting.php
@@ -138,6 +138,6 @@ abstract class NotificationSetting extends CommonDBTM
 
     public static function getIcon()
     {
-        return "fas fa-bell";
+        return "ti ti-bell";
     }
 }

--- a/src/Peripheral.php
+++ b/src/Peripheral.php
@@ -196,7 +196,7 @@ class Peripheral extends CommonDBTM
             Asset_PeripheralAsset::getMassiveActionsForItemtype($actions, __CLASS__, 0, $checkitem);
             $actions += [
                 'Item_SoftwareLicense' . MassiveAction::CLASS_ACTION_SEPARATOR . 'add'
-               => "<i class='ma-icon fas fa-key'></i>" .
+               => "<i class='ti ti-key'></i>" .
                   _sx('button', 'Add a license'),
             ];
             KnowbaseItem_Item::getMassiveActionsForItemtype($actions, __CLASS__, 0, $checkitem);

--- a/src/Phone.php
+++ b/src/Phone.php
@@ -233,7 +233,7 @@ class Phone extends CommonDBTM
             Asset_PeripheralAsset::getMassiveActionsForItemtype($actions, __CLASS__, 0, $checkitem);
             $actions += [
                 'Item_SoftwareLicense' . MassiveAction::CLASS_ACTION_SEPARATOR . 'add'
-               => "<i class='ma-icon fas fa-key'></i>" .
+               => "<i class='ti ti-key'></i>" .
                   _sx('button', 'Add a license'),
             ];
             KnowbaseItem_Item::getMassiveActionsForItemtype($actions, __CLASS__, 0, $checkitem);

--- a/src/PlanningEventCategory.php
+++ b/src/PlanningEventCategory.php
@@ -53,6 +53,6 @@ class PlanningEventCategory extends CommonDropdown
 
     public static function getIcon()
     {
-        return "fas fa-tag";
+        return "ti ti-tags";
     }
 }

--- a/src/PlanningExternalEventTemplate.php
+++ b/src/PlanningExternalEventTemplate.php
@@ -194,6 +194,6 @@ class PlanningExternalEventTemplate extends CommonDropdown
 
     public static function getIcon()
     {
-        return "fas fa-layer-group";
+        return "ti ti-stack-2-filled";
     }
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -2805,7 +2805,7 @@ TWIG;
             = "<i class='ti ti-toggle-left-filled'></i>" .
             __s('Disable');
             $actions[__CLASS__ . MassiveAction::CLASS_ACTION_SEPARATOR . 'clean']
-            = "<i class='fas fa-broom'></i>" .
+            = "<i class='ti ti-recycle'></i>" .
             __s('Clean');
         }
 

--- a/src/Printer.php
+++ b/src/Printer.php
@@ -361,7 +361,7 @@ class Printer extends CommonDBTM
             Asset_PeripheralAsset::getMassiveActionsForItemtype($actions, __CLASS__, 0, $checkitem);
             $actions += [
                 'Item_SoftwareLicense' . MassiveAction::CLASS_ACTION_SEPARATOR . 'add'
-               => "<i class='ma-icon fas fa-key'></i>" .
+               => "<i class='ti ti-key'></i>" .
                   _sx('button', 'Add a license'),
             ];
             KnowbaseItem_Item::getMassiveActionsForItemtype($actions, __CLASS__, 0, $checkitem);

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -1646,9 +1646,13 @@ class Profile extends CommonDBTM implements LinkableToTilesInterface
 
         if ($disabled) {
             $warning = __s('Notifications must be enabled to activate mentions.');
-            echo "<span class='form-help ms-2' data-bs-toggle='popover' data-bs-placement='top' data-bs-html='true' data-bs-content='" . $warning . "'>";
-            echo "<i class='fas fa-exclamation-triangle text-danger'></i>";
-            echo "</span>";
+            echo "<span class='form-help ms-2'
+                  data-bs-toggle='popover'
+                  data-bs-placement='top'
+                  data-bs-html='true'
+                  data-bs-content='" . $warning . "'>
+                ?
+            </span>";
         }
 
         echo "</td></tr>";

--- a/src/Project.php
+++ b/src/Project.php
@@ -1900,7 +1900,7 @@ TWIG, $twig_params);
                 $content .= reset($typematches)['name'] . '&nbsp;';
             }
             if (array_key_exists('is_milestone', $item) && $item['is_milestone']) {
-                $content .= "&nbsp;<i class='fas fa-map-signs' title='" . __s('Milestone') . "'></i>&nbsp;";
+                $content .= "&nbsp;<i class='ti ti-directions-filled' title='" . __s('Milestone') . "'></i>&nbsp;";
             }
             if (isset($item['_steps']) && count($item['_steps'])) {
                 $done = count(array_filter($item['_steps'], static fn($step) => (int) $step['percent_done'] === 100));

--- a/src/ProjectState.php
+++ b/src/ProjectState.php
@@ -93,6 +93,6 @@ class ProjectState extends CommonDropdown
 
     public static function getIcon()
     {
-        return "fas fa-columns";
+        return "ti ti-label";
     }
 }

--- a/src/ProjectTaskTemplate.php
+++ b/src/ProjectTaskTemplate.php
@@ -261,6 +261,6 @@ class ProjectTaskTemplate extends CommonDropdown
 
     public static function getIcon()
     {
-        return "fas fa-layer-group";
+        return "ti ti-stack-2-filled";
     }
 }

--- a/src/ProjectTaskType.php
+++ b/src/ProjectTaskType.php
@@ -47,6 +47,6 @@ class ProjectTaskType extends CommonDropdown
 
     public static function getIcon()
     {
-        return "fas fa-columns";
+        return "ti ti-category";
     }
 }

--- a/src/ProjectType.php
+++ b/src/ProjectType.php
@@ -47,6 +47,6 @@ class ProjectType extends CommonDropdown
 
     public static function getIcon()
     {
-        return "fas fa-columns";
+        return "ti ti-category";
     }
 }

--- a/src/ReservationItem.php
+++ b/src/ReservationItem.php
@@ -670,14 +670,15 @@ TWIG, $twig_params);
         ]);
 
         if ($ok && Session::haveRight("reservation", self::RESERVEANITEM)) {
-            echo "<i class='fas fa-level-up-alt fa-flip-horizontal fs-2 mx-2'></i>";
+            echo "<i class='ti ti-corner-left-up mx-3'></i>";
             echo "<th colspan='" . ($showentity ? "5" : "4") . "'>";
             if (isset($_POST['reserve'])) {
                 echo Html::hidden('begin', ['value' => $_POST['reserve']["begin"]]);
                 echo Html::hidden('end', ['value'   => $_POST['reserve']["end"]]);
             }
             echo Html::submit(_x('button', 'Book'), [
-                'icon'  => 'fas fs-2 fa-calendar-plus',
+                'class' => 'btn btn-primary mt-2 mb-2',
+                'icon'  => 'ti ti-calendar-plus',
             ]);
         }
 

--- a/src/Software.php
+++ b/src/Software.php
@@ -247,7 +247,7 @@ class Software extends CommonDBTM
             && (countElementsInTable("glpi_rules", ['sub_type' => 'RuleSoftwareCategory']) > 0)
         ) {
             $actions[__CLASS__ . MassiveAction::CLASS_ACTION_SEPARATOR . 'compute_software_category']
-            = "<i class='fas fa-calculator'></i>" .
+            = "<i class='ti ti-calculator'></i>" .
               __s('Recalculate the category');
         }
 
@@ -256,7 +256,7 @@ class Software extends CommonDBTM
             && (countElementsInTable("glpi_rules", ['sub_type' => 'RuleDictionnarySoftware']) > 0)
         ) {
             $actions[__CLASS__ . MassiveAction::CLASS_ACTION_SEPARATOR . 'replay_dictionnary']
-            = "<i class='fas fa-undo'></i>" .
+            = "<i class='ti ti-arrow-back-up'></i>" .
               __s('Replay the dictionary rules');
         }
 

--- a/src/SolutionTemplate.php
+++ b/src/SolutionTemplate.php
@@ -105,7 +105,7 @@ class SolutionTemplate extends AbstractITILChildTemplate
 
     public static function getIcon()
     {
-        return "fas fa-layer-group";
+        return "ti ti-stack-2-filled";
     }
 
     public function getCloneRelations(): array

--- a/src/State.php
+++ b/src/State.php
@@ -853,4 +853,9 @@ class State extends CommonTreeDropdown
             $this->fields['is_visible_' . strtolower($visibility['visible_itemtype'])] = $visibility['is_visible'];
         }
     }
+
+    public static function getIcon()
+    {
+        return "ti ti-label";
+    }
 }

--- a/src/Supplier.php
+++ b/src/Supplier.php
@@ -621,6 +621,6 @@ class Supplier extends CommonDBTM
 
     public static function getIcon()
     {
-        return "ti ti-shopping-cart";
+        return "ti ti-truck-loading";
     }
 }

--- a/src/Supplier.php
+++ b/src/Supplier.php
@@ -621,6 +621,6 @@ class Supplier extends CommonDBTM
 
     public static function getIcon()
     {
-        return "fas fa-dolly";
+        return "ti ti-shopping-cart";
     }
 }

--- a/src/TaskCategory.php
+++ b/src/TaskCategory.php
@@ -91,7 +91,7 @@ class TaskCategory extends CommonTreeDropdown
 
     public static function getIcon()
     {
-        return "fas fa-tags";
+        return "ti ti-tags";
     }
 
     public function getCloneRelations(): array

--- a/src/TaskTemplate.php
+++ b/src/TaskTemplate.php
@@ -322,7 +322,7 @@ class TaskTemplate extends AbstractITILChildTemplate
 
     public static function getIcon()
     {
-        return "fas fa-layer-group";
+        return "ti ti-stack-2-filled";
     }
 
     public function getCloneRelations(): array

--- a/src/Telemetry.php
+++ b/src/Telemetry.php
@@ -475,7 +475,7 @@ class Telemetry extends CommonGLPI
             sprintf(
                 "<a href='" . GLPI_TELEMETRY_URI . "/reference?showmodal&uuid=" .
                 self::getRegistrationUuid() . "' class='btn btn-sm btn-info' target='_blank'>
-               <i class='fas fa-pen-alt me-1'></i>
+               <i class='ti ti-writing-sign me-1'></i>
                %1\$s
             </a>",
                 __('the registration form')

--- a/src/Transfer.php
+++ b/src/Transfer.php
@@ -3869,7 +3869,7 @@ final class Transfer extends CommonDBTM
 
     public static function getIcon()
     {
-        return "fas fa-level-up-alt";
+        return "ti ti-corner-right-up";
     }
 
     public function getItemtypes(): array

--- a/src/User.php
+++ b/src/User.php
@@ -2996,7 +2996,7 @@ HTML;
                                                          = "<i class='ti ti-shield-minus'></i>" .
                                                            __s('Dissociate from a profile');
             $actions['Group_User' . MassiveAction::CLASS_ACTION_SEPARATOR . 'change_group_user']
-                                                         = "<i class='fas fa-users-cog'></i>" .
+                                                         = "<i class='ti ti-users-group'></i>" .
                                                            __s("Move to group");
             $actions["{$prefix}delete_emails"] = __s("Delete associated emails");
         }
@@ -3006,7 +3006,7 @@ HTML;
                                                       _sx('button', 'Change the authentication method');
             $actions[$prefix . 'force_user_ldap_update'] = "<i class='ti ti-refresh'></i>" .
                                                       __s('Force synchronization');
-            $actions[$prefix . 'clean_ldap_fields'] = "<i class='fas fa-broom'></i>" .
+            $actions[$prefix . 'clean_ldap_fields'] = "<i class='ti ti-recycle'></i>" .
                                                     __s('Clean LDAP fields and force synchronisation');
             $actions[$prefix . 'disable_2fa']           = "<i class='ti ti-shield-off'></i>" .
                                                       __s('Disable 2FA');

--- a/src/UserCategory.php
+++ b/src/UserCategory.php
@@ -43,6 +43,6 @@ class UserCategory extends CommonDropdown
 
     public static function getIcon()
     {
-        return "fas fa-user-tag";
+        return "ti ti-user-cog";
     }
 }

--- a/src/UserTitle.php
+++ b/src/UserTitle.php
@@ -43,6 +43,6 @@ class UserTitle extends CommonDropdown
 
     public static function getIcon()
     {
-        return "fas fa-user-tie";
+        return "ti ti-user-star";
     }
 }

--- a/src/WifiNetwork.php
+++ b/src/WifiNetwork.php
@@ -154,6 +154,6 @@ class WifiNetwork extends CommonDropdown
 
     public static function getIcon()
     {
-        return "fas fa-wifi";
+        return "ti ti-wifi";
     }
 }

--- a/templates/components/datatable.html.twig
+++ b/templates/components/datatable.html.twig
@@ -133,13 +133,13 @@
                                <span class="float-end log-toolbar mb-0">
                                    {% if nofilter is not defined %}
                                        <button class="btn btn-sm show_filters {{ filters|length > 0 ? 'btn-secondary active' : 'btn-outline-secondary' }}">
-                                           <i class="fas fa-filter"></i>
+                                           <i class="ti ti-filter"></i>
                                            <span class="d-none d-xl-block">{{ __('Filter') }}</span>
                                        </button>
                                    {% endif %}
                                    {% if csv_url|length %}
                                        <a href="{{ csv_url }}" class="btn btn-sm text-capitalize btn-outline-secondary">
-                                           <i class="fas fa-file-download"></i>
+                                           <i class="ti ti-download"></i>
                                            <span class="d-none d-xl-block">{{ __('Export') }}</span>
                                        </a>
                                    {% endif %}

--- a/templates/components/form/header_content.html.twig
+++ b/templates/components/form/header_content.html.twig
@@ -160,7 +160,7 @@
                {% endif %}
                <span class="form-check-label mb-0 mx-2">
                   {{ __('Child entities') }}
-                  <i class="fas fa-info ms-1" title="{{ comment }}"></i>
+                  <i class="ti ti-info-circle ms-1" title="{{ comment }}"></i>
                </span>
             </label>
          </span>

--- a/templates/components/form/inventory_info.html.twig
+++ b/templates/components/form/inventory_info.html.twig
@@ -34,9 +34,9 @@
 <div class="card m-n2 border-0 shadow-none">
    <div class="card-header">
       <div class="ribbon ribbon-bookmark ribbon-top ribbon-start bg-blue s-1">
-         <i class="ti ti-cloud-download"></i>
+         <i class="ti ti-cloud-download fa-2x"></i>
       </div>
-      <h4 class="card-title ps-4">
+      <h4 class="card-title ps-5">
          {{ __('Inventory information') }}
       </h4>
       {% set inventory_filename = item is usingtrait('Glpi\\Features\\Inventoriable') ? item.getInventoryFileName(false) : null %}

--- a/templates/components/form/networkname.html.twig
+++ b/templates/components/form/networkname.html.twig
@@ -72,7 +72,7 @@
                      {% set unaffect_btn %}
                         <a class="btn btn-sm btn-outline-danger"
                         onclick=" submitGetLink('{{ item.getFormURL }}', {'unaffect': 'unaffect', 'id': '{{ ID }}', '_glpi_csrf_token': '{{ csrf_token() }}', '_glpi_simple_form': '1'});">
-                           <span class="fas fa-unlink " title={{ __('Dissociate') }}>
+                           <span class="ti ti-unlink " title={{ __('Dissociate') }}>
                               <span class="sr-only">{{ __('Dissociate') }}</span>
                            </span>
                         </a>

--- a/templates/components/form/support_hours.html.twig
+++ b/templates/components/form/support_hours.html.twig
@@ -33,7 +33,7 @@
 {% import 'components/form/fields_macros.html.twig' as fields %}
 
 <div class="row mx-n2">
-   {{ fields.largeTitle(__('Support hours'), 'fas fa-business-time') }}
+   {{ fields.largeTitle(__('Support hours'), 'ti ti-calendar-clock') }}
    {{ fields.smallTitle(__('On week')) }}
    {{ fields.nullField({'field_class': 'col-12 col-sm-4'}) }}
    {{ fields.dropdownHoursField('week_begin_hour', item.fields['week_begin_hour'], __('Start'), {'field_class': 'col-12 col-sm-4'}) }}

--- a/templates/components/itilobject/actors/assign_to_me.html.twig
+++ b/templates/components/itilobject/actors/assign_to_me.html.twig
@@ -37,5 +37,5 @@
         class="btn btn-icon btn-sm btn-ghost-secondary float-end mt-1 ms-1"
         title="{{ __('Associate myself') }}"
         data-bs-toggle="tooltip" data-bs-placement="top">
-   <i class="fas fa-male"></i>
+   <i class="ti ti-user"></i>
 </button>

--- a/templates/components/itilobject/fields/status.html.twig
+++ b/templates/components/itilobject/fields/status.html.twig
@@ -65,7 +65,7 @@
       {% if item.canReopen() %}
          <a href="{{ item.getLinkURL() }}&amp;_openfollowup=1"
             class="btn btn-ghost-secondary">
-            <i class="far fa-folder-open"></i>
+            <i class="ti ti-folder-open"></i>
             <span>{{ __('Reopen') }}</span>
          </a>
       {% endif %}

--- a/templates/components/itilobject/fields_panel.html.twig
+++ b/templates/components/itilobject/fields_panel.html.twig
@@ -492,7 +492,7 @@
 
     <span class="d-none d-md-block">
         <button type="button" class="switch-panel-width btn btn-icon btn-ghost-secondary position-absolute bottom-0 start-0 mb-2">
-            <i class="fas fa-caret-left"></i>
+            <i class="ti ti-caret-left-filled"></i>
         </button>
     </span>
 </div>

--- a/templates/components/itilobject/linked_itilobjects.html.twig
+++ b/templates/components/itilobject/linked_itilobjects.html.twig
@@ -66,9 +66,9 @@
                                 name="id"
                                 value="{{ id }}"
                                 class="btn btn-sm btn-ghost-danger"
-                                title="{{ _x('button', 'Delete permanently') }}"
+                                title="{{ _x('button', 'Unlink') }}"
                                 data-bs-toggle="tooltip">
-                           <i class="fas fa-unlink"></i>
+                           <i class="ti ti-unlink"></i>
                         </button>
                      </div>
                   {% endif %}

--- a/templates/components/kanban/item_panels/default_panel.html.twig
+++ b/templates/components/kanban/item_panels/default_panel.html.twig
@@ -42,7 +42,7 @@
          </h5>
          <h6 class="card-subtitle">
             {% if item_fields.is_milestone %}
-               <i class="fas fa-map-signs me-2"></i>{{ __('Milestone') }}
+               <i class="ti ti-directions-filled me-2"></i>{{ __('Milestone') }}
             {% endif %}
          </h6>
       </div>

--- a/templates/components/logs.html.twig
+++ b/templates/components/logs.html.twig
@@ -51,11 +51,11 @@
             <th>
                <span class="float-end log-toolbar mb-0">
                   <button class="btn btn-sm show_filters {{ filters|length > 0 ? 'btn-secondary active' : 'btn-outline-secondary' }}">
-                     <i class="fas fa-filter"></i>
+                     <i class="ti ti-filter"></i>
                      <span class="d-none d-xl-block">{{ __('Filter') }}</span>
                   </button>
                   <a href="{{ csv_url }}" class="btn btn-sm text-capitalize btn-outline-secondary">
-                     <i class="fas fa-file-download"></i>
+                     <i class="ti ti-download"></i>
                      <span class="d-none d-xl-block">{{ __('Export') }}</span>
                   </a>
                </span>

--- a/templates/components/photoswipe.html.twig
+++ b/templates/components/photoswipe.html.twig
@@ -50,7 +50,7 @@
             <figure itemprop="associatedMedia" itemscope itemtype="https://schema.org/ImageObject" class="d-flex flex-column me-2">
                   {% if img['_video'] ?? false %}
                      <span class="bg-black pswp-trigger pointer d-flex justify-content-center align-items-center">
-                        <i class="fas fa-video"></i>
+                        <i class="ti ti-video-filled"></i>
                      </span>
                   {% else %}
                      <a href="{{ img['src']|escape }}" itemprop="contentUrl" data-index="0">

--- a/templates/components/search/table.html.twig
+++ b/templates/components/search/table.html.twig
@@ -87,7 +87,7 @@
 
                <th data-searchopt-id="{{ col['id'] }}" {% if not can_sort %}data-nosort="true"{% endif %} data-sort-order="{{ sort_order }}"
                   {% if sort_num is not empty %}data-sort-num="{{ sort_num - 1 }}"{% endif %}>
-                  {% set sort_icon = sort_order == 'ASC' ? 'fas fa-sort-up' : (sort_order == 'DESC' ? 'fas fa-sort-down' : '') %}
+                  {% set sort_icon = sort_order == 'ASC' ? 'ti ti-caret-down-filled' : (sort_order == 'DESC' ? 'ti ti-caret-up-filled' : '') %}
                   {{ col_name }}
                   {% if can_sort %}
                      <span class="sort-indicator"><i class="{{ sort_icon }}"></i><span class="sort-num">{{ sorts|length > 1 ? sort_num : '' }}</span></span>

--- a/templates/maintenance.html.twig
+++ b/templates/maintenance.html.twig
@@ -38,7 +38,7 @@
 <div class="flex-fill d-flex align-items-center justify-content-center">
    <div class="container-tight py-6">
       <div class="empty">
-         <i class="fas fa-tools fa-3x mb-3"></i>
+         <i class="ti ti-tools fs-3x mb-3"></i>
 
          <p class="empty-title">{{ __('Temporarily down for maintenance') }}</p>
 

--- a/templates/pages/assets/networkport/networkname_short.html.twig
+++ b/templates/pages/assets/networkport/networkname_short.html.twig
@@ -39,7 +39,7 @@
         {% set info_url = item.isNewItem() ? 'NetworkName'|itemtype_search_path : item.getLinkURL() %}
         {% set info_label = item.isNewItem() ? __('Show %s')|format('NetworkName'|itemtype_name(get_plural_number())) : item.getName() %}
         <a role="button" class="btn btn-outline-secondary p-2" title="{{ info_label }}" href="{{ info_url }}">
-            <i class="fas fa-info"></i>
+            <i class="ti ti-info-circle"></i>
         </a>
         {% if not item.isNewItem() %}
             <button type="button" name="unaffect_networkname" class="btn btn-outline-secondary p-2" title="{{ __('Dissociate') }}">

--- a/templates/pages/setup/authentication/sync.html.twig
+++ b/templates/pages/setup/authentication/sync.html.twig
@@ -44,7 +44,7 @@
          icon: 'ti ti-refresh'
       }) }}
       {{ inputs.submit('clean_ldap_fields', __('Clean LDAP fields and force synchronisation'), 1, {
-         icon: 'fas fa-broom'
+         icon: 'ti ti-recycle'
       }) }}
    {% endif %}
    {{ fields.htmlField('', call('Auth::dropdown', [{


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have tested that my feature works.

## Description

After my work, for all "fas/far fa-" there is only (unless I am mistaken):
- the icons that look like 'ethernet' and/or 'memory,' I couldn't find a correct equivalent in Tabler
- the icons for the 'spinner' feature in the Marketplace, which require CSS adjustments
- the 'stack' badge icons in the Projects Kanban; there is no easy equivalent 'stack' icon feature in Tabler, so I haven't made any changes at this level

Here is a screenshot of the remaining tasks (search for 'fas fa-' in the code):
![image](https://github.com/user-attachments/assets/a9d1ef32-3244-4cf7-acae-cda1bb4b9479)

I would do another pass for the "fa-" (those who currently do not have a "fas" or "far" class), and for those who have "fab-" class.

