### PR TITLE
Fix planning event rendering

### DIFF
--- a/css/legacy/includes/_planning.scss
+++ b/css/legacy/includes/_planning.scss
@@ -210,13 +210,11 @@
       }
    }
 
-   #planning {
+   .planning-view {
       flex-grow: 1;
       min-height: calc(100vh - 160px);
 
       .fc-time-grid-event {
-         // TODO check new version,
-         // Fullcalendar 2.4.0 seems to have removed this property
          overflow: hidden;
       }
 

--- a/src/CommonITILTask.php
+++ b/src/CommonITILTask.php
@@ -1662,7 +1662,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
 
         // $val['content'] has already been sanitized and decoded by self::populatePlanning()
         $content = $val['content'];
-        $html .= "<div class='event-description rich_text_container'>" . htmlescape($content) . "</div>";
+        $html .= "<div class='event-description rich_text_container'>" . $content . "</div>";
         $html .= $recall;
 
         $parent->getFromDB($val[$parent->getForeignKeyField()]);

--- a/templates/pages/assistance/planning/planning.html.twig
+++ b/templates/pages/assistance/planning/planning.html.twig
@@ -34,7 +34,7 @@
     {% if options.full_view %}
         {{ include('pages/assistance/planning/filters.html.twig') }}
     {% endif %}
-    <div id="planning{{ options.rand }}" class="flex-fill"></div>
+    <div id="planning{{ options.rand }}" class="planning-view flex-fill"></div>
 </div>
 <script>
     $(() => {


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Change CSS selector for the planning view from ID to a class. In GLPI 10, the "rand" option was only set for the planning views on the Central page. The CSS selector was expecting just "planning" without a random number attached. In GLPI 11, now both planning views have a random number and this broke the display in a few ways, with the most noticeable being the content overflowing.

Remove `htmlescape` call for planning event content. This content is allowed to be HTML and already suppose to have been sanitized as "safe" in the various `populatePlanning` methods. I checked that this was the case for the base PlanningEvent, ProjectTask, TicketTask, ChangeTask and ProblemTask.