### PR TITLE
Minor phpunit fixes

### DIFF
--- a/phpunit/bootstrap.php
+++ b/phpunit/bootstrap.php
@@ -85,7 +85,6 @@ if (file_exists(GLPI_CONFIG_DIR . DIRECTORY_SEPARATOR . CacheManager::CONFIG_FIL
 include_once __DIR__ . '/GLPITestCase.php';
 include_once __DIR__ . '/DbTestCase.php';
 include_once __DIR__ . '/CsvTestCase.php';
-include_once __DIR__ . '/APIBaseClass.php';
 include_once __DIR__ . '/FrontBaseClass.php';
 include_once __DIR__ . '/RuleBuilder.php';
 include_once __DIR__ . '/InventoryTestCase.php';

--- a/phpunit/functional/Glpi/Form/AnswersHandler/AnswersHandlerTest.php
+++ b/phpunit/functional/Glpi/Form/AnswersHandler/AnswersHandlerTest.php
@@ -61,7 +61,7 @@ class AnswersHandlerTest extends DbTestCase
 
     public function testSaveAnswers(): void
     {
-        self::login();
+        $this->login();
         $users_id = getItemByTypeName(User::class, TU_USER, true);
 
         // Fist form


### PR DESCRIPTION
## Description

Fix this error:
![image](https://github.com/user-attachments/assets/c35fd409-04ef-4a27-96fa-6432a261c54c)

Note sure what file it is supposed to include but it does not exist (no references to `ApiBaseClass` in the code base).

And a non static method being called statically in one test file.


