### PR TITLE
Fix timeline media lightbox and previews

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -7811,30 +7811,28 @@ abstract class CommonITILObject extends CommonDBTM
                 $item['_can_delete'] = Document::canDelete() && $document_obj->canDeleteItem() && $canupdate_parent;
 
                 $timeline_key = $document_item['itemtype'] . "_" . $document_item['items_id'];
+                $doc_entry = [
+                    'type' => Document_Item::class,
+                    'item' => $item,
+                    '_is_image' => false,
+                ];
+                $docpath = GLPI_DOC_DIR . "/" . $item['filepath'];
+                $is_image = Document::isImage($docpath);
+                if ($is_image) {
+                    $doc_entry['_is_image'] = true;
+                    $doc_entry['_size'] = getimagesize($docpath);
+                }
                 if ($document_item['itemtype'] == static::getType()) {
                     // document associated directly to itilobject
-                    $timeline["Document_" . $document_item['documents_id']] = [
-                        'type' => 'Document_Item',
-                        'item' => $item,
-                        'object' => $document_obj,
-                    ];
+                    $doc_entry['object'] = $document_obj;
+                    $timeline["Document_" . $document_item['documents_id']] = $doc_entry;
                 } elseif (isset($timeline[$timeline_key])) {
                     // document associated to a sub item of itilobject
                     if (!isset($timeline[$timeline_key]['documents'])) {
                         $timeline[$timeline_key]['documents'] = [];
                     }
 
-                    $docpath = GLPI_DOC_DIR . "/" . $item['filepath'];
-                    $is_image = Document::isImage($docpath);
-                    $sub_document = [
-                        'type' => 'Document_Item',
-                        'item' => $item,
-                    ];
-                    if ($is_image) {
-                        $sub_document['_is_image'] = true;
-                        $sub_document['_size'] = getimagesize($docpath);
-                    }
-                    $timeline[$timeline_key]['documents'][] = $sub_document;
+                    $timeline[$timeline_key]['documents'][] = $doc_entry;
                 }
             }
         }

--- a/templates/components/itilobject/timeline/document/document_list_item.html.twig
+++ b/templates/components/itilobject/timeline/document/document_list_item.html.twig
@@ -1,0 +1,103 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2025 Teclib' and contributors.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+{# A single document item displayed in a list format rather than a preview for a lightbox #}
+<div class="row align-items-center m-n2 test">
+    {% set name     = entry_i['name'] ?? entry_i['filename'] %}
+    {% set filename = entry_i['filename'] ?? entry_i['name'] %}
+    {% set fk = item.getForeignKeyField() %}
+
+    {% if entry_i['filename'] %}
+        {% set docpath = path('front/document.send.php?docid=' ~ entry_i['id'] ~ "&" ~ fk ~ "=" ~ item.fields["id"]) %}
+        <div class="col text-truncate">
+            <a href="{{ docpath }}" target="_blank" title="{{ name }}">
+                <img src="{{ filename|document_icon }}" alt="{{ __('File extension') }}" />
+                {{ filename }}
+            </a>
+        </div>
+    {% endif %}
+
+    {% if entry_i['link'] %}
+        <div class="col-auto">
+            <a href="{{ entry_i['link'] }}" target="_blank">
+                <i class="ti ti-external-link"></i>
+                {{ entry_i['name'] }}
+            </a>
+        </div>
+    {% endif %}
+
+    {% if entry_i['filepath'] is defined and entry_i['filepath'] is not null %}
+        <div class="col-auto text-muted ms-2">
+            {{ entry_i['filepath']|document_size }}
+        </div>
+    {% endif %}
+
+    <div class="col-auto">
+        <div class="list-group-item-actions">
+            {% if entry_i['_can_edit'] %}
+                <a href="{{ 'Document'|itemtype_form_path(entry_i['id']) }}"
+                   class="btn btn-sm btn-ghost-secondary" title="{{ _x('button', 'Edit') }}"
+                   data-bs-toggle="tooltip" data-bs-placement="top">
+                    <i class="ti ti-edit"></i>
+                </a>
+            {% endif %}
+
+            {% if entry_i['_can_delete'] %}
+                <form class="d-inline" method="post" action="{{ item.getFormURL() }}">
+                    <input type="hidden" name="{{ fk }}" value="{{ item.fields['id'] }}">
+                    <input type="hidden" name="documents_id" value="{{ entry_i['id'] }}">
+                    <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}" />
+                    <button type="submit" class="btn btn-sm btn-ghost-secondary" name="delete_document"
+                            title="{{ _x('button', 'Delete permanently') }}"
+                            data-bs-toggle="tooltip" data-bs-placement="top">
+                        <i class="ti ti-trash"></i>
+                    </button>
+                </form>
+            {% endif %}
+            {% if entry_i['_can_edit'] %}
+                {% set blacklisted_class    = entry_i['is_blacklisted'] ? 'red' : '' %}
+                {% set blacklisted_title    = entry_i['is_blacklisted'] ? _x('button', 'Remove from import exclusion list') : _x('button', 'Add to import exclusion list') %}
+                {% set blacklisted_value    = entry_i['is_blacklisted'] ? 0 : 1 %}
+                <form class="d-inline" method="post" action="{{ 'Document'|itemtype_form_path }}">
+                    <input type="hidden" name="id" value="{{ entry_i['id'] }}">
+                    <input type="hidden" name="is_blacklisted" value="{{ blacklisted_value }}">
+                    <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}" />
+                    <button type="submit" class="btn btn-sm btn-ghost-secondary" name="update"
+                            title="{{ blacklisted_title }}"
+                            data-bs-toggle="tooltip" data-bs-placement="top">
+                        <i class="ti ti-ban {{ blacklisted_class }}"></i>
+                    </button>
+                </form>
+            {% endif %}
+        </div>
+    </div>
+</div>

