### PR TITLE
Fix - Massive items addition actions in Licenses

### DIFF
--- a/phpunit/functional/MassiveActionTest.php
+++ b/phpunit/functional/MassiveActionTest.php
@@ -67,7 +67,7 @@ class MassiveActionTest extends DbTestCase
             ], [
                 'itemtype'     => 'SoftwareLicense',
                 'items_id'     => '_test_softlic_1',
-                'allcount'     => 14,
+                'allcount'     => 15,
                 'singlecount'  => 9,
             ], [
                 'itemtype'     => 'NetworkEquipment',

--- a/phpunit/functional/MassiveActionTest.php
+++ b/phpunit/functional/MassiveActionTest.php
@@ -67,8 +67,8 @@ class MassiveActionTest extends DbTestCase
             ], [
                 'itemtype'     => 'SoftwareLicense',
                 'items_id'     => '_test_softlic_1',
-                'allcount'     => 15,
-                'singlecount'  => 10,
+                'allcount'     => 14,
+                'singlecount'  => 9,
             ], [
                 'itemtype'     => 'NetworkEquipment',
                 'items_id'     => '_test_networkequipment_1',

--- a/src/MassiveAction.php
+++ b/src/MassiveAction.php
@@ -759,7 +759,7 @@ class MassiveAction
             }
 
             // Specific actions
-            $actions += $item->getSpecificMassiveActions($checkitem, $items_id);
+            $actions += $item->getSpecificMassiveActions($checkitem);
 
             Document::getMassiveActionsForItemtype($actions, $itemtype, $is_deleted, $checkitem);
             Contract::getMassiveActionsForItemtype($actions, $itemtype, $is_deleted, $checkitem);

--- a/src/MassiveAction.php
+++ b/src/MassiveAction.php
@@ -759,7 +759,7 @@ class MassiveAction
             }
 
             // Specific actions
-            $actions += $item->getSpecificMassiveActions($checkitem);
+            $actions += $item->getSpecificMassiveActions($checkitem, $items_id);
 
             Document::getMassiveActionsForItemtype($actions, $itemtype, $is_deleted, $checkitem);
             Contract::getMassiveActionsForItemtype($actions, $itemtype, $is_deleted, $checkitem);


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !37405
- Complete PR https://github.com/glpi-project/glpi/pull/19561
- Here is a brief description of what this PR does

This pull request fixes a bug where the system correctly disabled the "Add" button when the limit defined in the "Number" field was reached, but still allowed users to bypass this restriction by using the menu:
"Actions > Add an item".

## Screenshots (if appropriate):

![image_paste2678102](https://github.com/user-attachments/assets/8fbea513-c62a-4e65-b904-3e97bb9e9f8e)


