### PR TITLE
Fix(MassiveAction): fix item2 reconciliation

### DIFF
--- a/phpunit/functional/MassiveActionTest.php
+++ b/phpunit/functional/MassiveActionTest.php
@@ -37,6 +37,8 @@ namespace tests\units;
 use CommonDBTM;
 use Contract;
 use DbTestCase;
+use Location;
+use MassiveAction;
 use Notepad;
 use Problem;
 use Session;
@@ -160,6 +162,7 @@ class MassiveActionTest extends DbTestCase
             ->getMock();
 
         // Mock needed methods
+        $ma->POST = $input;
         $ma->method('getAction')->willReturn($action_code);
         $ma->method('addMessage')->willReturn(null);
         $ma->method('getInput')->willReturn($input);
@@ -698,5 +701,125 @@ class MassiveActionTest extends DbTestCase
                 $row["action_class"],
             );
         }
+    }
+
+    public function testProcessMassiveActionsForOneItemtype_updateDropdownOrCommonDBConnexity()
+    {
+        $this->login();
+
+        $provider = $this->updateDropdownOrCommonDBConnexityProvider();
+        foreach ($provider as $row) {
+            $item = $row['item'];
+            $input = $row['input'];
+            $has_right = $row['has_right'];
+            $should_work = $row['should_work'];
+
+
+            $old_session = $_SESSION['glpiactiveprofile'][Ticket::$rightname] ?? 0;
+            if ($has_right) {
+                $_SESSION['glpiactiveprofile'][Ticket::$rightname] = UPDATE;
+            } else {
+                $_SESSION['glpiactiveprofile'][Ticket::$rightname] = 0;
+            }
+
+
+
+            // Check rights set up was successful
+            $this->assertSame(
+                $has_right,
+                (bool) Session::haveRight(Ticket::$rightname, UPDATE)
+            );
+
+            // Default expectation: can't run
+            $expected_ok = 0;
+            $expected_ko = 0;
+
+            // Update expectation: this item should be OK
+            if ($should_work) {
+                $expected_ok = 1;
+            } else {
+                $expected_ko = 1;
+            }
+
+            // Execute action
+            $this->processMassiveActionsForOneItemtype(
+                "update",
+                $item,
+                [$item->fields['id']],
+                $input,
+                $expected_ok,
+                $expected_ko,
+                MassiveAction::class
+            );
+
+            // Reset rights
+            $_SESSION['glpiactiveprofile'][Ticket::$rightname] = $old_session;
+        }
+    }
+
+    protected function updateDropdownOrCommonDBConnexityProvider()
+    {
+        $ticket = new Ticket();
+        $location = new Location();
+        $id = $ticket->add([
+            'name'          => 'test',
+            'content'       => 'test',
+            'entities_id'   => getItemByTypeName('Entity', '_test_root_entity', true),
+        ]);
+        $ticket->getFromDB($id);
+        $this->assertGreaterThan(0, $id);
+        $this->assertSame($ticket->fields['entities_id'], getItemByTypeName('Entity', '_test_root_entity', true));
+
+        $this->createItem(
+            \Entity::class,
+            [
+                'name'          => '_test_root_subentity',
+                'entities_id'   => getItemByTypeName('Entity', '_test_root_entity', true),
+            ]
+        );
+
+        $location = new Location();
+        $location_id_1 = $location->add([
+            'name'        => 'test',
+            'entities_id' => getItemByTypeName('Entity', '_test_root_entity', true),
+        ]);
+        $this->assertGreaterThan(0, $location_id_1);
+
+        $location_id_2 = $location->add([
+            'name'        => 'test_sub',
+            'entities_id' => getItemByTypeName('Entity', '_test_root_subentity', true),
+        ]);
+        $this->assertGreaterThan(0, $location_id_2);
+
+        return [
+            [
+                // Should work
+                'item'        => $ticket,
+                'input'       => [
+                    'locations_id' => $location_id_1,
+                    'search_options' =>
+                    [
+                        $ticket->getType() => 83
+                    ],
+                    'field' => 'locations_id',
+                ],
+                'has_right'   => true,
+                'should_work' => true,
+            ],
+            [
+                // Should not work
+                'item'        => $ticket,
+                'input'       => [
+                    'locations_id' => $location_id_2,
+                    'search_options' =>
+                    [
+                        $ticket->getType() => 83
+                    ],
+                    'field' => 'locations_id',
+                ],
+                'has_right'   => true,
+                'should_work' => false, //not same entity
+            ],
+        ];
     }
 }

