### PR TITLE
Fix missing default value on install for "non_reusable_passwords_count"

### DIFF
--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -363,6 +363,7 @@ $empty_data_builder = new class {
             'projecttask_unstarted_states_id' => 0,
             'projecttask_inprogress_states_id' => 0,
             'projecttask_completed_states_id' => 0,
+            'non_reusable_passwords_count' => 1,
         ];
 
         $tables['glpi_configs'] = [];

--- a/phpunit/functional/ConfigTest.php
+++ b/phpunit/functional/ConfigTest.php
@@ -34,6 +34,7 @@
 
 namespace tests\units;
 
+use Config;
 use DbTestCase;
 use Glpi\Plugin\Hooks;
 use Log;
@@ -907,5 +908,20 @@ class ConfigTest extends DbTestCase
             'pdffont' => 'freesans',
         ]);
         $this->assertEquals('freesans', $CFG_GLPI['pdffont']);
+    }
+
+    public function testShowFormSecurity(): void
+    {
+        // Arrange: login
+        $this->login();
+
+        // Act: display the securitry from
+        $config = new Config();
+        ob_start();
+        $config->showFormSecurity();
+        $html = ob_get_clean();
+
+        // Assert: make sure we reached this point without errors
+        $this->assertNotEmpty($html);
     }
 }

--- a/phpunit/functional/ConfigTest.php
+++ b/phpunit/functional/ConfigTest.php
@@ -915,7 +915,7 @@ class ConfigTest extends DbTestCase
         // Arrange: login
         $this->login();
 
-        // Act: display the securitry from
+        // Act: display the security from
         $config = new Config();
         ob_start();
         $config->showFormSecurity();


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

This field is only initialized when migrating from GLPI 10 to 11, we forgot to include it in the empty data for a clean install.
This lead to an exception when trying to render the security config form.

## References

Introduced by: ba4c34277d25e5a1b753bc000ba1f394c64ad058.

