### PR TITLE
Block impact in templates and cloning

### DIFF
--- a/src/Database.php
+++ b/src/Database.php
@@ -64,7 +64,6 @@ class Database extends CommonDBChild
         return [
             Appliance_Item::class,
             Domain_Item::class,
-            ImpactRelation::class,
         ];
     }
 

--- a/src/Impact.php
+++ b/src/Impact.php
@@ -84,6 +84,10 @@ class Impact extends CommonGLPI
         /** @var \DBmysql $DB */
         global $DB;
 
+        if ($withtemplate != 0) {
+            return '';
+        }
+
         // Class of the current item
         $class = $item::class;
 
@@ -141,8 +145,8 @@ class Impact extends CommonGLPI
         $tabnum = 1,
         $withtemplate = 0
     ) {
-        // Impact analysis should not be available outside of central
-        if (Session::getCurrentInterface() !== "central") {
+        // Impact analysis should not be available outside of central or used with templates
+        if (Session::getCurrentInterface() !== "central" || $withtemplate != 0) {
             return false;
         }
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Fixes #19947
- Remove Impact Relation from clone relations for databases
- Disable Impact tab for templates

As far as I can tell, impact relations were never cloned even when a graph was defined in an asset template and an asset was created from that template. Further, no impact types have Impact Relations as a clone relation except Databases (added in #18554). This isn't the removal of a feature that never existed. This is removing an invalid relation and trying to prevent user confusion.

If we want to clone impact relations we likely need complex changes to support relationships where both sides are polymorphic, and also make all itemtypes that can be on an impact graph and cloned define Impact Relations as a relation to clone.