### PR TITLE
fix(change): unable to add a document without change update rights

### DIFF
--- a/phpunit/functional/ChangeTest.php
+++ b/phpunit/functional/ChangeTest.php
@@ -530,7 +530,7 @@ class ChangeTest extends DbTestCase
                             'items_id'  => $user->getID(),
                         ],
                     ],
-                ]
+                ],
             ]);
 
             $input = ['itemtype' => 'Change', 'items_id' => $change->getID()];

--- a/phpunit/functional/TicketTest.php
+++ b/phpunit/functional/TicketTest.php
@@ -8000,7 +8000,7 @@ HTML,
                 'ticket'   => 0,
                 'document' => CREATE,
             ],
-            'expected' => false,
+            'expected' => true, // requester can always add docs if the ticket is not modified
         ];
 
         yield [
@@ -8027,7 +8027,7 @@ HTML,
                 'ticket'   => CREATE,
                 'document' => CREATE,
             ],
-            'expected' => false,
+            'expected' => true, // requester can always add docs if the ticket is not modified
         ];
     }
 

--- a/phpunit/functional/TicketTest.php
+++ b/phpunit/functional/TicketTest.php
@@ -7964,4 +7964,108 @@ HTML,
         // Assert: only the non closed tickets should be found.
         $this->assertEquals(5, $results['data']['totalcount']);
     }
+
+    public static function canAddDocumentProvider(): iterable
+    {
+        yield [
+            'profilerights' => [
+                'followup' => 0,
+                'ticket'   => 0,
+                'document' => 0,
+            ],
+            'expected' => false,
+        ];
+
+        yield [
+            'profilerights' => [
+                'followup' => \ITILFollowup::ADDMYTICKET,
+                'ticket'   => 0,
+                'document' => 0,
+            ],
+            'expected' => true,
+        ];
+
+        yield [
+            'profilerights' => [
+                'followup' => 0,
+                'ticket'   => UPDATE,
+                'document' => 0,
+            ],
+            'expected' => false,
+        ];
+
+        yield [
+            'profilerights' => [
+                'followup' => 0,
+                'ticket'   => 0,
+                'document' => CREATE,
+            ],
+            'expected' => false,
+        ];
+
+        yield [
+            'profilerights' => [
+                'followup' => \ITILFollowup::ADDMYTICKET,
+                'ticket'   => UPDATE,
+                'document' => 0,
+            ],
+            'expected' => true,
+        ];
+
+        yield [
+            'profilerights' => [
+                'followup' => \ITILFollowup::ADDMYTICKET,
+                'ticket'   => 0,
+                'document' => CREATE,
+            ],
+            'expected' => true,
+        ];
+
+        yield [
+            'profilerights' => [
+                'followup' => 0,
+                'ticket'   => CREATE,
+                'document' => CREATE,
+            ],
+            'expected' => false,
+        ];
+    }
+
+    /**
+     * @dataProvider canAddDocumentProvider
+     */
+    public function testCanAddDocument(array $profilerights, bool $expected): void
+    {
+        global $DB;
+
+        foreach ($profilerights as $right => $value) {
+            $this->assertTrue($DB->update(
+                'glpi_profilerights',
+                ['rights' => $value],
+                [
+                    'profiles_id'  => 4,
+                    'name'         => $right,
+                ]
+            ));
+        }
+
+        $this->login();
+
+        $ticket = $this->createItem(\Change::class, [
+            'name' => 'Ticket Test',
+            'content' => 'Ticket content',
+            '_actors' => [
+                'requester' => [
+                    [
+                        'itemtype'  => 'User',
+                        'items_id'  => \Session::getLoginUserID(),
+                    ],
+                ],
+            ],
+        ]);
+
+        $input = ['itemtype' => \Ticket::class, 'items_id' => $ticket->getID()];
+        $doc = new \Document();
+        $this->assertEquals($expected, $doc->can(-1, CREATE, $input));
+    }
 }

--- a/src/Change.php
+++ b/src/Change.php
@@ -139,20 +139,6 @@ class Change extends CommonITILObject
         return Session::haveRight(self::$rightname, CREATE);
     }
 
