### PR TITLE
Fix paging on datatables

### DIFF
--- a/css/includes/components/_utils.scss
+++ b/css/includes/components/_utils.scss
@@ -100,3 +100,7 @@
 .hover-bg:hover {
     background-color: var(--glpi-hover-bg) !important;
 }
+
+.border-transparent {
+    border-color: transparent;
+}

--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -611,7 +611,6 @@ TWIG, ['authldaps_id' => $ID]);
 
             TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
                 'is_tab' => true,
-                'nopager' => true,
                 'nofilter' => true,
                 'nosort' => true,
                 'super_header' => __('List of LDAP directory replicates'),

--- a/src/Budget.php
+++ b/src/Budget.php
@@ -635,7 +635,6 @@ class Budget extends CommonDropdown
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
             'nofilter' => true,
-            'nopager' => true,
             'super_header' => __('Total spent on the budget'),
             'columns' => $columns,
             'formatters' => $formatters,

--- a/src/Cartridge.php
+++ b/src/Cartridge.php
@@ -912,7 +912,6 @@ TWIG, ['counts' => $counts, 'highlight' => $highlight]);
 
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
-            'nopager' => true,
             'nofilter' => true,
             'nosort' => true,
             'super_header' => $show_old ? __('Worn cartridges') : __('Used cartridges'),
@@ -1204,7 +1203,6 @@ TWIG, ['printer_id' => $printer->getID()]);
 
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
-            'nopager' => true,
             'nofilter' => true,
             'nosort' => true,
             'super_header' => $old ? __('Worn cartridges') : __('Used cartridges'),

--- a/src/Certificate_Item.php
+++ b/src/Certificate_Item.php
@@ -295,7 +295,6 @@ TWIG, $twig_params);
 
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
-            'nopager' => true,
             'nofilter' => true,
             'nosort' => true,
             'columns' => $columns,
@@ -448,7 +447,6 @@ TWIG, $twig_params);
 
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
-            'nopager' => true,
             'nofilter' => true,
             'nosort' => true,
             'columns' => $columns,

--- a/src/Change_Problem.php
+++ b/src/Change_Problem.php
@@ -174,7 +174,6 @@ class Change_Problem extends CommonITILObject_CommonITILObject
 
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
-            'nopager' => true,
             'nofilter' => true,
             'nosort' => true,
             'columns' => $columns,
@@ -266,7 +265,6 @@ class Change_Problem extends CommonITILObject_CommonITILObject
 
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
-            'nopager' => true,
             'nofilter' => true,
             'nosort' => true,
             'columns' => $columns,

--- a/src/Change_Ticket.php
+++ b/src/Change_Ticket.php
@@ -280,7 +280,6 @@ class Change_Ticket extends CommonITILObject_CommonITILObject
 
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
-            'nopager' => true,
             'nofilter' => true,
             'nosort' => true,
             'columns' => $columns,
