### PR TITLE
Handle null helpdesk types for custom assets

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -3274,7 +3274,7 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Function json_decode is unsafe to use\\. It can return FALSE instead of throwing an exception\\. Please add \'use function Safe\\\\json_decode;\' at the beginning of the file to use the variant provided by the \'thecodingmachine/safe\' library\\.$#',
 	'identifier' => 'theCodingMachineSafe.function',
-	'count' => 4,
+	'count' => 2,
 	'path' => __DIR__ . '/src/Glpi/Asset/AssetDefinition.php',
 ];
 $ignoreErrors[] = [

--- a/src/Glpi/Asset/AssetDefinition.php
+++ b/src/Glpi/Asset/AssetDefinition.php
@@ -894,10 +894,7 @@ TWIG, $twig_params);
     {
         $enabled_profiles = [];
         foreach ($profile_data as $data) {
-            $helpdesk_item_types = json_decode($data['helpdesk_item_type'], associative: true) ?? [];
-            if (!is_array($helpdesk_item_types)) {
-                $helpdesk_item_types = [];
-            }
+            $helpdesk_item_types = importArrayFromDB($data['helpdesk_item_type']);
             if (in_array($this->getCustomObjectClassName(), $helpdesk_item_types, true)) {
                 $enabled_profiles[] = $data['id'];
             }
@@ -938,7 +935,7 @@ TWIG, $twig_params);
             'FROM' => Profile::getTable(),
         ]);
         foreach ($it as $data) {
-            $old_values[$data['id']] = json_decode($data['helpdesk_item_type'], associative: true);
+            $old_values[$data['id']] = importArrayFromDB($data['helpdesk_item_type']);
             if (!is_array($old_values[$data['id']])) {
                 $old_values[$data['id']] = [];
             }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

In some cases, `helpdesk_item_type` for a profile may be null and this wasn't handled in a few places for custom assets so it was triggering a deprecation for `json_decode`.
This only really happens if you create a new profile and never set anything on the Assistance tab in the web UI and save it, which was my case. It is probably also possible to get to this state when using the API to configure profile rights.