### PR TITLE
Fix ticket link when used Promote to Ticket

### DIFF
--- a/phpunit/functional/TicketTest.php
+++ b/phpunit/functional/TicketTest.php
@@ -8092,7 +8092,7 @@ HTML,
         $task = $this->createItem(\TicketTask::class, [
             'content' => 'Task content',
             'tickets_id' => $ticket->getID(),
-            'users_id' => \Session::getLoginUserID()
+            'users_id' => \Session::getLoginUserID(),
         ]);
 
         $ticket2 = $this->createItem(\Ticket::class, [
@@ -8114,6 +8114,5 @@ HTML,
             'tickets_id_1' => $ticket2->getID(),
             'tickets_id_2' => $ticket->getID(),
         ]));
-        
     }
 }

--- a/phpunit/functional/TicketTest.php
+++ b/phpunit/functional/TicketTest.php
@@ -58,6 +58,7 @@ use Ticket_User;
 use TicketValidation;
 use User;
 use Session;
+use Ticket_Ticket;
 
 /* Test for inc/ticket.class.php */
 
@@ -8067,5 +8068,52 @@ HTML,
         $input = ['itemtype' => \Ticket::class, 'items_id' => $ticket->getID()];
         $doc = new \Document();
         $this->assertEquals($expected, $doc->can(-1, CREATE, $input));
+    }
+
+    public function testPromoteTaskToTicket(): void
+    {
+        global $DB;
+
+        $this->login();
+
+        $ticket = $this->createItem(\Ticket::class, [
+            'name' => 'Ticket Test',
+            'content' => 'Ticket content',
+            '_actors' => [
+                'requester' => [
+                    [
+                        'itemtype'  => 'User',
+                        'items_id'  => \Session::getLoginUserID(),
+                    ],
+                ],
+            ],
+        ]);
+
+        $task = $this->createItem(\TicketTask::class, [
+            'content' => 'Task content',
+            'tickets_id' => $ticket->getID(),
+            'users_id' => \Session::getLoginUserID()
+        ]);
+
+        $ticket2 = $this->createItem(\Ticket::class, [
+            'name' => 'Ticket Test 2',
+            'content' => 'Ticket content 2',
+            '_promoted_task_id' => $task->getID(),
+            '_actors' => [
+                'requester' => [
+                    [
+                        'itemtype'  => 'User',
+                        'items_id'  => \Session::getLoginUserID(),
+                    ],
+                ],
+            ],
+        ]);
+
+        $ticket_ticket = new Ticket_Ticket();
+        $this->assertNotFalse($ticket_ticket->getFromDBByCrit([
+            'tickets_id_1' => $ticket2->getID(),
+            'tickets_id_2' => $ticket->getID(),
+        ]));
+        
     }
 }

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -2168,7 +2168,7 @@ class Ticket extends CommonITILObject
             $fup->getFromDB($this->input['_promoted_fup_id']);
             $fup->update([
                 'id'                 => $this->input['_promoted_fup_id'],
-                'sourceof_items_id'  => $this->getID()
+                'sourceof_items_id'  => $this->getID(),
             ]);
 
             $ticketticket = new Ticket_Ticket();
@@ -2192,7 +2192,7 @@ class Ticket extends CommonITILObject
             $tickettask->getFromDB($this->input['_promoted_task_id']);
             $tickettask->update([
                 'id'                => $this->input['_promoted_task_id'],
-                'sourceof_items_id' => $this->getID()
+                'sourceof_items_id' => $this->getID(),
             ]);
 
             $ticketticket = new Ticket_Ticket();

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -2168,8 +2168,16 @@ class Ticket extends CommonITILObject
             $fup->getFromDB($this->input['_promoted_fup_id']);
             $fup->update([
                 'id'                 => $this->input['_promoted_fup_id'],
-                'sourceof_items_id'  => $this->getID(),
+                'sourceof_items_id'  => $this->getID()
             ]);
+
+            $ticketticket = new Ticket_Ticket();
+            $ticketticket->add([
+                'tickets_id_1' => $this->getID(),
+                'tickets_id_2' => $fup->fields['tickets_id'],
+                'link'         => Ticket_Ticket::LINK_TO,
+            ]);
+
             Event::log(
                 $this->getID(),
                 "ticket",
@@ -2184,8 +2192,16 @@ class Ticket extends CommonITILObject
             $tickettask->getFromDB($this->input['_promoted_task_id']);
             $tickettask->update([
                 'id'                => $this->input['_promoted_task_id'],
-                'sourceof_items_id' => $this->getID(),
+                'sourceof_items_id' => $this->getID()
             ]);
+
+            $ticketticket = new Ticket_Ticket();
+            $ticketticket->add([
+                'tickets_id_1' => $this->getID(),
+                'tickets_id_2' => $tickettask->fields['tickets_id'],
+                'link'         => Ticket_Ticket::LINK_TO,
+            ]);
+
             Event::log(
                 $this->getID(),
                 "ticket",


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !38051
- Here is a brief description of what this PR does
When the Promote to Ticket option is used on a task or followup, it creates a new ticket but does not add the link between this ticket and its parent.

## Screenshots (if appropriate):


