### PR TITLE
Fix request sources dashboard label

### DIFF
--- a/src/Dashboard/Grid.php
+++ b/src/Dashboard/Grid.php
@@ -1325,7 +1325,7 @@ HTML;
                 [
                     'ITILCategory' => __("Top ticket's categories"),
                     'Entity'       => __("Top ticket's entities"),
-                    'RequestType'  => __("Top ticket's request types"),
+                    'RequestType'  => __("Top ticket's request sources"),
                     'Location'     => __("Top ticket's locations"),
                 ] as $itemtype => $label
             ) {


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.

## Description

The label of this widget is incorrect, it targets the request sources of a ticket (email, phone, ...) not the request types (incident or request).

Fix #19698.


