### PR TITLE
Clean constants handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -236,6 +236,7 @@ The present file will list all changes made to the project; according to the
 - `Software::merge()` method is now private.
 - The refusal of the collected emails corresponding to a GLPI notification will now be made based on a default rule.
 - The `$store_path` parameter has been removed from the `Dropdown::dropdownIcons()` method.
+- The `PLUGINS_DIRECTORIES` constant has been renamed to `GLPI_PLUGINS_DIRECTORIES`.
 
 #### Deprecated
 - Usage of the `/marketplace` path for plugins URLs. All plugins URLs should now start with `/plugins`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -240,6 +240,7 @@ The present file will list all changes made to the project; according to the
 #### Deprecated
 - Usage of the `/marketplace` path for plugins URLs. All plugins URLs should now start with `/plugins`.
 - Usage of `GLPI_PLUGINS_PATH` javascript variable.
+- Usage of the `GLPI_FORCE_MAIL` constant.
 - Usage of `MAIL_SMTPSSL` and `MAIL_SMTPTLS` constants.
 - Usage of `name` and `users_id_validate` parameter in `ajax/dropdownValidator.php`.
 - Usage of `users_id_validate` parameter in `front/commonitilvalidation.form.php`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -326,7 +326,7 @@ The present file will list all changes made to the project; according to the
 - `Toolbox::stripslashes_deep()`
 
 #### Removed
-- `GLPI_USE_CSRF_CHECK`, `GLPI_USE_IDOR_CHECK`, `GLPI_CSRF_EXPIRES`, `GLPI_CSRF_MAX_TOKENS` and `GLPI_IDOR_EXPIRES` constants.
+- `GLPI_USE_CSRF_CHECK`, `GLPI_USE_IDOR_CHECK`, `GLPI_KEEP_CSRF_TOKEN`, `GLPI_CSRF_EXPIRES`, `GLPI_CSRF_MAX_TOKENS` and `GLPI_IDOR_EXPIRES` constants.
 - `GLPI_DEMO_MODE` constant.
 - `GLPI_DUMP_DIR` constant.
 - `GLPI_SQL_DEBUG` constant.

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -46,9 +46,11 @@ parameters:
         - GLPI_NETWORK_SERVICES
         - GLPI_PICTURE_DIR
         - GLPI_PLUGIN_DOC_DIR
+        - GLPI_PLUGINS_DIRECTORIES
         - GLPI_RSS_DIR
         - GLPI_SERVERSIDE_URL_ALLOWLIST
         - GLPI_SESSION_DIR
+        - GLPI_SKIP_UPDATES
         - GLPI_STRICT_ENV
         - GLPI_SYSTEM_CRON
         - GLPI_TELEMETRY_URI
@@ -60,8 +62,6 @@ parameters:
         - GLPI_USER_AGENT_EXTRA_COMMENTS
         - GLPI_VAR_DIR
         - GLPI_WEBHOOK_ALLOW_RESPONSE_SAVING
-        - PLUGINS_DIRECTORIES
-        - SKIP_UPDATES
         - TU_USER
     ignoreErrors:
         - '~Instantiated class XHProfRuns_Default not found~'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -50,6 +50,7 @@ parameters:
         - GLPI_SERVERSIDE_URL_ALLOWLIST
         - GLPI_SESSION_DIR
         - GLPI_STRICT_ENV
+        - GLPI_SYSTEM_CRON
         - GLPI_TELEMETRY_URI
         - GLPI_TEXT_MAXSIZE
         - GLPI_THEMES_DIR

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -56,6 +56,7 @@ parameters:
         - GLPI_THEMES_DIR
         - GLPI_TMP_DIR
         - GLPI_UPLOAD_DIR
+        - GLPI_USE_CSRF_CHECK
         - GLPI_USER_AGENT_EXTRA_COMMENTS
         - GLPI_VAR_DIR
         - GLPI_WEBHOOK_ALLOW_RESPONSE_SAVING

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -59,6 +59,7 @@ parameters:
         - GLPI_VAR_DIR
         - GLPI_WEBHOOK_ALLOW_RESPONSE_SAVING
         - PLUGINS_DIRECTORIES
+        - SKIP_UPDATES
         - TU_USER
     ignoreErrors:
         - '~Instantiated class XHProfRuns_Default not found~'

