### PR TITLE
fix illustration preview switching from custom to native

### DIFF
--- a/templates/components/illustration/icon.svg.twig
+++ b/templates/components/illustration/icon.svg.twig
@@ -31,8 +31,6 @@
  #}
 
 <svg role="img" width="{{ width }}" height="{{ height }}">
-    {% if (title ?? '') is not empty %}
-        <title>{{ title }}</title>
-    {% endif %}
+    <title>{{ title }}</title>
     <use xlink:href="{{ path(file_path) }}#{{ icon_id }}"/>
 </svg>

--- a/templates/components/illustration/icon.svg.twig
+++ b/templates/components/illustration/icon.svg.twig
@@ -31,6 +31,6 @@
  #}
 
 <svg role="img" width="{{ width }}" height="{{ height }}">
-    <title>{{ title ?? ''}}</title>
+    <title>{{ title ?? '' }}</title>
     <use xlink:href="{{ path(file_path) }}#{{ icon_id }}"/>
 </svg>

--- a/templates/components/illustration/icon.svg.twig
+++ b/templates/components/illustration/icon.svg.twig
@@ -31,6 +31,6 @@
  #}
 
 <svg role="img" width="{{ width }}" height="{{ height }}">
-    <title>{{ title }}</title>
+    <title>{{ title ?? ''}}</title>
     <use xlink:href="{{ path(file_path) }}#{{ icon_id }}"/>
 </svg>


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

When there is a custom illustration picked, the native illustration HTML is on the page but hidden and the title element is excluded. When you switch to a native illustration, the JS tries to update this missing element and it throws an error which prevents the preview from updating.