### PR TITLE
Require the Tokenizer PHP extension

### DIFF
--- a/composer-dependency-analyser.php
+++ b/composer-dependency-analyser.php
@@ -68,6 +68,7 @@ return $config
     ], [ErrorType::DEV_DEPENDENCY_IN_PROD])
 
     ->ignoreErrorsOnExtension('ext-bcmath', [ErrorType::UNUSED_DEPENDENCY]) // Required by tc-lib-barcode
+    ->ignoreErrorsOnExtension('ext-tokenizer', [ErrorType::UNUSED_DEPENDENCY]) // Required by symfony/routing
     ->ignoreErrorsOnPackages([
         'apereo/phpcas', // Not detected because the library doesn't have an autoloader
         'bacon/bacon-qr-code', // Used by TwoFactorAuth as suggested dependency

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "ext-openssl": "*",
         "ext-session": "*",
         "ext-simplexml": "*",
+        "ext-tokenizer": "*",
         "ext-zlib": "*",
         "apereo/phpcas": "^1.6",
         "bacon/bacon-qr-code": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "87e153a6c4f8ccdc6c41db0754cc5421",
+    "content-hash": "80c84af4b77cceedcc28aa4e75bd20da",
     "packages": [
         {
             "name": "apereo/phpcas",
@@ -13147,6 +13147,7 @@
         "ext-openssl": "*",
         "ext-session": "*",
         "ext-simplexml": "*",
+        "ext-tokenizer": "*",
         "ext-zlib": "*"
     },
     "platform-dev": {

--- a/src/Glpi/System/RequirementsManager.php
+++ b/src/Glpi/System/RequirementsManager.php
@@ -83,6 +83,7 @@ class RequirementsManager
                 'filter',
                 'libxml',
                 'simplexml',
+                'tokenizer', // required by `\Symfony\Component\Routing\Loader\AttributeFileLoader`
                 'xmlreader', // required/used by simplepie/simplepie and sabre/xml
                 'xmlwriter', // required/used by sabre/xml
             ]


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] This change requires a documentation update.

## Description

It fixes #20135 .

The extension is enabled by default but can be disabled on specific builds.