### PR TITLE
Fix(Twig): fix Monaco Editor lang

### DIFF
--- a/templates/components/form/fields_macros.html.twig
+++ b/templates/components/form/fields_macros.html.twig
@@ -990,7 +990,7 @@
     <script>
         $(() => {
             const editor_options = {{ options.single_line ? 'true' : 'false' }} ? window.GLPI.Monaco.getSingleLineEditorOptions() : {};
-            window.GLPI.Monaco.createEditor('{{ code_container_id }}', 'twig', "{{ value|e('js') }}", {{ options.completions|json_encode|raw }}, editor_options).then(() => {
+            window.GLPI.Monaco.createEditor('{{ code_container_id }}', '{{ options.language }}', "{{ value|e('js') }}", {{ options.completions|json_encode|raw }}, editor_options).then(() => {
                 $('#{{ code_container_id }}').closest('form').on('formdata', (e) => {
                     const editors = window.monaco.editor.getEditors().filter((editor) => {
                         return editor._domElement.id === '{{ code_container_id }}';


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

If the editor is not initialized with the correct language, the autocompletion feature stops working.

In this case, the Monaco Editor is supposed to handle JSON, but the autocomplete does not return any suggestions:
![image](https://github.com/user-attachments/assets/eff37d7f-a31a-457f-b0f6-365b256aa0ab)

After fixing the initialization issue, the autocomplete correctly returns the expected data:
![image](https://github.com/user-attachments/assets/7c6201da-2ebf-4b99-99f3-7694a39ba104)

I don’t know if this information will be useful, but here is what appears in the browser
![image](https://github.com/user-attachments/assets/6134d8d1-db6c-459f-981c-b620fd6c657d)



## Screenshots (if appropriate):


