### PR TITLE
Remove strict `npm` version requirement

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,4 @@
-# Prevent installation on an unexpected node/npm version
+# Prevent installation on an unexpected node version
 engine-strict=true
 
 # See https://github.com/tabler/tabler/pull/1864

--- a/package-lock.json
+++ b/package-lock.json
@@ -116,8 +116,7 @@
                 "webpack-dev-server": "^5.2.1"
             },
             "engines": {
-                "node": ">= 20.9",
-                "npm": ">= 10.1"
+                "node": ">= 20.9"
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {
@@ -16867,4 +16866,3 @@
         }
     }
 }
-

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
     "description": "GLPI dependencies",
     "license": "GPL-3.0-or-later",
     "engines": {
-        "node": ">= 20.9",
-        "npm": ">= 10.1"
+        "node": ">= 20.9"
     },
     "dependencies": {
         "@fontsource/inter": "^4.5.15",


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

The `npm` version used is not so important. We can consider that people using a compatible version of `node` will have a recent version of `npm` on their machine.

This will prevent dependabot to fail, since its `npm` version is `8.x` and is not going to be upgraded soon, see https://github.com/dependabot/dependabot-core/pull/9213.