### PR TITLE
Fix some dark theme styles

### DIFF
--- a/css/includes/_base.scss
+++ b/css/includes/_base.scss
@@ -40,6 +40,7 @@
     --tblr-primary-darken: color-mix(in srgb, var(--tblr-primary), black 10%);
     --tblr-secondary: #606f91;
     --tblr-secondary-fg: var(--tblr-body-bg);
+    --tblr-tertiary: #8a97ab;
     --tblr-muted: var(--tblr-secondary);
     --tblr-muted-darken: color-mix(in srgb, var(--tblr-muted), black 10%);
     --tblr-info: #80abe4;
@@ -417,7 +418,13 @@ body input {
 }
 
 :-webkit-autofill {
-   -webkit-text-fill-color: var(--tblr-body-color);
+    &, &:hover, &:focus, &:active {
+        color: var(--tblr-body-color);
+        -webkit-text-fill-color: var(--tblr-body-color);
+        -webkit-background-clip: text !important;
+        background-clip: text !important;
+        -webkit-box-shadow: 0 0 0 30px var(--tblr-bg-forms) inset !important;
+    }
 }
 
 body .dropdown-menu {
@@ -509,4 +516,13 @@ body pre {
 
 .text-muted {
     color: var(--tblr-muted) !important;
+}
+
+.input-group {
+    box-shadow: none !important;
+}
+
+.input-group-text {
+    color: inherit !important;
+    background-color: inherit !important;
 }

--- a/css/includes/_base.scss
+++ b/css/includes/_base.scss
@@ -420,9 +420,12 @@ body input {
 :-webkit-autofill {
     &, &:hover, &:focus, &:active {
         color: var(--tblr-body-color);
+        /* stylelint-disable-next-line property-no-vendor-prefix */
         -webkit-text-fill-color: var(--tblr-body-color);
+        /* stylelint-disable-next-line property-no-vendor-prefix */
         -webkit-background-clip: text !important;
         background-clip: text !important;
+        /* stylelint-disable-next-line property-no-vendor-prefix */
         -webkit-box-shadow: 0 0 0 30px var(--tblr-bg-forms) inset !important;
     }
 }

--- a/css/includes/_palette_dark.scss
+++ b/css/includes/_palette_dark.scss
@@ -37,6 +37,7 @@
     --tblr-info: #5885c0;
     --tblr-body-bg: #000;
     --tblr-body-color: #e6e6e6;
+    --tblr-body-color-rgb: 230, 230, 230;
     --tblr-bg-surface: color-mix(in srgb, var(--tblr-body-bg), black 2%);
     --tblr-border-color: color-mix(in srgb, var(--tblr-body-bg), white 33.33%);
     --tblr-gray-100: var(--tblr-dark);
@@ -102,10 +103,6 @@
 
         color: var(--tblr-light);
         border-color: #6d000a;
-    }
-
-    .accordion-item .accordion-button {
-        background-color: var(--tblr-dark) !important;
     }
 
     .search_page .search-container .search-card .search-results.deleted-results td {


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

- Fix input placeholder text color. Used to be hardcoded by Bootstrap to `#8a97ab` but is now linked to `--tblr-tertiary`.
![Selection_472](https://github.com/user-attachments/assets/141bb357-2ca0-4ab1-b7da-458d5d8340b9)
- Fix webkit autofill styles again. Previous fix seems to have broken from a Chrome update.
![Selection_473](https://github.com/user-attachments/assets/49858b62-a677-42bb-9b99-e7684906c78f)
- Remove box shadow for input group as it tends to extend past the actual contents in flexbox and doesn't look good with the border radius
- Fix input group text background color which was light in dark themes.
![Selection_474](https://github.com/user-attachments/assets/c3fcd3e9-89b1-47d2-86c9-d4047e52be98)
- Fix `.text-body` which is used for the search results in the helpdesk homepage being broken because it switched from `--tblr-body-color` to `--tblr-body-color-rgb` which wasn't overriden in the dark theme base css.
- Fix accordian button backgrounds extending past the rounded border of lists (dropdown type lists) causing the corners to appear invisible.
![Selection_486](https://github.com/user-attachments/assets/fc6b3611-dce0-46d8-b10a-2418f0048452)
