### PR TITLE
Add inventory oauth client_credentials tests

### DIFF
--- a/src/Glpi/Agent/Communication/AbstractRequest.php
+++ b/src/Glpi/Agent/Communication/AbstractRequest.php
@@ -220,8 +220,8 @@ abstract class AbstractRequest
             $request = new Request('POST', $_SERVER['REQUEST_URI'], $this->headers->getHeaders());
             try {
                 $client = Server::validateAccessToken($request);
-                // Agent must authenticate both using client credentials (and therefore no valid user ID associated) and have the "inventory" OAuth scope
-                if (!\User::isNewID($client['user_id']) || !in_array('inventory', $client['scopes'], true)) {
+                if (!in_array('inventory', $client['scopes'], true)) {
+                    $this->setMode(self::JSON_MODE);
                     $this->addError('Access denied. Agent must authenticate using client credentials and have the "inventory" OAuth scope', 401);
                     return false;
                 }

--- a/src/Glpi/Agent/Communication/AbstractRequest.php
+++ b/src/Glpi/Agent/Communication/AbstractRequest.php
@@ -221,7 +221,6 @@ abstract class AbstractRequest
             try {
                 $client = Server::validateAccessToken($request);
                 if (!in_array('inventory', $client['scopes'], true)) {
-                    $this->setMode(self::JSON_MODE);
                     $this->addError('Access denied. Agent must authenticate using client credentials and have the "inventory" OAuth scope', 401);
                     return false;
                 }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

PR #16727 does not work, the typo modification made before the merge (d23fe386f8667006705c34b9f2d23709dc732aee), prevents the oauth authentication feature from working on the inventory.

After discussion with @orthagh , we propose :
- to remove the part of code which prevents the oauth from working on the inventory
- to code a functional test
- and then to redo (in another PR) an adapted modification in the oauth inventory to put a functional code on the check of a non-existent user