--- a/phpunit/functional/MassiveActionTest.php
+++ b/phpunit/functional/MassiveActionTest.php
@@ -799,7 +799,7 @@ class MassiveActionTest extends DbTestCase
                     'locations_id' => $location_id_1,
                     'search_options' =>
                     [
-                        $ticket->getType() => 83
+                        $ticket->getType() => 83,
                     ],
                     'field' => 'locations_id',
                 ],
@@ -813,7 +813,7 @@ class MassiveActionTest extends DbTestCase
                     'locations_id' => $location_id_2,
                     'search_options' =>
                     [
-                        $ticket->getType() => 83
+                        $ticket->getType() => 83,
                     ],
                     'field' => 'locations_id',
                 ],

--- a/src/MassiveAction.php
+++ b/src/MassiveAction.php
@@ -1624,7 +1624,7 @@ class MassiveAction
                                         }
                                         // Case 2: The field is not a foreign key, but the target class supports connexity (relations)
                                         // Use getConnexityItem() to dynamically resolve the related object based on the main itemtype and id (items_id)
-                                    } else if (is_a($item2, CommonDBConnexity::class, true)) {
+                                    } elseif (is_a($item2, CommonDBConnexity::class, true)) {
                                         $related_item = $item2->getConnexityItem($item->getType(), $key);
                                     }
 

--- a/src/MassiveAction.php
+++ b/src/MassiveAction.php
@@ -1622,9 +1622,8 @@ class MassiveAction
                                         if ($item2->getFromDB($input[$input["field"]])) {
                                             $related_item = $item2;
                                         }
-
-                                    // Case 2: The field is not a foreign key, but the target class supports connexity (relations)
-                                    // Use getConnexityItem() to dynamically resolve the related object based on the main itemtype and id (items_id)
+                                        // Case 2: The field is not a foreign key, but the target class supports connexity (relations)
+                                        // Use getConnexityItem() to dynamically resolve the related object based on the main itemtype and id (items_id)
                                     } else if (is_a($item2, CommonDBConnexity::class, true)) {
                                         $related_item = $item2->getConnexityItem($item->getType(), $key);
                                     }

