### PR TITLE
fix(forms-migration): Use the option's uid instead of its label for the visibility condition value

### DIFF
--- a/src/Glpi/Form/Condition/ConditionHandler/MultipleChoiceFromValuesConditionHandler.php
+++ b/src/Glpi/Form/Condition/ConditionHandler/MultipleChoiceFromValuesConditionHandler.php
@@ -35,9 +35,12 @@
 namespace Glpi\Form\Condition\ConditionHandler;
 
 use Glpi\Form\Condition\ValueOperator;
+use Glpi\Form\Migration\ConditionHandlerDataConverterInterface;
 use Override;
 
-final class MultipleChoiceFromValuesConditionHandler implements ConditionHandlerInterface
+final class MultipleChoiceFromValuesConditionHandler implements
+    ConditionHandlerInterface,
+    ConditionHandlerDataConverterInterface
 {
     use ArrayConditionHandlerTrait;
 
@@ -72,5 +75,11 @@ final class MultipleChoiceFromValuesConditionHandler implements ConditionHandler
         mixed $b,
     ): bool {
         return $this->applyArrayValueOperator($a, $operator, $b);
+    }
+
+    #[Override]
+    public function convertConditionValue(string $value): int
+    {
+        return array_search($value, $this->values, true) ?: 0;
     }
 }


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Fixed import of visibility conditions targeting questions of type `AbstractQuestionTypeSelectable`.
The option label was used instead of its uid in the condition value, which rendered the condition invalid.