### PR TITLE
Fix profiles rights uniqueness

### DIFF
--- a/src/Profile.php
+++ b/src/Profile.php
@@ -42,7 +42,6 @@ use Glpi\Form\Form;
 use Glpi\Helpdesk\Tile\LinkableToTilesInterface;
 use Glpi\Helpdesk\Tile\TilesManager;
 use Glpi\RichText\UserMention;
-use Glpi\Search\SearchOption;
 use Glpi\Toolbox\ArrayNormalizer;
 
 /**
@@ -3747,10 +3746,11 @@ class Profile extends CommonDBTM implements LinkableToTilesInterface
         ];
 
         // Add custom asset definition rights
+        $custom_assets_right_offset = 1000;
         foreach (AssetDefinitionManager::getInstance()->getDefinitions(true) as $definition) {
             $asset = $definition->getAssetClassName();
             $tab[] = [
-                'id'                 => SearchOption::generateAProbablyUniqueId($asset),
+                'id'                 => $custom_assets_right_offset + $definition->getID(),
                 'table'              => 'glpi_profilerights',
                 'field'              => 'rights',
                 'name'               => $asset::getTypeName(1),


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

`SearchOption::generateAProbablyUniqueId()` has a high probability to generate redundant values. I tried to handle this in #16746, but it was not enough to achieve what I wanted to do, so it has never been finished.

Since this morning, and the merge of #19676, the test suite faile already multiple times with an error similar to:
```
1) tests\units\Glpi\Asset\Capacity\HasPlugCapacityTest::testCloneAsset
Unexpected entries in log in tests\units\Glpi\Asset\Capacity\HasPlugCapacityTest::GLPITestCase::tearDown:
Array
(
    [0] => Array
        (
            [channel] => glpi
            [level] => Warning
            [message] => User Warning: Duplicate key `11552` (`Test01`/`wEQrMgqEhcFbJVEB`) in `Profile` search options. at CommonDBTM.php line 3924
```

Using 1000 + the definition ID will make ot stable over time and will ensure that the ID is unique for each definition.