### PR TITLE
entities_id is added to 'changed' fields on CommonITILObject update.

### DIFF
--- a/phpunit/functional/RuleTest.php
+++ b/phpunit/functional/RuleTest.php
@@ -35,7 +35,6 @@
 namespace tests\units;
 
 use DbTestCase;
-use Glpi\PHPUnit\Tests\Glpi\ITILTrait;
 use PHPUnit\Framework\Attributes\DataProvider;
 use ReflectionClass;
 
@@ -43,8 +42,6 @@ use ReflectionClass;
 
 class RuleTest extends DbTestCase
 {
-    use ITILTrait;
-
     public function testGetTable()
     {
         $table = \Rule::getTable('RuleDictionnarySoftware');
@@ -1016,35 +1013,6 @@ class RuleTest extends DbTestCase
 
         $this->assertTrue($rules->getFromDBByCrit(['uuid' => 'glpi_rule_import_asset_no_creation_on_partial_import']));
         $this->assertNotSame($rules->fields['name'], 'Changed for tests');
-    }
-
-    /**
-     * - create a ticket
-     * - create an update ticket rule with a criteria on the entity
-     * - check it's applied on the ticket
-     */
-    public function testEntityIsInChangedFieldsOnUpdate(): void
-    {
-        $this->login();
-        $user_entity = \Session::getActiveEntity();
-        $new_priority = 4;
-
-        // arrange
-        $ticket = $this->createTicket();
-        assert($ticket->fields['priority'] !== $new_priority);
-
-        $builder = new \RuleBuilder('Change priority on update', \RuleTicket::class);
-        $builder->addCriteria('entities_id', \Rule::PATTERN_IS, $user_entity);
-        $builder->addAction('assign', 'priority', $new_priority);
-        $this->createRule($builder);
-
-        // act
-        $ticket = $this->updateItem($ticket::class, $ticket->getID(), ['name' => 'Updated ticket']);
-
-        // assert
-        $this->assertEquals($new_priority, $ticket->fields['priority']);
-
-        // @todo maybe write another test with non matching criteria
     }
 }
 

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -11196,9 +11196,6 @@ abstract class CommonITILObject extends CommonDBTM
         if ($condition === RuleCommonITILObject::ONUPDATE) {
             $rules_params['entities_id'] = $entid;
             $changes = [];
-            if (isset($input['entities_id'])) {
-                $changes[] = 'entities_id';
-            }
             foreach ($rule->getCriterias() as $key => $val) {
                 if (array_key_exists($key, $input)) {
                     if (

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -10645,6 +10645,10 @@ abstract class CommonITILObject extends CommonDBTM
         if (!$this->isNewItem() && !isset($input['priority'])) {
             $input['priority'] = $this->fields['priority'];
         }
+
+        if (!$this->isNewItem() && !isset($input['entities_id'])) {
+            $input['entities_id'] = $this->fields['entities_id'];
+        }
     }
 
     public static function cronInfo($name)
@@ -11192,6 +11196,9 @@ abstract class CommonITILObject extends CommonDBTM
         if ($condition === RuleCommonITILObject::ONUPDATE) {
             $rules_params['entities_id'] = $entid;
             $changes = [];
+            if (isset($input['entities_id'])) {
+                $changes[] = 'entities_id';
+            }
             foreach ($rule->getCriterias() as $key => $val) {
                 if (array_key_exists($key, $input)) {
                     if (


### PR DESCRIPTION
This is needed for rule criteria to match an entity on update.

<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

entities_id is added to 'changed' fields on CommonITILObject update.

This is needed for rule criteria to match an entity on update.

