### PR TITLE
Fix SCSS compiled URL

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -5058,7 +5058,7 @@ HTML;
             file_exists($prod_file)
             && $_SESSION['glpi_use_mode'] != Session::DEBUG_MODE
         ) {
-            $url = self::getPrefixedUrl(str_replace(GLPI_ROOT, '', $prod_file));
+            $url = self::getPrefixedUrl(str_replace(GLPI_ROOT . '/public', '', $prod_file));
         } else {
             $file = $url;
             $url = self::getPrefixedUrl('/front/css.php');


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

`Html::scss()` is used only for a few SCSS files. The path to compiled SCSS files was not correct, as it included the `/public` prefix that should not be used anymore. A similar replacement is already done for SCSS files paths generated in the Twig context : https://github.com/glpi-project/glpi/blob/2bc27a8359668996613c8f0fde9bfc9a34eaf0ab/src/Glpi/Application/View/Extension/FrontEndAssetsExtension.php#L129