### PR TITLE
Helpdesk search results should not use dark text

### DIFF
--- a/templates/pages/helpdesk/search.html.twig
+++ b/templates/pages/helpdesk/search.html.twig
@@ -48,7 +48,7 @@
                         {{ render_illustration("browse-kb", 60) }}
                     </div>
                     <div class="col text-truncate">
-                        <span class="text-dark text-reset d-block">{{ faq.name }}</span>
+                        <span class="text-body d-block">{{ faq.name }}</span>
                         <div class="d-block text-secondary text-truncate richtext-strip-margin">
                             {{ faq.answer|safe_html }}
                         </div>
@@ -82,7 +82,7 @@
                         {{ render_illustration(form.fields.illustration, 60) }}
                     </div>
                     <div class="col text-truncate">
-                        <span class="text-dark text-reset d-block"> {{ form.fields.name }} </span>
+                        <span class="text-body d-block"> {{ form.fields.name }} </span>
                         <div class="d-block text-secondary text-truncate">
                             {{ form.fields.description }}
                         </div>


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Search results on helpdesk homepage should not be forcing the results to use the dark text color as it makes the results unreadable in dark themes. The correct solution to fix the text color so it isn't the link color, is to use `text-body` to reset it to the body text color.
