### PR TITLE
Standardize "form category" labels

### DIFF
--- a/templates/layout/parts/context_links.html.twig
+++ b/templates/layout/parts/context_links.html.twig
@@ -98,9 +98,9 @@
       </li>
    {% elseif type == 'view_form_categories' %}
       <li class="nav-item">
-         <a href="{{ path(link) }}" role="button" class="btn btn-sm btn-ghost-secondary me-1 pe-2" title="{{ __('Form categories') }}">
+         <a href="{{ path(link) }}" role="button" class="btn btn-sm btn-ghost-secondary me-1 pe-2" title="{{ 'Glpi\\Form\\Category'|itemtype_name(get_plural_number()) }}">
             <i class="ti ti-folder"></i>
-            <span class="d-none d-xxl-block">{{ __('Form categories') }}</span>
+            <span class="d-none d-xxl-block">{{ 'Glpi\\Form\\Category'|itemtype_name(get_plural_number()) }}</span>
          </a>
       </li>
    {% elseif type == 'import_forms' %}


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

The context button label for categories is "Form categories" while `Category::getTypeName` returns "Service catalog categories" which affects the breadcrumbs and page title.
