### PR TITLE
Change reservation modals to use ajax endpoint

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -7528,7 +7528,7 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Function strtotime is unsafe to use\\. It can return FALSE instead of throwing an exception\\. Please add \'use function Safe\\\\strtotime;\' at the beginning of the file to use the variant provided by the \'thecodingmachine/safe\' library\\.$#',
 	'identifier' => 'theCodingMachineSafe.function',
-	'count' => 42,
+	'count' => 43,
 	'path' => __DIR__ . '/src/Reservation.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -7528,7 +7528,7 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Function strtotime is unsafe to use\\. It can return FALSE instead of throwing an exception\\. Please add \'use function Safe\\\\strtotime;\' at the beginning of the file to use the variant provided by the \'thecodingmachine/safe\' library\\.$#',
 	'identifier' => 'theCodingMachineSafe.function',
-	'count' => 43,
+	'count' => 41,
 	'path' => __DIR__ . '/src/Reservation.php',
 ];
 $ignoreErrors[] = [

--- a/ajax/reservations.php
+++ b/ajax/reservations.php
@@ -62,11 +62,7 @@ if (($_POST['action'] ?? null) === "update_event") {
 Html::header_nocache();
 header("Content-Type: text/html; charset=UTF-8");
 
-if ($_REQUEST["action"] == "add_reservation_fromselect") {
+if ($_REQUEST["action"] == "add_edit_reservation_fromselect") {
     $reservation = new Reservation();
-    $reservation->showForm(0, [
-        'item'  => [(int) $_REQUEST['id']],
-        'begin' => $_REQUEST['start'],
-        'end'   => $_REQUEST['end'],
-    ]);
+    $reservation->showForm($_REQUEST['id'], $_REQUEST);
 }

--- a/front/reservation.form.php
+++ b/front/reservation.form.php
@@ -46,10 +46,7 @@ Session::checkRight("reservation", ReservationItem::RESERVEANITEM);
 
 $rr = new Reservation();
 
-if (isset($_REQUEST['ajax'])) {
-    Html::header_nocache();
-    Html::popHeader(__('Simplified interface'));
-} elseif (Session::getCurrentInterface() == "helpdesk") {
+if (Session::getCurrentInterface() == "helpdesk") {
     Html::helpHeader(__('Simplified interface'));
 } else {
     Html::header(Reservation::getTypeName(Session::getPluralNumber()), '', "tools", "reservationitem");
@@ -108,9 +105,7 @@ if (isset($_POST["update"])) {
     }
 }
 
-if (isset($_REQUEST['ajax'])) {
-    Html::popFooter();
-} elseif (Session::getCurrentInterface() == "helpdesk") {
+if (Session::getCurrentInterface() == "helpdesk") {
     Html::helpFooter();
 } else {
     Html::footer();

--- a/js/reservations.js
+++ b/js/reservations.js
@@ -238,9 +238,10 @@ var Reservations = function() {
                         title: __("Add reservation"),
                         url: `${CFG_GLPI.root_doc}/ajax/reservations.php`,
                         params: {
-                            action: 'add_reservation_fromselect',
-                            id:     my.id,
-                            start:  info.start.toISOString(),
+                            action: 'add_edit_reservation_fromselect',
+                            id: 0,
+                            item:     [my.id],
+                            begin:  info.start.toISOString(),
                             end:    info.end.toISOString(),
                         },
                         dialogclass: 'modal-lg',
@@ -263,7 +264,7 @@ var Reservations = function() {
 
                 glpi_ajax_dialog({
                     title: __("Edit reservation"),
-                    url: `${ajaxurl}&ajax=true`,
+                    url: `${ajaxurl}`,
                     dialogclass: 'modal-lg',
                 });
             }

--- a/src/Reservation.php
+++ b/src/Reservation.php
@@ -497,8 +497,11 @@ JAVASCRIPT;
 
     public static function getEvents(array $params): array
     {
-        /** @var \DBmysql $DB */
-        global $DB;
+        /**
+         * @var \DBmysql $DB
+         * @var array $CFG_GLPI
+         */
+        global $DB, $CFG_GLPI;
 
         $defaults = [
             'start'               => '',
@@ -589,7 +592,7 @@ JAVASCRIPT;
                 'itemtype'    => $data['itemtype'],
                 'items_id'    => $data['items_id'],
                 'color'       => Toolbox::getColorForString($name),
-                'ajaxurl'     => self::getFormURLWithID($data['id']),
+                'ajaxurl'     => $CFG_GLPI['root_doc'] . '/ajax/reservations.php?action=add_edit_reservation_fromselect&id=' . $data['id'],
                 'editable'    => $editable, // "editable" is used by fullcalendar, but is not accessible
                 '_editable'   => $editable, // "_editable" will be used by custom event handlers
             ];
@@ -703,7 +706,7 @@ JAVASCRIPT;
         } else {
             $resa->getEmpty();
             $options = Planning::cleanDates($options);
-            $resa->fields["begin"] = date("Y-m-d H:i:s", strtotime($options['begin']));
+            $resa->fields["begin"] = !empty($options['begin']) ? date("Y-m-d H:i:s", strtotime($options['begin'])) : date('Y-m-d H:00:00');
             if (!isset($options['end'])) {
                 $resa->fields["end"] = date("Y-m-d H:00:00", strtotime($resa->fields["begin"]) + HOUR_TIMESTAMP);
             } else {

--- a/src/Reservation.php
+++ b/src/Reservation.php
@@ -706,7 +706,7 @@ JAVASCRIPT;
         } else {
             $resa->getEmpty();
             $options = Planning::cleanDates($options);
-            $resa->fields["begin"] = !empty($options['begin']) ? date("Y-m-d H:i:s", strtotime($options['begin'])) : date('Y-m-d H:00:00', strtotime(Session::getCurrentTime()));
+            $resa->fields["begin"] = !empty($options['begin']) ? date("Y-m-d H:i:s", Safe\strtotime($options['begin'])) : date('Y-m-d H:00:00', Safe\strtotime(Session::getCurrentTime()));
             if (!isset($options['end'])) {
                 $resa->fields["end"] = date("Y-m-d H:00:00", strtotime($resa->fields["begin"]) + HOUR_TIMESTAMP);
             } else {

--- a/src/Reservation.php
+++ b/src/Reservation.php
@@ -706,7 +706,7 @@ JAVASCRIPT;
         } else {
             $resa->getEmpty();
             $options = Planning::cleanDates($options);
-            $resa->fields["begin"] = !empty($options['begin']) ? date("Y-m-d H:i:s", strtotime($options['begin'])) : date('Y-m-d H:00:00');
+            $resa->fields["begin"] = !empty($options['begin']) ? date("Y-m-d H:i:s", strtotime($options['begin'])) : date('Y-m-d H:00:00', strtotime(Session::getCurrentTime()));
             if (!isset($options['end'])) {
                 $resa->fields["end"] = date("Y-m-d H:00:00", strtotime($resa->fields["begin"]) + HOUR_TIMESTAMP);
             } else {

--- a/templates/components/form/reservation.html.twig
+++ b/templates/components/form/reservation.html.twig
@@ -178,6 +178,7 @@
         item.fields['comment'],
         __("Comments"),
         {
+            full_width          : true,
             enable_richtext     : true,
             enable_fileupload   : false,
             cols                : 30,

--- a/tests/cypress/e2e/Tools/reservations.cy.js
+++ b/tests/cypress/e2e/Tools/reservations.cy.js
@@ -1,0 +1,67 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+describe('Reservations', () => {
+    before(() => {
+        // Create a computer that can be reserved
+        cy.createWithAPI('Computer', { name: 'Reservable computer', entities_id: 1 }).then((computers_id) => {
+            cy.createWithAPI('ReservationItem', { itemtype: 'Computer', items_id: computers_id }).as('reservation_items_id');
+        });
+    });
+    beforeEach(() => {
+        cy.login();
+        cy.changeProfile('Super-Admin');
+    });
+    it('Create a reservation and view', () => {
+        cy.get('@reservation_items_id').then((reservation_items_id) => {
+            cy.visit(`/front/reservation.php?reservationitems_id=${reservation_items_id}`);
+            //FIXME Work around known issue with sector-based JS loading not always loading the TinyMCE library in time
+            cy.on('uncaught:exception', (err) => {
+                if (err.message.includes('tinyMCE is not defined')) {
+                    return false;
+                }
+            });
+            cy.get('.fc-week .fc-day').first().click();
+            cy.findByRole('dialog', {name: 'Add reservation'}).within(() => {
+                cy.contains('Reservable computer');
+                cy.getDropdownByLabelText('By').selectDropdownValue('e2e_tests');
+                cy.findByRole('button', { name: 'Add' }).click();
+            });
+
+            cy.get('.fc-day-grid-event').first().click();
+            cy.findByRole('dialog', {name: 'Edit reservation'}).within(() => {
+                cy.contains('Reservable computer');
+                cy.findByRole('button', { name: 'Close' }).click();
+            });
+        });
+    });
+});

--- a/tests/cypress/e2e/Tools/reservations.cy.js
+++ b/tests/cypress/e2e/Tools/reservations.cy.js
@@ -53,7 +53,7 @@ describe('Reservations', () => {
             cy.get('.fc-week .fc-day').first().click();
             cy.findByRole('dialog', {name: 'Add reservation'}).within(() => {
                 cy.contains('Reservable computer');
-                cy.getDropdownByLabelText('By').selectDropdownValue('e2e_tests');
+                cy.getDropdownByLabelText('By').selectDropdownValue('E2E Tests');
                 cy.findByRole('button', { name: 'Add' }).click();
             });
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

Fixes #19946. Loading duplicate JS and other resources cause the page scripts to break. This PR makes the modal load using the AJAX endpoint for both new and editing reservations in modals. Previously, only new reservations were loaded using the AJAX script.