### PR TITLE
Add search options for custom asset rights

### DIFF
--- a/phpunit/functional/ProfileTest.php
+++ b/phpunit/functional/ProfileTest.php
@@ -336,15 +336,11 @@ class ProfileTest extends DbTestCase
                 foreach ($groups as $group => $rights) {
                     $previous_right = null;
                     foreach ($rights as $right) {
-                        if (empty($right['field'])) {
-                            echo 'A right is missing a field name. Please check that the class has the rightname property set or the right is otherwise defined with the field property in the array';
-                            if ($previous_right) {
-                                echo 'The previous right was: ' . print_r($previous_right, true) . " in ${$interface}/${$form}/${$group}";
-                            } else {
-                                echo "The right was the first one in ${$interface}/${$form}/${$group}";
-                            }
-                            continue;
-                        }
+                        $failure_message = 'A right is missing a field name. Please check that the class has the rightname property set or the right is otherwise defined with the field property in the array.';
+                        $locator_message = $previous_right ?
+                            "The previous right was: " . print_r($previous_right, true) . " in {$interface}/{$form}/{$group}" :
+                            "The right was the first one in {$interface}/{$form}/{$group}";
+                        $this->assertNotEmpty($right['field'], $failure_message . ' ' . $locator_message);
                         $search_opt_matches = array_filter($search_opts, static function ($opt) use ($right) {
                             return array_key_exists('rightname', $opt) && $opt['rightname'] === $right['field'];
                         });
@@ -358,9 +354,6 @@ class ProfileTest extends DbTestCase
         }
 
         $failures = array_unique($failures);
-        if (count($failures)) {
-            echo sprintf('The following rights do not have a search option: %s', implode(', ', $failures));
-        }
-        $this->assertEmpty($failures);
+        $this->assertEmpty($failures, sprintf('The following rights do not have a search option: %s', implode(', ', $failures)));
     }
 }

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -42,6 +42,7 @@ use Glpi\Form\Form;
 use Glpi\Helpdesk\Tile\LinkableToTilesInterface;
 use Glpi\Helpdesk\Tile\TilesManager;
 use Glpi\RichText\UserMention;
+use Glpi\Search\SearchOption;
 use Glpi\Toolbox\ArrayNormalizer;
 
 /**
@@ -3744,6 +3745,24 @@ class Profile extends CommonDBTM implements LinkableToTilesInterface
                 'condition'          => ['NEWTABLE.name' => Form::$rightname],
             ],
         ];
+
+        // Add custom asset definition rights
+        foreach (AssetDefinitionManager::getInstance()->getDefinitions(true) as $definition) {
+            $asset = $definition->getAssetClassName();
+            $tab[] = [
+                'id'                 => SearchOption::generateAProbablyUniqueId($asset),
+                'table'              => 'glpi_profilerights',
+                'field'              => 'rights',
+                'name'               => $asset::getTypeName(1),
+                'datatype'           => 'right',
+                'rightclass'         => $asset,
+                'rightname'          => $asset::$rightname,
+                'joinparams'         => [
+                    'jointype'           => 'child',
+                    'condition'          => ['NEWTABLE.name' => $asset::$rightname],
+                ],
+            ];
+        }
 
         return $tab;
     }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

As noted in #14570, all profile rights should have a search option to ensure changes to them can be logged in the Profile's history. A check was added in the form of a test to ensure every right had a search option, but this didn't catch that custom asset rights were missing a search option because no custom asset definition existed in the test data.
