### PR TITLE
Remove the `alisqi/twigqi` dev library

### DIFF
--- a/composer-dependency-analyser.php
+++ b/composer-dependency-analyser.php
@@ -65,7 +65,6 @@ return $config
     ->ignoreErrorsOnPackages([
         'symfony/twig-bundle',
         'symfony/web-profiler-bundle',
-        'alisqi/twigqi',
     ], [ErrorType::DEV_DEPENDENCY_IN_PROD])
 
     ->ignoreErrorsOnExtension('ext-bcmath', [ErrorType::UNUSED_DEPENDENCY]) // Required by tc-lib-barcode

--- a/composer.json
+++ b/composer.json
@@ -104,7 +104,6 @@
     },
     "require-dev": {
         "ext-xml": "*",
-        "alisqi/twigqi": "^3.0",
         "atoum/atoum": "^4.3",
         "friendsofphp/php-cs-fixer": "^3.75",
         "friendsoftwig/twigcs": "^6.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2dc03b6d0c6a952d3e62f93f79d26b23",
+    "content-hash": "3eac24d938e6578d482471f8cb8ee63b",
     "packages": [
         {
             "name": "apereo/phpcas",
@@ -9191,51 +9191,6 @@
         }
     ],
     "packages-dev": [
-        {
-            "name": "alisqi/twigqi",
-            "version": "3.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/alisqi/TwigQI.git",
-                "reference": "339509aa985842e1246239d720decb486f5fe47e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/alisqi/TwigQI/zipball/339509aa985842e1246239d720decb486f5fe47e",
-                "reference": "339509aa985842e1246239d720decb486f5fe47e",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^8.2",
-                "phpdocumentor/reflection-docblock": "^5.4",
-                "psr/log": "^3.0",
-                "twig/twig": "~3.15"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^11.5"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "AlisQI\\TwigQI\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jeroen Versteeg"
-                }
-            ],
-            "description": "Static code analysis for Twig templates",
-            "support": {
-                "issues": "https://github.com/alisqi/TwigQI/issues",
-                "source": "https://github.com/alisqi/TwigQI/tree/v3.0.0"
-            },
-            "time": "2025-04-02T09:58:26+00:00"
-        },
         {
             "name": "atoum/atoum",
             "version": "4.3.0",

--- a/src/Glpi/Application/View/TemplateRenderer.php
+++ b/src/Glpi/Application/View/TemplateRenderer.php
@@ -34,8 +34,6 @@
 
 namespace Glpi\Application\View;
 
-use AlisQI\TwigQI\Extension as TwigIQExtension;
-use AlisQI\TwigQI\Logger\TriggerErrorLogger;
 use Glpi\Application\Environment as GLPIEnvironment;
 use Glpi\Application\View\Extension\ConfigExtension;
 use Glpi\Application\View\Extension\DataHelpersExtension;
@@ -122,13 +120,6 @@ class TemplateRenderer
         $this->environment->addExtension(new SearchExtension());
         $this->environment->addExtension(new SessionExtension());
         $this->environment->addExtension(new TeamExtension());
-        if (GLPIEnvironment::get()->shouldEnableExtraDevAndDebugTools() || GLPI_STRICT_ENV) {
-            $this->environment->addExtension(
-                new TwigIQExtension(
-                    new TriggerErrorLogger()
-                )
-            );
-        }
 
         // add superglobals
         $this->environment->addGlobal('_post', $_POST);


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Sometimes, when an undefined variable is used in a template, in an AJAX request context, I get a `400` empty response from the web server, with nothing in logs, instead of getting a proper `500` error page with the Twig error stack trace.

This is pretty annoying, and as soon as I disable the `alisqi/twigqi` Twig extension, this behaviour disappear.

@Mary-Clb also faced this issue recently.

I am not able to reproduce the issue 100% of the time, and I suspect it depends on both the Twig cache and the PHP Opcache state (compiled templates are stored in PHP files that can then be cached by PHP).

Instead of spending too much time on debugging this, I propose to remove this extension.