### PR TITLE
Fix photoswipe twig js boolean params

### DIFF
--- a/templates/components/photoswipe.html.twig
+++ b/templates/components/photoswipe.html.twig
@@ -111,8 +111,8 @@
             dataSource: {{ imgs|json_encode|raw }},
             index: $(this).closest('figure').parent().index(),
 
-            close: {{ controls is defined ? controls.close|json_encode() : false }},
-            zoom: {{ controls is defined ? controls.zoom|json_encode() : false }},
+            close: {{ controls is defined ? controls.close|json_encode() : 'false' }},
+            zoom: {{ controls is defined ? controls.zoom|json_encode() : 'false' }},
 
             arrowNextTitle: __('Next (arrow right)'),
             arrowPrevTitle: __('Previous (arrow left)'),


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

With recent Twig changes, this code was changed to default to `false` if the parameters were no explicitly specified, which resulted in nothing being printed in the generated JS code for two object values which is not valid.

