### PR TITLE
Prevent relation duplicates for custom assets

### DIFF
--- a/inc/relation.constant.php
+++ b/inc/relation.constant.php
@@ -1704,7 +1704,7 @@ $RELATION = [
 
 ];
 
-$define_mapping_entry = static function (string $source_table, string $target_table_key) use (&$RELATION) {
+$add_mapping_entry = static function (string $source_table, string $target_table_key, string|array $relation_fields) use (&$RELATION) {
     if (!array_key_exists($source_table, $RELATION)) {
         $RELATION[$source_table] = [];
     }
@@ -1713,6 +1713,10 @@ $define_mapping_entry = static function (string $source_table, string $target_ta
     }
     if (!is_array($RELATION[$source_table][$target_table_key])) {
         $RELATION[$source_table][$target_table_key] = [$RELATION[$source_table][$target_table_key]];
+    }
+
+    if (!in_array($relation_fields, $RELATION[$source_table][$target_table_key], true)) {
+        $RELATION[$source_table][$target_table_key][] = $relation_fields;
     }
 };
 
@@ -1809,9 +1813,7 @@ foreach ($polymorphic_types_mapping as $target_itemtype => $source_itemtypes) {
         $target_table_key = $target_table_key_prefix . $target_itemtype::getTable();
         $source_table     = $source_itemtype::getTable();
 
-        $define_mapping_entry($source_table, $target_table_key);
-
-        $RELATION[$source_table][$target_table_key][] = ['items_id', 'itemtype'];
+        $add_mapping_entry($source_table, $target_table_key, ['items_id', 'itemtype']);
     }
 }
 
@@ -1821,9 +1823,7 @@ foreach ($CFG_GLPI['networkport_types'] as $source_itemtype) {
     $target_table_key = IPAddress::getTable();
     $source_table     = $source_itemtype::getTable();
 
-    $define_mapping_entry($source_table, $target_table_key);
-
-    $RELATION[$source_table][$target_table_key][] = ['mainitems_id', 'mainitemtype'];
+    $add_mapping_entry($source_table, $target_table_key, ['mainitems_id', 'mainitemtype']);
 }
 
 // Asset_PeripheralAsset specific case
@@ -1831,15 +1831,13 @@ foreach ($CFG_GLPI['directconnect_types'] as $directconnect_itemtype) {
     $target_table_key = Asset_PeripheralAsset::getTable();
     $source_table     = $directconnect_itemtype::getTable();
 
-    $define_mapping_entry($source_table, $target_table_key);
-    $RELATION[$source_table][$target_table_key][] = ['itemtype_peripheral', 'items_id_peripheral'];
+    $add_mapping_entry($source_table, $target_table_key, ['itemtype_peripheral', 'items_id_peripheral']);
 }
 foreach (Asset_PeripheralAsset::getPeripheralHostItemtypes() as $peripheralhost_itemtype) {
     $target_table_key = Asset_PeripheralAsset::getTable();
     $source_table     = $peripheralhost_itemtype::getTable();
 
-    $define_mapping_entry($source_table, $target_table_key);
-    $RELATION[$source_table][$target_table_key][] = ['itemtype_asset', 'items_id_asset'];
+    $add_mapping_entry($source_table, $target_table_key, ['itemtype_asset', 'items_id_asset']);
 }
 
 // Multiple groups assignments
@@ -1847,6 +1845,5 @@ $assignable_itemtypes = $CFG_GLPI['assignable_types'];
 foreach ($assignable_itemtypes as $assignable_itemtype) {
     $source_table_key = $assignable_itemtype::getTable();
 
-    $define_mapping_entry($source_table_key, '_glpi_groups_items');
-    $RELATION[$source_table_key]['_glpi_groups_items'][] = ['itemtype', 'items_id'];
+    $add_mapping_entry($source_table_key, '_glpi_groups_items', ['itemtype', 'items_id']);
 }

--- a/phpunit/functional/HtmlTest.php
+++ b/phpunit/functional/HtmlTest.php
@@ -276,6 +276,7 @@ class HtmlTest extends \GLPITestCase
             'Unmanaged',
             'Cable',
             'Glpi\CustomAsset\Test01',
+            'Glpi\CustomAsset\Test02',
             'Item_DeviceSimcard',
         ];
         $this->assertSame('Assets', $menu['assets']['title']);

--- a/tests/src/autoload/functions.php
+++ b/tests/src/autoload/functions.php
@@ -691,6 +691,13 @@ function loadDataset()
                 'is_active' => 1,
                 'profiles' => ['4' => ALLSTANDARDRIGHT | READ_ASSIGNED | UPDATE_ASSIGNED | READ_OWNED | UPDATE_OWNED],
             ],
+            [
+                'system_name' => 'Test02',
+                'icon' => 'ti ti-test-pipe',
+                'label' => 'Test02',
+                'is_active' => 1,
+                'profiles' => ['4' => ALLSTANDARDRIGHT | READ_ASSIGNED | UPDATE_ASSIGNED | READ_OWNED | UPDATE_OWNED],
+            ],
         ],
         'Glpi\\Asset\\CustomFieldDefinition' => [
             [
@@ -711,6 +718,16 @@ function loadDataset()
                 'name' => 'TestB',
                 'entities_id' => '_test_root_entity',
                 'custom_teststring' => 'Test String B',
+            ],
+        ],
+        'Glpi\\CustomAsset\\Test02' => [
+            [
+                'name' => 'Test02 A',
+                'entities_id' => '_test_root_entity',
+            ],
+            [
+                'name' => 'Test02 B',
+                'entities_id' => '_test_root_entity',
             ],
         ],
     ];


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

It fixes #19744.

All the custom assets are stored in the same table. The relation between the `glpi_assets_assets` table and other tables must be declared only once.