### PR TITLE
fix kanban team user icon

### DIFF
--- a/js/src/vue/Kanban/TeamBadgeProvider.js
+++ b/js/src/vue/Kanban/TeamBadgeProvider.js
@@ -210,7 +210,7 @@ export class TeamBadgeProvider {
         initials = initials.toUpperCase();
 
         if (!this.display_initials || initials.length === 0) {
-            return this.generateOtherBadge(team_member, 'fa-user');
+            return this.generateOtherBadge(team_member, 'ti ti-user');
         }
 
         const canvas = this.getBadgeCanvas(this.getBadgeColor(team_member));
@@ -232,7 +232,7 @@ export class TeamBadgeProvider {
         const name = team_member['name'].replace(/"/g, '&quot;').replace(/'/g, '&#39;');
 
         return `
-            <span class="badge badge-pill" style="background-color: ${bg_color}; font-size: ${(this.team_image_size / 2)}px; height: 26px">
+            <span class="badge badge-pill" style="background-color: ${bg_color}; font-size: ${(this.team_image_size / 2)}px; height: 26px; padding: 0.25em;">
                 <i class='${icon}' title="${name}" data-bs-toggle='tooltip' data-bs-placement='top'></i>
             </span>
         `;


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Fixes #20081
A recent PR which converted some icons to tabler removed the `fa`/`fas` class for the team badge while missing the use of `fa-user` in the same JS file. This PR also adjusts the padding of icon badges to be more circular with the Tabler icons.