### PR TITLE
Fix missing column in project task datatable

### DIFF
--- a/src/ProjectTask.php
+++ b/src/ProjectTask.php
@@ -1366,6 +1366,9 @@ TWIG, $twig_params);
                 $parent = new self();
                 $parent->getFromDB($data['projecttasks_id']);
                 $entry['fname'] = $parent->getLink();
+            } else {
+                // Entry must exist even if empty to make sure the <td> is rendered
+                $entry['fname'] = "";
             }
             $projecttask = new ProjectTask();
             $projecttask->getFromDB($data['id']);


### PR DESCRIPTION

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.

## Description

Tasks without parent task had a missing `<td>` in the project tasks tab:

![image](https://github.com/user-attachments/assets/3b4b47f8-56df-4769-abb9-567da118df94)

## References

Fix #19808.