--- a/src/CronTask.php
+++ b/src/CronTask.php
@@ -975,7 +975,7 @@ class CronTask extends CommonDBTM
             }
         }
         if (
-            defined('GLPI_SYSTEM_CRON')
+            GLPI_SYSTEM_CRON
             && ($input['allowmode'] & self::MODE_EXTERNAL)
             && !isset($input['mode'])
         ) {

--- a/src/DbUtils.php
+++ b/src/DbUtils.php
@@ -367,7 +367,7 @@ final class DbUtils
      *
      * @return string
      */
-    public function fixItemtypeCase(string $itemtype, $root_dir = GLPI_ROOT, array $plugins_dirs = PLUGINS_DIRECTORIES)
+    public function fixItemtypeCase(string $itemtype, $root_dir = GLPI_ROOT, array $plugins_dirs = GLPI_PLUGINS_DIRECTORIES)
     {
         /** @var \Psr\SimpleCache\CacheInterface $GLPI_CACHE */
         global $GLPI_CACHE;

--- a/src/Glpi/Application/Environment.php
+++ b/src/Glpi/Application/Environment.php
@@ -144,7 +144,7 @@ enum Environment: string
                     // calendar mockups
                     '/^file:\/\/.*\.ics$/',
                 ],
-                'PLUGINS_DIRECTORIES'           => [
+                'GLPI_PLUGINS_DIRECTORIES'      => [
                     $root_dir . '/plugins',
                     $root_dir . '/tests/fixtures/plugins',
                 ],

--- a/src/Glpi/Application/Environment.php
+++ b/src/Glpi/Application/Environment.php
@@ -133,6 +133,7 @@ enum Environment: string
             self::TESTING     => [
                 'GLPI_CONFIG_DIR'               => $root_dir . '/tests/config',
                 'GLPI_VAR_DIR'                  => $root_dir . '/tests/files',
+                'GLPI_LOG_LVL'                  => LogLevel::DEBUG,
                 'GLPI_STRICT_ENV'               => true,
                 'GLPI_SERVERSIDE_URL_ALLOWLIST' => [
                     // default allowlist entries
@@ -149,21 +150,10 @@ enum Environment: string
                 ],
             ],
             self::DEVELOPMENT => [
+                'GLPI_LOG_LVL'                       => LogLevel::DEBUG,
                 'GLPI_STRICT_ENV'                    => true,
                 'GLPI_WEBHOOK_ALLOW_RESPONSE_SAVING' => '1',
             ],
-        };
-    }
-
-    public function getLogLevel(): string
-    {
-        // Do not report debug, info, and notice messages unless in development/testing env.
-        // Notices are errors with no functional impact, so we do not want people to report them as issues.
-        // Suppressing the INFO level will prevent deprecations to be pushed in other environments logs.
-        return match ($this) {
-            default           => LogLevel::WARNING,
-            self::TESTING     => LogLevel::DEBUG,
-            self::DEVELOPMENT => LogLevel::DEBUG,
         };
     }
 

--- a/src/Glpi/Application/SystemConfigurator.php
+++ b/src/Glpi/Application/SystemConfigurator.php
@@ -39,6 +39,7 @@ use Glpi\Log\AccessLogHandler;
 use Glpi\Log\ErrorLogHandler;
 use Monolog\Logger;
 use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
 
 final class SystemConfigurator
 {
@@ -145,6 +146,7 @@ final class SystemConfigurator
 
                 // Constants dedicated to developers
                 'GLPI_DISABLE_ONLY_FULL_GROUP_BY_SQL_MODE' => '1', // '1' to disable ONLY_FULL_GROUP_BY 'sql_mode'
+                'GLPI_LOG_LVL'                             => LogLevel::WARNING,
                 'GLPI_STRICT_ENV'                          => false, // `true` to make environment more strict (strict variables in twig templates, etc)
 
                 // Other constants

--- a/src/Glpi/Application/SystemConfigurator.php
+++ b/src/Glpi/Application/SystemConfigurator.php
@@ -148,6 +148,7 @@ final class SystemConfigurator
                 'GLPI_DISABLE_ONLY_FULL_GROUP_BY_SQL_MODE' => '1', // '1' to disable ONLY_FULL_GROUP_BY 'sql_mode'
                 'GLPI_LOG_LVL'                             => LogLevel::WARNING,
                 'GLPI_STRICT_ENV'                          => false, // `true` to make environment more strict (strict variables in twig templates, etc)
+                'SKIP_UPDATES'                             => false, // `true` to bypass minor versions DB updates
 
                 // Other constants
                 'GLPI_AJAX_DASHBOARD'         => '1', // 1 for "multi ajax mode" 0 for "single ajax mode" (see Glpi\Dashboard\Grid::getCards)

--- a/src/Glpi/Application/SystemConfigurator.php
+++ b/src/Glpi/Application/SystemConfigurator.php
@@ -154,6 +154,7 @@ final class SystemConfigurator
                 'GLPI_AJAX_DASHBOARD'         => '1', // 1 for "multi ajax mode" 0 for "single ajax mode" (see Glpi\Dashboard\Grid::getCards)
                 'GLPI_CALDAV_IMPORT_STATE'    => 0, // external events created from a caldav client will take this state by default (0 = Planning::INFO)
                 'GLPI_CENTRAL_WARNINGS'       => '1', // display (1), or not (0), warnings on GLPI Central page
+                'GLPI_SYSTEM_CRON'            => false, // `true` to use the system cron provided by the downstream package
                 'GLPI_TEXT_MAXSIZE'           => '4000', // character threshold for displaying read more button
                 'GLPI_WEBHOOK_ALLOW_RESPONSE_SAVING' => '0', // allow (1) or not (0) to save webhook response in database
             ],

