### PR TITLE
Fix(Inventory): prevent duplicate software version

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -2794,13 +2794,13 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Negated boolean expression is always false\\.$#',
 	'identifier' => 'booleanNot.alwaysFalse',
-	'count' => 2,
+	'count' => 1,
 	'path' => __DIR__ . '/src/Inventory/Asset/Software.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Property Glpi\\\\Inventory\\\\Asset\\\\InventoryAsset\\:\\:\\$main_asset \\(Glpi\\\\Inventory\\\\Asset\\\\MainAsset\\) in isset\\(\\) is not nullable\\.$#',
 	'identifier' => 'isset.property',
-	'count' => 1,
+	'count' => 2,
 	'path' => __DIR__ . '/src/Inventory/Asset/Software.php',
 ];
 $ignoreErrors[] = [

--- a/src/Inventory/Asset/Software.php
+++ b/src/Inventory/Asset/Software.php
@@ -41,6 +41,7 @@ use Dropdown;
 use Entity;
 use Glpi\Inventory\Conf;
 use Glpi\Toolbox\Sanitizer;
+use Item_OperatingSystem;
 use QueryParam;
 use RuleDictionnarySoftwareCollection;
 use Software as GSoftware;
@@ -298,6 +299,26 @@ class Software extends InventoryAsset
             $os_soft_data->version = $os_data->version ?? '';
 
             $this->data[] = $os_soft_data;
+        } else {
+
+            // Verify that the main asset is set before accessing its properties
+            // This check is necessary because some unit tests call the handle function
+            // directly on the Software class, bypassing the main asset initialization.
+            // For more details, see the functional test case:
+            // phpunit/functional/Glpi/Inventory/Assets/SoftwareTest.php -> testHandle()
+            if (isset($this->main_asset)) {
+                // When $this->extra_data['\Glpi\Inventory\Asset\OperatingSystem'] is not set,
+                // it indicates that the inventory is running in partial mode (or without operating system data).
+                // Therefore, fall back to retrieving the operating system from the main asset.
+                $item_os = new Item_OperatingSystem();
+                $os_list = $item_os->find([
+                    'items_id' => $this->main_asset->item->fields['id'],
+                    'itemtype' => $this->main_asset->item->getType(),
+                ]);
+                if (count($os_list) == 1) {
+                    $operatingsystems_id = current($os_list)['operatingsystems_id'];
+                }
+            }
         }
 
         $db_software = [];