-    public function canAddItem($type)
-    {
-        if ($type == Document::class) {
-            if (in_array($this->fields['status'], $this->getClosedStatusArray())) {
-                return false;
-            }
-
-            if ($this->canAddFollowups()) {
-                return true;
-            }
-        }
-
-        return parent::canAddItem($type);
-    }
 
     /**
      * is the current user could reopen the current change

--- a/src/Change.php
+++ b/src/Change.php
@@ -160,7 +160,7 @@ class Change extends CommonITILObject
             }
         }
 
-        parent::canAddItem($type);
+        return parent::canAddItem($type);
     }
 
     /**

--- a/src/Change.php
+++ b/src/Change.php
@@ -139,19 +139,10 @@ class Change extends CommonITILObject
         return Session::haveRight(self::$rightname, CREATE);
     }
 
-    /**
-     * Overloaded from commonDBTM
-     *
-     * @since 0.83
-     *
-     * @param string $type itemtype of object to add
-     *
-     * @return boolean
-     **/
     public function canAddItem($type)
     {
         if ($type == 'Document') {
-            if ($this->getField('status') == self::CLOSED) {
+            if (in_array($this->fields['status'], $this->getClosedStatusArray())) {
                 return false;
             }
 

--- a/src/Change.php
+++ b/src/Change.php
@@ -139,7 +139,7 @@ class Change extends CommonITILObject
         return Session::haveRight(self::$rightname, CREATE);
     }
 
-        /**
+    /**
      * Overloaded from commonDBTM
      *
      * @since 0.83

--- a/src/Change.php
+++ b/src/Change.php
@@ -150,7 +150,6 @@ class Change extends CommonITILObject
      **/
     public function canAddItem($type)
     {
-
         if ($type == 'Document') {
             if ($this->getField('status') == self::CLOSED) {
                 return false;
@@ -161,7 +160,7 @@ class Change extends CommonITILObject
             }
         }
 
-        return $this->can($this->getID(), UPDATE);
+        parent::canAddItem($type);
     }
 
     /**

--- a/src/Change.php
+++ b/src/Change.php
@@ -141,7 +141,7 @@ class Change extends CommonITILObject
 
     public function canAddItem($type)
     {
-        if ($type == 'Document') {
+        if ($type == Document::class) {
             if (in_array($this->fields['status'], $this->getClosedStatusArray())) {
                 return false;
             }

--- a/src/Change.php
+++ b/src/Change.php
@@ -139,6 +139,30 @@ class Change extends CommonITILObject
         return Session::haveRight(self::$rightname, CREATE);
     }
 
+        /**
+     * Overloaded from commonDBTM
+     *
+     * @since 0.83
+     *
+     * @param string $type itemtype of object to add
+     *
+     * @return boolean
+     **/
+    public function canAddItem($type)
+    {
+
+        if ($type == 'Document') {
+            if ($this->getField('status') == self::CLOSED) {
+                return false;
+            }
+
+            if ($this->canAddFollowups()) {
+                return true;
+            }
+        }
+
+        return $this->can($this->getID(), UPDATE);
+    }
 
     /**
      * is the current user could reopen the current change

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -9998,6 +9998,32 @@ abstract class CommonITILObject extends CommonDBTM
         return self::canDelete();
     }
 
+    public function canAddItem($type)
+    {
+        if ($type == Document::class) {
+            return $this->canAddDocuments();
+        }
+
+        return parent::canAddItem($type);
+    }
+
+
+    /**
+     * Check whether the current user can add documents.
+     */
+    final protected function canAddDocuments(): bool
+    {
+        if (in_array($this->fields['status'], $this->getClosedStatusArray())) {
+            return false;
+        }
+
+        if ($this->canAddFollowups()) {
+            return true;
+        }
+
+        return false;
+    }
+
     public static function getTeamMemberForm(CommonITILObject $item): string
     {
         $itiltemplate = $item->getITILTemplateToUse(

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -2448,27 +2448,10 @@ class Ticket extends CommonITILObject
         }
     }
 
-
-    /**
-     * Overloaded from commonDBTM
-     *
-     * @since 0.83
-     *
-     * @param string $type itemtype of object to add
-     *
-     * @return boolean
-     **/
     public function canAddItem($type)
     {
-
-        if ($type == 'Document') {
-            if ($this->getField('status') == self::CLOSED) {
-                return false;
-            }
-
-            if ($this->canAddFollowups()) {
-                return true;
-            }
+        if ($type == Document::class) {
+            return $this->canAddDocuments();
         }
 
         // as self::canUpdate & $this->canUpdateItem checks more general rights


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !37694
- If a user has the right to add follow-ups and add documents, the user cannot add documents to my changes, he should also have the right to update changes.

## Screenshots (if appropriate):

![Capture d’écran du 2025-05-19 15-10-26](https://github.com/user-attachments/assets/2156cc24-1801-45af-81f9-996cfa7811a0)


