### PR TITLE
Fix initializing Kanban filter bar

### DIFF
--- a/js/src/vue/Kanban/Kanban.vue
+++ b/js/src/vue/Kanban/Kanban.vue
@@ -1296,34 +1296,35 @@
         all_kanbans.value = kanbans;
         kanban_switcher.value = props.item.items_id <= 0 ? -1 : props.item.items_id;
     });
-    filter_input = new SearchInput($(`#${props.element_id} input[name="filter"]`), {
-        allowed_tags: props.supported_filters,
-        on_result_change: (e, result) => {
-            filters.value = {
-                _text: ''
-            };
-            filters.value._text = result.getFullPhrase();
-            result.getTaggedTerms().forEach(t => filters.value[t.tag] = {
-                term: t.term || '',
-                exclusion: t.exclusion || false,
-                prefix: t.prefix
-            });
-        },
-        tokenizer_options: {
-            custom_prefixes: {
-                '#': { // Regex prefix
-                    label: __('Regex'),
-                    token_color: '#00800080'
-                }
-            }
-        }
-    });
-    refreshSearchTokenizer();
-    refreshSortables();
+
     await refresh(true);
     backgroundRefresh();
     onMounted(() => {
         initMutationObserver();
+        filter_input = new SearchInput($(`#${props.element_id} input[name="filter"]`), {
+            allowed_tags: props.supported_filters,
+            on_result_change: (e, result) => {
+                filters.value = {
+                    _text: ''
+                };
+                filters.value._text = result.getFullPhrase();
+                result.getTaggedTerms().forEach(t => filters.value[t.tag] = {
+                    term: t.term || '',
+                    exclusion: t.exclusion || false,
+                    prefix: t.prefix
+                });
+            },
+            tokenizer_options: {
+                custom_prefixes: {
+                    '#': { // Regex prefix
+                        label: __('Regex'),
+                        token_color: '#00800080'
+                    }
+                }
+            }
+        });
+        refreshSearchTokenizer();
+        refreshSortables();
         emit('kanban:post_init');
     });
 </script>

--- a/tests/cypress/e2e/Kanban/kanban.cy.js
+++ b/tests/cypress/e2e/Kanban/kanban.cy.js
@@ -1,0 +1,75 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+describe('Kanban', () => {
+    beforeEach(() => {
+        cy.login();
+        cy.changeProfile('Super-Admin');
+    });
+    it('Global project kanban loads', () => {
+        cy.visit('/front/project.form.php?showglobalkanban=1');
+
+        //TODO I am well aware this test is not using the "accessible" selectors, but that isn't the point.
+        // I am aware that the Kanban needs an accessibility review, but I will do that as a separate task with user experience in mind,
+        // not just blindly adding labels, roles or data attributes to everything just to make the test look "nicer".
+        cy.get('#kanban-app').within(() => {
+            // The loading spinner should disappear when the kanban is loaded
+            cy.get('.kanban-container').should('be.visible');
+            cy.findByRole('status').should('not.exist');
+
+            cy.get('.kanban-toolbar').within(() => {
+                cy.get('select[name="kanban-board-switcher"]').should('have.value', '-1');
+                cy.get('div.search-input').should('be.visible');
+                cy.findByRole('button', {name: 'Add column'}).should('be.visible');
+                cy.get('button.kanban-extra-toolbar-options').should('be.visible');
+
+                cy.get('.search-input-tag-input').click();
+                cy.get('.search-input-popover').should('be.visible');
+                cy.get('.search-input-popover').within(() => {
+                    const expected_tags = [
+                        'title', 'type', 'milestone', 'content', 'deleted', 'team', 'user', 'group', 'supplier', 'contact'
+                    ];
+                    expected_tags.forEach((tag) => {
+                        cy.get(`li[data-tag="${tag}"]`).within(() => {
+                            cy.get('b').contains(tag);
+                            cy.findByRole('button', {name: '!'}).should('be.visible').should('have.attr', 'title', 'Exclude');
+                            if (['title', 'content'].includes(tag)) {
+                                cy.findByRole('button', {name: '#'}).should('be.visible').should('have.attr', 'title', 'Regex');
+                            }
+                            cy.get('.text-muted').should('not.be.empty');
+                        });
+                    });
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

Fixes #20088
Moves the search input/filter initialization to be done after the Kanban component is mounted to ensure the source input element exists in the DOM at the time it tries to initialize the `SearchInput`.
