### PR TITLE
Remove lowered opacities for some forms UI

### DIFF
--- a/templates/pages/admin/form/access_control.html.twig
+++ b/templates/pages/admin/form/access_control.html.twig
@@ -65,8 +65,6 @@
 
                 <section
                     class="mb-5"
-                    style="{{ access_control.fields.is_active == false ? "opacity: 0.5" : "" }}"
-                    {# Disabled item are showed with a lower opacity #}
                     data-glpi-toggle-control-target
                     data-glpi-access-control-form
                     aria-label="{{ strategy.getLabel() }}"
@@ -121,13 +119,6 @@
 </div>
 
 <script>
-    // Toggle disabled state
-    $("[data-glpi-toggle-control]").on("change", function() {
-        $(this).closest("[data-glpi-toggle-control-target]")
-            .css("opacity", this.checked ? 1 : 0.5)
-        ;
-    });
-
     // Toggle state if any input is modified
     $("section[data-glpi-access-control-form] :input").on("change", function(e) {
         // Do not trigger on this is_active checkbox itself

--- a/templates/pages/admin/form/access_control.html.twig
+++ b/templates/pages/admin/form/access_control.html.twig
@@ -119,20 +119,6 @@
 </div>
 
 <script>
-    // Toggle state if any input is modified
-    $("section[data-glpi-access-control-form] :input").on("change", function(e) {
-        // Do not trigger on this is_active checkbox itself
-        if ($(this).data("glpi-toggle-control") !== undefined) {
-            return;
-        }
-
-        $(this).closest("section")
-            .find("[data-glpi-toggle-control]")
-            .prop("checked", true)
-            .trigger("change")
-        ;
-    });
-
     $('input[data-glpi-toggle-control]').on('change', (e) => {
         $(e.currentTarget).closest('section').find('.access-control-config-form').toggle(e.currentTarget.checked);
     }).trigger('change');

--- a/templates/pages/admin/form/access_control.html.twig
+++ b/templates/pages/admin/form/access_control.html.twig
@@ -89,7 +89,7 @@
                             >
                         </label>
                     </h3>
-                    <div>
+                    <div class="access-control-config-form">
                         {# Render custom config form #}
                         {{ strategy.renderConfigForm(access_control)|raw }}
                     </div>
@@ -132,4 +132,8 @@
             .trigger("change")
         ;
     });
+
+    $('input[data-glpi-toggle-control]').on('change', (e) => {
+        $(e.currentTarget).closest('section').find('.access-control-config-form').toggle(e.currentTarget.checked);
+    }).trigger('change');
 </script>

--- a/templates/pages/admin/form/service_catalog_tab.html.twig
+++ b/templates/pages/admin/form/service_catalog_tab.html.twig
@@ -34,9 +34,7 @@
 
 <form method="POST" action="{{ item.getFormURL() }}" data-submit-once>
     <div class="py-2 px-3 container-narrow ms-0">
-        <section data-service-catalog-config
-            style="{{ item.isField('show_in_service_catalog') and item.fields.show_in_service_catalog ? "opacity: 0.5" : "" }}"
-        >
+        <section data-service-catalog-config>
             <h2 class="d-flex align-items-center">
                 <i class="{{ icon }} me-2"></i>
                 {{ __("Service catalog configuration") }}
@@ -45,8 +43,6 @@
                         <input type="hidden" value="0" name="show_in_service_catalog">
                         <input aria-label="{{ __(" Active") }}" class="form-check-input" type="checkbox"
                             name="show_in_service_catalog" value="1"
-                            onchange="$('[data-service-catalog-config]').css('opacity', this.checked ? 1 : 0.5)"
-                            {{ item.fields.show_in_service_catalog == true ? "checked" : "" }}
                         >
                     </label>
                 {% endif %}

--- a/templates/pages/admin/form/service_catalog_tab.html.twig
+++ b/templates/pages/admin/form/service_catalog_tab.html.twig
@@ -43,6 +43,7 @@
                         <input type="hidden" value="0" name="show_in_service_catalog">
                         <input aria-label="{{ __(" Active") }}" class="form-check-input" type="checkbox"
                             name="show_in_service_catalog" value="1"
+                            {{ item.fields.show_in_service_catalog == true ? "checked" : "" }}
                         >
                     </label>
                 {% endif %}

--- a/tests/cypress/e2e/form/access_policies/access_control.cy.js
+++ b/tests/cypress/e2e/form/access_policies/access_control.cy.js
@@ -111,20 +111,4 @@ describe('Access Control', () => {
             });
         });
     });
-    it('activate policy when any input is modified', () => {
-        cy.findByRole('region', {
-            name: 'Allow direct access'
-        }).within(() => {
-            cy.findByRole('checkbox', {name: 'Active'})
-                .should('not.be.checked')
-            ;
-            cy.findByRole('checkbox', {name: 'Allow unauthenticated users ?'})
-                .should('not.be.checked')
-                .click()
-            ;
-            cy.findByRole('checkbox', {name: 'Active'})
-                .should('be.checked')
-            ;
-        });
-    });
 });

--- a/tests/cypress/e2e/form/form_plugins.cy.js
+++ b/tests/cypress/e2e/form/form_plugins.cy.js
@@ -75,12 +75,10 @@ describe('Form plugins', () => {
             name: 'Restrict access to a specific day of the week'
         }).within(() => {
             // Validate default values
-            cy.getDropdownByLabelText('Day').should('have.text', "Monday");
             cy.findByRole('checkbox', {name: 'Active'}).should('not.be.checked');
-
-            // Apply config
+            cy.findByRole('checkbox', {name: 'Active'}).check();
+            cy.getDropdownByLabelText('Day').should('have.text', "Monday");
             cy.getDropdownByLabelText('Day').selectDropdownValue('Thursday');
-            cy.findByRole('checkbox', {name: 'Active'}).should('be.checked');
         });
 
         // Save and reload


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

50% opacity for elements can be an accessibility issue when we expect the elements to still be interactive.

This is very easy to see when using the accessibility options in the Rendering tab of the Chrome dev tools.

Reduced contrast vision deficiencies emulation:
![Selection_500](https://github.com/user-attachments/assets/0939563c-c8ed-49d9-a449-87b54a39a983)

The toggle to enable direct access is completely invisible for me with the vision deficiency emulation.

Also, for the Service Catalog tab for KB items it isn't immediately obvious why the tab gets faded out when the article is in the service catalog; Nothing is disabled.

If there are other suggestions for conveying some meanings these locations, I am open to making those changes here.