### PR TITLE
Fix change and problem entity dropdown

### DIFF
--- a/templates/components/itilobject/fields_panel.html.twig
+++ b/templates/components/itilobject/fields_panel.html.twig
@@ -70,9 +70,7 @@
                      item.fields['entities_id'],
                      _n('Entity', 'Entities', 1),
                      field_options|merge({
-                        'entity': userentities|default(
-                           session('glpiactive_entity')
-                        ),
+                        'entity': userentities|default(-1),
                         'on_change': 'this.form.submit()',
                      })
                   ) }}


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Fixes #19919. A bad default value was added in #19729 which made it show only the current entity except in Tickets which was the only case that specified `userentities`.