### PR TITLE
Fix running web tests locally

### DIFF
--- a/install/install.php
+++ b/install/install.php
@@ -416,16 +416,6 @@ function step8()
         ]
     );
 
-    $url_base_api = "$url_base/apirest.php/";
-    $DB->update(
-        'glpi_configs',
-        ['value' => $url_base_api],
-        [
-            'context'   => 'core',
-            'name'      => 'url_base_api',
-        ]
-    );
-
     Session::destroy(); // Remove session data (debug mode for instance) set by web installation
 
     TemplateRenderer::getInstance()->display('install/step8.html.twig');

--- a/phpunit/web/APIRestTest.php
+++ b/phpunit/web/APIRestTest.php
@@ -76,7 +76,7 @@ class APIRestTest extends TestCase
         $this->assertNotSame(false, $file_updated);
 
         $this->http_client = new GuzzleHttp\Client();
-        $this->base_uri    = trim($CFG_GLPI['url_base_api'], "/") . "/";
+        $this->base_uri    = \Glpi\Api\HL\Router::getAPIVersions()[0]['endpoint'] . '/';
 
         $this->initSessionCredentials();
         parent::setUp();

--- a/templates/pages/setup/general/api_setup.html.twig
+++ b/templates/pages/setup/general/api_setup.html.twig
@@ -48,7 +48,7 @@
         '',
         endpoint_doc
     ) }}
-    {{ fields.textField('url_base_api', api_url, __('URL of the API'), {
+    {{ fields.textField('_url_base_api', api_url, __('URL of the API'), {
         readonly: true,
         copyable: true
     }) }}
@@ -81,7 +81,7 @@
          legacy_doc
       ) }}
       {{ fields.nullField() }}
-      {{ fields.textField('legacy_url_base_api', legacy_api_url, __('URL of the API'), {
+      {{ fields.textField('_legacy_url_base_api', legacy_api_url, __('URL of the API'), {
          readonly: true,
          copyable: true
       }) }}

--- a/tests/README.md
+++ b/tests/README.md
@@ -65,11 +65,6 @@ $ atoum -bf tests/bootstrap.php -f tests/functional/Html.php -m tests\units\Html
 ```
 In `tests\units\Html::testConvDateTime`, you may need to double the backslashes (depending on the shell you use);
 
-If you want to run the API tests suite, you need to run a development server:
-
-```bash
-php -S localhost:8088 -t public tests/router.php &>/dev/null &
-```
 
 Running `atoum` without any arguments will show you the possible options. Most important are:
 - `-bf` to set bootstrap file,

--- a/tests/src/autoload/functions.php
+++ b/tests/src/autoload/functions.php
@@ -728,12 +728,6 @@ function loadDataset()
 
     $DB->beginTransaction();
 
-    Config::setConfigurationValues('core', ['url_base'     => GLPI_URI,
-        'url_base_api' => GLPI_URI . '/apirest.php',
-    ]);
-    $CFG_GLPI['url_base']      = GLPI_URI;
-    $CFG_GLPI['url_base_api']  = GLPI_URI . '/apirest.php';
-
     // make all caldav component available for tests (for default usage we don't VTODO)
     $CFG_GLPI['caldav_supported_components']  = ['VEVENT', 'VJOURNAL', 'VTODO'];
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.

## Description

Tried to run the web suite locally and ran into the following issue:

* URL is hardcoded to use the `url_base_api`, which has been removed in GLPI 11.
* Documentation is no longer relevant.

I've removed the references to `url_base_api` and deleted the documentation as it is no longer relevant (router.php is no longer used on the CI and the example command won't work locally as the tests no longer target the given 8088 port AFAIK).
