### PR TITLE
Fix see task of my group option

### DIFF
--- a/phpunit/functional/TicketTest.php
+++ b/phpunit/functional/TicketTest.php
@@ -7247,7 +7247,7 @@ HTML,
             Group_User::class,
             [
                 'groups_id' => $group->getID(),
-                'users_id'  => $normal_user_id,
+                'users_id'  => $tech_user_id,
             ]
         );
 
@@ -7385,7 +7385,6 @@ HTML,
                 'public followup',
             ],
             'expected_tasks'     => [
-                'private task assigned to see group',
                 'private task assigned to normal user',
                 'private task of normal user',
                 'public task',

--- a/phpunit/functional/TicketTest.php
+++ b/phpunit/functional/TicketTest.php
@@ -7371,7 +7371,7 @@ HTML,
             ]
         );
 
-        // tech has rights to see all private followups/tasks
+        // glpi has rights to see all private followups/tasks
         yield [
             'login'              => 'glpi',
             'pass'               => 'glpi',
@@ -7391,6 +7391,7 @@ HTML,
             ],
         ];
 
+        // tech will only see own private tasks and all private followups
         yield [
             'login'              => 'tech',
             'pass'               => 'tech',
@@ -7407,7 +7408,7 @@ HTML,
             ],
         ];
 
-        // normal will only see own private followups/tasks
+        // normal will only see own private followups/tasks + private followups/tasks from its group
         yield [
             'login'              => 'normal',
             'pass'               => 'normal',
@@ -7485,7 +7486,6 @@ HTML,
     public function testGetTimelineItems(): void
     {
         $provider = $this->timelineItemsProvider();
-
         foreach ($provider as $row) {
             $login = $row['login'] ?? null;
             $pass = $row['pass'] ?? null;
@@ -7514,7 +7514,6 @@ HTML,
                     )
                 ),
             );
-
             $this->assertEquals($expected_followups, $followups_content);
 
             $tasks_content = array_map(

--- a/phpunit/functional/TicketTest.php
+++ b/phpunit/functional/TicketTest.php
@@ -7485,7 +7485,7 @@ HTML,
     public function testGetTimelineItems(): void
     {
         $provider = $this->timelineItemsProvider();
-        
+
         foreach ($provider as $row) {
             $login = $row['login'] ?? null;
             $pass = $row['pass'] ?? null;
@@ -7514,7 +7514,7 @@ HTML,
                     )
                 ),
             );
-            
+
             $this->assertEquals($expected_followups, $followups_content);
 
             $tasks_content = array_map(

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -7608,23 +7608,15 @@ abstract class CommonITILObject extends CommonDBTM
             } else {
                 $current_user_id = (Session::getCurrentInterface() === "central") ? (int) Session::getLoginUserID() : 0;
 
-                if (empty(Group_User::getUserGroups($current_user_id))) {
-                    // If the user is in a group, we can show tasks for that group
-                    $restrict_task = [
-                        'OR' => [
-                            'is_private' => 0,
-                            'users_id'   => $current_user_id,
-                        ],
-                    ];
-                } else {
-                    $restrict_task = [
-                        'OR' => [
-                            'is_private' => 0,
-                            'users_id'   => $current_user_id,
-                            'users_id_tech' => $current_user_id,
-                        ],
-                    ];
-
+                $restrict_task = [
+                    'OR' => [
+                        'is_private' => 0,
+                        'users_id'   => $current_user_id,
+                        'users_id_tech' => $current_user_id,
+                    ],
+                ];
+                
+                if (!empty(Group_User::getUserGroups($current_user_id))) {
                     if (Session::haveRight($task_obj::$rightname, CommonITILTask::SEEPRIVATEGROUPS)) {
                         $restrict_task['OR']['groups_id_tech'] = $_SESSION["glpigroups"];
                     }

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -7615,7 +7615,7 @@ abstract class CommonITILObject extends CommonDBTM
                         'users_id_tech' => $current_user_id,
                     ],
                 ];
-                
+
                 if (!empty(Group_User::getUserGroups($current_user_id))) {
                     if (Session::haveRight($task_obj::$rightname, CommonITILTask::SEEPRIVATEGROUPS)) {
                         $restrict_task['OR']['groups_id_tech'] = $_SESSION["glpigroups"];

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -7608,16 +7608,26 @@ abstract class CommonITILObject extends CommonDBTM
             } else {
                 $current_user_id = (Session::getCurrentInterface() === "central") ? (int) Session::getLoginUserID() : 0;
 
-                $restrict_task = [
-                    'OR' => [
-                        'is_private' => 0,
-                        'users_id'   => $current_user_id,
-                        'users_id_tech' => $current_user_id,
-                    ],
-                ];
+                if (empty(Group_User::getUserGroups($current_user_id))) {
+                    // If the user is in a group, we can show tasks for that group
+                    $restrict_task = [
+                        'OR' => [
+                            'is_private' => 0,
+                            'users_id'   => $current_user_id,
+                        ],
+                    ];
+                } else {
+                    $restrict_task = [
+                        'OR' => [
+                            'is_private' => 0,
+                            'users_id'   => $current_user_id,
+                            'users_id_tech' => $current_user_id,
+                        ],
+                    ];
 
-                if (Session::haveRight($task_obj::$rightname, CommonITILTask::SEEPRIVATEGROUPS)) {
-                    $restrict_task['OR']['groups_id_tech'] = $_SESSION["glpigroups"];
+                    if (Session::haveRight($task_obj::$rightname, CommonITILTask::SEEPRIVATEGROUPS)) {
+                        $restrict_task['OR']['groups_id_tech'] = $_SESSION["glpigroups"];
+                    }
                 }
             }
         }

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -7616,9 +7616,13 @@ abstract class CommonITILObject extends CommonDBTM
                     ],
                 ];
 
-                if (!empty(Group_User::getUserGroups($current_user_id))) {
+                $groupsuser = Group_User::getUserGroups($current_user_id);
+                if (!empty($groupsuser)) {
+                    foreach ($groupsuser as $groupuser) {
+                        $groups_ids[] = $groupuser['id'];
+                    }
                     if (Session::haveRight($task_obj::$rightname, CommonITILTask::SEEPRIVATEGROUPS)) {
-                        $restrict_task['OR']['groups_id_tech'] = $_SESSION["glpigroups"];
+                        $restrict_task['OR']['groups_id_tech'] = $groups_ids;
                     }
                 }
             }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !38049
- Here is a brief description of what this PR does
When the option to view tickets from my groups is activated for a user who does not have a group, that user can no longer view tickets with a stain.

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/465feb6e-903b-42ee-ad2e-6c2e3f798a5e)


