### PR TITLE
Enhance plugins routing

### DIFF
--- a/src/Glpi/Kernel/Listener/RequestListener/PluginsRouterListener.php
+++ b/src/Glpi/Kernel/Listener/RequestListener/PluginsRouterListener.php
@@ -139,20 +139,7 @@ final readonly class PluginsRouterListener implements EventSubscriberInterface
             ));
         }
 
-        try {
-            // Try to instantiate without any parameters
-            $object = new $class(); // @phpstan-ignore glpi.forbidDynamicInstantiation (Any class is valid here)
-        } catch (\Error) {
-            // Try to load the service from the DI container
-            $object = $this->plugin_container->get($class);
-        }
-
-        if (!\is_callable($object)) {
-            return \sprintf(
-                'Controller class `%s` cannot be called without a method name. You need to implement the `__invoke()` method, or add your route parameters on a public method with the `Route` attribute.',
-                $class
-            );
-        }
+        $object = $this->plugin_container->get($class);
 
         return $method ? [$object, $method] : $object;
     }

--- a/src/Glpi/Routing/PluginRoutesLoader.php
+++ b/src/Glpi/Routing/PluginRoutesLoader.php
@@ -39,7 +39,6 @@ use Symfony\Bundle\FrameworkBundle\Routing\AttributeRouteControllerLoader;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Loader\Loader;
 use Symfony\Component\Routing\Loader\AttributeDirectoryLoader;
-use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 
 class PluginRoutesLoader extends Loader
@@ -64,19 +63,13 @@ class PluginRoutesLoader extends Loader
             );
             $plugin_routes = $loader->load($plugin_path, 'attribute');
 
-            if (!$plugin_routes) {
+            if ($plugin_routes->count() === 0) {
                 // No route found in the plugin
                 continue;
             }
 
-            foreach ($plugin_routes as $route) {
-                /** @var Route $route */
-                $prefix = '/plugins/' . $plugin_key . '/';
-                if (!\str_starts_with($route->getPath(), $prefix)) {
-                    $route->setPath($prefix . \ltrim($route->getPath(), '/'));
-                }
-            }
-
+            $plugin_routes->addPrefix(sprintf('/plugins/%s/', $plugin_key));
+            $plugin_routes->addNamePrefix(sprintf('@%s:', $plugin_key));
             $routes->addCollection($plugin_routes);
         }
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

1) Always fetch controllers from the plugin container services.
If a controller has constructor arguments, trying to instantiate it directly will result in an error. Also, the controller is always expected to be present in the plugin container, so it can be fetched directly from there.

2) Add route name prefixes, to prevent conflicts between plugins.
If two plugins had a route with a same name (e.g. `#[Route("/config", name: "config")]`), only one of them was present in the plugins routes collection, as this collection is indexed by the routes names. Now, a `@{%plugin_key}:` prefix is added, with `RouteCollection::addNamePrefix()`. For instance the `config` route from the `myplugin` plugin will be named `@myplugin:config`. It is usefull if a plugin want to use the Symfony URL generator instead of hardcoding URLs.

3) Simplify route path prefix definition.
Previously, all the routes were parsed to prefix their path with a `/plugins/${plugin_key}/` prefix. This is now done in a single line code with `RouteCollection::addPrefix()`.

I cannot add unit tests right now, as the routing uses complex internal symfony logic that is difficult to mock, but I tested it manually with success.