### PR TITLE
Fix opacity concerns for form access controls

### DIFF
--- a/templates/pages/admin/form/access_control.html.twig
+++ b/templates/pages/admin/form/access_control.html.twig
@@ -65,9 +65,6 @@
 
                 <section
                     class="mb-5"
-                    style="{{ access_control.fields.is_active == false ? "opacity: 0.5" : "" }}"
-                    {# Disabled item are showed with a lower opacity #}
-                    data-glpi-toggle-control-target
                     data-glpi-access-control-form
                     aria-label="{{ strategy.getLabel() }}"
                 >
@@ -91,7 +88,11 @@
                             >
                         </label>
                     </h3>
-                    <div>
+                    <div
+                        style="{{ access_control.fields.is_active == false ? "opacity: 0.5" : "" }}"
+                        {# Disabled item are shown with a lower opacity #}
+                        data-glpi-toggle-control-target
+                    >
                         {# Render custom config form #}
                         {{ strategy.renderConfigForm(access_control)|raw }}
                     </div>
@@ -123,7 +124,8 @@
 <script>
     // Toggle disabled state
     $("[data-glpi-toggle-control]").on("change", function() {
-        $(this).closest("[data-glpi-toggle-control-target]")
+        $(this).closest("section[data-glpi-access-control-form]")
+            .find("[data-glpi-toggle-control-target]")
             .css("opacity", this.checked ? 1 : 0.5)
         ;
     });


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.

## Description

Replace #20062, do not reduce opacity of title + controls.

![image](https://github.com/user-attachments/assets/2dfcbd64-c6df-4545-823f-6bc25c7f24c9)


