### PR TITLE
Fix readonly templates fields

### DIFF
--- a/templates/components/form/basic_inputs_macros.html.twig
+++ b/templates/components/form/basic_inputs_macros.html.twig
@@ -227,6 +227,10 @@
         'id': name|slug ~ '_' ~ options.rand
     }|merge(options) %}
 
+    {% if options.fields_template is defined and options.fields_template.isReadonlyField(name)|default(false) %}
+        {% set options = options|merge({'readonly': true}) %}
+    {% endif %}
+
     {% if value == 'NULL' %}
       {% set value = null %}
    {% endif %}

--- a/templates/components/form/basic_inputs_macros.html.twig
+++ b/templates/components/form/basic_inputs_macros.html.twig
@@ -227,7 +227,7 @@
         'id': name|slug ~ '_' ~ options.rand
     }|merge(options) %}
 
-    {% if options.fields_template is defined and options.fields_template.isReadonlyField(name)|default(false) %}
+    {% if options.fields_template.isReadonlyField(name)|default(false) %}
         {% set options = options|merge({'readonly': true}) %}
     {% endif %}
 

--- a/templates/components/itilobject/fields_panel.html.twig
+++ b/templates/components/itilobject/fields_panel.html.twig
@@ -139,6 +139,7 @@
                   'width': '100%',
                   'display': false,
                   'rand': rand,
+                  'readonly': field_options.fields_template.isReadonlyField('type'),
                }|merge(field_options) %}
                {% if item.isNewItem() %}
                   {% set type_params = type_params|merge({'on_change': 'this.form.submit()',}) %}

--- a/templates/components/itilobject/service_levels.html.twig
+++ b/templates/components/itilobject/service_levels.html.twig
@@ -75,8 +75,8 @@
    }
 ]) %}
 
-{% set can_assign_sla_ola = canupdate and has_profile_right('slm', constant('SLM::RIGHT_ASSIGN')) %}
 {% for la_field in la_fields %}
+   {% set can_assign_sla_ola = canupdate and has_profile_right('slm', constant('SLM::RIGHT_ASSIGN')) and not field_options.fields_template.isReadonlyField(la_field.lafieldname) %}
    {% set rand = random() %}
    {% set date_displayed = field_options.fields_template is not defined or not field_options.fields_template.isHiddenField(la_field.datefieldname) %}
    {% set la_displayed = field_options.fields_template is not defined or not field_options.fields_template.isHiddenField(la_field.lafieldname) %}
@@ -238,7 +238,7 @@
             full_width: true,
             is_horizontal: false,
             add_field_class: (is_expanded ? 'col-sm-6' : ''),
-            required: field_options.fields_template.isMandatoryField(la_field.lafieldname)
+            required: field_options.fields_template.isMandatoryField(la_field.lafieldname),
          }
       ) }}
    {% endif %}


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
   -> Would like to be the code that test this form is a mess and do not support readonly fields. Maybe later if I have time.

## Description

Some readonly fields were not applied correctly for itil templates:
- Request type
- Opening date
- SLA

## References

Fix #19627.

