### PR TITLE
Improve error handling on profile redirection

### DIFF
--- a/src/Glpi/Controller/Session/ChangeProfileController.php
+++ b/src/Glpi/Controller/Session/ChangeProfileController.php
@@ -74,8 +74,7 @@ final class ChangeProfileController extends AbstractController
             $redirect = $request->getBasePath() . $route;
         } else {
             $redirect = Html::getBackUrl();
-            $has_query_string = parse_url($redirect, PHP_URL_QUERY) !== null;
-            $separator = $has_query_string ? "&" : "?";
+            $separator = str_contains($redirect, '?') ? "&" : "?";
             $redirect = $redirect . $separator . '_redirected_from_profile_selector=true';
         }
 

--- a/src/Glpi/Controller/Session/ChangeProfileController.php
+++ b/src/Glpi/Controller/Session/ChangeProfileController.php
@@ -73,8 +73,10 @@ final class ChangeProfileController extends AbstractController
             $route = $go_to_create_ticket ? "/ServiceCatalog" : "/Helpdesk";
             $redirect = $request->getBasePath() . $route;
         } else {
-            $_SESSION['_redirected_from_profile_selector'] = true;
             $redirect = Html::getBackUrl();
+            $has_query_string = parse_url($redirect, PHP_URL_QUERY) !== null;
+            $separator = $has_query_string ? "&" : "?";
+            $redirect = $redirect . $separator . '_redirected_from_profile_selector=true';
         }
 
         return new RedirectResponse($redirect);

--- a/src/Glpi/Kernel/Listener/ExceptionListener/AccessErrorListener.php
+++ b/src/Glpi/Kernel/Listener/ExceptionListener/AccessErrorListener.php
@@ -72,6 +72,13 @@ final readonly class AccessErrorListener implements EventSubscriberInterface
 
         $response = null;
 
+        // On profile change, we will redirect the user to the home page in case
+        // of access errors for the current page.
+        $redirect_to_home_on_error = $event->getRequest()
+            ->query
+            ->getBoolean('_redirected_from_profile_selector')
+        ;
+
         if ($throwable instanceof SessionExpiredException) {
             Session::destroy(); // destroy the session to prevent pesistence of unexpected data
 
@@ -84,10 +91,8 @@ final readonly class AccessErrorListener implements EventSubscriberInterface
             );
         } elseif (
             $throwable instanceof AccessDeniedHttpException
-            && ($_SESSION['_redirected_from_profile_selector'] ?? false)
+            && $redirect_to_home_on_error
         ) {
-            unset($_SESSION['_redirected_from_profile_selector']);
-
             $request = $event->getRequest();
             $response = new RedirectResponse(
                 sprintf(


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.

## Description

Same behavior as before but the `_redirected_from_profile_selector` flag is set in the query string instead of the session.
This make sure it can only be used for the next request and wont stay active for any further requests.

Fix #19630 (for main only).


