### PR TITLE
Remove all tab for forms

### DIFF
--- a/phpunit/functional/Glpi/Form/FormTest.php
+++ b/phpunit/functional/Glpi/Form/FormTest.php
@@ -748,7 +748,7 @@ class FormTest extends DbTestCase
         }
 
         // Act: get tabs names
-        $tabs = $form->defineTabs();
+        $tabs = array_filter($form->defineTabs(), static fn($tab): bool => $tab !== 'no_all_tab', ARRAY_FILTER_USE_KEY);
         $tabs = array_map('strip_tags', $tabs); // Strip html
         $tabs = array_values($tabs); // Ignore keys
 

--- a/src/Glpi/Form/Form.php
+++ b/src/Glpi/Form/Form.php
@@ -143,6 +143,7 @@ final class Form extends CommonDBTM implements
         $this->addStandardTab(FormDestination::class, $tabs, $options);
         $this->addStandardTab(FormTranslation::class, $tabs, $options);
         $this->addStandardTab(Log::class, $tabs, $options);
+        $tabs['no_all_tab'] = true;
         return $tabs;
     }
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

The "All" tab for forms is broken. It does load all of the tabs like it is supposed to, but the form editor always takes up the entire tab area and you are not allowed to scroll to see the other tabs. It seems best to just remove the All tab for forms.
