### PR TITLE
Fix(ITIL templates): category predefined field

### DIFF
--- a/phpunit/functional/ITILTemplateTest.php
+++ b/phpunit/functional/ITILTemplateTest.php
@@ -479,6 +479,19 @@ class ITILTemplateTest extends DbTestCase
         $entity = getItemByTypeName('Entity', '_test_child_1');
         $this->assertTrue($entity->update(['id' => $entity->fields['id'], $field => $entity_tpl_id]));
 
+        //add a predefined field
+        $predef_class = '\\' . $itiltype . 'TemplatePredefinedField';
+        $predef = new $predef_class();
+        $input = [
+            $predef::$items_id   => $entity_tpl_id,
+            'num'                => 7, // Category
+            'value'              => $cat_id,
+        ];
+        $this->createItem(
+            $predef_class,
+            $input
+        );
+
         //login back as tech
         $this->login('tech', 'tech');
 
@@ -488,6 +501,7 @@ class ITILTemplateTest extends DbTestCase
             'Not template expected from entity assignment'
         );
         $this->assertSame($entity_tpl_id, (int) $tt->fields['id']);
+        $this->assertSame($cat_id, (int) $tt->predefined['itilcategories_id']);
 
         $tt = $itilobject->getITILTemplateToUse(0, $type, $cat_id, $entity->fields['id']);
         $this->assertFalse(

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -7762,8 +7762,8 @@ abstract class CommonITILObject extends CommonDBTM
                 $newtype = $tt->predefined['type'];
             }
             if (
-                $newtype
-                && $newitilcategories_id
+                $newtype != $type
+                && $newitilcategories_id != $itilcategories_id
             ) {
                 $categ = new ITILCategory();
                 if ($categ->getFromDB($newitilcategories_id)) {


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !37529

At the creation of an ITIL object, the category defined in the predefined field was not filled in.

## Screenshots (if appropriate):


