### PR TITLE
Fix inability to assign actors to a new ticket

### DIFF
--- a/templates/components/itilobject/actors/field.html.twig
+++ b/templates/components/itilobject/actors/field.html.twig
@@ -54,9 +54,10 @@
         {{ required ? 'required' : '' }}>
    {% for actor in actors %}
       {% set unique_id = "user_opt_" ~ actortype ~ actor.itemtype ~ actor.items_id %}
+      {% set actor_use_notification = actor['use_notification'] ?? false %}
       <option selected="true" value="{{ actor['itemtype'] ~ '_' ~ actor['items_id'] }}"
             data-itemtype="{{ actor['itemtype'] }}" data-items-id="{{ actor['items_id'] }}"
-            data-use-notification="{{ actor['use_notification'] ?? false }}"
+            data-use-notification="{{ actor_use_notification ? 1 : 0 }}"
             data-default-email="{{ actor['default_email'] ?? '' }}"
             data-alternative-email="{{ actor['alternative_email'] ?? '' }}"
             {% if (actor['itemtype'] == 'User' and itiltemplate.isHiddenField('_users_id_' ~ actortype)) or (actor['itemtype'] == 'Group' and itiltemplate.isHiddenField('_groups_id_' ~ actortype)) %}


### PR DESCRIPTION

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.

## Description

Filling the "assigned" fields in a new ticket would lead to an SQL error:

```
[2025-07-04 08:33:31] glpi.CRITICAL:   *** Uncaught PHP Exception RuntimeException: "MySQL query error: Incorrect 
integer value: '' for column 'use_notification' at row 1 (1366) in SQL query "INSERT INTO `glpi_tickets_users` (`type`, 
`use_notification`, `alternative_email`, `tickets_id`, `users_id`) VALUES ('2', '', '', '123', '2')"." at DBmysql.php
line 369

  Backtrace :
  ./src/DBmysql.php:369                              
  ./src/DBmysql.php:1311                             DBmysql->doQuery()
  ./src/CommonDBTM.php:776                           DBmysql->insert()
  ./src/CommonDBTM.php:1392                          CommonDBTM->addToDB()
  ./src/CommonITILObject.php:9406                    CommonDBTM->add()
  ./src/CommonITILObject.php:3177                    CommonITILObject->updateActors()
  ./src/Ticket.php:1788                              CommonITILObject->post_addItem()
  ./src/CommonDBTM.php:1408                          Ticket->post_addItem()
  ./front/ticket.form.php:80                         CommonDBTM->add()
  ...Glpi/Controller/LegacyFileLoadController.php:59 require()
  ./vendor/symfony/http-kernel/HttpKernel.php:181    Glpi\Controller\LegacyFileLoadController->__invoke()
  ./vendor/symfony/http-kernel/HttpKernel.php:76     Symfony\Component\HttpKernel\HttpKernel->handleRaw()
  ./vendor/symfony/http-kernel/Kernel.php:197        Symfony\Component\HttpKernel\HttpKernel->handle()
  ./public/index.php:70                              Symfony\Component\HttpKernel\Kernel->handle()
```

This is because we are trying to render a boolean in the `data-use-notification` property.
Twig will render a false boolean as an empty string, we need to explicitly use `{{ boolean ? 1 : 0 }}` to get the expected "0" value our backend will expect.

## References

Fix #20194.