--- a/src/MassiveAction.php
+++ b/src/MassiveAction.php
@@ -1612,7 +1612,7 @@ class MassiveAction
                                 && $item2->isEntityAssign()
                                 && $item->isEntityAssign()
                             ) {
-                                if ($item2->getFromDB($input[$input["field"]])) {
+                                if ($input["field"] == "id" && $item2->getFromDB($input[$input["field"]])) {
                                     if (
                                         isset($item2->fields["entities_id"])
                                         && ($item2->fields["entities_id"] >= 0)

--- a/src/MassiveAction.php
+++ b/src/MassiveAction.php
@@ -1605,34 +1605,51 @@ class MassiveAction
                         /// Specific entity item
                         $itemtable = getTableForItemType($item->getType());
                         $itemtype2 = getItemTypeForTable($searchopt[$index]["table"]);
-                        if ($item2 = getItemForItemtype($itemtype2)) {
-                            if (
-                                ($index != 80) // No entities_id fields
-                                && ($searchopt[$index]["table"] != $itemtable)
-                                && $item2->isEntityAssign()
-                                && $item->isEntityAssign()
-                            ) {
-                                if ($input["field"] == "id" && $item2->getFromDB($input[$input["field"]])) {
-                                    if (
-                                        isset($item2->fields["entities_id"])
-                                        && ($item2->fields["entities_id"] >= 0)
-                                    ) {
+
+                        foreach ($ids as $key) {
+
+                            if ($item2 = getItemForItemtype($itemtype2)) {
+                                if (
+                                    ($index != 80) // No entities_id fields
+                                    && ($searchopt[$index]["table"] != $itemtable)
+                                    && $item2->isEntityAssign()
+                                    && $item->isEntityAssign()
+                                ) {
+                                    $related_item = null;
+                                    // Case 1: The modified field is a foreign key (ex : locations_id)
+                                    if (isForeignKeyField($input["field"])) {
+                                        // Attempt to load the related object using its ID (from the input value)
+                                        if ($item2->getFromDB($input[$input["field"]])) {
+                                            $related_item = $item2;
+                                        }
+
+                                    // Case 2: The field is not a foreign key, but the target class supports connexity (relations)
+                                    // Use getConnexityItem() to dynamically resolve the related object based on the main itemtype and id (items_id)
+                                    } else if (is_a($item2, CommonDBConnexity::class, true)) {
+                                        $related_item = $item2->getConnexityItem($item->getType(), $key);
+                                    }
+
+                                    if (!is_null($related_item)) {
                                         if (
-                                            isset($item2->fields["is_recursive"])
-                                            && $item2->fields["is_recursive"]
+                                            isset($related_item->fields["entities_id"])
+                                            && ($related_item->fields["entities_id"] >= 0)
                                         ) {
-                                            $link_entity_type = getSonsOf(
-                                                "glpi_entities",
-                                                $item2->fields["entities_id"]
-                                            );
-                                        } else {
-                                            $link_entity_type[] = $item2->fields["entities_id"];
+                                            if (
+                                                isset($related_item->fields["is_recursive"])
+                                                && $related_item->fields["is_recursive"]
+                                            ) {
+                                                $link_entity_type = getSonsOf(
+                                                    "glpi_entities",
+                                                    $related_item->fields["entities_id"]
+                                                );
+                                            } else {
+                                                $link_entity_type[] = $related_item->fields["entities_id"];
+                                            }
                                         }
                                     }
                                 }
                             }
-                        }
-                        foreach ($ids as $key) {
+
                             if (
                                 $item->canEdit($key)
                                 && $item->canMassiveAction(


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !37540

In `GLPI`, if a search option references a table different from the main object, the `MassiveAction` class will attempt (if the main item and the related item can be assigned to an `entity`) to load the related item to extract the entity (and the sub-entity if recursive) and compare it to the entity of the main item to "authorize" or deny the update.

However, the loading of the related item is performed via a `getFromDB()` (thus using the ID column) from the value of the modified field (=/).

Thus, when the field is text, the condition on the entity is never verified and update action is authorized.

But when the field is `numeric` (`dropdown` / `number` / `yes no`), the loading is erroneous.

For example, with `Yes` or `No`, GLPI will load sytematically the related item with `ID 1` or `ID 0` (which does not correspond to the `ID` of the line I am trying to modify via the massive actions).

This is a case we have detected in the `Fields` plugin since we added the `entities_id` and `is_recursive` columns.
https://github.com/pluginsGLPI/fields/pull/858

We have not found a similar case in GLPI (via the relation tables), primarily because there is no search option defined on a main asset for a relation table pointing to a 'numeric' field with 'allow_massiveaction => true'.

Let's take the example of a Ticket ID `14305`, which has a fields field of type `YesNo` and a related line indatabase concerning container table.

![image](https://github.com/user-attachments/assets/998aed55-a832-409a-9e1b-d945dd616c0a)


Via the massive actions, I want to update this field.

## First case: update to "No"
GLPI detects that the modified field references a different SQL table than the main item (Ticket) and the related / main item (PluginFieldsTickettickettest) can be assigned to an entity.
GLPI will then attempt to load the related item (PluginFieldsTickettickettest) with `getFromDB(value of the modified field => 0)`.
This line does not exist in the database, the check on the entity is bypassed, and GLPI authorizes the update.

## Second case: update to "Yes"
GLPI detects that the modified field references a different SQL table than the main item and that the main item (Ticket) and the related item (PluginFieldsTickettickettest) can be assigned to an entity.
GLPI will then attempt to load the related item (PluginFieldsTickettickettest) with `getFromDB(value of the modified field => 1)`.
This line does not exist in the database, the check on the entity is performed, and GLPI refuses the update because the entity of the main item (Ticket) and the entity of the related item (PluginFieldsTickettickettest) are not the same.

@cedric-anne I am available to show you (it will certainly be more effective in person).

## Screenshots (if appropriate):


