### PR TITLE
Add approval substitute notification recipients

### DIFF
--- a/src/Notification.php
+++ b/src/Notification.php
@@ -140,6 +140,8 @@ class Notification extends CommonDBTM implements FilterableInterface
     public const MENTIONNED_USER                     = 39;
     //Notification to the ticket's validation target (Who was asked to approve)
     public const VALIDATION_TARGET                   = 40;
+    // Notification to the ticket's validation substitutes (Who can approve if the target is not available)
+    public const VALIDATION_TARGET_SUBSTITUTES       = 41;
 
     // From CommonDBTM
     public $dohistory = true;


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

Ref #19626

Allow sending the approval notification to the target user's approval substitutes. Previously, if a user was asked for an approval and had substitutes set, only the user would be able to receive the notification while the substitutes had to log into GLPI and manually check the tickets waiting for their approval.