### PR TITLE
Added 2 tests

### DIFF
--- a/phpunit/functional/TicketTest.php
+++ b/phpunit/functional/TicketTest.php
@@ -40,6 +40,7 @@ use Computer;
 use CronTask;
 use DbTestCase;
 use Entity;
+use Glpi\PHPUnit\Tests\Glpi\ITILTrait;
 use Glpi\PHPUnit\Tests\Glpi\ValidationStepTrait;
 use Glpi\Search\SearchOption;
 use Glpi\Team\Team;
@@ -67,6 +68,7 @@ use Session;
 class TicketTest extends DbTestCase
 {
     use ValidationStepTrait;
+    use ITILTrait;
 
     public static function addActorsProvider(): iterable
     {
@@ -8779,5 +8781,30 @@ HTML,
         $input = ['itemtype' => \Ticket::class, 'items_id' => $ticket->getID()];
         $doc = new \Document();
         $this->assertEquals($expected, $doc->can(-1, CREATE, $input));
+    }
+
+    /**
+     * date & date_creation field initial value test
+     *
+     * - use the current time is not set
+     * - use the value provided otherwise
+     *
+     * date field can be changed in front office
+     * date_creation cannot be changed in front office, it is not supposed to be changed.
+     */
+    public function testDateFieldsInitialValues(): void
+    {
+        // test 1 : date & date_creation field is not set : current time is used
+        $now = $this->setCurrentTime('02:11:44');
+        $ticket = $this->createTicket();
+
+        $this->assertEquals($now->format('Y-m-d H:i:s'), $ticket->fields['date']);
+        $this->assertEquals($now->format('Y-m-d H:i:s'), $ticket->fields['date_creation']);
+
+        // test 2 : date & date_creation set : provided values used
+        $provided_date = '2023-11-27 10:00:00';
+        $ticket = $this->createTicket(['date' => $provided_date, 'date_creation' => $provided_date]);
+        $this->assertEquals($provided_date, $ticket->fields['date']);
+        $this->assertEquals($provided_date, $ticket->fields['date_creation']);
     }
 }


### PR DESCRIPTION
- ticket date & date_creation fields default values (+ can be defined)
- ola_begin_date values on ticket update on creation

<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

Added test to clarify behaviour on ticket date/date_creation + ola_begin_date values.

No code change, just added tests
