### PR TITLE
fix border radius of select2 dropdowns inside search panel

### DIFF
--- a/css/includes/components/_select2.scss
+++ b/css/includes/components/_select2.scss
@@ -226,7 +226,7 @@
         }
     }
 
-    .btn-group & {
+    .btn-group > & {
         flex-grow: 1;
         flex-basis: content;
 


### PR DESCRIPTION
## Description

I saw the thing while working on #19635 where it's much more prominent.
The bug has been present for years, but as we moved the search form inside a .btn-group in 11, it's more on the front.

## Screenshots (if appropriate):

**After:**
![image](https://github.com/user-attachments/assets/c15d2126-7f80-4e8e-907d-8dc6b7c7e8be)

**Before:**
![image](https://github.com/user-attachments/assets/3a39f997-4336-4bbb-a03b-99e489fcf8b7)
