### PR TITLE
fix(notification): Only one notification is sent when a ticket is resolved on creation using a solution template rule

### DIFF
--- a/phpunit/functional/TicketTest.php
+++ b/phpunit/functional/TicketTest.php
@@ -8083,7 +8083,7 @@ HTML,
             [
                 'entities_id' => 0,
                 'name' => 'ITILsolution Template',
-                'content' => 'ITILsolution Content'
+                'content' => 'ITILsolution Content',
             ]
         );
 
@@ -8095,7 +8095,7 @@ HTML,
                 'sub_type' => 'RuleTicket',
                 'match' => 'AND',
                 'is_active' => 1,
-                'condition' => 3,
+                'condition' => 1,
             ]
         );
 
@@ -8135,6 +8135,50 @@ HTML,
 
         $queue = new \QueuedNotification();
         $this->assertEquals(1, count($queue->find([
+            'itemtype' => Ticket::class,
+            'items_id' => $ticket->getID(),
+            'event' => 'solved',
+            'mode' => 'mailing',
+            'recipientname' => 'tech',
+        ])));
+
+        $solution = new \ITILSolution();
+        $this->assertEquals(1, count($solution->find([
+            'items_id' => $ticket->getID(),
+            'itemtype' => Ticket::class,
+            'status'   => 2,
+        ])));
+        $solution->getFromDBByCrit([
+            'items_id' => $ticket->getID(),
+            'itemtype' => Ticket::class,
+            'status'   => 2,
+        ]);
+        $this->updateItem(
+            \ITILSolution::class,
+            $solution->getID(),
+            [
+                'status' => 3,
+            ],
+        );
+
+        $this->updateItem(
+            \Ticket::class,
+            $ticket->getID(),
+            [
+                'status'     => CommonITILObject::ASSIGNED,
+            ],
+        );
+
+        $this->createItem(
+            ITILSolution::class,
+            [
+                'items_id' => $ticket->getID(),
+                'itemtype' => Ticket::class,
+                'status'   => 2,
+            ],
+        );
+
+        $this->assertEquals(2, count($queue->find([
             'itemtype' => Ticket::class,
             'items_id' => $ticket->getID(),
             'event' => 'solved',

--- a/phpunit/functional/TicketTest.php
+++ b/phpunit/functional/TicketTest.php
@@ -8170,7 +8170,7 @@ HTML,
         );
 
         $this->createItem(
-            ITILSolution::class,
+            \ITILSolution::class,
             [
                 'items_id' => $ticket->getID(),
                 'itemtype' => Ticket::class,

--- a/phpunit/functional/TicketTest.php
+++ b/phpunit/functional/TicketTest.php
@@ -8137,10 +8137,9 @@ HTML,
         $this->assertEquals(1, count($queue->find([
             'itemtype' => Ticket::class,
             'items_id' => $ticket->getID(),
-            'notificationtemplate_id' => 4,
             'event' => 'solved',
             'mode' => 'mailing',
-            'recipientname' => 'tech@tech.tech',
+            'recipientname' => 'tech',
         ])));
     }
 }

--- a/phpunit/functional/TicketTest.php
+++ b/phpunit/functional/TicketTest.php
@@ -8068,4 +8068,79 @@ HTML,
         $doc = new \Document();
         $this->assertEquals($expected, $doc->can(-1, CREATE, $input));
     }
+
+    public function testRequesterHaveDoubleSolvedTicketNotification()
+    {
+        global $CFG_GLPI;
+        $CFG_GLPI['use_notifications'] = 1;
+        $CFG_GLPI['notifications_mailing'] = 1;
+        $this->login('glpi', 'glpi');
+
+        $user = getItemByTypeName(User::class, 'tech');
+
+        $itilsolution_template = $this->createItem(
+            \SolutionTemplate::class,
+            [
+                'entities_id' => 0,
+                'name' => 'ITILsolution Template',
+                'content' => 'ITILsolution Content'
+            ]
+        );
+
+        $rule = $this->createItem(
+            \Rule::class,
+            [
+                'entities_id' => 0,
+                'name' => 'Rule name',
+                'sub_type' => 'RuleTicket',
+                'match' => 'AND',
+                'is_active' => 1,
+                'condition' => 3,
+            ]
+        );
+
+        $this->createItem(\RuleAction::class, [
+            'rules_id' => $rule->getID(),
+            'action_type' => 'assign',
+            'field' => 'solution_template',
+            'value' => $itilsolution_template->getID(),
+        ]);
+
+        $this->createItem(\RuleCriteria::class, [
+            'rules_id' => $rule->getID(),
+            'criteria' => 'name',
+            'condition' => \Rule::PATTERN_CONTAIN,
+            'pattern' => 'ITILsolution',
+        ]);
+
+        $this->createItem(\UserEmail::class, [
+            'users_id' => $user->getID(),
+            'is_default' => 1,
+            'email' => 'tech@tech.tech',
+        ]);
+
+        $ticket = $this->createItem(
+            \Ticket::class,
+            [
+                'name'        => 'ITILsolution',
+                'content'     => '',
+                'entities_id' => 0,
+                '_actors'     => [
+                    'requester' => [
+                        ['itemtype' => 'User', 'items_id' => $user->getID(), 'use_notification' => 1],
+                    ],
+                ],
+            ]
+        );
+
+        $queue = new \QueuedNotification();
+        $this->assertEquals(1, count($queue->find([
+            'itemtype' => Ticket::class,
+            'items_id' => $ticket->getID(),
+            'notificationtemplate_id' => 4,
+            'event' => 'solved',
+            'mode' => 'mailing',
+            'recipientname' => 'tech@tech.tech',
+        ])));
+    }
 }

--- a/phpunit/functional/TicketTest.php
+++ b/phpunit/functional/TicketTest.php
@@ -8074,6 +8074,7 @@ HTML,
         global $CFG_GLPI;
         $CFG_GLPI['use_notifications'] = 1;
         $CFG_GLPI['notifications_mailing'] = 1;
+
         $this->login('glpi', 'glpi');
 
         $user = getItemByTypeName(User::class, 'tech');
@@ -8143,34 +8144,14 @@ HTML,
             'recipientname' => 'tech',
         ]));
 
