### PR TITLE
fix(forms): Exclude deleted forms froms service catalog and tiles display

### DIFF
--- a/phpunit/functional/Glpi/Form/FormTest.php
+++ b/phpunit/functional/Glpi/Form/FormTest.php
@@ -52,6 +52,7 @@ use Glpi\Form\QuestionType\QuestionTypeEmail;
 use Glpi\Form\QuestionType\QuestionTypeShortText;
 use Glpi\Form\QuestionType\QuestionTypesManager;
 use Glpi\Form\Section;
+use Glpi\Helpdesk\Tile\FormTile;
 use Glpi\Tests\FormBuilder;
 use Glpi\Tests\FormTesterTrait;
 use Log;
@@ -447,6 +448,7 @@ class FormTest extends DbTestCase
         $comments = countElementsInTable(Comment::getTable());
         $destinations = countElementsInTable(FormDestination::getTable());
         $access_controls = countElementsInTable(FormAccessControl::getTable());
+        $form_tiles = countElementsInTable(FormTile::getTable());
 
         // Test subject that we are going to delete
         $form_to_be_deleted = $this->createForm(
@@ -466,8 +468,16 @@ class FormTest extends DbTestCase
                 ->addAccessControl(DirectAccess::class, new DirectAccessConfig())
         );
 
+        // Add a tile to the form, it should be deleted with the form
+        $this->createItem(
+            FormTile::class,
+            [
+                Form::getForeignKeyField() => $form_to_be_deleted->getID(),
+            ]
+        );
+
         // Control subject that we are going to keep, its data shouldn't be deleted
