### PR TITLE
Fix dashboard night mode toggle

### DIFF
--- a/js/modules/Dashboard/Dashboard.js
+++ b/js/modules/Dashboard/Dashboard.js
@@ -253,7 +253,7 @@ class GLPIDashboard {
             if (!document.webkitIsFullScreen
                 && !document.mozFullScreen
                 && !document.msFullscreenElement) {
-                this.disableFullscreenMode();
+                this.removeFullscreenModeClass();
             }
         });
 
@@ -941,8 +941,7 @@ class GLPIDashboard {
     toggleFullscreenMode(fs_ctrl) {
         const fs_enabled = !fs_ctrl.hasClass('active');
 
-        this.element.toggleClass('fullscreen')
-            .find('.night-mode').toggle(fs_enabled);
+        this.element.toggleClass('fullscreen');
         fs_ctrl.toggleClass('active');
 
         // desactivate edit mode
@@ -958,13 +957,10 @@ class GLPIDashboard {
         }
     }
 
-    disableFullscreenMode() {
+    removeFullscreenModeClass() {
         this.element
             .removeClass('fullscreen')
-            .find('.night-mode').hide().end()
             .find('.toggle-fullscreen').removeClass('active');
-
-        GoOutFullscreen();
     }
 
     /**

--- a/tests/js/modules/Dashboard/Dashboard.test.js
+++ b/tests/js/modules/Dashboard/Dashboard.test.js
@@ -962,13 +962,6 @@ describe('Dashboard', () => {
         expect(window.GoOutFullscreen).not.toHaveBeenCalled();
     });
 
-    test('disableFullscreenMode', () => {
-        const dashboard = new GLPIDashboard({'rand': '12345'});
-        window.GoOutFullscreen = jest.fn().mockImplementation(() => {});
-        dashboard.disableFullscreenMode();
-        expect(window.GoOutFullscreen).toHaveBeenCalled();
-    });
-
     test('clone', async () => {
         const dashboard = new GLPIDashboard({
             'rand': '12345',


### PR DESCRIPTION
## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.

## Description

Fix #19644 (Dashboard dark mode icon disappear after fullscreen toggle).

Two fixes:
* I've removed the code that hide/move the night mode button (as it must always be always displayed, this code is not necessary. I guess the code was necessary when it was only shown inside the full screen mode in GLPI 10). 
* Removed the `disableFullscreenMode` method which didn't made sense. It was called when a browser event happened that indicated that the full screen mode was disabled and yet the code of the method itself try to exit the fullscreen mode again.
This triggered JS errors as `document.exitFullscreen()` crash when we have already existed fullscreen.
I've only kept the UI update (changing a class) and changed the name accordingly.

