### PR TITLE
Fix front-end routing with PHP built-in server

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -4472,12 +4472,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Http/Firewall.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Function preg_replace is unsafe to use\\. It can return FALSE instead of throwing an exception\\. Please add \'use function Safe\\\\preg_replace;\' at the beginning of the file to use the variant provided by the \'thecodingmachine/safe\' library\\.$#',
-	'identifier' => 'theCodingMachineSafe.function',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Http/Firewall.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Function json_encode is unsafe to use\\. It can return FALSE instead of throwing an exception\\. Please add \'use function Safe\\\\json_encode;\' at the beginning of the file to use the variant provided by the \'thecodingmachine/safe\' library\\.$#',
 	'identifier' => 'theCodingMachineSafe.function',
 	'count' => 1,
@@ -4928,45 +4922,15 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Kernel/Listener/PostBootListener/SessionStart.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Function parse_url is unsafe to use\\. It can return FALSE instead of throwing an exception\\. Please add \'use function Safe\\\\parse_url;\' at the beginning of the file to use the variant provided by the \'thecodingmachine/safe\' library\\.$#',
-	'identifier' => 'theCodingMachineSafe.function',
-	'count' => 2,
-	'path' => __DIR__ . '/src/Glpi/Kernel/Listener/PostBootListener/SessionStart.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Function preg_match is unsafe to use\\. It can return FALSE instead of throwing an exception\\. Please add \'use function Safe\\\\preg_match;\' at the beginning of the file to use the variant provided by the \'thecodingmachine/safe\' library\\.$#',
-	'identifier' => 'theCodingMachineSafe.function',
-	'count' => 8,
-	'path' => __DIR__ . '/src/Glpi/Kernel/Listener/PostBootListener/SessionStart.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Function preg_replace is unsafe to use\\. It can return FALSE instead of throwing an exception\\. Please add \'use function Safe\\\\preg_replace;\' at the beginning of the file to use the variant provided by the \'thecodingmachine/safe\' library\\.$#',
-	'identifier' => 'theCodingMachineSafe.function',
-	'count' => 3,
-	'path' => __DIR__ . '/src/Glpi/Kernel/Listener/PostBootListener/SessionStart.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Function mime_content_type is unsafe to use\\. It can return FALSE instead of throwing an exception\\. Please add \'use function Safe\\\\mime_content_type;\' at the beginning of the file to use the variant provided by the \'thecodingmachine/safe\' library\\.$#',
 	'identifier' => 'theCodingMachineSafe.function',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Glpi/Kernel/Listener/RequestListener/FrontEndAssetsListener.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Function parse_url is unsafe to use\\. It can return FALSE instead of throwing an exception\\. Please add \'use function Safe\\\\parse_url;\' at the beginning of the file to use the variant provided by the \'thecodingmachine/safe\' library\\.$#',
-	'identifier' => 'theCodingMachineSafe.function',
-	'count' => 2,
-	'path' => __DIR__ . '/src/Glpi/Kernel/Listener/RequestListener/FrontEndAssetsListener.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Function preg_match is unsafe to use\\. It can return FALSE instead of throwing an exception\\. Please add \'use function Safe\\\\preg_match;\' at the beginning of the file to use the variant provided by the \'thecodingmachine/safe\' library\\.$#',
 	'identifier' => 'theCodingMachineSafe.function',
