### PR TITLE
Store progress indicator into files

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -4580,12 +4580,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Controller/DropdownFormController.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Function ini_set is unsafe to use\\. It can return FALSE instead of throwing an exception\\. Please add \'use function Safe\\\\ini_set;\' at the beginning of the file to use the variant provided by the \'thecodingmachine/safe\' library\\.$#',
-	'identifier' => 'theCodingMachineSafe.function',
-	'count' => 2,
-	'path' => __DIR__ . '/src/Glpi/Controller/InstallController.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Function unlink is unsafe to use\\. It can return FALSE instead of throwing an exception\\. Please add \'use function Safe\\\\unlink;\' at the beginning of the file to use the variant provided by the \'thecodingmachine/safe\' library\\.$#',
 	'identifier' => 'theCodingMachineSafe.function',
 	'count' => 1,
@@ -5994,18 +5988,6 @@ $ignoreErrors[] = [
 	'identifier' => 'theCodingMachineSafe.class',
 	'count' => 3,
 	'path' => __DIR__ . '/src/Glpi/Progress/AbstractProgressIndicator.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Function ini_set is unsafe to use\\. It can return FALSE instead of throwing an exception\\. Please add \'use function Safe\\\\ini_set;\' at the beginning of the file to use the variant provided by the \'thecodingmachine/safe\' library\\.$#',
-	'identifier' => 'theCodingMachineSafe.function',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Progress/ProgressStorage.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Function session_write_close is unsafe to use\\. It can return FALSE instead of throwing an exception\\. Please add \'use function Safe\\\\session_write_close;\' at the beginning of the file to use the variant provided by the \'thecodingmachine/safe\' library\\.$#',
-	'identifier' => 'theCodingMachineSafe.function',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Progress/ProgressStorage.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Call to function is_array\\(\\) with array will always evaluate to true\\.$#',

--- a/install/install.php
+++ b/install/install.php
@@ -345,15 +345,12 @@ function step4($databasename, $newdatabasename)
         echo '</div>';
         echo '</div>';
 
-        echo \sprintf(
-            <<<HTML
-                <script defer type="module">
-                    import { init_database } from '/js/modules/GlpiInstall.js';
-                    init_database("%s");
-                </script>
-HTML,
-            \Glpi\Controller\InstallController::PROGRESS_KEY_INIT_DATABASE,
-        );
+        echo <<<HTML
+            <script defer type="module">
+                import { init_database } from '/js/modules/GlpiInstall.js';
+                init_database();
+            </script>
+        HTML;
     } else { // can't create config_db file
         echo "<p>" . __s('Impossible to write the database setup file') . "</p>";
         $prev_form($host, $user, $password);

--- a/install/update.php
+++ b/install/update.php
@@ -184,15 +184,12 @@ if (($_SESSION['can_process_update'] ?? false) === false) {
             echo '</div>';
             echo '</div>';
 
-            echo \sprintf(
-                <<<HTML
-                    <script defer type="module">
-                        import { update_database } from '/js/modules/GlpiInstall.js';
-                        update_database("%s");
-                    </script>
-HTML,
-                \Glpi\Controller\InstallController::PROGRESS_KEY_UPDATE_DATABASE,
-            );
+            echo <<<HTML
+                <script defer type="module">
+                    import { update_database } from '/js/modules/GlpiInstall.js';
+                    update_database();
+                </script>
+            HTML;
         }
     } else {
         echo "<h3>";

--- a/js/modules/GlpiInstall.js
+++ b/js/modules/GlpiInstall.js
@@ -34,7 +34,7 @@
 
 import { ProgressIndicator } from '/js/modules/ProgressIndicator.js';
 
-export function init_database(progress_key)
+export function init_database()
 {
     const messages_container = document.getElementById('glpi_install_messages_container');
     const success_container = document.getElementById('glpi_install_success');
@@ -54,7 +54,6 @@ export function init_database(progress_key)
     );
 
     const progress_indicator = new ProgressIndicator({
-        key: progress_key,
         container: messages_container,
         request: request,
         success_callback: () => {
@@ -70,7 +69,7 @@ export function init_database(progress_key)
     progress_indicator.start();
 }
 
-export async function update_database(progress_key)
+export async function update_database()
 {
     const messages_container = document.getElementById('glpi_update_messages_container');
     const success_container = document.getElementById('glpi_update_success');
@@ -89,7 +88,6 @@ export async function update_database(progress_key)
     );
 
     const progress_indicator = new ProgressIndicator({
-        key: progress_key,
         container: messages_container,
         request: request,
         success_callback: () => {

--- a/js/modules/ProgressIndicator.js
+++ b/js/modules/ProgressIndicator.js
@@ -84,22 +84,17 @@ export class ProgressIndicator
 
     /**
      * @param parameters
-     * @param {string} parameters.key Mandatory. The progress indicator unique key.
      * @param {HTMLElement} parameters.container Mandatory. The HTML container that will contain the progress indicator.
      * @param {Request} parameters.request Mandatory. The request corresponding to the operation to execute.
      * @param {Function} parameters.success_callback The function that will be called if the operation succeed.
      * @param {Function} parameters.error_callback The function that will be called if the operation fails.
      */
     constructor({
-        key,
         container,
         request,
         success_callback = () => {},
         error_callback = () => {},
     }) {
-        if (!key) {
-            throw new Error('`key` key is mandatory.');
-        }
         if (!(container instanceof HTMLElement)) {
             throw new Error(`\`container\` must be an \`HTMLElement\`, "${container?.constructor?.name || typeof container}" found.`);
         }
@@ -107,7 +102,6 @@ export class ProgressIndicator
             throw new Error(`\`request\` must be a \`Request\`, "${request?.constructor?.name || typeof request}" found.`);
         }
 
-        this.#key = key;
         this.#container = container;
         this.#request = request;
         this.#success_callback = success_callback;
@@ -135,21 +129,16 @@ export class ProgressIndicator
         `;
         this.#container.appendChild(self_dom_el);
 
+        const response = await fetch(this.#request);
+        const encoded_key = (await response.body.getReader().read()).value;
+        this.#key = (new TextDecoder()).decode(encoded_key);
+
         setTimeout(
             () => {
                 this.#check_progress();
             },
             this.#refresh_timeout
         );
-
-        try {
-            await fetch(this.#request);
-        } catch {
-            // DB installation is really long and can result in a `Proxy timeout` error.
-            // It does not mean that the process is killed, it just mean that the proxy did not wait for the response
-            // and send an error to the client.
-            // Here we catch any error to make it silent, but we will handle it with the progress indicator error_callback.
-        }
     }
 
     /**
@@ -186,13 +175,13 @@ export class ProgressIndicator
      */
     async #check_progress() {
         try {
-            const res = await fetch(`${CFG_GLPI.root_doc}/progress/check/${this.#key}`);
+            const response = await fetch(`${CFG_GLPI.root_doc}/progress/check/${this.#key}`);
 
-            if (res.status >= 400) {
-                throw new Error(`Error response from server with code "${res.status.toString()}".`);
+            if (response.status >= 400) {
+                throw new Error(`Error response from server with code "${response.status.toString()}".`);
             }
 
-            const json =  await res.json();
+            const json = await response.json();
 
             this.#update_progress_bar(json['current_step'], json['max_steps'], json['progress_bar_message']);
 

--- a/src/Glpi/Controller/InstallController.php
+++ b/src/Glpi/Controller/InstallController.php
@@ -34,7 +34,6 @@
 
 namespace Glpi\Controller;
 
-use Config;
 use DB;
 use Glpi\Cache\CacheManager;
 use Glpi\Exception\Http\AccessDeniedHttpException;
@@ -53,11 +52,12 @@ use Symfony\Component\Routing\Attribute\Route;
 use Toolbox;
 use Update;
 
+use function Safe\ini_set;
+use function Safe\ob_end_clean;
+use function Safe\session_write_close;
+
 class InstallController extends AbstractController
 {
-    public const PROGRESS_KEY_INIT_DATABASE = 'init_database';
-    public const PROGRESS_KEY_UPDATE_DATABASE = 'update_database';
-
     public function __construct(
         private readonly ProgressStorage $progress_storage,
         private readonly LoggerInterface $logger
@@ -72,18 +72,44 @@ class InstallController extends AbstractController
         }
 
         ini_set('max_execution_time', '300'); // Allow up to 5 minutes to prevent unexpected timeout
+        session_write_close(); // Prevent the session file lock to block the progress check requests
 
-        $progress_indicator = new StoredProgressIndicator($this->progress_storage, self::PROGRESS_KEY_INIT_DATABASE);
+        $progress_indicator = new StoredProgressIndicator($this->progress_storage);
 
-        return new StreamedResponse(function () use ($progress_indicator) {
-            try {
-                Toolbox::createSchema($_SESSION["glpilanguage"], null, $progress_indicator);
-            } catch (\Throwable $e) {
-                $progress_indicator->fail();
-                // Try to remove the config file, to be able to restart the process.
-                @unlink(GLPI_CONFIG_DIR . '/config_db.php');
-            }
-        });
+        // Be sure to remove any unexpected header value.
+        header_remove();
+
+        return new StreamedResponse(
+            function () use ($progress_indicator) {
+                // Be sure to disable the output buffering.
+                // It is necessary to make the `flush()` works as expected.
+                while (ob_get_level() > 0) {
+                    ob_end_clean();
+                }
+
+                echo $progress_indicator->getStorageKey();
+
+                // Send headers and content.
+                // The browser will consider that the response is complete due to the `Connection: close` header
+                // and will not have to wait for operation to finish to consider the request as ended.
+                flush();
+
+                try {
+                    Toolbox::createSchema($_SESSION["glpilanguage"], null, $progress_indicator);
+                } catch (\Throwable $e) {
+                    $progress_indicator->fail();
+                    // Try to remove the config file, to be able to restart the process.
+                    @unlink(GLPI_CONFIG_DIR . '/config_db.php');
+                }
+            },
+            headers: [
+                'Content-Type'   => 'text/html',
+                'Content-Length' => \strlen($progress_indicator->getStorageKey()),
+                'Cache-Control'  => 'no-cache,no-store',
+                'Pragma'         => 'no-cache',
+                'Connection'     => 'close',
+            ]
+        );
     }
 
     #[Route("/Install/UpdateDatabase", methods: 'POST')]
@@ -94,8 +120,6 @@ class InstallController extends AbstractController
             throw new AccessDeniedHttpException();
         }
 
-        ini_set('max_execution_time', '300'); // Allow up to 5 minutes to prevent unexpected timeout
-
         if (!file_exists(GLPI_CONFIG_DIR . '/config_db.php')) {
             throw new \RuntimeException('Missing database configuration file.');
         } else {
@@ -105,34 +129,55 @@ class InstallController extends AbstractController
             }
         }
 
+        ini_set('max_execution_time', '300'); // Allow up to 5 minutes to prevent unexpected timeout
+        session_write_close(); // Prevent the session file lock to block the progress check requests
+
         /** @var \DBmysql $DB */
         global $DB;
         $DB = new DB();
         $DB->disableTableCaching(); // Prevents issues on fieldExists upgrading from old versions
 
-        // Required, at least, by usage of `Plugin::unactivateAll()`
-        // FIXME: We should not have to load the configuration before running the update process.
-        Config::loadLegacyConfiguration();
-
-        $progress_indicator = new StoredProgressIndicator($this->progress_storage, self::PROGRESS_KEY_UPDATE_DATABASE);
+        $progress_indicator = new StoredProgressIndicator($this->progress_storage);
 
         $update = new Update($DB);
         $update->setMigration(new Migration(GLPI_VERSION, $progress_indicator));
         $update->setLogger($this->logger);
 
-        return new StreamedResponse(function () use ($update, $progress_indicator) {
-            try {
-                $update->doUpdates(
-                    current_version: $update->getCurrents()['version'],
-                    progress_indicator: $progress_indicator
-                );
+        return new StreamedResponse(
+            function () use ($update, $progress_indicator) {
+                // Be sure to disable the output buffering.
+                // It is necessary to make the `flush()` works as expected.
+                while (ob_get_level() > 0) {
+                    ob_end_clean();
+                }
 
-                // Force cache cleaning to ensure it will not contain stale data
-                (new CacheManager())->resetAllCaches();
-            } catch (\Throwable $e) {
-                $progress_indicator->fail();
-            }
-        });
+                echo $progress_indicator->getStorageKey();
+
+                // Send headers and content.
+                // The browser will consider that the response is complete due to the `Connection: close` header
+                // and will not have to wait for operation to finish to consider the request as ended.
+                flush();
+
+                try {
+                    $update->doUpdates(
+                        current_version: $update->getCurrents()['version'],
+                        progress_indicator: $progress_indicator
+                    );
+
+                    // Force cache cleaning to ensure it will not contain stale data
+                    (new CacheManager())->resetAllCaches();
+                } catch (\Throwable $e) {
+                    $progress_indicator->fail();
+                }
+            },
+            headers: [
+                'Content-Type'   => 'text/html',
+                'Content-Length' => \strlen($progress_indicator->getStorageKey()),
+                'Cache-Control'  => 'no-cache,no-store',
+                'Pragma'         => 'no-cache',
+                'Connection'     => 'close',
+            ]
+        );
     }
 
     /**

--- a/src/Glpi/Progress/ProgressStorage.php
+++ b/src/Glpi/Progress/ProgressStorage.php
@@ -34,28 +34,71 @@
 
 namespace Glpi\Progress;
 
-use Session;
+use function Safe\fclose;
+use function Safe\fflush;
+use function Safe\flock;
+use function Safe\fopen;
+use function Safe\fread;
+use function Safe\ftruncate;
+use function Safe\fwrite;
+use function Safe\session_id;
 
 /**
  * @final
  */
 class ProgressStorage
 {
+    public function getUniqueStorageKey(): string
+    {
+        $session_id = session_id();
+
+        do {
+            $key = $session_id . \substr(
+                \str_shuffle(
+                    str_repeat('0123456789abcdef', 10)
+                ),
+                0,
+                16
+            );
+        } while (\file_exists($this->getStorageFilePath($key)));
+
+        return $key;
+    }
+
     public function hasProgress(string $key): bool
     {
-        return isset($_SESSION['progress'][$key]) && $_SESSION['progress'][$key] instanceof StoredProgressIndicator;
+        if (!$this->canAccessProgress($key)) {
+            return false;
+        }
+
+        return \file_exists($this->getStorageFilePath($key));
     }
 
     public function getCurrentProgress(string $key): StoredProgressIndicator
     {
-        if (!$this->hasProgress($key)) {
+        if (!$this->canAccessProgress($key) || !$this->hasProgress($key)) {
             throw new \RuntimeException(\sprintf(
                 "Cannot find a progress bar for key \"%s\".",
                 $key,
             ));
         }
 
-        $progress = $_SESSION['progress'][$key];
+        $path = $this->getStorageFilePath($key);
+
+        $handle = fopen($path, 'rb');
+
+        flock($handle, LOCK_EX); // lock the file
+
+        $file_contents = '';
+        while (!\feof($handle)) {
+            $file_contents .= fread($handle, 8192);
+        }
+
+        flock($handle, LOCK_UN); // unlock the file
+
+        fclose($handle);
+
+        $progress = \unserialize($file_contents);
 
         if (!$progress instanceof StoredProgressIndicator) {
             throw new \RuntimeException(\sprintf(
@@ -69,19 +112,38 @@ class ProgressStorage
 
     public function save(StoredProgressIndicator $progress): void
     {
-        // Mandatory here:
-        // If you execute "save($progress)" several times, PHP will send a "Cookie: ..." HTTP header.
-        // Use it thousands of times and you will have thousands of "Cookie: ..." HTTP header lines,
-        // resulting in a "Header too big" or "File too big" HTTP error response.
-        @ini_set('session.use_cookies', 0);
+        $key = $progress->getStorageKey();
 
-        // Restart the session that may have been closed by a previous call to the current method.
-        Session::start();
+        if (!$this->canAccessProgress($key)) {
+            throw new \LogicException();
+        }
 
-        $_SESSION['progress'][$progress->getStorageKey()] = $progress;
+        $path = $this->getStorageFilePath($key);
 
-        // Close the session to release the lock on its storage file.
-        // This is required to not block the execution of concurrent requests.
-        session_write_close();
+        $handle = fopen($path, 'c');
+
+        flock($handle, LOCK_EX); // lock the file
+
+        ftruncate($handle, 0);
+        fwrite($handle, \serialize($progress));
+        fflush($handle);
+
+        flock($handle, LOCK_UN); // unlock the file
+
+        fclose($handle);
+    }
+
+    private function canAccessProgress(string $key): bool
+    {
+        return \str_starts_with($key, session_id());
+    }
+
+    private function getStorageFilePath(string $key): string
+    {
+        return \sprintf(
+            '%s/%s.progress',
+            GLPI_TMP_DIR,
+            $key
+        );
     }
 }

--- a/src/Glpi/Progress/StoredProgressIndicator.php
+++ b/src/Glpi/Progress/StoredProgressIndicator.php
@@ -58,12 +58,12 @@ class StoredProgressIndicator extends AbstractProgressIndicator
      */
     private array $messages = [];
 
-    public function __construct(ProgressStorage $progress_storage, string $storage_key)
+    public function __construct(ProgressStorage $progress_storage)
     {
         parent::__construct();
 
         $this->progress_storage = $progress_storage;
-        $this->storage_key      = $storage_key;
+        $this->storage_key      = $progress_storage->getUniqueStorageKey();
 
         $this->store();
     }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.

## Description

Storing the progress indicator into the session was blocking the ability to delegate to the progress storage the responsability of generating a unique key. Indeed, it was not possible to send before the end of the operation using a `flush()` operation because we had to play with session open/close state to store the progress and it cannot be done after a `flush()`.

Delegating the key generation to the progress storage will permit to be sure that it is impossible to use conflicting keys due to a copied/pasted piece of code or due to the usage of a static key for operations that can be executed in parallel (e.g. massive actions from multiple users).