### PR TITLE
[HLAPI] Expanded permission checks

### DIFF
--- a/phpunit/functional/Glpi/Api/HL/Controller/GraphQLControllerTest.php
+++ b/phpunit/functional/Glpi/Api/HL/Controller/GraphQLControllerTest.php
@@ -34,6 +34,7 @@
 
 namespace tests\units\Glpi\Api\HL\Controller;
 
+use Glpi\Api\HL\Middleware\InternalAuthMiddleware;
 use Glpi\Http\Request;
 
 class GraphQLControllerTest extends \HLAPITestCase
@@ -229,5 +230,59 @@ GRAPHQL);
                     $this->assertFalse($content['data']['Computer'][0]['status']['visibilities']['monitor']);
                 });
         });
+    }
+
+    public function testGetTicketDirectlyWithoutRight()
+    {
+        /** @var \DBmysql $DB */
+        global $DB;
+
+        $this->assertTrue($DB->insert('glpi_tickets', [
+            'name' => __FUNCTION__,
+            'content' => __FUNCTION__,
+            'entities_id' => $this->getTestRootEntity(true),
+        ]));
+        $tickets_id = $DB->insertId();
+
+        $this->loginWeb();
+        $this->api->getRouter()->registerAuthMiddleware(new InternalAuthMiddleware());
+
+        $_SESSION['glpi_use_mode'] = 2;
+
+        // Can see no tickets
+        $_SESSION['glpiactiveprofile']['ticket'] = 0;
+        $this->api->call(new Request('POST', '/GraphQL', [], 'query { Ticket { id name } }'), function ($call) {
+            /** @var \HLAPICallAsserter $call */
+            $call->response
+                ->status(fn($status) => $this->assertEquals(200, $status))
+                ->jsonContent(function ($content) {
+                    $this->assertEmpty($content['data']['Ticket']);
+                });
+        });
+
+        // Can only see my own tickets
+        $_SESSION['glpiactiveprofile']['ticket'] = READ;
+
+        $this->api->call(new Request('POST', '/GraphQL', [], 'query { Ticket { id name } }'), function ($call) use ($tickets_id) {
+            /** @var \HLAPICallAsserter $call */
+            $call->response
+                ->status(fn($status) => $this->assertEquals(200, $status))
+                ->jsonContent(function ($content) use ($tickets_id) {
+                    $this->assertNotContains($tickets_id, array_column($content['data']['Ticket'], 'id'));
+                });
+        });
+        $this->api->call(new Request('POST', '/GraphQL', [], 'query { Ticket(id: ' . $tickets_id . ') { id name } }'), function ($call) {
+            /** @var \HLAPICallAsserter $call */
+            $call->response
+                ->status(fn($status) => $this->assertEquals(200, $status))
+                ->jsonContent(function ($content) {
+                    $this->assertEmpty($content['data']['Ticket']);
+                });
+        });
+    }
+
+    public function testGetTicketIndirectlyWithoutRight()
+    {
+        //TODO
     }
 }

--- a/phpunit/functional/Glpi/Api/HL/Controller/GraphQLControllerTest.php
+++ b/phpunit/functional/Glpi/Api/HL/Controller/GraphQLControllerTest.php
@@ -232,7 +232,7 @@ GRAPHQL);
         });
     }
 
