### PR TITLE
Prevent invalid associated item to be selected for predefined fields

### DIFF
--- a/phpunit/functional/ChangeTemplatePredefinedFieldTest.php
+++ b/phpunit/functional/ChangeTemplatePredefinedFieldTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units;
+
+use ChangeTemplatePredefinedField;
+use Glpi\Tests\AbstractITILTemplatePredefinedFieldTest;
+use ITILTemplatePredefinedField;
+
+final class ChangeTemplatePredefinedFieldTest extends AbstractITILTemplatePredefinedFieldTest
+{
+    public function getConcreteClass(): ITILTemplatePredefinedField
+    {
+        return new ChangeTemplatePredefinedField();
+    }
+}

--- a/phpunit/functional/ProblemTemplatePredefinedFieldTest.php
+++ b/phpunit/functional/ProblemTemplatePredefinedFieldTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units;
+
+use Glpi\Tests\AbstractITILTemplatePredefinedFieldTest;
+use ITILTemplatePredefinedField;
+use ProblemTemplatePredefinedField;
+
+final class ProblemTemplatePredefinedFieldTest extends AbstractITILTemplatePredefinedFieldTest
+{
+    public function getConcreteClass(): ITILTemplatePredefinedField
+    {
+        return new ProblemTemplatePredefinedField();
+    }
+}

--- a/phpunit/functional/TicketTemplatePredefinedFieldTest.php
+++ b/phpunit/functional/TicketTemplatePredefinedFieldTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units;
+
+use Glpi\Tests\AbstractITILTemplatePredefinedFieldTest;
+use ITILTemplatePredefinedField;
+use TicketTemplatePredefinedField;
+
+final class TicketTemplatePredefinedFieldTest extends AbstractITILTemplatePredefinedFieldTest
+{
+    public function getConcreteClass(): ITILTemplatePredefinedField
+    {
+        return new TicketTemplatePredefinedField();
+    }
+}

--- a/src/ITILTemplatePredefinedField.php
+++ b/src/ITILTemplatePredefinedField.php
@@ -75,9 +75,20 @@ abstract class ITILTemplatePredefinedField extends ITILTemplateField
         }
 
         if ((int) $input['num'] === 13) { // 13 - Search option ID for Associated Items for CommonITILObject types
+            // An itemtype must be selected
             if ((string) $input['value'] === '0') {
                 Session::addMessageAfterRedirect(
                     __('You must select an associated item'),
+                    true,
+                    ERROR
+                );
+                return false;
+            }
+
+            // An item must be selected
+            if (isset($input['add_items_id']) && $input['add_items_id'] == 0) {
+                Session::addMessageAfterRedirect(
+                    __s('You must select an associated item'),
                     true,
                     ERROR
                 );

--- a/tests/src/AbstractITILTemplatePredefinedFieldTest.php
+++ b/tests/src/AbstractITILTemplatePredefinedFieldTest.php
@@ -1,0 +1,106 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Tests;
+
+use DbTestCase;
+use ITILTemplatePredefinedField;
+
+abstract class AbstractITILTemplatePredefinedFieldTest extends DbTestCase
+{
+    abstract public function getConcreteClass(): ITILTemplatePredefinedField;
+
+    public static function getAssociatedItemsInputs(): iterable
+    {
+        yield [
+            'input' => [
+                'num'          => 13,
+                'value'        => "Computer_1",
+                'add_items_id' => 1,
+                'entities_id'  => 0,
+                'is_recursive' => false,
+            ],
+            'expected_result' => true,
+        ];
+        yield [
+            'input' => [
+                'num'          => 13,
+                'value'        => 0,
+                'entities_id'  => 0,
+                'is_recursive' => false,
+            ],
+            'expected_result' => false,
+            'expected_errors' => ["You must select an associated item"],
+        ];
+        yield [
+            'input' => [
+                'num'          => 13,
+                'value'        => "Computer_0",
+                'add_items_id' => 0,
+                'entities_id'  => 0,
+                'is_recursive' => false,
+            ],
+            'expected_result' => false,
+            'expected_errors' => ["You must select an associated item"],
+        ];
+    }
+
+    /**
+     * @dataProvider getAssociatedItemsInputs
+     */
+    public function testValidAssociatedItemsInput(
+        array $input,
+        bool $expected_result,
+        array $expected_errors = []
+    ): void {
+        // Arrange: create a valid template and insert it into the input
+        $tpl_class = $this->getConcreteClass()::$itemtype;
+        $tpl = $this->createItem(
+            $tpl_class,
+            ['name' => 'my template']
+        );
+        $input[$tpl_class::getForeignKeyField()] = $tpl->getID();
+
+        // Act: login and prepare input
+        $this->login('glpi', 'glpi');
+        $result = $this->getConcreteClass()->prepareInputForAdd($input);
+
+        // Assert: check validity and error message
+        $this->assertEquals($expected_result, (bool) $result);
+        if ($expected_errors) {
+            $this->hasSessionMessages(ERROR, $expected_errors);
+        }
+    }
+}


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.

## Description

Prevent adding an invalid associated items in the predefined fields (e.g. the itemtype was picker but the item was not selected).

## References

Fix #19701.

