### PR TITLE
Fix planning ajax form actions

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -5586,12 +5586,12 @@ HTML;
 
 
     /**
-     * This function provides a mecanism to send html form by ajax
+     * This function provides a mechanism to send HTML form by ajax
      *
      * @param string $selector selector of a HTML form
-     * @param string $success  jacascript code of the success callback
-     * @param string $error    jacascript code of the error callback
-     * @param string $complete jacascript code of the complete callback
+     * @param string $success  JavaScript code of the success callback
+     * @param string $error    JavaScript code of the error callback
+     * @param string $complete JavaScript code of the complete callback
      *
      * @see https://api.jquery.com/jQuery.ajax/
      *
@@ -5599,7 +5599,7 @@ HTML;
      **/
     public static function ajaxForm($selector, $success = "console.log(html);", $error = "console.error(html)", $complete = '')
     {
-        echo Html::scriptBlock("
+        echo Html::scriptBlock(<<<JS
       $(function() {
          var lastClicked = null;
          $('input[type=submit], button[type=submit]').click(function(e) {
@@ -5633,7 +5633,7 @@ HTML;
             });
          });
       });
-      ");
+JS);
     }
 
     /**

--- a/src/Planning.php
+++ b/src/Planning.php
@@ -1050,7 +1050,7 @@ TWIG, $twig_params);
             $rand = mt_rand();
             $options = [
                 'from_planning_edit_ajax' => true,
-                'formoptions'             => "id='edit_event_form$rand'",
+                'form_id'                 => "edit_event_form$rand",
                 'start'                   => date("Y-m-d", strtotime($params['start'])),
             ];
             if (isset($params['parentitemtype'])) {
@@ -1261,7 +1261,7 @@ TWIG, $twig_params);
                 'end'                => $params['end'],
                 'res_itemtype'       => $params['res_itemtype'],
                 'res_items_id'       => $params['res_items_id'],
-                'formoptions'        => "id='ajax_reminder$rand'",
+                'form_id'            => "ajax_reminder$rand",
             ]);
             $callback = "glpi_close_all_dialogs();
                       GLPIPlanning.refresh();

--- a/templates/components/form/header.html.twig
+++ b/templates/components/form/header.html.twig
@@ -36,6 +36,7 @@
 {% set nametype     = params['formtitle'] ?? item.getTypeName(1) %}
 {% set no_id        = params['noid'] ?? false %}
 {% set formoptions  = params['formoptions'] ?? '' %}
+{% set form_id      = params['form_id']|default('main-form') %}
 
 {% set entity_id = 0 %}
 {% set entity_name = '' %}
@@ -57,7 +58,7 @@
 {% set canedit = params['canedit']|default(item.canEdit(item.fields['id'])) %}
 
 {% if open_form and canedit %}
-<form id="main-form" name="asset_form" method="post" action="{{ target }}" {{ formoptions|raw }} enctype="multipart/form-data" data-submit-once>
+<form id="{{ form_id }}" name="asset_form" method="post" action="{{ target }}" {{ formoptions|raw }} enctype="multipart/form-data" data-submit-once>
    {% if item.isField("entities_id") %}
        <input type="hidden" name="entities_id" value="{{ entity_id }}" />
    {% endif %}


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Fixes #19920
The JS that intercepted form submits for the planning form was not working ~(probably broken since the first 10.0 release)~ because the form ID was not being set properly.
Now, the Add, Save and Delete form buttons for planning events will not force redirections/reloads.