### PR TITLE
Throw exceptions when `getFromXXX()` unexpectedly found multiple results

### DIFF
--- a/phpunit/functional/CommonDBTMTest.php
+++ b/phpunit/functional/CommonDBTMTest.php
@@ -146,16 +146,13 @@ class CommonDBTMTest extends DbTestCase
         $this->assertFalse($instance->isNewItem());
 
         $instance = new \Computer();
-        $result = $instance->getFromDbByRequest([
+
+        $this->expectExceptionMessage(
+            '`Computer::getFromDBByRequest()` expects to get one result, 2 found in query "SELECT `glpi_computers`.* FROM `glpi_computers` WHERE `contact` = \'johndoe\'".'
+        );
+        $instance->getFromDbByRequest([
             'WHERE' => ['contact' => 'johndoe'],
         ]);
-        $this->hasPhpLogRecordThatContains(
-            'getFromDBByRequest expects to get one result, 2 found in query "SELECT `glpi_computers`.* FROM `glpi_computers` WHERE `contact` = \'johndoe\'".',
-            LogLevel::WARNING
-        );
-        $this->assertFalse($result);
-        // the instance must not be populated
-        $this->assertTrue($instance->isNewItem());
     }
 
     public function testGetFromResultSet()

--- a/phpunit/functional/ComputerTest.php
+++ b/phpunit/functional/ComputerTest.php
@@ -408,11 +408,11 @@ class ComputerTest extends DbTestCase
         $this->assertTrue($comp->getFromDBByCrit(['name' => '_test_pc01']));
         $this->assertSame('_test_pc01', $comp->getField('name'));
 
-        $this->assertFalse($comp->getFromDBByCrit(['name' => ['LIKE', '_test%']]));
-        $this->hasPhpLogRecordThatContains(
-            'getFromDBByCrit expects to get one result, 9 found in query "SELECT `id` FROM `glpi_computers` WHERE `name` LIKE \'_test%\'".',
-            LogLevel::WARNING
+
+        $this->expectExceptionMessage(
+            '`Computer::getFromDBByCrit()` expects to get one result, 9 found in query "SELECT `id` FROM `glpi_computers` WHERE `name` LIKE \'_test%\'".'
         );
+        $comp->getFromDBByCrit(['name' => ['LIKE', '_test%']]);
     }
 
     public function testClone()

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -346,13 +346,13 @@ class CommonDBTM extends CommonGLPI
             $this->post_getFromDB();
             return true;
         } elseif (count($iterator) > 1) {
-            trigger_error(
+            throw new \RuntimeException(
                 sprintf(
-                    'getFromDB expects to get one result, %1$s found in query "%2$s".',
+                    '`%1$s::getFromDB()` expects to get one result, %2$s found in query "%3$s".',
+                    static::class,
                     count($iterator),
                     $iterator->getSql()
-                ),
-                E_USER_WARNING
+                )
             );
         }
 
@@ -423,13 +423,13 @@ class CommonDBTM extends CommonGLPI
             $row = $iter->current();
             return $this->getFromDB($row[static::getIndexName()]);
         } elseif (count($iter) > 1) {
-            trigger_error(
+            throw new \RuntimeException(
                 sprintf(
-                    'getFromDBByCrit expects to get one result, %1$s found in query "%2$s".',
+                    '`%1$s::getFromDBByCrit()` expects to get one result, %2$s found in query "%3$s".',
+                    static::class,
                     count($iter),
                     $iter->getSql()
-                ),
-                E_USER_WARNING
+                )
             );
         }
         return false;
@@ -468,13 +468,13 @@ class CommonDBTM extends CommonGLPI
             $this->post_getFromDB();
             return true;
         } elseif (count($iterator) > 1) {
-            trigger_error(
+            throw new \RuntimeException(
                 sprintf(
-                    'getFromDBByRequest expects to get one result, %1$s found in query "%2$s".',
+                    '`%1$s::getFromDBByRequest()` expects to get one result, %2$s found in query "%3$s".',
+                    static::class,
                     count($iterator),
                     $iterator->getSql()
-                ),
-                E_USER_WARNING
+                )
             );
         }
         return false;

--- a/src/Glpi/Dashboard/Dashboard.php
+++ b/src/Glpi/Dashboard/Dashboard.php
@@ -128,9 +128,13 @@ class Dashboard extends \CommonDBTM
             $this->post_getFromDB();
             return true;
         } elseif (count($iterator) > 1) {
-            trigger_error(
-                sprintf('getFromDB expects to get one result, %1$s found!', count($iterator)),
-                E_USER_WARNING
+            throw new \RuntimeException(
+                sprintf(
+                    '`%1$s::getFromDB()` expects to get one result, %2$s found in query "%3$s".',
+                    static::class,
+                    count($iterator),
+                    $iterator->getSql()
+                )
             );
         }
 

--- a/src/ItemVirtualMachine.php
+++ b/src/ItemVirtualMachine.php
@@ -419,13 +419,13 @@ class ItemVirtualMachine extends CommonDBChild
             $result = $iterator->current();
             return $result['id'];
         } elseif (count($iterator) > 1) {
-            trigger_error(
+            throw new \RuntimeException(
                 sprintf(
-                    'findVirtualMachine expects to get one result, %1$s found in query "%2$s".',
+                    '`%1$s::findVirtualMachine()` expects to get one result, %2$s found in query "%3$s".',
+                    static::class,
                     count($iterator),
                     $iterator->getSql()
-                ),
-                E_USER_WARNING
+                )
             );
         }
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

`CommonDBTM::getFromDB*()` are made to load an item from the DB based on criteria that are supposed to match either one entry or no entry. It it matches multiple entries, it mean that the criteria used are bad and must be fixed.

When the result is `false`, the developer consider that no matching entry was found, but currently this assertion is wrong. For instance, in the past, we had an issue in the inventory that was creating many duplicated domains because the criteria were not including the entities filtering, so `Domain::getFromDBByCrit()` was returning `false` whereas matching entries were found, and our code was then generating a new duplicated entry considering that no entry was found (see #14494).

I propose to throw exceptions when a `CommonDBTM::getFromDB*()` method finds multiple matching entries. It will permit to prevent the execution of the subsequent code. Also, it will permit to ease the issue detection. Indeed, in (pre)production environments, warnings may not be visible.