--- a/templates/components/itilobject/timeline/document/post_figure_content.html.twig
+++ b/templates/components/itilobject/timeline/document/post_figure_content.html.twig
@@ -1,0 +1,74 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2025 Teclib' and contributors.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+{% set fk = item.getForeignKeyField() %}
+
+<div class="col-auto">
+    <div class="list-group-item-actions d-flex flex-column">
+        {% if document['item']['_can_edit'] %}
+            <a href="{{ 'Document'|itemtype_form_path(document['item']['id']) }}"
+               class="btn btn-sm btn-ghost-secondary" title="{{ _x('button', 'Edit') }}"
+               data-bs-toggle="tooltip" data-bs-placement="top">
+                <i class="ti ti-edit"></i>
+            </a>
+        {% endif %}
+
+        {% if document['item']['_can_delete'] %}
+            <form class="d-inline" method="post" action="{{ item.getFormURL() }}">
+                <input type="hidden" name="{{ fk }}" value="{{ item.fields['id'] }}">
+                <input type="hidden" name="documents_id" value="{{ document['item']['id'] }}">
+                <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}" />
+                <button type="submit" class="btn btn-sm btn-ghost-secondary" name="delete_document"
+                        title="{{ _x('button', 'Delete permanently') }}"
+                        data-bs-toggle="tooltip" data-bs-placement="top">
+                    <i class="ti ti-trash"></i>
+                </button>
+            </form>
+        {% endif %}
+
+        {% if document['item']['_can_edit'] %}
+            {% set blacklisted_class    = document['item']['is_blacklisted'] ? 'red' : '' %}
+            {% set blacklisted_title    = document['item']['is_blacklisted'] ? _x('button', 'Remove from import exclusion list') : _x('button', 'Add to import exclusion list') %}
+            {% set blacklisted_value    = document['item']['is_blacklisted'] ? 0 : 1 %}
+            <form class="d-inline" method="post" action="{{ 'Document'|itemtype_form_path }}">
+                <input type="hidden" name="id" value="{{ document['item']['id'] }}">
+                <input type="hidden" name="is_blacklisted" value="{{ blacklisted_value }}">
+                <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}" />
+                <button type="submit" class="btn btn-sm btn-ghost-secondary" name="update"
+                        title="{{ blacklisted_title }}"
+                        data-bs-toggle="tooltip" data-bs-placement="top">
+                    <i class="ti ti-ban {{ blacklisted_class }}"></i>
+                </button>
+            </form>
+        {% endif %}
+    </div>
+</div>

--- a/templates/components/itilobject/timeline/form_document_item.html.twig
+++ b/templates/components/itilobject/timeline/form_document_item.html.twig
@@ -34,81 +34,17 @@
 {% import 'components/form/fields_macros.html.twig' as fields %}
 
 {% block timeline_card %}
