### PR TITLE
Fix SCSS compilation memory limit

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -290,12 +290,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/front/cron.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Function ini_set is unsafe to use\\. It can return FALSE instead of throwing an exception\\. Please add \'use function Safe\\\\ini_set;\' at the beginning of the file to use the variant provided by the \'thecodingmachine/safe\' library\\.$#',
-	'identifier' => 'theCodingMachineSafe.function',
-	'count' => 1,
-	'path' => __DIR__ . '/front/css.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Function sha1_file is unsafe to use\\. It can return FALSE instead of throwing an exception\\. Please add \'use function Safe\\\\sha1_file;\' at the beginning of the file to use the variant provided by the \'thecodingmachine/safe\' library\\.$#',
 	'identifier' => 'theCodingMachineSafe.function',
 	'count' => 1,
@@ -1970,18 +1964,17 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/DBmysql.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Function preg_split is unsafe to use\\. It can return FALSE instead of throwing an exception\\. Please add \'use function Safe\\\\preg_split;\' at the beginning of the file to use the variant provided by the \'thecodingmachine/safe\' library\\.$#',
-	'identifier' => 'theCodingMachineSafe.function',
-	'count' => 2,
-	'path' => __DIR__ . '/src/DBmysql.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Function preg_replace is unsafe to use\\. It can return FALSE instead of throwing an exception\\. Please add \'use function Safe\\\\preg_replace;\' at the beginning of the file to use the variant provided by the \'thecodingmachine/safe\' library\\.$#',
 	'identifier' => 'theCodingMachineSafe.function',
 	'count' => 1,
 	'path' => __DIR__ . '/src/DBmysql.php',
 ];
-
+$ignoreErrors[] = [
+	'message' => '#^Function preg_split is unsafe to use\\. It can return FALSE instead of throwing an exception\\. Please add \'use function Safe\\\\preg_split;\' at the beginning of the file to use the variant provided by the \'thecodingmachine/safe\' library\\.$#',
+	'identifier' => 'theCodingMachineSafe.function',
+	'count' => 2,
+	'path' => __DIR__ . '/src/DBmysql.php',
+];
 $ignoreErrors[] = [
 	'message' => '#^Function preg_replace is unsafe to use\\. It can return FALSE instead of throwing an exception\\. Please add \'use function Safe\\\\preg_replace;\' at the beginning of the file to use the variant provided by the \'thecodingmachine/safe\' library\\.$#',
 	'identifier' => 'theCodingMachineSafe.function',

--- a/front/css.php
+++ b/front/css.php
@@ -38,12 +38,15 @@ require_once(__DIR__ . '/_check_webserver_config.php');
 use Glpi\Application\Environment;
 use Glpi\UI\ThemeManager;
 
-// Main CSS compilation requires about 120MB of memory.
-// Ensure to have enough memory to not reach memory limit.
-// To be also defined in `src/Glpi/Console/Build/CompileScssCommand.php`.
-$max_memory = 192;
-if (Toolbox::getMemoryLimit() < ($max_memory * 1024 * 1024)) {
-    ini_set('memory_limit', sprintf('%dM', $max_memory));
+use function Safe\ini_set;
+use function Safe\preg_match;
+
+if (preg_match('~^css/glpi(\.scss)?$~', $_GET['file'] ?? '') === 1) {
+    // Ensure to have enough memory to not reach memory limit.
+    $max_memory = Html::MAIN_SCSS_COMPILATION_REQUIRED_MEMORY;
+    if (Toolbox::getMemoryLimit() < ($max_memory * 1024 * 1024)) {
+        ini_set('memory_limit', sprintf('%dM', $max_memory));
+    }
 }
 
 // If a custom theme is requested, we need to get the real path of the theme

--- a/src/Glpi/Console/Build/CompileScssCommand.php
+++ b/src/Glpi/Console/Build/CompileScssCommand.php
@@ -44,6 +44,8 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Toolbox;
 
+use function Safe\ini_set;
+
 class CompileScssCommand extends Command
 {
     /**
@@ -89,10 +91,8 @@ class CompileScssCommand extends Command
             );
         }
 
-        // Main CSS compilation requires about 120MB of memory.
         // Ensure to have enough memory to not reach memory limit.
-        // To be also defined in `front/css.php`.
-        $max_memory = 192;
+        $max_memory = Html::MAIN_SCSS_COMPILATION_REQUIRED_MEMORY;
         if (Toolbox::getMemoryLimit() < ($max_memory * 1024 * 1024)) {
             ini_set('memory_limit', sprintf('%dM', $max_memory));
         }

--- a/src/Html.php
+++ b/src/Html.php
@@ -59,6 +59,12 @@ use Symfony\Component\HttpFoundation\Request;
 class Html
 {
     /**
+     * Memory required to compile the main GLPI scss file (`css/glpi.scss`).
+     * It currently requires 120 MB, but may increase a bit when the dependencies are updated.
+     */
+    public const MAIN_SCSS_COMPILATION_REQUIRED_MEMORY = 192 * 1024 * 1024;
+
+    /**
      * Recursivly execute html_entity_decode on an array
      *
      * @param string|array $value


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Replace #20121.

I guess the latest tabler version provides a SCSS file that requires more resources to be compiled.

I reuse the same piece of code in the SCSS compilation command than the one already present in the `front/css.php` script.