### PR TITLE
Fix netpoint API deprecation

### DIFF
--- a/src/Api/Deprecated/Netpoint.php
+++ b/src/Api/Deprecated/Netpoint.php
@@ -35,6 +35,8 @@
 
 namespace Glpi\Api\Deprecated;
 
+use Glpi\Socket;
+
 /**
  * @since 10.0.0
  */
@@ -44,7 +46,7 @@ class Netpoint implements DeprecatedInterface
 
     public function getType(): string
     {
-        return "Socket";
+        return Socket::class;
     }
 
     public function mapCurrentToDeprecatedHateoas(array $hateoas): array


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

API deprecation class for Netpoint was changing the itemtype to the "Socket" class from the PHP sockets extension instead of using the one in the GLPI namespace.