### PR TITLE
Fix(CommonDBTM) Fix filtervalues method for completename used as itemlink (for display)

### DIFF
--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -4330,7 +4330,10 @@ class CommonDBTM extends CommonGLPI
                         case 'email':
                         case 'string':
                         case 'itemlink':
-                            if (is_string($value) && ($length = mb_strlen($value, 'UTF-8')) > 255) {
+                            // Some 'completename' fields may be typed as 'itemlink' (e.g., in CommonTreeDropdown::class).
+                            // These should be excluded from the length check, as they are stored as TEXT or MEDIUMTEXT,
+                            // not VARCHAR. These fields are used solely as item links, not as standard string fields.
+                            if ($key !== 'completename' && is_string($value) && ($length = mb_strlen($value, 'UTF-8')) > 255) {
                                 trigger_error(
                                     "{$value} exceed 255 characters long ({$length}), it will be truncated.",
                                     E_USER_WARNING


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !37801

In certain hierarchical classes, such as `IPNetwork`, the `completename` field is used to represent the full hierarchy as a text string. This field is often very long and typically stored as a `TEXT` or `MEDIUMTEXT` type in the database.

To enable converting the `completename` into a clickable link pointing to the related object, it is defined with the `itemlink` datatype. This type is used solely for visual rendering, particularly within the `CommonTreeDropdown` component.

However, when the `completename` field is updated, `CommonDBTM` and `FilterValues` apply a truncation mechanism to fields exceeding 255 characters when their datatype is `itemlink`. This can lead to data loss in certain edge cases (entity deleteion in my case).


## Screenshots (if appropriate):