@@ -382,7 +381,6 @@ class Change_Ticket extends CommonITILObject_CommonITILObject
 
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
-            'nopager' => true,
             'nofilter' => true,
             'nosort' => true,
             'columns' => $columns,

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -5437,7 +5437,6 @@ class CommonDBTM extends CommonGLPI
         $twig_params = [
             'datatable_params' => [
                 'is_tab' => true,
-                'nopager' => true,
                 'nofilter' => true,
                 'nosort' => true,
                 'columns' => $columns,

--- a/src/CommonDBVisible.php
+++ b/src/CommonDBVisible.php
@@ -353,7 +353,6 @@ abstract class CommonDBVisible extends CommonDBTM
 
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
-            'nopager' => true,
             'nofilter' => true,
             'nosort' => true,
             'columns' => [

--- a/src/CommonITILCost.php
+++ b/src/CommonITILCost.php
@@ -635,7 +635,6 @@ TWIG, $twig_params);
             'datatable_id' => 'datatable_costs' . $ID . $rand,
             'is_tab' => true,
             'nofilter' => true,
-            'nopager' => true,
             'super_header' => $super_header,
             'columns' => $columns,
             'formatters' => [

--- a/src/CommonITILValidation.php
+++ b/src/CommonITILValidation.php
@@ -1069,8 +1069,8 @@ abstract class CommonITILValidation extends CommonDBChild
                 ]);
 
                 $script = <<<HTML
-                    <span class="ti ti-edit" style="cursor:pointer" title="{$edit_title}" 
-                          onclick="viewEditValidation{$item_id}{$row_id}{$rand}();" 
+                    <span class="ti ti-edit" style="cursor:pointer" title="{$edit_title}"
+                          onclick="viewEditValidation{$item_id}{$row_id}{$rand}();"
                           id="viewvalidation{$view_validation_id}{$row_id}{$rand}">
                     </span>
                     <script>
@@ -1109,7 +1109,6 @@ HTML;
 
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
-            'nopager' => true,
             'nofilter' => true,
             'nosort' => true,
             'columns' => [

--- a/src/CommonTreeDropdown.php
+++ b/src/CommonTreeDropdown.php
@@ -657,7 +657,6 @@ TWIG, $twig_params);
         $columns['comment'] = __('Comments');
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
-            'nopager' => true,
             'nofilter' => true,
             'nosort' => true,
             'super_header' => [

--- a/src/Consumable.php
+++ b/src/Consumable.php
@@ -804,7 +804,6 @@ class Consumable extends CommonDBChild
 
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
-            'nopager' => true,
             'nofilter' => true,
             'nosort' => true,
             'columns' => $columns,

--- a/src/Contact_Supplier.php
+++ b/src/Contact_Supplier.php
@@ -181,7 +181,6 @@ class Contact_Supplier extends CommonDBRelation
 
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
-            'nopager' => true,
             'nofilter' => true,
             'nosort' => true,
             'columns' => $columns,
@@ -282,7 +281,6 @@ class Contact_Supplier extends CommonDBRelation
 
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
-            'nopager' => true,
             'nofilter' => true,
             'nosort' => true,
             'columns' => $columns,

--- a/src/ContractCost.php
+++ b/src/ContractCost.php
@@ -385,7 +385,6 @@ TWIG, $twig_params);
             'datatable_id' => 'contractcostlist' . $rand,
             'is_tab' => true,
             'nofilter' => true,
-            'nopager' => true,
             'sort' => $sort,
             'order' => $order,
             'columns' => [

--- a/src/Contract_Item.php
+++ b/src/Contract_Item.php
@@ -352,7 +352,6 @@ TWIG, $twig_params);
 
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
-            'nopager' => true,
             'nofilter' => true,
             'nosort' => true,
             'columns' => [
@@ -605,7 +604,6 @@ TWIG, $twig_params);
 
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
-            'nopager' => true,
             'nofilter' => true,
             'nosort' => true,
             'columns' => [

--- a/src/Contract_Supplier.php
+++ b/src/Contract_Supplier.php
@@ -193,7 +193,6 @@ TWIG, $twig_params);
 
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
-            'nopager' => true,
             'nofilter' => true,
             'nosort' => true,
             'columns' => [
@@ -315,7 +314,6 @@ TWIG, $twig_params);
 
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
-            'nopager' => true,
             'nofilter' => true,
             'nosort' => true,
             'columns' => [

--- a/src/Contract_User.php
+++ b/src/Contract_User.php
@@ -209,7 +209,6 @@ TWIG, $twig_params);
 
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
-            'nopager' => true,
             'nofilter' => true,
             'nosort' => true,
             'columns' => [

--- a/src/CronTask.php
+++ b/src/CronTask.php
@@ -1271,7 +1271,6 @@ TWIG, ['msg' => __('Last run list')]);
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
             'nofilter' => true,
-            'nopager' => true,
             'columns' => [
                 'date' => _n('Date', 'Dates', 1),
                 'state' => __('Status'),

--- a/src/Document_Item.php
+++ b/src/Document_Item.php
@@ -474,7 +474,6 @@ TWIG, $twig_params);
 
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
-            'nopager' => true,
             'nofilter' => true,
             'columns' => [
                 'linked_itemtype' => _n('Type', 'Types', 1),
@@ -727,7 +726,6 @@ TWIG, $twig_params);
 
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
-            'nopager' => true,
             'nofilter' => true,
             'columns' => $columns,
             'formatters' => [

--- a/src/DomainRecord.php
+++ b/src/DomainRecord.php
@@ -439,7 +439,7 @@ class DomainRecord extends CommonDBChild
                           action="{{ 'Domain'|itemtype_form_path }}" data-submit-once>
                         {{ inputs.hidden('_glpi_csrf_token', csrf_token()) }}
                         {{ inputs.hidden('domains_id', domains_id) }}
-                        
+
                         <div class="d-flex">
                             {{ fields.dropdownField('DomainRecord', 'domainrecords_id', 0, label, {
                                 'condition': condition
@@ -498,7 +498,6 @@ TWIG, $twig_params);
 
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
-            'nopager' => true,
             'nofilter' => true,
             'columns' => [
                 'type' => _n('Type', 'Types', 1),

--- a/src/Domain_Item.php
+++ b/src/Domain_Item.php
@@ -326,7 +326,6 @@ TWIG, $twig_params);
 
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
-            'nopager' => true,
             'nofilter' => true,
             'columns' => $columns,
             'formatters' => [
@@ -596,7 +595,6 @@ TWIG, $twig_params);
 
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
-            'nopager' => true,
             'nofilter' => true,
             'columns' => $columns,
             'formatters' => [

--- a/src/DropdownTranslation.php
+++ b/src/DropdownTranslation.php
@@ -422,7 +422,6 @@ TWIG, $twig_params);
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'datatable_id' => 'datatable_translations' . $rand,
             'is_tab' => true,
-            'nopager' => true,
             'nofilter' => true,
             'columns' => [
                 'language' => __('Language'),

--- a/src/FieldUnicity.php
+++ b/src/FieldUnicity.php
@@ -577,7 +577,6 @@ class FieldUnicity extends CommonDropdown
         $columns['number'] = _x('quantity', 'Number');
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
-            'nopager' => true,
             'nofilter' => true,
             'columns' => $columns,
             'entries' => $entries,

--- a/src/Glpi/Asset/Asset_PeripheralAsset.php
+++ b/src/Glpi/Asset/Asset_PeripheralAsset.php
@@ -429,7 +429,6 @@ TWIG, $twig_params);
 
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
-            'nopager' => true,
             'nofilter' => true,
             'nosort' => true,
             'columns' => [
@@ -572,7 +571,6 @@ TWIG, $twig_params);
 
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
-            'nopager' => true,
             'nofilter' => true,
             'nosort' => true,
             'columns' => [

--- a/src/Group_User.php
+++ b/src/Group_User.php
@@ -212,7 +212,6 @@ class Group_User extends CommonDBRelation
 
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
-            'nopager' => true,
             'nofilter' => true,
             'columns' => [
                 'group' => Group::getTypeName(1),
@@ -486,7 +485,7 @@ class Group_User extends CommonDBRelation
             'start' => $start,
             'limit' => $_SESSION['glpilist_limit'],
             'is_tab' => true,
-            'nopager' => false,
+            'use_pager' => true,
             'nosort' => true,
             'filters' => $_GET['filters'] ?? [],
             'columns' => [

--- a/src/ItemAntivirus.php
+++ b/src/ItemAntivirus.php
@@ -342,7 +342,6 @@ class ItemAntivirus extends CommonDBChild
         }
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
-            'nopager' => true,
             'nofilter' => true,
             'nosort' => true,
             'columns' => [

--- a/src/ItemVirtualMachine.php
+++ b/src/ItemVirtualMachine.php
@@ -223,7 +223,6 @@ class ItemVirtualMachine extends CommonDBChild
                 }
                 TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
                     'is_tab' => true,
-                    'nopager' => true,
                     'nofilter' => true,
                     'nosort' => true,
                     'columns' => [
@@ -310,7 +309,6 @@ class ItemVirtualMachine extends CommonDBChild
 
             TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
                 'is_tab' => true,
-                'nopager' => true,
                 'nofilter' => true,
                 'nosort' => true,
                 'columns' => [

--- a/src/Item_Line.php
+++ b/src/Item_Line.php
@@ -200,7 +200,6 @@ class Item_Line extends CommonDBRelation
 
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
-            'nopager' => true,
             'nofilter' => true,
             'nosort' => true,
             'super_header' => [
@@ -259,7 +258,6 @@ class Item_Line extends CommonDBRelation
 
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
-            'nopager' => true,
             'nofilter' => true,
             'nosort' => true,
             'super_header' => [
@@ -341,7 +339,6 @@ class Item_Line extends CommonDBRelation
 
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
-            'nopager' => true,
             'nofilter' => true,
             'nosort' => true,
             'super_header' => [
@@ -399,7 +396,6 @@ class Item_Line extends CommonDBRelation
 
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
-            'nopager' => true,
             'nofilter' => true,
             'nosort' => true,
             'super_header' => [

--- a/src/Item_Project.php
+++ b/src/Item_Project.php
@@ -363,7 +363,6 @@ class Item_Project extends CommonDBRelation
             'used' => $used,
             'datatable_params' => [
                 'is_tab' => true,
-                'nopager' => true,
                 'nofilter' => true,
                 'nosort' => true,
                 'columns' => $cols['columns'],

--- a/src/Itil_Project.php
+++ b/src/Itil_Project.php
@@ -228,7 +228,6 @@ TWIG, $twig_params);
         }
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
-            'nopager' => true,
             'nofilter' => true,
             'nosort' => true,
             'columns' => $cols['columns'],
@@ -343,7 +342,6 @@ TWIG, $twig_params);
 
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
-            'nopager' => true,
             'nofilter' => true,
             'nosort' => true,
             'columns' => $cols['columns'],

--- a/src/KnowbaseItemTranslation.php
+++ b/src/KnowbaseItemTranslation.php
@@ -223,7 +223,6 @@ TWIG, $twig_params);
         }
 
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
-            'nopager' => true,
             'is_tab' => true,
             'nofilter' => true,
             'nosort' => true,

--- a/src/LevelAgreement.php
+++ b/src/LevelAgreement.php
@@ -394,7 +394,6 @@ TWIG, $twig_params);
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'datatable_id' => 'levelagreement' . $instID,
             'is_tab' => true,
-            'nopager' => true,
             'nofilter' => true,
             'nosort' => true,
             'columns' => [
@@ -456,7 +455,6 @@ TWIG, $twig_params);
 
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
-            'nopager' => true,
             'nofilter' => true,
             'nosort' => true,
             'columns' => [

--- a/src/LevelAgreementLevel.php
+++ b/src/LevelAgreementLevel.php
@@ -517,7 +517,6 @@ TWIG, ['la_level' => $la_level]);
 
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
-            'nopager' => true,
             'nofilter' => true,
             'nosort' => true,
             'columns' => [

--- a/src/Link.php
+++ b/src/Link.php
@@ -636,7 +636,6 @@ TWIG, $buttons_params);
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
             'nofilter' => true,
-            'nopager' => true,
             'superheader' => '',
             'columns' => [
                 'type' => __('Linked to'),

--- a/src/Lock.php
+++ b/src/Lock.php
@@ -296,7 +296,6 @@ TWIG;
 
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
-            'nopager' => true,
             'nofilter' => true,
             'nosort' => true,
             'super_header' => _n('Locked field', 'Locked fields', Session::getPluralNumber()),
@@ -424,7 +423,6 @@ TWIG, $twig_params);
                 ],
             ]);
             $subtable = [
-                'nopager' => true,
                 'nosort' => true,
                 'nofilter' => true,
                 'columns' => [
@@ -467,7 +465,6 @@ TWIG, $twig_params);
             ]);
 
             $subtable = [
-                'nopager' => true,
                 'nosort' => true,
                 'nofilter' => true,
                 'columns' => [
@@ -1033,7 +1030,6 @@ TWIG, $twig_params);
             // Common Params
             $datatable_params['is_tab'] = true;
             $datatable_params['nosort'] = true;
-            $datatable_params['nopager'] = true;
             $datatable_params['nofilter'] = true;
             $datatable_params['total_number'] = count($datatable_params['entries']);
             $datatable_params['filtered_number'] = count($datatable_params['entries']);
@@ -1045,7 +1041,6 @@ TWIG, $twig_params);
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
             'table_class_style' => 'table-sm',
-            'nopager' => true,
             'nofilter' => true,
             'nosort' => true,
             'super_header' => __('Locked items'),

--- a/src/NetworkPortConnectionLog.php
+++ b/src/NetworkPortConnectionLog.php
@@ -160,7 +160,6 @@ class NetworkPortConnectionLog extends CommonDBChild
 
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
-            'nopager' => true,
             'nofilter' => true,
             'nosort' => true,
             'columns' => [

--- a/src/NetworkPort_Vlan.php
+++ b/src/NetworkPort_Vlan.php
@@ -177,7 +177,6 @@ TWIG, $twig_params);
 
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
-            'nopager' => true,
             'nofilter' => true,
             'nosort' => true,
             'columns' => [
@@ -250,7 +249,6 @@ TWIG, $twig_params);
 
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
-            'nopager' => true,
             'nofilter' => true,
             'nosort' => true,
             'columns' => [

--- a/src/NotificationTemplateTranslation.php
+++ b/src/NotificationTemplateTranslation.php
@@ -161,7 +161,6 @@ TWIG, $twig_params);
 
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
-            'nopager' => true,
             'nofilter' => true,
             'nosort' => true,
             'columns' => [

--- a/src/Notification_NotificationTemplate.php
+++ b/src/Notification_NotificationTemplate.php
@@ -184,7 +184,6 @@ TWIG, $twig_params);
 
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
-            'nopager' => true,
             'nofilter' => true,
             'nosort' => true,
             'columns' => [
@@ -261,7 +260,6 @@ TWIG, $twig_params);
 
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
-            'nopager' => true,
             'nofilter' => true,
             'nosort' => true,
             'columns' => [

--- a/src/Printer_CartridgeInfo.php
+++ b/src/Printer_CartridgeInfo.php
@@ -129,7 +129,6 @@ HTML;
         if (count($entries)) {
             TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
                 'is_tab' => true,
-                'nopager' => true,
                 'nofilter' => true,
                 'nosort' => true,
                 'super_header' => self::getTypeName(Session::getPluralNumber()),

--- a/src/Problem_Ticket.php
+++ b/src/Problem_Ticket.php
@@ -239,7 +239,6 @@ class Problem_Ticket extends CommonITILObject_CommonITILObject
 
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
-            'nopager' => true,
             'nofilter' => true,
             'nosort' => true,
             'columns' => $columns,
@@ -315,7 +314,6 @@ class Problem_Ticket extends CommonITILObject_CommonITILObject
 
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
-            'nopager' => true,
             'nofilter' => true,
             'nosort' => true,
             'columns' => $columns,

--- a/src/Project.php
+++ b/src/Project.php
@@ -1346,7 +1346,6 @@ TWIG, ['projects_id' => $ID, 'label' => __('Create a sub project from this proje
         $entries = self::getDatatableEntries($entries_to_fetch);
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
-            'nopager' => true,
             'nofilter' => true,
             'nosort' => true,
             'columns' => $header['columns'],
@@ -1477,7 +1476,6 @@ TWIG, $twig_params);
 
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
-            'nopager' => true,
             'nofilter' => true,
             'nosort' => true,
             'columns' => [

--- a/src/ProjectTask.php
+++ b/src/ProjectTask.php
@@ -1381,7 +1381,6 @@ TWIG, $twig_params);
 
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
-            'nopager' => true,
             'nofilter' => true,
             'sort' => $_GET['sort'],
             'order' => $order,
@@ -1515,7 +1514,6 @@ TWIG, $twig_params);
 
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
-            'nopager' => true,
             'nofilter' => true,
             'nosort' => true,
             'columns' => [

--- a/src/ProjectTask_Ticket.php
+++ b/src/ProjectTask_Ticket.php
@@ -191,7 +191,6 @@ class ProjectTask_Ticket extends CommonDBRelation
 
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
-            'nopager' => true,
             'nofilter' => true,
             'nosort' => true,
             'columns' => $columns,
@@ -455,7 +454,6 @@ class ProjectTask_Ticket extends CommonDBRelation
 
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
-            'nopager' => true,
             'nofilter' => true,
             'columns' => $columns,
             'formatters' => [

--- a/src/ReminderTranslation.php
+++ b/src/ReminderTranslation.php
@@ -188,7 +188,6 @@ TWIG, $twig_params);
             'datatable_id' => 'translationlist' . $rand,
             'is_tab' => true,
             'nofilter' => true,
-            'nopager' => true,
             'columns' => [
                 'language' => __('Language'),
                 'subject' => __('Subject'),

--- a/src/Report.php
+++ b/src/Report.php
@@ -820,7 +820,6 @@ TWIG, ['title' => $report['title'], 'counts' => $counts]);
 
         $datatable_params = [
             'is_tab' => true,
-            'nopager' => true,
             'nofilter' => true,
             'nosort' => true,
             'super_header' => $super_header,
@@ -1098,7 +1097,6 @@ TWIG, $twig_params);
             if (!isset($datatable_params[$itemtype])) {
                 $datatable_params[$itemtype] = [
                     'is_tab' => true,
-                    'nopager' => true,
                     'nofilter' => true,
                     'nosort' => true,
                     'columns' => $columns,
@@ -1378,7 +1376,6 @@ TWIG, $twig_params);
             if (!isset($datatable_params[$itemtype])) {
                 $datatable_params[$itemtype] = [
                     'is_tab' => true,
-                    'nopager' => true,
                     'nofilter' => true,
                     'nosort' => true,
                     'columns' => $columns,
@@ -1559,7 +1556,6 @@ TWIG, $twig_params);
             if (!isset($datatable_params[$itemtype])) {
                 $datatable_params[$itemtype] = [
                     'is_tab' => true,
-                    'nopager' => true,
                     'nofilter' => true,
                     'nosort' => true,
                     'columns' => $columns,

--- a/src/Reservation.php
+++ b/src/Reservation.php
@@ -1100,7 +1100,6 @@ JAVASCRIPT;
         ];
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
-            'nopager' => true,
             'nofilter' => true,
             'nosort' => true,
             'table_class_style' => 'table-hover mb-3',

--- a/src/ReservationItem.php
+++ b/src/ReservationItem.php
@@ -653,7 +653,6 @@ TWIG, $twig_params);
         $columns['calendar'] = __("Booking calendar");
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
-            'nopager' => true,
             'nofilter' => true,
             'nosort' => true,
             'columns' => $columns,

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -2120,7 +2120,6 @@ JS
             'is_tab' => true,
             'nofilter' => true,
             'nosort' => true,
-            'nopager' => true,
             'super_header' => __('Result details'),
             'columns' => [
                 'criterion' => _n('Criterion', 'Criteria', 1),
@@ -2190,7 +2189,6 @@ JS
             'is_tab' => true,
             'nofilter' => true,
             'nosort' => true,
-            'nopager' => true,
             'super_header' => __('Rule results'),
             'columns' => [
                 'action' => __('Action'),
@@ -3009,7 +3007,6 @@ JS
             'is_tab' => true,
             'nofilter' => true,
             'nosort' => true,
-            'nopager' => true,
             'columns' => [
                 'name' => $this->getTitle(),
                 'description' => __('Description'),

--- a/src/Software.php
+++ b/src/Software.php
@@ -976,7 +976,6 @@ class Software extends CommonDBTM
 
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
-            'nopager' => true,
             'nofilter' => true,
             'nosort' => true,
             'columns' => [

--- a/src/SoftwareLicense_User.php
+++ b/src/SoftwareLicense_User.php
@@ -177,7 +177,6 @@ TWIG, $twig_params);
 
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
-            'nopager' => true,
             'nofilter' => true,
             'nosort' => true,
             'columns' => [

--- a/src/SoftwareVersion.php
+++ b/src/SoftwareVersion.php
@@ -345,7 +345,6 @@ TWIG, $twig_params);
 
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
-            'nopager' => true,
             'nofilter' => true,
             'nosort' => true,
             'columns' => [

--- a/src/State.php
+++ b/src/State.php
@@ -258,7 +258,6 @@ class State extends CommonTreeDropdown
 
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
-            'nopager' => true,
             'nofilter' => true,
             'nosort' => true,
             'columns' => $columns,

--- a/src/Ticket_Contract.php
+++ b/src/Ticket_Contract.php
@@ -189,7 +189,6 @@ TWIG, $twig_params);
 
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
-            'nopager' => true,
             'nofilter' => true,
             'nosort' => true,
             'columns' => $columns,

--- a/templates/components/datatable.html.twig
+++ b/templates/components/datatable.html.twig
@@ -42,6 +42,13 @@
 {% set footers = footers|default([]) %}
 {% set showmassiveactions = showmassiveactions|default(false) %}
 
+{# This value should be false by default because paging will no work on usages
+   of this template unless it is explicitly implemented #}
+{% set use_pager = use_pager|default(false) %}
+
+{# nopager is deprecated, use "use_pager" instead #}
+{% set use_pager = nopager is defined ? not nopager : use_pager %}
+
 {% if total_number < 1 and filters|length == 0 %}
     <table id="{{ datatable_id }}" class="table">
         <thead>
@@ -69,7 +76,7 @@
     </table>
 {% else %}
     {% set total_cols = columns|length + (showmassiveactions ? 1 : 0) + ((nofilter ?? false) ? 0 : 1) %}
-    {% if nopager is not defined or not nopager %}
+    {% if use_pager %}
         {{ include('components/pager.html.twig', {
             'count': filtered_number,
             'additional_params': additional_params ~ '&sort=' ~ sort ~ '&order=' ~ order
@@ -218,7 +225,7 @@
                 {% if entries|length > 0 %}
                     {% for entry in entries %}
                         {% set row_massiveactions = entry['showmassiveactions']|default(showmassiveactions) %}
-                        <tr class="{{ row_class|default('') }} {{ entry['row_class']|default('') }}"{% if row_massiveactions %} data-itemtype="{{ entry['itemtype'] }}" data-id="{{ entry['id'] }}"{% endif %}>
+                        <tr class="{{ loop.last ? "border-transparent" : "" }} {{ row_class|default('') }} {{ entry['row_class']|default('') }}"{% if row_massiveactions %} data-itemtype="{{ entry['itemtype'] }}" data-id="{{ entry['id'] }}"{% endif %}>
                             {% if row_massiveactions %}
                                 <td style="width: 10px">
                                     {% if entry['skip_ma'] is not defined or entry['skip_ma'] == false %}
@@ -337,7 +344,7 @@
         </table>
     </div>
 
-    {% if nopager is not defined or not nopager %}
+    {% if use_pager %}
         <div class="ms-auto d-inline-flex align-items-center d-none d-md-block my-2">
             {{ __('Entries to show:') }}
             {% include 'components/dropdown/limit.html.twig' %}

--- a/templates/components/form/item_itilobject_item_list.html.twig
+++ b/templates/components/form/item_itilobject_item_list.html.twig
@@ -64,7 +64,6 @@
             'is_raw': superheader_raw|default(false),
         },
         'is_tab': true,
-        'nopager': true,
         'nofilter': true,
         'nosort': true,
         'entries': entries,
@@ -89,7 +88,6 @@
         {% set datatable_params = {
             'super_header': __('%s on linked items')|format(itemtype_1|itemtype_name(number)),
             'is_tab': true,
-            'nopager': true,
             'nofilter': true,
             'nosort': true,
             'entries': entries2,

--- a/templates/components/form/item_remotemanagement_list.html.twig
+++ b/templates/components/form/item_remotemanagement_list.html.twig
@@ -44,7 +44,6 @@
 {% if entries|length > 0 %}
     {{ include('components/datatable.html.twig', {
         'is_tab': true,
-        'nopager': true,
         'nofilter': true,
         'nosort': true,
         'columns': {

--- a/templates/components/pager.html.twig
+++ b/templates/components/pager.html.twig
@@ -39,7 +39,9 @@
 {% endif %}
 
 {% set href = href|default('') %}
-{% set start = start|default(1) %}
+
+{# "start" is 0 based, the 1 based index is "current_start" #}
+{% set start = start|default(0) %}
 
 {% set href_separator = '?' in href ? '&' : '?' %}
 {% set href = href ~ href_separator ~ "start=%start%" ~ additional_params %}

--- a/templates/pages/admin/form/form_translation.html.twig
+++ b/templates/pages/admin/form/form_translation.html.twig
@@ -149,7 +149,6 @@
                         'entries': entries,
                         'total_number': 1,
                         'nofilter': true,
-                        'nopager': true,
                         'nosort': true,
                     } only %}
                 </div>

--- a/templates/pages/admin/form/form_translations.html.twig
+++ b/templates/pages/admin/form/form_translations.html.twig
@@ -70,7 +70,6 @@
             }),
             'total_number': 1,
             'nofilter': true,
-            'nopager': true
         } only %}
     </div>
 

--- a/templates/pages/tools/kb/article.html.twig
+++ b/templates/pages/tools/kb/article.html.twig
@@ -67,7 +67,6 @@
     {% if attachments|length > 0 %}
         {% include 'components/datatable.html.twig' with {
             is_tab: true,
-            nopager: true,
             nofilter: true,
             columns: {
                 filename: __('File'),


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
      -> Can't add any new non critical e2e tests, too slow already.

## Description

The following issues have been found on the predefined fields page:
* The "X of Y" count start on 2 instead of 1.
* The list size setting is not applied
* The pagination start on page 2 and doesn't work

![image](https://github.com/user-attachments/assets/bfe7cd9a-cec4-4941-b64a-62ab298d76a0)

The real root issue is that pagination should not be displayed on this page because it does not support it.

I've found that the `datatable.html.twig` component will display a pager by default despite the fact that 99% of its usages do not support paging as it needs to be manually implemented by the endpoint.

I've thus made the following changes:
* Fixed the "X of Y" display (this is a side effect of another recent PR where a default value of `1` was set for the variable that render it, it need to be `0` as the index is 0 based).
* Renamed the `nopager` option to `use_pager` as negative variables are a bad practice
* Made `use_pager` false by default. This make sure it is never enabled without explicitly setting the value and avoid having to set its value everywhere.
* Remove border bottom of the last `tr` of the datatable (improve UI).

After changes:
![image](https://github.com/user-attachments/assets/c07cb382-943d-467a-894a-c053a10dbca5)

The `nopager` -> `use_pager` renaming is split into another commit to ease reviews.

## References

Fix #19699.

