### PR TITLE
fix(forms): fixed untitled label for comment blocks

### DIFF
--- a/src/Glpi/Form/BlockInterface.php
+++ b/src/Glpi/Form/BlockInterface.php
@@ -40,4 +40,6 @@ use Glpi\ItemTranslation\Context\ProvideTranslationsInterface;
 interface BlockInterface extends ProvideTranslationsInterface
 {
     public function displayBlockForEditor(): void;
+
+    public function getUntitledLabel(): string;
 }

--- a/src/Glpi/Form/Comment.php
+++ b/src/Glpi/Form/Comment.php
@@ -175,6 +175,7 @@ final class Comment extends CommonDBChild implements
         return [new VisibilityConditionHandler()];
     }
 
+    #[Override]
     public function displayBlockForEditor(): void
     {
         TemplateRenderer::getInstance()->display('pages/admin/form/form_comment.html.twig', [
@@ -183,6 +184,12 @@ final class Comment extends CommonDBChild implements
             'section'    => $this->getItem(),
             'can_update' => $this->getForm()->canUpdate(),
         ]);
+    }
+
+    #[Override]
+    public function getUntitledLabel(): string
+    {
+        return __('Untitled comment');
     }
 
     /**

--- a/src/Glpi/Form/Question.php
+++ b/src/Glpi/Form/Question.php
@@ -145,6 +145,7 @@ final class Question extends CommonDBChild implements BlockInterface, Conditiona
         return $handlers;
     }
 
+    #[Override]
     public function displayBlockForEditor(): void
     {
         TemplateRenderer::getInstance()->display('pages/admin/form/form_question.html.twig', [
@@ -156,6 +157,12 @@ final class Question extends CommonDBChild implements BlockInterface, Conditiona
             'can_update'                   => $this->getForm()->canUpdate(),
             'allow_unauthenticated_access' => FormAccessControlManager::getInstance()->allowUnauthenticatedAccess($this->getForm()),
         ]);
+    }
+
+    #[Override]
+    public function getUntitledLabel(): string
+    {
+        return __('Untitled question');
     }
 
     /**

--- a/templates/pages/form_renderer.html.twig
+++ b/templates/pages/form_renderer.html.twig
@@ -171,7 +171,7 @@
                                                 {% endif %}
                                             >
                                                 <h3 class="mb-2 {{ not form_block.fields.name ? "text-muted" : "" }}">
-                                                    {{ translate_item_key(form_block, constant('TRANSLATION_KEY_NAME', form_block))|default(__('Untitled question')) }}
+                                                    {{ translate_item_key(form_block, constant('TRANSLATION_KEY_NAME', form_block))|default(form_block.getUntitledLabel()) }}
                                                     {% if form_block.fields.is_mandatory ?? false %}
                                                         <span class="text-danger">*</span>
                                                     {% endif %}

--- a/tests/cypress/e2e/form/form_rendering.cy.js
+++ b/tests/cypress/e2e/form/form_rendering.cy.js
@@ -250,6 +250,29 @@ describe('Form rendering', () => {
             cy.findByRole('button', {name: 'Submit'}).should('have.class', 'pointer-events-none');
         });
     });
+
+    it("Display untitled labels for questions and comments in form preview", () => {
+        // Login and create a new form
+        cy.login();
+        cy.createFormWithAPI().visitFormTab();
+
+        // Add a question and a comment to the form
+        cy.findByRole('button', { name: 'Add a question' }).click();
+        cy.findByRole('button', { name: 'Add a comment' }).click();
+
+        // Save the form configuration
+        cy.findByRole('button', { name: 'Save' }).click();
+        cy.checkAndCloseAlert('Item successfully updated');
+
+        // Navigate to the preview page (changing target to avoid opening in new tab)
+        cy.findByRole("link", { name: "Preview" })
+            .invoke('attr', 'target', '_self')
+            .click();
+
+        // Verify both elements appear in the preview
+        cy.findByRole('heading', { name: 'Untitled question' }).should('exist');
+        cy.findByRole('heading', { name: 'Untitled comment' }).should('exist');
+    });
 });
 
 function addQuestionAndGetUuuid(name, type = null, subtype = null) {


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

The label used for questions and comments when they don't have a defined title is the same : `Untitled question`.
Added a more personalized label for comments: `Untitled comment`.