### PR TITLE
Cache session content for phpunit

### DIFF
--- a/phpunit/HLAPITestCase.php
+++ b/phpunit/HLAPITestCase.php
@@ -65,8 +65,14 @@ class HLAPITestCase extends \DbTestCase
         return parent::login($user_name, $user_pass, $noauto, $expected);
     }
 
-    public function login(string $user_name = TU_USER, string $user_pass = TU_PASS, bool $noauto = true, bool $expected = true): \Auth
-    {
+    #[Override]
+    public function login(
+        string $user_name = TU_USER,
+        string $user_pass = TU_PASS,
+        bool $noauto = true,
+        bool $expected = true,
+        bool $use_cache = true,
+    ): \Auth {
         $request = new Request('POST', '/token', [
             'Content-Type' => 'application/json',
         ], json_encode([

--- a/phpunit/functional/Certificate_ItemTest.php
+++ b/phpunit/functional/Certificate_ItemTest.php
@@ -50,7 +50,7 @@ class Certificate_ItemTest extends DbTestCase
 
         $this->initAssetDefinition(capacities: [new Capacity(name: HasCertificatesCapacity::class)]);
 
-        $this->login(); // tab will be available only if corresponding right is available in the current session
+        $this->login(use_cache: false); // tab will be available only if corresponding right is available in the current session
 
         foreach ($CFG_GLPI['certificate_types'] as $itemtype) {
             $item = $this->createItem(

--- a/phpunit/functional/CommonDBTMTest.php
+++ b/phpunit/functional/CommonDBTMTest.php
@@ -970,7 +970,7 @@ class CommonDBTMTest extends DbTestCase
         $this->assertTrue($user->getFromDB($user->fields['id']));
         $this->assertSame('Europe/Paris', $user->fields['timezone']);
 
-        $this->login('glpi', 'glpi');
+        $this->login('glpi', 'glpi', use_cache: false);
         $this->assertTrue($comp->getFromDB($cid));
         $this->assertMatchesRegularExpression('/2019-03-04 1[12]:00:00/', $comp->fields['date_creation']);
     }

--- a/phpunit/functional/CommonITILTaskTest.php
+++ b/phpunit/functional/CommonITILTaskTest.php
@@ -189,7 +189,7 @@ class CommonITILTaskTest extends DbTestCase
                     'name'          => $task_class::$rightname,
                 ]
             );
-            $this->login();
+            $this->login(use_cache: false);
             $task_item->fields = $task_input + [$itil_fkey  => $my_item->getID()];
             $this->assertFalse($task_item->canCreateItem());
 
@@ -204,7 +204,7 @@ class CommonITILTaskTest extends DbTestCase
                     'name'          => $task_class::$rightname,
                 ]
             );
-            $this->login();
+            $this->login(use_cache: false);
             $task_item->fields = $task_input + [$itil_fkey  => $my_item->getID()];
             $this->assertTrue($task_item->canCreateItem());
             $task_item->fields = $task_input + [$itil_fkey  => $tech_item->getID()];
@@ -284,7 +284,7 @@ class CommonITILTaskTest extends DbTestCase
                     'name' => $task_class::$rightname,
                 ]
             );
-            $this->login();
+            $this->login(use_cache: false);
             $task_item->fields = $task_input + [$itil_fkey => $my_item->getID()];
             $this->assertFalse($task_item->canCreateItem());
 
@@ -299,7 +299,7 @@ class CommonITILTaskTest extends DbTestCase
                     'name' => $task_class::$rightname,
                 ]
             );
-            $this->login();
+            $this->login(use_cache: false);
             $task_item->fields = $task_input + [$itil_fkey => $my_item->getID()];
             $this->assertTrue($task_item->canCreateItem());
             $task_item->fields = $task_input + [$itil_fkey => $tech_item->getID()];
@@ -390,7 +390,7 @@ class CommonITILTaskTest extends DbTestCase
                     'name' => $task_class::$rightname,
                 ]
             );
-            $this->login();
+            $this->login(use_cache: false);
             $task_item->fields = $task_input + [$itil_fkey => $my_item->getID()];
             $this->assertFalse($task_item->canCreateItem());
 
@@ -405,7 +405,7 @@ class CommonITILTaskTest extends DbTestCase
                     'name' => $task_class::$rightname,
                 ]
             );
