### PR TITLE
Mock login in tests

### DIFF
--- a/phpunit/DbTestCase.php
+++ b/phpunit/DbTestCase.php
@@ -72,7 +72,7 @@ class DbTestCase extends \GLPITestCase
      *
      * @return \Auth
      */
-    protected function login(
+    protected function realLogin(
         string $user_name = TU_USER,
         string $user_pass = TU_PASS,
         bool $noauto = true,
@@ -83,6 +83,33 @@ class DbTestCase extends \GLPITestCase
 
         $auth = new Auth();
         $this->assertEquals($expected, $auth->login($user_name, $user_pass, $noauto));
+
+        return $auth;
+    }
+
+    /**
+     * "Fake" login process (for performances reason), if you need a real login
+     * use the realLogin() method instead.
+     *
+     * The rule engine will not be executed.
+     *
+     * A session will be loaded for the supplied user without checking if his
+     * account is valid.
+     *
+     * The "user_pass" parameter is no longer used but was not removed to
+     * avoid needing to update all the occurences in existings tests.
+     */
+    protected function login(
+        string $user_name = TU_USER,
+        string $user_pass = "",
+    ): \Auth {
+        \Session::destroy();
+        \Session::start();
+
+        $auth = new Auth();
+        $auth->user = getItemByTypeName(User::class, $user_name);
+        $auth->auth_succeded = true;
+        Session::init($auth);
 
         return $auth;
     }

--- a/phpunit/LDAP/AuthLdapTest.php
+++ b/phpunit/LDAP/AuthLdapTest.php
@@ -1226,7 +1226,7 @@ class AuthLDAPTest extends DbTestCase
     public function testLdapAuth()
     {
         //try to log in from a user that does not exist yet
-        $auth = $this->login('brazil6', 'password', false);
+        $auth = $this->realLogin('brazil6', 'password', false);
 
         $user = new \User();
         $user->getFromDBbyName('brazil6');
@@ -1266,7 +1266,7 @@ class AuthLDAPTest extends DbTestCase
         $this->assertSame('brazil7', $user->fields['name']);
         $this->assertSame('uid=brazil7,ou=people,ou=R&D,dc=glpi,dc=org', $user->fields['user_dn']);
 
-        $auth = $this->login('brazil7', 'password', false, true);
+        $auth = $this->realLogin('brazil7', 'password', false, true);
 
         $this->assertTrue($auth->user_present);
         $this->assertSame($user->fields['user_dn'], $auth->user_dn);
@@ -1283,8 +1283,8 @@ class AuthLDAPTest extends DbTestCase
             )
         );
 
-        $this->login('brazil7', 'password', false, false);
-        $auth = $this->login('brazil7test', 'password', false);
+        $this->realLogin('brazil7', 'password', false, false);
+        $auth = $this->realLogin('brazil7test', 'password', false);
 
         //reset entry before any test can fail
         $this->assertTrue(
@@ -1322,7 +1322,7 @@ class AuthLDAPTest extends DbTestCase
             (int) $user->add($dup)
         );
 
-        $auth = $this->login('brazil6', 'password', false);
+        $auth = $this->realLogin('brazil6', 'password', false);
         $this->assertSame($aid, $auth->user->fields['auths_id']);
         $this->assertSame('brazil6', $auth->user->fields['name']);
         $this->assertSame('uid=brazil6,ou=people,ou=R&D,dc=glpi,dc=org', $auth->user->fields['user_dn']);
@@ -2305,7 +2305,7 @@ class AuthLDAPTest extends DbTestCase
         ]);
 
         // login the user to force a real synchronisation and get it's glpi id
-        $this->login('brazil6', 'password', false);
+        $this->realLogin('brazil6', 'password', false);
         $users_id = \User::getIdByName('brazil6');
         $this->assertGreaterThan(0, $users_id);
         // check the user got the entity/profiles assigned
@@ -2389,7 +2389,7 @@ class AuthLDAPTest extends DbTestCase
         ])->getID();
 
         // login the user to force a real synchronisation and get it's glpi id
-        $this->login('brazil6', 'password', false);
+        $this->realLogin('brazil6', 'password', false);
         $users_id = \User::getIdByName('brazil6');
         $this->assertGreaterThan(0, $users_id);
 
