### PR TITLE
fix(forms): Add an empty option for the dropdown question type when no default value is set

### DIFF
--- a/js/modules/Forms/QuestionDropdown.js
+++ b/js/modules/Forms/QuestionDropdown.js
@@ -97,7 +97,10 @@ export class GlpiFormQuestionTypeDropdown extends GlpiFormQuestionTypeSelectable
         // Make visible the right preview dropdown
         this._container.closest('[data-glpi-form-editor-question-type-specific]')
             .find('[data-glpi-form-editor-preview-dropdown]')
-            .children().toggleClass('d-none');
+            .children().toggleClass('d-none')
+            .find('select').prop('disabled', function() {
+                return !$(this).prop('disabled');
+            });
     }
 
     /**

--- a/src/Glpi/Form/QuestionType/QuestionTypeDropdown.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeDropdown.php
@@ -162,6 +162,7 @@ TWIG;
                     'init': init,
                     'no_label': true,
                     'multiple': false,
+                    'disabled': is_multiple_dropdown,
                     'display_emptychoice': true,
                     'field_class': 'single-preview-dropdown col-12' ~ (is_multiple_dropdown ? ' d-none' : ''),
                     'mb': '',
@@ -177,6 +178,7 @@ TWIG;
                     'init': init,
                     'no_label': true,
                     'multiple': true,
+                    'disabled': not is_multiple_dropdown,
                     'values': checked_values,
                     'field_class': 'multiple-preview-dropdown col-12' ~ (not is_multiple_dropdown ? ' d-none' : ''),
                     'mb': '',
@@ -246,11 +248,12 @@ TWIG;
                 values,
                 '',
                 {
-                    'no_label'  : true,
-                    'values'    : checked_values,
-                    'multiple'  : is_multiple,
-                    'mb'        : '',
-                    'aria_label': label,
+                    'no_label'           : true,
+                    'values'             : checked_values,
+                    'multiple'           : is_multiple,
+                    'mb'                 : '',
+                    'aria_label'         : label,
+                    'display_emptychoice': checked_values|length == 0,
                 }
             ) }}
 TWIG;


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

- It fixes #20228

When a `Dropdown` question was defined with options but without a default option selected, the first option was automatically selected when the form was rendered.
This behavior causes several problems in managing visibility conditions and is inconsistent with the desire to have an editor that resembles the final rendering.
This empty default option is added only if necessary, in cases where no default value has been defined.