### PR TITLE
fix invalid reference to cfg_glpi in socket form

### DIFF
--- a/templates/pages/assets/socket_networkport.html.twig
+++ b/templates/pages/assets/socket_networkport.html.twig
@@ -46,7 +46,7 @@
 {% do call('Ajax::updateItemOnSelectEvent', [
     'dropdown_itemtype' ~ rand,
     'show_items_id_field',
-    config('root_doc') ~ '/ajax/cable.php',
+    path('/ajax/cable.php'),
     {
         itemtype: '__VALUE__',
         dom_rand: rand,


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

A real bug found by having strict variables enabled in Twig. `CFG_GLPI['root_doc']` was used mistakenly in Twig instead of `config('root_doc')`.
