### PR TITLE
Move `CFG_GLPI` JS var definition in the HTML header

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -3848,12 +3848,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Application/View/Extension/DocumentExtension.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Function json_encode is unsafe to use\\. It can return FALSE instead of throwing an exception\\. Please add \'use function Safe\\\\json_encode;\' at the beginning of the file to use the variant provided by the \'thecodingmachine/safe\' library\\.$#',
-	'identifier' => 'theCodingMachineSafe.function',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Application/View/Extension/FrontEndAssetsExtension.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Function parse_url is unsafe to use\\. It can return FALSE instead of throwing an exception\\. Please add \'use function Safe\\\\parse_url;\' at the beginning of the file to use the variant provided by the \'thecodingmachine/safe\' library\\.$#',
 	'identifier' => 'theCodingMachineSafe.function',
 	'count' => 2,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -471,6 +471,7 @@ The present file will list all changes made to the project; according to the
 - `Html::displayAccessDeniedPage()`
 - `Html::displayAjaxMessageAfterRedirect()`. The JS function is already provided by `js/misc.js`.
 - `Html::displayItemNotFoundPage()`
+- `Html::getCoreVariablesForJavascript()`
 - `Html::jsConfirmCallback()`
 - `Html::jsHide()`
 - `Html::jsShow()`

--- a/install/install.php
+++ b/install/install.php
@@ -76,9 +76,6 @@ function header_html($etape)
         'custom_header_tags' => [],
     ]);
 
-    // CFG
-    echo Html::getCoreVariablesForJavascript();
-
     echo "<body>";
     echo "<div id='principal'>";
     echo "<div id='bloc'>";

--- a/install/update.php
+++ b/install/update.php
@@ -119,9 +119,6 @@ TemplateRenderer::getInstance()->display('layout/parts/head.html.twig', [
     'custom_header_tags' => [],
 ]);
 
-// CFG
-echo Html::getCoreVariablesForJavascript();
-
 echo "<body>";
 echo "<div id='principal'>";
 echo "<div id='bloc'>";

--- a/src/Glpi/Application/View/Extension/FrontEndAssetsExtension.php
+++ b/src/Glpi/Application/View/Extension/FrontEndAssetsExtension.php
@@ -35,6 +35,7 @@
 
 namespace Glpi\Application\View\Extension;
 
+use Config;
 use DBmysql;
 use Entity;
 use Glpi\Application\ImportMapGenerator;
@@ -46,6 +47,8 @@ use Plugin;
 use Session;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
+
+use function Safe\json_encode;
 
 /**
  * @since 10.0.0
@@ -70,6 +73,7 @@ class FrontEndAssetsExtension extends AbstractExtension
             new TwigFunction('css_path', [$this, 'cssPath']),
             new TwigFunction('js_path', [$this, 'jsPath']),
             new TwigFunction('custom_css', [$this, 'customCss'], ['is_safe' => ['html']]),
+            new TwigFunction('config_js', [$this, 'configJs'], ['is_safe' => ['html']]),
             new TwigFunction('locales_js', [$this, 'localesJs'], ['is_safe' => ['html']]),
             new TwigFunction('current_theme', [$this, 'currentTheme']),
             new TwigFunction('importmap', [$this, 'importmap'], ['is_safe' => ['html']]),
@@ -266,6 +270,34 @@ JAVASCRIPT;
             });
 JAVASCRIPT;
         }
+
+        return Html::scriptBlock($script);
+    }
+
+    /**
+     * Return config (CFG_GLPI) JS code.
+     *
+     * @return string
+     */
+    public function configJs(): string
+    {
+        /** @var array $CFG_GLPI */
+        global $CFG_GLPI;
+
+        $cfg_glpi = [
+            'url_base' => $CFG_GLPI['url_base'] ?? '', // may not be defined during the install process
+            'root_doc' => $CFG_GLPI['root_doc'],
+        ];
+        if (Session::getLoginUserID(true) !== false) {
+            // expose full config only for connected users
+            $cfg_glpi += Config::getSafeConfig(true);
+        }
+
+        $plugins_path = \array_map(fn(string $plugin_key) => "/plugins/{$plugin_key}", Plugin::getPlugins());
+
+        $script = sprintf('const CFG_GLPI = %s;', json_encode($cfg_glpi, JSON_PRETTY_PRINT))
+            . "\n"
+            . sprintf('const GLPI_PLUGINS_PATH = %s;', json_encode($plugins_path, JSON_PRETTY_PRINT));
 
         return Html::scriptBlock($script);
     }

--- a/src/Html.php
+++ b/src/Html.php
@@ -1666,8 +1666,6 @@ TWIG,
         }
         $FOOTER_LOADED = true;
 
-        echo self::getCoreVariablesForJavascript(true);
-
         if (isset($CFG_GLPI['notifications_ajax']) && $CFG_GLPI['notifications_ajax'] && !Session::isImpersonateActive()) {
             $options = [
                 'interval'  => ($CFG_GLPI['notifications_ajax_check_interval'] ?: 5) * 1000,
@@ -5963,9 +5961,6 @@ HTML;
          * @var array $PLUGIN_HOOKS
          */
         global $CFG_GLPI, $PLUGIN_HOOKS;
-
-        // transfer core variables to javascript side
-        echo self::getCoreVariablesForJavascript(true);
 
         //load on demand scripts
         if (isset($_SESSION['glpi_js_toload'])) {

--- a/templates/layout/parts/head.html.twig
+++ b/templates/layout/parts/head.html.twig
@@ -74,6 +74,8 @@
 
    {{ importmap() }}
 
+   {{ config_js() }}
+
    {% for js_file in js_files %}
       <script type="text/javascript" src="{{ js_path(js_file.path, js_file.options ?? []) }}"></script>
    {% endfor %}


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

In the massive action process script, the GLPI footer is not displayed, as we only want to display a progress bar. The `CFG_GLPI` JS variable was therefore not defined and an error was triggered in the `vue/app.js` script that is executed on every page to register the path to every vue component.

I moved the definition of these variables in the `templates/layout/parts/head.html.twig` template that is used to display the HTML `<head>` section of every page.