### PR TITLE
Change the return of `getItemTypeForTable()` from `UNKNOWN` to `null`

### DIFF
--- a/phpunit/functional/DBTest.php
+++ b/phpunit/functional/DBTest.php
@@ -380,7 +380,7 @@ class DBTest extends \GLPITestCase
                 continue;
             }
             $type = $dbu->getItemTypeForTable($table);
-            $this->assertNotEquals('UNKNOWN', $type, 'Cannot find type for table ' . $table);
+            $this->assertNotNull($type, 'Cannot find type for table ' . $table);
             $item = $dbu->getItemForItemtype($type);
             $this->assertInstanceOf(\CommonDBTM::class, $item, get_class($item));
             $this->assertEquals($type, get_class($item));

--- a/phpunit/functional/DbUtilsTest.php
+++ b/phpunit/functional/DbUtilsTest.php
@@ -230,14 +230,14 @@ class DbUtilsTest extends DbTestCase
         if ($is_valid_type) {
             $this->assertSame($type, $instance->getItemTypeForTable($table));
         } else {
-            $this->assertSame('UNKNOWN', $instance->getItemTypeForTable($table));
+            $this->assertNull($instance->getItemTypeForTable($table));
         }
 
         //keep testing old method from db.function
         if ($is_valid_type) {
             $this->assertSame($type, getItemTypeForTable($table));
         } else {
-            $this->assertSame('UNKNOWN', getItemTypeForTable($table));
+            $this->assertNull(getItemTypeForTable($table));
         }
     }
 

--- a/phpunit/functional/Glpi/Dashboard/DashboardTest.php
+++ b/phpunit/functional/Glpi/Dashboard/DashboardTest.php
@@ -108,9 +108,7 @@ class DashboardTest extends DbTestCase
                     ],
                 ],
                 [
-                    [
-                        'entities_id' => 0,
-                    ],
+                    'entities_id' => [0],
                 ]
             )
         );
@@ -272,9 +270,7 @@ class DashboardTest extends DbTestCase
                     ],
                 ],
                 'rights'  => [
-                    [
-                        'entities_id' => 0,
-                    ],
+                    'entities_id' => [0],
                 ],
             ],
         ];

--- a/src/DbUtils.php
+++ b/src/DbUtils.php
@@ -262,7 +262,8 @@ final class DbUtils
      *
      * @param string $table table name
      *
-     * @return string itemtype corresponding to a table name parameter
+     * @return class-string<CommonDBTM>|null itemtype corresponding to a table name parameter,
+     *      or null if no valid itemtype is attached to the table
      */
     public function getItemTypeForTable($table)
     {
@@ -354,7 +355,7 @@ final class DbUtils
                 return $itemtype;
             }
 
-            return "UNKNOWN";
+            return null;
         }
     }
 
@@ -495,7 +496,7 @@ final class DbUtils
      *
      * @param string $itemtype itemtype
      *
