### PR TITLE
Replace Validation term with Approval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ The present file will list all changes made to the project; according to the
 - Validations are only allowed on Tickets and Changes that are not solved or closed.
 - Searching project tasks in the legacy API is no longer restricted to only tasks the user is assigned to.
 - Renamed `From email header` and `To email header` criteria in the mails receiver rules to `From email address` and `To email address` respectively.
+- Replaced text mentions of "Validations" with "Approvals" to unify the terminology used.
 
 ### Deprecated
 - Survey URL tags `TICKETCATEGORY_ID` and `TICKETCATEGORY_NAME` are deprecated and replaced by `ITILCATEGORY_ID` and `ITILCATEGORY_NAME` respectively.

--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -2721,7 +2721,7 @@ $empty_data_builder = new class {
                 'is_active' => 1,
             ], [
                 'id' => 12,
-                'name' => 'Ticket Validation',
+                'name' => 'Ticket Approval',
                 'itemtype' => 'Ticket',
                 'event' => 'validation',
                 'is_recursive' => 1,
@@ -2896,7 +2896,7 @@ $empty_data_builder = new class {
                 'is_active' => 1,
             ], [
                 'id' => 37,
-                'name' => 'Ticket Validation Answer',
+                'name' => 'Ticket Approval Answer',
                 'itemtype' => 'Ticket',
                 'event' => 'validation_answer',
                 'is_recursive' => 1,
@@ -4614,7 +4614,7 @@ $empty_data_builder = new class {
                 'itemtype' => 'Ticket',
             ], [
                 'id' => '7',
-                'name' => 'Tickets Validation',
+                'name' => 'Tickets Approval',
                 'itemtype' => 'Ticket',
             ], [
                 'id' => '8',
@@ -9540,7 +9540,7 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
         // initial validation steps
         $tables[ValidationStep::getTable()][] = [
             'id' => 1,
-            'name' => _n('Approval', 'Approvals', 1),
+            'name' => CommonITILValidation::getTypeName(1),
             'minimal_required_validation_percent' => 100,
             'is_default' => 1,
             'date_creation' => date('Y-m-d H:i:s'),

--- a/phpunit/functional/ChangeTest.php
+++ b/phpunit/functional/ChangeTest.php
@@ -455,7 +455,7 @@ class ChangeTest extends DbTestCase
         ob_start();
         \Change::showCentralList(0, 'tovalidate', false);
         $output = ob_get_clean();
-        $this->assertStringContainsString("Your changes to validate <span class='primary-bg primary-fg count'>1</span>", $output);
+        $this->assertStringContainsString("Your changes to approve <span class='primary-bg primary-fg count'>1</span>", $output);
         $this->assertMatchesRegularExpression("/href='\/front\/change.form.php\?id=" . $change->getID() . "[^']+'>/", $output);
 
         // login as tech to check if the change validation is not shown
@@ -464,7 +464,7 @@ class ChangeTest extends DbTestCase
         ob_start();
         \Change::showCentralList(0, 'tovalidate', false);
         $output = ob_get_clean();
-        $this->assertStringNotContainsString("Your changes to validate", $output);
+        $this->assertStringNotContainsString("Your changes to approve", $output);
     }
 
     public function testShowFormNewItem(): void

--- a/src/Change.php
+++ b/src/Change.php
@@ -1281,7 +1281,7 @@ class Change extends CommonITILObject
 
                         $main_header = "<a href=\"" . Change::getSearchURL() . "?" .
                         Toolbox::append_params($options, '&amp;') . "\">" .
-                        Html::makeTitle(__('Your changes to validate'), $displayed_row_count, $total_row_count) . "</a>";
+                        Html::makeTitle(__('Your changes to approve'), $displayed_row_count, $total_row_count) . "</a>";
 
                         break;
 

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -7448,8 +7448,8 @@ abstract class CommonITILObject extends CommonDBTM
                 'type'          => 'ITILValidation',
                 'class'         => $validation::getType(),
                 'icon'          => CommonITILValidation::getIcon(),
-                'label'         => _x('button', 'Ask for validation'),
-                'short_label'   => _x('button', 'Validation'),
+                'label'         => _x('button', 'Ask for approval'),
+                'short_label'   => CommonITILValidation::getTypeName(1),
                 'template'      => 'components/itilobject/timeline/form_validation.html.twig',
                 'item'          => $validation,
                 'hide_in_menu'  => !$canadd_validation,
@@ -7748,7 +7748,7 @@ abstract class CommonITILObject extends CommonDBTM
                 $request_key = $validation_obj::getType() . '_' . $validations_id
                     . (empty($validation_row['validation_date']) ? '' : '_request'); // If no answer, no suffix to see attached documents on request
 
-                $content = __('Validation request');
+                $content = __('Approval request');
                 if (is_a($validation_row['itemtype_target'], CommonDBTM::class, true)) {
                     $validation_target = new $validation_row['itemtype_target']();
                     if ($validation_target->getFromDB($validation_row['items_id_target'])) {
@@ -7787,7 +7787,7 @@ abstract class CommonITILObject extends CommonDBTM
                         'item' => [
                             'id'        => $validations_id,
                             'date'      => $validation_row['validation_date'],
-                            'content'   => __('Validation request answer') . " : " .
+                            'content'   => __('Approval request answer') . " : " .
                             _sx('status', ucfirst($validation_class::getStatus($validation_row['status']))),
                             'comment_validation' => $validation_row['comment_validation'],
                             'users_id'  => $validation_row['users_id_validate'],

--- a/src/CommonITILValidation.php
+++ b/src/CommonITILValidation.php
@@ -1111,7 +1111,7 @@ abstract class CommonITILValidation extends CommonDBChild
                     'waiting_percent'    => $step_achievements[self::WAITING],
                     'step_threshold'     => $step_threshold,
                     'edit_dialog_params' => $edit_dialog_params,
-                    'edit_button_label'  => __('Edit validation step'),
+                    'edit_button_label'  => __('Edit approval step'),
                     'progress_label'     => __('Progress: %1$s%% of %2$s%% required'),
                 ]
             );

--- a/src/Glpi/Dashboard/FakeProvider.php
+++ b/src/Glpi/Dashboard/FakeProvider.php
@@ -155,7 +155,7 @@ final class FakeProvider extends Provider
                     'color'  => '#f1a129',
                 ], [
                     'number' => 31,
-                    'label'  => __("To validate"),
+                    'label'  => __("To approve"),
                     'url'    => '#',
                     'color'  => '#266ae9',
                 ], [
@@ -192,7 +192,7 @@ final class FakeProvider extends Provider
         $label = match ($case) {
             'notold' => _x('status', 'Not solved'),
             'late' => __("Late tickets"),
-            'waiting_validation' => __("Tickets waiting for validation"),
+            'waiting_validation' => __("Tickets waiting for approval"),
             'incoming' => __("Incoming tickets"),
             'waiting' => __("Pending tickets"),
             'assigned' => __("Assigned tickets"),

--- a/src/Glpi/Dashboard/Provider.php
+++ b/src/Glpi/Dashboard/Provider.php
@@ -326,7 +326,7 @@ class Provider
 
             case 'waiting_validation':
                 $params['icon']  = "ti ti-eye";
-                $params['label'] = __("Tickets waiting for validation");
+                $params['label'] = __("Tickets waiting for approval");
                 $search_criteria = [
                     [
                         'field'      => 55,
@@ -1682,7 +1682,7 @@ class Provider
                     'color'  => '#f1a129',
                 ], [
                     'number' => $tovalidate['number'],
-                    'label'  => __("To validate"),
+                    'label'  => __("To approve"),
                     'url'    => $tovalidate['url'],
                     'color'  => '#266ae9',
                 ], [

--- a/src/Glpi/Form/Condition/ValidationStrategy.php
+++ b/src/Glpi/Form/Condition/ValidationStrategy.php
@@ -46,7 +46,7 @@ enum ValidationStrategy: string implements StrategyInterface
     public function getLabel(): string
     {
         return match ($this) {
-            self::NO_VALIDATION => __('No approval'),
+            self::NO_VALIDATION => __('No validation'),
             self::VALID_IF      => __('Valid if...'),
             self::INVALID_IF    => __('Invalid if...'),
         };

--- a/src/Glpi/Form/Condition/ValidationStrategy.php
+++ b/src/Glpi/Form/Condition/ValidationStrategy.php
@@ -46,7 +46,7 @@ enum ValidationStrategy: string implements StrategyInterface
     public function getLabel(): string
     {
         return match ($this) {
-            self::NO_VALIDATION => __('No validation'),
+            self::NO_VALIDATION => __('No approval'),
             self::VALID_IF      => __('Valid if...'),
             self::INVALID_IF    => __('Invalid if...'),
         };

--- a/src/Glpi/Form/Destination/CommonITILField/ValidationField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ValidationField.php
@@ -34,6 +34,7 @@
 
 namespace Glpi\Form\Destination\CommonITILField;
 
+use CommonITILValidation;
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\JsonFieldInterface;
 use Glpi\Form\AnswersSet;
@@ -60,7 +61,7 @@ final class ValidationField extends AbstractConfigField implements DestinationFi
     #[Override]
     public function getLabel(): string
     {
-        return _n('Validation', 'Validations', 1);
+        return CommonITILValidation::getTypeName(1);
     }
 
     #[Override]

--- a/src/Glpi/Form/Destination/CommonITILField/ValidationFieldStrategy.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ValidationFieldStrategy.php
@@ -46,7 +46,7 @@ enum ValidationFieldStrategy: string
     public function getLabel(): string
     {
         return match ($this) {
-            self::NO_VALIDATION    => __("No validation"),
+            self::NO_VALIDATION    => __("No approval"),
             self::SPECIFIC_ACTORS   => __("Specific actors"),
             self::SPECIFIC_ANSWERS => __("Answer from specific questions"),
         };

--- a/src/Glpi/Helpdesk/DefaultDataManager.php
+++ b/src/Glpi/Helpdesk/DefaultDataManager.php
@@ -117,7 +117,7 @@ final class DefaultDataManager
 
         $this->tiles_manager->addTile($root_entity, GlpiPageTile::class, [
             'title'        => __("View approval requests"),
-            'description'  => __("View all tickets waiting for your validation."),
+            'description'  => __("View all tickets waiting for your approval."),
             'illustration' => "approve-requests",
             'page'         => GlpiPageTile::PAGE_APPROVAL,
         ]);

--- a/src/ITILValidationTemplate.php
+++ b/src/ITILValidationTemplate.php
@@ -51,7 +51,7 @@ class ITILValidationTemplate extends AbstractITILChildTemplate
 
     public static function getTypeName($nb = 0)
     {
-        return _n('Validation template', 'Validation templates', $nb);
+        return _n('Approval template', 'Approval templates', $nb);
     }
 
     public function prepareInputForUpdate($input)

--- a/src/ITILValidationTemplate_Target.php
+++ b/src/ITILValidationTemplate_Target.php
@@ -47,7 +47,7 @@ class ITILValidationTemplate_Target extends CommonDBRelation
 
     public static function getTypeName($nb = 0)
     {
-        return _n('Validation template target', 'Validation template targets', $nb);
+        return _n('Approval template target', 'Approval template targets', $nb);
     }
 
     public static function getTargets($itilvalidationtemplates_id)

--- a/src/NotificationTargetChange.php
+++ b/src/NotificationTargetChange.php
@@ -60,8 +60,8 @@ class NotificationTargetChange extends NotificationTargetCommonITILObject
         $events = ['new'               => __('New change'),
             'update'            => __('Update of a change'),
             'solved'            => __('Change solved'),
-            'validation'        => __('Validation request'),
-            'validation_answer' => __('Validation request answer'),
+            'validation'        => __('Approval request'),
+            'validation_answer' => __('Approval request answer'),
             'closed'            => __('Closure of a change'),
             'delete'            => __('Deleting a change'),
             'satisfaction'      => __('Satisfaction survey'),
@@ -319,7 +319,7 @@ class NotificationTargetChange extends NotificationTargetCommonITILObject
             ),
             'validation.validationdate'    => sprintf(
                 __('%1$s: %2$s'),
-                _n('Validation', 'Validations', 1),
+                CommonITILValidation::getTypeName(1),
                 _n('Date', 'Dates', 1)
             ),
             'validation.validator_target_type'  => __('Approval target type (User or Group)'),
@@ -327,7 +327,7 @@ class NotificationTargetChange extends NotificationTargetCommonITILObject
             'validation.validator'              => __('Approver'),
             'validation.commentvalidation'      => sprintf(
                 __('%1$s: %2$s'),
-                _n('Validation', 'Validations', 1),
+                CommonITILValidation::getTypeName(1),
                 _n('Comment', 'Comments', Session::getPluralNumber())
             ),
         ];
@@ -342,13 +342,13 @@ class NotificationTargetChange extends NotificationTargetCommonITILObject
 
         //Tags without lang for validation
         $tags = ['validation.submission.title'
-                                    => __('A validation request has been submitted'),
+                                    => __('An approval request has been submitted'),
             'validation.answer.title'
-                                    => __('An answer to a validation request was produced'),
+                                    => __('An answer to an approval request was produced'),
             'change.urlvalidation'
                                     => sprintf(
                                         __('%1$s: %2$s'),
-                                        __('Validation request'),
+                                        __('Approval request'),
                                         __('URL')
                                     ),
         ];
@@ -366,7 +366,7 @@ class NotificationTargetChange extends NotificationTargetCommonITILObject
         $tags = ['tickets'     => _n('Ticket', 'Tickets', Session::getPluralNumber()),
             'problems'    => Problem::getTypeName(Session::getPluralNumber()),
             'items'       => _n('Item', 'Items', Session::getPluralNumber()),
-            'validations' => _n('Validation', 'Validations', Session::getPluralNumber()),
+            'validations' => CommonITILValidation::getTypeName(Session::getPluralNumber()),
             'documents'   => Document::getTypeName(Session::getPluralNumber()),
         ];
 

--- a/src/NotificationTargetTicket.php
+++ b/src/NotificationTargetTicket.php
@@ -138,9 +138,9 @@ class NotificationTargetTicket extends NotificationTargetCommonITILObject
             'update'            => __('Update of a ticket'),
             'solved'            => __('Ticket solved'),
             'rejectsolution'    => __('Solution rejected'),
-            'validation'        => __('Validation request'),
-            'validation_answer' => __('Validation request answer'),
-            'validation_reminder' => __('Validation reminder'),
+            'validation'        => __('Approval request'),
+            'validation_answer' => __('Approval request answer'),
+            'validation_reminder' => __('Approval reminder'),
             'closed'            => __('Closing of the ticket'),
             'delete'            => __('Deletion of a ticket'),
             'alertnotclosed'    => __('Not solved tickets'),
@@ -698,7 +698,7 @@ class NotificationTargetTicket extends NotificationTargetCommonITILObject
             ),
             'validation.validationdate'    => sprintf(
                 __('%1$s: %2$s'),
-                _n('Validation', 'Validations', 1),
+                CommonITILValidation::getTypeName(1),
                 _n('Date', 'Dates', 1)
             ),
             'validation.validator_target_type'  => __('Approval target type (User or Group)'),
@@ -706,7 +706,7 @@ class NotificationTargetTicket extends NotificationTargetCommonITILObject
             'validation.validator'              => __('Approver'),
             'validation.commentvalidation'      => sprintf(
                 __('%1$s: %2$s'),
-                _n('Validation', 'Validations', 1),
+                CommonITILValidation::getTypeName(1),
                 _n('Comment', 'Comments', Session::getPluralNumber())
             ),
         ];
@@ -720,9 +720,9 @@ class NotificationTargetTicket extends NotificationTargetCommonITILObject
         }
         //Tags without lang for validation
         $tags = ['validation.submission.title'
-                                          => __('A validation request has been submitted'),
+                                          => __('An approval request has been submitted'),
             'validation.answer.title'
-                                          => __('An answer to a validation request was produced'),
+                                          => __('An answer to an approval request was produced'),
         ];
 
         foreach ($tags as $tag => $label) {
@@ -735,7 +735,8 @@ class NotificationTargetTicket extends NotificationTargetCommonITILObject
         }
 
         //Foreach global tags
-        $tags = ['validations'   => _n('Validation', 'Validations', Session::getPluralNumber()),
+        $tags = [
+            'validations'   => CommonITILValidation::getTypeName(Session::getPluralNumber()),
             'problems'      => Problem::getTypeName(Session::getPluralNumber()),
             'changes'       => _n('Change', 'Changes', Session::getPluralNumber()),
             'items'         => _n('Associated item', 'Associated items', Session::getPluralNumber()),
@@ -784,7 +785,7 @@ class NotificationTargetTicket extends NotificationTargetCommonITILObject
         //Tags without lang
         $tags = ['ticket.urlvalidation'    => sprintf(
             __('%1$s: %2$s'),
-            __('Validation request'),
+            __('Approval request'),
             __('URL')
         ),
             'problem.id'              => sprintf(__('%1$s: %2$s'), Problem::getTypeName(1), __('ID')),

--- a/src/RuleCommonITILObject.php
+++ b/src/RuleCommonITILObject.php
@@ -156,7 +156,7 @@ TWIG, ['message' => __('Urgency or impact used in actions, think to add Priority
                 <div class="alert alert-warning">
                     {{ message }}
                 </div>
-TWIG, ['message' => __('An action defines the validation step, but there is no action related to this validation step. Did you forgot to add an action?')]);
+TWIG, ['message' => __('An action defines the approval step, but there is no action related to this approval step. Did you forgot to add an action?')]);
         } elseif (
             count(array_intersect($action_keys, $fields_trigerring_validation)) > 0
             && in_array('validationsteps_id', $action_keys, true) === false
@@ -166,7 +166,7 @@ TWIG, ['message' => __('An action defines the validation step, but there is no a
                 <div class="alert alert-warning">
                     {{ message }}
                 </div>
-TWIG, ['message' => __('An action related to a validation exists, but there is no action assigning the corresponding validation step. Therefore, the default one will be used.')]);
+TWIG, ['message' => __('An action related to an approval exists, but there is no action assigning the approval validation step. Therefore, the default one will be used.')]);
         }
 
         return;
@@ -802,7 +802,7 @@ TWIG, ['message' => __('An action related to a validation exists, but there is n
         $criterias['_contract_types']['type']                 = 'dropdown';
 
         if ($itemtype::getValidationClassInstance() !== null) {
-            $criterias['global_validation']['name'] = _n('Validation', 'Validations', 1);
+            $criterias['global_validation']['name'] = CommonITILValidation::getTypeName(1);
             $criterias['global_validation']['type'] = 'dropdown_validation_status';
         }
 

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -4256,7 +4256,7 @@ JAVASCRIPT;
 
                         $main_header = "<a href=\"" . Ticket::getSearchURL() . "?" .
                         Toolbox::append_params($options, '&amp;') . "\">" .
-                        Html::makeTitle(__('Your tickets to validate'), $displayed_row_count, $total_row_count) . "</a>";
+                        Html::makeTitle(__('Your tickets to approve'), $displayed_row_count, $total_row_count) . "</a>";
 
                         break;
 

--- a/src/TicketValidation.php
+++ b/src/TicketValidation.php
@@ -106,16 +106,16 @@ class TicketValidation extends CommonITILValidation
 
         $values[self::CREATEREQUEST]
                               = ['short' => __('Create for request'),
-                                  'long'  => __('Create a validation request for a request'),
+                                  'long'  => __('Create an approval request for a request'),
                               ];
         $values[self::CREATEINCIDENT]
                               = ['short' => __('Create for incident'),
-                                  'long'  => __('Create a validation request for an incident'),
+                                  'long'  => __('Create an approval request for an incident'),
                               ];
         $values[self::VALIDATEREQUEST]
-                              = __('Validate a request');
+                              = __('Approve a request');
         $values[self::VALIDATEINCIDENT]
-                              = __('Validate an incident');
+                              = __('Approve an incident');
 
         if ($interface == 'helpdesk') {
             unset($values[PURGE]);

--- a/src/ValidatorSubstitute.php
+++ b/src/ValidatorSubstitute.php
@@ -153,7 +153,7 @@ final class ValidatorSubstitute extends CommonDBTM
     {
         if (isset($input['users_id']) && $input['users_id'] != $this->fields['users_id']) {
             // Do not change the user.
-            Session::addMessageAfterRedirect(__s('Cannot change the validation delegator'));
+            Session::addMessageAfterRedirect(__s('Cannot change the approval delegator'));
             return [];
         }
 

--- a/templates/components/itilobject/fields/global_validation.html.twig
+++ b/templates/components/itilobject/fields/global_validation.html.twig
@@ -81,7 +81,7 @@
             'ValidationStep',
             '_validationsteps_id',
             '',
-            __('Validation step'),
+            'ValidationStep'|itemtype_name,
             {
                'rand': rand,
                'value': call('ValidationStep::getDefault').id,

--- a/templates/components/itilobject/timeline/filter_timeline.html.twig
+++ b/templates/components/itilobject/timeline/filter_timeline.html.twig
@@ -56,7 +56,7 @@
       'checked': true,
    },
    'validations': {
-      'title': _n('Validation', 'Validations', get_plural_number()),
+      'title': 'CommonITILValidation'|itemtype_name(get_plural_number()),
       'icon': 'CommonITILValidation'|itemtype_icon,
       'itemtype': 'ITILValidation',
       'checked': true,

--- a/templates/components/itilobject/timeline/timeline.html.twig
+++ b/templates/components/itilobject/timeline/timeline.html.twig
@@ -220,7 +220,7 @@
     {{ include('components/itilobject/timeline/todo-list-summary.html.twig') }}
 
     <div class="timeline-item validations-title d-none mt-4">
-        <h3>{{ _n('Validation', 'Validations', get_plural_number()) }}</h3>
+        <h3>{{ 'CommonITILValidation'|itemtype_name(get_plural_number()) }}</h3>
     </div>
 
     {% if not is_timeline_reversed %}

--- a/templates/components/itilobject/validationstep.html.twig
+++ b/templates/components/itilobject/validationstep.html.twig
@@ -39,7 +39,7 @@
     {{ fields.dropdownNumberField(
         'minimal_required_validation_percent',
         item.fields['minimal_required_validation_percent'],
-        __('Minimum validation required (%)'),
+        __('Minimum approval required (%)'),
         {
             'required': true,
             'label_class': 'col-9',

--- a/templates/pages/admin/user.substitute.html.twig
+++ b/templates/pages/admin/user.substitute.html.twig
@@ -75,7 +75,7 @@
                         'User',
                         'substitutes',
                         [],
-                        __('Validation substitutes'),
+                        __('Approval substitutes'),
                         {
                               'multiple': 'multiple',
                               'used': [user.fields['id']],

--- a/tests/cypress/e2e/form/destination_config_fields/validation.cy.js
+++ b/tests/cypress/e2e/form/destination_config_fields/validation.cy.js
@@ -66,13 +66,13 @@ describe('Validation configuration', () => {
     });
 
     it('can use all possibles configuration options', () => {
-        cy.findByRole('region', {'name': "Validation configuration"}).as("config");
+        cy.findByRole('region', {'name': "Approval configuration"}).as("config");
         cy.get('@config').getDropdownByLabelText('Select strategy...').as("validation_dropdown");
 
         // Default value
         cy.get('@validation_dropdown').should(
             'have.text',
-            'No validation'
+            'No approval'
         );
 
         // Make sure hidden dropdowns are not displayed
@@ -112,7 +112,7 @@ describe('Validation configuration', () => {
 
     it('can create ticket using a specific question answer', () => {
         // Switch to "Answer from specific questions"
-        cy.findByRole('region', {'name': "Validation configuration"}).as("config");
+        cy.findByRole('region', {'name': "Approval configuration"}).as("config");
         cy.get('@config').getDropdownByLabelText('Select strategy...').selectDropdownValue('Answer from specific questions');
         cy.get('@config').getDropdownByLabelText('Select questions...').as('specific_answers_dropdown');
         cy.get('@specific_answers_dropdown').selectDropdownValue('My User question');

--- a/tests/src/Command/TestUpdatedDataCommand.php
+++ b/tests/src/Command/TestUpdatedDataCommand.php
@@ -150,17 +150,9 @@ class TestUpdatedDataCommand extends Command
             $table_name = $table_data['TABLE_NAME'];
 
             $itemtype = getItemTypeForTable($table_name);
-            if (!class_exists($itemtype)) {
-                $itemtype = null;
-            }
 
             $excluded_fields = $this->getExcludedFields($table_name);
             $excluded_fields[] = $itemtype != null ? $itemtype::getIndexName() : 'id';
-
-            $itemtype = getItemTypeForTable($table_name);
-            if (!class_exists($itemtype)) {
-                $itemtype = null;
-            }
 
             $row_iterator = $fresh_db->request(['FROM' => $table_name]);
             foreach ($row_iterator as $row_data) {
@@ -245,7 +237,7 @@ class TestUpdatedDataCommand extends Command
             'glpi_notifications',
             'glpi_notifications_notificationtemplates',
             'glpi_notificationtargets',
-            'glpi_notificationtemplate',
+            'glpi_notificationtemplates',
             'glpi_notificationtemplatetranslations',
 
             // Profiles are not automatically updated


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

The UI currently has both validation and approval, and other forms of these words, to refer to the same things. This PR standardizes it to be Approval which seems more correct in English. Internally, these are still referred to as validations.

https://forum.glpi-project.org/viewtopic.php?id=292619