-        $this->createForm(
+        $form_to_keep = $this->createForm(
             (new FormBuilder())
                 ->addSection('Section 1')
                 ->addQuestion('Question 1', QuestionTypeShortText::class)
@@ -477,6 +487,14 @@ class FormTest extends DbTestCase
                 ->addAccessControl(DirectAccess::class, new DirectAccessConfig())
         );
 
+        // Add a tile to the form, it should be kept with the form
+        $this->createItem(
+            FormTile::class,
+            [
+                Form::getForeignKeyField() => $form_to_keep->getID(),
+            ]
+        );
+
         // Count items before deletion
         $this->assertEquals(2 + $forms, countElementsInTable(Form::getTable()));
         $this->assertEquals(6 + $questions, countElementsInTable(Question::getTable()));
@@ -484,6 +502,7 @@ class FormTest extends DbTestCase
         $this->assertEquals(3 + $comments, countElementsInTable(Comment::getTable()));
         $this->assertEquals(4 + $destinations, countElementsInTable(FormDestination::getTable())); // +1 mandatory for each form
         $this->assertEquals(3 + $access_controls, countElementsInTable(FormAccessControl::getTable()));
+        $this->assertEquals(2 + $form_tiles, countElementsInTable(FormTile::getTable()));
 
         // Delete item
         $this->deleteItem(
@@ -499,6 +518,7 @@ class FormTest extends DbTestCase
         $this->assertEquals(1 + $comments, countElementsInTable(Comment::getTable()));
         $this->assertEquals(2 + $destinations, countElementsInTable(FormDestination::getTable()));
         $this->assertEquals(1 + $access_controls, countElementsInTable(FormAccessControl::getTable()));
+        $this->assertEquals(1 + $form_tiles, countElementsInTable(FormTile::getTable()));
     }
 
     /**

--- a/src/Glpi/Form/Form.php
+++ b/src/Glpi/Form/Form.php
@@ -57,6 +57,7 @@ use Glpi\Form\Condition\ConditionableVisibilityInterface;
 use Glpi\Form\Condition\ConditionableVisibilityTrait;
 use Glpi\Form\QuestionType\QuestionTypesManager;
 use Glpi\Form\ServiceCatalog\ServiceCatalogLeafInterface;
+use Glpi\Helpdesk\Tile\FormTile;
 use Glpi\UI\IllustrationManager;
 use Glpi\ItemTranslation\Context\TranslationHandler;
 use Glpi\ItemTranslation\Context\ProvideTranslationsInterface;
@@ -381,6 +382,7 @@ final class Form extends CommonDBTM implements
                 Section::class,
                 FormDestination::class,
                 FormAccessControl::class,
+                FormTile::class,
             ]
         );
     }

--- a/src/Glpi/Form/ServiceCatalog/Provider/FormProvider.php
+++ b/src/Glpi/Form/ServiceCatalog/Provider/FormProvider.php
@@ -69,7 +69,8 @@ final class FormProvider implements LeafProviderInterface
 
         $forms = [];
         $raw_forms = (new Form())->find([
-            'is_active' => 1,
+            'is_active'           => 1,
+            'is_deleted'          => 0,
             'forms_categories_id' => $category ? $category->getID() : 0,
         ] + $entity_restriction, ['name']);
 

--- a/src/Glpi/Helpdesk/Tile/FormTile.php
+++ b/src/Glpi/Helpdesk/Tile/FormTile.php
@@ -126,8 +126,18 @@ final class FormTile extends CommonDBChild implements TileInterface
     {
         $form_access_manager = FormAccessControlManager::getInstance();
 
+        // Form must be defined
+        if ($this->form === null) {
+            return false;
+        }
+
         // Form must be active
         if (!$this->form->isActive()) {
+            return false;
+        }
+
+        // Form must not be deleted
+        if ($this->form->isDeleted()) {
             return false;
         }
 

--- a/tests/cypress/e2e/self-service/home_config.cy.js
+++ b/tests/cypress/e2e/self-service/home_config.cy.js
@@ -313,7 +313,7 @@ describe(`Helpdesk home page configuration - entities specific`, () => {
         cy.createWithAPI("Entity", {
             'name': `Entity for e2e tests ${(new Date()).getTime()}`,
             'entities_id': 1, // E2ETestEntity
-        }).then((id) => {
+        }).as('entityId').then((id) => {
             cy.visit(`/front/entity.form.php?id=${id}&forcetab=Entity$9`);
         });
     });
@@ -469,6 +469,79 @@ describe(`Helpdesk home page configuration - entities specific`, () => {
             });
             validateSvgSpriteIsShown();
         });
+    });
+
+    it('tiles with deleted form are not displayed', () => {
+        const uuid = Cypress._.random(0, 1e6);
+
+        // Create a form
+        cy.get('@entityId').then((entityId) => {
+            cy.createFormWithAPI({
+                'name': `Test form - ${uuid}`,
+                'is_active': true,
+                'entities_id': entityId,
+            }).as('formId');
+        });
+
+        // Create a form tile
+        cy.findByRole('button', {
+            name: "Define tiles for this entity from scratch"
+        }).click();
+        cy.findByRole('button', {name: "Add tile"}).click();
+        cy.getDropdownByLabelText('Type').selectDropdownValue('Form');
+        cy.getDropdownByLabelText('Target form').selectDropdownValue(`Test form - ${uuid}`);
+        cy.findByRole('dialog').findByRole('button', {name: 'Add tile'}).click();
+        cy.findAllByRole('alert')
+            .contains("Configuration updated successfully.")
+            .should('be.visible')
+        ;
+
+        // Save the configuration
+        cy.findByRole('button', {name: "Save tiles order"}).click();
+        cy.findAllByRole('alert')
+            .contains("Configuration updated successfully.")
+            .should('be.visible')
+        ;
+
+        // Validate the tile is displayed
+        cy.changeProfile('Self-Service');
+        cy.get('@entityId').then((entityId) => cy.changeEntity(entityId));
+        cy.visit('/Helpdesk');
+        cy.findByRole('heading', {name: `Test form - ${uuid}`}).should('be.visible');
+
+        // Delete the form
+        cy.changeProfile('Super-Admin');
+        cy.get('@formId').then(formId => {
+            // Visit the form to ensure it exists
+            cy.visit(`front/form/form.form.php?id=${formId}`);
+        });
+        cy.findByRole('button', {'name': 'Put in trashbin'}).click();
+        cy.findByRole('alert').should('contain.text', 'Item successfully deleted');
+
+        // Go back to the self-service page
+        cy.changeProfile('Self-Service');
+        cy.get('@entityId').then((entityId) => cy.changeEntity(entityId));
+        cy.visit('/Helpdesk');
+
+        // Validate the tile is not displayed anymore
+        cy.findByRole('heading', {name: `Test form - ${uuid}`}).should('not.exist');
+
+        // Purge the form
+        cy.changeProfile('Super-Admin');
+        cy.get('@formId').then(formId => {
+            // Visit the form to ensure it exists
+            cy.visit(`front/form/form.form.php?id=${formId}`);
+        });
+        cy.findByRole('button', {'name': 'Delete permanently'}).click();
+        cy.findByRole('alert').should('contain.text', 'Item successfully purged');
+
+        // Go back to the self-service page
+        cy.changeProfile('Self-Service');
+        cy.get('@entityId').then((entityId) => cy.changeEntity(entityId));
+        cy.visit('/Helpdesk');
+
+        // Validate the tile is not displayed anymore
+        cy.findByRole('heading', {name: `Test form - ${uuid}`}).should('not.exist');
     });
 });
 


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

- It fixes #19926

Soft-deleted forms were still displayed in the service catalog and could also be displayed via tiles.
Tiles pointing to a completely deleted form returned an error.