### PR TITLE
fix(forms): hide toolbar when drag question placeholder is present

### DIFF
--- a/css/includes/components/form/_form-editor-horizontal-layout.scss
+++ b/css/includes/components/form/_form-editor-horizontal-layout.scss
@@ -222,6 +222,12 @@
                 border-radius: var(--tblr-border-radius);
             }
 
+            &:has(.glpi-form-editor-drag-question-placeholder) {
+                [data-glpi-form-editor-toolbar] {
+                    display: none !important;
+                }
+            }
+
             min-height: 100px;
             flex: 1;
             display: flex;


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

When you want to move a question/comment to a placeholder in a horizontal layout, the toolbar doesn't hide, leaving the UI unclear.

## Screenshots (if appropriate):

### Before :
![image](https://github.com/user-attachments/assets/8894ac37-948b-465d-b248-e1e39a3a746f)
### After :
![image](https://github.com/user-attachments/assets/97c5dd29-56bc-4604-bbf6-04677e5dcfe5)
