### PR TITLE
fix(task): visibility of documents linked to private tasks assigned to user

### DIFF
--- a/phpunit/functional/TicketTest.php
+++ b/phpunit/functional/TicketTest.php
@@ -7380,6 +7380,17 @@ HTML,
             ]
         );
 
+        $task6 = $this->createItem(
+            \TicketTask::class,
+            [
+                'tickets_id'    => $ticket->getID(),
+                'content'       => 'private task assign to tech user',
+                'is_private'    => 1,
+                'users_id_tech' => $tech_user_id,
+                'date_creation' => date('Y-m-d H:i:s', strtotime('+20s', $now)), // to ensure result order is correct
+            ]
+        );
+
         $document = $this->createTxtDocument();
 
         $this->createItems(
@@ -7410,6 +7421,11 @@ HTML,
                     'items_id'       => $task5->getID(),
                     'itemtype'       => \TicketTask::class,
                 ],
+                [
+                    'documents_id'   => $document->getID(),
+                    'items_id'       => $task6->getID(),
+                    'itemtype'       => \TicketTask::class,
+                ],
             ]
         );
 
@@ -7429,6 +7445,7 @@ HTML,
                 'private task assigned to normal user',
                 'private task of normal user',
                 'private task of tech user',
+                'private task assign to tech user',
                 'public task',
             ],
         ];
@@ -7446,6 +7463,7 @@ HTML,
             ],
             'expected_tasks'     => [
                 'private task of tech user',
+                'private task assign to tech user',
                 'public task',
             ],
         ];
@@ -7502,6 +7520,7 @@ HTML,
                     'private task assigned to normal user',
                     'private task of normal user',
                     'private task of tech user',
+                    'private task assign to tech user',
                     'public task',
                 ],
             ];
@@ -7572,8 +7591,9 @@ HTML,
             foreach ($timeline as $entry) {
                 if (
                     $entry['type'] === \TicketTask::class &&
-                    isset($entry['item']['object']['fields']['name']) &&
-                    $entry['item']['object']['fields']['name'] !== 'private task assigned to normal user') {
+                    isset($entry['item']['content']) &&
+                    $entry['item']['content'] !== 'private task assigned to normal user'
+                ) {
                     $this->assertArrayHasKey('documents', $entry);
                 }
             }

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -8584,7 +8584,11 @@ abstract class CommonITILObject extends CommonDBTM
             if (!$bypass_rights) {
                 $private_task_crit = [];
                 if (!Session::haveRight($task_class::$rightname, CommonITILTask::SEEPRIVATE)) {
-                    $private_task_crit = ['is_private' => 0, 'users_id' => Session::getLoginUserID()];
+                    $private_task_crit = [
+                        'is_private' => 0,
+                        'users_id' => Session::getLoginUserID(),
+                        'users_id_tech' => Session::getLoginUserID(),
+                    ];
                 }
                 if (Session::haveRight($task_class::$rightname, CommonITILTask::SEEPRIVATEGROUPS) && !empty($_SESSION["glpigroups"])) {
                     $private_task_crit['groups_id_tech'] = $_SESSION["glpigroups"];


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !38027
- Complete #19970 

If a task is set as private and a technician does not have the rights to view private tasks but is assigned to a private task, he has the option to see the task but cannot see the associated documents 

## Screenshots (if appropriate):

Before
![image](https://github.com/user-attachments/assets/3614163f-d110-466d-ac38-b330f3dd45c2)

After
![image](https://github.com/user-attachments/assets/778b5c68-c5b7-4275-8ca9-523e0e4ba641)


