### PR TITLE
Fix - Profile templates fields dropdown elements load

### DIFF
--- a/src/Profile.php
+++ b/src/Profile.php
@@ -1230,7 +1230,7 @@ class Profile extends CommonDBTM
         echo "<td>";
         // Only root entity ones and recursive
         $options = ['value'     => $this->fields["tickettemplates_id"],
-            'condition' => ['entities_id' => 0]
+            'condition' => ['entities_id' => 0],
         ];
         if (Session::isMultiEntitiesMode()) {
             $options['condition'] = ['is_recursive' => 1];
@@ -1248,7 +1248,7 @@ class Profile extends CommonDBTM
         echo "<td>";
         // Only root entity ones and recursive
         $options = ['value'     => $this->fields["changetemplates_id"],
-            'condition' => ['entities_id' => 0]
+            'condition' => ['entities_id' => 0],
         ];
         if (Session::isMultiEntitiesMode()) {
             $options['condition'] = ['is_recursive' => 1];
@@ -1266,7 +1266,7 @@ class Profile extends CommonDBTM
         echo "<td>";
         // Only root entity ones and recursive
         $options = ['value'     => $this->fields["problemtemplates_id"],
-            'condition' => ['entities_id' => 0]
+            'condition' => ['entities_id' => 0],
         ];
         if (Session::isMultiEntitiesMode()) {
             $options['condition'] = ['is_recursive' => 1];


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !37321
- Here is a brief description of what this PR does

This PR fixes a bug affecting the **"Default ticket template"** dropdown field in the **Assistance** tab of the profile configuration page.

#### Problem

When editing a profile within a **sub-entity**, the dropdown list for selecting a ticket template fails to load. Although the AJAX call to `getDropdownValue.php` is triggered, the `entity_restrict` parameter is passed as an **empty array (`[]`)**, which results in no values being returned.  
At the root entity level, `entity_restrict` is set to `0`, and values load correctly.

#### Solution

A fallback mechanism has been added to the `Dropdown::getDropdownValue()` method:

- If the decoded `entity_restrict` array is empty, the method now falls back to `$_SESSION['glpiactiveentities']`.
- This ensures entity filtering remains consistent with the user's active entities.

#### User Scenario

A Super-Admin user tries to assign a default ticket template to a profile within a sub-entity. Without this fix, the user sees:  
**"Results could not be loaded."**  
With this change, the dropdown properly displays available templates and restores expected functionality.


## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/255eca71-1988-4a31-b06a-787948096f52)
