### PR TITLE
Remove forced dark text color in form destinations

### DIFF
--- a/templates/pages/admin/form/form_destination.html.twig
+++ b/templates/pages/admin/form/form_destination.html.twig
@@ -181,13 +181,3 @@
         new m.GlpiFormDestinationConditionController();
     });
 </script>
-
-<style>
-    /* Should be handled by tabler but it doesn't seem to be active */
-    .accordion-header {
-        color: var(--tblr-dark);
-    }
-    .accordion-item {
-        color: var(--tblr-dark);
-    }
-</style>


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Forced use of the dark color for text in several places in the form destination tab made the feature look broken and hid many of the options in dark themes. I don't see a reason not to use the default color.

Before:
Auror             |  Midnight
:-------------------------:|:-------------------------:
![Selection_516](https://github.com/user-attachments/assets/603aaead-e581-44aa-a8ac-3269da1ce51f)  |  ![Selection_515](https://github.com/user-attachments/assets/4a8625d0-0d88-46dc-a329-d06fbf3ab0f8)

After:
Auror             |  Midnight
:-------------------------:|:-------------------------:
![Selection_519](https://github.com/user-attachments/assets/8e13ed82-4f1b-4056-9a43-5504c397207b) | ![Selection_518](https://github.com/user-attachments/assets/2e3a604f-5f9f-4971-9b6f-6375bef7cb6b)


