### PR TITLE
Fix(Inventory): add missing model to RuleImportAsset for Monitor

### DIFF
--- a/phpunit/functional/Glpi/Inventory/Assets/MonitorTest.php
+++ b/phpunit/functional/Glpi/Inventory/Assets/MonitorTest.php
@@ -1333,11 +1333,6 @@ class MonitorTest extends AbstractInventoryAsset
         $this->assertTrue($rule->update([
             'id' => $rules_id,
             'is_active' => 0,
-            'entities_id' => 0,
-            'sub_type' => \RuleImportAsset::class,
-            'match' => \Rule::AND_MATCHING,
-            'condition' => 0,
-            'description' => '',
         ]));
     }
 }

--- a/phpunit/functional/Glpi/Inventory/Assets/MonitorTest.php
+++ b/phpunit/functional/Glpi/Inventory/Assets/MonitorTest.php
@@ -1237,7 +1237,7 @@ class MonitorTest extends AbstractInventoryAsset
         $this->assertCount(0, $DB->request(['FROM' => \Computer_Item::getTable(), 'WHERE' => ['itemtype' => \Monitor::class, 'computers_id' => $computers_id]]));
     }
 
-        public function testMonitorModelRuleImportAsset()
+    public function testMonitorModelRuleImportAsset()
     {
         $monitor = new \Monitor();
         $item_monitor = new \Computer_Item();
@@ -1275,17 +1275,18 @@ class MonitorTest extends AbstractInventoryAsset
         $criteria = new \RuleCriteria();
         $action = new \RuleAction();
 
-        $rules_id = $rule->add(['name' => 'Exclude Monitor Model PHL 460C9RQ',
+        $rules_id = $rule->add([
+            'name' => 'Exclude Monitor Model PHL 460C9RQ',
             'is_active' => 1,
             'entities_id' => 0,
-            'sub_type' => 'RuleImportAsset',
+            'sub_type' => \RuleImportAsset::class,
             'match' => \Rule::AND_MATCHING,
             'condition' => 0,
             'description' => '',
         ]);
         $this->assertGreaterThan(0, $rules_id);
 
-                $this->assertTrue($collection->moveRule($rules_id, 0, $collection::MOVE_BEFORE));
+        $this->assertTrue($collection->moveRule($rules_id, 0, $collection::MOVE_BEFORE));
 
         $this->assertGreaterThan(
             0,
@@ -1303,7 +1304,7 @@ class MonitorTest extends AbstractInventoryAsset
                 'rules_id' => $rules_id,
                 'criteria' => 'itemtype',
                 'condition' => \Rule::PATTERN_IS,
-                'pattern' => 'Monitor',
+                'pattern' => \Monitor::class,
             ])
         );
 
@@ -1323,7 +1324,7 @@ class MonitorTest extends AbstractInventoryAsset
         $this->assertGreaterThan(0, $computers_id);
 
         //we only have 1 monitor items linked to the computer
-        $monitors = $item_monitor->find(['itemtype' => 'Monitor', 'computers_id' => $computers_id]);
+        $monitors = $item_monitor->find(['itemtype' => \Monitor::class, 'computers_id' => $computers_id]);
         $this->assertCount(1, $monitors);
         $this->assertTrue($monitor->getFromDB(reset($monitors)['items_id']));
         $this->assertSame($monitor->fields['name'], '230B8Q');

--- a/phpunit/functional/Glpi/Inventory/Assets/MonitorTest.php
+++ b/phpunit/functional/Glpi/Inventory/Assets/MonitorTest.php
@@ -1328,5 +1328,16 @@ class MonitorTest extends AbstractInventoryAsset
         $this->assertCount(1, $monitors);
         $this->assertTrue($monitor->getFromDB(reset($monitors)['items_id']));
         $this->assertSame($monitor->fields['name'], '230B8Q');
+
+        //disable rule
+        $this->assertTrue($rule->update([
+            'id' => $rules_id,
+            'is_active' => 0,
+            'entities_id' => 0,
+            'sub_type' => \RuleImportAsset::class,
+            'match' => \Rule::AND_MATCHING,
+            'condition' => 0,
+            'description' => '',
+        ]));
     }
 }

--- a/src/Inventory/Asset/Monitor.php
+++ b/src/Inventory/Asset/Monitor.php
@@ -147,7 +147,7 @@ class Monitor extends InventoryAsset
 
         foreach ($this->data as $key => $val) {
             $input = [
-                'itemtype'          => Monitor::class,
+                'itemtype'          => \Monitor::class,
                 'name'              => $val->name,
                 'serial'            => $val->serial ?? '',
                 'entities_id'       => $entities_id,

--- a/src/Inventory/Asset/Monitor.php
+++ b/src/Inventory/Asset/Monitor.php
@@ -147,7 +147,7 @@ class Monitor extends InventoryAsset
 
         foreach ($this->data as $key => $val) {
             $input = [
-                'itemtype'          => 'Monitor',
+                'itemtype'          => Monitor::class,
                 'name'              => $val->name,
                 'serial'            => $val->serial ?? '',
                 'entities_id'       => $entities_id,

--- a/src/Inventory/Asset/Monitor.php
+++ b/src/Inventory/Asset/Monitor.php
@@ -59,6 +59,7 @@ class Monitor extends InventoryAsset
                     $val->$dest = $val->$origin;
                 }
             }
+
             $val->is_dynamic = 1;
 
             if (!property_exists($val, 'name')) {
@@ -146,10 +147,11 @@ class Monitor extends InventoryAsset
 
         foreach ($this->data as $key => $val) {
             $input = [
-                'itemtype'     => 'Monitor',
-                'name'         => $val->name,
-                'serial'       => $val->serial ?? '',
-                'entities_id'  => $entities_id,
+                'itemtype'          => 'Monitor',
+                'name'              => $val->name,
+                'serial'            => $val->serial ?? '',
+                'entities_id'       => $entities_id,
+                'model'             => $val->monitormodels_id ?? '',
             ];
             $data = $rule->processAllRules($input, [], ['class' => $this, 'return' => true]);
 


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !38385

Add missing model to RuleImportAsset for Monitor

## Screenshots (if appropriate):