-	'count' => 9,
-	'path' => __DIR__ . '/src/Glpi/Kernel/Listener/RequestListener/FrontEndAssetsListener.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Function preg_replace is unsafe to use\\. It can return FALSE instead of throwing an exception\\. Please add \'use function Safe\\\\preg_replace;\' at the beginning of the file to use the variant provided by the \'thecodingmachine/safe\' library\\.$#',
-	'identifier' => 'theCodingMachineSafe.function',
-	'count' => 3,
+	'count' => 1,
 	'path' => __DIR__ . '/src/Glpi/Kernel/Listener/RequestListener/FrontEndAssetsListener.php',
 ];
 $ignoreErrors[] = [
@@ -4988,21 +4952,9 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Kernel/Listener/RequestListener/LegacyRouterListener.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Function parse_url is unsafe to use\\. It can return FALSE instead of throwing an exception\\. Please add \'use function Safe\\\\parse_url;\' at the beginning of the file to use the variant provided by the \'thecodingmachine/safe\' library\\.$#',
-	'identifier' => 'theCodingMachineSafe.function',
-	'count' => 2,
-	'path' => __DIR__ . '/src/Glpi/Kernel/Listener/RequestListener/LegacyRouterListener.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Function preg_match is unsafe to use\\. It can return FALSE instead of throwing an exception\\. Please add \'use function Safe\\\\preg_match;\' at the beginning of the file to use the variant provided by the \'thecodingmachine/safe\' library\\.$#',
 	'identifier' => 'theCodingMachineSafe.function',
-	'count' => 9,
-	'path' => __DIR__ . '/src/Glpi/Kernel/Listener/RequestListener/LegacyRouterListener.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Function preg_replace is unsafe to use\\. It can return FALSE instead of throwing an exception\\. Please add \'use function Safe\\\\preg_replace;\' at the beginning of the file to use the variant provided by the \'thecodingmachine/safe\' library\\.$#',
-	'identifier' => 'theCodingMachineSafe.function',
-	'count' => 3,
+	'count' => 1,
 	'path' => __DIR__ . '/src/Glpi/Kernel/Listener/RequestListener/LegacyRouterListener.php',
 ];
 $ignoreErrors[] = [

--- a/phpunit/functional/Glpi/Http/FirewallTest.php
+++ b/phpunit/functional/Glpi/Http/FirewallTest.php
@@ -40,6 +40,7 @@ use Glpi\Http\Firewall;
 use KnowbaseItem;
 use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\Attributes\DataProvider;
+use Psr\Log\LogLevel;
 use Symfony\Component\HttpFoundation\Request;
 
 class FirewallTest extends \DbTestCase
@@ -267,6 +268,14 @@ class FirewallTest extends \DbTestCase
             $instance->computeFallbackStrategy($request),
             $path
         );
+
+        if (\str_contains($path, '/marketplace/')) {
+            $this->hasPhpLogRecordThatContains('User Deprecated: Accessing the plugins resources from the `/marketplace/` path is deprecated. Use the `/plugins/` path instead.', LogLevel::INFO);
+        }
+
+        if (\str_contains($path, '/public/')) {
+            $this->hasPhpLogRecordThatContains('User Deprecated: Plugins URLs containing the `/public` path are deprecated. You should remove the `/public` prefix from the URL.', LogLevel::INFO);
+        }
     }
 
     public static function provideStrategy(): iterable

--- a/phpunit/functional/Glpi/Kernel/Listener/RequestListener/FrontEndAssetsListenerTest.php
+++ b/phpunit/functional/Glpi/Kernel/Listener/RequestListener/FrontEndAssetsListenerTest.php
@@ -319,13 +319,6 @@ class FrontEndAssetsListenerTest extends \GLPITestCase
                 'file_path' => $file,
                 'is_served' => true,
             ];
-
-            // extra leading slash should not change result
-            yield '/' . $file => [
-                'url_path'  => '/' . $file,
-                'file_path' => $file,
-                'is_served' => true,
-            ];
         }
 
         foreach ($glpi_protected_static_files as $file) {
@@ -339,18 +332,6 @@ class FrontEndAssetsListenerTest extends \GLPITestCase
             // but any file inside the `/public` dir should be served
             yield $file . ' (in /public)' => [
                 'url_path'  => $file,
-                'file_path' => '/public' . $file,
-                'is_served' => true,
-            ];
-
-            // extra leading slash should not change result
-            yield '/' . $file => [
-                'url_path'  => '/' . $file,
-                'file_path' => $file,
-                'is_served' => false,
-            ];
-            yield '/' . $file . ' (in /public)' => [
-                'url_path'  => '/' . $file,
                 'file_path' => '/public' . $file,
                 'is_served' => true,
             ];
@@ -371,18 +352,6 @@ class FrontEndAssetsListenerTest extends \GLPITestCase
             // even if the file is inside the `/public`
             yield $file . ' (in /public)' => [
                 'url_path'  => $file,
-                'file_path' => '/public' . $file,
-                'is_served' => false,
-            ];
-
-            // extra leading slash should not change result
-            yield '/' . $file => [
-                'url_path'  => '/' . $file,
-                'file_path' => $file,
-                'is_served' => false,
-            ];
-            yield '/' . $file . ' (in /public)' => [
-                'url_path'  => '/' . $file,
                 'file_path' => '/public' . $file,
                 'is_served' => false,
             ];
@@ -483,18 +452,6 @@ class FrontEndAssetsListenerTest extends \GLPITestCase
                 'file_path' => '/plugins/tester/public' . $file,
                 'is_served' => true,
             ];
