### PR TITLE
fix expanding group planning filters

### DIFF
--- a/templates/pages/assistance/planning/single_filter.html.twig
+++ b/templates/pages/assistance/planning/single_filter.html.twig
@@ -94,7 +94,7 @@
             </div>
         {% endif %}
     </span>
-    {% if (caldav_item_url ?? '') is not empty and filter_data.type == 'group_users' %}
+    {% if (caldav_url ?? '') is not empty and filter_data.type == 'group_users' %}
         <ul class="group_listofusers filters">
             {% for user_key, user_data in filter_data.users %}
                 {% do call('Planning::showSingleLinePlanningFilter', [user_key, user_data, {


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Fixes #20082
An invalid caldav url variable name was causing the group filter list of users to not be added to the DOM.