-     * @return string|null
+     * @return class-string<CommonGLPI>|null
      */
     public function getClassForItemtype(string $itemtype): ?string
     {
@@ -2286,7 +2287,8 @@ final class DbUtils
      *
      * @param string $fkname Foreign key
      *
-     * @return class-string<CommonDBTM> Itemtype class for the fkname parameter
+     * @return class-string<CommonDBTM>|null Itemtype class for the fkname parameter,
+     *      or null if no valid itemtype is attached to the foreign key field
      */
     public function getItemtypeForForeignKeyField($fkname)
     {

--- a/src/Glpi/Api/API.php
+++ b/src/Glpi/Api/API.php
@@ -1752,7 +1752,7 @@ abstract class API
                 $col_ref_itemtype = $col_ref_table !== '' && $col_ref_field !== ''
                     ? \getItemTypeForTable($col['searchopt']['table'] ?? '')
                     : null;
-                if ($col_ref_itemtype !== null && \is_a($col_ref_itemtype, CommonDBTM::class, true)) {
+                if ($col_ref_itemtype !== null) {
                     $tmp_fields = [$col_ref_field => $current_values];
                     if (array_key_exists('additionalfields', $col['searchopt'])) {
                         foreach ($col['searchopt']['additionalfields'] as $field_name) {

--- a/src/Glpi/Console/Migration/BuildMissingTimestampsCommand.php
+++ b/src/Glpi/Console/Migration/BuildMissingTimestampsCommand.php
@@ -78,8 +78,8 @@ class BuildMissingTimestampsCommand extends AbstractCommand
             $itemtype = getItemTypeForTable($table);
             $column   = $table_info['COLUMN_NAME'];
 
-            if (!is_a($itemtype, CommonDBTM::class, true)) {
-                continue; // getItemTypeForTable() may not return a class name ("UNKNOWN" for example)
+            if ($itemtype === null) {
+                continue;
             }
             /* @var CommonDBTM $item */
             $item = new $itemtype();

--- a/src/Glpi/Dashboard/Filters/GroupRequesterFilter.php
+++ b/src/Glpi/Dashboard/Filters/GroupRequesterFilter.php
@@ -80,8 +80,12 @@ class GroupRequesterFilter extends AbstractFilter
                     "$table.groups_id" => $groups_id,
                 ];
             } elseif (in_array($table, [Ticket::getTable(), Change::getTable(), Problem::getTable()])) {
-                $itemtype  = getItemTypeForTable($table);
-                $main_item = getItemForItemtype($itemtype);
+                $main_item = match ($table) {
+                    Ticket::getTable() => new Ticket(),
+                    Change::getTable() => new Change(),
+                    Problem::getTable() => new Problem(),
+                    default => throw new \UnexpectedValueException(),
+                };
                 $grouplink = $main_item->grouplinkclass;
                 $gl_table  = $grouplink::getTable();
                 $fk        = $main_item->getForeignKeyField();

--- a/src/Glpi/Dashboard/Filters/GroupTechFilter.php
+++ b/src/Glpi/Dashboard/Filters/GroupTechFilter.php
@@ -81,8 +81,12 @@ class GroupTechFilter extends AbstractFilter
                     "$table.groups_id_tech" => $groups_id,
                 ];
             } elseif (in_array($table, [Ticket::getTable(), Change::getTable(), Problem::getTable()])) {
-                $itemtype  = getItemTypeForTable($table);
-                $main_item = getItemForItemtype($itemtype);
+                $main_item = match ($table) {
+                    Ticket::getTable() => new Ticket(),
+                    Change::getTable() => new Change(),
+                    Problem::getTable() => new Problem(),
+                    default => throw new \UnexpectedValueException(),
+                };
                 $grouplink = $main_item->grouplinkclass;
                 $gl_table  = $grouplink::getTable();
                 $fk        = $main_item->getForeignKeyField();

--- a/src/Glpi/Dashboard/Filters/UserTechFilter.php
+++ b/src/Glpi/Dashboard/Filters/UserTechFilter.php
@@ -82,8 +82,12 @@ class UserTechFilter extends AbstractFilter
                     "$table.users_id_tech" => $users_id,
                 ];
             } elseif (in_array($table, [Ticket::getTable(), Change::getTable(), Problem::getTable()])) {
-                $itemtype  = getItemTypeForTable($table);
-                $main_item = getItemForItemtype($itemtype);
+                $main_item = match ($table) {
+                    Ticket::getTable() => new Ticket(),
+                    Change::getTable() => new Change(),
+                    Problem::getTable() => new Problem(),
+                    default => throw new \UnexpectedValueException(),
+                };
                 $userlink  = $main_item->userlinkclass;
                 $ul_table  = $userlink::getTable();
                 $fk        = $main_item->getForeignKeyField();

--- a/src/Glpi/Migration/GenericobjectPluginMigration.php
+++ b/src/Glpi/Migration/GenericobjectPluginMigration.php
@@ -1239,7 +1239,7 @@ class GenericobjectPluginMigration extends AbstractPluginMigration
                 $target_type = $this->getTargetItemtype($source_type);
             } else {
                 $target_type = \getItemtypeForForeignKeyField($field_name);
-                if ($target_type === 'UNKNOWN') {
+                if ($target_type === null) {
                     throw new MigrationException(
                         sprintf(__('Unable to import the "%s" field.'), $field_name),
                         sprintf('Unable to import the `%s` field.', $field_name)

--- a/src/Glpi/Search/SearchOption.php
+++ b/src/Glpi/Search/SearchOption.php
@@ -572,7 +572,7 @@ final class SearchOption implements \ArrayAccess
 
                     // Specific case of TreeDropdown : add under
                     $itemtype_linked = $searchopt[$field_num]['itemtype'] ?? getItemTypeForTable($searchopt[$field_num]['table']);
-                    if ($itemlinked = getItemForItemtype($itemtype_linked)) {
+                    if ($itemtype_linked !== null && $itemlinked = getItemForItemtype($itemtype_linked)) {
                         if ($itemlinked instanceof \CommonTreeDropdown) {
                             $actions['under']    = __('under');
                             $actions['notunder'] = __('not under');

--- a/src/Lock.php
+++ b/src/Lock.php
@@ -221,7 +221,7 @@ TWIG;
                 } elseif (isForeignKeyField($row['field'])) {
                     // on fkey, we can try to retrieve the object
                     $object = getItemtypeForForeignKeyField($row['field']);
-                    if ($object !== 'UNKNOWN') {
+                    if ($object !== null) {
                         $field_label = $object::getTypeName(1);
                     }
                 }

--- a/src/Lockedfield.php
+++ b/src/Lockedfield.php
@@ -479,7 +479,7 @@ class Lockedfield extends CommonDBTM
                     if ($field_name === $field) {
                         //name not found :(
                         $table = getTableNameForForeignKeyField($field);
-                        if ($table !== '' && $table !== 'UNKNOWN') {
+                        if ($table !== '') {
                             $type = getItemTypeForTable($table);
                             $field_name = $type::getTypeName(1);
                         }

--- a/src/Migration.php
+++ b/src/Migration.php
@@ -691,7 +691,7 @@ class Migration
             // Clear possibly forced value of table name.
             // Actually the only forced value in core is for config table.
             $itemtype = getItemTypeForTable($newtable);
-            if (class_exists($itemtype)) {
+            if ($itemtype !== null && class_exists($itemtype)) {
                 $itemtype::forceTable($newtable);
             }
 

--- a/src/autoload/dbutils-aliases.php
+++ b/src/autoload/dbutils-aliases.php
@@ -95,7 +95,8 @@ function getTableNameForForeignKeyField($fkname)
  *
  * @param $table string table name
  *
- * @return string itemtype corresponding to a table name parameter
+ * @return class-string<CommonDBTM>|null itemtype corresponding to a table name parameter,
+ *      or null if no valid itemtype is attached to the table
  **/
 function getItemTypeForTable($table)
 {
@@ -108,7 +109,8 @@ function getItemTypeForTable($table)
  *
  * @param string $fkname
  *
- * @return class-string<CommonDBTM> Itemtype class for the fkname parameter
+ * @return class-string<CommonDBTM>|null Itemtype class for the fkname parameter,
+ *      or null if no valid itemtype is attached to the foreign key field
  */
 function getItemtypeForForeignKeyField($fkname)
 {

--- a/tests/src/autoload/functions.php
+++ b/tests/src/autoload/functions.php
@@ -770,7 +770,7 @@ function loadDataset()
                         $input[$k] = $ids[$foreigntype][$v];
                     } elseif ($k == 'items_id'  &&  isset($input['itemtype']) && isset($ids[$input['itemtype']][$v]) && !is_numeric($v)) {
                         $input[$k] = $ids[$input['itemtype']][$v];
-                    } elseif ($foreigntype && $foreigntype != 'UNKNOWN' && !is_numeric($v)) {
+                    } elseif ($foreigntype && !is_numeric($v)) {
                         // not found in ids array, then must get it from DB
                         $foreign_id = getItemByTypeName($foreigntype, $v, true);
                         $input[$k] = $foreign_id;


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Returning an `UNKNOWN` value when there is no valid class that matches a given table name makes the return value more complex to handle. Also, returning `null` will probably help to make IDEs and static analysis tools more efficients.