--- a/src/Glpi/Application/SystemConfigurator.php
+++ b/src/Glpi/Application/SystemConfigurator.php
@@ -100,7 +100,7 @@ final class SystemConfigurator
 
                 // Where to load plugins.
                 // Order in this array is important (priority to first found).
-                'PLUGINS_DIRECTORIES'  => [
+                'GLPI_PLUGINS_DIRECTORIES' => [
                     '{GLPI_MARKETPLACE_DIR}',
                     $this->root_dir . '/plugins',
                 ],
@@ -147,8 +147,8 @@ final class SystemConfigurator
                 // Constants dedicated to developers
                 'GLPI_DISABLE_ONLY_FULL_GROUP_BY_SQL_MODE' => '1', // '1' to disable ONLY_FULL_GROUP_BY 'sql_mode'
                 'GLPI_LOG_LVL'                             => LogLevel::WARNING,
+                'GLPI_SKIP_UPDATES'                        => false, // `true` to bypass minor versions DB updates
                 'GLPI_STRICT_ENV'                          => false, // `true` to make environment more strict (strict variables in twig templates, etc)
-                'SKIP_UPDATES'                             => false, // `true` to bypass minor versions DB updates
 
                 // Other constants
                 'GLPI_AJAX_DASHBOARD'         => '1', // 1 for "multi ajax mode" 0 for "single ajax mode" (see Glpi\Dashboard\Grid::getCards)

--- a/src/Glpi/Console/Application.php
+++ b/src/Glpi/Console/Application.php
@@ -252,7 +252,7 @@ class Application extends BaseApplication
 
         if (
             $is_db_available
-            && defined('SKIP_UPDATES')
+            && SKIP_UPDATES
             && (!($command instanceof GlpiCommandInterface) || $command->requiresUpToDateDb())
             && !Update::isDbUpToDate()
         ) {

--- a/src/Glpi/Console/Application.php
+++ b/src/Glpi/Console/Application.php
@@ -252,7 +252,7 @@ class Application extends BaseApplication
 
         if (
             $is_db_available
-            && SKIP_UPDATES
+            && GLPI_SKIP_UPDATES
             && (!($command instanceof GlpiCommandInterface) || $command->requiresUpToDateDb())
             && !Update::isDbUpToDate()
         ) {

--- a/src/Glpi/Console/CommandLoader.php
+++ b/src/Glpi/Console/CommandLoader.php
@@ -218,7 +218,7 @@ class CommandLoader implements CommandLoaderInterface
         }
 
         $plugins_directories = new AppendIterator();
-        foreach (PLUGINS_DIRECTORIES as $directory) {
+        foreach (GLPI_PLUGINS_DIRECTORIES as $directory) {
             $directory = str_replace(GLPI_ROOT, $this->rootdir, $directory);
             $plugins_directories->append(new DirectoryIterator($directory));
         }

--- a/src/Glpi/Console/Plugin/InstallCommand.php
+++ b/src/Glpi/Console/Plugin/InstallCommand.php
@@ -185,7 +185,7 @@ class InstallCommand extends AbstractPluginCommand
 
         // Fetch directory list
         $directories = [];
-        foreach (PLUGINS_DIRECTORIES as $plugins_directory) {
+        foreach (GLPI_PLUGINS_DIRECTORIES as $plugins_directory) {
             $directory_handle  = opendir($plugins_directory);
             while (false !== ($filename = readdir($directory_handle))) {
                 if (

--- a/src/Glpi/Error/ErrorHandler.php
+++ b/src/Glpi/Error/ErrorHandler.php
@@ -236,8 +236,7 @@ final class ErrorHandler extends BaseErrorHandler
         $reporting_level = E_ALL;
 
         // Compute max error level that should be reported
-        $env_psr_level = Environment::get()->getLogLevel();
-        $env_report_value = self::PSR_ERROR_LEVEL_VALUES[$env_psr_level];
+        $env_report_value = self::PSR_ERROR_LEVEL_VALUES[GLPI_LOG_LVL];
 
         foreach (self::ERROR_LEVEL_MAP as $value => $log_level) {
             $psr_level_value = self::PSR_ERROR_LEVEL_VALUES[$log_level];

--- a/src/Glpi/Http/Firewall.php
+++ b/src/Glpi/Http/Firewall.php
@@ -109,7 +109,7 @@ final class Firewall
     public function __construct(?string $root_dir = null, ?array $plugins_dirs = null)
     {
         $this->root_dir = $root_dir ?? GLPI_ROOT;
-        $this->plugins_dirs = $plugins_dirs ?? PLUGINS_DIRECTORIES;
+        $this->plugins_dirs = $plugins_dirs ?? GLPI_PLUGINS_DIRECTORIES;
     }
 
     /**

--- a/src/Glpi/Kernel/Listener/ControllerListener/CheckCsrfListener.php
+++ b/src/Glpi/Kernel/Listener/ControllerListener/CheckCsrfListener.php
@@ -76,12 +76,13 @@ final readonly class CheckCsrfListener implements EventSubscriberInterface
         }
 
         if ($request->isXmlHttpRequest()) {
-            // Keep CSRF token as many AJAX requests may be made at the same time.
-            // This is due to the fact that read operations are often made using POST method (see #277).
-            define('GLPI_KEEP_CSRF_TOKEN', true);
-
             // For AJAX requests, check CSRF token located into "X-Glpi-Csrf-Token" header.
-            Session::checkCSRF(['_glpi_csrf_token' => $request->server->get('HTTP_X_GLPI_CSRF_TOKEN') ?? '']);
+            Session::checkCSRF(
+                ['_glpi_csrf_token' => $request->server->get('HTTP_X_GLPI_CSRF_TOKEN') ?? ''],
+                // Keep CSRF token as many AJAX requests may be made at the same time.
+                // This is due to the fact that read operations are often made using POST method (see #277).
+                preserve_token: true
+            );
         } else {
             Session::checkCSRF($request->request->all());
         }

--- a/src/Glpi/Kernel/Listener/PostBootListener/SessionStart.php
+++ b/src/Glpi/Kernel/Listener/PostBootListener/SessionStart.php
@@ -51,7 +51,7 @@ final class SessionStart implements EventSubscriberInterface
     public function __construct(
         #[Autowire('%kernel.project_dir%')]
         string $glpi_root,
-        array $plugin_directories = PLUGINS_DIRECTORIES,
+        array $plugin_directories = GLPI_PLUGINS_DIRECTORIES,
     ) {
         $this->glpi_root = $glpi_root;
         $this->plugin_directories = $plugin_directories;

--- a/src/Glpi/Kernel/Listener/RequestListener/FrontEndAssetsListener.php
+++ b/src/Glpi/Kernel/Listener/RequestListener/FrontEndAssetsListener.php
@@ -51,7 +51,7 @@ final class FrontEndAssetsListener implements EventSubscriberInterface
     public function __construct(
         #[Autowire('%kernel.project_dir%')]
         string $glpi_root,
-        array $plugin_directories = PLUGINS_DIRECTORIES,
+        array $plugin_directories = GLPI_PLUGINS_DIRECTORIES,
     ) {
         $this->glpi_root = $glpi_root;
         $this->plugin_directories = $plugin_directories;

--- a/src/Glpi/Kernel/Listener/RequestListener/LegacyRouterListener.php
+++ b/src/Glpi/Kernel/Listener/RequestListener/LegacyRouterListener.php
@@ -53,7 +53,7 @@ final class LegacyRouterListener implements EventSubscriberInterface
     public function __construct(
         #[Autowire('%kernel.project_dir%')]
         string $glpi_root,
-        array $plugin_directories = PLUGINS_DIRECTORIES,
+        array $plugin_directories = GLPI_PLUGINS_DIRECTORIES,
     ) {
         $this->glpi_root = $glpi_root;
         $this->plugin_directories = $plugin_directories;

--- a/src/Glpi/Log/AbstractLogHandler.php
+++ b/src/Glpi/Log/AbstractLogHandler.php
@@ -34,19 +34,12 @@
 
 namespace Glpi\Log;
 
-use Glpi\Application\Environment;
 use Monolog\Handler\StreamHandler;
 
 abstract class AbstractLogHandler extends StreamHandler
 {
     public function __construct(string $logfile)
     {
-        if (\defined('GLPI_LOG_LVL')) {
-            $log_level = GLPI_LOG_LVL;
-        } else {
-            $log_level = Environment::get()->getLogLevel();
-        }
-
-        parent::__construct($logfile, $log_level);
+        parent::__construct($logfile, GLPI_LOG_LVL);
     }
 }

--- a/src/Glpi/Marketplace/Controller.php
+++ b/src/Glpi/Marketplace/Controller.php
@@ -309,7 +309,7 @@ class Controller extends CommonGLPI
 
         // Compute marketplace dir priority
         $marketplace_priority = null;
-        foreach (PLUGINS_DIRECTORIES as $position => $base_dir) {
+        foreach (GLPI_PLUGINS_DIRECTORIES as $position => $base_dir) {
             if (realpath($base_dir) !== false && realpath($base_dir) === realpath(GLPI_MARKETPLACE_DIR)) {
                 $marketplace_priority = -$position;
                 break;
@@ -318,7 +318,7 @@ class Controller extends CommonGLPI
 
         $found_outside_marketplace = false;
         $found_dir_priority        = null;
-        foreach (PLUGINS_DIRECTORIES as $position => $base_dir) {
+        foreach (GLPI_PLUGINS_DIRECTORIES as $position => $base_dir) {
             if (file_exists($base_dir . '/' . $this->plugin_key . '/setup.php')) {
                 $found_outside_marketplace = true;
                 $found_dir_priority = -$position;

--- a/src/NotificationEventMailing.php
+++ b/src/NotificationEventMailing.php
@@ -399,6 +399,7 @@ class NotificationEventMailing extends NotificationEventAbstract
 
                 $recipient = $current->getField('recipient');
                 if (defined('GLPI_FORCE_MAIL')) {
+                    Toolbox::deprecated('Usage of the `GLPI_FORCE_MAIL` constant is deprecated. Please use a mail catcher service instead.');
                     //force recipient to configured email address
                     $recipient = GLPI_FORCE_MAIL;
                     //add original email address to message body

--- a/src/NotificationMailing.php
+++ b/src/NotificationMailing.php
@@ -112,6 +112,7 @@ class NotificationMailing implements NotificationInterface
         $text = __('This is a test email.') . "\n-- \n" . $CFG_GLPI["mailing_signature"];
         $recipient = $CFG_GLPI['admin_email'];
         if (defined('GLPI_FORCE_MAIL')) {
+            Toolbox::deprecated('Usage of the `GLPI_FORCE_MAIL` constant is deprecated. Please use a mail catcher service instead.');
             //force recipient to configured email address
             $recipient = GLPI_FORCE_MAIL;
             //add original email address to message body

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -329,7 +329,7 @@ class Plugin extends CommonDBTM
     public static function load($plugin_key, $withhook = false)
     {
         $loaded = false;
-        foreach (PLUGINS_DIRECTORIES as $base_dir) {
+        foreach (GLPI_PLUGINS_DIRECTORIES as $base_dir) {
             if (!is_dir($base_dir)) {
                 continue;
             }
@@ -445,7 +445,7 @@ class Plugin extends CommonDBTM
 
         // New localisation system
         $mofile = false;
-        foreach (PLUGINS_DIRECTORIES as $base_dir) {
+        foreach (GLPI_PLUGINS_DIRECTORIES as $base_dir) {
             if (!is_dir($base_dir)) {
                 continue;
             }
@@ -564,7 +564,7 @@ class Plugin extends CommonDBTM
             $this->filesystem_plugin_keys = [];
 
             $plugins_directories = new AppendIterator();
-            foreach (PLUGINS_DIRECTORIES as $base_dir) {
+            foreach (GLPI_PLUGINS_DIRECTORIES as $base_dir) {
                 if (!is_dir($base_dir)) {
                     continue;
                 }
@@ -1771,7 +1771,7 @@ class Plugin extends CommonDBTM
             return false;
         }
 
-        foreach (PLUGINS_DIRECTORIES as $base_dir) {
+        foreach (GLPI_PLUGINS_DIRECTORIES as $base_dir) {
             if (!is_dir($base_dir)) {
                 continue;
             }
@@ -1844,7 +1844,7 @@ class Plugin extends CommonDBTM
      */
     public static function includeHook(string $plugin_key = "")
     {
-        foreach (PLUGINS_DIRECTORIES as $base_dir) {
+        foreach (GLPI_PLUGINS_DIRECTORIES as $base_dir) {
             if (file_exists("$base_dir/$plugin_key/hook.php")) {
                 include_once("$base_dir/$plugin_key/hook.php");
                 break;
@@ -2727,7 +2727,7 @@ TWIG;
     public static function getPhpDir(string $plugin_key = "", $full = true)
     {
         $directory = false;
-        foreach (PLUGINS_DIRECTORIES as $plugins_directory) {
+        foreach (GLPI_PLUGINS_DIRECTORIES as $plugins_directory) {
             if (is_dir("$plugins_directory/$plugin_key")) {
                 $directory = "$plugins_directory/$plugin_key";
                 break;

--- a/src/Session.php
+++ b/src/Session.php
@@ -1724,13 +1724,6 @@ class Session
      **/
     public static function checkCSRF($data, bool $preserve_token = false)
     {
-        if (defined('GLPI_USE_CSRF_CHECK')) {
-            trigger_error(
-                'Definition of "GLPI_USE_CSRF_CHECK" constant is deprecated and is ignore for security reasons.',
-                E_USER_WARNING
-            );
-        }
-
         if (!Session::validateCSRF($data, $preserve_token)) {
             $requested_url = ($_SERVER['REQUEST_URI'] ?? 'Unknown');
             $user_id = self::getLoginUserID() ?? 'Anonymous';

--- a/src/Session.php
+++ b/src/Session.php
@@ -1688,11 +1688,12 @@ class Session
      *
      * @since 0.83.3
      *
-     * @param array $data $_POST data
+     * @param array $data           $_POST data
+     * @param bool  $preserve_token Whether to preserve token after it has been validated.
      *
      * @return boolean
      **/
-    public static function validateCSRF($data)
+    public static function validateCSRF($data, bool $preserve_token = false)
     {
         Session::cleanCSRFTokens();
 
@@ -1701,7 +1702,7 @@ class Session
         }
         $requestToken = $data['_glpi_csrf_token'];
         if (isset($_SESSION['glpicsrftokens'][$requestToken])) {
-            if (!defined('GLPI_KEEP_CSRF_TOKEN')) { /* When post open a new windows */
+            if (!$preserve_token) {
                 unset($_SESSION['glpicsrftokens'][$requestToken]);
             }
             return true;
@@ -1716,11 +1717,12 @@ class Session
      *
      * @since 0.84.2
      *
-     * @param array $data $_POST data
+     * @param array $data           $_POST data
+     * @param bool  $preserve_token Whether to preserve token after it has been validated.
      *
      * @return void
      **/
-    public static function checkCSRF($data)
+    public static function checkCSRF($data, bool $preserve_token = false)
     {
         if (defined('GLPI_USE_CSRF_CHECK')) {
             trigger_error(
@@ -1729,7 +1731,7 @@ class Session
             );
         }
 
-        if (!Session::validateCSRF($data)) {
+        if (!Session::validateCSRF($data, $preserve_token)) {
             $requested_url = ($_SERVER['REQUEST_URI'] ?? 'Unknown');
             $user_id = self::getLoginUserID() ?? 'Anonymous';
             Toolbox::logInFile('access-errors', "CSRF check failed for User ID: $user_id at $requested_url\n");

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -2091,7 +2091,7 @@ class Toolbox
         $default_lang_weight = 1;
         $cron_config_weight = 1;
         $number_of_steps += $init_form_weight + $init_rules_weight + $generate_keys_weight + $default_lang_weight;
-        if (defined('GLPI_SYSTEM_CRON')) {
+        if (GLPI_SYSTEM_CRON) {
             $number_of_steps += $cron_config_weight;
         }
 
@@ -2175,7 +2175,7 @@ class Toolbox
         }
         $progress_indicator?->advance($default_lang_weight);
 
-        if (defined('GLPI_SYSTEM_CRON')) {
+        if (GLPI_SYSTEM_CRON) {
             // Downstream packages may provide a good system cron
             $database->update(
                 'glpi_crontasks',

--- a/src/Update.php
+++ b/src/Update.php
@@ -246,7 +246,7 @@ class Update
             + $structure_check_weight
             + $post_update_weight
             + $generate_keys_weight;
-        if (defined('GLPI_SYSTEM_CRON')) {
+        if (GLPI_SYSTEM_CRON) {
             $number_of_steps += $cron_config_weight;
         }
 
@@ -344,7 +344,7 @@ class Update
 
         $progress_indicator?->setProgressBarMessage(__('Finalizing the update…'));
 
-        if (defined('GLPI_SYSTEM_CRON')) {
+        if (GLPI_SYSTEM_CRON) {
             // Downstream packages may provide a good system cron
             $DB->update(
                 'glpi_crontasks',

--- a/src/Update.php
+++ b/src/Update.php
@@ -544,7 +544,7 @@ class Update
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        if (defined('SKIP_UPDATES')) {
+        if (SKIP_UPDATES) {
             // If `SKIP_UPDATES`, bugfixes update are not mandatory.
             $installed_intermediate_version = VersionParser::getIntermediateVersion($CFG_GLPI['version'] ?? '0.0.0-dev');
             $defined_intermediate_version   = VersionParser::getIntermediateVersion(GLPI_VERSION);

--- a/src/Update.php
+++ b/src/Update.php
@@ -544,8 +544,8 @@ class Update
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        if (SKIP_UPDATES) {
-            // If `SKIP_UPDATES`, bugfixes update are not mandatory.
+        if (GLPI_SKIP_UPDATES) {
+            // If `GLPI_SKIP_UPDATES` is set to `true`, bugfixes update are not mandatory.
             $installed_intermediate_version = VersionParser::getIntermediateVersion($CFG_GLPI['version'] ?? '0.0.0-dev');
             $defined_intermediate_version   = VersionParser::getIntermediateVersion(GLPI_VERSION);
             return $installed_intermediate_version !== $defined_intermediate_version;

--- a/src/autoload/constants.php
+++ b/src/autoload/constants.php
@@ -54,9 +54,6 @@ define('GLPI_MIN_PHP', '8.2'); // Must also be changed in top of public/index.ph
 define('GLPI_MAX_PHP', '8.4'); // Must also be changed in top of public/index.php
 define('GLPI_YEAR', '2025');
 
-//Define a global recipient address for email notifications
-//define('GLPI_FORCE_MAIL', 'me@localhost');
-
 // namespaces
 define('NS_GLPI', 'Glpi\\');
 define('NS_PLUG', 'GlpiPlugin\\');

--- a/src/autoload/legacy-autoloader.php
+++ b/src/autoload/legacy-autoloader.php
@@ -59,7 +59,7 @@ function glpi_autoload($classname)
     }
 
     $plugin_path = null;
-    foreach (PLUGINS_DIRECTORIES as $plugins_dir) {
+    foreach (GLPI_PLUGINS_DIRECTORIES as $plugins_dir) {
         $dir_to_check = sprintf('%s/%s', $plugins_dir, $plugin_key);
         if (is_dir($dir_to_check)) {
             $plugin_path = $dir_to_check;

--- a/stubs/glpi_constants.php
+++ b/stubs/glpi_constants.php
@@ -86,6 +86,7 @@
     define('GLPI_NETWORK_SERVICES', 'https://services.glpi-network.com');
     define('GLPI_SERVERSIDE_URL_ALLOWLIST', $random_val([[], ['/^.*$/']]));
     define('GLPI_STRICT_ENV', $random_val([false, true]));
+    define('GLPI_SYSTEM_CRON', $random_val([false, true]));
     define('GLPI_TELEMETRY_URI', 'https://telemetry.glpi-project.org');
     define('GLPI_TEXT_MAXSIZE', $random_val([1000, 2000, 3000, 4000]));
     define('GLPI_USER_AGENT_EXTRA_COMMENTS', $random_val(['', 'app-version:5']));

--- a/stubs/glpi_constants.php
+++ b/stubs/glpi_constants.php
@@ -91,4 +91,5 @@
     define('GLPI_USER_AGENT_EXTRA_COMMENTS', $random_val(['', 'app-version:5']));
     define('GLPI_WEBHOOK_ALLOW_RESPONSE_SAVING', $random_val([false, true]));
     define('PLUGINS_DIRECTORIES', [dirname(__FILE__, 2) . '/plugins', dirname(__FILE__, 2) . '/marketplace']);
+    define('SKIP_UPDATES', $random_val([false, true]));
 })();

--- a/stubs/glpi_constants.php
+++ b/stubs/glpi_constants.php
@@ -63,7 +63,6 @@
     // Optionnal constants
     if ($random_val([false, true]) === true) {
         define('GLPI_FORCE_MAIL', 'example@glpi-project.org');
-        define('GLPI_LOG_LVL', 'DEBUG');
     }
 
     // Other constants
@@ -76,6 +75,7 @@
     define('GLPI_DISALLOWED_UPLOADS_PATTERN', $random_val(['', '/\.(php\d*|phar)$/i']));
     define('GLPI_ENVIRONMENT_TYPE', $random_val(['development', 'testing', 'staging', 'production']));
     define('GLPI_INSTALL_MODE', $random_val(['GIT', 'TARBALL']));
+    define('GLPI_LOG_LVL', $random_val(['emergency', 'alert', 'critical', 'error', 'warning', 'notice', 'info', 'debug']));
     define('GLPI_MARKETPLACE_ALLOW_OVERRIDE', $random_val([false, true]));
     define('GLPI_MARKETPLACE_ENABLE', $random_val([0, 1, 2, 3]));
     define('GLPI_MARKETPLACE_MANUAL_DOWNLOADS', $random_val([false, true]));

--- a/stubs/glpi_constants.php
+++ b/stubs/glpi_constants.php
@@ -84,13 +84,13 @@
     define('GLPI_NETWORK_REGISTRATION_API_URL', 'https://services.glpi-network.com/api/registration/');
     define('GLPI_NETWORK_MAIL', 'glpi@teclib.com');
     define('GLPI_NETWORK_SERVICES', 'https://services.glpi-network.com');
+    define('GLPI_PLUGINS_DIRECTORIES', [dirname(__FILE__, 2) . '/plugins', dirname(__FILE__, 2) . '/marketplace']);
     define('GLPI_SERVERSIDE_URL_ALLOWLIST', $random_val([[], ['/^.*$/']]));
+    define('GLPI_SKIP_UPDATES', $random_val([false, true]));
     define('GLPI_STRICT_ENV', $random_val([false, true]));
     define('GLPI_SYSTEM_CRON', $random_val([false, true]));
     define('GLPI_TELEMETRY_URI', 'https://telemetry.glpi-project.org');
     define('GLPI_TEXT_MAXSIZE', $random_val([1000, 2000, 3000, 4000]));
     define('GLPI_USER_AGENT_EXTRA_COMMENTS', $random_val(['', 'app-version:5']));
     define('GLPI_WEBHOOK_ALLOW_RESPONSE_SAVING', $random_val([false, true]));
-    define('PLUGINS_DIRECTORIES', [dirname(__FILE__, 2) . '/plugins', dirname(__FILE__, 2) . '/marketplace']);
-    define('SKIP_UPDATES', $random_val([false, true]));
 })();

--- a/templates/layout/parts/page_header.html.twig
+++ b/templates/layout/parts/page_header.html.twig
@@ -37,7 +37,7 @@
 {% set is_helpdesk = get_current_interface() == 'helpdesk' %}
 
 <body class="{{ user_pref('fold_menu') and is_vertical ? 'navbar-collapsed' : '' }} {{ is_vertical ? 'vertical-layout' : 'horizontal-layout' }} {{ is_debug_active ? 'debug-active' : '' }} {{ is_helpdesk ? 'helpdesk' : 'central' }}">
-   {% if call('DBConnection::isDbAvailable') and constant('SKIP_UPDATES') is defined and not call('Update::isDbUpToDate') %}
+   {% if call('DBConnection::isDbAvailable') and constant('GLPI_SKIP_UPDATES') is defined and not call('Update::isDbUpToDate') %}
       <div class="banner-need-update">
          {{ __("You are bypassing a needed update") }}
       </div>

--- a/templates/layout/parts/page_header_empty.html.twig
+++ b/templates/layout/parts/page_header_empty.html.twig
@@ -31,7 +31,7 @@
  #}
 
 <body class="horizontal-layout">
-   {% if call('DBConnection::isDbAvailable') and constant('SKIP_UPDATES') is defined and not call('Update::isDbUpToDate') %}
+   {% if call('DBConnection::isDbAvailable') and constant('SKIP_UPDATES') and not call('Update::isDbUpToDate') %}
       <div class="banner-need-update">
          {{ __("You are bypassing a needed update") }}
       </div>

--- a/templates/layout/parts/page_header_empty.html.twig
+++ b/templates/layout/parts/page_header_empty.html.twig
@@ -31,7 +31,7 @@
  #}
 
 <body class="horizontal-layout">
-   {% if call('DBConnection::isDbAvailable') and constant('SKIP_UPDATES') and not call('Update::isDbUpToDate') %}
+   {% if call('DBConnection::isDbAvailable') and constant('GLPI_SKIP_UPDATES') and not call('Update::isDbUpToDate') %}
       <div class="banner-need-update">
          {{ __("You are bypassing a needed update") }}
       </div>


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

1. Make the `GLPI_LOG_LVL` constant always defined and use it instead of having a `Environment::getLogLevel()` method.
2. Deprecate the `GLPI_FORCE_MAIL` constant. A mail catcher service is a better alternative than using a real SMTP server that may lead to unexpected message sending when the developer forgot to configure this constant.
3. Make the `SKIP_UPDATES` always defined (and rename it to `GLPI_SKIP_UPDATES` to follow the naming convention of our constants).
4. Make the `GLPI_SYSTEM_CRON` constant always defined.
5. Replace the `GLPI_KEEP_CSRF_TOKEN` constant by a safer implementation based on method params.
6. Rename the `PLUGINS_DIRECTORIES` to `GLPI_PLUGINS_DIRECTORIES` to follow the naming convention of our constants.


IMHO, we should also remove the `defined('TU_USER')` from our codebase and use either `Environment::get() === Environment::TESTING` for really specific cases, `Environment::shouldExpectResourcesToChange()` when the code has to handle resources changes triggered by tests, or even remove this specific condition to make sure that the behaviour is similar whatever the current env is. This should anyway be done in distinct PRs, as each case may be subject to debate.