### PR TITLE
Refactor OAuth\Server::generateKeys() for readability/debugging

### DIFF
--- a/src/Glpi/OAuth/Server.php
+++ b/src/Glpi/OAuth/Server.php
@@ -190,12 +190,22 @@ final class Server
             return;
         }
 
-        try {
-            // Reset keys in case of partial data (i.e. only the private or only
-            // the public key exist). Should not be able to happen but let's be
-            // safe.
-            self::deleteKeys();
+        // Partial data: unsure how to proceed, let the user review the files.
+        if (
+            file_exists(self::PRIVATE_KEY_PATH)
+            && !file_exists(self::PUBLIC_KEY_PATH)
+        ) {
+            throw new RuntimeException("Mising file: " . self::PUBLIC_KEY_PATH);
+        }
+        if (
+            file_exists(self::PUBLIC_KEY_PATH)
+            && !file_exists(self::PRIVATE_KEY_PATH)
+        ) {
+            throw new RuntimeException("Mising file: " . self::PRIVATE_KEY_PATH);
+        }
 
+        // If we reach this point, both file are missing and must be generated
+        try {
             // Generate keys
             self::doGenerateKeys();
         } catch (Throwable $e) {


### PR DESCRIPTION
## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.

## Description

I am reading the `OAuth\Server::generateKeys()` method for the #19673 issue and it suffer from too many nested conditions.
I've rewritten it with early return to make it easier to read and added calls to `openssl_error_string` to get clearer error messages (thanks @trasher for mentioning the method in the issue, I was not aware of its existence).

This does not fix the ongoing issue.

