### PR TITLE
Deprecated QuerySubQuery class misses alias argument

### DIFF
--- a/src/QuerySubQuery.php
+++ b/src/QuerySubQuery.php
@@ -38,9 +38,9 @@
  */
 class QuerySubQuery extends Glpi\DBAL\QuerySubQuery
 {
-    public function __construct($expression)
+    public function __construct($expression, $alias = null)
     {
         Toolbox::deprecated('\QuerySubQuery is deprecated, use \Glpi\DBAL\QuerySubQuery instead');
-        parent::__construct($expression);
+        parent::__construct($expression, $alias);
     }
 }


### PR DESCRIPTION

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Class QuerySubQuery had 2 arguments in GLPI 10; the 2nd was used to specify the alias of a subquery. The Retrocompatibility implementation does not contains that argument anymore, causing broken SQL queries 

This PR restores the missing argument and transmits it to the new implementation.

## Screenshots (if appropriate):


