### PR TITLE
Fix(NetworkPort): do not diplay current item network port link

### DIFF
--- a/src/NetworkPort.php
+++ b/src/NetworkPort.php
@@ -1189,6 +1189,11 @@ class NetworkPort extends CommonDBChild
                                     }
 
                                     $itemtypes = $CFG_GLPI["networkport_types"];
+                                    //Remove the current itemtype from the list to avoid displaying it as a linked asset in the hub
+                                    $itemtypes = array_filter($itemtypes, function($type) use ($device1) {
+                                        return $type !== $device1->getType();
+                                    });
+
                                     $union = new \QueryUnion();
                                     foreach ($itemtypes as $related_class) {
                                         $table = getTableForItemType($related_class);

--- a/src/NetworkPort.php
+++ b/src/NetworkPort.php
@@ -1216,6 +1216,10 @@ class NetworkPort extends CommonDBChild
                                             'WHERE'  => [
                                                 'netp.itemtype'  => $related_class,
                                                 'netp.id'        => $list_ports,
+                                                'NOT'                => [
+                                                    'netp.itemtype'  => $device1->getType(),
+                                                    'netp.items_id'  => $device1->getID(),
+                                                ],
                                             ],
                                         ]);
                                     }
@@ -1229,13 +1233,6 @@ class NetworkPort extends CommonDBChild
                                         ) . '</div>';
                                     } else {
                                         foreach ($hub_equipments as $hrow) {
-                                            if (
-                                                $hrow['itemtype'] === $device1->getType() &&
-                                                $hrow['items_id'] === $device1->getID()
-                                            ) {
-                                                continue; // Skip  asset is the same as the current device
-                                            }
-
                                             $asset = new $hrow['itemtype']();
                                             $asset->getFromDB($hrow['items_id']);
                                             $asset->fields['mac'] = $hrow['mac'];

--- a/src/NetworkPort.php
+++ b/src/NetworkPort.php
@@ -1189,11 +1189,6 @@ class NetworkPort extends CommonDBChild
                                     }
 
                                     $itemtypes = $CFG_GLPI["networkport_types"];
-                                    //Remove the current itemtype from the list to avoid displaying it as a linked asset in the hub
-                                    $itemtypes = array_filter($itemtypes, function($type) use ($device1) {
-                                        return $type !== $device1->getType();
-                                    });
-
                                     $union = new \QueryUnion();
                                     foreach ($itemtypes as $related_class) {
                                         $table = getTableForItemType($related_class);
@@ -1234,6 +1229,13 @@ class NetworkPort extends CommonDBChild
                                         ) . '</div>';
                                     } else {
                                         foreach ($hub_equipments as $hrow) {
+                                            if (
+                                                $hrow['itemtype'] === $device1->getType() &&
+                                                $hrow['items_id'] === $device1->getID()
+                                            ) {
+                                                continue; // Skip  asset is the same as the current device
+                                            }
+
                                             $asset = new $hrow['itemtype']();
                                             $asset->getFromDB($hrow['items_id']);
                                             $asset->fields['mac'] = $hrow['mac'];

--- a/src/NetworkPort.php
+++ b/src/NetworkPort.php
@@ -1217,7 +1217,7 @@ class NetworkPort extends CommonDBChild
                                                 'netp.itemtype'  => $related_class,
                                                 'netp.id'        => $list_ports,
                                                 'NOT'                => [
-                                                    'netp.itemtype'  => $device1->getType(),
+                                                    'netp.itemtype'  => $device1->getType(), // Do not include the current asset
                                                     'netp.items_id'  => $device1->getID(),
                                                 ],
                                             ],


### PR DESCRIPTION

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

* It fixes !37769

Follow-up to the PR  https://github.com/glpi-project/glpi/pull/19829

Prevent displaying the asset linked from the hub corresponding to the current asset.

In this example, I am looking at a network device, **FDB-HR-SW1**, where port **1/1/2** is connected to a hub. Naturally, this hub contains a port linked back to **FDB-HR-SW1**.

![image](https://github.com/user-attachments/assets/c39b200a-ac6c-4035-b688-725d61ff695c)


Displaying this connection is unnecessary and could lead to confusion or misunderstanding.


## Screenshots (if appropriate):


