### PR TITLE
Remove duplicate user_header elements

### DIFF
--- a/templates/layout/parts/page_header.html.twig
+++ b/templates/layout/parts/page_header.html.twig
@@ -65,13 +65,6 @@
                </span>
             {% endif %}
 
-            {% if user is not null %}
-               {# There may still be a user logged in without a profile or entity. This is seen when they need to reset their password. #}
-               <div class="d-lg-none">
-                  {{ include('layout/parts/user_header.html.twig') }}
-               </div>
-            {% endif %}
-
             {% if not anonymous %}
                <div class="collapse navbar-collapse" id="navbar-menu">
                    <span class="d-inline-block d-lg-none ms-2">
@@ -111,10 +104,6 @@
                   <span class="glpi-logo"></span>
                </a>
 
-               <div class="d-lg-none">
-                  {{ include('layout/parts/user_header.html.twig') }}
-               </div>
-
                <div class="collapse navbar-collapse justify-content-center" id="navbar-menu">
                   {{ include('layout/parts/menu.html.twig') }}
                   <span class="ms-xl-2 d-inline-block mt-2 mt-xl-2">
@@ -123,9 +112,11 @@
                </div>
             {% endif %}
 
-            <div class="ms-md-4 d-none d-lg-block">
-               {{ include('layout/parts/user_header.html.twig') }}
-            </div>
+            {% if user is not null %}
+               <div class="ms-md-4">
+                  {{ include('layout/parts/user_header.html.twig') }}
+               </div>
+            {% endif %}
          </div>
       </header>
 

--- a/tests/cypress/e2e/page_layout.cy.js
+++ b/tests/cypress/e2e/page_layout.cy.js
@@ -43,11 +43,11 @@ describe('Page layout', () => {
             cy.get('aside.navbar.sidebar').injectAndCheckA11y();
         });
 
-        cy.get('.navbar-nav.user-menu:visible').click();
-        cy.get('.navbar-nav.user-menu:visible .dropdown-menu').injectAndCheckA11y();
+        cy.get('.navbar-nav.user-menu').click();
+        cy.get('.navbar-nav.user-menu .dropdown-menu').injectAndCheckA11y();
 
-        cy.get('.navbar-nav.user-menu:visible .dropdown-menu a.entity-dropdown-toggle').click();
-        cy.get('.navbar-nav.user-menu:visible .dropdown-menu a.entity-dropdown-toggle + .dropdown-menu').injectAndCheckA11y();
+        cy.get('.navbar-nav.user-menu .dropdown-menu a.entity-dropdown-toggle').click();
+        cy.get('.navbar-nav.user-menu .dropdown-menu a.entity-dropdown-toggle + .dropdown-menu').injectAndCheckA11y();
 
         cy.get('header.navbar').injectAndCheckA11y();
     });


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

In both horizontal and vertical menu modes, the `user_header.html.twig` template is always included twice and set so that when the `lg` breakpoint is reached, one is hidden while the other appears. I am not able to see any difference in behavior between that and having a single inclusion.