@@ -495,7 +516,7 @@ class Software extends InventoryAsset
 
     public function getOsForKey($val)
     {
-        if (!$this->main_asset || !$this->main_asset->isPartial()) {
+        if ($val->operatingsystems_id > 0) {
             return $val->operatingsystems_id;
         } else {
             return '%';

--- a/tests/fixtures/inventories/software/01_computer_full_inventory_soft_and_os.json
+++ b/tests/fixtures/inventories/software/01_computer_full_inventory_soft_and_os.json
@@ -1,0 +1,62 @@
+{
+    "action": "inventory",
+    "content": {
+        "bios": {
+            "assettag": "SYS_CHASSIS_ASSET_TAG_NUM_1",
+            "bdate": "2021-07-02",
+            "bmanufacturer": "Intel Corp.",
+            "bversion": "EBTGL357.0061.2021.0702.1707",
+            "mmanufacturer": "Intel Corporation",
+            "mmodel": "flghfgh5fgh",
+            "msn": "sdf15sd5f1sd65fsLV",
+            "smanufacturer": "Intel(R) Client Systems",
+            "smodel": "flghfgh5fgh",
+            "ssn": "df56dfg-dfg41f5g1f-df4fdg"
+        },
+        "hardware": {
+            "chassis_type": "Mini PC",
+            "defaultgateway": "192.168.8.1",
+            "dns": "192.168.8.1",
+            "memory": 7817,
+            "name": "ARN2032",
+            "uuid": "sdf5s1dfsd-sd5f48q7eaz8e-sd41sdf-5sd4fsdf",
+            "vmsystem": "Physical",
+            "winlang": "1033",
+            "workgroup": "WORKGROUP"
+        },
+        "operatingsystem": {
+            "arch": "64-bit",
+            "boot_time": "2025-05-15 21:40:57",
+            "dns_domain": "WORKGROUP",
+            "fqdn": "ARN2032",
+            "full_name": "Microsoft Windows 10 IoT Enterprise LTSC",
+            "install_date": "2022-07-18 18:34:14",
+            "kernel_name": "MSWin32",
+            "kernel_version": "10.0.19044",
+            "name": "Windows",
+            "service_pack": "19044.5854",
+            "timezone": {
+                "name": "Asia\/Riyadh",
+                "offset": "+0300"
+            },
+            "version": "21H2"
+        },
+        "softwares": [
+            {
+                "arch": "x86_64",
+                "from": "registry",
+                "guid": "Teclib_Software",
+                "install_date": "2025-05-19",
+                "name": "Teclib Software Software",
+                "publisher": "Teclib",
+                "system_category": "application",
+                "uninstall_string": " ",
+                "version": "2.20.4853.2486"
+            }
+        ],
+        "versionclient": "GLPI-Agent_v1.9"
+    },
+    "deviceid": "ARN2032",
+    "itemtype": "Computer",
+    "partial": false
+}

--- a/tests/fixtures/inventories/software/02_computer_full_inventory_soft_and_os.json
+++ b/tests/fixtures/inventories/software/02_computer_full_inventory_soft_and_os.json
@@ -1,0 +1,63 @@
+{
+    "action": "inventory",
+    "content": {
+        "bios": {
+            "assettag": "SYS_CHASSIS_ASSET_TAG_NUM_1",
+            "bdate": "2021-07-02",
+            "bmanufacturer": "Intel Corp.",
+            "bversion": "EBTGL357.0061.2021.0702.1707",
+            "mmanufacturer": "Intel Corporation",
+            "mmodel": "dfg4df5g",
+            "msn": "SDFDFGsd6f4sdf",
+            "smanufacturer": "Intel(R) Client Systems",
+            "smodel": "dfg4df5g",
+            "ssn": "qsdfsdf213-qaz5jkl-fgh4hjk45-45ghjghj"
+        },
+        "hardware": {
+            "chassis_type": "Mini PC",
+            "defaultgateway": "192.168.8.1",
+            "dns": "192.168.8.1",
+            "memory": 7817,
+            "name": "ARN2045",
+            "uuid": "sdf45sdf4sf-sd541s645f-4sd1fsf4",
+            "vmsystem": "Physical",
+            "winlang": "1033",
+            "winowner": "User",
+            "workgroup": "WORKGROUP"
+        },
+        "operatingsystem": {
+            "arch": "64-bit",
+            "boot_time": "2025-05-17 23:41:15",
+            "dns_domain": "WORKGROUP",
+            "fqdn": "ARN2045",
+            "full_name": "Microsoft Windows 10 IoT Enterprise LTSC",
+            "install_date": "2022-07-18 18:34:14",
+            "kernel_name": "MSWin32",
+            "kernel_version": "10.0.19044",
+            "name": "Windows",
+            "service_pack": "19044.5854",
+            "timezone": {
+                "name": "Asia\/Riyadh",
+                "offset": "+0300"
+            },
+            "version": "21H2"
+        },
+        "softwares": [
+            {
+                "arch": "x86_64",
+                "from": "registry",
+                "guid": "Teclib_Software",
+                "install_date": "2025-05-19",
+                "name": "Teclib Software Software",
+                "publisher": "Teclib",
+                "system_category": "application",
+                "uninstall_string": " ",
+                "version": "2.20.4853.2486"
+            }
+        ],
+        "versionclient": "GLPI-Agent_v1.9"
+    },
+    "deviceid": "ARN2045",
+    "itemtype": "Computer",
+    "partial": false
+}

--- a/tests/fixtures/inventories/software/03_computer_partial_inventory_with_os.json
+++ b/tests/fixtures/inventories/software/03_computer_partial_inventory_with_os.json
@@ -1,0 +1,63 @@
+{
+    "action": "inventory",
+    "content": {
+        "bios": {
+            "assettag": "SYS_CHASSIS_ASSET_TAG_NUM_1",
+            "bdate": "2021-07-02",
+            "bmanufacturer": "Intel Corp.",
+            "bversion": "EBTGL357.0061.2021.0702.1707",
+            "mmanufacturer": "Intel Corporation",
+            "mmodel": "sdf21sd645fd",
+            "msn": "sdf44dfg7",
+            "smanufacturer": "Intel(R) Client Systems",
+            "smodel": "sdf21sd645fd",
+            "ssn": "qsdf321-sdf231-51sdf23-123123"
+        },
+        "hardware": {
+            "chassis_type": "Mini PC",
+            "defaultgateway": "192.168.8.1",
+            "dns": "192.168.8.1",
+            "memory": 7817,
+            "name": "ARN3045",
+            "uuid": "sdfsd51f-56sd1f561sdf-sd5f1sd45f-4sdf54sdf",
+            "vmsystem": "Physical",
+            "winlang": "1033",
+            "winowner": "User",
+            "workgroup": "WORKGROUP"
+        },
+        "operatingsystem": {
+            "arch": "64-bit",
+            "boot_time": "2025-05-17 23:41:15",
+            "dns_domain": "WORKGROUP",
+            "fqdn": "ARN3045",
+            "full_name": "Microsoft Windows 10 IoT Enterprise LTSC",
+            "install_date": "2022-07-18 18:34:14",
+            "kernel_name": "MSWin32",
+            "kernel_version": "10.0.19044",
+            "name": "Windows",
+            "service_pack": "19044.5854",
+            "timezone": {
+                "name": "Asia\/Riyadh",
+                "offset": "+0300"
+            },
+            "version": "21H2"
+        },
+        "softwares": [
+            {
+                "arch": "x86_64",
+                "from": "registry",
+                "guid": "Teclib_Software",
+                "install_date": "2025-05-19",
+                "name": "Teclib Software Software",
+                "publisher": "Teclib",
+                "system_category": "application",
+                "uninstall_string": " ",
+                "version": "2.20.4853.2486"
+            }
+        ],
+        "versionclient": "GLPI-Agent_v1.9"
+    },
+    "deviceid": "ARN3045",
+    "itemtype": "Computer",
+    "partial": true
+}

--- a/tests/fixtures/inventories/software/04_computer_full_inventory_with_os_without_soft.json
+++ b/tests/fixtures/inventories/software/04_computer_full_inventory_with_os_without_soft.json
@@ -1,0 +1,78 @@
+{
+    "action": "inventory",
+    "content": {
+        "accesslog": {
+            "logdate": "2025-05-20 14:39:00"
+        },
+        "antivirus": [
+            {
+                "base_version": "1.429.84.0",
+                "company": "Microsoft Corporation",
+                "enabled": true,
+                "guid": "{D68DDC3A-831F-4fae-9E44-DA132C1ACF46}",
+                "name": "Windows Defender",
+                "uptodate": true,
+                "version": "4.18.25030.2"
+            }
+        ],
+        "bios": {
+            "assettag": "SYS_CHASSIS_ASSET_TAG_NUM_1",
+            "bdate": "2021-07-02",
+            "bmanufacturer": "Intel Corp.",
+            "bversion": "EBTGL357.0061.2021.0702.1707",
+            "mmanufacturer": "Intel Corporation",
+            "mmodel": "sdfsdf62651sdf",
+            "msn": "qsd54sdf456sdf",
+            "smanufacturer": "Intel(R) Client Systems",
+            "smodel": "sdfsdf62651sdf",
+            "ssn": "qsd5qs1d-5qs1d564qsd-qs5d4685q4sd"
+        },
+        "hardware": {
+            "chassis_type": "Mini PC",
+            "defaultgateway": "192.168.8.1",
+            "dns": "192.168.8.1",
+            "memory": 7817,
+            "name": "ARN4058",
+            "uuid": "dfdfg-dfg5156fdg-5df1g615dfg-54dfg5d4fg",
+            "vmsystem": "Physical",
+            "winlang": "1033",
+            "winowner": "User",
+            "workgroup": "WORKGROUP"
+        },
+        "operatingsystem": {
+            "arch": "64-bit",
+            "boot_time": "2025-05-17 23:41:15",
+            "dns_domain": "WORKGROUP",
+            "fqdn": "ARN4058",
+            "full_name": "Microsoft Windows 10 IoT Enterprise LTSC",
+            "install_date": "2022-07-18 18:34:14",
+            "kernel_name": "MSWin32",
+            "kernel_version": "10.0.19044",
+            "name": "Windows",
+            "service_pack": "19044.5854",
+            "timezone": {
+                "name": "Asia\/Riyadh",
+                "offset": "+0300"
+            },
+            "version": "21H2"
+        },
+        "versionclient": "GLPI-Agent_v1.9",
+        "versionprovider": {
+            "comments": [
+                "Provided by Teclib Edition",
+                "Installer built on Tue May 28 09:10:25 2024 UTC",
+                "Built with Strawberry Perl 5.38.2",
+                "Built on github actions windows image for glpi-project\/glpi-agent repository"
+            ],
+            "etime": 25,
+            "name": "GLPI",
+            "perl_exe": "C:\\Program Files\\GLPI-Agent\\perl\\bin\\glpi-agent.exe",
+            "perl_version": "v5.38.2",
+            "program": "C:\\Program Files\\GLPI-Agent\\perl\\bin\\glpi-win32-service",
+            "version": "1.9"
+        }
+    },
+    "deviceid": "ARN4058",
+    "itemtype": "Computer",
+    "partial": false
+}

--- a/tests/fixtures/inventories/software/05_computer_full_inventory_without_os_with_soft.json
+++ b/tests/fixtures/inventories/software/05_computer_full_inventory_without_os_with_soft.json
@@ -1,0 +1,46 @@
+{
+    "action": "inventory",
+    "content": {
+        "bios": {
+            "assettag": "SYS_CHASSIS_ASSET_TAG_NUM_1",
+            "bdate": "2021-07-02",
+            "bmanufacturer": "Intel Corp.",
+            "bversion": "EBTGL357.0061.2021.0702.1707",
+            "mmanufacturer": "Intel Corporation",
+            "mmodel": "sdfsdf62651sdf",
+            "msn": "qsd54sdf456sdf",
+            "smanufacturer": "Intel(R) Client Systems",
+            "smodel": "sdfsdf62651sdf",
+            "ssn": "qsd5qs1d-5qs1d564qsd-qs5d4685q4sd"
+        },
+        "hardware": {
+            "chassis_type": "Mini PC",
+            "defaultgateway": "192.168.8.1",
+            "dns": "192.168.8.1",
+            "memory": 7817,
+            "name": "ARN4058",
+            "uuid": "dfdfg-dfg5156fdg-5df1g615dfg-54dfg5d4fg",
+            "vmsystem": "Physical",
+            "winlang": "1033",
+            "winowner": "User",
+            "workgroup": "WORKGROUP"
+        },
+        "softwares": [
+            {
+                "arch": "x86_64",
+                "from": "registry",
+                "guid": "Teclib_Software",
+                "install_date": "2025-05-19",
+                "name": "Teclib Software Software",
+                "publisher": "Teclib",
+                "system_category": "application",
+                "uninstall_string": " ",
+                "version": "2.20.4853.2486"
+            }
+        ],
+        "versionclient": "GLPI-Agent_v1.9"
+    },
+    "deviceid": "ARN4058",
+    "itemtype": "Computer",
+    "partial": true
+}


### PR DESCRIPTION

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Currently, when processing a new software entry in GLPI, the system checks whether the corresponding version already exists in the database. This verification is performed using a prepared SQL query built with the following criteria:

```php
$criteria = [
    'SELECT' => ['id', 'name', 'arch', 'softwares_id', 'operatingsystems_id'],
    'FROM'   => \SoftwareVersion::getTable(),
    'WHERE'  => [
        'entities_id'           => $this->entities_id,
        'name'                  => new QueryParam(),
        'arch'                  => new QueryParam(),
        'softwares_id'          => new QueryParam(),
        'operatingsystems_id'   => new QueryParam(),
    ],
];
```

The query parameters typically look like this:

```php
[
    'version'      => $val->version,
    'arch'         => $val->arch ?? '',
    'softwares_id' => $softwares_id,
    'osid'         => $this->getOsForKey($val),
]
```

However, in the case of a **partial inventory**, the `getOsForKey()` method always returns the wildcard character `'%'`. This causes the query to return no results, as the `operatingsystems_id` condition is evaluated strictly rather than using a pattern match. As a result, GLPI fails to detect that an equivalent version already exists, leading to the **creation of duplicate software entries**.

Using an SQL `LIKE` clause to handle the wildcard `'%'` in the OS ID field may be risky, as it could return multiple results and lead to ambiguous or incorrect matches. This initial approach will allow me to evaluate the outcome using the existing unit tests. However, it's highly likely that we will need to revise the `prepare()` method, particularly the following section:

```php
// Get operating system
$operatingsystems_id = 0;

if (isset($this->extra_data['\Glpi\Inventory\Asset\OperatingSystem'])) {
    if (is_array($this->extra_data['\Glpi\Inventory\Asset\OperatingSystem'])) {
        $os = $this->extra_data['\Glpi\Inventory\Asset\OperatingSystem'][0];
    } else {
        $os = $this->extra_data['\Glpi\Inventory\Asset\OperatingSystem'];
    }
    $operatingsystems_id = $os->getId();

    // Add Operating System as Software
    $os_data = $os->getData()[0];
    $os_soft_data = new \stdClass();
    $os_soft_data->name = $os_data->full_name ?? $os_data->name;
    $os_soft_data->arch = $os_data->arch ?? null;
    $os_soft_data->comment = null;
    $os_soft_data->manufacturers_id = 0;
    $os_soft_data->version = $os_data->version ?? '';

    $this->data[] = $os_soft_data;
}
```

This implementation assumes that the operating system information is always present under `$this->extra_data['\Glpi\Inventory\Asset\OperatingSystem']`. However, in the case of a **partial inventory**, this key may not exist at all. To handle this scenario properly, an `else` block should be added to retrieve the OS from the `mainasset`, ensuring the logic remains robust even when inventory data is incomplete.

## Screenshots (if appropriate):


