### PR TITLE
Fix inventory_lockable_objects list

### DIFF
--- a/inc/define.php
+++ b/inc/define.php
@@ -497,7 +497,7 @@ $CFG_GLPI['inventory_lockable_objects'] = ['Computer_Item',  'Item_SoftwareLicen
     'Item_DeviceHardDrive', 'Item_DeviceMemory', 'Item_DeviceMotherboard', 'Item_DeviceNetworkCard', 'Item_DevicePci',
     'Item_DevicePowerSupply', 'Item_DeviceProcessor', 'Item_DeviceSensor', 'Item_DeviceSimcard', 'Item_DeviceSoundCard',
     'DatabaseInstance', 'Item_RemoteManagement','Monitor', 'Domain_Item', 'Peripheral', 'Unmanaged', 'Database',
-    'Item_DeviceCamera', 'Item_DeviceCamera_ImageFormat', 'Item_DeviceCamera_ImageResolution'
+    'Item_DeviceCamera', 'Item_DeviceCamera_ImageFormat', 'Item_DeviceCamera_ImageResolution',
 ];
 
 $CFG_GLPI["kb_types"]              = ['Budget', 'Change', 'Computer',

--- a/inc/define.php
+++ b/inc/define.php
@@ -496,7 +496,8 @@ $CFG_GLPI['inventory_lockable_objects'] = ['Computer_Item',  'Item_SoftwareLicen
     'Item_DeviceControl', 'Item_DeviceDrive', 'Item_DeviceFirmware', 'Item_DeviceGeneric', 'Item_DeviceGraphicCard',
     'Item_DeviceHardDrive', 'Item_DeviceMemory', 'Item_DeviceMotherboard', 'Item_DeviceNetworkCard', 'Item_DevicePci',
     'Item_DevicePowerSupply', 'Item_DeviceProcessor', 'Item_DeviceSensor', 'Item_DeviceSimcard', 'Item_DeviceSoundCard',
-    'DatabaseInstance', 'Item_RemoteManagement','Monitor', 'Domain_Item',
+    'DatabaseInstance', 'Item_RemoteManagement','Monitor', 'Domain_Item', 'Peripheral', 'Unmanaged', 'Database',
+    'Item_DeviceCamera', 'Item_DeviceCamera_ImageFormat', 'Item_DeviceCamera_ImageResolution'
 ];
 
 $CFG_GLPI["kb_types"]              = ['Budget', 'Change', 'Computer',

--- a/phpunit/functional/LockedfieldTest.php
+++ b/phpunit/functional/LockedfieldTest.php
@@ -935,7 +935,7 @@ class LockedfieldTest extends DbTestCase
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
         foreach ($CFG_GLPI['inventory_lockable_objects'] as $itemtype) {
-            $this->assertTrue($DB->fieldExists($itemtype::getTable(), 'is_dynamic'));
+            $this->assertTrue($DB->fieldExists($itemtype::getTable(), 'is_dynamic'), "$itemtype does not have is_dynamic field");
         }
 
 
@@ -964,7 +964,7 @@ class LockedfieldTest extends DbTestCase
                 $this->assertContains(
                     $itemtype,
                     $global_inventory_type,
-                    "Add a clear message here in case of validation failure."
+                    "$itemtype is not in inventory_lockable_objects or inventory_types"
                 );
             }
         }

--- a/phpunit/functional/LockedfieldTest.php
+++ b/phpunit/functional/LockedfieldTest.php
@@ -924,4 +924,48 @@ class LockedfieldTest extends DbTestCase
         $this->assertTrue($computer->getFromDB($cid));
         $this->assertEquals($computer->fields['locations_id'], 0);
     }
+
+    public function testCheckAllInventoryLockableObjects()
+    {
+        $this->login('glpi', 'glpi');
+
+        /** @var \DBmysql $DB */
+        global $DB;
+
+        /** @var array $CFG_GLPI */
+        global $CFG_GLPI;
+        foreach ($CFG_GLPI['inventory_lockable_objects'] as $itemtype) {
+            $this->assertTrue($DB->fieldExists($itemtype::getTable(), 'is_dynamic'));
+        }
+
+
+        // Excluded type with is_dynamic field but not in inventory_lockable_objects
+        $excluded = [
+            'UserEmail',
+            'Group_User',
+            'Profile_User'
+        ];
+
+        $global_inventory_type = array_merge(
+            $CFG_GLPI['inventory_lockable_objects'],
+            $CFG_GLPI['inventory_types']
+        );
+
+        $tables = $DB->listTables();
+        foreach ($tables as $table_data) {
+            $table = $table_data['TABLE_NAME'];
+
+            if ($DB->fieldExists($table, 'is_dynamic')) {
+                $itemtype = getItemTypeForTable($table);
+                if (in_array($itemtype, $excluded)) {
+                    continue;
+                }
+
+                $this->assertContains(
+                    $itemtype,
+                    $global_inventory_type,
+                );
+            }
+        }
+    }
 }

--- a/phpunit/functional/LockedfieldTest.php
+++ b/phpunit/functional/LockedfieldTest.php
@@ -964,6 +964,7 @@ class LockedfieldTest extends DbTestCase
                 $this->assertContains(
                     $itemtype,
                     $global_inventory_type,
+                    "Add a clear message here in case of validation failure."
                 );
             }
         }

--- a/phpunit/functional/LockedfieldTest.php
+++ b/phpunit/functional/LockedfieldTest.php
@@ -943,7 +943,7 @@ class LockedfieldTest extends DbTestCase
         $excluded = [
             'UserEmail',
             'Group_User',
-            'Profile_User'
+            'Profile_User',
         ];
 
         $global_inventory_type = array_merge(

--- a/phpunit/functional/MassiveActionTest.php
+++ b/phpunit/functional/MassiveActionTest.php
@@ -72,7 +72,7 @@ class MassiveActionTest extends DbTestCase
             ], [
                 'itemtype'     => 'Peripheral',
                 'items_id'     => '_test_peripheral_1',
-                'allcount'     => 18,
+                'allcount'     => 20,
                 'singlecount'  => 12,
             ], [
                 'itemtype'     => 'Printer',


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !37675
- Here is a brief description of what this PR does
Dynamic objects that should have their fields locked were not in the list $CFG_GLPI['inventory_lockable_objects']  

## Screenshots (if appropriate):


