### PR TITLE
Wait for kanban to fully load before showing

### DIFF
--- a/js/src/vue/Kanban/Kanban.vue
+++ b/js/src/vue/Kanban/Kanban.vue
@@ -114,54 +114,6 @@
         }
     });
 
-    onMounted(() => {
-        emit('kanban:pre_init');
-        loadState().then(() => {
-            $(() => {
-                $.ajax({
-                    type: 'GET',
-                    url: CFG_GLPI.root_doc + '/ajax/kanban.php',
-                    data: {
-                        action: 'get_kanbans',
-                        itemtype: props.item.itemtype,
-                        items_id: props.item.items_id,
-                    }
-                }).then((kanbans) => {
-                    all_kanbans.value = kanbans;
-                    kanban_switcher.value = props.item.items_id <= 0 ? -1 : props.item.items_id;
-                });
-            });
-            filter_input = new SearchInput($(`#${props.element_id} input[name="filter"]`), {
-                allowed_tags: props.supported_filters,
-                on_result_change: (e, result) => {
-                    filters.value = {
-                        _text: ''
-                    };
-                    filters.value._text = result.getFullPhrase();
-                    result.getTaggedTerms().forEach(t => filters.value[t.tag] = {
-                        term: t.term || '',
-                        exclusion: t.exclusion || false,
-                        prefix: t.prefix
-                    });
-                },
-                tokenizer_options: {
-                    custom_prefixes: {
-                        '#': { // Regex prefix
-                            label: __('Regex'),
-                            token_color: '#00800080'
-                        }
-                    }
-                }
-            });
-            refreshSearchTokenizer();
-            refreshSortables();
-            initMutationObserver();
-            refresh(true);
-            backgroundRefresh();
-            emit('kanban:post_init');
-        });
-    });
-
     function initMutationObserver() {
         mutation_observer = new MutationObserver((records) => {
             records.forEach(r => {
@@ -1328,6 +1280,51 @@
         return ordered.filter((c) => c.visible !== false);
 
         return ordered;
+    });
+
+    emit('kanban:pre_init');
+    await loadState();
+    await $.ajax({
+        type: 'GET',
+        url: CFG_GLPI.root_doc + '/ajax/kanban.php',
+        data: {
+            action: 'get_kanbans',
+            itemtype: props.item.itemtype,
+            items_id: props.item.items_id,
+        }
+    }).then((kanbans) => {
+        all_kanbans.value = kanbans;
+        kanban_switcher.value = props.item.items_id <= 0 ? -1 : props.item.items_id;
+    });
+    filter_input = new SearchInput($(`#${props.element_id} input[name="filter"]`), {
+        allowed_tags: props.supported_filters,
+        on_result_change: (e, result) => {
+            filters.value = {
+                _text: ''
+            };
+            filters.value._text = result.getFullPhrase();
+            result.getTaggedTerms().forEach(t => filters.value[t.tag] = {
+                term: t.term || '',
+                exclusion: t.exclusion || false,
+                prefix: t.prefix
+            });
+        },
+        tokenizer_options: {
+            custom_prefixes: {
+                '#': { // Regex prefix
+                    label: __('Regex'),
+                    token_color: '#00800080'
+                }
+            }
+        }
+    });
+    refreshSearchTokenizer();
+    refreshSortables();
+    await refresh(true);
+    backgroundRefresh();
+    onMounted(() => {
+        initMutationObserver();
+        emit('kanban:post_init');
     });
 </script>
 

--- a/js/src/vue/Kanban/KanbanApp.vue
+++ b/js/src/vue/Kanban/KanbanApp.vue
@@ -1,0 +1,18 @@
+<script setup>
+    import Kanban from "./Kanban.vue";
+</script>
+
+<template>
+    <Suspense>
+        <Kanban v-bind="$attrs"></Kanban>
+        <template #fallback>
+            <div class="d-flex justify-content-center align-items-center h-100">
+                <div class="spinner-border" role="status" aria-hidden="true"></div>
+            </div>
+        </template>
+    </Suspense>
+</template>
+
+<style scoped>
+
+</style>

--- a/templates/components/kanban/kanban.html.twig
+++ b/templates/components/kanban/kanban.html.twig
@@ -56,7 +56,7 @@
 <script>
    $(function(){
       // Create Kanban
-      window.Vue.createApp(window.Vue.components['Kanban/Kanban'].component, {
+      window.Vue.createApp(window.Vue.components['Kanban/KanbanApp'].component, {
           element_id: '{{ kanban_id|default('kanban') }}',
           rights: {{ rights|json_encode|raw }},
           supported_itemtypes: {{ supported_itemtypes|json_encode|raw }},


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

A quick UX win for the Kanban especially for larger global Kanbans and slow network connections. Currently, the Kanban is shown immediately before the extra needed data is loaded. The Kanban switcher dropdown is empty and an info message is shown saying there are no columns in the view. Then the switcher content loads, followed by the columns.

By wrapping the Kanban in another component using `<Suspense>` and moving the loading function calls to be top-level awaits in `<Kanban>`, we can show a loading indicator and then show the Kanban when it is fully ready.