### PR TITLE
fix(forms): Add restrictions for request source configuration

### DIFF
--- a/templates/pages/admin/form/itil_config_fields/request_source.html.twig
+++ b/templates/pages/admin/form/itil_config_fields/request_source.html.twig
@@ -45,6 +45,10 @@
                 display_emptychoice: true,
                 emptylabel: specific_value_extra_field.empty_label,
                 aria_label: specific_value_extra_field.empty_label,
+                condition: {
+                    is_active: 1,
+                    is_ticketheader: 1
+                }
             })
     ) }}
 </div>

--- a/tests/cypress/e2e/form/destination_config_fields/request_source.cy.js
+++ b/tests/cypress/e2e/form/destination_config_fields/request_source.cy.js
@@ -95,4 +95,36 @@ describe('Request source configuration', () => {
 
         // Others possibles configurations are tested directly by the backend.
     });
+
+    it('only assigns request source to ticket are displayed', () => {
+        const uuid = Date.now();
+
+        // Create request sources
+        cy.createWithAPI('RequestType', {
+            'name'           : `Assignable request source ${uuid}`,
+            'is_active'      : 1,
+            'is_ticketheader': 1,
+        });
+        cy.createWithAPI('RequestType', {
+            'name'           : `Non assignable request source ${uuid}`,
+            'is_active'      : 1,
+            'is_ticketheader': 0,
+        });
+        cy.createWithAPI('RequestType', {
+            'name'           : `Disabled request source ${uuid}`,
+            'is_active'      : 0,
+            'is_ticketheader': 1,
+        });
+
+        cy.openAccordionItem('Destination fields accordion', 'Properties');
+        cy.findByRole('region', { 'name': "Request source configuration" }).as("config");
+        cy.get('@config').getDropdownByLabelText('Request source').as("source_dropdown");
+        cy.get('@source_dropdown').selectDropdownValue('Specific request source');
+        cy.get('@config').getDropdownByLabelText('Select a request source...').as('specific_request_source_id_dropdown');
+
+        // Check that only assignable request sources are displayed
+        cy.get('@specific_request_source_id_dropdown').hasDropdownValue(`Assignable request source ${uuid}`, true);
+        cy.get('@specific_request_source_id_dropdown').hasDropdownValue(`Non assignable request source ${uuid}`, false);
+        cy.get('@specific_request_source_id_dropdown').hasDropdownValue(`Disabled request source ${uuid}`, false);
+    });
 });


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Added restrictions on the items returned by the `Request source` configuration field when `Specific request source` is selected.
It was possible to assign disabled or non-assignable sources to tickets.