@@ -2408,7 +2408,7 @@ class AuthLDAPTest extends DbTestCase
         ]);
 
         // Login
-        $this->login('brazil6', 'password', false);
+        $this->realLogin('brazil6', 'password', false);
         $users_id = \User::getIdByName('brazil6');
         $this->assertGreaterThan(0, $users_id);
 
@@ -2452,7 +2452,7 @@ class AuthLDAPTest extends DbTestCase
         ]);
 
         // Login
-        $this->login('brazil6', 'password', false);
+        $this->realLogin('brazil6', 'password', false);
         $users_id = \User::getIdByName('brazil6');
         $this->assertGreaterThan(0, $users_id);
 
@@ -2493,7 +2493,7 @@ class AuthLDAPTest extends DbTestCase
         $this->createRule($builder);
 
         // login the user to force a real synchronisation (and creation into DB)
-        $this->login('brazil7', 'password', false);
+        $this->realLogin('brazil7', 'password', false);
         $users_id = \User::getIdByName('brazil7');
 
         // Add group to user
@@ -2510,7 +2510,7 @@ class AuthLDAPTest extends DbTestCase
         $this->assertCount(0, $rights);
 
         // Log in again to trigger rule
-        $this->login('brazil7', 'password', false);
+        $this->realLogin('brazil7', 'password', false);
 
         // Check that the correct profile was set
         $rights = (new Profile_User())->find([
@@ -2525,7 +2525,7 @@ class AuthLDAPTest extends DbTestCase
     public function testLdapUnavailable()
     {
         //Import user that doesn't exist yet
-        $auth = $this->login('brazil5', 'password', false);
+        $auth = $this->realLogin('brazil5', 'password', false);
 
         $user = new \User();
         $user->getFromDBbyName('brazil5');
@@ -2551,7 +2551,7 @@ class AuthLDAPTest extends DbTestCase
             ])
         );
 
-        $this->login('brazil5', 'password', false, false);
+        $this->realLogin('brazil5', 'password', false, false);
         $this->hasPhpLogRecordThatContains(
             "Unable to bind to LDAP server `openldap:1234` with RDN `cn=Manager,dc=glpi,dc=org`\nerror: Can't contact LDAP server (-1)",
             LogLevel::WARNING
@@ -2588,7 +2588,7 @@ class AuthLDAPTest extends DbTestCase
         );
 
         //Import user that doesn't exist yet
-        $auth = $this->login('logintest', 'password');
+        $auth = $this->realLogin('logintest', 'password');
 
         $user = new \User();
         $user->getFromDBbyName('logintest');
@@ -2665,7 +2665,7 @@ class AuthLDAPTest extends DbTestCase
             'value'       => '1', // Reject
         ]);
         // login the user to force synchronisation
-        $this->login('brazil6', 'password', false, false);
+        $this->realLogin('brazil6', 'password', false, false);
 
         // Check title not created
         $ut = new UserTitle();

--- a/phpunit/functional/CommonDBTMTest.php
+++ b/phpunit/functional/CommonDBTMTest.php
@@ -949,7 +949,7 @@ class CommonDBTMTest extends DbTestCase
         $this->assertGreaterThan(0, count($DB->getTimezones()));
 
         //login with default TZ
-        $this->login();
+        $this->realLogin();
         //add a Computer with creation and update dates
         $comp = new \Computer();
         $cid = $comp->add([
@@ -970,7 +970,7 @@ class CommonDBTMTest extends DbTestCase
         $this->assertTrue($user->getFromDB($user->fields['id']));
         $this->assertSame('Europe/Paris', $user->fields['timezone']);
 
-        $this->login('glpi', 'glpi');
+        $this->realLogin('glpi', 'glpi');
         $this->assertTrue($comp->getFromDB($cid));
         $this->assertMatchesRegularExpression('/2019-03-04 1[12]:00:00/', $comp->fields['date_creation']);
     }

--- a/phpunit/functional/RuleRightTest.php
+++ b/phpunit/functional/RuleRightTest.php
@@ -111,7 +111,7 @@ class RuleRightTest extends DbTestCase
         ]);
 
         // login the user to force a real synchronisation and get it's glpi id
