### PR TITLE
Fix error code returned by the update command

### DIFF
--- a/src/Glpi/Console/Database/UpdateCommand.php
+++ b/src/Glpi/Console/Database/UpdateCommand.php
@@ -224,11 +224,15 @@ class UpdateCommand extends AbstractCommand implements ConfigurationCommandInter
 
         $update->setMigration(new Migration(GLPI_VERSION, $progress_indicator));
         try {
-            $update->doUpdates(
+            $success = $update->doUpdates(
                 current_version: $current_version,
                 force_latest: $force,
                 progress_indicator: $progress_indicator
             );
+            if ($success === false) {
+                $output->writeln('<error>' . __('Upddate failed.') . '</error>', OutputInterface::VERBOSITY_QUIET);
+                return self::ERROR_UPDATE_FAILED;
+            }
         } catch (\Throwable $e) {
             $progress_indicator->fail();
 

--- a/src/Glpi/Controller/InstallController.php
+++ b/src/Glpi/Controller/InstallController.php
@@ -122,10 +122,14 @@ class InstallController extends AbstractController
 
         return new StreamedResponse(function () use ($update, $progress_indicator) {
             try {
-                $update->doUpdates(
+                $success = $update->doUpdates(
                     current_version: $update->getCurrents()['version'],
                     progress_indicator: $progress_indicator
                 );
+
+                if ($success === false) {
+                    $progress_indicator->fail();
+                }
 
                 // Force cache cleaning to ensure it will not contain stale data
                 (new CacheManager())->resetAllCaches();

--- a/src/Update.php
+++ b/src/Update.php
@@ -167,13 +167,13 @@ class Update
      * @param string $current_version  Current version
      * @param bool   $force_latest     Force replay of latest migration
      *
-     * @return void
+     * @return bool
      */
     public function doUpdates(
         $current_version = null,
         bool $force_latest = false,
         ?AbstractProgressIndicator $progress_indicator = null
-    ) {
+    ): bool {
         if ($current_version === null) {
             if ($this->version === null) {
                 throw new \RuntimeException('Cannot process updates without any version specified!');
@@ -187,7 +187,7 @@ class Update
                 sprintf(__('Upgrade from version lower than %s is not supported.'), '0.85.5')
             );
             $progress_indicator?->fail();
-            return;
+            return false;
         }
         if (version_compare($current_version, GLPI_VERSION, '>')) {
             $progress_indicator?->addMessage(
@@ -195,7 +195,7 @@ class Update
                 sprintf(__('Downgrading to version %s is not supported.'), GLPI_VERSION)
             );
             $progress_indicator?->fail();
-            return;
+            return false;
         }
 
         $DB = $this->DB;
@@ -265,7 +265,7 @@ class Update
                 );
                 $progress_indicator?->fail();
                 $this->logger?->error($e->getMessage(), context: ['exception' => $e]);
-                return;
+                return false;
             }
 
             if ($key !== array_key_last($migrations)) {
@@ -410,6 +410,8 @@ class Update
         $progress_indicator?->setProgressBarMessage('');
         $progress_indicator?->addMessage(MessageType::Success, __('Update done.'));
         $progress_indicator?->finish();
+
+        return true;
     }
 
     /**


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

SQL errors are caught by the update process to visually indicates that the operation failed, but the result code of the update command was `0` in this case (only when the `--skip-db-checks` option is used, as in the CI).

Adding a boolean return value to `Update::doUpdate()` permit to adapt the command result code.