### PR TITLE
Simplify history values trimming

### DIFF
--- a/src/Log.php
+++ b/src/Log.php
@@ -272,8 +272,8 @@ class Log extends CommonDBTM
         }
 
         // Security to be sure that values do not pass over the max length
-        $old_value = Toolbox::substr($old_value, 0, 255);
-        $new_value = Toolbox::substr($new_value, 0, 255);
+        $old_value = mb_substr($old_value, 0, 255);
+        $new_value = mb_substr($new_value, 0, 255);
 
         $params = [
             'items_id'          => $items_id,

--- a/src/Log.php
+++ b/src/Log.php
@@ -271,16 +271,9 @@ class Log extends CommonDBTM
             );
         }
 
-        $old_value = Toolbox::substr($old_value, 0, 180);
-        $new_value = Toolbox::substr($new_value, 0, 180);
-
         // Security to be sure that values do not pass over the max length
-        if (Toolbox::strlen($old_value) > 255) {
-            $old_value = Toolbox::substr($old_value, 0, 250);
-        }
-        if (Toolbox::strlen($new_value) > 255) {
-            $new_value = Toolbox::substr($new_value, 0, 250);
-        }
+        $old_value = Toolbox::substr($old_value, 0, 255);
+        $new_value = Toolbox::substr($new_value, 0, 255);
 
         $params = [
             'items_id'          => $items_id,


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

Trimming of old and new value strings seems redundant included dead code. Seen while answering a question on the forum.
First, the values are trimmed to 180 characters. Then if the strings are over 255 characters (which they would never be), they are trimmed to 250.
We should only need to trim them to 255 characters which is the size of the columns in the database. In reality, I think the only thing gained by trimming on the PHP side is to reduce the amount of data sent over the network to the database in the case of extremely long content.

Functionally, the only change from this PR should be that old/new values for historical entries are now trimmed to 255 characters instead of 180.