### PR TITLE
Exclude is_global field from lock form

### DIFF
--- a/src/Lockedfield.php
+++ b/src/Lockedfield.php
@@ -404,6 +404,12 @@ class Lockedfield extends CommonDBTM
         return true;
     }
 
+    public function getFormFields(): array
+    {
+        $fields = parent::getFormFields();
+        return array_filter($fields, static fn ($field) => $field !== 'is_global');
+    }
+
 
     /**
      * List of itemtypes/fields that can be locked globally

--- a/src/Lockedfield.php
+++ b/src/Lockedfield.php
@@ -407,7 +407,7 @@ class Lockedfield extends CommonDBTM
     public function getFormFields(): array
     {
         $fields = parent::getFormFields();
-        return array_filter($fields, static fn ($field) => $field !== 'is_global');
+        return array_filter($fields, static fn($field) => $field !== 'is_global');
     }
 
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

The `is_global` field for locked fields has no purpose in the form display and the value is always removed prior to showing the form anyways. In development env, this causes a Twig strict mode error. The form is only used to create new global locked fields it seems.