### PR TITLE
Fix(NetworkPort): display all items related to hub

### DIFF
--- a/src/NetworkPort.php
+++ b/src/NetworkPort.php
@@ -1202,7 +1202,7 @@ class NetworkPort extends CommonDBChild
                                                 NetworkPort::getTable() . ' AS netp' => [
                                                     'ON' => [
                                                         'netp'   => 'items_id',
-                                                        'unm'    => 'id',
+                                                        'asset'    => 'id',
                                                         [
                                                             'AND' => [
                                                                 'netp.itemtype' => $related_class,

--- a/src/NetworkPort.php
+++ b/src/NetworkPort.php
@@ -1369,7 +1369,13 @@ class NetworkPort extends CommonDBChild
         return $iterator;
     }
 
-    protected function getAssetLink(CommonDBTM $asset)
+    protected function getUnmanagedLink($device, $port)
+    {
+        Toolbox::deprecated('Use NetworkPort::getAssetLink() instead.', true, '11.0.0');
+        return $this->getAssetLink($port);
+    }
+
+    private function getAssetLink(CommonDBTM $asset): string
     {
 
         if (is_a($asset, NetworkPort::class)) {

--- a/src/NetworkPort.php
+++ b/src/NetworkPort.php
@@ -985,8 +985,10 @@ class NetworkPort extends CommonDBChild
      */
     protected function showPort(array $port, $dprefs, $so, $canedit, $agg, $rand, $with_ma = true)
     {
-        /** @var \DBmysql $DB */
-        global $DB;
+        /**  @var \DBmysql $DB
+         * @var array $CFG_GLPI
+         */
+        global $DB, $CFG_GLPI;
 
         $css_class = 'netport';
         if ($port['ifstatus'] == 1) {

--- a/src/NetworkPort.php
+++ b/src/NetworkPort.php
@@ -1166,7 +1166,7 @@ class NetworkPort extends CommonDBChild
 
                             $device2 = $oppositePort->getItem();
                             if ($device2 !== false) {
-                                $output .= $this->getUnmanagedLink($device2, $oppositePort);
+                                $output .= $this->getAssetLink($oppositePort);
 
                                 //equipments connected to hubs
                                 if ($device2->getType() == Unmanaged::getType() && $device2->fields['hub'] == 1) {
@@ -1186,26 +1186,39 @@ class NetworkPort extends CommonDBChild
                                         $list_ports[] = $npo;
                                     }
 
-                                    $hub_equipments = $DB->request([
-                                        'SELECT' => ['unm.*', 'netp.mac'],
-                                        'FROM'   => Unmanaged::getTable() . ' AS unm',
-                                        'INNER JOIN'   => [
-                                            NetworkPort::getTable() . ' AS netp' => [
-                                                'ON' => [
-                                                    'netp'   => 'items_id',
-                                                    'unm'    => 'id', [
-                                                        'AND' => [
-                                                            'netp.itemtype' => $device2->getType(),
+                                    $itemtypes = [Computer::class, Printer::class, NetworkEquipment::class, Phone::class, Unmanaged::class];
+                                    $union = new \QueryUnion();
+                                    foreach ($itemtypes as $related_class) {
+                                        $table = getTableForItemType($related_class);
+                                        $union->addQuery([
+                                            'SELECT' => [
+                                                'unm.id',
+                                                'netp.mac',
+                                                'netp.itemtype',
+                                                'netp.items_id',
+                                            ],
+                                            'FROM'   => $table . ' AS unm',
+                                            'INNER JOIN'   => [
+                                                NetworkPort::getTable() . ' AS netp' => [
+                                                    'ON' => [
+                                                        'netp'   => 'items_id',
+                                                        'unm'    => 'id',
+                                                        [
+                                                            'AND' => [
+                                                                'netp.itemtype' => $related_class,
+                                                            ],
                                                         ],
                                                     ],
                                                 ],
                                             ],
-                                        ],
-                                        'WHERE'  => [
-                                            'netp.itemtype'  => $device2->getType(),
-                                            'netp.id'  => $list_ports,
-                                        ],
-                                    ]);
+                                            'WHERE'  => [
+                                                'netp.itemtype'  => $related_class,
+                                                'netp.id'        => $list_ports,
+                                            ],
+                                        ]);
+                                    }
+
+                                    $hub_equipments = $DB->request(['FROM' => $union]);
 
                                     if (count($hub_equipments) > 10) {
                                         $houtput .= '<div>' . sprintf(
@@ -1214,10 +1227,10 @@ class NetworkPort extends CommonDBChild
                                         ) . '</div>';
                                     } else {
                                         foreach ($hub_equipments as $hrow) {
-                                            $hub = new Unmanaged();
-                                            $hub->getFromDB($hrow['id']);
-                                            $hub->fields['mac'] = $hrow['mac'];
-                                            $houtput .= '<div>' . $this->getUnmanagedLink($hub, $hub) . '</div>';
+                                            $asset = new $hrow['itemtype']();
+                                            $asset->getFromDB($hrow['items_id']);
+                                            $asset->fields['mac'] = $hrow['mac'];
+                                            $houtput .= '<div>' . $this->getAssetLink($asset) . '</div>';
                                         }
                                     }
 
@@ -1354,15 +1367,25 @@ class NetworkPort extends CommonDBChild
         return $iterator;
     }
 
-    protected function getUnmanagedLink($device, $port)
+    protected function getAssetLink(CommonDBTM $asset)
     {
-        $link = $port->getLink();
 
-        if (!empty($port->fields['mac'])) {
-            $link .= '<br/>' . $port->fields['mac'];
+        if (is_a($asset, NetworkPort::class)) {
+            $link = $asset->getLink();
+        } else {
+            $link = sprintf(
+                '<i class="%1$s"></i> %2$s </i>',
+                $asset->getIcon(),
+                $asset->getLink(),
+            );
         }
 
-        $ips_iterator = $this->getIpsForPort($port->getType(), $port->getID());
+
+        if (!empty($asset->fields['mac'])) {
+            $link .= '<br/>' . $asset->fields['mac'];
+        }
+
+        $ips_iterator = $this->getIpsForPort($asset->getType(), $asset->getID());
         $ips = '';
         foreach ($ips_iterator as $ipa) {
             $ips .= ' ' . $ipa['name'];

--- a/src/NetworkPort.php
+++ b/src/NetworkPort.php
@@ -1192,7 +1192,7 @@ class NetworkPort extends CommonDBChild
                                         $table = getTableForItemType($related_class);
                                         $union->addQuery([
                                             'SELECT' => [
-                                                'unm.id',
+                                                'asset.id',
                                                 'netp.mac',
                                                 'netp.itemtype',
                                                 'netp.items_id',

--- a/src/NetworkPort.php
+++ b/src/NetworkPort.php
@@ -1186,7 +1186,7 @@ class NetworkPort extends CommonDBChild
                                         $list_ports[] = $npo;
                                     }
 
-                                    $itemtypes = [Computer::class, Printer::class, NetworkEquipment::class, Phone::class, Unmanaged::class];
+                                    $itemtypes = $CFG_GLPI["networkport_types"];
                                     $union = new \QueryUnion();
                                     foreach ($itemtypes as $related_class) {
                                         $table = getTableForItemType($related_class);

--- a/src/NetworkPort.php
+++ b/src/NetworkPort.php
@@ -1197,7 +1197,7 @@ class NetworkPort extends CommonDBChild
                                                 'netp.itemtype',
                                                 'netp.items_id',
                                             ],
-                                            'FROM'   => $table . ' AS unm',
+                                            'FROM'   => $table . ' AS asset',
                                             'INNER JOIN'   => [
                                                 NetworkPort::getTable() . ' AS netp' => [
                                                     'ON' => [


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !37769

When a hub is connected to a NetworkPort in GLPI, all unmanaged devices connected to that hub are displayed directly in the NetworkPort view.

![image](https://github.com/user-attachments/assets/5062a0e1-b42b-480f-b8ad-778e04d087d2)

All related equipment is displayed correctly, except for the one corresponding to the main object (in this case, the switch), which is excluded from the list (While this exclusion might be intentional, the information is available, so omitting it from the display seems unnecessary).

![image](https://github.com/user-attachments/assets/90225d0e-b0bd-4f6c-b016-7b402e723670)

I now want to convert two unmanaged devices into clearly identified assets within GLPI.

- `RICOH COMPANY, LTD` → `Printer`
- `Apple, Inc.` → `Computer`

Once these unmanaged devices are converted, even though they remain physically connected to the hub, 

![image](https://github.com/user-attachments/assets/8bd0af34-7854-45d2-ad7d-1ebcd36c5bb4)

they no longer appear in the list of devices linked to the network port in GLPI (from `NetworkEquipement` view).

![image](https://github.com/user-attachments/assets/fd12145d-771a-4a2b-a8ee-9dd4a6696c2e)


This pull request fixes the issue by properly handling unmanaged devices that have been converted, so they are displayed in the list of equipment linked to the hub.

![image](https://github.com/user-attachments/assets/b969056d-2282-41bf-a3a8-dff718481512)


1. **Replaced `getUnmanagedLink()` with a more generic `getAssetLink()` method**

   * Enables rendering links for any type of device, not just unmanaged ones.

2. **Replaced direct SQL request with a unified query (`QueryUnion`)**

   * Handles multiple related device types: `Computer`, `Printer`, `NetworkEquipment`, `Phone`, and `Unmanaged`.
   * Ensures all devices connected to the hub are considered, whether managed or not.

3. **Refactored `getAssetLink(CommonDBTM $asset)`**

   * Centralized method to build clean HTML links, compatible with all supported asset types.

## Screenshots (if appropriate):


