### PR TITLE
fix(forms): Prevent access to deleted forms

### DIFF
--- a/phpunit/functional/Glpi/Form/AccessControl/FormAccessControlManagerTest.php
+++ b/phpunit/functional/Glpi/Form/AccessControl/FormAccessControlManagerTest.php
@@ -236,6 +236,46 @@ final class FormAccessControlManagerTest extends DbTestCase
         );
     }
 
+    public function testDeletedFormCannotBeAnswered(): void
+    {
+        // Create a form with active access controls
+        $form = $this->createAndGetFormAccessibleOnlyToTechUserWithMandatoryToken();
+
+        // Ensure the form can be answered before deletion
+        $this->checkCanAnswerForm(
+            form: $form,
+            parameters: self::getTechUserAndValidTokenParameters(),
+            expected: true,
+        );
+
+        // Mark the form as deleted by setting is_deleted = 1
+        $this->updateItem(
+            Form::class,
+            $form->getID(),
+            ['is_deleted' => 1]
+        );
+
+        // Reload the form to get the updated state
+        $form->getFromDB($form->getID());
+
+        // Verify that the form cannot be answered when deleted
+        $this->checkCanAnswerForm(
+            form: $form,
+            parameters: self::getTechUserAndValidTokenParameters(),
+            expected: false,
+        );
+
+        // Also test with admin bypass
+        $admin_parameters = new FormAccessParameters(
+            bypass_restriction: true,
+        );
+        $this->checkCanAnswerForm(
+            form: $form,
+            parameters: $admin_parameters,
+            expected: true,
+        );
+    }
+
     private function checkCanAnswerForm(
         Form $form,
         FormAccessParameters $parameters,

--- a/src/Glpi/Form/AccessControl/FormAccessControlManager.php
+++ b/src/Glpi/Form/AccessControl/FormAccessControlManager.php
@@ -121,6 +121,10 @@ final class FormAccessControlManager
             return true;
         }
 
+        if ($form->isDeleted()) {
+            return false;
+        }
+
         if (!$form->isActive()) {
             return false;
         }


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Currently, forms placed in the trash can be viewed by end users.
It is also possible to respond to this form.
This fix prevents end users from viewing and responding to the form while allowing the administrator to edit and preview it.