### PR TITLE
Allow custom dropdowns ending with Model or Type

### DIFF
--- a/phpunit/functional/Glpi/Asset/AssetDefinitionTest.php
+++ b/phpunit/functional/Glpi/Asset/AssetDefinitionTest.php
@@ -37,7 +37,6 @@ namespace tests\units\Glpi\Asset;
 use Computer;
 use DbTestCase;
 use Glpi\Asset\AssetDefinition;
-use Glpi\Asset\AssetDefinitionManager;
 use Glpi\Asset\Capacity;
 use Glpi\Asset\Capacity\HasDocumentsCapacity;
 use Glpi\Asset\Capacity\HasInfocomCapacity;
@@ -299,7 +298,24 @@ class AssetDefinitionTest extends DbTestCase
             }
         }
 
-        foreach (AssetDefinitionManager::getInstance()->getReservedSystemNames() as $system_name) {
+        $reserved_names = [
+            'Computer',
+            'Monitor',
+            'Software',
+            'NetworkEquipment',
+            'Peripheral',
+            'Printer',
+            'Cartridge',
+            'Consumable',
+            'Phone',
+            'Rack',
+            'Enclosure',
+            'PDU',
+            'PassiveDCEquipment',
+            'Unmanaged',
+            'Cable',
+        ];
+        foreach ($reserved_names as $system_name) {
             // System name must not be a reserved name
             yield [
                 'input'    => [
@@ -308,7 +324,7 @@ class AssetDefinitionTest extends DbTestCase
                 'output'   => false,
                 'messages' => [
                     ERROR => [
-                        sprintf('The system name must not be the reserved word &quot;%s&quot;.', $system_name),
+                        'The system name is a reserved name.',
                     ],
                 ],
             ];

--- a/phpunit/functional/Glpi/Dropdown/DropdownDefinitionTest.php
+++ b/phpunit/functional/Glpi/Dropdown/DropdownDefinitionTest.php
@@ -36,7 +36,6 @@ namespace tests\units\Glpi\Dropdown;
 
 use DbTestCase;
 use Glpi\Dropdown\DropdownDefinition;
-use Glpi\Dropdown\DropdownDefinitionManager;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Profile;
 
@@ -239,7 +238,131 @@ class DropdownDefinitionTest extends DbTestCase
             }
         }
 
-        foreach (DropdownDefinitionManager::getInstance()->getReservedSystemNames() as $system_name) {
+        // Extracted from Dropdown::getStandardDropdownItemTypes()
+        $reserved_names = [
+            'Location',
+            'State',
+            'Manufacturer',
+            'Blacklist',
+            'BlacklistedMailContent',
+            'DefaultFilter',
+            'ITILCategory',
+            'TaskCategory',
+            'TaskTemplate',
+            'SolutionType',
+            'SolutionTemplate',
+            'ITILValidationTemplate',
+            'RequestType',
+            'ITILFollowupTemplate',
+            'ProjectState',
+            'ProjectType',
+            'ProjectTaskType',
+            'ProjectTaskTemplate',
+            'PlanningExternalEventTemplate',
+            'PlanningEventCategory',
+            'PendingReason',
+            'ComputerType',
+            'NetworkEquipmentType',
+            'PrinterType',
+            'MonitorType',
+            'PeripheralType',
+            'PhoneType',
+            'SoftwareLicenseType',
+            'CartridgeItemType',
+            'ConsumableItemType',
+            'ContractType',
+            'ContactType',
+            'DeviceGenericType',
+            'DeviceSensorType',
+            'DeviceMemoryType',
+            'SupplierType',
+            'InterfaceType',
+            'DeviceCaseType',
+            'PhonePowerSupply',
+            'Filesystem',
+            'CertificateType',
+            'BudgetType',
+            'DeviceSimcardType',
+            'LineType',
+            'RackType',
+            'PDUType',
+            'PassiveDCEquipmentType',
+            'ClusterType',
+            'DatabaseInstanceType',
+            'ComputerModel',
+            'NetworkEquipmentModel',
+            'PrinterModel',
+            'MonitorModel',
+            'PeripheralModel',
+            'PhoneModel',
+            'DeviceCameraModel',
+            'DeviceCaseModel',
+            'DeviceControlModel',
+            'DeviceDriveModel',
+            'DeviceGenericModel',
+            'DeviceGraphicCardModel',
+            'DeviceHardDriveModel',
+            'DeviceMemoryModel',
+            'DeviceMotherboardModel',
+            'DeviceNetworkCardModel',
+            'DevicePciModel',
+            'DevicePowerSupplyModel',
+            'DeviceProcessorModel',
+            'DeviceSoundCardModel',
+            'DeviceSensorModel',
+            'RackModel',
+            'EnclosureModel',
+            'PDUModel',
+            'PassiveDCEquipmentModel',
+            'VirtualMachineType',
+            'VirtualMachineSystem',
+            'VirtualMachineState',
+            'DocumentCategory',
+            'DocumentType',
+            'BusinessCriticity',
+            'DatabaseInstanceCategory',
+            'KnowbaseItemCategory',
+            'Calendar',
+            'Holiday',
+            'OperatingSystem',
+            'OperatingSystemVersion',
+            'OperatingSystemServicePack',
+            'OperatingSystemArchitecture',
+            'OperatingSystemEdition',
+            'OperatingSystemKernel',
+            'OperatingSystemKernelVersion',
+            'AutoUpdateSystem',
+            'NetworkInterface',
+            'Network',
+            'NetworkPortType',
+            'Vlan',
+            'LineOperator',
+            'DomainType',
+            'DomainRelation',
+            'DomainRecordType',
+            'NetworkPortFiberchannelType',
+            'CableType',
+            'CableStrand',
+            'IPNetwork',
+            'FQDN',
+            'WifiNetwork',
+            'NetworkName',
+            'SoftwareCategory',
+            'UserTitle',
+            'UserCategory',
+            'RuleRightParameter',
+            'Fieldblacklist',
+            'SsoVariable',
+            'Plug',
+            'ApplianceType',
+            'ApplianceEnvironment',
+            'ImageResolution',
+            'ImageFormat',
+            'USBVendor',
+            'PCIVendor',
+            'WebhookCategory',
+        ];
+        foreach ($reserved_names as $system_name) {
             // System name must not be a reserved name
             yield [
                 'input'    => [
@@ -248,7 +371,7 @@ class DropdownDefinitionTest extends DbTestCase
                 'output'   => false,
                 'messages' => [
                     ERROR => [
-                        sprintf('The system name must not be the reserved word &quot;%s&quot;.', $system_name),
+                        'The system name is a reserved name.',
                     ],
                 ],
             ];
@@ -320,19 +443,20 @@ class DropdownDefinitionTest extends DbTestCase
             ],
         ];
 
-        // System name must not end with `Model` suffix
+        // System name can end with `Model` suffix
         yield [
             'input'    => [
                 'system_name' => 'TestDropdownModel',
             ],
-            'output'   => false,
-            'messages' => [
-                ERROR => [
-                    'The system name must not end with the word &quot;Model&quot; or the word &quot;Type&quot;.',
-                ],
+            'output'   => [
+                'system_name'  => 'TestDropdownModel',
+                'label'        => 'TestDropdownModel',
+                'profiles'     => '[]',
+                'translations' => '[]',
             ],
+            'messages' => [],
         ];
-        // but system name can contains `Model`
+        // and can contain `Model`
         yield [
             'input'    => [
                 'system_name' => 'TestDropdownModeling',
@@ -346,19 +470,20 @@ class DropdownDefinitionTest extends DbTestCase
             'messages' => [],
         ];
 
-        // System name must not end with `Type` suffix
+        // System name can end with `Type` suffix
         yield [
             'input'    => [
                 'system_name' => 'TestDropdownType',
             ],
-            'output'   => false,
-            'messages' => [
-                ERROR => [
-                    'The system name must not end with the word &quot;Model&quot; or the word &quot;Type&quot;.',
-                ],
+            'output'   => [
+                'system_name'  => 'TestDropdownType',
+                'label'        => 'TestDropdownType',
+                'profiles'     => '[]',
+                'translations' => '[]',
             ],
+            'messages' => [],
         ];
-        // but system name can contains `Type`
+        // and can contain `Type`
         yield [
             'input'    => [
                 'system_name' => 'TestDropdownTyped',

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -1382,7 +1382,7 @@ HTML;
                     'ApplianceEnvironment' => null,
                 ],
                 DeviceCamera::getTypeName(1) => [
-                    'Resolution'     => null,
+                    'ImageResolution' => null,
                     'ImageFormat'  => null,
                 ],
                 __('Others') => [

--- a/src/Glpi/Asset/AssetDefinition.php
+++ b/src/Glpi/Asset/AssetDefinition.php
@@ -266,6 +266,16 @@ TWIG, $twig_params);
             }
         }
         $input = $this->managePictures($input);
+
+        if (\array_key_exists('system_name', $input) && preg_match('/(Model|Type)$/i', $input['system_name']) === 1) {
+            Session::addMessageAfterRedirect(
+                __s('The system name must not end with the word "Model" or the word "Type".'),
+                false,
+                ERROR
+            );
+            return false;
+        }
+
         return parent::prepareInputForAdd($input);
     }
 

--- a/src/Glpi/Asset/AssetDefinitionManager.php
+++ b/src/Glpi/Asset/AssetDefinitionManager.php
@@ -152,9 +152,9 @@ final class AssetDefinitionManager extends AbstractDefinitionManager
         return AssetDefinition::class;
     }
 
-    public function getReservedSystemNames(): array
+    public function getReservedSystemNamesPattern(): string
     {
-        $names = [
+        $core_assets = [
             'Computer',
             'Monitor',
             'Software',
@@ -172,9 +172,7 @@ final class AssetDefinitionManager extends AbstractDefinitionManager
             'Cable',
         ];
 
-        sort($names);
-
-        return $names;
+        return '/^(.+(Model|Type)|' . \implode('|', $core_assets) . ')$/i';
     }
 
     public function bootstrapDefinition(AbstractDefinition $definition): void

--- a/src/Glpi/CustomObject/AbstractDefinitionManager.php
+++ b/src/Glpi/CustomObject/AbstractDefinitionManager.php
@@ -55,10 +55,10 @@ abstract class AbstractDefinitionManager
     abstract public static function getDefinitionClass(): string;
 
     /**
-     * Returns the list of reserved system names
-     * @return array
+     * Returns the regex pattern of reserved system names
+     * @return string
      */
-    abstract public function getReservedSystemNames(): array;
+    abstract public function getReservedSystemNamesPattern(): string;
 
     /**
      * Register the class autoload function.

--- a/src/Glpi/Dropdown/DropdownDefinitionManager.php
+++ b/src/Glpi/Dropdown/DropdownDefinitionManager.php
@@ -76,16 +76,15 @@ final class DropdownDefinitionManager extends AbstractDefinitionManager
         return DropdownDefinition::class;
     }
 
-    public function getReservedSystemNames(): array
+    public function getReservedSystemNamesPattern(): string
     {
-        $standard_dropdowns = \Dropdown::getStandardDropdownItemTypes();
+        $standard_dropdowns = \Dropdown::getStandardDropdownItemTypes(check_rights: false);
         $core_dropdowns = [];
         foreach ($standard_dropdowns as $optgroup) {
             foreach (array_keys($optgroup) as $classname) {
                 if (
                     !is_subclass_of($classname, Dropdown::class)
                     && !isPluginItemType($classname)
-                    && preg_match('/(Model|Type)$/i', $classname) !== 1 // `*Model` and `*Type` patterns are already blacklisted
                 ) {
                     // Dropdown is not a custom one or from a plugin
                     $core_dropdowns[] = $classname;
@@ -93,7 +92,7 @@ final class DropdownDefinitionManager extends AbstractDefinitionManager
             }
         }
 
-        return $core_dropdowns;
+        return '/^(' . \implode('|', \array_map(fn($classname) => \preg_quote($classname, '/'), $core_dropdowns)) . ')$/i';
     }
 
     public function autoloadClass(string $classname): void

--- a/templates/pages/admin/customobjects/main.html.twig
+++ b/templates/pages/admin/customobjects/main.html.twig
@@ -135,14 +135,14 @@
             }
         });
         $('#mainformtable input[name="system_name"]').on('input', () => {
-            const reserved_names = {{ reserved_system_names|json_encode()|raw }}.map((n) => n.toLowerCase());
-            const existing_names = {{ existing_system_names|json_encode()|raw }}.map((n) => n.toLowerCase());
-            const system_name = $('#mainformtable input[name="system_name"]').val().toLowerCase();
+            const reserved_system_names_pattern = {{ reserved_system_names_pattern|raw }};
+            const existing_names = {{ existing_system_names|json_encode()|raw }};
+            const system_name = $('#mainformtable input[name="system_name"]').val();
             const system_name_pattern = /^{{ constant('Glpi\\CustomObject\\AbstractDefinition::SYSTEM_NAME_PATTERN')|raw }}$/;
 
-            if (reserved_names.includes(system_name) || system_name.endsWith('type') || system_name.endsWith('model')) {
+            if (reserved_system_names_pattern.test(system_name) === true) {
                 $('#mainformtable input[name="system_name"]').get(0).setCustomValidity(__('The system name is a reserved name. Please enter a different label or manually change the system name.'));
-            } else if (existing_names.includes(system_name)) {
+            } else if (existing_names.map((n) => n.toLowerCase()).includes(system_name.toLowerCase())) {
                 $('#mainformtable input[name="system_name"]').get(0).setCustomValidity(__('The system name is already in use. Please enter a different label or manually change the system name.'));
             } else if (system_name_pattern.test(system_name) === false) {
                 {# See pattern used in \Glpi\CustomObject\AbstractDefinition::prepareInput() #}


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

See #19658.

People may want to create custom dropdowns with names that ends with `Model` or `Type`. Allowing this does not seems to be a problem.

Allowing this for custom assets is also possible, but it requires to ensure it will not conflict with another definition, for instance, if you create a `CarModel` asset definition, it would conflict with a `Car` asset definition that automatically registers its `CarModel` asset model class. I have no time to do it for the moment, so I did not do this in the current PR.