### PR TITLE
Add buttons to suspend/resume individual plugins execution

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -161,12 +161,6 @@ $ignoreErrors[] = [
 	'message' => '#^Function json_encode is unsafe to use\\. It can return FALSE instead of throwing an exception\\. Please add \'use function Safe\\\\json_encode;\' at the beginning of the file to use the variant provided by the \'thecodingmachine/safe\' library\\.$#',
 	'identifier' => 'theCodingMachineSafe.function',
 	'count' => 1,
-	'path' => __DIR__ . '/ajax/marketplace.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Function json_encode is unsafe to use\\. It can return FALSE instead of throwing an exception\\. Please add \'use function Safe\\\\json_encode;\' at the beginning of the file to use the variant provided by the \'thecodingmachine/safe\' library\\.$#',
-	'identifier' => 'theCodingMachineSafe.function',
-	'count' => 1,
 	'path' => __DIR__ . '/ajax/notificationmailingsettings.php',
 ];
 $ignoreErrors[] = [

--- a/ajax/marketplace.php
+++ b/ajax/marketplace.php
@@ -70,10 +70,11 @@ if (isset($_POST['key']) && isset($_POST["action"])) {
     if ($_POST["action"] == "disable_plugin") {
         $marketplace_ctrl->disablePlugin();
     }
-    if ($_POST["action"] == "suspend_plugin") {
-        header("Content-Type: application/json; charset=UTF-8");
-        echo json_encode(['success' => $marketplace_ctrl->suspendPlugin()]);
-        return;
+    if ($_POST["action"] == "suspend_plugin_execution") {
+        $marketplace_ctrl->suspendPluginExecution();
+    }
+    if ($_POST["action"] == "resume_plugin_execution") {
+        $marketplace_ctrl->resumePluginExecution();
     }
 
     echo MarketplaceView::getButtons($_POST['key']);

--- a/front/plugin.form.php
+++ b/front/plugin.form.php
@@ -64,6 +64,14 @@ switch ($action) {
     case 'clean':
         $plugin->clean($id);
         break;
+    case 'suspend_execution':
+        $plugin->getFromDB($id);
+        $plugin->suspendExecution();
+        break;
+    case 'resume_execution':
+        $plugin->getFromDB($id);
+        $plugin->resumeExecution();
+        break;
     default:
         throw new BadRequestHttpException();
 }

--- a/js/marketplace.js
+++ b/js/marketplace.js
@@ -85,7 +85,7 @@ $(document).ready(function() {
             // The plugin execution must be suspended first to ensure that its `setup.php` file is not loaded before
             // its new version is downloaded.
             $.post(ajax_url, {
-                'action': 'suspend_plugin',
+                'action': 'suspend_plugin_execution',
                 'key': plugin_key
             }).done(function() {
                 executeAction();

--- a/src/Glpi/Marketplace/Controller.php
+++ b/src/Glpi/Marketplace/Controller.php
@@ -573,15 +573,28 @@ class Controller extends CommonGLPI
     }
 
     /**
-     * Suspend current plugin
-     *
-     * @return bool
+     * Suspend current plugin execution
      */
-    public function suspendPlugin(): bool
+    public function suspendPluginExecution(): bool
     {
         $plugin = new Plugin();
+
         if ($plugin->getFromDBbyDir($this->plugin_key)) {
-            return $plugin->suspend();
+            return $plugin->suspendExecution();
+        }
+
+        return true;
+    }
+
+    /**
+     * Suspend current plugin execution
+     */
+    public function resumePluginExecution(): bool
+    {
+        $plugin = new Plugin();
+
+        if ($plugin->getFromDBbyDir($this->plugin_key)) {
+            return $plugin->resumeExecution();
         }
 
         return true;

--- a/src/Glpi/Marketplace/View.php
+++ b/src/Glpi/Marketplace/View.php
@@ -613,6 +613,7 @@ JS;
 
         $config_page        = $PLUGIN_HOOKS['config_page'][$plugin_key] ?? "";
         $must_be_cleaned   = $exists && !$plugin_inst->isLoadable($plugin_key);
+        $is_suspended      = $exists && $plugin_inst->fields['state'] === Plugin::SUSPENDED;
         $has_local_install = $exists && !$must_be_cleaned && !$is_installed;
         $has_local_update  = $exists && !$must_be_cleaned && $plugin_inst->isUpdatable($plugin_key);
 
@@ -789,6 +790,17 @@ JS;
                                          data-action='disable_plugin'
                                          title='" . __s("Disable") . "'>
                             <i class='ti ti-toggle-right-filled'></i>
+                        </button>";
+                    $buttons .= "<button class='modify_plugin'
+                                         data-action='suspend_plugin_execution'
+                                         title='" . __s("Suspend plugin execution") . "'>
+                            <i class='ti ti-player-pause-filled'></i>
+                        </button>";
+                } elseif ($is_suspended) {
+                    $buttons .= "<button class='modify_plugin'
+                                         data-action='resume_plugin_execution'
+                                         title='" . __s("Resume plugin execution") . "'>
+                            <i class='ti ti-player-play-filled'></i>
                         </button>";
                 } else {
                     $buttons .= "<button class='modify_plugin'

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -1126,11 +1126,9 @@ class Plugin extends CommonDBTM
     }
 
     /**
-     * Suspend a plugin. This can be used to disable the execution of a plugin during its update process.
-     *
-     * @return boolean
-     **/
-    public function suspend(): bool
+     * Suspend a plugin execution.
+     */
+    final public function suspendExecution(): bool
     {
         $success = $this->update([
             'id'    => $this->getID(),
@@ -1139,6 +1137,24 @@ class Plugin extends CommonDBTM
 
         if ($success) {
             $this->unload($this->fields['directory']);
+        }
+
+        return $success;
+    }
+
+    /**
+     * Resume a plugin execution.
+     */
+    final public function resumeExecution(): bool
+    {
+        $success = $this->update([
+            'id'    => $this->getID(),
+            'state' => self::ACTIVATED,
+        ]);
+
+        if ($success) {
+            $this->load($this->fields['directory']);
+            self::$activated_plugins[] = $this->fields['directory'];
         }
 
         return $success;
@@ -1364,7 +1380,7 @@ class Plugin extends CommonDBTM
 
         if ($this->getFromDBbyDir($directory)) {
             return $this->isLoadable($directory)
-                && in_array($this->fields['state'], [self::ACTIVATED, self::TOBECONFIGURED, self::NOTACTIVATED]);
+                && in_array($this->fields['state'], [self::ACTIVATED, self::TOBECONFIGURED, self::NOTACTIVATED, self::SUSPENDED]);
         }
 
         return false;
@@ -2485,6 +2501,23 @@ class Plugin extends CommonDBTM
                         _x('button', 'Disable'),
                         ['id' => $ID],
                         'ti-toggle-right-filled fs-2x enabled'
+                    ) . '&nbsp;';
+                    // Suspend execution button for active plugins
+                    $output .= Html::getSimpleForm(
+                        static::getFormURL(),
+                        ['action' => 'suspend_execution'],
+                        _x('button', 'Suspend plugin execution'),
+                        ['id' => $ID],
+                        'ti-player-pause-filled fs-2x'
+                    ) . '&nbsp;';
+                } elseif ($state === self::SUSPENDED) {
+                    // Resume execution button for suspended plugins
+                    $output .= Html::getSimpleForm(
+                        static::getFormURL(),
+                        ['action' => 'resume_execution'],
+                        _x('button', 'Resume plugin execution'),
+                        ['id' => $ID],
+                        'ti-player-play-filled fs-2x'
                     ) . '&nbsp;';
                 } elseif ($state === self::NOTACTIVATED) {
                     // Activate button for configured and up to date plugins


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] This change requires a documentation update.

## Description

For active plugins, add a "Suspend plugin execution", and dfor suspended plugins, add a "Resume plugin execution" button, in both the classic plugin page and the marketplace page.

Handling these states individualy is required to be able to implement the "Suspend all plugins execution" / "Resume all plugins execution" features and to be able to set active plugins as "suspended" during the GLPI update instead of disabling them.

## Screenshots (if appropriate):

Marketplace page:
![image](https://github.com/user-attachments/assets/155b0896-c84f-4ebf-a9e9-24c7e809928d)
![image](https://github.com/user-attachments/assets/1b047776-6137-45d5-a5d7-92d573a5f39a)

Classic plugins page:
![image](https://github.com/user-attachments/assets/7abca93f-415f-4af5-b104-680d4a8b10fa)
![image](https://github.com/user-attachments/assets/bd24bec6-0603-42f0-922a-f1edda418044)
