### PR TITLE
Must declare CFG_GLPI in JS on the window

### DIFF
--- a/src/Glpi/Application/View/Extension/FrontEndAssetsExtension.php
+++ b/src/Glpi/Application/View/Extension/FrontEndAssetsExtension.php
@@ -295,9 +295,9 @@ JAVASCRIPT;
 
         $plugins_path = \array_map(fn(string $plugin_key) => "/plugins/{$plugin_key}", Plugin::getPlugins());
 
-        $script = sprintf('const CFG_GLPI = %s;', json_encode($cfg_glpi, JSON_PRETTY_PRINT))
+        $script = sprintf('window.CFG_GLPI = %s;', json_encode($cfg_glpi, JSON_PRETTY_PRINT))
             . "\n"
-            . sprintf('const GLPI_PLUGINS_PATH = %s;', json_encode($plugins_path, JSON_PRETTY_PRINT));
+            . sprintf('window.GLPI_PLUGINS_PATH = %s;', json_encode($plugins_path, JSON_PRETTY_PRINT));
 
         return Html::scriptBlock($script);
     }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

One of the few cases where `var` produced the desired effect, but `const` does not. We need to make sure these variables get added to the `window` as before so they can be accessed from within modules.

Modules can access these variables using `window.CFG_GLPI` or simply `CFG_GLPI` as before. With `const`, they were not accessible at all.