### PR TITLE
Fix(Inventory): prevent raw data when handle locked field on add

### DIFF
--- a/src/Inventory/Asset/InventoryAsset.php
+++ b/src/Inventory/Asset/InventoryAsset.php
@@ -471,7 +471,12 @@ abstract class InventoryAsset
                     $input[$key] = $this->known_links[$known_key];
                     $input['_raw' . $key] = $this->raw_links[$known_key];
                 } else {
-                    $input[$key] = $this->raw_links[$known_key];
+                    // If $item is new and the input key is locked, we do not want to set it using the raw value.
+                    // This is because locked fields are no longer processed or sanitized during the addition process.
+                    // For more details, see: https://github.com/glpi-project/glpi/pull/19426
+                    if (!$item->isNewItem()) {
+                        $input[$key] = $this->raw_links[$known_key];
+                    }
                 }
             } elseif (isset($this->known_links[$known_key])) {
                 $input[$key] = $this->known_links[$known_key];

--- a/src/Inventory/Asset/InventoryAsset.php
+++ b/src/Inventory/Asset/InventoryAsset.php
@@ -474,7 +474,18 @@ abstract class InventoryAsset
                     // If $item is new and the input key is locked, we do not want to set it using the raw value.
                     // This is because locked fields are no longer processed or sanitized during the addition process.
                     // For more details, see: https://github.com/glpi-project/glpi/pull/19426
-                    if (!$item->isNewItem()) {
+                    // Bypass for :
+                    // - states_id if default value is define from inventory conf
+                    // - entities_id default inventory conf is 0 'root entity'
+                    $config = \Config::getConfigurationValues('inventory');
+
+                    if (
+                        !$item->isNewItem()
+                        || (
+                            ($key === 'states_id' && !empty($config['states_id_default']))
+                            || $key === 'entities_id'
+                        )
+                    ) {
                         $input[$key] = $this->raw_links[$known_key];
                     }
                 }

--- a/src/Inventory/Asset/InventoryAsset.php
+++ b/src/Inventory/Asset/InventoryAsset.php
@@ -474,18 +474,7 @@ abstract class InventoryAsset
                     // If $item is new and the input key is locked, we do not want to set it using the raw value.
                     // This is because locked fields are no longer processed or sanitized during the addition process.
                     // For more details, see: https://github.com/glpi-project/glpi/pull/19426
-                    // Bypass for :
-                    // - states_id if default value is define from inventory conf
-                    // - entities_id default inventory conf is 0 'root entity'
-                    $config = \Config::getConfigurationValues('inventory');
-
-                    if (
-                        !$item->isNewItem()
-                        || (
-                            ($key === 'states_id' && !empty($config['states_id_default']))
-                            || $key === 'entities_id'
-                        )
-                    ) {
+                    if (!$item->isNewItem()) {
                         $input[$key] = $this->raw_links[$known_key];
                     }
                 }

--- a/src/Inventory/Asset/MainAsset.php
+++ b/src/Inventory/Asset/MainAsset.php
@@ -675,6 +675,12 @@ abstract class MainAsset extends InventoryAsset
             $val->states_id = $default_states_id > 0 ? $default_states_id : 0;
         }
 
+        // set states_id in known links if needed
+        if (property_exists($val, 'states_id')) {
+            $state_key = md5('states_id' . $val->states_id);
+            $this->known_links[$state_key] = $val->states_id;
+        }
+
         // append data from RuleImportEntity
         foreach ($this->ruleentity_data as $attribute => $value) {
             $known_key = md5($attribute . $value);
@@ -700,6 +706,10 @@ abstract class MainAsset extends InventoryAsset
         if ($items_id != 0) {
             $this->item->getFromDB($items_id);
         }
+
+        // set entities_id in known links
+        $entities_key = md5('entities_id' . $val->entities_id);
+        $this->known_links[$entities_key] = $val->entities_id;
 
         //handleLinks relies on $this->data; update it before the call
         $this->handleLinks();
@@ -753,6 +763,11 @@ abstract class MainAsset extends InventoryAsset
             $entities_id = $this->item->fields['entities_id'];
         }
         $val->entities_id = $entities_id;
+
+
+        // set entities_id in known links
+        $entities_key = md5('entities_id' . $val->entities_id);
+        $this->known_links[$entities_key] = $val->entities_id;
 
         //handle domains
         if (property_exists($val, 'domains_id')) {

--- a/src/Inventory/Asset/MainAsset.php
+++ b/src/Inventory/Asset/MainAsset.php
@@ -677,8 +677,9 @@ abstract class MainAsset extends InventoryAsset
 
         // set states_id in known links if needed
         if (property_exists($val, 'states_id')) {
-            $state_key = md5('states_id' . $val->states_id);
-            $this->known_links[$state_key] = $val->states_id;
+            $known_key = md5('states_id' . $val->states_id);
+            $this->known_links[$known_key] = $val->states_id;
+            $this->raw_links[$known_key] = $val->states_id;
         }
 
         // append data from RuleImportEntity
@@ -754,20 +755,13 @@ abstract class MainAsset extends InventoryAsset
         } else {
             $val->states_id =  $this->item->fields['states_id'];
         }
