### PR TITLE
Fix generic form redirection target when creation fails

### DIFF
--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -6785,14 +6785,11 @@ TWIG, $twig_params);
 
     /**
      * Return the action to execute after a generic form action has been done.
-     *
-     * @param string $form_action
-     * @return string|null
      */
-    public static function getPostFormAction(string $form_action): ?string
+    public static function getPostFormAction(string $form_action, bool $action_success): ?string
     {
         return match ($form_action) {
-            'add' => 'backcreated',
+            'add' => $action_success ? 'backcreated' : 'back',
             'update' => 'back',
             'delete', 'restore', 'purge' => 'list',
             'unglobalize' => 'form',

--- a/src/Glpi/Controller/GenericFormController.php
+++ b/src/Glpi/Controller/GenericFormController.php
@@ -163,7 +163,7 @@ class GenericFormController extends AbstractController
             );
         }
 
-        $post_action = $object::getPostFormAction($form_action);
+        $post_action = $object::getPostFormAction($form_action, $action_result);
 
         return match ($post_action) {
             'backcreated' => $_SESSION['glpibackcreated']

--- a/src/Infocom.php
+++ b/src/Infocom.php
@@ -939,7 +939,7 @@ class Infocom extends CommonDBChild
         Html::popFooter();
     }
 
-    public static function getPostFormAction(string $form_action): ?string
+    public static function getPostFormAction(string $form_action, bool $action_success): ?string
     {
         // Always return to the previous page
         return 'back';

--- a/src/Lockedfield.php
+++ b/src/Lockedfield.php
@@ -108,7 +108,7 @@ class Lockedfield extends CommonDBTM
         return false;
     }
 
-    public static function getPostFormAction(string $form_action): ?string
+    public static function getPostFormAction(string $form_action, bool $action_success): ?string
     {
         // Always return to the locked fields list page
         return 'list';


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

When an item creation fails, the user cannot be redirected to the created item and should just be redirected to the previous page.