### PR TITLE
Fix(Inventory): fix output when actio n is RULE_ACTION_LINK_OR_NO_IMPORT

### DIFF
--- a/src/RuleImportAsset.php
+++ b/src/RuleImportAsset.php
@@ -1026,6 +1026,9 @@ class RuleImportAsset extends Rule
                         }
                         $output['found_inventories'] = [0, $back_class, $rules_id];
                         return $output;
+                    } elseif ($action->fields["value"] == self::RULE_ACTION_LINK_OR_NO_IMPORT) {
+                        // no import
+                        $output['action'] = self::LINK_RESULT_DENIED;
                     }
                 }
             }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes #37313

Fix PHP warning

A PHP warning is triggered during inventory when the `RuleImportAsset` rule executes the `RULE_ACTION_LINK_OR_NO_IMPORT` action:

```
[2025-06-30 13:56:55] glpiphplog.WARNING:   *** PHP Warning (2): Undefined array key "action" in /home/stanislas/GLPI/10bugfixes/src/Inventory/Asset/MainAsset.php at line 594
  Backtrace :
  src/Inventory/Inventory.php:727                    Glpi\Inventory\Asset\MainAsset->handle()
  src/Inventory/Inventory.php:358                    Glpi\Inventory\Inventory->handleItem()
  src/Inventory/Request.php:381                      Glpi\Inventory\Inventory->doInventory()
  src/Inventory/Request.php:90                       Glpi\Inventory\Request->inventory()
  src/Agent/Communication/AbstractRequest.php:332    Glpi\Inventory\Request->handleAction()
  src/Agent/Communication/AbstractRequest.php:269    Glpi\Agent\Communication\AbstractRequest->handleXMLRequest()
  src/Inventory/Conf.php:249                         Glpi\Agent\Communication\AbstractRequest->handleRequest()
  src/Inventory/Conf.php:194                         Glpi\Inventory\Conf->importContentFile()
  src/Inventory/Conf.php:298                         Glpi\Inventory\Conf->importFiles()
  front/inventory.conf.php:47                        Glpi\Inventory\Conf->displayImportFiles()
  public/index.php:82                                require()
```

It looks like the `action` key is missing in the array at this point.

![image](https://github.com/user-attachments/assets/c0eff1c1-5ca4-4987-a4bb-9af4a08486f7)


## Screenshots (if appropriate):


