### PR TITLE
Fix generic form controller rights checks

### DIFF
--- a/src/Glpi/Controller/GenericFormController.php
+++ b/src/Glpi/Controller/GenericFormController.php
@@ -96,7 +96,7 @@ class GenericFormController extends AbstractController
      */
     private function handleFormAction(Request $request, string $form_action, string $class): Response
     {
-        $id = $request->query->get('id', -1);
+        $id = $request->isMethod('GET') ? $request->query->get('id', -1) : $request->request->get('id', -1);
         $post_data = $request->request->all();
 
         /* @var CommonDBTM $object */


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

The generic controller was trying to fetch the `id` from the query parameters . For the POST requests the `id` should be fetched from the request body.
The `$object->can($id, UPDATE, $post_data)` was using the wrong `id`, and the current fields values were therefore not populated, resulting in unexpected result, mostly for `CommonDBConnexity` items that are checking for the relation fields validity in their `canUpdateItem()` method.