### PR TITLE
Fix unexpected variable in Twig macro

### DIFF
--- a/templates/pages/admin/log_viewer.html.twig
+++ b/templates/pages/admin/log_viewer.html.twig
@@ -52,7 +52,7 @@
 {% macro log_entries(log_entries) %}
     {% if log_entries|length %}
         {% for log_entry in log_entries %}{{ _self.log_entry(log_entry) }}{% endfor %}
-    {% elseif not only_content %}
+    {% else %}
         <div class="empty">
             <div class="empty-icon display-6" style="display: contents">
                 <i class="ti ti-mood-empty"></i>


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

This variable does not exist in the macro.