### PR TITLE
lighten requirements badges

### DIFF
--- a/templates/install/blocks/requirements_table.html.twig
+++ b/templates/install/blocks/requirements_table.html.twig
@@ -44,9 +44,9 @@
             <tr class="tab_bg_1">
                <td class="text-start">
                   {% if not requirement.isOptional() %}
-                     <span class="badge bg-warning text-warning-fg">{{ __('Required') }}</span>
+                     <span class="badge bg-warning-lt">{{ __('Required') }}</span>
                   {% elseif requirement.isRecommendedForSecurity() %}
-                     <span class="badge bg-danger text-danger-fg">{{ __('Security') }}</span>
+                     <span class="badge bg-danger-lt">{{ __('Security') }}</span>
                   {% else %}
                      <span class="badge bg-secondary text-secondary-fg">{{ __('Suggested') }}</span>
                   {% endif %}


### PR DESCRIPTION
## Description

A quick fix to lighten the badge on the requirements page. The idea is to avoid thinking there is an error when not.
Especially regarding security lines.

## Screenshots (if appropriate):

**Now:**
![image](https://github.com/user-attachments/assets/4580793f-ae20-498b-b9a5-a00eef2f0db8)

**Before:**
![image](https://github.com/user-attachments/assets/160bed3c-bade-45d8-82c8-b49bb0361e26)
