### PR TITLE
Fix url validation with urlencoded chars

### DIFF
--- a/phpunit/functional/ToolboxTest.php
+++ b/phpunit/functional/ToolboxTest.php
@@ -1198,6 +1198,7 @@ HTML;
     {
         return [
             ['http://localhost', true],
+            ['ftp://localhost', false], // Only http and https protocol are supported
             ['https://localhost', true],
             ['https;//localhost', false],
             ['https://glpi-project.org', true],
@@ -1239,6 +1240,8 @@ HTML;
             ['https://localhost/front/computer.php?is_deleted=0&as_map=0&criteria[0][link]=AND&criteria[0][field]=80&criteria[0][searchtype]=equals&criteria[0][value]=254&search=Search&itemtype=Computer', true],
             ['https://localhost?test=true&#38;othertest=false', true], /* sanitized URL, &#38; is & */
             ['https://localhost/this+is+a+test', true], // + to denote a space allowed
+            ['https://localhost/withvadlidencoded%20', true],
+            ['https://localhost/withinvalidencoded%G1', false], // %G1 is not a valid html encoded value
         ];
     }
 

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -3562,8 +3562,8 @@ HTML;
     {
         // Based on https://github.com/symfony/symfony/blob/7.3/src/Symfony/Component/Validator/Constraints/UrlValidator.php
         $pattern = '~^
-            (https?)://                                 # protocol
-            (((?:[\_\.\pL\pN-]|%%[0-9A-Fa-f]{2})+:)?((?:[\_\.\pL\pN-]|%%[0-9A-Fa-f]{2})+)@)?  # basic auth
+            (http|https)://                                 # protocol
+            (((?:[\_\.\pL\pN-]|%[0-9A-Fa-f]{2})+:)?((?:[\_\.\pL\pN-]|%[0-9A-Fa-f]{2})+)@)?  # basic auth
             (
                 (?:
                     (?:xn--[a-z0-9-]++\.)*+xn--[a-z0-9-]++            # a domain name using punycode
@@ -3580,10 +3580,12 @@ HTML;
                 \]  # an IPv6 address
             )
             (:[0-9]+)?                              # a port (optional)
-            (?:/ (?:[\pL\pN\pS\pM\-._\~!$&\'()*+,;=:@]|%%[0-9A-Fa-f]{2})* )*    # a path
-            (?:\? (?:[\pL\pN\-._\~!$&\'\[\]()*+,;=:@/?]|%%[0-9A-Fa-f]{2})* )?   # a query (optional)
-            (?:\# (?:[\pL\pN\-._\~!$&\'()*+,;=:@/?]|%%[0-9A-Fa-f]{2})* )?       # a fragment (optional)
+            (?:/ (?:[\pL\pN\pS\pM\-._\~!$&\'()*+,;=:@]|%[0-9A-Fa-f]{2})* )*    # a path
+            (?:\? (?:[\pL\pN\-._\~!$&\'\[\]()*+,;=:@/?]|%[0-9A-Fa-f]{2})* )?   # a query (optional)
+            (?:\# (?:[\pL\pN\-._\~!$&\'()*+,;=:@/?]|%[0-9A-Fa-f]{2})* )?       # a fragment (optional)
         $~ixuD';
+
+
         return (preg_match(
             $pattern,
             Sanitizer::unsanitize($url)


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Fix #19634.

Url containing urlencoded values were marked as invalid by the `Toolbox::isValidWebUrl()` method.

The original regex was copied from Symfony: https://github.com/symfony/symfony/blob/7.3/src/Symfony/Component/Validator/Constraints/UrlValidator.php#L24.
It does not work for GLPI because we don't process it the same way.

Symfony use it in a `sprintf` call so it require the `%` char to be escaped as `%%`.
Since we do not call sprint on the value, the `%%` char is never replaced by `%` on our side which lead to a regex that can't detect url encoded values such as `%20` (it looks for `%%20` instead).

Fixed by replaced the `%%` occurrences by `%`.

In this future, it would be better to require the dependency and use it directly rather than manually copying its internal behavior (but I do not want to make this change on a minor release to be safe).
