### PR TITLE
limit selection of all checkbox for displaypreference to a sub div

### DIFF
--- a/templates/components/search/displaypreference_list.html.twig
+++ b/templates/components/search/displaypreference_list.html.twig
@@ -33,7 +33,7 @@
 {% import 'components/form/basic_inputs_macros.html.twig' as inputs %}
 
 {% if preferences|length > 0 %}
-    <div class="m-3">
+    <div class="m-3" id="displayprefences-setup">
         {% if massiveactionparams['specific_actions']|length > 0 %}
             <form id="massDisplayPreference{{ rand }}" method="get" action="{{ path('front/massiveaction.php') }}"
                 data-search-itemtype="DisplayPreference" data-submit-once>
@@ -127,7 +127,7 @@
 
             // (un)toggle all capacities button
             $('#select-all-itemtypes').on('click', function() {
-                var $checkboxes = $('input[type=checkbox]');
+                var $checkboxes = $('#displayprefences-setup input[type=checkbox]');
                 var $checkedCheckboxes = $checkboxes.filter(':checked');
 
                 if ($checkedCheckboxes.length === $checkboxes.length) {


### PR DESCRIPTION

## Description

A quick fix on an issue reported orally by @flegastelois; when you go on the "All" tab in Setup > General, the "Select All" button for the display preferences paragraph interferes with other parts of the page

## Screenshots (if appropriate):

The bug: 
![image](https://github.com/user-attachments/assets/88deb709-6a8f-4e07-ae1a-66469f9e5609)
