### PR TITLE
fix(forms): enhance error display for radio and checkbox questions

### DIFF
--- a/css/includes/components/form/_form-renderer.scss
+++ b/css/includes/components/form/_form-renderer.scss
@@ -126,6 +126,12 @@
             }
         }
 
+        &:has(input[type="radio"].is-invalid, input[type="checkbox"].is-invalid) {
+            .invalid-tooltip {
+                display: block !important;
+            }
+        }
+
         .invalid-tooltip {
             position: relative;
             background-color: unset;

--- a/js/modules/Forms/RendererController.js
+++ b/js/modules/Forms/RendererController.js
@@ -165,22 +165,33 @@ export class GlpiFormRendererController
                 }
 
                 // Find the input field within the question
-                const inputField = question.find('input:not([type=hidden]):not([data-uploader-name]):not(.select2-search__field), select, textarea');
-                if (!inputField.length) {
+                const inputFields = question.find('input:not([type=hidden]):not([data-uploader-name]):not(.select2-search__field), select, textarea');
+                if (!inputFields.length) {
                     return;
                 }
 
                 // Generate a unique ID for the error message
                 const errorId = `error-${error.question_id}`;
 
-                // Add validation classes and accessibility attributes
-                inputField
+                // Add validation classes and accessibility attributes to all inputs
+                inputFields
                     .addClass('is-invalid')
                     .attr('aria-invalid', 'true')
                     .attr('aria-errormessage', errorId);
 
                 // Add a tooltip with the error message
-                inputField.parent().append(
+                let targetElement;
+                if (inputFields.filter('[type="radio"], [type="checkbox"]').length > 0) {
+                    // For radio/checkbox, find the first common parent
+                    targetElement = inputFields.first().closest('.form-check').parent();
+                    if (targetElement.length === 0) {
+                        targetElement = inputFields.first().parent();
+                    }
+                } else {
+                    targetElement = inputFields.parent();
+                }
+
+                targetElement.append(
                     `<span id="${errorId}" class="invalid-tooltip">${error.message}</span>`
                 );
             });


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.

## Description

Improved error message display for `radio` and `checkbox` questions.
Previously, the message was displayed below each input. It is now displayed only once, below the question. 

## Screenshots (if appropriate):

### Before :
![image](https://github.com/user-attachments/assets/ae3fc742-78f6-4be0-b9b3-233472bef746)

### After :
![image](https://github.com/user-attachments/assets/61de1440-43ef-4128-ba8d-b579d3c1d033)

