### PR TITLE
Add missing '--env=testing' parameter to test-db-update command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,8 @@ test-db-update: ## Update testing's database
 		-n \
 		--allow-unstable \
 		--force \
-		--skip-db-checks
+		--skip-db-checks \
+		--env=testing
 .PHONY: db-update
 
 ## —— Dependencies —————————————————————————————————————————————————————————————


### PR DESCRIPTION
This parameter was missing, meaning the command would update the main DB instead of the test DB.