### PR TITLE
fix(forms): null twig template value in item condition handler

### DIFF
--- a/templates/pages/admin/form/condition_handler_templates/item_dropdown.html.twig
+++ b/templates/pages/admin/form/condition_handler_templates/item_dropdown.html.twig
@@ -49,7 +49,7 @@
 {{ fields.dropdownField(
     itemtype,
     input_name ~ '[items_id]',
-    input_value.items_id,
+    input_value.items_id|default(0),
     '',
     {
         'no_label'     : true,


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Following the strict declaration of variables in Twig templates initiated by #19667, a bug occurred when adding a new condition targeting questions of type `QuestionTypeItem`.

This fix should resolve the E2E test problems on the `conditions.cy.js` file.