### PR TITLE
Fix legacy itemtype router

### DIFF
--- a/phpunit/functional/Glpi/Kernel/Listener/RequestListener/LegacyItemtypeRouteListenerTest.php
+++ b/phpunit/functional/Glpi/Kernel/Listener/RequestListener/LegacyItemtypeRouteListenerTest.php
@@ -443,6 +443,10 @@ final class LegacyItemtypeRouteListenerTest extends TestCase
             'path_info' => '/plugins/tester/front/mypsr4dropdown.php',
             'class'     => \GlpiPlugin\Tester\MyPsr4Dropdown::class,
         ];
+                yield [
+            'path_info' => '/plugins/tester/front/computer.php',
+            'class'     => \GlpiPlugin\Tester\Computer::class,
+        ];
     }
 
     private function createRequest(string $path_info): Request

--- a/phpunit/functional/Glpi/Kernel/Listener/RequestListener/LegacyItemtypeRouteListenerTest.php
+++ b/phpunit/functional/Glpi/Kernel/Listener/RequestListener/LegacyItemtypeRouteListenerTest.php
@@ -443,7 +443,7 @@ final class LegacyItemtypeRouteListenerTest extends TestCase
             'path_info' => '/plugins/tester/front/mypsr4dropdown.php',
             'class'     => \GlpiPlugin\Tester\MyPsr4Dropdown::class,
         ];
-                yield [
+        yield [
             'path_info' => '/plugins/tester/front/computer.php',
             'class'     => \GlpiPlugin\Tester\Computer::class,
         ];

--- a/src/Glpi/Kernel/Listener/RequestListener/LegacyItemtypeRouteListener.php
+++ b/src/Glpi/Kernel/Listener/RequestListener/LegacyItemtypeRouteListener.php
@@ -348,12 +348,6 @@ final readonly class LegacyItemtypeRouteListener implements EventSubscriberInter
             return null;
         }
 
-        $item = \getItemForItemtype($itemtype);
-
-        if ($item instanceof CommonGLPI) {
-            return $item::class;
-        }
-
         // PluginMyPluginItem -> /plugins/myplugin/front/item.php
         $legacy_item = \getItemForItemtype(\sprintf('Plugin%s%s', ucfirst($plugin), ucfirst($itemtype)));
         if ($legacy_item instanceof CommonGLPI) {

--- a/tests/fixtures/plugins/tester/src/Computer.php
+++ b/tests/fixtures/plugins/tester/src/Computer.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace GlpiPlugin\Tester;
+
+use CommonDBTM;
+
+final class Computer extends CommonDBTM
+{
+    public static function getTypeName($nb = 0): string
+    {
+        return 'Tester Computer';
+    }
+}


### PR DESCRIPTION

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

**Prevent incorrect redirection when a plugin itemtype shares the same name as a native GLPI itemtype**

In the case of the `PluginCollaborativetoolsWebHook` itemtype, an issue arises when using the generic controller.

Specifically, the plugin’s `webhook.php` controller is mistakenly interpreted as GLPI’s native `webhook.php`, leading to an incorrect redirection or execution context.

This fix ensures that the correct controller is resolved when an itemtype provided by a plugin has the same class name or file name as a native GLPI component.

## Screenshots (if appropriate):