-
-            // extra leading slash should not change result
-            yield '/plugins/tester' . '/' . $file => [
-                'url_path'  => '/plugins/tester' . '/' . $file,
-                'file_path' => '/plugins/tester' . $file,
-                'is_served' => false,
-            ];
-            yield '/plugins/tester' . '/' . $file . ' (in /public)' => [
-                'url_path'  => '/plugins/tester' . '/' . $file,
-                'file_path' => '/plugins/tester/public' . $file,
-                'is_served' => true,
-            ];
         }
 
         $not_served_files = \array_merge(
@@ -512,18 +469,6 @@ class FrontEndAssetsListenerTest extends \GLPITestCase
             // even if the file is inside the `/public`
             yield '/plugins/tester' . $file . ' (in /public)' => [
                 'url_path'  => '/plugins/tester' . $file,
-                'file_path' => '/plugins/tester/public' . $file,
-                'is_served' => false,
-            ];
-
-            // extra leading slash should not change result
-            yield '/plugins/tester' . '/' . $file => [
-                'url_path'  => '/plugins/tester' . '/' . $file,
-                'file_path' => '/plugins/tester' . $file,
-                'is_served' => false,
-            ];
-            yield '/plugins/tester' . '/' . $file . ' (in /public)' => [
-                'url_path'  => '/plugins/tester' . '/' . $file,
                 'file_path' => '/plugins/tester/public' . $file,
                 'is_served' => false,
             ];

--- a/phpunit/functional/Glpi/Kernel/Listener/RequestListener/LegacyRouterListenerTest.php
+++ b/phpunit/functional/Glpi/Kernel/Listener/RequestListener/LegacyRouterListenerTest.php
@@ -83,13 +83,6 @@ class LegacyRouterListenerTest extends \GLPITestCase
             'target_pathinfo' => null,
             'included'        => false,
         ];
-        yield '///ajax' => [
-            'structure'       => $structure,
-            'path'            => '///ajax', // triple `/` in URL
-            'target_path'     => '/ajax',
-            'target_pathinfo' => null,
-            'included'        => false,
-        ];
 
         // Path to an invalid PHP script.
         yield '/is/not/valid.php' => [
@@ -104,13 +97,6 @@ class LegacyRouterListenerTest extends \GLPITestCase
         yield '/front/index.php' => [
             'structure'       => $structure,
             'path'            => '/front/index.php',
-            'target_path'     => '/front/index.php',
-            'target_pathinfo' => null,
-            'included'        => true,
-        ];
-        yield '//front/index.php' => [
-            'structure'       => $structure,
-            'path'            => '//front/index.php', // double `/` in URL
             'target_path'     => '/front/index.php',
             'target_pathinfo' => null,
             'included'        => true,
@@ -309,13 +295,6 @@ class LegacyRouterListenerTest extends \GLPITestCase
                 'file_path' => $file,
                 'is_served' => true,
             ];
-
-            // extra leading slash should not change result
-            yield '/' . $file => [
-                'url_path'  => '/' . $file,
-                'file_path' => $file,
-                'is_served' => true,
-            ];
         }
 
         foreach ($glpi_protected_php_files as $file) {
@@ -329,18 +308,6 @@ class LegacyRouterListenerTest extends \GLPITestCase
             // but any file inside the `/public` dir should be served
             yield $file . ' (in /public)' => [
                 'url_path'  => $file,
-                'file_path' => '/public' . $file,
-                'is_served' => true,
-            ];
-
-            // extra leading slash should not change result
-            yield '/' . $file => [
-                'url_path'  => '/' . $file,
-                'file_path' => $file,
-                'is_served' => false,
-            ];
-            yield '/' . $file . ' (in /public)' => [
-                'url_path'  => '/' . $file,
                 'file_path' => '/public' . $file,
                 'is_served' => true,
             ];
@@ -361,18 +328,6 @@ class LegacyRouterListenerTest extends \GLPITestCase
             // even if the file is inside the `/public`
             yield $file . ' (in /public)' => [
                 'url_path'  => $file,
-                'file_path' => '/public' . $file,
-                'is_served' => false,
-            ];
-
-            // extra leading slash should not change result
-            yield '/' . $file => [
-                'url_path'  => '/' . $file,
-                'file_path' => $file,
-                'is_served' => false,
-            ];
-            yield '/' . $file . ' (in /public)' => [
-                'url_path'  => '/' . $file,
                 'file_path' => '/public' . $file,
                 'is_served' => false,
             ];
@@ -470,13 +425,6 @@ class LegacyRouterListenerTest extends \GLPITestCase
                 'file_path' => '/plugins/tester' . $file,
                 'is_served' => true,
             ];