-        $known_key = md5('states_id' . $val->states_id);
-        $this->known_links[$known_key] = $val->states_id;
-        $this->raw_links[$known_key] = $val->states_id;
+
         $val->id = $this->item->fields['id'];
 
         if ($entities_id == -1) {
             $entities_id = $this->item->fields['entities_id'];
         }
         $val->entities_id = $entities_id;
-
-
-        // set entities_id in known links
-        $entities_key = md5('entities_id' . $val->entities_id);
-        $this->known_links[$entities_key] = $val->entities_id;
 
         //handle domains
         if (property_exists($val, 'domains_id')) {


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !37931

Since the merge of [[PR #19426](https://github.com/glpi-project/glpi/pull/19426)](https://github.com/glpi-project/glpi/pull/19426), if a global locked field is created for dropdown fields an error is thrown by the GLPI Inventory module during asset import:



```shell
SQL: INSERT INTO `glpi_networkequipments` (`autoupdatesystems_id`, `last_inventory_update`, `is_deleted`, `name`, `ram`, `serial`, `uptime`, `sysdescr`, `networkequipmentmodels_id`, `networkequipmenttypes_id`, `manufacturers_id`, `is_dynamic`, `entities_id`, `states_id`, `date_creation`, `date_mod`) VALUES ('1', '2025-06-02 07:23:03', '0', 'FDB-HR-SW1', '3420', 'xxxxxxxx', '48 days, 22:50:03.23', 'Aruba JL677A 6100 24G CL4 4SFP+ Swch PL.10.13.1040', '2', 'Networking', '155', '1', '0', '0', '2025-06-02 07:23:03', '2025-06-02 07:23:03')
  Error: Incorrect integer value: 'Networking' for column `10bugfixes`.`glpi_networkequipments`.`networkequipmenttypes_id` at row 1
  Backtrace :
  src/DBmysql.php:1376                               DBmysql->doQuery()
  src/CommonDBTM.php:726                             DBmysql->insert()
  src/CommonDBTM.php:1345                            CommonDBTM->addToDB()
  src/Inventory/Asset/MainAsset.php:711              CommonDBTM->add()
  src/Inventory/Asset/NetworkEquipment.php:231       Glpi\Inventory\Asset\MainAsset->rulepassed()
  src/RuleImportAsset.php:1004                       Glpi\Inventory\Asset\NetworkEquipment->rulepassed()
  src/Rule.php:1537                                  RuleImportAsset->executeActions()
  src/RuleCollection.php:1658                        Rule->process()
  src/Inventory/Asset/MainAsset.php:581              RuleCollection->processAllRules()
  src/Inventory/Inventory.php:727                    Glpi\Inventory\Asset\MainAsset->handle()
  src/Inventory/Inventory.php:358                    Glpi\Inventory\Inventory->handleItem()
  src/Inventory/Request.php:381                      Glpi\Inventory\Inventory->doInventory()
  src/Inventory/Request.php:285                      Glpi\Inventory\Request->inventory()
  src/Inventory/Request.php:252                      Glpi\Inventory\Request->network()
  src/Inventory/Request.php:98                       Glpi\Inventory\Request->networkInventory()
  src/Agent/Communication/AbstractRequest.php:332    Glpi\Inventory\Request->handleAction()
  src/Agent/Communication/AbstractRequest.php:269    Glpi\Agent\Communication\AbstractRequest->handleXMLRequest()
  src/Inventory/Conf.php:249                         Glpi\Agent\Communication\AbstractRequest->handleRequest()
  src/Inventory/Conf.php:194                         Glpi\Inventory\Conf->importContentFile()
  src/Inventory/Conf.php:298                         Glpi\Inventory\Conf->importFiles()
  front/inventory.conf.php:47                        Glpi\Inventory\Conf->displayImportFiles()
  public/index.php:82                                require()
```


The issue comes from the way `$input` is filled during the inventory process. If a dropdown field is locked and there's no matching value in `$this->known_links`, the raw string value (e.g., `'Networking'`) is assigned directly to the `$input`.

Previously, such cases were sanitized through the `cleanLockedsOnAdd()` method. However, this method was removed during the creation phase as part of [[PR #19426](https://github.com/glpi-project/glpi/pull/19426)](https://github.com/glpi-project/glpi/pull/19426).

As a result, without proper cleaning, an invalid string value can be inserted into a field expecting an integer, which triggers a SQL error.


## Screenshots (if appropriate):


