### PR TITLE
Fix error with plugins deactivation on install UI

### DIFF
--- a/src/Glpi/Kernel/KernelListenerTrait.php
+++ b/src/Glpi/Kernel/KernelListenerTrait.php
@@ -34,6 +34,7 @@
 
 namespace Glpi\Kernel;
 
+use Config;
 use DBConnection;
 use Symfony\Component\HttpFoundation\Request;
 use Update;
@@ -77,6 +78,8 @@ trait KernelListenerTrait
      */
     protected function isDatabaseUsable(): bool
     {
-        return DBConnection::isDbAvailable() && Update::isUpdateMandatory() === false;
+        return DBConnection::isDbAvailable()
+            && Config::isLegacyConfigurationLoaded()
+            && Update::isUpdateMandatory() === false;
     }
 }

--- a/src/Glpi/Kernel/Listener/PostBootListener/DisablePluginsOnVersionChange.php
+++ b/src/Glpi/Kernel/Listener/PostBootListener/DisablePluginsOnVersionChange.php
@@ -34,6 +34,7 @@
 
 namespace Glpi\Kernel\Listener\PostBootListener;
 
+use Config;
 use DBConnection;
 use Glpi\Debug\Profiler;
 use Glpi\Kernel\ListenersPriority;
@@ -53,7 +54,7 @@ final readonly class DisablePluginsOnVersionChange implements EventSubscriberInt
 
     public function onPostBoot(): void
     {
-        if (!DBConnection::isDbAvailable()) {
+        if (!DBConnection::isDbAvailable() || !Config::isLegacyConfigurationLoaded()) {
             return;
         }
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Fixes the following issue:
```
glpi.CRITICAL:   *** Uncaught Exception: MySQL query error: Table 'glpi.glpi_plugins' doesn't exist (1146) in SQL query "UPDATE `glpi_plugins` SET `state` = '4' WHERE `state` = '1'".
  Backtrace :
  ./src/DBmysql.php:369                              
  ./src/DBmysql.php:1430                             DBmysql->doQuery()
  ./src/Plugin.php:1221                              DBmysql->update()
  ...otListener/DisablePluginsOnVersionChange.php:65 Plugin->unactivateAll()
  .../event-dispatcher/Debug/WrappedListener.php:116 Glpi\Kernel\Listener\PostBootListener\DisablePluginsOnVersionChange->onPostBoot()
  ...ymfony/event-dispatcher/EventDispatcher.php:220 Symfony\Component\EventDispatcher\Debug\WrappedListener->__invoke()
  ...symfony/event-dispatcher/EventDispatcher.php:56 Symfony\Component\EventDispatcher\EventDispatcher->callListeners()
  ...spatcher/Debug/TraceableEventDispatcher.php:139 Symfony\Component\EventDispatcher\EventDispatcher->dispatch()
  ./src/Glpi/Kernel/Kernel.php:144                   Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcher->dispatch()
  ./vendor/symfony/http-kernel/Kernel.php:192        Glpi\Kernel\Kernel->boot()
  ./public/index.php:56                              Symfony\Component\HttpKernel\Kernel->handle()

```