### PR TITLE
Unactivate all plugins once a mandatory update is detected

### DIFF
--- a/src/Glpi/Kernel/Listener/PostBootListener/DisablePluginsOnVersionChange.php
+++ b/src/Glpi/Kernel/Listener/PostBootListener/DisablePluginsOnVersionChange.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Kernel\Listener\PostBootListener;
+
+use DBConnection;
+use Glpi\Debug\Profiler;
+use Glpi\Kernel\ListenersPriority;
+use Glpi\Kernel\PostBootEvent;
+use Plugin;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Update;
+
+final readonly class DisablePluginsOnVersionChange implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            PostBootEvent::class => ['onPostBoot', ListenersPriority::POST_BOOT_LISTENERS_PRIORITIES[self::class]],
+        ];
+    }
+
+    public function onPostBoot(): void
+    {
+        if (!DBConnection::isDbAvailable()) {
+            return;
+        }
+
+        Profiler::getInstance()->start('DisablePluginsOnVersionChange::execute', Profiler::CATEGORY_BOOT);
+
+        if (Update::isUpdateMandatory()) {
+            // Disable all plugins once a new mandatory update is detected.
+            // This prevents incompatible plugins to be loaded.
+            (new Plugin())->unactivateAll();
+            return;
+        }
+
+        Profiler::getInstance()->stop('DisablePluginsOnVersionChange::execute');
+    }
+}

--- a/src/Glpi/Kernel/ListenersPriority.php
+++ b/src/Glpi/Kernel/ListenersPriority.php
@@ -47,6 +47,7 @@ final class ListenersPriority
         PostBootListener\LoadLegacyConfiguration::class =>             160,
         PostBootListener\LoadLanguage::class =>                        150,
         PostBootListener\CustomObjectsAutoloaderRegistration::class => 140,
+        PostBootListener\DisablePluginsOnVersionChange::class =>       135,
         PostBootListener\InitializePlugins::class =>                   130,
         PostBootListener\CustomObjectsBootstrap::class =>              120,
     ];

--- a/src/Update.php
+++ b/src/Update.php
@@ -227,10 +227,6 @@ class Update
             $DB->doQuery(sprintf('SET SESSION sql_mode = %s', $DB->quote(implode(',', $sql_mode_flags))));
         }
 
-        // Update process desactivate all plugins
-        $plugin = new Plugin();
-        $plugin->unactivateAll();
-
         $migrations = $this->getMigrationsToDo($current_version, $force_latest);
 
         $number_of_steps = count($migrations);


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

It fixes #19629.

Since now plugins are loaded during the GLPI boot sequence, they are now loaded prior to the initialization of the GLPI console, and it is therefore impossible to not load them for some specific commandas as it was done in GLPI 10.0. Indeed, it is nearly impossible to know what exact command will be executed during the kernel boot, as Symfony is able to match many identifiers for a same command, for instance the install command can be executed with `d:i`, `db:i`, `data:inst`, `database:install`, `db:install`, ... as long as there is no ambiguity between multiple commands.

Until now the plugins were deactivated by the update process itself, when it was actually executed. I propose to deactivate the plugins earlier, during the GLPI boot sequence, before they are actually loaded, as long as we detect that the GLPI version has changed and required the update process to be executed.