-    public function testGetTicketDirectlyWithoutRight()
+    public function testGetDirectlyWithoutRight()
     {
         /** @var \DBmysql $DB */
         global $DB;

--- a/src/Change.php
+++ b/src/Change.php
@@ -59,10 +59,6 @@ class Change extends CommonITILObject
     public const IMPACT_MASK_FIELD             = 'impact_mask';
     public const STATUS_MATRIX_FIELD           = 'change_status';
 
-
-    public const READMY                        = 1;
-    public const READALL                       = 1024;
-
     // Specific status for changes
     public const EVALUATION             = 9;
     public const TEST                   = 11;

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -105,6 +105,8 @@ abstract class CommonITILObject extends CommonDBTM
     public const TIMELINE_ORDER_NATURAL = 'natural';
     public const TIMELINE_ORDER_REVERSE = 'reverse';
 
+    public const READMY           =      1;
+    public const READALL          =   1024;
     public const SURVEY           = 131072;
 
     abstract public static function getTaskClass();

--- a/src/Glpi/Api/HL/Controller/ITILController.php
+++ b/src/Glpi/Api/HL/Controller/ITILController.php
@@ -39,6 +39,7 @@ use Calendar;
 use Change;
 use ChangeTemplate;
 use CommonDBTM;
+use CommonITILActor;
 use CommonITILObject;
 use Entity;
 use Glpi\Api\HL\Doc as Doc;
@@ -54,6 +55,7 @@ use Group;
 use PlanningEventCategory;
 use PlanningExternalEventTemplate;
 use Problem;
+use Session;
 use Ticket;
 use TicketTemplate;
 use User;
@@ -201,6 +203,138 @@ final class ITILController extends AbstractController
         foreach ($itil_types as $itil_type) {
             $schemas[$itil_type] = $base_schema;
             $schemas[$itil_type]['x-version-introduced'] = '2.0';
+
+            $schemas[$itil_type]['x-rights-conditions'] = [
+                'read' => static function () use ($itil_type) {
+                    if (Session::haveRight($itil_type::$rightname, CommonITILObject::READALL)) {
+                        return true; // Can see all. No extra SQL conditions needed.
+                    }
+
+                    if ($itil_type !== Ticket::class) {
+                        if (Session::haveRight($itil_type::$rightname, CommonITILObject::READMY)) {
+                            $item = new $itil_type();
+                            $group_table = $item->grouplinkclass::getTable();
+                            $user_table = $item->userlinkclass::getTable();
+                            $criteria = [
+                                'LEFT JOIN' => [
+                                    $user_table => [
+                                        'ON' => [
+                                            $user_table => $itil_type::getForeignKeyField(),
+                                            '_' => 'id',
+                                        ],
+                                    ],
+                                ],
+                                'WHERE' => [
+                                    'OR' => [
+                                        '_.users_id_recipient' => Session::getLoginUserID(),
+                                        $user_table . '.users_id' => Session::getLoginUserID()
+                                    ],
+                                ],
+                            ];
+
+                            if (!empty($_SESSION['glpigroups'])) {
+                                $criteria['LEFT JOIN'][$group_table] = [
+                                    'ON' => [
+                                        $group_table => $itil_type::getForeignKeyField(),
+                                        '_' => 'id',
+                                    ],
+                                ];
+                                $criteria['WHERE']['OR'][$group_table . '.groups_id'] = $_SESSION['glpigroups'];
+                            }
+                            return $criteria;
+                        }
+                    } else {
+                        // Tickets have expanded permissions
+                        $criteria = [
+                            'LEFT JOIN' => [
+                                'glpi_tickets_users' => [
+                                    'ON' => [
+                                        'glpi_tickets_users' => Ticket::getForeignKeyField(),
+                                        '_' => 'id',
+                                    ],
+                                ],
+                                'glpi_groups_tickets' => [
+                                    'ON' => [
+                                        'glpi_groups_tickets' => Ticket::getForeignKeyField(),
+                                        '_' => 'id',
+                                    ],
+                                ],
+                            ],
+                            'WHERE' => ['OR' => []],
+                        ];
+                        if (Session::haveRight(Ticket::$rightname, CommonITILObject::READMY)) {
+                            // Permission to see tickets as direct requester, observer or writer
+                            $criteria['WHERE']['OR'][] = [
+                                '_.users_id_recipient' => Session::getLoginUserID(),
+                                [
+                                    'AND' => [
+                                        'glpi_tickets_users' . '.users_id' => Session::getLoginUserID(),
+                                        'glpi_tickets_users' . '.type' => [CommonITILActor::REQUESTER, CommonITILActor::OBSERVER],
+                                    ],
+                                ],
+                            ];
+                        }
+                        if (!empty($_SESSION['glpigroups']) && Session::haveRight(Ticket::$rightname, Ticket::READGROUP)) {
+                            // Permission to see tickets as requester or observer group member
+                            $criteria['WHERE']['OR'][] = [
+                                'AND' => [
+                                    'glpi_groups_tickets.groups_id' => $_SESSION['glpigroups'],
+                                    'glpi_groups_tickets.type' => [CommonITILActor::REQUESTER, CommonITILActor::OBSERVER],
+                                ],
+                            ];
+                        }
+
+                        if (Session::haveRight(Ticket::$rightname, Ticket::OWN) || Session::haveRight(Ticket::$rightname, Ticket::READASSIGN)) {
+                            $criteria['WHERE']['OR'][] = [
+                                'AND' => [
+                                    'glpi_tickets_users' . '.users_id' => Session::getLoginUserID(),
+                                    'glpi_tickets_users' . '.type' => CommonITILActor::ASSIGN,
+                                ],
+                            ];
+                        }
+                        if (Session::haveRight(Ticket::$rightname, Ticket::READASSIGN)) {
+                            $criteria['WHERE']['OR'][] = [
+                                'AND' => [
+                                    'glpi_groups_tickets.groups_id' => $_SESSION['glpigroups'],
+                                    'glpi_groups_tickets.type' => CommonITILActor::ASSIGN,
+                                ],
+                            ];
+                        }
+                        if (Session::haveRight(Ticket::$rightname, Ticket::READNEWTICKET)) {
+                            $criteria['WHERE']['OR'][] = [
+                                '_.status' => CommonITILObject::INCOMING,
+                            ];
+                        }
+
+                        if (
+                            Session::haveRightsOr(
+                                'ticketvalidation',
+                                [\TicketValidation::VALIDATEINCIDENT,
+                                    \TicketValidation::VALIDATEREQUEST,
+                                ]
+                            )
+                        ) {
+                            $criteria['OR'][] = [
+                                'AND' => [
+                                    "glpi_ticketvalidations.itemtype_target" => User::class,
+                                    "glpi_ticketvalidations.items_id_target" => Session::getLoginUserID(),
+                                ],
+                            ];
+                            if (count($_SESSION['glpigroups'])) {
+                                $criteria['OR'][] = [
+                                    'AND' => [
+                                        "glpi_ticketvalidations.itemtype_target" => Group::class,
+                                        "glpi_ticketvalidations.items_id_target" => $_SESSION['glpigroups'],
+                                    ],
+                                ];
+                            }
+                        }
+                        return empty($criteria['WHERE']['OR']) ? false : $criteria;
+                    }
+                    return false; // Cannot see anything.
+                },
+            ];
+
             if ($itil_type === Ticket::class) {
                 $schemas[$itil_type]['properties']['type'] = [
                     'type' => Doc\Schema::TYPE_INTEGER,

--- a/src/Glpi/Api/HL/GraphQL.php
+++ b/src/Glpi/Api/HL/GraphQL.php
@@ -104,6 +104,10 @@ final class GraphQL
     {
         $is_schema_array = array_key_exists('items', $schema) && !array_key_exists('properties', $schema);
         $itemtype = self::getSchemaItemtype($schema, $api_version);
+        if (is_subclass_of($itemtype, \CommonDBTM::class) && !$itemtype::canView()) {
+            // Cannot view this itemtype so we shouldn't expand it further
+            return $schema;
+        }
         if ($is_schema_array) {
             $properties = $schema['items']['properties'];
         } else {

--- a/src/Glpi/Api/HL/GraphQL.php
+++ b/src/Glpi/Api/HL/GraphQL.php
@@ -36,6 +36,7 @@
 namespace Glpi\Api\HL;
 
 use Glpi\Http\Request;
+use GraphQL\Error\Error;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Utils\BuildSchema;
 
@@ -55,6 +56,7 @@ final class GraphQL
         $query = (string) $request->getBody();
         $generator = new GraphQLGenerator($api_version);
         $schema_str = $generator->getSchema();
+
         try {
             $result = \GraphQL\GraphQL::executeQuery(
                 schema: BuildSchema::build($schema_str),
@@ -75,10 +77,17 @@ final class GraphQL
                         $completed_schema = self::expandSchemaFromRequestedFields($schema, $field_selection, null, $api_version);
 
                         if (isset($args['id'])) {
-                            $result = json_decode(Search::getOneBySchema($completed_schema, ['id' => $args['id']], [])->getBody(), true);
-                            return [$result];
+                            $result = Search::getOneBySchema($completed_schema, ['id' => $args['id']], []);
+                            if ($result->getStatusCode() !== 200) {
+                                throw new Error($result->getBody());
+                            }
+                            return [json_decode($result->getBody(), true)];
                         }
-                        return json_decode(Search::searchBySchema($completed_schema, $args)->getBody(), true);
+                        $result = Search::searchBySchema($completed_schema, $args);
+                        if ($result->getStatusCode() !== 200) {
+                            throw new Error($result->getBody());
+                        }
+                        return json_decode($result->getBody(), true);
                     }
 
                     return $source[$info->fieldName] ?? null;

--- a/src/Glpi/Api/HL/RightConditionNotMetException.php
+++ b/src/Glpi/Api/HL/RightConditionNotMetException.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Api\HL;
+
+/**
+ * An exception thrown specifically when a right condition is known to be a failure without needing to perform any SQL query.
+ * For example, if a user has no Ticket permission then we know they cannot read any Tickets.
+ * Instead of performing a SQL query with a condition that always resolve to no records, we can fail-fast and use an empty iterator result.
+ */
+class RightConditionNotMetException extends APIException {}

--- a/src/Glpi/Api/HL/Search.php
+++ b/src/Glpi/Api/HL/Search.php
@@ -115,7 +115,8 @@ final class Search
             }
             throw new APIException(
                 message: 'A SQL error occured while trying to get data from the database',
-                user_message: $message
+                user_message: $message,
+                code: 500
             );
         }
     }
@@ -479,7 +480,11 @@ final class Search
                 $direction = strtoupper($sort_parts[1] ?? 'ASC') === 'DESC' ? 'DESC' : 'ASC';
                 // Verify the property is valid
                 if (!isset($this->flattened_properties[$property])) {
-                    throw new APIException('Invalid property for sorting: ' . $property, 'Invalid property for sorting: ' . $property);
+                    throw new APIException(
+                        message: 'Invalid property for sorting: ' . $property,
+                        user_message: 'Invalid property for sorting: ' . $property,
+                        code: 400
+                    );
                 }
                 $sql_field = $this->getSQLFieldForProperty($property);
                 $orderby[] = "{$sql_field} {$direction}";
@@ -526,12 +531,16 @@ final class Search
      * If the schema has a read right condition, add it to the criteria.
      * @param array $criteria The current criteria. Will be modified in-place.
      * @return void
+     * @throws RightConditionNotMetException If the read condition check returns false indicating we know the user cannot view any of the resources without needing to check the database.
      */
     private function addReadRestrictCriteria(array &$criteria): void
     {
         $read_right_criteria = $this->schema['x-rights-conditions']['read'] ?? [];
         if (is_callable($read_right_criteria)) {
             $read_right_criteria = $read_right_criteria();
+        }
+        if ($read_right_criteria === false) {
+            throw new RightConditionNotMetException();
         }
         if (!empty($read_right_criteria)) {
             $join_types = ['LEFT JOIN', 'INNER JOIN', 'RIGHT JOIN'];
@@ -639,29 +648,37 @@ final class Search
 
         $criteria['FROM'] = $this->getFrom($criteria);
 
-        if ($this->union_search_mode) {
-            unset($criteria['LEFT JOIN'], $criteria['INNER JOIN'], $criteria['RIGHT JOIN'], $criteria['WHERE']);
-        } else {
-            $this->addReadRestrictCriteria($criteria);
-        }
-
-        $criteria['SELECT'] = ['_.id'];
-        if ($this->union_search_mode) {
-            $criteria['SELECT'][] = '_itemtype';
-            $criteria['GROUPBY'] = ['_itemtype', '_.id'];
-        } else {
-            foreach ($this->joins as $join_alias => $join) {
-                $s = $this->getSelectCriteriaForProperty($this->getPrimaryKeyPropertyForJoin($join_alias), true);
-                if ($s !== null) {
-                    $criteria['SELECT'][] = $s;
-                }
+        try {
+            if ($this->union_search_mode) {
+                unset($criteria['LEFT JOIN'], $criteria['INNER JOIN'], $criteria['RIGHT JOIN'], $criteria['WHERE']);
+            } else {
+                $this->addReadRestrictCriteria($criteria);
             }
-            $criteria['GROUPBY'] = ['_.id'];
-        }
 
-        // request just to get the ids/union itemtypes
-        $iterator = $this->db_read->request($criteria);
-        $this->validateIterator($iterator);
+            $criteria['SELECT'] = ['_.id'];
+            if ($this->union_search_mode) {
+                $criteria['SELECT'][] = '_itemtype';
+                $criteria['GROUPBY'] = ['_itemtype', '_.id'];
+            } else {
+                foreach ($this->joins as $join_alias => $join) {
+                    $s = $this->getSelectCriteriaForProperty($this->getPrimaryKeyPropertyForJoin($join_alias), true);
+                    if ($s !== null) {
+                        $criteria['SELECT'][] = $s;
+                    }
+                }
+                $criteria['GROUPBY'] = ['_.id'];
+            }
+
+            // request just to get the ids/union itemtypes
+            $iterator = $this->db_read->request($criteria);
+            $this->validateIterator($iterator);
+        } catch (RightConditionNotMetException) {
+            // The read restrict check seems to have returned false indicating that we already know the user cannot view any of these resources
+            /** @var \DBmysql $DB */
+            global $DB;
+            $iterator = new \DBmysqlIterator($DB);
+            // No validation done because we know the inner result isn't a mysqli result
+        }
 
         if ($this->union_search_mode) {
             // group by _itemtype
@@ -1186,10 +1203,14 @@ final class Search
         } catch (RSQLException $e) {
             return new JSONResponse(AbstractController::getErrorResponseBody(AbstractController::ERROR_INVALID_PARAMETER, $e->getMessage(), $e->getDetails()), 400);
         } catch (APIException $e) {
-            return new JSONResponse(AbstractController::getErrorResponseBody(AbstractController::ERROR_GENERIC, $e->getUserMessage(), $e->getDetails()));
+            return new JSONResponse(AbstractController::getErrorResponseBody(AbstractController::ERROR_GENERIC, $e->getUserMessage(), $e->getDetails()), $e->getCode() ?: 400);
         } catch (\Throwable $e) {
             $message = (new APIException())->getUserMessage();
-            return new JSONResponse(AbstractController::getErrorResponseBody(AbstractController::ERROR_GENERIC, $message));
+            $detail = null;
+            if ($_SESSION['glpi_use_mode'] === \Session::DEBUG_MODE) {
+                $detail = $e->getMessage();
+            }
+            return new JSONResponse(AbstractController::getErrorResponseBody(AbstractController::ERROR_GENERIC, $message, $detail), 500);
         }
         $has_more = $results['start'] + $results['limit'] < $results['total'];
         $end = max(0, ($results['start'] + $results['limit'] - 1));
@@ -1330,10 +1351,10 @@ final class Search
         } catch (RSQLException $e) {
             return new JSONResponse(AbstractController::getErrorResponseBody(AbstractController::ERROR_INVALID_PARAMETER, $e->getUserMessage()), 400);
         } catch (APIException $e) {
-            return new JSONResponse(AbstractController::getErrorResponseBody(AbstractController::ERROR_GENERIC, $e->getUserMessage()));
+            return new JSONResponse(AbstractController::getErrorResponseBody(AbstractController::ERROR_GENERIC, $e->getUserMessage()), $e->getCode() ?: 400);
         } catch (\Throwable $e) {
             $message = (new APIException())->getUserMessage();
-            return new JSONResponse(AbstractController::getErrorResponseBody(AbstractController::ERROR_GENERIC, $message));
+            return new JSONResponse(AbstractController::getErrorResponseBody(AbstractController::ERROR_GENERIC, $message), 500);
         }
         if (count($results['results']) === 0) {
             return AbstractController::getNotFoundErrorResponse();

--- a/src/Problem.php
+++ b/src/Problem.php
@@ -60,9 +60,6 @@ class Problem extends CommonITILObject
     public const IMPACT_MASK_FIELD    = 'impact_mask';
     public const STATUS_MATRIX_FIELD  = 'problem_status';
 
-    public const READMY               = 1;
-    public const READALL              = 1024;
-
 
     /**
      * Name of the type

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -78,8 +78,6 @@ class Ticket extends CommonITILObject
     // Demand type
     public const DEMAND_TYPE   = 2;
 
-    public const READMY           =      1;
-    public const READALL          =   1024;
     public const READGROUP        =   2048;
     public const READASSIGN       =   4096;
     public const ASSIGN           =   8192;


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

This will address the last major blocker, AFIAK, with the new API for the stable GLPI 11 release.

Expand permission checks and some GraphQL handling:
- Add more item-level checks and more unit tests related to permissions.
- Rely on permission checking at the `Search` level instead of a middleware to account for permissions on indirectly requested itemtypes (GraphQL). For example this query is requesting Computers as the main itemtype, but also States which have different permissions:

```gql
query {
    Computer(limit: 10) {
        id
        status {
            name
            visibilities {
                computer
                monitor
            }
        }
    }
}
```
- Fix GraphQL response having `null` values at incorrect levels when missing permissions.
- Fix GraphQL response not including errors from the API.
- Prevent expanding the schemas of itemtypes the user cannot view. For example, if a user can view Computers but not "Statuses of items", the user can see the computer with the ID and Name of the status (included directly in the Computer schema), but none of the expanded properties from the State schema like `visibilities`.
- Add a "fast-fail" functionality to the read permission SQL restriction criteria. If a schema returns false for `x-rights-critieria['read']`, we know the user cannot view any of that itemtype so we can avoid querying the DB completely. This avoids sending a query with a condition like "1=0" which will resolve as false and return nothing anyways.
- Fix HTTP status codes used for some API error responses.

This was originally waiting for another PR which may have reduced duplication on the SQL criteria between the new API and the search engine but that is a complex thing to make generic enough, notably with the different table aliases being used, and it is too late to continue that work for GLPI 11.0.