### PR TITLE
Fix (RecurrentTicket) - Update next_creation_date from an update via massive action

### DIFF
--- a/phpunit/abstracts/CommonITILRecurrentTest.php
+++ b/phpunit/abstracts/CommonITILRecurrentTest.php
@@ -664,4 +664,76 @@ abstract class CommonITILRecurrentTest extends DbTestCase
             }
         }
     }
+
+    public function testPrepareInputForUpdateWithPartialData()
+    {
+        $this->login();
+
+        $child_class = $this->getChildClass();
+        $template_class = $child_class::getTemplateClass();
+
+        // Create a template
+        $template = $this->createItem($template_class, ['name' => 'Test template']);
+
+        // Create a recurrent ticket with all required fields
+        $recurrent = $this->createItem(
+            \TicketRecurrent::class,
+            [
+                'name' => 'Test recurrent ticket',
+                'tickettemplates_id' => $template->getID(),
+                'begin_date' => date('Y-m-d H:i:s', strtotime('-7 days')),
+                'end_date' => date('Y-m-d H:i:s', strtotime('+1 month')),
+                'periodicity' => HOUR_TIMESTAMP,
+                'create_before' => 0,
+                'calendars_id' => 0,
+                'is_active' => 1,
+            ]
+        );
+
+        // Store the original next_creation_date
+        $original_date = $recurrent->fields['next_creation_date'];
+
+        // Update with partial data (only name)
+        $update_result = $recurrent->update([
+            'id' => $recurrent->getID(),
+            'name' => 'Updated name',
+        ]);
+
+        // Check that the update was successful
+        $this->assertTrue($update_result);
+
+        // Reload the recurrent ticket to get fresh data
+        $recurrent->getFromDB($recurrent->getID());
+
+        // Check that next_creation_date was computed correctly despite missing fields in the input
+        $this->assertEquals($original_date, $recurrent->fields['next_creation_date']);
+
+        // Now update with a new begin_date to see if next_creation_date changes
+        $new_begin_date = date('Y-m-d H:i:s', strtotime('+1 day'));
+        $update_result = $recurrent->update([
+            'id' => $recurrent->getID(),
+            'begin_date' => $new_begin_date,
+        ]);
+
+        // Check that the update was successful
+        $this->assertTrue($update_result);
+
+        // Reload the recurrent ticket
+        $recurrent->getFromDB($recurrent->getID());
+
+        // Verify that next_creation_date was recomputed
+        $this->assertNotEquals($original_date, $recurrent->fields['next_creation_date']);
+
+        // Compute the expected next_creation_date for comparison
+        $expected_date = $recurrent->computeNextCreationDate(
+            $new_begin_date,
+            $recurrent->fields['end_date'],
+            $recurrent->fields['periodicity'],
+            $recurrent->fields['create_before'],
+            $recurrent->fields['calendars_id']
+        );
+
+        // Verify it matches what was saved in the database
+        $this->assertEquals($expected_date, $recurrent->fields['next_creation_date']);
+    }
 }

--- a/src/CommonITILRecurrent.php
+++ b/src/CommonITILRecurrent.php
@@ -144,19 +144,27 @@ abstract class CommonITILRecurrent extends CommonDropdown
 
     public function prepareInputForUpdate($input)
     {
-        if (
-            isset($input['begin_date'])
-            && isset($input['periodicity'])
-            && isset($input['create_before'])
-        ) {
-            $input['next_creation_date'] = $this->computeNextCreationDate(
-                $input['begin_date'],
-                $input['end_date'],
-                $input['periodicity'],
-                $input['create_before'],
-                $input['calendars_id']
-            );
+        $fields_to_check = [
+            'begin_date',
+            'end_date',
+            'periodicity',
+            'create_before',
+            'calendars_id'
+        ];
+
+        foreach ($fields_to_check as $field) {
+            if (!isset($input[$field])) {
+                $input[$field] = $this->fields[$field];
+            }
         }
+
+        $input['next_creation_date'] = $this->computeNextCreationDate(
+            $input['begin_date'],
+            $input['end_date'],
+            $input['periodicity'],
+            $input['create_before'],
+            $input['calendars_id']
+        );
 
         return $input;
     }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !37657
- Here is a brief description of what this PR does

### Issue
When using massive actions to update recurrent tickets, the `next_creation_date` field was not properly recalculated because the input array was missing required fields that weren't explicitly included in the massive action.

### Solution
Modified the `prepareInputForUpdate` method in `CommonITILRecurrent` class to use an array of required fields and check each one, adding missing values from the current object when needed. This ensures that `next_creation_date` is properly calculated even when only partial data is provided through massive actions.