### PR TITLE
Do not filter pinned forms

### DIFF
--- a/src/Glpi/Form/ServiceCatalog/Provider/FormProvider.php
+++ b/src/Glpi/Form/ServiceCatalog/Provider/FormProvider.php
@@ -83,7 +83,8 @@ final class FormProvider implements LeafProviderInterface
             $name = $form->fields['name'] ?? "";
             $description = $form->fields['description'] ?? "";
             if (
-                !$this->matcher->match($name, $filter)
+                !$form->fields['is_pinned'] // Pinned forms are not filtered
+                && !$this->matcher->match($name, $filter)
                 && !$this->matcher->match($description, $filter)
             ) {
                 continue;


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Always return the pinned forms no matter what the search input was.

![image](https://github.com/user-attachments/assets/690ff0fc-44f3-44aa-879a-1ebd469bee66)

Requester by our partners as this was the behavior of formcreator.
