### PR TITLE
Fix (SearchOption) - Specific priority values not displayed

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -3108,11 +3108,6 @@ abstract class CommonITILObject extends CommonDBTM
             $active_priorities = array_unique($active_priorities);
             if (count($active_priorities) > 0) {
                 foreach ($values as $priority => $name) {
-                    // dont unset non-standard priorities
-                    if ($priority <= 0 && $p['showtype'] == 'search') {
-                        continue;
-                    }
-
                     if (!in_array($priority, $active_priorities)) {
                         if ($p['withmajor'] && $priority == 6) {
                             continue;
@@ -3842,6 +3837,7 @@ abstract class CommonITILObject extends CommonDBTM
             case 'priority':
                 $options['name']  = $name;
                 $options['value'] = $values[$field];
+                $options['enable_filtering'] = false;
                 return static::dropdownPriority($options);
 
             case 'global_validation':


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !37963
- Here is a brief description of what this PR does

### Issue
When using the priority search dropdown in ITIL objects, sometimes only standard priority values (Major, Very high, High, etc.) are displayed, while non-standard values (All, At least very low, etc.) are missing from the list, despite being initially added to the values array.

### Root cause
In the `CommonITILObject::dropdownPriority()` method, there's a filtering mechanism that removes priorities not found in the active priorities matrix. However, the current code doesn't properly preserve non-standard priority values (priority <= 0) in search mode. These values are needed in search filters but are being incorrectly removed during the filtering process.

### Solution
Disable priority filtering in this context.

## Screenshots (if appropriate):

Before : 

![image](https://github.com/user-attachments/assets/36ea21e8-3c73-439f-b15a-f5036964156c)


After : 
![image](https://github.com/user-attachments/assets/ba91f34a-7caa-49e4-a3dd-11d5580079b4)

