### PR TITLE
Permit plugins to register stateless URLs

### DIFF
--- a/phpunit/functional/Glpi/Http/FirewallTest.php
+++ b/phpunit/functional/Glpi/Http/FirewallTest.php
@@ -166,14 +166,6 @@ class FirewallTest extends \DbTestCase
                 expected_strategy: $default_for_core_legacy,
             );
 
-            $_GET['token'] = 'abc';
-            $this->dotestComputeFallbackStrategy(
-                root_doc: $root_doc,
-                path: $root_doc . '/front/planning.php',
-                expected_strategy: 'no_check',
-            );
-            unset($_GET['token']);
-
             $legacy_faq_urls = ['/front/helpdesk.faq.php'];
             foreach ($legacy_faq_urls as $faq_url) {
                 $this->dotestComputeFallbackStrategy(
@@ -185,9 +177,7 @@ class FirewallTest extends \DbTestCase
 
             $legacy_no_check_urls = [
                 '/ajax/common.tabs.php',
-                '/ajax/dashboard.php',
                 '/ajax/telemetry.php',
-                '/front/cron.php',
                 '/front/css.php',
                 '/front/document.send.php',
                 '/front/locale.php',

--- a/phpunit/functional/Glpi/Http/SessionManagerTest.php
+++ b/phpunit/functional/Glpi/Http/SessionManagerTest.php
@@ -1,0 +1,217 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Http;
+
+use Glpi\Http\SessionManager;
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Component\HttpFoundation\Request;
+
+class SessionManagerTest extends \DbTestCase
+{
+    public static function requestStateProvider(): iterable
+    {
+        foreach (['', '/glpi', '/path/to/app'] as $root_doc) {
+            // GLPI index
+            yield [
+                'root_doc'     => $root_doc,
+                'path'         => $root_doc,
+                'is_stateless' => false,
+            ];
+
+            // Central page
+            yield [
+                'root_doc'     => $root_doc,
+                'path'         => $root_doc . '/front/central.php',
+                'is_stateless' => false,
+            ];
+
+            // Computer form
+            yield [
+                'root_doc'     => $root_doc,
+                'path'         => $root_doc . '/front/computer.form.php',
+                'is_stateless' => false,
+            ];
+
+            //
+            // Specific stateless cases below
+            //
+
+            // Symfony dev tools
+            yield [
+                'root_doc'     => $root_doc,
+                'path'         => $root_doc . '/_wdt/24a46e',
+                'is_stateless' => true,
+            ];
+            yield [
+                'root_doc'     => $root_doc,
+                'path'         => $root_doc . '/_profiler/24a46e',
+                'is_stateless' => true,
+            ];
+
+            // API
+            yield [
+                'root_doc'     => $root_doc,
+                'path'         => $root_doc . '/api.php',
+                'is_stateless' => true,
+            ];
+            yield [
+                'root_doc'     => $root_doc,
+                'path'         => $root_doc . '/apirest.php',
+                'is_stateless' => true,
+            ];
+
+            // CalDAV
+            yield [
+                'root_doc'     => $root_doc,
+                'path'         => $root_doc . '/caldav.php',
+                'is_stateless' => true,
+            ];
+
+            // Embed dashboards
+            yield [
+                'root_doc'     => $root_doc,
+                'path'         => $root_doc . '/front/central.php?embed&dashboard=central&entities_id=0&is_recursive=1&token=e0c6ae82-e544-564f-b565-e37e6afd7ed6',
+                'is_stateless' => true,
+            ];
+            yield [
+                'root_doc'     => $root_doc,
+                'path'         => $root_doc . '/ajax/dashboard.php?action=get_card&dashboard=central&card_id=bn_count_Group&force=0&args%5Bcolor%5D=%23e0e0e0&args%5Bwidgettype%5D=bigNumber&args%5Buse_gradient%5D=0&args%5Blimit%5D=7&args%5Bcard_id%5D=bn_count_Group&args%5Bgridstack_id%5D=bn_count_Group_b84a93f2-a26c-49d7-82a4-5446697cc5b0&d_cache_key=8edf7b23477238c731e8a785ebc0f5a22f127e12&c_cache_key=&embed=1&token=e0c6ae82-e544-564f-b565-e37e6afd7ed6&entities_id=0&is_recursive=1',
+                'is_stateless' => true,
+            ];
+
+            // Cron endpoint
+            yield [
+                'root_doc'     => $root_doc,
+                'path'         => $root_doc . '/front/cron.php',
+                'is_stateless' => true,
+            ];
+
+            // Planing export
+            yield [
+                'root_doc'     => $root_doc,
+                'path'         => $root_doc . '/front/planning.php?genical',
+                'is_stateless' => true,
+            ];
+        }
+    }
+
+    #[DataProvider('requestStateProvider')]
+    public function testIsResourceStateless(string $root_doc, string $path, bool $is_stateless): void
+    {
+        $instance = new SessionManager();
+        $request  = $this->getMockedRequest($root_doc, $path);
+
+        $this->assertEquals($is_stateless, $instance->isResourceStateless($request));
+    }
+
+    public function testIsResourceStatelessForFrontendFile(): void
+    {
+        vfsStream::setup(
+            'glpi',
+            null,
+            [
+                'public' => [
+                    'pics' => [
+                        'icon.png' => 'file contents',
+                    ],
+                    'foo' => [
+                        'index.php' => '<?php //...',
+                    ],
+                ],
+            ]
+        );
+
+        $instance = new SessionManager(vfsStream::url('glpi'));
+
+        foreach (['', '/glpi', '/path/to/app'] as $root_doc) {
+            // Check an URL matching a front-end file
+            $request = $this->getMockedRequest($root_doc, '/pics/icon.png');
+            $this->assertEquals(true, $instance->isResourceStateless($request));
+
+            // Check an URL not matching a valid front-end file
+            $request = $this->getMockedRequest($root_doc, '/pics/invalid-icon.png');
+            $this->assertEquals(false, $instance->isResourceStateless($request));
+
+            // Check an URL matching a PHP file
+            $request = $this->getMockedRequest($root_doc, '/foo/index.php');
+            $this->assertEquals(false, $instance->isResourceStateless($request));
+        }
+    }
+
+    public function testIsResourceStatelessForPlugin(): void
+    {
+        $instance = new SessionManager();
+
+        $instance->registerPluginStatelessPath('myplugin', '#^/api/#');
+        $instance->registerPluginStatelessPath('myplugin', '#^/front/state.less.php#');
+
+        foreach (['', '/glpi', '/path/to/app'] as $root_doc) {
+            // Check an URL matching the API stateless pattern
+            $request = $this->getMockedRequest($root_doc, '/plugins/myplugin/api/Computer/1');
+            $this->assertEquals(true, $instance->isResourceStateless($request));
+
+            // Check an URL matching the front stateless pattern
+            $request = $this->getMockedRequest($root_doc, '/plugins/myplugin/front/state.less.php?id=5');
+            $this->assertEquals(true, $instance->isResourceStateless($request));
+
+            // Check an URL not matching any stateless pattern
+            $request = $this->getMockedRequest($root_doc, '/plugins/myplugin/front/foo.form.php');
+            $this->assertEquals(false, $instance->isResourceStateless($request));
+
+            // Check that the pattern is not altering GLPI results
+            $request = $this->getMockedRequest($root_doc, '/front/state.less.php?id=5');
+            $this->assertEquals(false, $instance->isResourceStateless($request));
+
+            // Check that the pattern is not altering anothe plugin results
+            $request = $this->getMockedRequest($root_doc, '/plugins/anotherplugin/front/state.less.php?id=5');
+            $this->assertEquals(false, $instance->isResourceStateless($request));
+        }
+    }
+
+    private function getMockedRequest(string $root_doc, string $path): Request
+    {
+        $query_array = [];
+        if ($query = \parse_url($path, PHP_URL_QUERY)) {
+            \parse_str($query, $query_array);
+        }
+        $request = new Request($query_array);
+        $request->server->set('SCRIPT_FILENAME', $root_doc . '/index.php');
+        $request->server->set('SCRIPT_NAME', $root_doc . '/index.php');
+        $request->server->set('REQUEST_URI', $path);
+
+        return $request;
+    }
+}

--- a/src/Glpi/CalDAV/Backend/Auth.php
+++ b/src/Glpi/CalDAV/Backend/Auth.php
@@ -36,6 +36,7 @@
 namespace Glpi\CalDAV\Backend;
 
 use Sabre\DAV\Auth\Backend\AbstractBasic;
+use Session;
 
 /**
  * Basic authentication backend for CalDAV server.
@@ -48,8 +49,14 @@ class Auth extends AbstractBasic
 
     protected function validateUserPass($username, $password)
     {
-        $auth = new \Auth();
         // TODO Enforce security by accepting here only CalDAV application dedicated password
-        return $auth->validateLogin($username, $password, true);
+
+        $auth = new \Auth();
+        if ($auth->validateLogin($username, $password, true)) {
+            Session::init($auth);
+            return true;
+        }
+
+        return false;
     }
 }

--- a/src/Glpi/Dashboard/Grid.php
+++ b/src/Glpi/Dashboard/Grid.php
@@ -498,6 +498,7 @@ TWIG, $twig_params);
     public function initEmbedSession(array $params = [])
     {
         // load minimal session
+        Session::start();
         $_SESSION["glpiactive_entity"]           = $params['entities_id'];
         $_SESSION["glpiactive_entity_recursive"] = $params['is_recursive'];
         $_SESSION["glpiname"]                    = 'embed_dashboard';

--- a/src/Glpi/Http/Firewall.php
+++ b/src/Glpi/Http/Firewall.php
@@ -187,32 +187,15 @@ final class Firewall
     private function computeFallbackStrategyForCore(string $path): string
     {
         if (!file_exists($this->glpi_root . $path)) {
-            $paths = [
-                '/_wdt/' => self::STRATEGY_NO_CHECK,
-                '/_profiler/' => self::STRATEGY_NO_CHECK,
-            ];
-            foreach ($paths as $checkPath => $strategy) {
-                if (\str_starts_with($path, $checkPath)) {
-                    return $strategy;
-                }
-            }
-
             // Modern controllers
             return self::FALLBACK_STRATEGY;
-        }
-
-        if (isset($_GET["token"]) && str_starts_with($path, '/front/planning.php')) {
-            // Token based access for ical/webcal access can be made anonymously.
-            return 'no_check';
         }
 
         $paths = [
             '/front/helpdesk.faq.php' => self::STRATEGY_FAQ_ACCESS,
 
             '/ajax/common.tabs.php' => self::STRATEGY_NO_CHECK, // specific checks done later to allow anonymous access to public FAQ tabs
-            '/ajax/dashboard.php' => self::STRATEGY_NO_CHECK, // specific checks done later to allow anonymous access to embed dashboards
             '/ajax/telemetry.php' => self::STRATEGY_NO_CHECK, // Must be available during installation. This script already checks for permissions when the flag usually set by the installer is missing.
-            '/front/cron.php' => self::STRATEGY_NO_CHECK, // in GLPI mode, cronjob can also be triggered from public pages
             '/front/css.php' => self::STRATEGY_NO_CHECK, // CSS must be accessible also on public pages
             '/front/document.send.php' => self::STRATEGY_NO_CHECK, // may allow unauthenticated access, for public FAQ images
             '/front/locale.php' => self::STRATEGY_NO_CHECK, // locales must be accessible also on public pages

--- a/src/Glpi/Http/SessionManager.php
+++ b/src/Glpi/Http/SessionManager.php
@@ -1,0 +1,146 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Http;
+
+use Symfony\Component\HttpFoundation\Request;
+
+use function Safe\preg_match;
+
+final class SessionManager
+{
+    use RequestRouterTrait;
+
+    /**
+     * Registered plugins stateless paths patterns.
+     *
+     * @var array<string, string[]>
+     */
+    private static array $plugins_statelass_paths = [];
+
+    /**
+     * @param ?string $glpi_root             GLPI root directory on filesystem
+     * @param ?array  $plugin_directories         GLPI plugins root directories on filesystem
+     */
+    public function __construct(?string $glpi_root = null, ?array $plugin_directories = null)
+    {
+        $this->glpi_root = $glpi_root ?? GLPI_ROOT;
+        $this->plugin_directories = $plugin_directories ?? GLPI_PLUGINS_DIRECTORIES;
+    }
+
+    /**
+     * Add a pattern of stateless path for the given plugin.
+     *
+     * @param string $plugin_key    The plugin key.
+     * @param string $pattern       The resource pattern, relative to the plugin root URI (e.g. `#^/front/api.php/#`).
+     */
+    public static function registerPluginStatelessPath(string $plugin_key, string $pattern): void
+    {
+        self::$plugins_statelass_paths[$plugin_key] ??= [];
+        self::$plugins_statelass_paths[$plugin_key][] = $pattern;
+    }
+
+    /**
+     * Compute the fallback strategy for given path.
+     */
+    public function isResourceStateless(Request $request): bool
+    {
+        $path = $this->normalizePath($request);
+
+        $path_matches = [];
+        $plugin_path_pattern = '#^/plugins/(?<plugin_key>[^/]+)(?<plugin_resource>/.+)$#';
+        if (preg_match($plugin_path_pattern, $path, $path_matches) === 1) {
+            $plugin_key      = $path_matches['plugin_key'];
+            $plugin_resource = $path_matches['plugin_resource'];
+
+            foreach (self::$plugins_statelass_paths[$plugin_key] ?? [] as $pattern) {
+                if (preg_match($pattern, $plugin_resource) === 1) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        if (\str_starts_with($path, '/_wdt/') || \str_starts_with($path, '/_profiler/')) {
+            // Symfony profiler and web developer toolbar are not using sessions.
+            return true;
+        }
+
+        if (\str_starts_with($path, '/api.php') || \str_starts_with($path, '/apirest.php')) {
+            // API clients must not use cookies, as the session token is expected to be passed in headers.
+            return true;
+        }
+
+        if ($this->getTargetFile($path) !== null && !$this->isTargetAPhpScript($path)) {
+            // Static files loaded by the FrontEndAssetsListener must not start
+            // a session or it'll prevent them from being cached.
+            return true;
+        }
+
+        if (\str_starts_with($path, '/caldav.php')) {
+            // CalDAV clients must not use cookies, as the authentication is expected to be passed in headers.
+            return true;
+        }
+
+        if (
+            $request->query->has('embed')
+            && (
+                (
+                    \str_starts_with($path, '/front/central.php')
+                    && $request->query->has('dashboard')
+                )
+                || (
+                    \str_starts_with($path, '/ajax/dashboard.php')
+                    && \in_array($request->get('action'), ['get_dashboard_items', 'get_card', 'get_cards'], true)
+                )
+            )
+        ) {
+            // Embed dashboards will need to act in an isolated session context.
+            return true;
+        }
+
+        if (\str_starts_with($path, '/front/cron.php')) {
+            // The cron endpoint is not expected to use the authenticated user session.
+            return true;
+        }
+
+        if (\str_starts_with($path, '/front/planning.php') && $request->query->has('genical')) {
+            // The `genical` endpoint must not use cookies, as the authentication is expected to be passed in the query parameters.
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Glpi/Kernel/Listener/PostBootListener/CheckPluginsStates.php
+++ b/src/Glpi/Kernel/Listener/PostBootListener/CheckPluginsStates.php
@@ -44,7 +44,7 @@ use Plugin;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Update;
 
-final readonly class DisablePluginsOnVersionChange implements EventSubscriberInterface
+final readonly class CheckPluginsStates implements EventSubscriberInterface
 {
     public static function getSubscribedEvents(): array
     {
@@ -57,7 +57,6 @@ final readonly class DisablePluginsOnVersionChange implements EventSubscriberInt
     {
         /** @var \DBmysql|null $DB */
         global $DB;
-
         if (
             !DBConnection::isDbAvailable()
             || !Config::isLegacyConfigurationLoaded()
@@ -67,15 +66,18 @@ final readonly class DisablePluginsOnVersionChange implements EventSubscriberInt
             return;
         }
 
-        Profiler::getInstance()->start('DisablePluginsOnVersionChange::execute', Profiler::CATEGORY_BOOT);
+        Profiler::getInstance()->start('CheckPluginsStates::execute', Profiler::CATEGORY_BOOT);
+
+        $plugin = new Plugin();
 
         if (Update::isUpdateMandatory()) {
             // Disable all plugins once a new mandatory update is detected.
             // This prevents incompatible plugins to be loaded.
-            (new Plugin())->unactivateAll();
-            return;
+            $plugin->unactivateAll();
+        } else {
+            $plugin->checkStates();
         }
 
-        Profiler::getInstance()->stop('DisablePluginsOnVersionChange::execute');
+        Profiler::getInstance()->stop('CheckPluginsStates::execute');
     }
 }

--- a/src/Glpi/Kernel/Listener/PostBootListener/InitializePlugins.php
+++ b/src/Glpi/Kernel/Listener/PostBootListener/InitializePlugins.php
@@ -63,14 +63,14 @@ final readonly class InitializePlugins implements EventSubscriberInterface
             return;
         }
 
+        Profiler::getInstance()->start('InitializePlugins::execute', Profiler::CATEGORY_BOOT);
+
         if (Environment::get()->shouldSetupTesterPlugin()) {
             $this->setupTesterPlugin();
         }
 
-        Profiler::getInstance()->start('InitializePlugins::execute', Profiler::CATEGORY_BOOT);
-
         $plugin = new Plugin();
-        $plugin->init(true);
+        $plugin->init();
 
         $this->pluginContainer->initializeContainer();
 

--- a/src/Glpi/Kernel/Listener/PostBootListener/ProfilerStart.php
+++ b/src/Glpi/Kernel/Listener/PostBootListener/ProfilerStart.php
@@ -34,7 +34,6 @@
 
 namespace Glpi\Kernel\Listener\PostBootListener;
 
-use Session;
 use Glpi\Debug\Profile;
 use Glpi\Debug\Profiler;
 use Glpi\Kernel\ListenersPriority;
@@ -56,12 +55,7 @@ final readonly class ProfilerStart implements EventSubscriberInterface
             Profiler::getInstance()->disable();
         } else {
             Profiler::getInstance()->start('php_request');
-        }
 
-        if (
-            isset($_SESSION['glpi_use_mode'])
-            && ($_SESSION['glpi_use_mode'] == Session::DEBUG_MODE)
-        ) {
             // Start the debug profile
             Profile::getCurrent();
         }

--- a/src/Glpi/Kernel/Listener/PostBootListener/SessionStart.php
+++ b/src/Glpi/Kernel/Listener/PostBootListener/SessionStart.php
@@ -36,6 +36,7 @@ namespace Glpi\Kernel\Listener\PostBootListener;
 
 use Glpi\Debug\Profiler;
 use Glpi\Http\RequestRouterTrait;
+use Glpi\Http\SessionManager;
 use Glpi\Kernel\KernelListenerTrait;
 use Glpi\Kernel\ListenersPriority;
 use Glpi\Kernel\PostBootEvent;
@@ -50,6 +51,7 @@ final class SessionStart implements EventSubscriberInterface
     use RequestRouterTrait;
 
     public function __construct(
+        private SessionManager $session_manager,
         #[Autowire('%kernel.project_dir%')]
         string $glpi_root,
         array $plugin_directories = GLPI_PLUGINS_DIRECTORIES,
@@ -85,60 +87,14 @@ final class SessionStart implements EventSubscriberInterface
             );
         }
 
-        // The session must be started even in CLI context.
-        // The GLPI code refers to the session in many places
-        // and we cannot safely remove its initialization in the CLI context.
-        $start_session = true;
-
-        if (isset($_SERVER['REQUEST_URI'])) {
-            // Specific configuration related to web context
-
+        if (PHP_SAPI === 'cli') {
+            $is_stateless = true;
+        } else {
             $request = Request::createFromGlobals();
-            $path = $this->normalizePath($request);
-
-            $use_cookies = true;
-            if (\str_starts_with($path, '/api.php') || \str_starts_with($path, '/apirest.php')) {
-                // API clients must not use cookies, as the session token is expected to be passed in headers.
-                $use_cookies = false;
-                // The API endpoint is starting the session manually.
-                $start_session = false;
-            } elseif (
-                $this->getTargetFile($path) !== null
-                && !$this->isTargetAPhpScript($path)
-            ) {
-                // Static files loaded by the FrontEndAssetsListener must not start
-                // a session or it'll prevent them from being cached.
-                $start_session = false;
-            } elseif (\str_starts_with($path, '/caldav.php')) {
-                // CalDAV clients must not use cookies, as the authentication is expected to be passed in headers.
-                $use_cookies = false;
-            } elseif (
-                (
-                    \str_starts_with($path, '/front/central.php')
-                    && $request->query->has('dashboard')
-                )
-                || (
-                    \str_starts_with($path, '/ajax/dashboard.php')
-                    && \in_array($request->get('action'), ['get_dashboard_items', 'get_card', 'get_cards'], true)
-                    && (bool) $request->get('embed')
-                )
-            ) {
-                // Embed dashboards will need to act in an isolated session context
-                $use_cookies = false;
-            } elseif (\str_starts_with($path, '/front/cron.php')) {
-                // The cron endpoint is not expected to use the authenticated user session.
-                $use_cookies = false;
-            } elseif (\str_starts_with($path, '/front/planning.php') && $request->query->has('genical')) {
-                // The `genical` endpoint must not use cookies, as the authentication is expected to be passed in the query parameters.
-                $use_cookies = false;
-            }
-
-            if (!$use_cookies) {
-                ini_set('session.use_cookies', 0);
-            }
+            $is_stateless = $this->session_manager->isResourceStateless($request);
         }
 
-        if ($start_session) {
+        if (!$is_stateless) {
             Session::start();
 
             // Copy the configuration defaults to the session
@@ -147,6 +103,15 @@ final class SessionStart implements EventSubscriberInterface
                     $_SESSION["glpi$field"] = $CFG_GLPI[$field];
                 }
             }
+        } else {
+            // Stateless endpoints will often have to start their own PHP session (based on a token for instance).
+            // Be sure to not use cookies defined in the request or to send a cookie in the response.
+            ini_set('session.use_cookies', 0);
+
+            // The session base vars must always be defined.
+            // Indeed, the GLPI code often refers to the `$_SESSION` variable
+            // and we have to set them to prevent massive undefined array key access.
+            Session::initVars();
         }
 
         Profiler::getInstance()->stop('SessionStart::execute');

--- a/src/Glpi/Kernel/ListenersPriority.php
+++ b/src/Glpi/Kernel/ListenersPriority.php
@@ -40,16 +40,17 @@ use Glpi\Kernel\Listener\RequestListener as RequestListener;
 final class ListenersPriority
 {
     public const POST_BOOT_LISTENERS_PRIORITIES = [
-        PostBootListener\SessionStart::class =>                        200,
-        PostBootListener\ProfilerStart::class =>                       190,
-        PostBootListener\InitializeDbConnection::class =>              180,
-        PostBootListener\InitializeCache::class =>                     170,
-        PostBootListener\LoadLegacyConfiguration::class =>             160,
-        PostBootListener\LoadLanguage::class =>                        150,
-        PostBootListener\CustomObjectsAutoloaderRegistration::class => 140,
-        PostBootListener\DisablePluginsOnVersionChange::class =>       135,
-        PostBootListener\InitializePlugins::class =>                   130,
-        PostBootListener\CustomObjectsBootstrap::class =>              120,
+        PostBootListener\ProfilerStart::class =>                       200,
+        PostBootListener\InitializeDbConnection::class =>              190,
+        PostBootListener\InitializeCache::class =>                     180,
+        PostBootListener\LoadLegacyConfiguration::class =>             170,
+        PostBootListener\CustomObjectsAutoloaderRegistration::class => 160,
+        PostBootListener\CheckPluginsStates::class =>                  150,
+        PostBootListener\BootPlugins::class =>                         140,
+        PostBootListener\SessionStart::class =>                        130,
+        PostBootListener\LoadLanguage::class =>                        120,
+        PostBootListener\InitializePlugins::class =>                   110,
+        PostBootListener\CustomObjectsBootstrap::class =>              100,
     ];
 
     public const REQUEST_LISTENERS_PRIORITIES = [

--- a/src/Glpi/Marketplace/Controller.php
+++ b/src/Glpi/Marketplace/Controller.php
@@ -379,7 +379,7 @@ class Controller extends CommonGLPI
     public static function getAllUpdates()
     {
         $plugin_inst = new Plugin();
-        $plugin_inst->init(true);
+        $plugin_inst->checkStates(true); // force synchronization of the DB data with the filesystem data
         $installed   = $plugin_inst->getList();
 
         $updates = [];
@@ -662,7 +662,13 @@ class Controller extends CommonGLPI
         $plugin->getFromDBbyDir($this->plugin_key);
 
         // reload plugins
-        $plugin->init(true);
+        // FIXME: The marketplace should use 2 distinct requests for its actions
+        // 1. call the method (install, update, ...)
+        // 2. call an endpoint to refresh the corresponding plugin card
+        //
+        // Indeed, forcing the plugins boot/init here may cause issues when trying to reload a plugin already loaded.
+        $plugin->bootPlugins();
+        $plugin->init();
 
         ob_end_clean();
 

--- a/src/Glpi/Marketplace/View.php
+++ b/src/Glpi/Marketplace/View.php
@@ -220,7 +220,7 @@ class View extends CommonGLPI
         global $CFG_GLPI;
 
         $plugin_inst = new Plugin();
-        $plugin_inst->init(true); // reload plugins
+        $plugin_inst->checkStates(true); // force synchronization of the DB data with the filesystem data
         $installed   = $plugin_inst->getList();
 
         $apiplugins  = [];

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -118,11 +118,18 @@ class Plugin extends CommonDBTM
     public static $rightname = 'config';
 
     /**
-     * Indicates whether plugin states have been checked.
+     * Indicates whether plugins have been initialized.
      *
      * @var boolean
      */
-    private static $plugins_state_checked = false;
+    private static $plugins_initialized = false;
+
+    /**
+     * Booted plugin list
+     *
+     * @var string[]
+     */
+    private static $booted_plugins = [];
 
     /**
      * Activated plugin list
@@ -268,52 +275,84 @@ class Plugin extends CommonDBTM
         return $this->getFromDBByCrit([$this->getTable() . '.directory' => $dir]);
     }
 
-
     /**
-     * Init plugins list.
-     *
-     * @param boolean $load_plugins     Whether to load active/configurable plugins or not.
-     *
-     * @return void
-     **/
-    public function init(bool $load_plugins = false)
+     * Boot active plugins.
+     */
+    public function bootPlugins(): void
     {
         /** @var \DBmysql|null $DB */
         global $DB;
 
-        self::$plugins_state_checked = false;
+        self::$booted_plugins = [];
         self::$activated_plugins = [];
         self::$loaded_plugins = [];
 
-        $this->checkStates(false);
-
         $plugins = $this->find(['state' => [self::ACTIVATED, self::TOBECONFIGURED]]);
 
-        // Store plugins that are loadable and still marked as active in DB after call to `self::checkStates()`,
-        // but before actually calling plugins init functions,
-        // in order to not have to do a DB query on `self::isActivated()` calls which are commonly use in plugins init functions.
-        $directories_to_load = [];
         foreach ($plugins as $plugin) {
-            if (!$this->isLoadable($plugin['directory'])) {
+            $plugin_key = $plugin['directory'];
+
+            if (!$this->isLoadable($plugin_key)) {
                 continue;
             }
 
-            $directories_to_load[] = $plugin['directory'];
+            foreach (GLPI_PLUGINS_DIRECTORIES as $base_dir) {
+                $plugin_directory = "$base_dir/$plugin_key";
 
-            if ((int) $plugin['state'] === self::ACTIVATED) {
-                self::$activated_plugins[] = $plugin['directory'];
+                if (!is_dir($plugin_directory)) {
+                    continue; // try with next base dir
+                }
+
+                // Register PSR-4 autoloader
+                $psr4_dir = $plugin_directory . '/src/';
+                if (is_dir($psr4_dir)) {
+                    $psr4_autoloader = new \Composer\Autoload\ClassLoader();
+                    $psr4_autoloader->addPsr4(NS_PLUG . ucfirst($plugin_key) . '\\', $psr4_dir);
+                    $psr4_autoloader->register();
+                }
+
+                $boot_function = sprintf('plugin_%s_boot', $plugin_key);
+                if (function_exists($boot_function)) {
+                    try {
+                        $boot_function();
+                    } catch (\Throwable $e) {
+                        // Log error
+                        /** @var \Psr\Log\LoggerInterface $PHPLOGGER */
+                        global $PHPLOGGER;
+                        $PHPLOGGER->error(
+                            sprintf('An error occurred during the `%s` plugin boot: %s', $plugin_key, $e->getMessage()),
+                            ['exception' => $e]
+                        );
+                        continue 2; // ignore this plugin
+                    }
+                }
+
+                self::$booted_plugins[] = $plugin_key;
+
+                if ((int) $plugin['state'] === self::ACTIVATED) {
+                    self::$activated_plugins[] = $plugin_key;
+                }
+
             }
         }
+    }
 
-        if ($load_plugins) {
-            foreach ($directories_to_load as $directory) {
-                \Glpi\Debug\Profiler::getInstance()->start("{$directory}:init", \Glpi\Debug\Profiler::CATEGORY_PLUGINS);
-                Plugin::load($directory);
-                \Glpi\Debug\Profiler::getInstance()->stop("{$directory}:init");
-            }
-            // For plugins which require action after all plugin init
-            Plugin::doHook(Hooks::POST_INIT);
+    /**
+     * Initialize active plugins.
+     */
+    public function init()
+    {
+        self::$plugins_initialized = false;
+
+        foreach (self::$booted_plugins as $plugin_key) {
+            \Glpi\Debug\Profiler::getInstance()->start("{$plugin_key}:init", \Glpi\Debug\Profiler::CATEGORY_PLUGINS);
+            Plugin::load($plugin_key);
+            \Glpi\Debug\Profiler::getInstance()->stop("{$plugin_key}:init");
         }
+        // For plugins which require action after all plugin init
+        Plugin::doHook(Hooks::POST_INIT);
+
+        self::$plugins_initialized = true;
     }
 
 
@@ -343,14 +382,6 @@ class Plugin extends CommonDBTM
             if ((new self())->loadPluginSetupFile($plugin_key)) {
                 $loaded = true;
                 if (!in_array($plugin_key, self::$loaded_plugins)) {
-                    // Register PSR-4 autoloader
-                    $psr4_dir = $plugin_directory . '/src/';
-                    if (is_dir($psr4_dir)) {
-                        $psr4_autoloader = new \Composer\Autoload\ClassLoader();
-                        $psr4_autoloader->addPsr4(NS_PLUG . ucfirst($plugin_key) . '\\', $psr4_dir);
-                        $psr4_autoloader->register();
-                    }
-
                     // Init plugin
                     self::$loaded_plugins[] = $plugin_key;
                     $init_function = "plugin_init_$plugin_key";
@@ -541,8 +572,6 @@ class Plugin extends CommonDBTM
         foreach ($directories as $directory) {
             $this->checkPluginState($directory, $scan_inactive_and_new_plugins);
         }
-
-        self::$plugins_state_checked = true;
     }
 
     /**
@@ -551,7 +580,7 @@ class Plugin extends CommonDBTM
     private function getPluginInformation(string $plugin_key): ?array
     {
         if (!array_key_exists($plugin_key, $this->plugins_information)) {
-            $information = $this->getInformationsFromDirectory($plugin_key);
+            $information = $this->getInformationsFromDirectory($plugin_key, with_lang: false);
             $this->plugins_information[$plugin_key] = !empty($information) ? $information : null;
         }
 
@@ -1292,9 +1321,8 @@ class Plugin extends CommonDBTM
      */
     public function isActivated($directory)
     {
-        if (!self::$plugins_state_checked) {
-            // Plugins are not actually loaded/activated before plugins state checks,
-            // and so $activated_plugins will be empty.
+        if (!self::$plugins_initialized) {
+            // `$activated_plugins` content will not be reliable until plugins have been initialized.
             // In this case, plugins states have to be fetched from DB.
             $self = new self();
             return $self->getFromDBbyDir($directory)

--- a/src/Session.php
+++ b/src/Session.php
@@ -255,6 +255,14 @@ class Session
             session_start();
         }
 
+        self::initVars();
+    }
+
+    /**
+     * Initialize session variables.
+     */
+    public static function initVars(): void
+    {
         // Define current time for sync of action timing
         $_SESSION["glpi_currenttime"] = date("Y-m-d H:i:s");
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] This change requires a documentation update.

## Description

Some plugins are requiring to be able to use "stateless" endpoints. Stateless endpoints are already used in GLPI form machine-to-machine endpoints (API, CalDAV, ...), or for resources that can be publicly shared (embed dashboards, webcal, ...).

The problem is that the session was started prior to the plugins initialization, and some plugins are requiring this because they have to manipulate the session during their initialization. For instance the `localeoverride` plugin have to load its locale files according to the connected user locale, and this information is only available once the session is started.

I had to refactor a little the GLPI (post) boot sequence to add a new `plugin_xxx_boot()` hook that can be used to do some actions during the GLPI boot sequence, after the DB init and the configuration loading, but before the session start and the actual plugins initialization.

To register a stateless URL pattern, plugins will have be able to do this:
```php
function plugin_myplugin_boot() {
    SessionManager::registerPluginStatelessPath('myplugin', '#^/api/#');
}
```

I also refactored how stateless GLPI endpoints are handled, to ensure that they actually start their PHP session themselves.