### PR TITLE
Fix transfer list twig variable name

### DIFF
--- a/templates/pages/admin/transfer_list.html.twig
+++ b/templates/pages/admin/transfer_list.html.twig
@@ -74,7 +74,7 @@
                {% for item in items %}
                   <tr>
                      <td>{{ itemtype|itemtype_name }}</td>
-                     <td>{{ item['locname'] }}</td>
+                     <td>{{ item['entname'] }}</td>
                      <td>{{ item['id'] }}</td>
                      <td>{{ item['name']|default('(' ~ item['id'] ~ ')') }}</td>
                   </tr>


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

The array key for entity names was renamed a while ago but the reference was not changed in the twig template.

