### PR TITLE
improve multistep - no deletion of used ValidationSteps - fix #19933

### DIFF
--- a/phpunit/src/Glpi/ValidationStepTrait.php
+++ b/phpunit/src/Glpi/ValidationStepTrait.php
@@ -49,6 +49,10 @@ trait ValidationStepTrait
 
     /**
      * @return array{\Ticket|\Change, \TicketValidationStep|\ChangeValidationStep}
+     * @param ValidationStep $validation_step
+     * @param array<int, int> $validations_statuses CommonITILValidation:: statuses constants
+     * @param int|null $expected_status Expected status of the created ITIL_ValidationStep
+     * @param string|null $itil_classname Class name of the ITIL object to create (e.g. Ticket, Change)
      *
      * Also create the related itilobject
      */

--- a/src/ValidationStep.php
+++ b/src/ValidationStep.php
@@ -203,10 +203,13 @@ class ValidationStep extends \CommonDropdown
 
     private function isInUsage(): bool
     {
-        return (count(
-            (new ChangeValidationStep())->find([static::getForeignKeyField() => $this->getID()])
-                + (new TicketValidationStep())->find([static::getForeignKeyField() => $this->getID()])
-        )
-        ) > 0;
+        if (count((new TicketValidationStep())->find([static::getForeignKeyField() => $this->getID()])) > 0) {
+            return true;
+        }
+        if (count((new ChangeValidationStep())->find([static::getForeignKeyField() => $this->getID()])) > 0) {
+            return true;
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION

<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

- **Disallow deletion of used validation step.**
- **Do not show delete button on validation step that cannot be deleted**
- **add "default" search column for validationsteps**
- It fixes #19933

