### PR TITLE
Forms: add a min width for conditions values

### DIFF
--- a/css/includes/components/_utils.scss
+++ b/css/includes/components/_utils.scss
@@ -104,3 +104,7 @@
 .border-transparent {
     border-color: transparent;
 }
+
+.min-width-200 {
+    min-width: 200px;
+}

--- a/templates/pages/admin/form/condition_handler_templates/input.html.twig
+++ b/templates/pages/admin/form/condition_handler_templates/input.html.twig
@@ -31,7 +31,7 @@
  #}
 
 <input
-    class="me-2 form-control value-selector flex-grow-1"
+    class="me-2 form-control value-selector flex-grow-1 min-width-200"
     value="{{ input_value }}"
     name="{{ input_name }}"
     placeholder="{{ __("Enter a value...") }}"


### PR DESCRIPTION
## Description

Small UI change.
When a question has a very long name, it takes most of the space and conditions using this question don't have a lot of space left for the value:

![image](https://github.com/user-attachments/assets/0f0cc722-032d-47bd-80bb-135fe450703b)

Fixed by adding a min width:

![image](https://github.com/user-attachments/assets/63ef4249-a7cb-464a-9e6f-e430a848ac80)