-   {% if form_mode == 'view' %}
-      <div class="row align-items-center m-n2">
-         {% set name     = entry_i['name'] ?? entry_i['filename'] %}
-         {% set filename = entry_i['filename'] ?? entry_i['name'] %}
-         {% set fk = item.getForeignKeyField() %}
-
-         {% if entry_i['filename'] %}
-            {% set docpath = path('front/document.send.php?docid=' ~ entry_i['id'] ~ "&" ~ fk ~ "=" ~ item.fields["id"]) %}
-            <div class="col text-truncate">
-               <a href="{{ docpath }}" target="_blank" title="{{ name }}">
-                  <img src="{{ filename|document_icon }}" alt="{{ __('File extension') }}" />
-                  {{ filename }}
-               </a>
-            </div>
-         {% endif %}
-
-         {% if entry_i['link'] %}
-            <div class="col-auto">
-               <a href="{{ entry_i['link'] }}" target="_blank">
-                  <i class="ti ti-external-link"></i>
-                  {{ entry_i['name'] }}
-               </a>
-            </div>
-         {% endif %}
-
-         {% if entry_i['filepath'] is defined and entry_i['filepath'] is not null %}
-            <div class="col-auto text-muted ms-2">
-               {{ entry_i['filepath']|document_size }}
-            </div>
-         {% endif %}
-
-         <div class="col-auto">
-            <div class="list-group-item-actions">
-               {% if entry_i['_can_edit'] %}
-                  <a href="{{ 'Document'|itemtype_form_path(entry_i['id']) }}"
-                     class="btn btn-sm btn-ghost-secondary" title="{{ _x('button', 'Edit') }}"
-                     data-bs-toggle="tooltip" data-bs-placement="top">
-                     <i class="ti ti-edit"></i>
-                  </a>
-               {% endif %}
-
-               {% if entry_i['_can_delete'] %}
-                  <form class="d-inline" method="post" action="{{ item.getFormURL() }}">
-                     <input type="hidden" name="{{ fk }}" value="{{ item.fields['id'] }}">
-                     <input type="hidden" name="documents_id" value="{{ entry_i['id'] }}">
-                     <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}" />
-                     <button type="submit" class="btn btn-sm btn-ghost-secondary" name="delete_document"
-                             title="{{ _x('button', 'Delete permanently') }}"
-                             data-bs-toggle="tooltip" data-bs-placement="top">
-                        <i class="ti ti-trash"></i>
-                     </button>
-                  </form>
-               {% endif %}
-                {% if document is defined and entry_i['_can_edit'] %}
-                    {% set blacklisted_class    = entry_i['is_blacklisted'] ? 'red' : '' %}
-                    {% set blacklisted_title    = entry_i['is_blacklisted'] ? _x('button', 'Remove from import exclusion list') : _x('button', 'Add to import exclusion list') %}
-                    {% set blacklisted_value    = entry_i['is_blacklisted'] ? 0 : 1 %}
-                     <form class="d-inline" method="post" action="{{ 'Document'|itemtype_form_path }}">
-                        <input type="hidden" name="id" value="{{ document['item']['id'] }}">
-                        <input type="hidden" name="is_blacklisted" value="{{ blacklisted_value }}">
-                        <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}" />
-                        <button type="submit" class="btn btn-sm btn-ghost-secondary" name="update"
-                                title="{{ blacklisted_title }}"
-                                data-bs-toggle="tooltip" data-bs-placement="top">
-                           <i class="ti ti-ban {{ blacklisted_class }}"></i>
-                        </button>
-                     </form>
-                {% endif %}
-            </div>
-         </div>
-      </div>
+    {% if form_mode == 'view' %}
+        {{ include('components/itilobject/timeline/sub_documents.html.twig', {
+            'entry': {
+                'documents': [entry],
+            },
+            'item': item,
+        }, with_context: false) }}
     {% else %}
         <div class="document_item">
             <form name="asset_form" style="width: 100%;" class="d-flex flex-column" method="post"
-                action="{{ "Document"|itemtype_form_path() }}" enctype="multipart/form-data" data-track-changes="true" data-submit-once>
+                  action="{{ "Document"|itemtype_form_path() }}" enctype="multipart/form-data" data-track-changes="true" data-submit-once>
                 <input type="hidden" name="entities_id" value="{{ item.getEntityID() }}" />
                 <input type="hidden" name="is_recursive" value="{{ item.isRecursive() }}" />
                 <input type="hidden" name="itemtype" value="{{ item.getType() }}" />
@@ -184,5 +120,5 @@
         <script type="module">
             import('/js/modules/ITIL/Timeline/DocumentForm.js');
         </script>
-   {% endif %}
+    {% endif %}
 {% endblock %}

--- a/templates/components/itilobject/timeline/sub_documents.html.twig
+++ b/templates/components/itilobject/timeline/sub_documents.html.twig
@@ -31,6 +31,7 @@
  #}
 
 {% set documents = entry['documents'] ?? [] %}
