### PR TITLE
Fix(Purgelog): fix Software purge

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -3312,7 +3312,7 @@ HTML;
 
         echo "<tr class='tab_bg_1'><th colspan='4'>" . _n('Software', 'Software', Session::getPluralNumber()) . "</th></tr>";
         echo "<tr class='tab_bg_1'><td class='center'>" .
-           __("Installation/update/uninstallation of software on items") . "</td><td>";
+           __("Installation/uninstallation of software on items") . "</td><td>";
         self::showLogsInterval(
             'purge_item_software_install',
             $CFG_GLPI["purge_item_software_install"]

--- a/src/Config.php
+++ b/src/Config.php
@@ -3312,7 +3312,7 @@ HTML;
 
         echo "<tr class='tab_bg_1'><th colspan='4'>" . _n('Software', 'Software', Session::getPluralNumber()) . "</th></tr>";
         echo "<tr class='tab_bg_1'><td class='center'>" .
-           __("Installation/uninstallation of software on items") . "</td><td>";
+           __("Installation/update/uninstallation of software on items") . "</td><td>";
         self::showLogsInterval(
             'purge_item_software_install',
             $CFG_GLPI["purge_item_software_install"]

--- a/src/PurgeLogs.php
+++ b/src/PurgeLogs.php
@@ -97,7 +97,7 @@ class PurgeLogs extends CommonDBTM
                         Log::HISTORY_UNINSTALL_SOFTWARE,
                         Log::HISTORY_ADD_SUBITEM,
                         Log::HISTORY_UPDATE_SUBITEM,
-                        Log::HISTORY_DELETE_SUBITEM
+                        Log::HISTORY_DELETE_SUBITEM,
                     ],
                 ] + $month
             );

--- a/src/PurgeLogs.php
+++ b/src/PurgeLogs.php
@@ -95,7 +95,10 @@ class PurgeLogs extends CommonDBTM
                     'linked_action'   => [
                         Log::HISTORY_INSTALL_SOFTWARE,
                         Log::HISTORY_UNINSTALL_SOFTWARE,
-                    ],
+                        Log::HISTORY_ADD_SUBITEM,
+                        Log::HISTORY_UPDATE_SUBITEM,
+                        Log::HISTORY_DELETE_SUBITEM
+                    ]
                 ] + $month
             );
         }
@@ -120,8 +123,24 @@ class PurgeLogs extends CommonDBTM
             $DB->delete(
                 'glpi_logs',
                 [
-                    'itemtype'        => 'Software',
-                    'itemtype_link'   => 'SoftwareVersion',
+                    'OR' => [
+                        [
+                            'itemtype'        => 'Computer',
+                            'itemtype_link'   => 'Software',
+                        ],
+                        [
+                            'itemtype'        => 'Software',
+                            'itemtype_link'   => 'SoftwareVersion',
+                        ],
+                        [
+                            'itemtype'        => 'Software',
+                            'itemtype_link'   => 'Item_SoftwareVersion',
+                        ],
+                        [
+                            'itemtype'        => 'SoftwareVersion',
+                            'itemtype_link'   => 'Item_SoftwareVersion',
+                        ],
+                    ],
                     'linked_action'   => [
                         Log::HISTORY_ADD_SUBITEM,
                         Log::HISTORY_UPDATE_SUBITEM,

--- a/src/PurgeLogs.php
+++ b/src/PurgeLogs.php
@@ -98,7 +98,7 @@ class PurgeLogs extends CommonDBTM
                         Log::HISTORY_ADD_SUBITEM,
                         Log::HISTORY_UPDATE_SUBITEM,
                         Log::HISTORY_DELETE_SUBITEM
-                    ]
+                    ],
                 ] + $month
             );
         }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !37300

Fix Software purge

### `purge_item_software_install` option 

![image](https://github.com/user-attachments/assets/98a79738-4cf2-4bea-9c9d-cf1683ae0a35)


should remove entries where the `itemtype` matches one of the following: `Computer, Monitor, NetworkEquipment, Peripheral, Phone, or Printer`, as well as entries with `linked_action` **4** (`Log::HISTORY_INSTALL_SOFTWARE`) and **5** (`Log::HISTORY_UNINSTALL_SOFTWARE`).

However, some residual data remains in the database for `linked_action` types **17** (`Log::HISTORY_ADD_SUBITEM`), **18** (`Log::HISTORY_UPDATE_SUBITEM`), and **19** (`Log::HISTORY_DELETE_SUBITEM`).
For instance, at a client site, actions of type **4** and **5** are properly purged, but types **17**, **18**, and **19** remain in the database.

```sql
+----------+-------------------------------------------------------+---------------+-----------+
| itemtype | itemtype_link                                         | linked_action | row_count |
+----------+-------------------------------------------------------+---------------+-----------+
| Computer | Software                                              |            17 |  15538935 |
| Computer | Software                                              |            19 |  15221821 |
| Computer | Software                                              |            18 |   2004387 |
+----------+-------------------------------------------------------+---------------+-----------+
```

I have updated the label of the option to clarify that it also covers update actions.


### `purge_software_version_install` option 

![image](https://github.com/user-attachments/assets/ebb1f93e-1612-4320-b5ce-e46eb9c37865)

The purge mechanism correctly removes entries where `itemtype = 'Software'` and `itemtype_link = 'SoftwareVersion'` for `linked_action` types 17 (`Log::HISTORY_ADD_SUBITEM`) and 19 (`Log::HISTORY_DELETE_SUBITEM`).
However, residual entries remain in the database for the following combinations:

* `itemtype = 'Computer'` and `itemtype_link = 'Software'`
* `itemtype = 'Software'` and `itemtype_link = 'Item_SoftwareVersion'`
* `itemtype = 'SoftwareVersion'` and `itemtype_link = 'Item_SoftwareVersion'`

These entries do not appear to be handled by the current purge logic.


```sql
+-----------------+-------------------------------------------------------+---------------+-----------+
| itemtype        | itemtype_link                                         | linked_action | row_count |
+-----------------+-------------------------------------------------------+---------------+-----------+
| Software        | Item_SoftwareVersion                                  |            17 |  21465948 |
| SoftwareVersion | Item_SoftwareVersion                                  |            17 |  21461390 |
| Software        | Item_SoftwareVersion                                  |            19 |  15433831 |
| SoftwareVersion | Item_SoftwareVersion                                  |            19 |  15432020 |
| Software        | SoftwareVersion                                       |            17 |    557017 |
+-----------------+-------------------------------------------------------+---------------+-----------+
```

## Screenshots (if appropriate):


