### PR TITLE
Fix(Inventory): prevent lock when inventory update Item_SoftwareVersion

### DIFF
--- a/phpunit/functional/Glpi/Inventory/Assets/SoftwareTest.php
+++ b/phpunit/functional/Glpi/Inventory/Assets/SoftwareTest.php
@@ -1647,7 +1647,13 @@ class SoftwareTest extends AbstractInventoryAsset
             "date_install" => "2024-03-04",
         ]));
 
-        //check computer-softwareverison relation is the same (ID)
+        //check that no lock have been added
+        $lock = new \Lockedfield();
+        $this->assertFalse($lock->getFromDBByCrit([
+            "itemtype" => \Item_SoftwareVersion::class,
+            "items_id" => $item_version->fields['id'],
+            "field" => "date_install",
+        ]));
     }
 
     public function testSubCategoryDictionnary()

--- a/src/Glpi/Inventory/Asset/Software.php
+++ b/src/Glpi/Inventory/Asset/Software.php
@@ -412,6 +412,7 @@ class Software extends InventoryAsset
                 $software_version = new Item_SoftwareVersion();
                 $software_version->update([
                     "id" => $db_software[$key_w_version]['id'],
+                    "is_dynamic" => 1,
                     "date_install" => $val->date_install,
                 ], 0);
             }


### PR DESCRIPTION

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !37653

Prevent `lockedfield` when inventory update `Item_SoftwareVersion` (date_install)

Introduced by https://github.com/glpi-project/glpi/pull/16598


## Screenshots (if appropriate):


