### PR TITLE
Disable "clone" massive action for saved searches

### DIFF
--- a/phpunit/functional/SavedSearchTest.php
+++ b/phpunit/functional/SavedSearchTest.php
@@ -35,6 +35,8 @@
 namespace tests\units;
 
 use DbTestCase;
+use MassiveAction;
+use SavedSearch;
 
 /* Test for inc/savedsearch.class.php */
 
@@ -262,5 +264,21 @@ class SavedSearchTest extends DbTestCase
             $expected,
             array_column($mine, 'name')
         );
+    }
+
+    public function testAvailableMassiveActions(): void
+    {
+        // Act: get saved searches massive actions
+        $this->login();
+        $actions = MassiveAction::getAllMassiveActions(SavedSearch::class);
+
+        // Assert: validate the available actions
+        $this->assertEquals([
+            'Delete permanently',
+            'Unset as default',
+            'Change count method',
+            'Change visibility',
+            'Change entity',
+        ], array_values($actions));
     }
 }

--- a/src/SavedSearch.php
+++ b/src/SavedSearch.php
@@ -64,7 +64,6 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
         return ['add'];
     }
 
-
     public static function getTypeName($nb = 0)
     {
         return _n('Saved search', 'Saved searches', $nb);
@@ -78,9 +77,9 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
 
     public function getForbiddenStandardMassiveAction()
     {
-
         $forbidden   = parent::getForbiddenStandardMassiveAction();
         $forbidden[] = 'update';
+        $forbidden[] = 'clone';
         return $forbidden;
     }
 


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Prevent saved searches from being cloned as it does not work (probably not fully implemented).
Note that you can still clone and modify the search by loading it in the search results then using "Saved as new...".

## References

Fix #19716


