### PR TITLE
Fix (ITILFollowup) - Parent status update after notification

### DIFF
--- a/src/ITILFollowup.php
+++ b/src/ITILFollowup.php
@@ -274,16 +274,6 @@ class ITILFollowup extends CommonDBChild
             $this->input["users_id"]
         );
 
-
-        $donotif = !isset($this->input['_disablenotif']) && $CFG_GLPI["use_notifications"];
-
-        if ($donotif) {
-            $options = ['followup_id' => $this->fields["id"],
-                'is_private'  => $this->fields['is_private'],
-            ];
-            NotificationEvent::raiseEvent("add_followup", $parentitem, $options);
-        }
-
         // Add log entry in the ITILObject
         $changes = [
             0,
@@ -300,6 +290,15 @@ class ITILFollowup extends CommonDBChild
 
         $this->updateParentStatus($this->input['_job'], $this->input);
         PendingReason_Item::handlePendingReasonUpdateFromNewTimelineItem($this);
+
+        $donotif = !isset($this->input['_disablenotif']) && $CFG_GLPI["use_notifications"];
+
+        if ($donotif) {
+            $options = ['followup_id' => $this->fields["id"],
+                'is_private'  => $this->fields['is_private'],
+            ];
+            NotificationEvent::raiseEvent("add_followup", $parentitem, $options);
+        }
 
         parent::post_addItem();
     }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !37813
- Here is a brief description of what this PR does

This patch corrects a regression introduced by PR #17543 where follow-up notifications were sent before the status of the parent ticket was updated.

### Problem:
When a solution is approved via the Approvalbymail plugin, a follow-up is created and a notification is sent while the ticket is still in the "Resolved" state (status 5). Only then does the ticket change to "Closed" (status 6). As a result, the notification again includes the approval form, which is misleading and no longer relevant.

### Root cause:
In ITILFollowup::post_addItem(), NotificationEvent::raiseEvent() is called before updateParentStatus().

### Solution:
Move the notification logic after the call to updateParentStatus() and PendingReason_Item::handlePendingReasonUpdateFromNewTimelineItem() so that the notification reflects the ticket status update.

This maintains the intent of https://github.com/glpi-project/glpi/pull/17543 (to ensure that follow-ups are created before closing the ticket) while correcting the inconsistency of the notification content.

