### PR TITLE
feat(forms): Add duplicate button for form destinations

### DIFF
--- a/templates/pages/admin/form/form_destination.html.twig
+++ b/templates/pages/admin/form/form_destination.html.twig
@@ -84,13 +84,14 @@
             {{ __("No items will be created for this form.") }}
         </p>
     {% else %}
-        <div class="accordion mt-4" id="glpi-destinations-accordion">
+        <section class="accordion mt-4" id="glpi-destinations-accordion" aria-label="{{ __("Form destinations") }}">
             {% for destination in destinations %}
                 {% set is_expanded = active_destination == destination.getID() or destinations|length == 1 %}
                 {% set concrete_destination = destination.getConcreteDestinationItem() %}
                 {% set rand = random() %}
-                <div
+                <section
                     class="accordion-item"
+                    aria-label="{{ destination.getName() }}"
                 >
                     <div class="accordion-header">
                         <div
@@ -165,9 +166,9 @@
                             </form>
                         </div>
                     </div>
-                </div>
+                </section>
             {% endfor %}
-        </div>
+        </section>
     {% endif %}
 </div>
 

--- a/templates/pages/admin/form/form_destination_actions.html.twig
+++ b/templates/pages/admin/form/form_destination_actions.html.twig
@@ -54,6 +54,16 @@
                 {{ __("Delete") }}
             </button>
         {% endif %}
+        <button
+            class="btn btn-ghost-secondary me-1"
+            name="duplicate"
+            type="submit"
+            formaction="{{ path('/Form/%d/Destination/Add'|format(form.getID())) }}"
+            formmethod="post"
+        >
+            <i class="ti ti-copy me-2"></i>
+            {{ __("Duplicate") }}
+        </button>
     </div>
     <div>
         <button

--- a/tests/cypress/e2e/form/form_destination.cy.js
+++ b/tests/cypress/e2e/form/form_destination.cy.js
@@ -193,4 +193,53 @@ describe('Form destination', () => {
             cy.findByRole('combobox', {name: 'User who filled the form'}).should('exist');
         });
     });
+
+    it('can duplicate a form destination', () => {
+        // Configure the destination with some custom values
+        cy.findByRole("textbox", {name: "Form destination name"}).clear();
+        cy.findByRole("textbox", {name: "Form destination name"}).type('Original destination');
+
+        // Configure title field
+        cy.findByRole('region', {name: 'Title configuration'}).awaitTinyMCE().as("title_field");
+        cy.get("@title_field").clear();
+        cy.get("@title_field").type('Custom title for duplication test');
+
+        // Save the original configuration
+        cy.findByRole("button", {name: "Update item"}).click();
+        cy.checkAndCloseAlert('Item successfully updated');
+
+        // Click the duplicate button
+        cy.findByRole("button", {name: "Duplicate"}).click();
+
+        // Check that the duplication was successful
+        cy.findAllByRole('region', {name: 'Original destination'})
+            .should('have.length', 2);
+
+        // Check that the duplicated destination has the same configuration
+        cy.findByRole("textbox", {name: "Form destination name"}).should('have.value', 'Original destination');
+
+        // Verify the title field content is duplicated
+        cy.findByRole('region', {name: 'Title configuration'}).awaitTinyMCE().as("duplicated_title_field");
+        cy.get("@duplicated_title_field").should('contain.text', 'Custom title for duplication test');
+
+        // Verify this is indeed a new destination by changing the name
+        cy.findByRole("textbox", {name: "Form destination name"}).clear();
+        cy.findByRole("textbox", {name: "Form destination name"}).type('Duplicated destination');
+        cy.findByRole("button", {name: "Update item"}).click();
+        cy.checkAndCloseAlert('Item successfully updated');
+
+        // Verify the name change
+        cy.findByRole("textbox", {name: "Form destination name"}).should('have.value', 'Duplicated destination');
+        cy.findAllByRole('region', {name: 'Duplicated destination'})
+            .should('have.length', 1);
+
+        // Verify the original destination is still there
+        cy.findAllByRole('region', {name: 'Original destination'})
+            .should('have.length', 1)
+            .click();
+
+        cy.findByRole("textbox", {name: "Form destination name"}).should('have.value', 'Original destination');
+        cy.findByRole('region', {name: 'Title configuration'}).awaitTinyMCE().as("original_title_field");
+        cy.get("@original_title_field").should('contain.text', 'Custom title for duplication test');
+    });
 });


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

It fixes #19886
Add duplicate button for form destinations

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/6702381a-037b-4432-91d2-632da04c9300)
![image](https://github.com/user-attachments/assets/dc3011d7-41e7-4335-8c05-cd82aa5a5796)

