### PR TITLE
Fix criteria filter button UI

### DIFF
--- a/src/Glpi/Search/Input/QueryBuilder.php
+++ b/src/Glpi/Search/Input/QueryBuilder.php
@@ -85,6 +85,7 @@ final class QueryBuilder implements SearchInputInterface
         $p['showmassiveactions']            = true;
         $p['extra_actions_templates']       = [];
         $p['hide_criteria']                 = $params['hide_criteria'] ?? false;
+        $p['is_criteria_filter']            = $params['is_criteria_filter'] ?? false;
 
         foreach ($params as $key => $val) {
             $p[$key] = $val;

--- a/templates/components/search/criteria_filter.html.twig
+++ b/templates/components/search/criteria_filter.html.twig
@@ -67,6 +67,22 @@
     </div>
 </div>
 
+<style>
+    #manage_filter_ux button[name=search] {
+       --tblr-btn-padding-x: 1rem !important;
+       --tblr-btn-padding-y: 0.4375rem !important;
+       --tblr-btn-line-height: 1.4285714286 !important;
+       font-size: inherit !important;
+       --tblr-btn-color: var(--tblr-secondary-fg);
+       --tblr-btn-bg: var(--tblr-secondary);
+       --tblr-btn-hover-color: var(--tblr-secondary-fg);
+       --tblr-btn-hover-bg: var(--tblr-secondary-darken);
+       --tblr-btn-active-color: var(--tblr-secondary-fg);
+       --tblr-btn-active-bg: var(--tblr-secondary-darken);
+       --tblr-btn-disabled-bg: var(--tblr-secondary);
+       --tblr-btn-disabled-color: var(--tblr-secondary-fg);
+    }
+</style>
 <script>
     // Display search results
     $('button[name=search]').on('click', function(e) {

--- a/templates/components/search/criteria_filter.html.twig
+++ b/templates/components/search/criteria_filter.html.twig
@@ -44,7 +44,7 @@
         <div id="manage_filter_ux" class="{{ filter_enabled ? "" : "d-none" }}">
 
             {# Display search UX #}
-            {% do call('Glpi\\Search\\Input\\QueryBuilder::showGenericSearch', [itemtype, params]) %}
+            {% do call('Glpi\\Search\\Input\\QueryBuilder::showGenericSearch', [itemtype, params + {is_criteria_filter: true}]) %}
 
             {# Display search results, hidden until a search is executed #}
             <div id="criteria_filter_preview" class="d-none">
@@ -67,22 +67,6 @@
     </div>
 </div>
 
-<style>
-    #manage_filter_ux button[name=search] {
-       --tblr-btn-padding-x: 1rem !important;
-       --tblr-btn-padding-y: 0.4375rem !important;
-       --tblr-btn-line-height: 1.4285714286 !important;
-       font-size: inherit !important;
-       --tblr-btn-color: var(--tblr-secondary-fg);
-       --tblr-btn-bg: var(--tblr-secondary);
-       --tblr-btn-hover-color: var(--tblr-secondary-fg);
-       --tblr-btn-hover-bg: var(--tblr-secondary-darken);
-       --tblr-btn-active-color: var(--tblr-secondary-fg);
-       --tblr-btn-active-bg: var(--tblr-secondary-darken);
-       --tblr-btn-disabled-bg: var(--tblr-secondary);
-       --tblr-btn-disabled-color: var(--tblr-secondary-fg);
-    }
-</style>
 <script>
     // Display search results
     $('button[name=search]').on('click', function(e) {

--- a/templates/components/search/criteria_filter_actions.html.twig
+++ b/templates/components/search/criteria_filter_actions.html.twig
@@ -30,7 +30,7 @@
  # ---------------------------------------------------------------------
  #}
 
-<div>
+<div class="ms-1">
     <button
         class="btn btn-sm btn-primary me-1 {{ show_save ? "" : "d-none" }}"
         type="submit"

--- a/templates/components/search/criteria_filter_actions.html.twig
+++ b/templates/components/search/criteria_filter_actions.html.twig
@@ -32,7 +32,7 @@
 
 <div class="ms-2">
     <button
-        class="btn btn-sm btn-primary me-1 {{ show_save ? "" : "d-none" }}"
+        class="btn btn-primary me-1 {{ show_save ? "" : "d-none" }}"
         type="submit"
         name="save_filters"
     >
@@ -42,7 +42,7 @@
     </button>
 
     <button
-        class="btn btn-sm btn-outline-danger me-1 {{ show_delete ? "" : "d-none" }}"
+        class="btn btn-outline-danger me-1 {{ show_delete ? "" : "d-none" }}"
         name="delete_filters"
     >
         <i class="ti ti-trash"></i>

--- a/templates/components/search/criteria_filter_actions.html.twig
+++ b/templates/components/search/criteria_filter_actions.html.twig
@@ -30,7 +30,7 @@
  # ---------------------------------------------------------------------
  #}
 
-<div class="ms-1">
+<div class="ms-2">
     <button
         class="btn btn-sm btn-primary me-1 {{ show_save ? "" : "d-none" }}"
         type="submit"

--- a/templates/components/search/query_builder/main.html.twig
+++ b/templates/components/search/query_builder/main.html.twig
@@ -116,7 +116,8 @@
             <span class="d-none d-sm-block">{{ __('group') }}</span>
          </button>
          {% if mainform %}
-            <span class="ms-auto btn-group">
+            {% set action_count = showaction + p['showbookmark'] + p['showreset'] %}
+            <span class="ms-auto {{ action_count > 1 ? 'btn-group' : '' }}">
                 {% if (showaction) %}
                 {# Display submit button #}
                 <button class="btn btn-sm btn-primary" type="button" name="{{ p['actionname'] }}">

--- a/templates/components/search/query_builder/main.html.twig
+++ b/templates/components/search/query_builder/main.html.twig
@@ -120,7 +120,7 @@
             <span class="ms-auto {{ action_count > 1 ? 'btn-group' : '' }}">
                 {% if (showaction) %}
                 {# Display submit button #}
-                <button class="btn btn-sm btn-primary" type="button" name="{{ p['actionname'] }}">
+                <button class="btn {{ p['is_criteria_filter'] ? 'btn-ghost-secondary' : 'btn-sm btn-primary' }}" type="button" name="{{ p['actionname'] }}">
                     <i class="ti ti-search"></i>
                     <span class="d-none d-sm-block">{{ p['actionvalue'] }}</span>
                 </button>


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Fixes #19724

There is only so much that can be done, without adding complexity or refactoring, because the criteria filter feature directly uses components of the main search engine and it wasn't really intended to be reused in that way. The criteria filter feature just changes the search button label.

This PR fixes the button group styles when there is only one button in the main query builder template, and add some spacing between the default buttons and the one added for the criteria filter UI.

I've also added a commit that forces non .btn-sm and .btn-secondary styles but it isn't a clean solution. If the default button CSS changes, this button won't match.