-        $queue->delete([
-            'id' => $queue->getID(),
-            'itemtype' => Ticket::class,
-            'items_id' => $ticket->getID(),
-            'event' => 'solved',
-            'mode' => 'mailing',
-            'recipientname' => 'tech',
-        ], true);
-
-        $this->assertEquals(0, count($queue->find([
-            'itemtype' => Ticket::class,
-            'items_id' => $ticket->getID(),
-            'event' => 'solved',
-            'mode' => 'mailing',
-            'recipientname' => 'tech',
-        ])));
+        $this->assertTrue($queue->delete(['id' => $queue->getID()], true));
 
         $solution = new \ITILSolution();
-        $this->assertEquals(1, count($solution->find([
+        $this->assertTrue($solution->getFromDBByCrit([
             'items_id' => $ticket->getID(),
             'itemtype' => Ticket::class,
             'status'   => 2,
-        ])));
-        $solution->getFromDBByCrit([
-            'items_id' => $ticket->getID(),
-            'itemtype' => Ticket::class,
-            'status'   => 2,
-        ]);
+        ]));
 
         // Test Notification for solved ticket with solution template rule at update
         $this->updateItem(
@@ -8199,22 +8180,7 @@ HTML,
             'recipientname' => 'tech',
         ]));
 
-        $queue->delete([
-            'id' => $queue->getID(),
-            'itemtype' => Ticket::class,
-            'items_id' => $ticket->getID(),
-            'event' => 'solved',
-            'mode' => 'mailing',
-            'recipientname' => 'tech',
-        ], true);
-
-        $this->assertEquals(0, count($queue->find([
-            'itemtype' => Ticket::class,
-            'items_id' => $ticket->getID(),
-            'event' => 'solved',
-            'mode' => 'mailing',
-            'recipientname' => 'tech',
-        ])));
+        $this->assertTrue($queue->delete(['id' => $queue->getID()], true));
 
         $this->updateItem(
             \Ticket::class,

--- a/phpunit/functional/TicketTest.php
+++ b/phpunit/functional/TicketTest.php
@@ -8215,5 +8215,32 @@ HTML,
             'mode' => 'mailing',
             'recipientname' => 'tech',
         ])));
