### PR TITLE
feat: setup option view for default marketplace

### DIFF
--- a/templates/pages/setup/general/glpinetwork_setup.html.twig
+++ b/templates/pages/setup/general/glpinetwork_setup.html.twig
@@ -98,7 +98,7 @@
 
     {{ fields.dropdownArrayField(
         'marketplace_replace_plugins',
-        config('marketplace_replace_plugins'),
+        config('marketplace_replace_plugins')|default(1),
         {
             '1': __('Ask before replacing'),
             '2': __('Replace plugins page with marketplace'),

--- a/templates/pages/setup/general/glpinetwork_setup.html.twig
+++ b/templates/pages/setup/general/glpinetwork_setup.html.twig
@@ -93,4 +93,26 @@
             }) }}
         {% endif %}
     {% endif %}
+
+    {{ fields.largeTitle(__('Marketplace')) }}
+
+    {{ fields.dropdownArrayField(
+        'marketplace_replace_plugins',
+        config('marketplace_replace_plugins'),
+        {
+            '1': __('Ask before replacing'),
+            '2': __('Replace plugins page with marketplace'),
+            '3': __('Never replace plugins page')
+        },
+        __('Plugin page replacement'),
+        {
+            'full_width': true,
+            'add_field_html': '<div class="form-text">' ~ __('Choose whether to replace the classic plugins page with the new marketplace interface.') ~ '</div>'
+        }
+    ) }}
+
+    {{ fields.htmlField('', '<a href="' ~ path('/front/marketplace.php') ~ '" class="btn btn-primary">' ~ __('Access GLPI Network Marketplace') ~ '</a>', null, {
+        full_width: true,
+    }) }}
+
 {% endblock %}


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

This is to help users who find the place to add their GLPI Network key, but then cannot find the Marketplace (because one day another admin answered "Never" in the popup when opening the plugins page).

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/78a1dbeb-2b5c-4692-8f78-fe2d638cb7ae)

