### PR TITLE
fix(forms-migration): force json_decode to return associative arrays in convertExtraData methods

### DIFF
--- a/src/Glpi/Form/QuestionType/AbstractQuestionTypeSelectable.php
+++ b/src/Glpi/Form/QuestionType/AbstractQuestionTypeSelectable.php
@@ -208,7 +208,7 @@ TWIG;
     public function convertExtraData(array $rawData): array
     {
         $config = new QuestionTypeSelectableExtraDataConfig(
-            options: json_decode($rawData['values']) ?? []
+            options: json_decode($rawData['values'], true) ?? []
         );
         return $config->jsonSerialize();
     }

--- a/src/Glpi/Form/QuestionType/QuestionTypeDropdown.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeDropdown.php
@@ -62,7 +62,7 @@ final class QuestionTypeDropdown extends AbstractQuestionTypeSelectable implemen
     public function convertExtraData(array $rawData): array
     {
         $config = new QuestionTypeDropdownExtraDataConfig(
-            options: json_decode($rawData['values']) ?? [],
+            options: json_decode($rawData['values'], true) ?? [],
             is_multiple_dropdown: $rawData['fieldtype'] === 'multiselect'
         );
         return $config->jsonSerialize();


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

It fixes #19792
Fixed `convertExtraData` method to use `json_decode` with `true` flag, ensuring that decoded JSON is returned as an associative array.