### PR TITLE
Use `GLPI_URI` in web tests

### DIFF
--- a/phpunit/FrontBaseClass.php
+++ b/phpunit/FrontBaseClass.php
@@ -42,10 +42,8 @@ class FrontBaseClass extends \GLPITestCase
     private array $items_to_cleanup = [];
     public function setUp(): void
     {
-        global $CFG_GLPI;
-
         $this->http_client = new HttpBrowser();
-        $this->base_uri    = trim($CFG_GLPI['url_base'], "/") . "/";
+        $this->base_uri    = trim(GLPI_URI, '/') . '/';
 
         $this->doCleanup();
         parent::setUp();

--- a/phpunit/web/APIRestTest.php
+++ b/phpunit/web/APIRestTest.php
@@ -67,7 +67,7 @@ class APIRestTest extends TestCase
 
     public function setUp(): void
     {
-        global $CFG_GLPI, $GLPI_CACHE;
+        global $GLPI_CACHE;
 
         $GLPI_CACHE->clear();
 
@@ -76,7 +76,7 @@ class APIRestTest extends TestCase
         $this->assertNotSame(false, $file_updated);
 
         $this->http_client = new GuzzleHttp\Client();
-        $this->base_uri    = \Glpi\Api\HL\Router::getAPIVersions()[0]['endpoint'] . '/';
+        $this->base_uri    = trim(GLPI_URI, '/') . '/api.php/v1/';
 
         $this->initSessionCredentials();
         parent::setUp();

--- a/phpunit/web/Glpi/Inventory/InventoryTest.php
+++ b/phpunit/web/Glpi/Inventory/InventoryTest.php
@@ -43,10 +43,8 @@ class InventoryTest extends \GLPITestCase
 
     public function setUp(): void
     {
-        global $CFG_GLPI;
-
         $this->http_client = new GuzzleHttp\Client();
-        $this->base_uri    = trim($CFG_GLPI['url_base'], "/") . "/";
+        $this->base_uri    = trim(GLPI_URI, '/') . '/';
 
         parent::setUp();
     }

--- a/phpunit/web/Glpi/Inventory/RequestTest.php
+++ b/phpunit/web/Glpi/Inventory/RequestTest.php
@@ -45,10 +45,8 @@ class RequestTest extends \DbTestCase
 
     public function setUp(): void
     {
-        global $CFG_GLPI;
-
         $this->http_client = new GuzzleHttp\Client();
-        $this->base_uri    = trim($CFG_GLPI['url_base'], "/") . "/";
+        $this->base_uri    = trim(GLPI_URI, '/') . '/';
 
         parent::setUp();
     }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

`GLPI_URI` is supposed to permit to override the URL used by web tests, these tests should not rely on `$CFG_GLPI['url_base']` that correspond to an hardcoded `http://localhost` value defined during installation in CLI context.