### PR TITLE
Fix itil cost edit form

### DIFF
--- a/src/CommonITILCost.php
+++ b/src/CommonITILCost.php
@@ -662,10 +662,6 @@ TWIG, $twig_params);
             echo Html::scriptBlock(<<<JS
                 $(() => {
                     $('#datatable_costs{$ID}{$rand}').on('click', 'tbody tr', (e) => {
-                        //ignore click in first column (the massive action checkbox)
-                        if ($(e.target).closest('td').is('td:first-child')) {
-                            return;
-                        }
                         const cost_id = $(e.currentTarget).data('id');
                         if (cost_id) {
                             $('#viewcost{$ID}_{$rand}').load('/ajax/viewsubitem.php',{

--- a/templates/components/datatable.html.twig
+++ b/templates/components/datatable.html.twig
@@ -225,7 +225,11 @@
                 {% if entries|length > 0 %}
                     {% for entry in entries %}
                         {% set row_massiveactions = entry['showmassiveactions']|default(showmassiveactions) %}
-                        <tr class="{{ loop.last ? "border-transparent" : "" }} {{ row_class|default('') }} {{ entry['row_class']|default('') }}"{% if row_massiveactions %} data-itemtype="{{ entry['itemtype'] }}" data-id="{{ entry['id'] }}"{% endif %}>
+                        <tr
+                            class="{{ loop.last ? "border-transparent" : "" }} {{ row_class|default('') }} {{ entry['row_class']|default('') }}"
+                            data-itemtype="{{ entry['itemtype'] }}"
+                            data-id="{{ entry['id'] }}"
+                        >
                             {% if row_massiveactions %}
                                 <td style="width: 10px">
                                     {% if entry['skip_ma'] is not defined or entry['skip_ma'] == false %}


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
    -> don't want to add any new e2e until we improve execution times, tests are too long already

## Description

The js code that handle displaying the itil cost edit form didn't work as expected due to a missing data attribute that it relies on.
See comments below.

## References

Fix #19812.