-            $this->login();
+            $this->login(use_cache: false);
             $task_item->fields = $task_input + [$itil_fkey => $my_item->getID()];
             $this->assertTrue($task_item->canCreateItem());
             $task_item->fields = $task_input + [$itil_fkey => $tech_item->getID()];
@@ -472,7 +472,7 @@ class CommonITILTaskTest extends DbTestCase
                     'name' => $task_class::$rightname,
                 ]
             );
-            $this->login();
+            $this->login(use_cache: false);
             $this->assertFalse($my_task->canUpdateItem());
             $this->assertFalse($tech_task->canUpdateItem());
 
@@ -487,7 +487,7 @@ class CommonITILTaskTest extends DbTestCase
                     'name' => $task_class::$rightname,
                 ]
             );
-            $this->login();
+            $this->login(use_cache: false);
             $this->assertTrue($my_task->canUpdateItem());
             $this->assertFalse($tech_task->canUpdateItem());
         }

--- a/phpunit/functional/Glpi/Asset/Capacity/HasAntivirusCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/HasAntivirusCapacityTest.php
@@ -94,7 +94,7 @@ class HasAntivirusCapacityTest extends DbTestCase
 
             // Check that the corresponding tab is present on items
             $item = $this->createItem($classname, ['name' => __FUNCTION__, 'entities_id' => $root_entity_id]);
