### PR TITLE
fix(inventory): margin ui import success

### DIFF
--- a/templates/pages/admin/inventory/upload_result.html.twig
+++ b/templates/pages/admin/inventory/upload_result.html.twig
@@ -35,13 +35,13 @@
         <div class="search-container">
             <div class="card card-sm search-card">
                 <div class="card-header search-header pe-0">
-                    <div class='btn-group flex-wrap mb-3'>
+                    <div class='btn-group flex-wrap'>
                         <span class="btn bg-blue-lt pe-none" aria-disabled="true">
                             <i class='ti ti-check fs-2 me-2'></i>
                             {{ __('Import process is complete.') }}
                         </span>
                     </div>
-                    <div class='btn-group flex-wrap mb-3 ms-2'>
+                    <div class='btn-group flex-wrap ms-2'>
                         <a href="javascript:history.back();" class="btn btn-primary">
                         <i class='ti ti-player-track-prev-filled fs-2 me-2'></i>
                             {{ __('Back') }}


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

Fixes a margin offset for buttons on the manual inventory import confirmation page.

Before 
![image](https://github.com/user-attachments/assets/5dad8cc0-c0a2-40c6-a021-d4c319a217a1)

After
![image](https://github.com/user-attachments/assets/06c5ff59-3217-44a7-a177-eb6a0600b279)