+{% set fk = item.getForeignKeyField() %}
 <div class="list-group list-group-hoverable sub-documents">
    {% set media_docs = documents|filter(d => (d['_is_image'] ?? false) or d['item']['mime'] starts with 'video') %}
    {% set other_docs = documents|filter(d => not ((d['_is_image'] ?? false) or d['item']['mime'] starts with 'video')) %}
@@ -38,51 +39,14 @@
    {% if media_docs|length > 0 %}
       {% set imgs = [] %}
       {% for document in media_docs %}
-         {% set fk = item.getForeignKeyField() %}
          {% set docpath = path('front/document.send.php?docid=' ~ document['item']['id'] ~ '&' ~ fk ~ '=' ~ item.fields['id']) %}
          {% set delete_link = item.getFormURL() ~ '?delete_document&documents_id=' ~ document['item']['id'] ~ '&' ~ fk ~ '=' ~ item.fields['id'] %}
 
          {% set post_figure_content %}
-            <div class="col-auto">
-               <div class="list-group-item-actions d-flex flex-column">
-                  {% if document['item']['_can_edit'] %}
-                     <a href="{{ 'Document'|itemtype_form_path(document['item']['id']) }}"
-                        class="btn btn-sm btn-ghost-secondary" title="{{ _x('button', 'Edit') }}"
-                        data-bs-toggle="tooltip" data-bs-placement="top">
-                        <i class="ti ti-edit"></i>
-                     </a>
-                  {% endif %}
-
-                  {% if document['item']['_can_delete'] %}
-                     <form class="d-inline" method="post" action="{{ item.getFormURL() }}">
-                        <input type="hidden" name="{{ fk }}" value="{{ item.fields['id'] }}">
-                        <input type="hidden" name="documents_id" value="{{ document['item']['id'] }}">
-                        <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}" />
-                        <button type="submit" class="btn btn-sm btn-ghost-secondary" name="delete_document"
-                                title="{{ _x('button', 'Delete permanently') }}"
-                                data-bs-toggle="tooltip" data-bs-placement="top">
-                           <i class="ti ti-trash"></i>
-                        </button>
-                     </form>
-                  {% endif %}
-
-                  {% if document['item']['_can_edit'] %}
-                    {% set blacklisted_class    = document['item']['is_blacklisted'] ? 'red' : '' %}
-                    {% set blacklisted_title    = document['item']['is_blacklisted'] ? _x('button', 'Remove from import exclusion list') : _x('button', 'Add to import exclusion list') %}
-                    {% set blacklisted_value    = document['item']['is_blacklisted'] ? 0 : 1 %}
-                     <form class="d-inline" method="post" action="{{ 'Document'|itemtype_form_path }}">
-                        <input type="hidden" name="id" value="{{ document['item']['id'] }}">
-                        <input type="hidden" name="is_blacklisted" value="{{ blacklisted_value }}">
-                        <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}" />
-                        <button type="submit" class="btn btn-sm btn-ghost-secondary" name="update"
-                                title="{{ blacklisted_title }}"
-                                data-bs-toggle="tooltip" data-bs-placement="top">
-                           <i class="ti ti-ban {{ blacklisted_class }}"></i>
-                        </button>
-                     </form>
-                  {% endif %}
-               </div>
-            </div>
+            {{ include('components/itilobject/timeline/document/post_figure_content.html.twig', {
+                'item': item,
+                'document': document,
+            }, with_context: false) }}
          {% endset %}
 
          {% if document['_is_image'] %}
@@ -123,10 +87,10 @@
 
    {% for document in other_docs %}
       <div class="list-group-item border-0">
-         {{ include('components/itilobject/timeline/form_document_item.html.twig', {
-            'form_mode': 'view',
-            'entry_i': document['item'],
-         }) }}
+          {{ include('components/itilobject/timeline/document/document_list_item.html.twig', {
+              'item': item,
+              'entry_i': document['item'],
+          }, with_context: false) }}
       </div>
    {% endfor %}
 </div>


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Fixes #19991

Images that were uploaded as sub-documents of another item like a followup were using the PhotoSwipe gallery/lightbox, but documents uploaded separately were not. This PR enables that functionality by reorganizing the Twig templates a bit and unifying the data for the document items regardless of if they are sub-documents or standalone.

1. The "post figure content" in the sub-document template was extracted to a separate file for better readability.
2. The HTML for a non-media document list item was extracted to a separate template.
3. Sub-documents that are not media call the new list item template instead of the document item form.
4. The standalone document form now calls the sub-document template to optionally display it as a gallery item/lightbox or a list item.

## Screenshots (if appropriate):
![Selection_520](https://github.com/user-attachments/assets/62b43366-56f1-4036-8656-8d381e770358)
