### PR TITLE
Fix repeatable predefined fields

### DIFF
--- a/src/ITILTemplateField.php
+++ b/src/ITILTemplateField.php
@@ -54,6 +54,12 @@ abstract class ITILTemplateField extends CommonDBChild
     // From CommonDBTM
     public $dohistory = true;
 
+    public static function getMultiplePredefinedValues(): array
+    {
+        // List of fields that are allowed to be defined multiples times.
+        return [];
+    }
+
 
     public function getForbiddenStandardMassiveAction()
     {
@@ -181,6 +187,15 @@ abstract class ITILTemplateField extends CommonDBChild
             }
             $entries[] = $entry;
             $used[$data['num']]        = $data['num'];
+        }
+
+        // Remove fields that are allowed to have multiple values from the 'used'
+        // list.
+        $multiple = static::getMultiplePredefinedValues();
+        foreach ($multiple as $val) {
+            if (isset($used[$val])) {
+                unset($used[$val]);
+            }
         }
 
         $fields_dropdown_values = [];

--- a/src/ITILTemplatePredefinedField.php
+++ b/src/ITILTemplatePredefinedField.php
@@ -202,7 +202,7 @@ abstract class ITILTemplatePredefinedField extends ITILTemplateField
     /**
      * @since 0.85
      **/
-    public static function getMultiplePredefinedValues()
+    public static function getMultiplePredefinedValues(): array
     {
 
         $itil_class = static::$itiltype;


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
    -> Can't easily add a backend test as the method is not designed in a way that makes it testable and we already have too much e2e tests right now...

## Description

Some predefined fields like "associated assets" are supposed to "repeatable" (= can be defined multiple times).
This is no longer the case in GLPI 11 due to some refactoring that was done without keeping this feature.

I've found the original code from GLPI 10 and integrated it:

![image](https://github.com/user-attachments/assets/04fc3c67-bd6e-480b-bce5-c779cff5eae4)

Fix #19682.

## Screenshots (if appropriate):

Before:
![image](https://github.com/user-attachments/assets/5d8c5490-6945-4549-a86b-d31d30131a81)


After:
![image](https://github.com/user-attachments/assets/66f1dba0-268d-4bc2-8cde-7faca5cbb86c)

