### PR TITLE
Bypass rights when creating tickets from forms

### DIFF
--- a/phpunit/functional/Glpi/Form/Destination/CommonITILField/SLATTOFieldTest.php
+++ b/phpunit/functional/Glpi/Form/Destination/CommonITILField/SLATTOFieldTest.php
@@ -55,7 +55,7 @@ final class SLATTOFieldTest extends AbstractDestinationFieldTest
 
     public function testDefaultTemplateWithPredefinedField(): void
     {
-        $this->login();
+        $this->login('normal');
         $default_template = (new Ticket())->getITILTemplateToUse(
             entities_id: $_SESSION["glpiactive_entity"]
         );
@@ -89,7 +89,7 @@ final class SLATTOFieldTest extends AbstractDestinationFieldTest
 
     public function testSpecificSLATTO(): void
     {
-        $this->login();
+        $this->login('normal');
         $created_sla_tto = $this->createItem(
             SLA::class,
             [
@@ -112,7 +112,7 @@ final class SLATTOFieldTest extends AbstractDestinationFieldTest
 
     public function testSpecificSLATTOWithDefaultTemplateWithPredefinedField(): void
     {
-        $this->login();
+        $this->login('normal');
         $default_template = (new Ticket())->getITILTemplateToUse(
             entities_id: $_SESSION["glpiactive_entity"]
         );

--- a/src/Glpi/Form/Destination/AbstractCommonITILFormDestination.php
+++ b/src/Glpi/Form/Destination/AbstractCommonITILFormDestination.php
@@ -56,6 +56,7 @@ use Glpi\Form\Export\Context\DatabaseMapper;
 use Glpi\Form\Export\Serializer\DynamicExportDataField;
 use Glpi\Form\Form;
 use Override;
+use Session;
 use Ticket;
 
 abstract class AbstractCommonITILFormDestination implements FormDestinationInterface
@@ -158,7 +159,11 @@ abstract class AbstractCommonITILFormDestination implements FormDestinationInter
         $input = $this->setFilesInput($input, $answers_set);
 
         // Create commonitil object
-        if (!$itil_object->add($input)) {
+        // We use 'callAsSystem' here because Ticket::prepareInputForAdd() has
+        // rights checks for some features (SLA, ...) and will yield different
+        // results depending on the current user rights
+        $id = Session::callAsSystem(fn() => $itil_object->add($input));
+        if (!$id) {
             throw new \Exception(
                 "Failed to create $typename: " . json_encode($input)
             );


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

As often in GLPI's there are some rights checks that are misplaced in a low level method (`Ticket::prepareInputForAdd`):

![image](https://github.com/user-attachments/assets/3e40c764-de3c-4ef9-bc91-9dd748e9ec22)

This impact scripts that should not be subject to rights checks, leading to the linked issue.

Fixed by calling the `Session::callAsSystem` method, which is a temporary bypass until we can fix these rights issues correctly.

## References

Fix #20229.