-        $this->login(TU_USER, TU_PASS, false);
+        $this->realLogin(TU_USER, TU_PASS, false);
         $users_id = \User::getIdByName(TU_USER);
         $this->assertGreaterThan(0, $users_id);
 
@@ -126,7 +126,7 @@ class RuleRightTest extends DbTestCase
             'value'       => -1, // Full structure
         ]);
 
-        $this->login(TU_USER, TU_PASS, false);
+        $this->realLogin(TU_USER, TU_PASS, false);
         $user->getFromDB($users_id);
         $this->assertEquals(null, $user->fields['entities_id']);
 
@@ -159,7 +159,7 @@ class RuleRightTest extends DbTestCase
         \SingletonRuleList::getInstance("RuleRight", 0)->list = [];
 
         // login again
-        $this->login(TU_USER, TU_PASS, false);
+        $this->realLogin(TU_USER, TU_PASS, false);
 
         // check the user got the entity/profiles assigned
         $pu = \Profile_User::getForUser($users_id, true);
@@ -188,7 +188,7 @@ class RuleRightTest extends DbTestCase
         ];
 
         $user = new \User();
-        $this->login();
+        $this->realLogin();
         $users_id = $user->add($testuser);
         $this->assertGreaterThan(0, $users_id);
 
@@ -202,7 +202,7 @@ class RuleRightTest extends DbTestCase
         $this->assertEquals(1, $right['is_default_profile']);
 
         // Log in to force rules right processing
-        $this->login($testuser['name'], $testuser['password'], false);
+        $this->realLogin($testuser['name'], $testuser['password'], false);
 
         // Get rights again, should not have changed
         $pu = \Profile_User::getForUser($users_id, true);
@@ -210,7 +210,7 @@ class RuleRightTest extends DbTestCase
         $right2 = array_pop($pu);
         $this->assertEquals($right, $right2);
 
-        $this->login();
+        $this->realLogin();
         // Change the $right profile, since this is the default profile it should
         // be fixed on next login
         $pu = new \Profile_User();
@@ -223,7 +223,7 @@ class RuleRightTest extends DbTestCase
         $this->assertEquals(1, $pu->fields['is_default_profile']);
         $this->assertEquals(1, $pu->fields['is_dynamic']);
 
-        $this->login($testuser['name'], $testuser['password'], false);
+        $this->realLogin($testuser['name'], $testuser['password'], false);
         $pu = \Profile_User::getForUser($users_id, true);
         $this->assertCount(1, $pu);
         $right3 = array_pop($pu);
@@ -232,9 +232,6 @@ class RuleRightTest extends DbTestCase
         unset($right['id']);
         unset($right3['id']);
         $this->assertEquals($right, $right3);
-
-        // Clean session
-        $this->login();
     }
 
     public function testDenyLogin()
@@ -273,7 +270,7 @@ class RuleRightTest extends DbTestCase
             ])
         );
 
-        $this->login(TU_USER, TU_PASS, true, false);
+        $this->realLogin(TU_USER, TU_PASS, true, false);
         $events = getAllDataFromTable('glpi_events', [
             'service' => 'login',
             'type' => 'system',
@@ -321,7 +318,7 @@ class RuleRightTest extends DbTestCase
         $this->assertEquals(null, $user->getField('language'));
 
         // login
-        $this->login(TU_USER, TU_PASS);
+        $this->realLogin(TU_USER, TU_PASS);
 
         // language from rule
         $user->getFromDBByName(TU_USER);


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.

## Description

Logging in cost a lot of test time, especially since most of the time we are not testing the login process itself but instead we just need a valid session for a given username.

I've changed the login session to do a "fake" logging that is much faster and added another `realLogin()` method that keep the original behavior for the few tests that actually do test the login feature.

With these changes:
![image](https://github.com/user-attachments/assets/6ffc1805-5bde-4002-8fe7-f00e6e1d4c12)

On another unrelated PR for comparison:
![image](https://github.com/user-attachments/assets/a7c70ba1-4fff-437b-8039-eb3c03f5b736)


