### PR TITLE
Add glpi log artifact on failed e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,3 +275,9 @@ jobs:
         with:
           name: cypress-screenshots
           path: tests/cypress/screenshots
+      - name: "Upload GLPI logs"
+        if: "${{ failure() && steps.e2e.conclusion == 'failure' }}"
+        uses: actions/upload-artifact@v4
+        with:
+            name: glpi-logs
+            path: tests/files/_log


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Add artifact with the test environment GLPI logs when E2E tests fail to add additional context since the cause of a lot of failures may not be obvious just from the screenshots and may not be quickly fixable locally especially if a common failure causes a lot of specs to fail.
