### PR TITLE
Fix supplier tooltip card

### DIFF
--- a/ajax/comments.php
+++ b/ajax/comments.php
@@ -115,6 +115,36 @@ if (
             echo($tmpname["comment"]);
             break;
 
+        case Supplier::getType():
+            $tmpname = [
+                'comment' => "",
+            ];
+            if ($_POST['value'] != 0) {
+                $supplier = new \Supplier();
+                if (!is_array($_POST["value"]) && $supplier->getFromDB($_POST['value']) && $supplier->canView()) {
+                    $supplier_params = [
+                        'id' => $supplier->getID(),
+                        'supplier_name' => $supplier->fields['name'],
+                        'comment' => $supplier->fields['comment'],
+                        'address' => $supplier->fields['address'],
+                        'postcode' => $supplier->fields['postcode'],
+                        'town' => $supplier->fields['town'],
+                        'email' => $supplier->fields['email'],
+                        'fax' => $supplier->fields['fax'],
+                        'registration_number' => $supplier->fields['registration_number'],
+                        'phonenumber' => $supplier->fields['phonenumber'],
+                    ];
+                    $comment = TemplateRenderer::getInstance()->render('components/supplier/info_card.html.twig', [
+                        'supplier' => $supplier_params,
+                    ]);
+                    $tmpname = [
+                        'comment' => $comment,
+                    ];
+                }
+            }
+            echo($tmpname["comment"]);
+            break;
+
         default:
             if ($_POST["value"] > 0) {
                 if (

--- a/templates/components/itilobject/actors/field.html.twig
+++ b/templates/components/itilobject/actors/field.html.twig
@@ -201,6 +201,23 @@
             });
          }
 
+         if (is_selection && itemtype == "Supplier") {
+            const unique_id = "supplier_opt_" + actor_select.attr('data-actor-type') + "Supplier" + items_id;
+            $.ajax({
+               url: '{{ path('/ajax/comments.php') }}',
+               type: 'POST',
+               data: {
+                  'itemtype': 'Supplier',
+                  'value': items_id,
+               }
+            }).then((result) => {
+               if (result) {
+                  actor_select.parent().append('<' + `div id="content${unique_id}" style="display: none;">` + result + '<' + '/div>');
+                  option_element.attr('data-glpi-popover-source', `content${unique_id}`);
+               }
+            });
+         }
+
          // manage ticket information (number of assigned ticket for an actor)
          if (is_selection && itemtype != "Email") {
             var label = '';
@@ -320,6 +337,10 @@
             }
             // prevent closing popover when group card is hover
             if ($('.group-info-card:hover').length > 0) {
+               return false;
+            }
+            // prevent closing popover when supplier card is hover
+            if ($('.supplier-info-card:hover').length > 0) {
                return false;
             }
          });

--- a/templates/components/supplier/info_card.html.twig
+++ b/templates/components/supplier/info_card.html.twig
@@ -74,7 +74,7 @@
             {% if not supplier['address'] is empty or not supplier['town'] is empty or not supplier['postcode'] is empty %}
                 <div>
                     <i class="ti ti-home"></i>
-                    {% if not supplier['town'] is empty %}
+                    {% if not supplier['address'] is empty %}
                         {{ supplier['address'] }}
                     {% endif %}
                     {% if not supplier['town'] is empty %}

--- a/templates/components/supplier/info_card.html.twig
+++ b/templates/components/supplier/info_card.html.twig
@@ -1,0 +1,93 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2025 Teclib' and contributors.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+<div class="p-0 supplier-info-card">
+    <div class="row">
+        <h4 class="card-title mb-1">
+            {% if supplier['id'] %}
+                <a href="{{ 'Supplier'|itemtype_form_path(supplier['id']) }}">{{ supplier['supplier_name'] }}</a>
+            {% else %}
+                {{ supplier['supplier_name'] }}
+            {% endif %}
+        </h4>
+
+        <div class="text-muted">
+            {% if supplier['registration_number']|length > 0 %}
+                <div>
+                    <i class="ti ti-id-badge"></i>
+                    {{ supplier['registration_number'] }}
+                </div>
+            {% endif %}
+            {% if supplier['comment']|length > 0 %}
+                <div>
+                    <i class="ti ti-notes"></i>
+                    {{ supplier['comment'] }}
+                </div>
+            {% endif %}
+            {% if not supplier['phonenumber'] is empty %}
+                <div>
+                    <i class="ti ti-phone"></i>
+                    <a href="tel:{{ supplier['phonenumber'] }}">{{ supplier['phonenumber'] }}</a>
+                </div>
+            {% endif %}
+            {% if not supplier['email'] is empty %}
+                <div>
+                    <i class="ti ti-mail"></i>
+                    <a href="mailto:{{ supplier['email'] }}">{{ supplier['email'] }}</a>
+                </div>
+            {% endif %}
+            {% if not supplier['fax'] is empty %}
+                <div>
+                    <i class="ti ti-printer"></i>
+                    {{ supplier['fax'] }}
+                </div>
+            {% endif %}
+            {% if not supplier['address'] is empty or not supplier['town'] is empty or not supplier['postcode'] is empty %}
+                <div>
+                    <i class="ti ti-home"></i>
+                    {% if not supplier['town'] is empty %}
+                        {{ supplier['address'] }}
+                    {% endif %}
+                    {% if not supplier['town'] is empty %}
+                        {{ supplier['town'] }}
+                    {% endif %}
+                    {% if not supplier['address'] is empty and not supplier['town'] is empty and not supplier['postcode'] is empty %}
+                        -
+                    {% endif %}
+                    {% if not supplier['postcode'] is empty %}
+                            {{ supplier['postcode'] }}
+                    {% endif %}
+                </div>
+            {% endif %}
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !37627
- Here is a brief description of what this PR does
The tooltip map of suppliers has disappeared with the switch to 10, although it was visible in 9.5 in the past.

## Screenshots (if appropriate):
**GLPI 9.5**
![image](https://github.com/user-attachments/assets/663878bd-612d-472f-b153-66e075a1d91b)

**GLPI 10 before**
![image](https://github.com/user-attachments/assets/0da3945c-6518-4b47-88fc-089713968040)

**GLPI 10 after**
![image](https://github.com/user-attachments/assets/554b5dba-ca3f-46c5-996f-92c1f7e8c143)


