### PR TITLE
Toggle xdebug on docker using makefile

### DIFF
--- a/.docker/app/Dockerfile
+++ b/.docker/app/Dockerfile
@@ -7,7 +7,7 @@ USER root
 # Allow extra PHP configuration to be placed in a dedicated folder than can serve
 # as a volume
 ENV PHP_INI_SCAN_DIR "/usr/local/etc/php/conf.d/:/usr/local/etc/php/custom_conf.d/"
-RUN sudo mkdir /usr/local/etc/php/custom_conf.d/
+RUN mkdir /usr/local/etc/php/custom_conf.d/
 
 # Workaround to make apache use same UID/GID as host user.
 ARG HOST_GROUP_ID=1000

--- a/.docker/app/Dockerfile
+++ b/.docker/app/Dockerfile
@@ -4,6 +4,11 @@ FROM ghcr.io/glpi-project/glpi-development-env:$PHP_VERSION
 
 USER root
 
+# Allow extra PHP configuration to be placed in a dedicated folder than can serve
+# as a volume
+ENV PHP_INI_SCAN_DIR "/usr/local/etc/php/conf.d/:/usr/local/etc/php/custom_conf.d/"
+RUN sudo mkdir /usr/local/etc/php/custom_conf.d/
+
 # Workaround to make apache use same UID/GID as host user.
 ARG HOST_GROUP_ID=1000
 RUN groupmod --gid ${HOST_GROUP_ID} www-data

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ SHELL=bash
 COMPOSE = docker compose
 
 PHP = $(COMPOSE) exec app
+PHP_ROOT = $(COMPOSE) exec --user=root app
 DB = $(COMPOSE) exec db
 CONSOLE = $(PHP) bin/console
 INI_DIR = /usr/local/etc/php/custom_conf.d
@@ -166,18 +167,18 @@ lint-js: ## Run the js linter script
 XDEBUG_FILE = xdebug-mode.ini
 
 xdebug-off: ## Disable xdebug
-	@$(PHP) sudo bash -c 'echo "xdebug.mode=off" > $(INI_DIR)/$(XDEBUG_FILE)'
-	@$(PHP) sudo service apache2 reload
+	@$(PHP_ROOT) bash -c 'echo "xdebug.mode=off" > $(INI_DIR)/$(XDEBUG_FILE)'
+	@$(PHP_ROOT) service apache2 reload
 .PHONY: xdebug-off
 
 xdebug-on: ## Enable xdebug
-	@$(PHP) sudo bash -c 'echo "xdebug.mode=debug" > $(INI_DIR)/$(XDEBUG_FILE)'
-	@$(PHP) sudo bash -c 'echo "xdebug.start_with_request=1" >> $(INI_DIR)/$(XDEBUG_FILE)'
-	@$(PHP) sudo service apache2 reload
+	@$(PHP_ROOT) bash -c 'echo "xdebug.mode=debug" > $(INI_DIR)/$(XDEBUG_FILE)'
+	@$(PHP_ROOT) bash -c 'echo "xdebug.start_with_request=1" >> $(INI_DIR)/$(XDEBUG_FILE)'
+	@$(PHP_ROOT) service apache2 reload
 .PHONY: xdebug-on
 
 xdebug-profile: ## Enable xdebug performance profiling
-	@$(PHP) sudo bash -c 'echo "xdebug.mode=profile" > $(INI_DIR)/$(XDEBUG_FILE)'
-	@$(PHP) sudo bash -c 'echo "xdebug.start_with_request=1" >> $(INI_DIR)/$(XDEBUG_FILE)'
-	@$(PHP) sudo service apache2 reload
+	@$(PHP_ROOT) bash -c 'echo "xdebug.mode=profile" > $(INI_DIR)/$(XDEBUG_FILE)'
+	@$(PHP_ROOT) bash -c 'echo "xdebug.start_with_request=1" >> $(INI_DIR)/$(XDEBUG_FILE)'
+	@$(PHP_ROOT) service apache2 reload
 .PHONY: xdebug-profile

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ COMPOSE = docker compose
 PHP = $(COMPOSE) exec app
 DB = $(COMPOSE) exec db
 CONSOLE = $(PHP) bin/console
+INI_DIR = /usr/local/etc/php/custom_conf.d
 
 # Helper variables
 _TITLE := "\033[32m[%s]\033[0m %s\n" # Green text
@@ -160,3 +161,23 @@ lint-twig: ## Run the twig linter script
 lint-js: ## Run the js linter script
 	@$(PHP) .github/actions/lint_js-lint.sh
 .PHONY: lint-js
+
+## —— Xdebug ———————————————————————————————————————————————————————————————————
+XDEBUG_FILE = xdebug-mode.ini
+
+xdebug-off: ## Disable xdebug
+	@$(PHP) sudo bash -c 'echo "xdebug.mode=off" > $(INI_DIR)/$(XDEBUG_FILE)'
+	@$(PHP) sudo service apache2 reload
+.PHONY: xdebug-off
+
+xdebug-on: ## Enable xdebug
+	@$(PHP) sudo bash -c 'echo "xdebug.mode=debug" > $(INI_DIR)/$(XDEBUG_FILE)'
+	@$(PHP) sudo bash -c 'echo "xdebug.start_with_request=1" >> $(INI_DIR)/$(XDEBUG_FILE)'
+	@$(PHP) sudo service apache2 reload
+.PHONY: xdebug-on
+
+xdebug-profile: ## Enable xdebug performance profiling
+	@$(PHP) sudo bash -c 'echo "xdebug.mode=profile" > $(INI_DIR)/$(XDEBUG_FILE)'
+	@$(PHP) sudo bash -c 'echo "xdebug.start_with_request=1" >> $(INI_DIR)/$(XDEBUG_FILE)'
+	@$(PHP) sudo service apache2 reload
+.PHONY: xdebug-profile

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,6 +8,7 @@ services:
     restart: "unless-stopped"
     volumes:
       - ".:/var/www/glpi:rw"
+      - "custom_php_ini:/usr/local/etc/php/custom_conf.d/"
     ports:
       - "8080:80"
       - "9637:9637"
@@ -58,3 +59,4 @@ services:
 
 volumes:
   db:
+  custom_php_ini:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
     restart: "unless-stopped"
     volumes:
       - ".:/var/www/glpi:rw"
-      - "custom_php_ini:/usr/local/etc/php/custom_conf.d/"
+      - "custom_php_ini:/usr/local/etc/php/custom_conf.d/:rw"
     ports:
       - "8080:80"
       - "9637:9637"


### PR DESCRIPTION
## Description

Toggle xdebug on dev container using makefile.

Added as a volume to keep the config persistant when killing/rebuilding the containers.