### PR TITLE
Replace watcher term with observer again

### DIFF
--- a/src/Glpi/Helpdesk/DefaultDataManager.php
+++ b/src/Glpi/Helpdesk/DefaultDataManager.php
@@ -60,6 +60,7 @@ use Glpi\Helpdesk\Tile\GlpiPageTile;
 use Glpi\Helpdesk\Tile\TilesManager;
 use ITILCategory;
 use Location;
+use Session;
 use Ticket;
 
 final class DefaultDataManager
@@ -144,7 +145,7 @@ final class DefaultDataManager
         $this->addQuestion($section, $this->getUrgencyQuestionData());
         $this->addQuestion($section, $this->getCategoryQuestionData());
         $this->addQuestion($section, $this->getUserDevicesQuestionData());
-        $this->addQuestion($section, $this->getWatchersQuestionData());
+        $this->addQuestion($section, $this->getObserversQuestionData());
         $this->addQuestion($section, $this->getLocationQuestionData());
         $title_question = $this->addQuestion($section, $this->getTitleQuestionData());
         $description_question = $this->addQuestion($section, $this->getDescriptionQuestionData());
@@ -204,7 +205,7 @@ final class DefaultDataManager
         $this->addQuestion($section, $this->getUrgencyQuestionData());
         $this->addQuestion($section, $this->getCategoryQuestionData());
         $this->addQuestion($section, $this->getUserDevicesQuestionData());
-        $this->addQuestion($section, $this->getWatchersQuestionData());
+        $this->addQuestion($section, $this->getObserversQuestionData());
         $this->addQuestion($section, $this->getLocationQuestionData());
         $title_question = $this->addQuestion($section, $this->getTitleQuestionData());
         $description_question = $this->addQuestion($section, $this->getDescriptionQuestionData());
@@ -348,11 +349,11 @@ final class DefaultDataManager
         ];
     }
 
-    private function getWatchersQuestionData(): array
+    private function getObserversQuestionData(): array
     {
         return [
             'type' => QuestionTypeObserver::class,
-            'name' => __("Watchers"),
+            'name' => _n('Observer', 'Observers', Session::getPluralNumber()),
             'extra_data' => json_encode(['is_multiple_actors' => true]),
         ];
     }

--- a/src/RuleCommonITILObject.php
+++ b/src/RuleCommonITILObject.php
@@ -859,7 +859,7 @@ TWIG, ['message' => __('Urgency or impact used in actions, think to add Priority
         $actions['_groups_id_observer']['appendto']                 = '_additional_groups_observers';
 
         $actions['_groups_id_observer_by_completename']['table']              = 'glpi_groups';
-        $actions['_groups_id_observer_by_completename']['name']               = sprintf(__('%1$s (%2$s)'), _n('Watcher group', 'Watcher groups', 1), __('by completename'));
+        $actions['_groups_id_observer_by_completename']['name']               = sprintf(__('%1$s (%2$s)'), _n('Observer group', 'Observer groups', 1), __('by completename'));
         $actions['_groups_id_observer_by_completename']['type']               = 'dropdown';
         $actions['_groups_id_observer_by_completename']['condition']          = ['is_watcher' => 1];
         $actions['_groups_id_observer_by_completename']['force_actions']      = ['regex_result'];

--- a/tests/cypress/e2e/form/service_catalog/default_forms.cy.js
+++ b/tests/cypress/e2e/form/service_catalog/default_forms.cy.js
@@ -53,7 +53,7 @@ function testDefaultForm({ profile, formId }) {
     cy.getDropdownByLabelText('Urgency').selectDropdownValue('High');
     cy.getDropdownByLabelText('Category').selectDropdownValue(`»Test ITILCategory - ${uuid}`);
     cy.getDropdownByLabelText('User devices').selectDropdownValue(`Computers - Test Computer - ${uuid}`);
-    cy.getDropdownByLabelText('Watchers').selectDropdownValue('glpi');
+    cy.getDropdownByLabelText('Observers').selectDropdownValue('glpi');
     cy.getDropdownByLabelText('Location').selectDropdownValue(`»Test Location - ${uuid}`);
     cy.findByRole('textbox', { name: "Title" }).type("My title");
     cy.findByLabelText("Description").awaitTinyMCE().type("My description");

--- a/tests/fixtures/export-of-2-forms.json
+++ b/tests/fixtures/export-of-2-forms.json
@@ -26,7 +26,7 @@
                 {
                     "id": 1,
                     "uuid": "question-1",
-                    "name": "Watchers",
+                    "name": "Observers",
                     "type": "Glpi\\Form\\QuestionType\\QuestionTypeObserver",
                     "is_mandatory": false,
                     "vertical_rank": 2,


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

The terms "Watcher" and "Observer" were standardized a few years ago (#12649) as they meant the same thing but both terms were used throughout GLPI, causing user confusion. Recently "Watcher" has returned.