-            $this->login(); // must be logged in to get tabs list
+            $this->login(use_cache: false); // must be logged in to get tabs list
             if ($has_capacity) {
                 $this->assertArrayHasKey('ItemAntivirus$1', $item->defineAllTabs());
             } else {

--- a/phpunit/functional/Glpi/Asset/Capacity/HasAppliancesCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/HasAppliancesCapacityTest.php
@@ -87,7 +87,7 @@ class HasAppliancesCapacityTest extends DbTestCase
 
         foreach ($has_capacity_mapping as $classname => $has_capacity) {
             // Check that the class is globally registered
-            $this->login(); // must be logged in to have class in Appliance::getTypes()
+            $this->login(use_cache: false); // must be logged in to have class in Appliance::getTypes()
             if ($has_capacity) {
                 $this->assertContains($classname, $CFG_GLPI['appliance_types']);
                 $this->assertContains($classname, Appliance::getTypes());
@@ -98,7 +98,7 @@ class HasAppliancesCapacityTest extends DbTestCase
 
             // Check that the corresponding tab is present on items
             $item = $this->createItem($classname, ['name' => __FUNCTION__, 'entities_id' => $root_entity_id]);
-            $this->login(); // must be logged in to get tabs list
+            $this->login(use_cache: false); // must be logged in to get tabs list
             if ($has_capacity) {
                 $this->assertArrayHasKey('Appliance_Item$1', $item->defineAllTabs());
             } else {

--- a/phpunit/functional/Glpi/Asset/Capacity/HasCertificatesCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/HasCertificatesCapacityTest.php
@@ -85,7 +85,7 @@ class HasCertificatesCapacityTest extends DbTestCase
             $classname_3 => true,
         ];
 
-        $this->login(); // must be logged in to have class in Certificate::getTypes()
+        $this->login(use_cache: false); // must be logged in to have class in Certificate::getTypes()
         foreach ($has_certificates_mapping as $classname => $has_certificates) {
             // Check that the class is globally registered
             if ($has_certificates) {

--- a/phpunit/functional/Glpi/Asset/Capacity/HasDevicesCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/HasDevicesCapacityTest.php
@@ -104,7 +104,7 @@ class HasDevicesCapacityTest extends DbTestCase
 
             // Check that the corresponding tab is present on items
             $item = $this->createItem($classname, ['name' => __FUNCTION__, 'entities_id' => $root_entity_id]);
-            $this->login(); // must be logged in to get tabs list
+            $this->login(use_cache: false); // must be logged in to get tabs list
             if ($has_capacity) {
                 $this->assertArrayHasKey('Item_Devices$1', $item->defineAllTabs());
             } else {

--- a/phpunit/functional/Glpi/Asset/Capacity/HasDomainsCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/HasDomainsCapacityTest.php
@@ -88,7 +88,7 @@ class HasDomainsCapacityTest extends DbTestCase
 
         foreach ($has_domains_mapping as $classname => $has_domains) {
             // Check that the class is globally registered
-            $this->login(); // must be logged in to have class in Domain::getTypes()
+            $this->login(use_cache: false); // must be logged in to have class in Domain::getTypes()
             if ($has_domains) {
                 $this->assertContains($classname, $CFG_GLPI['domain_types']);
                 $this->assertContains($classname, Domain::getTypes());
@@ -99,7 +99,7 @@ class HasDomainsCapacityTest extends DbTestCase
 
             // Check that the corresponding tab is present on items
             $item = $this->createItem($classname, ['name' => __FUNCTION__, 'entities_id' => $root_entity_id]);
-            $this->login(); // must be logged in to get tabs list
+            $this->login(use_cache: false); // must be logged in to get tabs list
             if ($has_domains) {
                 $this->assertArrayHasKey('Domain_Item$1', $item->defineAllTabs());
             } else {
@@ -111,7 +111,7 @@ class HasDomainsCapacityTest extends DbTestCase
                 205, // Name
                 206, // Type
             ];
-            $this->login(); // must be logged in to get search options
+            $this->login(use_cache: false); // must be logged in to get search options
             $options = $item->getOptions();
             foreach ($so_keys as $so_key) {
                 if ($has_domains) {

--- a/phpunit/functional/Glpi/Asset/Capacity/HasNotepadCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/HasNotepadCapacityTest.php
@@ -96,7 +96,7 @@ class HasNotepadCapacityTest extends DbTestCase
         foreach ($has_notepad_mapping as $classname => $has_notepad) {
             // Check that the corresponding tab is present on items
             $item = $this->createItem($classname, ['name' => __FUNCTION__, 'entities_id' => $root_entity_id]);
-            $this->login(); // must be logged in to get tabs list
+            $this->login(use_cache: false); // must be logged in to get tabs list
             if ($has_notepad) {
                 $this->assertArrayHasKey('Notepad$1', $item->defineAllTabs());
             } else {
@@ -252,7 +252,7 @@ class HasNotepadCapacityTest extends DbTestCase
         ];
 
         // By default, no rights are enabled on Notepad
-        $this->login();
+        $this->login(use_cache: false);
         $this->assertArrayNotHasKey('Notepad$1', $item->defineAllTabs());
         $this->assertFalse((new Notepad())->can(-1, CREATE, $new_notepad_input));
         $this->assertFalse((new Notepad())->can($notepad_1->getID(), UPDATE));
@@ -265,7 +265,7 @@ class HasNotepadCapacityTest extends DbTestCase
             ],
         ]);
         $this->assertTrue($updated);
-        $this->login();
+        $this->login(use_cache: false);
         $this->assertArrayHasKey('Notepad$1', $item->defineAllTabs());
         $this->assertFalse((new Notepad())->can(-1, CREATE, $new_notepad_input));
         $this->assertFalse((new Notepad())->can($notepad_1->getID(), UPDATE));
@@ -278,7 +278,7 @@ class HasNotepadCapacityTest extends DbTestCase
             ],
         ]);
         $this->assertTrue($updated);
-        $this->login();
+        $this->login(use_cache: false);
         $this->assertArrayNotHasKey('Notepad$1', $item->defineAllTabs());
         $this->assertTrue((new Notepad())->can(-1, CREATE, $new_notepad_input));
         $this->assertTrue((new Notepad())->can($notepad_1->getID(), UPDATE));

--- a/phpunit/functional/Glpi/Asset/Capacity/HasPeripheralAssetsCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/HasPeripheralAssetsCapacityTest.php
@@ -89,7 +89,7 @@ class HasPeripheralAssetsCapacityTest extends DbTestCase
 
             // Check that the corresponding tab is present on items
             $item = $this->createItem($classname, ['name' => __FUNCTION__, 'entities_id' => $root_entity_id]);
-            $this->login(); // must be logged in to get tabs list
+            $this->login(use_cache: false); // must be logged in to get tabs list
             if ($has_capacity) {
                 $this->assertArrayHasKey('Glpi\\Asset\\Asset_PeripheralAsset$1', $item->defineAllTabs());
             } else {

--- a/phpunit/functional/Glpi/Asset/Capacity/HasVirtualMachineCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/HasVirtualMachineCapacityTest.php
@@ -94,7 +94,7 @@ class HasVirtualMachineCapacityTest extends DbTestCase
 
             // Check that the corresponding tab is present on items
             $item = $this->createItem($classname, ['name' => __FUNCTION__, 'entities_id' => $root_entity_id]);
-            $this->login(); // must be logged in to get tabs list
+            $this->login(use_cache: false); // must be logged in to get tabs list
             if ($has_capacity) {
                 $this->assertArrayHasKey('ItemVirtualMachine$1', $item->defineAllTabs());
             } else {

--- a/phpunit/functional/Glpi/Asset/Capacity/HasVolumesCapacityTest.php
+++ b/phpunit/functional/Glpi/Asset/Capacity/HasVolumesCapacityTest.php
@@ -95,7 +95,7 @@ class HasVolumesCapacityTest extends DbTestCase
 
             // Check that the corresponding tab is present on items
             $item = $this->createItem($classname, ['name' => __FUNCTION__, 'entities_id' => $root_entity_id]);
-            $this->login(); // must be logged in to get tabs list
+            $this->login(use_cache: false); // must be logged in to get tabs list
             if ($has_capacity) {
                 $this->assertArrayHasKey('Item_Disk$1', $item->defineAllTabs());
             } else {

--- a/phpunit/functional/Glpi/CalDAV/ServerTest.php
+++ b/phpunit/functional/Glpi/CalDAV/ServerTest.php
@@ -392,7 +392,7 @@ class ServerTest extends DbTestCase
             $login = $row['login'];
             $pass = $row['pass'];
 
-            $this->login($login, $pass);
+            $this->login($login, $pass, use_cache: false);
 
             $server = $this->getServerInstance('PROPFIND', $path);
             $server->httpRequest->addHeader('Authorization', 'Basic ' . base64_encode($login . ':' . $pass));

--- a/phpunit/functional/Glpi/Dropdown/DropdownDefinitionManagerTest.php
+++ b/phpunit/functional/Glpi/Dropdown/DropdownDefinitionManagerTest.php
@@ -72,7 +72,7 @@ class DropdownDefinitionManagerTest extends DbTestCase
 
         \Dropdown::resetItemtypesStaticCache();
 
-        $this->login();
+        $this->login(use_cache: false);
         $dropdowns = \Dropdown::getStandardDropdownItemTypes();
         $has_dropdown = false;
         foreach ($dropdowns as $items) {

--- a/phpunit/functional/Glpi/Helpdesk/HomePageTabsTest.php
+++ b/phpunit/functional/Glpi/Helpdesk/HomePageTabsTest.php
@@ -48,8 +48,9 @@ final class HomePageTabsTest extends DbTestCase
     public function testDefaultTabs(): void
     {
         // Arrange: create a new user without reminders / rssfeeds
+        $login = 'tmp_user_' . mt_rand();
         $this->createItem(User::class, [
-            'name'          => 'tmp_user',
+            'name'          => $login,
             'password'      => 'tmp_user',
             'password2'     => 'tmp_user',
             '_profiles_id'  => getItemByTypeName(Profile::class, 'Self-Service', true),
@@ -58,7 +59,7 @@ final class HomePageTabsTest extends DbTestCase
         ], ['password', 'password2']);
 
         // Act: get tabs names
-        $this->login('tmp_user', 'tmp_user');
+        $this->login($login, 'tmp_user');
         $tabs = $this->getHomeTabsNames();
 
         // Assert: the reminder and rss tabs should not be displayed as there is no data.
@@ -71,8 +72,9 @@ final class HomePageTabsTest extends DbTestCase
     public function testPublicReminderTabIsAddedWhenReminderExists(): void
     {
         // Arrange: create a new user and one public reminder
+        $login = 'tmp_user_' . mt_rand();
         $user = $this->createItem(User::class, [
-            'name'          => 'tmp_user',
+            'name'          => $login,
             'password'      => 'tmp_user',
             'password2'     => 'tmp_user',
             '_profiles_id'  => getItemByTypeName(Profile::class, 'Self-Service', true),
@@ -88,7 +90,7 @@ final class HomePageTabsTest extends DbTestCase
         ]);
 
         // Act: get tabs names
-        $this->login('tmp_user', 'tmp_user');
+        $this->login($login, 'tmp_user');
         $tabs = $this->getHomeTabsNames();
 
         // Assert: the reminder and rss tabs should not be displayed as there is no data.
@@ -102,15 +104,16 @@ final class HomePageTabsTest extends DbTestCase
     public function testRssFeedsTabIsAddedWhenRssFeedsExists(): void
     {
         // Arrange: create a new user and one public reminder
+        $login = 'tmp_user_' . mt_rand();
         $user = $this->createItem(User::class, [
-            'name'          => 'tmp_user',
+            'name'          => $login,
             'password'      => 'tmp_user',
             'password2'     => 'tmp_user',
             '_profiles_id'  => getItemByTypeName(Profile::class, 'Self-Service', true),
             '_entities_id'  => $this->getTestRootEntity(true),
             '_is_recursive' => true,
         ], ['password', 'password2']);
-        $this->login('tmp_user', 'tmp_user'); // Need to be logged in to create the RSS feed
+        $this->login($login, 'tmp_user'); // Need to be logged in to create the RSS feed
         $reminder = $this->createItem(RSSFeed::class, [
             'name' => 'My feed',
             'url'  => 'https://fake-rss.localhost.com/feed',

--- a/phpunit/functional/ITILTemplateTest.php
+++ b/phpunit/functional/ITILTemplateTest.php
@@ -457,7 +457,7 @@ class ITILTemplateTest extends DbTestCase
         //   check if category has precedence
         $entity_tpl_id = $this->createTemplate($itiltype);
         //login as admin to change entity conf
-        $this->login();
+        $this->login(use_cache: false);
         $entity = getItemByTypeName('Entity', '_test_child_1');
         $this->assertTrue($entity->update(['id' => $entity->fields['id'], $field => $entity_tpl_id]));
 

--- a/phpunit/functional/ItemAntivirusTest.php
+++ b/phpunit/functional/ItemAntivirusTest.php
@@ -50,7 +50,7 @@ class ItemAntivirusTest extends DbTestCase
 
         $this->initAssetDefinition(capacities: [new Capacity(name: HasAntivirusCapacity::class)]);
 
-        $this->login(); // tab will be available only if corresponding right is available in the current session
+        $this->login(use_cache: false); // tab will be available only if corresponding right is available in the current session
 
         foreach ($CFG_GLPI['itemantivirus_types'] as $itemtype) {
             $item = $this->createItem(

--- a/phpunit/functional/ItemVirtualMachineTest.php
+++ b/phpunit/functional/ItemVirtualMachineTest.php
@@ -50,7 +50,7 @@ class ItemVirtualMachineTest extends DbTestCase
 
         $this->initAssetDefinition(capacities: [new Capacity(name: HasVirtualMachineCapacity::class)]);
 
-        $this->login(); // tab will be available only if corresponding right is available in the current session
+        $this->login(use_cache: false); // tab will be available only if corresponding right is available in the current session
 
         foreach ($CFG_GLPI['itemvirtualmachines_types'] as $itemtype) {
             $item = $this->createItem(

--- a/phpunit/functional/Item_DeviceSimcardTest.php
+++ b/phpunit/functional/Item_DeviceSimcardTest.php
@@ -115,7 +115,7 @@ class Item_DeviceSimcardTest extends DbTestCase
         );
 
         // Profile changed then login
-        $this->login();
+        $this->login(use_cache: false);
         //reset rights. Done here so ACLs are reset even if tests fails.
         $DB->update(
             'glpi_profilerights',

--- a/phpunit/functional/Item_DevicesTest.php
+++ b/phpunit/functional/Item_DevicesTest.php
@@ -51,7 +51,7 @@ class Item_DevicesTest extends DbTestCase
 
         $this->initAssetDefinition(capacities: [new Capacity(name: HasDevicesCapacity::class)]);
 
-        $this->login(); // tab will be available only if corresponding right is available in the current session
+        $this->login(use_cache: false); // tab will be available only if corresponding right is available in the current session
 
         foreach ($CFG_GLPI['itemdevices_types'] as $itemtype) {
             $item = $this->createItem(

--- a/phpunit/functional/Item_DiskTest.php
+++ b/phpunit/functional/Item_DiskTest.php
@@ -50,7 +50,7 @@ class Item_DiskTest extends DbTestCase
 
         $this->initAssetDefinition(capacities: [new Capacity(name: HasVolumesCapacity::class)]);
 
-        $this->login(); // tab will be available only if corresponding right is available in the current session
+        $this->login(use_cache: false); // tab will be available only if corresponding right is available in the current session
 
         foreach ($CFG_GLPI['disk_types'] as $itemtype) {
             $item = $this->createItem(

--- a/phpunit/functional/Item_EnvironmentTest.php
+++ b/phpunit/functional/Item_EnvironmentTest.php
@@ -50,7 +50,7 @@ class Item_EnvironmentTest extends DbTestCase
 
         $this->initAssetDefinition(capacities: [new Capacity(name: IsInventoriableCapacity::class)]);
 
-        $this->login(); // tab will be available only if corresponding right is available in the current session
+        $this->login(use_cache: false); // tab will be available only if corresponding right is available in the current session
 
         foreach ($CFG_GLPI['environment_types'] as $itemtype) {
             $item = $this->createItem(

--- a/phpunit/functional/Item_ProcessTest.php
+++ b/phpunit/functional/Item_ProcessTest.php
@@ -50,7 +50,7 @@ class Item_ProcessTest extends DbTestCase
 
         $this->initAssetDefinition(capacities: [new Capacity(name: IsInventoriableCapacity::class)]);
 
-        $this->login(); // tab will be available only if corresponding right is available in the current session
+        $this->login(use_cache: false); // tab will be available only if corresponding right is available in the current session
 
         foreach ($CFG_GLPI['process_types'] as $itemtype) {
             $item = $this->createItem(

--- a/phpunit/functional/KnowbaseItemTest.php
+++ b/phpunit/functional/KnowbaseItemTest.php
@@ -944,7 +944,7 @@ HTML,
     {
         global $DB;
 
-        $this->login('glpi', 'glpi');
+        $this->login('glpi', 'glpi', use_cache: false);
 
         // Removing existing data
         $DB->delete(\KnowbaseItem::getTable(), [1]);
@@ -1154,7 +1154,7 @@ HTML,
         yield ['articles' => ['FAQ 1', 'FAQ 2', 'FAQ 3', 'FAQ 4', 'FAQ 5', 'FAQ 6', 'FAQ 7', 'FAQ 8', 'FAQ 9', 'FAQ 10', 'FAQ 11']];
 
         // Check articles visible for "post-only" user
-        $this->login('post-only', 'postonly');
+        $this->login('post-only', 'postonly', use_cache: false);
         yield ['articles' => ['FAQ 1', 'FAQ 3', 'FAQ 5', 'FAQ 7', 'FAQ 8', 'FAQ 9', 'FAQ 10']];
         $this->setEntity("FAQ 1 entity", true);
         yield ['articles' => ['FAQ 1', 'FAQ 5', 'FAQ 7', 'FAQ 8', 'FAQ 10']];
@@ -1164,7 +1164,7 @@ HTML,
         yield ['articles' => ['FAQ 1', 'FAQ 5', 'FAQ 7', 'FAQ 10']];
 
         // Check articles visible for "tech" user
-        $this->login('tech', 'tech');
+        $this->login('tech', 'tech', use_cache: false);
         yield ['articles' => ['FAQ 2', 'FAQ 4', 'FAQ 6', 'FAQ 7', 'FAQ 8', 'FAQ 9', 'FAQ 10']];
         $this->setEntity("FAQ 1 entity", true);
         yield ['articles' => ['FAQ 2', 'FAQ 6', 'FAQ 7', 'FAQ 8', 'FAQ 10']];
@@ -1404,7 +1404,7 @@ HTML,
         ]);
 
         // Check articles visible for "tech" user
-        $this->login('tech', 'tech');
+        $this->login('tech', 'tech', use_cache: false);
         yield [
             'articles' => [
                 'FAQ 2', 'KB 2', 'KB 3', 'KB 4', 'KB 6', 'KB 7', 'KB 8', 'KB 9',
@@ -1421,7 +1421,7 @@ HTML,
         ];
 
         // Last test, admin should see all articles
-        $this->login('glpi', 'glpi');
+        $this->login('glpi', 'glpi', use_cache: false);
         yield [
             'articles' => [
                 'FAQ 1', 'FAQ 2', 'FAQ 3', 'KB 1', 'KB 2', 'KB 3', 'KB 4',

--- a/phpunit/functional/RuleRightTest.php
+++ b/phpunit/functional/RuleRightTest.php
@@ -111,7 +111,7 @@ class RuleRightTest extends DbTestCase
         ]);
 
         // login the user to force a real synchronisation and get it's glpi id
-        $this->login(TU_USER, TU_PASS, false);
+        $this->login(TU_USER, TU_PASS, false, use_cache: false);
         $users_id = \User::getIdByName(TU_USER);
         $this->assertGreaterThan(0, $users_id);
 
@@ -126,7 +126,7 @@ class RuleRightTest extends DbTestCase
             'value'       => -1, // Full structure
         ]);
 
-        $this->login(TU_USER, TU_PASS, false);
+        $this->login(TU_USER, TU_PASS, false, use_cache: false);
         $user->getFromDB($users_id);
         $this->assertEquals(null, $user->fields['entities_id']);
 
@@ -159,7 +159,7 @@ class RuleRightTest extends DbTestCase
         \SingletonRuleList::getInstance("RuleRight", 0)->list = [];
 
         // login again
-        $this->login(TU_USER, TU_PASS, false);
+        $this->login(TU_USER, TU_PASS, false, use_cache: false);
 
         // check the user got the entity/profiles assigned
         $pu = \Profile_User::getForUser($users_id, true);
@@ -188,7 +188,7 @@ class RuleRightTest extends DbTestCase
         ];
 
         $user = new \User();
-        $this->login();
+        $this->login(use_cache: false);
         $users_id = $user->add($testuser);
         $this->assertGreaterThan(0, $users_id);
 
@@ -202,7 +202,7 @@ class RuleRightTest extends DbTestCase
         $this->assertEquals(1, $right['is_default_profile']);
 
         // Log in to force rules right processing
-        $this->login($testuser['name'], $testuser['password'], false);
+        $this->login($testuser['name'], $testuser['password'], false, use_cache: false);
 
         // Get rights again, should not have changed
         $pu = \Profile_User::getForUser($users_id, true);
@@ -210,7 +210,7 @@ class RuleRightTest extends DbTestCase
         $right2 = array_pop($pu);
         $this->assertEquals($right, $right2);
 
-        $this->login();
+        $this->login(use_cache: false);
         // Change the $right profile, since this is the default profile it should
         // be fixed on next login
         $pu = new \Profile_User();
@@ -223,7 +223,7 @@ class RuleRightTest extends DbTestCase
         $this->assertEquals(1, $pu->fields['is_default_profile']);
         $this->assertEquals(1, $pu->fields['is_dynamic']);
 
-        $this->login($testuser['name'], $testuser['password'], false);
+        $this->login($testuser['name'], $testuser['password'], false, use_cache: false);
         $pu = \Profile_User::getForUser($users_id, true);
         $this->assertCount(1, $pu);
         $right3 = array_pop($pu);
@@ -232,9 +232,6 @@ class RuleRightTest extends DbTestCase
         unset($right['id']);
         unset($right3['id']);
         $this->assertEquals($right, $right3);
-
-        // Clean session
-        $this->login();
     }
 
     public function testDenyLogin()

--- a/phpunit/functional/UserTest.php
+++ b/phpunit/functional/UserTest.php
@@ -1856,7 +1856,7 @@ class UserTest extends \DbTestCase
 
         // logout/login and check prefs
         $this->logOut();
-        $this->login('for preferences', 'for preferences');
+        $this->login('for preferences', 'for preferences', use_cache: false);
         $this->assertEquals(0, $_SESSION['glpishow_count_on_tabs']);
         $this->assertEquals($itil_layout_1, $_SESSION['glpiitil_layout']);
 
@@ -1880,7 +1880,7 @@ class UserTest extends \DbTestCase
 
         // logout/login and check prefs
         $this->logOut();
-        $this->login('for preferences', 'for preferences');
+        $this->login('for preferences', 'for preferences', use_cache: false);
         $this->assertEquals(1, $_SESSION['glpishow_count_on_tabs']);
         $this->assertEquals($itil_layout_2, $_SESSION['glpiitil_layout']);
 


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Working on some quick tests performances gains while waiting for the tests to run on my other works (I hope you can see the irony in that :D).

The login process take a lot of times and is done over 1000+ times in our tests.
Since we end up with the same session data 99.9% of the time (because the database is not supposed to change between tests), this process is not very useful and we can gain time by reloading a previously known session.

WIP, running it here to see which tests will fail with this change and measure the improvement in execution time.

