### PR TITLE
Add missing config for simplified interface mention right

### DIFF
--- a/templates/pages/admin/profile/assistance_simple.html.twig
+++ b/templates/pages/admin/profile/assistance_simple.html.twig
@@ -45,6 +45,31 @@
 
     {{ _self.displayRightsMatrix(item, 'helpdesk', 'tracking', 'general', __('Assistance')) }}
 
+    {% if config('use_notifications') == '0' %}
+        {% set activation_msg %}
+            <span class="alert alert-warning">
+                {{ __('Notifications must be enabled to activate mentions.') }}
+            </span>
+        {% endset %}
+        {{ fields.htmlField('use_mentions', activation_msg, __('Mentions configuration'), {full_width: true}) }}
+    {% else %}
+        {% set user_mention_helper %}
+            {{ __('Enables or disables the ability to mention users within the application.') }}
+            {{ __('Disabled') ~ ': ' ~ __('User mentions are disabled for this profile.') }}
+            {{ __('Full') ~ ': ' ~ __('Displays all users. Mentioned users will be added as observers if they are not already actors.') }}
+        {% endset %}
+        {{ fields.dropdownArrayField(
+            'use_mentions',
+            item.fields['use_mentions'],
+            {
+                (constant('Glpi\\RichText\\UserMention::USER_MENTION_DISABLED')): __('Disabled'),
+                (constant('Glpi\\RichText\\UserMention::USER_MENTION_FULL')): __('Full'),
+            },
+            __('Mentions configuration'),
+            {helper: user_mention_helper}
+        ) }}
+    {% endif %}
+
     {{ fields.smallTitle(__('Association')) }}
     {{ fields.checkboxField('_show_group_hardware', item.fields['show_group_hardware'], __('See hardware of my groups'), {
         full_width: true


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Fixes #19981
This config option for simplified interfaces was missing from the original PR. As noted in the issue, the "Restricted" option is complicated to support when considering the anonymization feature. So, for simplified interfaces I limited the configuration of user mentions to Disabled and Full. This limitation should still meet the original client's request.
