### PR TITLE
Disallow "File" question type for unauthenticated forms

### DIFF
--- a/src/Glpi/Form/QuestionType/QuestionTypeFile.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeFile.php
@@ -135,6 +135,6 @@ TWIG;
     #[Override]
     public function isAllowedForUnauthenticatedAccess(): bool
     {
-        return true;
+        return false;
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.

## Description

See #19834, anonymous users can't upload files and won't be able to fill this question.

We should thus disable it, as it was the case in formcreator for a while:

![image](https://github.com/user-attachments/assets/0d9645c3-1f2b-4541-88d2-634e3f32f336)

Note that pasting images into rich text fields does work for anonymous forms right now, is it safe to keep it enabled or should we look into disabled it too ?
