### PR TITLE
Fix(Auth): Fix External Auth + MFA + 'is_users_auto_add' -> false

### DIFF
--- a/src/Auth.php
+++ b/src/Auth.php
@@ -903,6 +903,7 @@ class Auth extends CommonGLPI
                 ) {
                     // Case of using external auth and no LDAP servers, so get data from external auth
                     $this->user->getFromSSO();
+                    $this->user_present = $this->user->getFromDBbyName($this->user->fields['name']);
                 } else {
                     if ($this->user->fields['authtype'] === self::LDAP) {
                         if (!$ldapservers_status) {
@@ -1030,6 +1031,7 @@ class Auth extends CommonGLPI
         if ($mfa_pre_auth) {
             $this->user = new User();
             $this->user->fields = $mfa_pre_auth['user'];
+            $this->user_present = $mfa_pre_auth['user_present'];
             $this->auth_type = $mfa_pre_auth['auth_type'];
             $this->extauth = $mfa_pre_auth['extauth'];
             $remember_me = $mfa_pre_auth['remember_me'];
@@ -1064,6 +1066,7 @@ class Auth extends CommonGLPI
                                 'auth_type' => $this->auth_type,
                                 'extauth' => $this->extauth,
                                 'remember_me' => $remember_me,
+                                'user_present' => $this->user_present,
                             ];
 
                             $redirect_params = [
@@ -1089,6 +1092,7 @@ class Auth extends CommonGLPI
                                 'auth_type' => $this->auth_type,
                                 'extauth' => $this->extauth,
                                 'remember_me' => $remember_me,
+                                'user_present' => $this->user_present,
                             ];
                             Html::redirect($CFG_GLPI["root_doc"] . '/?mfa_setup=1');
                         }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes  #19913
- Better solution than  #20096 

I was finally able to understand what's going on.

### Configuration

* **GLPI**: Beta 6
* **OauthSSO plugin**: 1.11.0-beta5

### Authentication Flow

1. The user authenticates with the identity provider.
2. The user is redirected back to the `OauthSSO` plugin, which fills in the user's information into the appropriate `SSO` fields.
3. A login attempt is made by `OauthSSO` using `Auth->login()` based on the SSO data.
4. GLPI correctly identifies the user but does **not** set `$this->user_present = true` (this issue is addressed in the related pull request).
5. Since `MFA` is enabled for the user, GLPI triggers the `MFA` process.
6. The user enters the verification code.
7. GLPI performs another call to `Auth->login()`.
8. At this point, GLPI loses the `$this->user_present = true` state and run last par of this condition

```php
                if ($this->user_present) {
                    // Add the user e-mail if present
                    if (isset($this->user_email)) {
                        $this->user->fields['_useremails'] = $this->user_email;
                    }
                    $this->user->update($this->user->fields);
                } elseif ($CFG_GLPI["is_users_auto_add"]) {
                    // Auto add user
                    $input = $this->user->fields;
                    $this->user->fields = [];
                    if ($this->auth_type == self::EXTERNAL && !isset($input["authtype"])) {
                        $input["authtype"] = $this->auth_type;
                    }
                    $this->user->add($input);
                } else {
                    // Auto add not enable so auth failed
                    $this->addToError(__('User not authorized to connect in GLPI'));
                    $this->auth_succeded = false;
                }
```

To resolve this, I added the `$_SESSION['mfa_pre_auth']` variable to persist this information between authentication steps.






## Screenshots (if appropriate):


