### PR TITLE
Drop tests that depends on 3rd party lib version

### DIFF
--- a/phpunit/functional/Glpi/UI/IllustrationManagerTest.php
+++ b/phpunit/functional/Glpi/UI/IllustrationManagerTest.php
@@ -85,38 +85,16 @@ final class IllustrationManagerTest extends GLPITestCase
         yield [
             'page' => 1,
             'page_size' => 3,
-            'expected' => [
-                'advanced-dashboards',
-                'alert',
-                'anonymise',
-            ],
         ];
 
         yield [
             'page' => 2,
             'page_size' => 3,
-            'expected' => [
-                'anonymize-alt',
-                'ansible',
-                'antivirus',
-            ],
         ];
 
         yield [
             'page' => 1,
             'page_size' => 10,
-            'expected' => [
-                'advanced-dashboards',
-                'alert',
-                'anonymise',
-                'anonymize-alt',
-                'ansible',
-                'antivirus',
-                'application',
-                'application-altenative',
-                'application-edit',
-                'approval-by-mail',
-            ],
         ];
     }
 
@@ -124,14 +102,10 @@ final class IllustrationManagerTest extends GLPITestCase
     public function testSearchIconsIdsUsingPagination(
         int $page,
         int $page_size,
-        array $expected,
     ): void {
         // Act: get icons matching the requester filter.
         $manager = new IllustrationManager();
         $ids = $manager->searchIcons(page: $page, page_size: $page_size);
-
-        // Assert: the expected icons ids are found
-        $this->assertEquals($expected, $ids);
     }
 
     public function testIllustrationsTranslationsAreGenerated(): void

--- a/tests/cypress/e2e/form/form_category.cy.js
+++ b/tests/cypress/e2e/form/form_category.cy.js
@@ -45,7 +45,7 @@ describe('Form category', () => {
         cy.findByRole('button', { name: 'Select an illustration' }).click();
         cy.findByRole('dialog').as('modal');
         cy.get('@modal').should('have.attr', 'data-cy-shown', 'true');
-        cy.get('@modal').findByRole('img', { name: 'Car' }).click();
+        cy.get('@modal').findByRole('img', { name: 'Cartridge' }).click();
 
         // Create and go to the new category
         cy.findByRole('button', { name: 'Add' }).click();
@@ -56,7 +56,7 @@ describe('Form category', () => {
         cy.findByLabelText('Description')
             .should('have.value', '<p>This is a test category</p>')
             .awaitTinyMCE().should('have.text', 'This is a test category');
-        cy.findByRole('img', { name: 'Car' }).should('be.visible');
+        cy.findByRole('img', { name: 'Cartridge' }).should('be.visible');
     });
 
     it('can open illustration picker, show forms attached to the category and go back to illustration picker', () => {
@@ -76,9 +76,9 @@ describe('Form category', () => {
         cy.findByRole('button', { name: 'Select an illustration' }).click();
         cy.findByRole('dialog').as('modal');
         cy.get('@modal').should('have.attr', 'data-cy-shown', 'true');
-        cy.get('@modal').findByRole('img', { name: 'Car' }).click();
+        cy.get('@modal').findByRole('img', { name: 'Cartridge' }).click();
         cy.get('@modal').should('not.exist');
-        cy.findByRole('img', { name: 'Car' }).should('be.visible');
+        cy.findByRole('img', { name: 'Cartridge' }).should('be.visible');
 
         // Go to forms tab
         cy.findByRole('tab', { name: 'Forms 1' }).click();
@@ -88,8 +88,8 @@ describe('Form category', () => {
         cy.findByRole('tab', { name: 'Service catalog category' }).click();
         cy.findByRole('button', { name: 'Select an illustration' }).click();
         cy.get('@modal').should('have.attr', 'data-cy-shown', 'true');
-        cy.get('@modal').findByRole('img', { name: 'Car' }).click();
+        cy.get('@modal').findByRole('img', { name: 'Cartridge' }).click();
         cy.get('@modal').should('not.exist');
-        cy.findByRole('img', { name: 'Car' }).should('be.visible');
+        cy.findByRole('img', { name: 'Cartridge' }).should('be.visible');
     });
 });

--- a/tests/cypress/e2e/illustration_picker.cy.js
+++ b/tests/cypress/e2e/illustration_picker.cy.js
@@ -73,9 +73,9 @@ describe('Illustration picker', () => {
             'Network equipment',
         ];
         const icons_from_second_page = [
-            'Folder',
-            'Gear',
-            'Group',
+            'Browse help articles',
+            'Car',
+            'Area chart',
         ];
 
         // We are on the first page by default.

--- a/tests/cypress/e2e/illustration_picker.cy.js
+++ b/tests/cypress/e2e/illustration_picker.cy.js
@@ -74,8 +74,8 @@ describe('Illustration picker', () => {
         ];
         const icons_from_second_page = [
             'Browse help articles',
-            'Car',
             'Area chart',
+            'Search chart',
         ];
 
         // We are on the first page by default.


### PR DESCRIPTION
Until there is a way to get results from 3rd party libs that do not change between versions; this almost just cause noise. see: #19397, #19544 and #20024.