### PR TITLE
Fix the console execution as a super user

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -34,25 +34,12 @@
  */
 
 // Try detecting if we are running with the root user (Not available on Windows)
-if (function_exists('posix_geteuid') && posix_geteuid() === 0) {
+if (!in_array('--allow-superuser', $_SERVER['argv'], true) && function_exists('posix_geteuid') && posix_geteuid() === 0) {
     // Translation functions not available here
     echo "\t" . 'WARNING: running as root is discouraged.' . "\n";
     echo "\t" . 'You should run the script as the same user that your web server runs as to avoid file permissions being ruined.' . "\n";
-
-    if (!in_array('--allow-superuser', $_SERVER['argv'], true)) {
-        if (in_array('-n', $_SERVER['argv'], true) || in_array('--no-interaction', $_SERVER['argv'], true)) {
-            echo "\t" . 'Use --allow-superuser option to bypass this limitation.' . "\n";
-            exit(1);
-        } else {
-            echo "\t" . 'Do you want to continue anyway? [yes/No]' . ' ';
-            $handle = fopen('php://stdin', 'rb');
-            $line = fgets($handle);
-            fclose($handle);
-            if (trim($line) !== 'yes' && trim($line) !== 'y') {
-                exit(1);
-            }
-        }
-    }
+    echo "\t" . 'Use --allow-superuser option to bypass this limitation.' . "\n";
+    exit(1);
 }
 
 // Extract command line arguments

--- a/composer-dependency-analyser.php
+++ b/composer-dependency-analyser.php
@@ -55,7 +55,7 @@ return $config
         'src/UploadHandler.php',
     ], [ErrorType::SHADOW_DEPENDENCY])
     ->ignoreErrorsOnExtensionAndPaths('ext-pcntl', ['src/CronTask.php'], [ErrorType::SHADOW_DEPENDENCY])
-    ->ignoreErrorsOnExtensionAndPaths('ext-posix', ['front/cron.php'], [ErrorType::SHADOW_DEPENDENCY])
+    ->ignoreErrorsOnExtensionAndPaths('ext-posix', ['front/cron.php', 'src/Glpi/Console/Application.php'], [ErrorType::SHADOW_DEPENDENCY])
     ->ignoreErrorsOnExtension('ext-ldap', [ErrorType::SHADOW_DEPENDENCY])
     ->ignoreErrorsOnExtension('ext-sodium', [ErrorType::SHADOW_DEPENDENCY])
     ->ignoreErrorsOnExtension('ext-zend-opcache', [ErrorType::SHADOW_DEPENDENCY])


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

It fixes !37968.

The console execution as root user, using the `--allow-superuser` option, does not work.

Two isses are fixed by this PR:

1. It dynamically adds the `--allow-superuser` option to the console definition when the current user is root. It prevents the `The --allow-superuser option does not exist` error to block the console execution when it is actually executed with this option.

2. The previous implemntation was showing a `Session cannot be started after headers have already been sent` warning when the execution was allowed, because the `WARNING: running as root is discouraged.` was displayed before the session initialization.
I changed a bit the logic to display the warning messages at different times wether the `--allow-superuser` option is used.


## Screenshots

When the execution is blocked:
![image](https://github.com/user-attachments/assets/3295317b-97ab-4bbe-a914-0ca095e9dac1)

When the execution is allowed:
![image](https://github.com/user-attachments/assets/45f4ebc9-f30a-485f-a038-eb2fb02fe4b2)