+
+        $this->updateItem(
+            \Ticket::class,
+            $ticket->getID(),
+            [
+                'status'      => \CommonITILObject::ASSIGNED,
+            ],
+            ['status']
+        );
+        $solution = new \ITILSolution();
+        $this->createItem(
+            \ITILSolution::class,
+            [
+                'items_id' => $ticket->getID(),
+                'itemtype' => Ticket::class,
+                'content' => 'ITILsolution Content',
+                'status' => 2,
+            ]
+        );
+
+        $this->assertTrue($queue->getFromDBByCrit([
+            'itemtype' => Ticket::class,
+            'items_id' => $ticket->getID(),
+            'event' => 'solved',
+            'mode' => 'mailing',
+            'recipientname' => 'tech',
+        ]));
     }
 }

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -8276,7 +8276,7 @@ abstract class CommonITILObject extends CommonDBTM
             $has_solution = $solution->getFromDBByCrit([
                 'itemtype' => Ticket::class,
                 'items_id' => $this->getID(),
-                'status'   => 2,
+                'status'   => CommonITILValidation::WAITING,
             ]);
             if (in_array($status, $this->getSolvedStatusArray()) && !$has_solution) {
                 NotificationEvent::raiseEvent('solved', $this);

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -8271,14 +8271,18 @@ abstract class CommonITILObject extends CommonDBTM
             NotificationEvent::raiseEvent('new', $this);
 
             $status = $this->fields['status'] ?? null;
+
             //Check if a waiting ITIL solution has been posted to avoid sending duplicate notifications.
-            $solution = new ITILSolution();
-            $has_solution = $solution->getFromDBByCrit([
-                'itemtype' => Ticket::class,
-                'items_id' => $this->getID(),
-                'status'   => CommonITILValidation::WAITING,
-            ]);
-            if (in_array($status, $this->getSolvedStatusArray()) && !$has_solution) {
+            $has_waiting_solution = countElementsInTable(
+                ITILSolution::getTable(),
+                [
+                    'itemtype' => Ticket::class,
+                    'items_id' => $this->getID(),
+                    'status'   => CommonITILValidation::WAITING,
+                ]
+            ) > 0;
+
+            if (in_array($status, $this->getSolvedStatusArray()) && !$has_waiting_solution) {
                 NotificationEvent::raiseEvent('solved', $this);
             }
             if (in_array($status, $this->getClosedStatusArray())) {

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -8271,7 +8271,12 @@ abstract class CommonITILObject extends CommonDBTM
             NotificationEvent::raiseEvent('new', $this);
 
             $status = $this->fields['status'] ?? null;
-            if (in_array($status, $this->getSolvedStatusArray())) {
+            $solution = new ITILSolution();
+            $has_solution = $solution->getFromDBByCrit([
+                'itemtype' => Ticket::class,
+                'items_id' => $this->getID(),
+            ]);
+            if (in_array($status, $this->getSolvedStatusArray()) && !$has_solution) {
                 NotificationEvent::raiseEvent('solved', $this);
             }
             if (in_array($status, $this->getClosedStatusArray())) {

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -8271,10 +8271,12 @@ abstract class CommonITILObject extends CommonDBTM
             NotificationEvent::raiseEvent('new', $this);
 
             $status = $this->fields['status'] ?? null;
+            //Check if a waiting ITIL solution has been posted to avoid sending duplicate notifications.
             $solution = new ITILSolution();
             $has_solution = $solution->getFromDBByCrit([
                 'itemtype' => Ticket::class,
                 'items_id' => $this->getID(),
+                'status'   => 2,
             ]);
             if (in_array($status, $this->getSolvedStatusArray()) && !$has_solution) {
                 NotificationEvent::raiseEvent('solved', $this);


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !37860
- If the user executes a rule that applies a solution template during ticket creation, requesters receive a double notification that the ticket has been resolved.

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/84245199-5ed5-466b-b381-5671561b93e4)
![image](https://github.com/user-attachments/assets/3a700169-a959-42c4-a9c3-4ff351c3a970)



