### PR TITLE
fix(Document): include missing Rack in Document menu dropdown

### DIFF
--- a/inc/define.php
+++ b/inc/define.php
@@ -222,7 +222,7 @@ $CFG_GLPI["document_types"]               = ['Budget', 'CartridgeItem', 'Change'
     'SoftwareLicense', 'Supplier', 'Ticket','User',
     'Certificate', 'Cluster', 'ITILFollowup', 'ITILSolution',
     'ChangeTask', 'ProblemTask', 'TicketTask', 'Appliance',
-    'DatabaseInstance', 'Rack'
+    'DatabaseInstance', 'Rack',
 ];
 
 $CFG_GLPI["consumables_types"]            = ['Group', 'User'];

--- a/inc/define.php
+++ b/inc/define.php
@@ -222,7 +222,7 @@ $CFG_GLPI["document_types"]               = ['Budget', 'CartridgeItem', 'Change'
     'SoftwareLicense', 'Supplier', 'Ticket','User',
     'Certificate', 'Cluster', 'ITILFollowup', 'ITILSolution',
     'ChangeTask', 'ProblemTask', 'TicketTask', 'Appliance',
-    'DatabaseInstance',
+    'DatabaseInstance', 'Rack'
 ];
 
 $CFG_GLPI["consumables_types"]            = ['Group', 'User'];

--- a/phpunit/functional/DocumentTest.php
+++ b/phpunit/functional/DocumentTest.php
@@ -82,11 +82,26 @@ class DocumentTest extends DbTestCase
 
     public function testGetItemtypesThatCanHave()
     {
+        /** @var array $CFG_GLPI */
+        global $CFG_GLPI;
+
         $doc = new \Document();
-        $this->assertGreaterThan(
-            50,
-            count($doc->getItemtypesThatCanHave())
+        $itemtypes_doc = $doc->getItemtypesThatCanHave();
+
+        $item_device_types = [];
+        foreach ($CFG_GLPI['device_types'] as $device_type) {
+            $item_device_types[] = $device_type::getItem_DeviceType();
+        }
+        $itemtypes = array_merge(
+            $CFG_GLPI['document_types'],
+            $CFG_GLPI['device_types'],
+            $item_device_types,
         );
+
+        $this->assertEquals(count($itemtypes_doc), count($itemtypes));
+        foreach($itemtypes as $itemtype) {
+            $this->assertContains($itemtype, $itemtypes_doc);
+        }
     }
 
     public function testDefineTabs()

--- a/phpunit/functional/DocumentTest.php
+++ b/phpunit/functional/DocumentTest.php
@@ -99,7 +99,7 @@ class DocumentTest extends DbTestCase
         );
 
         $this->assertEquals(count($itemtypes_doc), count($itemtypes));
-        foreach($itemtypes as $itemtype) {
+        foreach ($itemtypes as $itemtype) {
             $this->assertContains($itemtype, $itemtypes_doc);
         }
     }


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !38289
- Adds the Rack asset to the document dropdown

![image](https://github.com/user-attachments/assets/9e9891de-23f7-477e-901b-519b0d7a2565)


