### PR TITLE
fix(helpdesk): Rename 'link' to 'url' in external page tile configuration

### DIFF
--- a/templates/pages/admin/external_page_tile_config_fields.html.twig
+++ b/templates/pages/admin/external_page_tile_config_fields.html.twig
@@ -60,7 +60,7 @@
 ) }}
 
 {{ fields.urlField(
-    'link',
+    'url',
     tile.getTileUrl(),
     __('Target url'),
     {

--- a/tests/cypress/e2e/self-service/home_config.cy.js
+++ b/tests/cypress/e2e/self-service/home_config.cy.js
@@ -274,6 +274,11 @@ for (const test of tests) {
                 "My external tile title",
             ]);
             cy.findByText("My description").should('be.visible');
+            validateTileFields(
+                "My external tile title",
+                "My description",
+                "support.teclib.com"
+            );
         });
 
         it(`can add a "Form" tile (${test.label})`, () => {
@@ -473,6 +478,13 @@ function validateTilesOrder(tiles) {
             cy.findAllByRole("region").eq(i).should('have.attr', 'aria-label', title);
         });
     });
+}
+
+function validateTileFields(title, description, target) {
+    cy.findByRole("region", {'name': title}).click();
+    cy.findByRole("heading", {'name': title}).should('be.visible');
+    cy.findByLabelText('Description').awaitTinyMCE().should('contain', description);
+    cy.findByLabelText('Target url').should('have.value', target);
 }
 
 function moveTileAfterTile(subject, destination) {


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

- It fixes #19717

The name of the field used to define the external url did not match the base field.
Modification of a Cypress test to verify the configuration of an external tile after addition.