-
-            // extra leading slash should not change result
-            yield '/plugins/tester' . '/' . $file => [
-                'url_path'  => '/plugins/tester' . '/' . $file,
-                'file_path' => '/plugins/tester' . $file,
-                'is_served' => true,
-            ];
         }
 
         foreach ($plugins_protected_php_files as $file) {
@@ -490,18 +438,6 @@ class LegacyRouterListenerTest extends \GLPITestCase
             // unless the file is inside the `/public`
             yield '/plugins/tester' . $file . ' (in /public)' => [
                 'url_path'  => '/plugins/tester' . $file,
-                'file_path' => '/plugins/tester/public' . $file,
-                'is_served' => true,
-            ];
-
-            // extra leading slash should not change result
-            yield '/plugins/tester' . '/' . $file => [
-                'url_path'  => '/plugins/tester' . '/' . $file,
-                'file_path' => '/plugins/tester' . $file,
-                'is_served' => false,
-            ];
-            yield '/plugins/tester' . '/' . $file . ' (in /public)' => [
-                'url_path'  => '/plugins/tester' . '/' . $file,
                 'file_path' => '/plugins/tester/public' . $file,
                 'is_served' => true,
             ];
@@ -522,18 +458,6 @@ class LegacyRouterListenerTest extends \GLPITestCase
             // even if the file is inside the `/public`
             yield '/plugins/tester' . $file . ' (in /public)' => [
                 'url_path'  => '/plugins/tester' . $file,
-                'file_path' => '/plugins/tester/public' . $file,
-                'is_served' => false,
-            ];
-
-            // extra leading slash should not change result
-            yield '/plugins/tester' . '/' . $file => [
-                'url_path'  => '/plugins/tester' . '/' . $file,
-                'file_path' => '/plugins/tester' . $file,
-                'is_served' => false,
-            ];
-            yield '/plugins/tester' . '/' . $file . ' (in /public)' => [
-                'url_path'  => '/plugins/tester' . '/' . $file,
                 'file_path' => '/plugins/tester/public' . $file,
                 'is_served' => false,
             ];

--- a/public/index.php
+++ b/public/index.php
@@ -49,6 +49,20 @@ require_once dirname(__DIR__) . '/src/Glpi/Application/ResourcesChecker.php';
 
 require_once dirname(__DIR__) . '/vendor/autoload.php';
 
+// When the PHP built-in server is used, if a valid resource is requested (e.g. `/front/ticket.php`),
+// `$_SERVER['SCRIPT_NAME']` will match the requested file instead of being `/index.php`.
+//
+// To make the Symfony request prefix/path computation working as expected, it is necessary to fix these values.
+// See https://github.com/symfony-cli/symfony-cli/blob/b5c22ed3d10c79784cbb7a771af94f683e8f1795/local/php/php_builtin_server.go#L53-L57
+$self_script = DIRECTORY_SEPARATOR . basename(__FILE__);
+if (php_sapi_name() === 'cli-server' && $_SERVER['SCRIPT_NAME'] !== $self_script) {
+    $_SERVER['DOCUMENT_ROOT']   = dirname(__FILE__);
+    $_SERVER['SCRIPT_FILENAME'] = $_SERVER['DOCUMENT_ROOT'] . $self_script;
+    $_SERVER['SCRIPT_NAME']     = $self_script;
+    $_SERVER['PHP_SELF']        = $self_script;
+}
+unset($self_script);
+
 $kernel = new Kernel();
 
 $request = Request::createFromGlobals();

--- a/src/Glpi/Kernel/Listener/PostBootListener/SessionStart.php
+++ b/src/Glpi/Kernel/Listener/PostBootListener/SessionStart.php
@@ -34,7 +34,7 @@
 
 namespace Glpi\Kernel\Listener\PostBootListener;
 
-use Glpi\Http\LegacyRouterTrait;
+use Glpi\Http\RequestRouterTrait;
 use Glpi\Kernel\KernelListenerTrait;
 use Glpi\Kernel\ListenersPriority;
 use Glpi\Kernel\PostBootEvent;
@@ -45,8 +45,8 @@ use Symfony\Component\HttpFoundation\Request;
 
 final class SessionStart implements EventSubscriberInterface
 {
-    use LegacyRouterTrait;
     use KernelListenerTrait;
+    use RequestRouterTrait;
 
     public function __construct(
         #[Autowire('%kernel.project_dir%')]
@@ -86,7 +86,7 @@ final class SessionStart implements EventSubscriberInterface
             // Specific configuration related to web context
 
             $request = Request::createFromGlobals();
-            [$uri_prefix, $path] = $this->extractPathAndPrefix($request);
+            $path = $this->normalizePath($request);
 
             $use_cookies = true;
             if (\str_starts_with($path, '/api.php') || \str_starts_with($path, '/apirest.php')) {

--- a/src/Glpi/Kernel/Listener/RequestListener/FrontEndAssetsListener.php
+++ b/src/Glpi/Kernel/Listener/RequestListener/FrontEndAssetsListener.php
@@ -35,7 +35,7 @@
 namespace Glpi\Kernel\Listener\RequestListener;
 
 use Glpi\Exception\Http\NotFoundHttpException;
-use Glpi\Http\LegacyRouterTrait;
+use Glpi\Http\RequestRouterTrait;
 use Glpi\Kernel\ListenersPriority;
 use Plugin;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
@@ -46,7 +46,7 @@ use Symfony\Component\HttpKernel\KernelEvents;
 
 final class FrontEndAssetsListener implements EventSubscriberInterface
 {
-    use LegacyRouterTrait;
+    use RequestRouterTrait;
 
     public function __construct(
         #[Autowire('%kernel.project_dir%')]
@@ -68,7 +68,7 @@ final class FrontEndAssetsListener implements EventSubscriberInterface
     {
         $request = $event->getRequest();
 
-        [$uri_prefix, $path] = $this->extractPathAndPrefix($request);
+        $path = $this->normalizePath($request);
 
         $target_file = $this->getTargetFile($path);
 

--- a/src/Glpi/Kernel/Listener/RequestListener/LegacyRouterListener.php
+++ b/src/Glpi/Kernel/Listener/RequestListener/LegacyRouterListener.php
@@ -36,7 +36,7 @@ namespace Glpi\Kernel\Listener\RequestListener;
 
 use Glpi\Controller\LegacyFileLoadController;
 use Glpi\Exception\Http\NotFoundHttpException;
-use Glpi\Http\LegacyRouterTrait;
+use Glpi\Http\RequestRouterTrait;
 use Glpi\Kernel\KernelListenerTrait;
 use Glpi\Kernel\ListenersPriority;
 use Plugin;
@@ -47,7 +47,7 @@ use Symfony\Component\HttpKernel\KernelEvents;
 
 final class LegacyRouterListener implements EventSubscriberInterface
 {
-    use LegacyRouterTrait;
+    use RequestRouterTrait;
     use KernelListenerTrait;
 
     public function __construct(
@@ -75,7 +75,7 @@ final class LegacyRouterListener implements EventSubscriberInterface
             return;
         }
 
-        [$uri_prefix, $path] = $this->extractPathAndPrefix($request);
+        $path = $this->normalizePath($request);
 
         $target_file = $this->getTargetFile($path);
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

It fixes #19948.

When the PHP built-in web server is used (`php -s 0:8080 public/index.php`), it handle all requests through the `public/index.php` file (as defined by the command line), even static files. For them, the `$_SERVER['SCRIPT_NAME']` contains the requested static file path instead of the `/public/index.php` value, and both GLPI and Symfony are not handling that properly.

The proposed patch permits to handle this pescial case and make GLPI compatible with the PHP built-in web server.
