### PR TITLE
Fix dashboard widget type images in dark mode

### DIFF
--- a/css/standalone/dashboard.scss
+++ b/css/standalone/dashboard.scss
@@ -1334,3 +1334,9 @@ $break_tablet: 1400px;
         }
     }
 }
+
+html[data-glpi-theme-dark="1"] {
+    .widgettype_field img {
+        filter: invert(1);
+    }
+}


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Invert widget type images when using a dark theme so they are visible.

## Screenshots

Before             |  After
:-------------------------:|:-------------------------:
![Selection_524](https://github.com/user-attachments/assets/bf3560ff-7f15-4960-afd4-2c57a7b28881) | ![Selection_525](https://github.com/user-attachments/assets/e58c5417-eacd-4275-a8ad-3a25aefe69e6)