### PR TITLE
Fix(Notification): prevent error when mode is not available

### DIFF
--- a/src/NotificationEvent.php
+++ b/src/NotificationEvent.php
@@ -211,7 +211,12 @@ class NotificationEvent extends CommonDBTM
                         'Missing event class for mode ' . $data['mode'] . ' (' . $eventclass . ')',
                         E_USER_WARNING
                     );
-                    $label = Notification_NotificationTemplate::getMode($data['mode'])['label'];
+                    $mode = Notification_NotificationTemplate::getMode($data['mode']);
+                    if (is_array($mode) && !empty($mode['label'])) {
+                        $label = $mode['label'];
+                    } else {
+                        $label = sprintf('%s (%s)', NOT_AVAILABLE, $data['mode']);
+                    }
                     Session::addMessageAfterRedirect(
                         htmlescape(sprintf(__('Unable to send notification using %1$s'), $label)),
                         true,

--- a/src/QueuedNotification.php
+++ b/src/QueuedNotification.php
@@ -463,7 +463,11 @@ class QueuedNotification extends CommonDBTM
                 }
                 return $out;
             case 'mode':
-                return Notification_NotificationTemplate::getMode($values[$field])['label'];
+                $mode = Notification_NotificationTemplate::getMode($values[$field]);
+                if (is_array($mode) && !empty($mode['label'])) {
+                    return $mode['label'];
+                }
+                return sprintf('%s (%s)', NOT_AVAILABLE, $values[$field]);
         }
         return parent::getSpecificValueToDisplay($field, $values, $options);
     }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

When a notification mode added by a plugin is no longer available _typically because the plugin is disabled or uninstalled_
GLPI throws a runtime error during template rendering.

This was observed in the **QueuedNotification** list view, where some queued notifications used the `webhook` mode provided by the **CollaborativeTools** plugin, which was not active at the time.

## Error

```shell
[2025-05-28 12:04:30] glpi.CRITICAL:   *** Uncaught PHP Exception Twig\Error\RuntimeError: "An exception has been thrown during the rendering of a template ("Cannot access offset of type string on string")." at generic_list.html.twig line 38
  Backtrace :
  ./templates/pages/generic_list.html.twig:38        
  ./vendor/twig/twig/src/Template.php:344            Twig\Template->yield()
  ./vendor/twig/twig/src/Template.php:359            Twig\Template->display()
  ./vendor/twig/twig/src/TemplateWrapper.php:51      Twig\Template->render()
  .../Glpi/Application/View/TemplateRenderer.php:177 Twig\TemplateWrapper->render()
  ./src/Glpi/Controller/AbstractController.php:68    Glpi\Application\View\TemplateRenderer->render()
  ./src/Glpi/Controller/GenericListController.php:51 Glpi\Controller\AbstractController->render()
  ./vendor/symfony/http-kernel/HttpKernel.php:181    Glpi\Controller\GenericListController->__invoke()
  ./vendor/symfony/http-kernel/HttpKernel.php:76     Symfony\Component\HttpKernel\HttpKernel->handleRaw()
  ./vendor/symfony/http-kernel/Kernel.php:197        Symfony\Component\HttpKernel\HttpKernel->handle()
  ./public/index.php:56                              Symfony\Component\HttpKernel\Kernel->handle()
  Previous: Cannot access offset of type string on string
  ./src/QueuedNotification.php:466                   
  ./src/Glpi/Search/Provider/SQLProvider.php:6441    QueuedNotification::getSpecificValueToDisplay()
  ./src/Glpi/Search/Provider/SQLProvider.php:4892    Glpi\Search\Provider\SQLProvider::giveItem()
  ./src/Glpi/Search/SearchEngine.php:642             Glpi\Search\Provider\SQLProvider::constructData()
  ./src/Glpi/Search/SearchEngine.php:657             Glpi\Search\SearchEngine::getData()
  ./src/Glpi/Search/SearchEngine.php:614             Glpi\Search\SearchEngine::showOutput()
  :                                                  Glpi\Search\SearchEngine::show()
  .../Application/View/Extension/PhpExtension.php:91 call_user_func_array()
  ...ates/a1/a14e2fe4d4e75165289601b55548d66e.php:59 Glpi\Application\View\Extension\PhpExtension->call()
  ./vendor/twig/twig/src/Template.php:388            __TwigTemplate_d5d55c2fe09bf998bab2a2df44b6ea96->doDisplay()
  ./vendor/twig/twig/src/Template.php:344            Twig\Template->yield()
  ./vendor/twig/twig/src/Template.php:359            Twig\Template->display()
  ./vendor/twig/twig/src/TemplateWrapper.php:51      Twig\Template->render()
  .../Glpi/Application/View/TemplateRenderer.php:177 Twig\TemplateWrapper->render()
  ./src/Glpi/Controller/AbstractController.php:68    Glpi\Application\View\TemplateRenderer->render()
  ./src/Glpi/Controller/GenericListController.php:51 Glpi\Controller\AbstractController->render()
  ./vendor/symfony/http-kernel/HttpKernel.php:181    Glpi\Controller\GenericListController->__invoke()
  ./vendor/symfony/http-kernel/HttpKernel.php:76     Symfony\Component\HttpKernel\HttpKernel->handleRaw()
  ./vendor/symfony/http-kernel/Kernel.php:197        Symfony\Component\HttpKernel\HttpKernel->handle()
  ./public/index.php:56                              Symfony\Component\HttpKernel\Kernel->handle()
```

## Root cause
The method `Notification_NotificationTemplate::getMode($mode)` returns either:

* an **array** with a `label` key for known modes, or
* a **string** (`NOT_AVAILABLE`) for unknown or missing modes.

The rendering logic incorrectly assumes the result is always an array, leading to the fatal error:
**"Cannot access offset of type string on string"** when trying to access `$mode['label']`.

## Fix proposed
This PR improves the code by safely handling the return value of getMode(), ensuring that:

if the returned value is an array and contains a non-empty label, it is displayed;

otherwise, a fallback is shown with NOT_AVAILABLE and the raw mode name for debugging.

## Note
Other usages of `Notification_NotificationTemplate::getMode()` in GLPI already correctly handle its return value by:

explicitly comparing it to `NOT_AVAILABLE`, or checking whether the returned value is an `array` before accessing it.

## Screenshots (if appropriate):


