### PR TITLE
fix(forms): Filter visible ITIL categories in helpdesk interface

### DIFF
--- a/src/Glpi/Form/QuestionType/QuestionTypeItemDropdown.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeItemDropdown.php
@@ -253,8 +253,13 @@ final class QuestionTypeItemDropdown extends QuestionTypeItem
             return $params;
         }
 
-        // Apply categories filter if itemtype is an ITILCategory
         if (is_a($itemtype, ITILCategory::class, true)) {
+            // Ensure only visible categories are shown
+            if (Session::getCurrentInterface() == "helpdesk") {
+                $params['is_helpdeskvisible'] = 1;
+            }
+
+            // Apply categories filter if itemtype is an ITILCategory
             $categories_filter = $this->getCategoriesFilter($question);
             if (is_array($categories_filter) && count($categories_filter) > 0) {
                 foreach ($categories_filter as $category) {


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

- It fixes #19960

It is possible to define whether an ITIL category is visible or not on helpdesk interface.
This option was not taken into account by the `QuestioonTypeDropdownItem` question type and displayed hidden categories on self-service interface.