### PR TITLE
Fix timeline document form UI issues

### DIFF
--- a/css/includes/_palette_dark.scss
+++ b/css/includes/_palette_dark.scss
@@ -65,6 +65,8 @@
     --glpi-timeline-solution-bg: #3a4d55;
     --glpi-timeline-solution-fg: #89bfd3;
     --glpi-timeline-solution-border-color: #435963;
+    --glpi-timeline-document-bg: #2b4137;
+    --glpi-timeline-document-fg: #68b997;
     --glpi-timeline-badge-bg: rgb(104, 104, 104, 15%);
     --glpi-timeline-badge-fg: rgb(236, 236, 236, 80%);
     --glpi-badge-bg: color-mix(in srgb, var(--tblr-link-color), var(--tblr-dark) 85%);

--- a/templates/components/itilobject/timeline/form_document_item.html.twig
+++ b/templates/components/itilobject/timeline/form_document_item.html.twig
@@ -137,7 +137,7 @@
                             {% endif %}
                         </div>
                         <div id="screen_capture_preview" class="w-100">
-                            <div class="previews overflow-x-scroll my-2 d-flex px-2"></div>
+                            <div class="previews overflow-x-auto my-2 d-flex px-2"></div>
                             <button type="button" name="stop_recording" class="btn btn-secondary d-none">{{ __('Stop recording') }}</button>
                         </div>
                         <hr class="my-1">
@@ -156,12 +156,6 @@
                     ) }}
                 {% endif %}
 
-                {% set max_size %}
-                    <div class="alert alert-info">
-                        {{ call("Document::getMaxUploadSize") }}
-                    </div>
-                {% endset %}
-
                 {{ fields.fileField(
                     'filename',
                     null,
@@ -170,7 +164,6 @@
                         'multiple': true,
                         'full_width': true,
                         'is_horizontal': false,
-                        'add_field_html': max_size,
                     }
                 ) }}
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

- Fixed issue where the "Upload from" section, where screen captures can be attached, always showed a horizontal scrollbar. You need to be connected in a secure context (HTTPS or localhost) to have the screen capture section show.
- Fixed issue where the text color was too dark in dark palettes in the form because it was never overridden in the base dark palette.
- Removed duplicate max filesize info message. This was originally done as part of #18990 but that PR wasn't accepted. The max upload size is already shown directly in the file input.
