### PR TITLE
Fix wrong ldap group deletion

### DIFF
--- a/phpunit/LDAP/AuthLdapTest.php
+++ b/phpunit/LDAP/AuthLdapTest.php
@@ -44,7 +44,7 @@ use Glpi\Toolbox\Sanitizer;
 
 /* Test for inc/authldap.class.php */
 
-class AuthLDAPTest extends DbTestCase
+class AuthLdapTest extends DbTestCase
 {
     /**
      * @var \AuthLDAP

--- a/phpunit/LDAP/AuthLdapTest.php
+++ b/phpunit/LDAP/AuthLdapTest.php
@@ -2232,7 +2232,7 @@ class AuthLdapTest extends DbTestCase
         $group2_id = $this->createItem(Group::class, ["name" => "testgroup2"])->getID();
         $this->assertGreaterThan(0, $group2_id);
 
-        $group3_id = $this->createItem(Group::class, ["name" => "testgroup3", "ldap_field" => "uid", "ldap_value" => "brazil6"])->getID();
+        $group3_id = $this->createItem(Group::class, ["name" => "testgroup3", "ldap_field" => "login", "ldap_value" => "brazil6"])->getID();
         $this->assertGreaterThan(0, $group3_id);
 
         // Add groups with a rule

--- a/phpunit/LDAP/AuthLdapTest.php
+++ b/phpunit/LDAP/AuthLdapTest.php
@@ -2252,7 +2252,6 @@ class AuthLDAPTest extends DbTestCase
         $gu = new Group_User();
         $gus = $gu->find([
             'users_id' => $users_id,
-            'groups_id' => $group_id,
             'is_dynamic' => 1,
         ]);
         $this->assertCount(2, $gus);

--- a/phpunit/LDAP/AuthLdapTest.php
+++ b/phpunit/LDAP/AuthLdapTest.php
@@ -2232,6 +2232,9 @@ class AuthLDAPTest extends DbTestCase
         $group2_id = $this->createItem(Group::class, ["name" => "testgroup2"])->getID();
         $this->assertGreaterThan(0, $group2_id);
 
+        $group3_id = $this->createItem(Group::class, ["name" => "testgroup3", "ldap_field" => "uid", "ldap_value" => "brazil6"])->getID();
+        $this->assertGreaterThan(0, $group3_id);
+
         // Add groups with a rule
         $act_id = $this->createItem(\RuleAction::class, [
             'rules_id'    => $rules_id,
@@ -2252,7 +2255,10 @@ class AuthLDAPTest extends DbTestCase
             'groups_id' => $group_id,
             'is_dynamic' => 1,
         ]);
-        $this->assertCount(1, $gus);
+        $this->assertCount(2, $gus);
+
+        $this->assertTrue(\Group_User::isUserInGroup($users_id, $group_id));
+        $this->assertTrue(\Group_User::isUserInGroup($users_id, $group3_id));
 
         // update criteria
         $this->updateItem(\RuleAction::class, $act_id, [
@@ -2267,6 +2273,7 @@ class AuthLDAPTest extends DbTestCase
         // Check the dynamic group is deleted without losing the manual groups
         $this->assertFalse(\Group_User::isUserInGroup($users_id, $group_id));
         $this->assertTrue(\Group_User::isUserInGroup($users_id, $group2_id));
+        $this->assertTrue(\Group_User::isUserInGroup($users_id, $group3_id));
 
         // Create 2 manual groups
         $mgroup_id = $this->createItem(Group::class, ["name" => "manualgroup1"])->getID();

--- a/phpunit/LDAP/AuthLdapTest.php
+++ b/phpunit/LDAP/AuthLdapTest.php
@@ -2232,7 +2232,7 @@ class AuthLdapTest extends DbTestCase
         $group2_id = $this->createItem(Group::class, ["name" => "testgroup2"])->getID();
         $this->assertGreaterThan(0, $group2_id);
 
-        $group3_id = $this->createItem(Group::class, ["name" => "testgroup3", "ldap_field" => "login", "ldap_value" => "brazil6"])->getID();
+        $group3_id = $this->createItem(Group::class, ["name" => "testgroup3", "ldap_field" => "uid", "ldap_value" => "brazil6"])->getID();
         $this->assertGreaterThan(0, $group3_id);
 
         // Add groups with a rule
@@ -2248,6 +2248,9 @@ class AuthLdapTest extends DbTestCase
         $users_id = \User::getIdByName('brazil6');
         $this->assertGreaterThan(0, $users_id);
 
+        $this->assertTrue(\Group_User::isUserInGroup($users_id, $group_id));
+        $this->assertTrue(\Group_User::isUserInGroup($users_id, $group3_id));
+
         // Check group
         $gu = new Group_User();
         $gus = $gu->find([
@@ -2255,9 +2258,6 @@ class AuthLdapTest extends DbTestCase
             'is_dynamic' => 1,
         ]);
         $this->assertCount(2, $gus);
-
-        $this->assertTrue(\Group_User::isUserInGroup($users_id, $group_id));
-        $this->assertTrue(\Group_User::isUserInGroup($users_id, $group3_id));
 
         // update criteria
         $this->updateItem(\RuleAction::class, $act_id, [

--- a/src/User.php
+++ b/src/User.php
@@ -1430,8 +1430,11 @@ class User extends CommonDBTM
      */
     public function syncLdapGroups()
     {
-        /** @var \DBmysql $DB */
-        global $DB;
+        /**
+         * @var array $CFG_GLPI
+         * @var \DBmysql $DB
+         */
+        global $CFG_GLPI, $DB;
 
         // input["_groups"] not set when update from user.form or preference
         if (
@@ -1446,7 +1449,7 @@ class User extends CommonDBTM
                 if (count($authtype)) {
                     // Clean groups
                     $this->input["_groups"] = array_unique($this->input["_groups"]);
-                    $this->oldvalues["_ldap_groups"] = $this->input["_groups"];
+                    $CFG_GLPI["_ldap_groups"] = $this->input["_groups"];
 
                     // Delete not available groups like to LDAP
                     $iterator = $DB->request([
@@ -6584,6 +6587,9 @@ HTML;
      */
     public function applyGroupsRules()
     {
+        /** @var array $CFG_GLPI */
+        global $CFG_GLPI;
+
         if (!isset($this->input["_ldap_rules"]['groups_id'])) {
             if (isset($this->input["_ldap_rules"]) && isset($this->input['id'])) {
                 $group_user = new Group_User();
@@ -6592,7 +6598,7 @@ HTML;
                     'is_dynamic' => true,
                 ]);
                 foreach ($groups as $group) {
-                    if (!isset($this->oldvalues['_ldap_groups']) || !in_array($group['groups_id'], $this->oldvalues['_ldap_groups'])) {
+                    if (!isset($CFG_GLPI['_ldap_groups']) || !in_array($group['groups_id'], $CFG_GLPI['_ldap_groups'])) {
                         $group_user->delete($group);
                     }
                 }

--- a/src/User.php
+++ b/src/User.php
@@ -6596,7 +6596,7 @@ HTML;
                         $group_user->delete($group);
                     }
                 }
-                if (!isset($_SESSION['_ldap_groups'])) {
+                if (isset($_SESSION['_ldap_groups'])) {
                     unset($_SESSION['_ldap_groups']);
                 }
             }

--- a/src/User.php
+++ b/src/User.php
@@ -6597,6 +6597,9 @@ HTML;
                         $group_user->delete($group);
                     }
                 }
+                if (!isset($_SESSION['_ldap_groups'])) {
+                    unset($_SESSION['_ldap_groups']);
+                }
             }
             return;
         }

--- a/src/User.php
+++ b/src/User.php
@@ -1446,6 +1446,7 @@ class User extends CommonDBTM
                 if (count($authtype)) {
                     // Clean groups
                     $this->input["_groups"] = array_unique($this->input["_groups"]);
+                    $this->oldvalues["_ldap_groups"] = $this->input["_groups"];
 
                     // Delete not available groups like to LDAP
                     $iterator = $DB->request([
@@ -6591,7 +6592,9 @@ HTML;
                     'is_dynamic' => true,
                 ]);
                 foreach ($groups as $group) {
-                    $group_user->delete($group);
+                    if (!isset($this->oldvalues['_ldap_groups']) || !in_array($group['groups_id'], $this->oldvalues['_ldap_groups'])) {
+                        $group_user->delete($group);
+                    }
                 }
             }
             return;

--- a/src/User.php
+++ b/src/User.php
@@ -1430,11 +1430,8 @@ class User extends CommonDBTM
      */
     public function syncLdapGroups()
     {
-        /**
-         * @var array $CFG_GLPI
-         * @var \DBmysql $DB
-         */
-        global $CFG_GLPI, $DB;
+        /** @var \DBmysql $DB */
+        global $DB;
 
         // input["_groups"] not set when update from user.form or preference
         if (
@@ -1449,7 +1446,7 @@ class User extends CommonDBTM
                 if (count($authtype)) {
                     // Clean groups
                     $this->input["_groups"] = array_unique($this->input["_groups"]);
-                    $CFG_GLPI["_ldap_groups"] = $this->input["_groups"];
+                    $_SESSION["_ldap_groups"] = $this->input["_groups"];
 
                     // Delete not available groups like to LDAP
                     $iterator = $DB->request([
@@ -6587,8 +6584,6 @@ HTML;
      */
     public function applyGroupsRules()
     {
-        /** @var array $CFG_GLPI */
-        global $CFG_GLPI;
 
         if (!isset($this->input["_ldap_rules"]['groups_id'])) {
             if (isset($this->input["_ldap_rules"]) && isset($this->input['id'])) {
@@ -6598,7 +6593,7 @@ HTML;
                     'is_dynamic' => true,
                 ]);
                 foreach ($groups as $group) {
-                    if (!isset($CFG_GLPI['_ldap_groups']) || !in_array($group['groups_id'], $CFG_GLPI['_ldap_groups'])) {
+                    if (!isset($_SESSION['_ldap_groups']) || !in_array($group['groups_id'], $_SESSION['_ldap_groups'])) {
                         $group_user->delete($group);
                     }
                 }

--- a/src/User.php
+++ b/src/User.php
@@ -6584,7 +6584,6 @@ HTML;
      */
     public function applyGroupsRules()
     {
-
         if (!isset($this->input["_ldap_rules"]['groups_id'])) {
             if (isset($this->input["_ldap_rules"]) && isset($this->input['id'])) {
                 $group_user = new Group_User();


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !36835
- Here is a brief description of what this PR does
Fix accidental deletion of dynamic groups added by something other than rules

## Screenshots (if appropriate):


