### PR TITLE
Support new and old SQL format in hooks

### DIFF
--- a/src/Glpi/Plugin/Hooks.php
+++ b/src/Glpi/Plugin/Hooks.php
@@ -1191,7 +1191,7 @@ class Hooks
      * - 'itemtype' => The type of the items being searched.
      * - 'reference_table' => The name of the reference table. This should be the table for the itemtype.
      * - 'already_link_table' => An array of tables that are already joined.
-     * The function is expected to return a SQL JOIN clause as a string or an empty string if the default behavior should be used.
+     * The function is expected to return a SQL JOIN clause in the iterator array format, raw SQL string or an empty string if the default behavior should be used.
      */
     public const AUTO_ADD_DEFAULT_JOIN = 'addDefaultJoin';
 
@@ -1207,7 +1207,7 @@ class Hooks
      * Automatic hook function to add a WHERE clause to the SQL query for a searchof itemtypes added by the plugin.
      * The function is called with the following parameters:
      * - 'itemtype' => The type of the items being searched.
-     * The function is expected to return a SQL WHERE clause as a string or an empty string if the default behavior should be used.
+     * The function is expected to return a SQL WHERE clause in the iterator array format, raw SQL string or an empty string if the default behavior should be used.
      */
     public const AUTO_ADD_DEFAULT_WHERE = 'addDefaultWhere';
 
@@ -1240,7 +1240,7 @@ class Hooks
      * - 'search_option_id' => The ID of the search option of the criteria.
      * - 'search_value' => The value to search for.
      * - 'num' => A string in the form of "${itemtype}_{$search_option_id}". The alias of the related field in the SELECT clause will be "ITEM_{$num}".
-     * The function is expected to return a SQL HAVING clause as a string or an empty string if the default behavior should be used.
+     * The function is expected to return a SQL HAVING clause in the iterator array format, raw SQL string or an empty string if the default behavior should be used.
      */
     public const AUTO_ADD_HAVING = 'addHaving';
 
@@ -1253,7 +1253,7 @@ class Hooks
      * - 'new_table' => The name of the table to be joined. Typically, this is the table related to the search option.
      * - 'link_field' => The name of the field in the reference table that links to the new table.
      * - 'already_link_table' => An array of tables that are already joined.
-     * The function is expected to return a SQL JOIN clause as a string or an empty string if the default behavior should be used.
+     * The function is expected to return a SQL JOIN clause in the iterator array format, raw SQL string or an empty string if the default behavior should be used.
      */
     public const AUTO_ADD_LEFT_JOIN = 'addLeftJoin';
 
@@ -1287,7 +1287,7 @@ class Hooks
      * - 'search_option_id' => The ID of the search option of the criteria.
      * - 'search_value' => The value to search for.
      * - 'search_type' => The type of the search (notcontains, contains, equals, etc.).
-     * The function is expected to return a SQL WHERE clause as a string or an empty string if the default behavior should be used.
+     * The function is expected to return a SQL WHERE clause in the iterator array format, raw SQL string or an empty string if the default behavior should be used.
      */
     public const AUTO_ADD_WHERE = 'addWhere';
 

--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -1074,7 +1074,7 @@ final class SQLProvider implements SearchProviderInterface
                 if ($plug = isPluginItemType($itemtype)) {
                     $default_where = Plugin::doOneHook($plug['plugin'], Hooks::AUTO_ADD_DEFAULT_WHERE, $itemtype);
                     if (!empty($default_where)) {
-                        $criteria = [new QueryExpression($default_where)];
+                        $criteria = is_array($default_where) ? $default_where : [new QueryExpression($default_where)];
                     }
                 }
                 break;
@@ -1089,7 +1089,6 @@ final class SQLProvider implements SearchProviderInterface
         }
 
         /* Hook to restrict user right on current itemtype */
-        //TODO Plugin call works on raw SQL, should use criteria array instead
         [$itemtype, $criteria] = Plugin::doHookFunction(Hooks::ADD_DEFAULT_WHERE, [$itemtype, $criteria]);
         return $criteria;
     }
@@ -1292,7 +1291,7 @@ final class SQLProvider implements SearchProviderInterface
                 $searchtype
             );
             if (!empty($out)) {
-                return [new QueryExpression($out)];
+                return is_array($out) ? $out : [new QueryExpression($out)];
             }
         }
 
@@ -1683,7 +1682,7 @@ final class SQLProvider implements SearchProviderInterface
                     $searchtype
                 );
                 if (!empty($out)) {
-                    return [new QueryExpression($out)];
+                    return is_array($out) ? $out : [new QueryExpression($out)];
                 }
             }
         }
@@ -2544,11 +2543,11 @@ final class SQLProvider implements SearchProviderInterface
                 $hook_function = 'plugin_' . strtolower($plugin_name) . '_' . Hooks::AUTO_ADD_LEFT_JOIN;
                 $hook_closure  = static function () use ($hook_function, $itemtype, $ref_table, $new_table, $linkfield, &$already_link_tables) {
                     if (is_callable($hook_function)) {
-                        return self::parseJoinString($hook_function($itemtype, $ref_table, $new_table, $linkfield, $already_link_tables) ?? '');
+                        return $hook_function($itemtype, $ref_table, $new_table, $linkfield, $already_link_tables);
                     }
                     return '';
                 };
-                $specific_leftjoin_criteria = self::parseJoinString(Plugin::doOneHook($plugin_name, $hook_closure) ?? '');
+                $specific_leftjoin_criteria = self::parseJoinString(Plugin::doOneHook($plugin_name, $hook_closure));
             }
         }
         if (!empty($linkfield)) {
@@ -3519,9 +3518,7 @@ final class SQLProvider implements SearchProviderInterface
                 "{$itemtype}_{$ID}"
             );
             if (!empty($out)) {
-                return [
-                    new QueryExpression($out),
-                ];
+                return is_array($out) ? $out : [new QueryExpression($out)];
             }
         }
 
@@ -3541,9 +3538,7 @@ final class SQLProvider implements SearchProviderInterface
                     "{$itemtype}_{$ID}"
                 );
                 if (!empty($out)) {
-                    return [
-                        new QueryExpression($out),
-                    ];
+                    return is_array($out) ? $out : [new QueryExpression($out)];
                 }
             }
         }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Fixes #20050
Fixes issue with double parsing raw JOIN SQL from plugin hook.
Add support in other hooks for both the new (array) and old (raw strings) formats. For now, neither is truly deprecated even if plugins should start using the array format when possible.