### PR TITLE
fix(forms): change `answers` field type to longtext in forms_answerssets

### DIFF
--- a/install/migrations/update_10.0.x_to_11.0.0/form.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/form.php
@@ -175,7 +175,7 @@ if (!$DB->tableExists('glpi_forms_answerssets')) {
             `date_creation` timestamp NULL DEFAULT NULL,
             `date_mod` timestamp NULL DEFAULT NULL,
             `index` int NOT NULL DEFAULT '0',
-            `answers` text COMMENT 'JSON - Answers for each questions of the parent form',
+            `answers` longtext COMMENT 'JSON - Answers for each questions of the parent form',
             PRIMARY KEY (`id`),
             KEY `name` (`name`),
             KEY `date_creation` (`date_creation`),
@@ -376,6 +376,14 @@ if (!$DB->fieldExists('glpi_forms_questions', 'validation_conditions')) {
         ]
     );
 }
+
+// Change the type of the 'answers' field in glpi_forms_answerssets
+$migration->changeField(
+    'glpi_forms_answerssets',
+    'answers',
+    'answers',
+    "longtext COMMENT 'JSON - Answers for each questions of the parent form'",
+);
 
 // Add rights for the forms object
 $migration->addRight("form", ALLSTANDARDRIGHT, ['config' => UPDATE]);

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -9626,7 +9626,7 @@ CREATE TABLE `glpi_forms_answerssets` (
     `date_creation` timestamp NULL DEFAULT NULL,
     `date_mod` timestamp NULL DEFAULT NULL,
     `index` int NOT NULL DEFAULT '0',
-    `answers` text COMMENT 'JSON - Answers for each questions of the parent form',
+    `answers` longtext COMMENT 'JSON - Answers for each questions of the parent form',
     PRIMARY KEY (`id`),
     KEY `name` (`name`),
     KEY `date_creation` (`date_creation`),


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.

## Description

- It fixes #19927

Change the data type of the “answers” field so that it can accommodate larger JSON data.
Formcreator currently uses this type to manage the storage of form responses.