### PR TITLE
Fix - Consistency of exported knowledge base data

### DIFF
--- a/front/report.dynamic.php
+++ b/front/report.dynamic.php
@@ -58,7 +58,7 @@ if (isset($_GET["display_type"])) {
 
     switch ($itemtype) {
         case 'KnowbaseItem':
-            KnowbaseItem::showList($_GET, $_GET["is_faq"]);
+            KnowbaseItem::showList($_GET, $_GET["type"]);
             break;
 
         case 'Stat':

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -1920,7 +1920,13 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria
             // Pager
             $parameters = "start=" . $params["start"] . "&amp;knowbaseitemcategories_id=" .
                         $params['knowbaseitemcategories_id'] . "&amp;contains=" .
-                        $params["contains"] . "&amp;is_faq=" . $params['faq'];
+                        $params["contains"];
+
+            if ($type != 'search' && $type != 'browse') {
+                $parameters .= "&amp;is_faq=" . $type;
+            } else {
+                $parameters .= "&amp;is_faq=" . $params['faq'];
+            }
 
             if (
                 isset($options['item_itemtype'])

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -1920,7 +1920,7 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria
             // Pager
             $parameters = "start=" . $params["start"] . "&amp;knowbaseitemcategories_id=" .
                         $params['knowbaseitemcategories_id'] . "&amp;contains=" .
-                        $params["contains"] . "&amp;faq=" . $params['faq'] . "&amp;type=" . $type;
+                        $params["contains"] . "&amp;is_faq=" . $params['faq'] . "&amp;type=" . $type;
 
             if (
                 isset($options['item_itemtype'])

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -1920,13 +1920,7 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria
             // Pager
             $parameters = "start=" . $params["start"] . "&amp;knowbaseitemcategories_id=" .
                         $params['knowbaseitemcategories_id'] . "&amp;contains=" .
-                        $params["contains"];
-
-            if ($type != 'search' && $type != 'browse') {
-                $parameters .= "&amp;is_faq=" . $type;
-            } else {
-                $parameters .= "&amp;is_faq=" . $params['faq'];
-            }
+                        $params["contains"] . "&amp;faq=" . $params['faq'] . "&amp;type=" . $type;
 
             if (
                 isset($options['item_itemtype'])


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !37420
- Here is a brief description of what this PR does

Incorrect export of knowledge base articles. For example, if I choose to export `All my articles`, the export will show `All published articles`. The problem is that the field containing the data to be displayed is not sent when the export is called.

