### PR TITLE
Handle install/update operations timeout on server side

### DIFF
--- a/js/modules/ProgressIndicator.js
+++ b/js/modules/ProgressIndicator.js
@@ -71,7 +71,7 @@ export class ProgressIndicator
     #started = false;
 
     /**
-     * Progress indicator refresh timeout.
+     * Progress indicator refresh timeout (milliseconds).
      * @type {Number}
      */
     #refresh_timeout = 250;
@@ -202,20 +202,6 @@ export class ProgressIndicator
             }
 
             if (json['failed'] === true) {
-                this.#error_callback();
-                this.#show_progress_failure();
-                return;
-            }
-
-            const now = new Date().getTime();
-            const updated_at = new Date(json['updated_at']).getTime();
-            const diff = now - updated_at;
-            const max_diff = 1000 * 60; // 60 seconds timeout
-            if (diff > max_diff) {
-                this.#display_message(
-                    'error',
-                    __('Main process seems to have timed out. It may be still running in the background though.')
-                );
                 this.#error_callback();
                 this.#show_progress_failure();
                 return;

--- a/phpunit/functional/Glpi/Progress/ProgressStorageTest.php
+++ b/phpunit/functional/Glpi/Progress/ProgressStorageTest.php
@@ -32,7 +32,7 @@
  * ---------------------------------------------------------------------
  */
 
-namespace tests\units\Glpi\Log;
+namespace tests\units\Glpi\Progress;
 
 use Glpi\Progress\ProgressStorage;
 use Glpi\Progress\StoredProgressIndicator;
@@ -84,11 +84,13 @@ class ProgressStorageTest extends GLPITestCase
             ]
         );
         $storage = new ProgressStorage(vfsStream::url('glpi/files/_tmp'));
-        $progress_indicator = new StoredProgressIndicator($storage, $storage_key);
+        $progress_indicator = new StoredProgressIndicator($storage_key);
+        $progress_indicator->setProgressStorage($storage);
 
         // Act
         $storage->save($progress_indicator);
         $fetched_progress_indicator = $storage->getProgressIndicator($storage_key);
+        $fetched_progress_indicator->setProgressStorage($storage); // to simplify comparison, this would be the only diff
 
         // Assert
         $this->assertEquals($progress_indicator, $fetched_progress_indicator);
@@ -139,7 +141,8 @@ class ProgressStorageTest extends GLPITestCase
         $storage = new ProgressStorage(vfsStream::url('glpi/files/_tmp'));
 
         foreach ([$another_sess_id, \session_id()] as $prefix) {
-            $progress_indicator = new StoredProgressIndicator($storage, $prefix . $storage_key_suffix);
+            $progress_indicator = new StoredProgressIndicator($prefix . $storage_key_suffix);
+            $progress_indicator->setProgressStorage($storage);
 
             vfsStream::newFile($prefix . $storage_key_suffix . '.progress')
                 ->at($structure->getChild('files/_tmp'))
@@ -174,7 +177,8 @@ class ProgressStorageTest extends GLPITestCase
             ]
         );
         $storage = new ProgressStorage(vfsStream::url('glpi/files/_tmp'));
-        $progress_indicator = new StoredProgressIndicator($storage, $storage_key);
+        $progress_indicator = new StoredProgressIndicator($storage_key);
+        $progress_indicator->setProgressStorage($storage);
 
         // Act
         $exception = null;

--- a/phpunit/functional/Glpi/Progress/StoredProgressIndicatorTest.php
+++ b/phpunit/functional/Glpi/Progress/StoredProgressIndicatorTest.php
@@ -52,7 +52,8 @@ class StoredProgressIndicatorTest extends GLPITestCase
         $date = new DateTimeImmutable();
 
         // Act
-        $instance = new StoredProgressIndicator($storage, $storage_key);
+        $instance = new StoredProgressIndicator($storage_key);
+        $instance->setProgressStorage($storage);
 
         // Assert
         $this->assertEquals($instance->getStartedAt(), $instance->getUpdatedAt());
@@ -69,10 +70,12 @@ class StoredProgressIndicatorTest extends GLPITestCase
     public function testMessagesAccessors(): void
     {
         // Arrange
+        $storage = $this->createMock(ProgressStorage::class);
+
         $instance = new StoredProgressIndicator(
-            $storage = $this->createMock(ProgressStorage::class),
             $this->getUniqueString()
         );
+        $instance->setProgressStorage($storage);
 
         // Saving into the storage will be triggered during each message adding operation
         $storage->expects($this->exactly(7))->method('save');
@@ -123,10 +126,12 @@ class StoredProgressIndicatorTest extends GLPITestCase
     public function testUpdate(): void
     {
         // Arrange
+        $storage = $this->createMock(ProgressStorage::class);
+
         $instance = new StoredProgressIndicator(
-            $storage = $this->createMock(ProgressStorage::class),
             $this->getUniqueString()
         );
+        $instance->setProgressStorage($storage);
 
         // Saving into the storage will be triggered by the `update` call.
         $storage->expects($this->once())->method('save');

--- a/src/Glpi/Controller/Traits/AsyncOperationProgressControllerTrait.php
+++ b/src/Glpi/Controller/Traits/AsyncOperationProgressControllerTrait.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Controller\Traits;
+
+use Glpi\Progress\StoredProgressIndicator;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+use function Safe\ini_set;
+use function Safe\session_write_close;
+use function Safe\ob_end_clean;
+use function Safe\fastcgi_finish_request;
+
+trait AsyncOperationProgressControllerTrait
+{
+    /**
+     * Return the response to be used by the `ProgressIndicator` js module to be able to follow the operation progress.
+     *
+     * @param callable $operation_callable  The callable corresponding to the operation to execute.
+     */
+    protected function getProgressInitResponse(
+        StoredProgressIndicator $progress_indicator,
+        callable $operation_callable
+    ): StreamedResponse {
+        ini_set('max_execution_time', '300'); // Allow up to 5 minutes to prevent unexpected timeout
+        session_write_close(); // Prevent the session file lock to block the progress check requests
+
+        // Be sure to disable the output buffering.
+        // It is necessary to make the `flush()` works as expected.
+        while (\ob_get_level() > 0) {
+            ob_end_clean();
+        }
+
+        return new StreamedResponse(
+            function () use ($progress_indicator, $operation_callable) {
+                echo $progress_indicator->getStorageKey();
+
+                // Send headers and content.
+                // The browser will consider that the response is complete due to the `Connection: close` header
+                // and will not have to wait for operation to finish to consider the request as ended.
+                \flush();
+
+                if (\function_exists('fastcgi_finish_request')) {
+                    // In PHP-FPM context, it indicates to the client (Apache, Nginx, ...)
+                    // that the request is finished.
+                    fastcgi_finish_request();
+                }
+
+                // Prevent the request to be terminated by the client.
+                \ignore_user_abort(true);
+
+                $operation_callable();
+            },
+            headers: [
+                'Content-Type'   => 'text/html',
+                'Content-Length' => \strlen($progress_indicator->getStorageKey()),
+                'Cache-Control'  => 'no-cache,no-store',
+                'Pragma'         => 'no-cache',
+                'Connection'     => 'close',
+            ]
+        );
+    }
+}

--- a/src/Glpi/Kernel/Listener/ExceptionListener/ProgressErrorListener.php
+++ b/src/Glpi/Kernel/Listener/ExceptionListener/ProgressErrorListener.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Kernel\Listener\ExceptionListener;
+
+use Glpi\Progress\ProgressStorage;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+final readonly class ProgressErrorListener implements EventSubscriberInterface
+{
+    public function __construct(private ProgressStorage $progress_storage) {}
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::EXCEPTION => ['onKernelException', 1],
+        ];
+    }
+
+    public function onKernelException(ExceptionEvent $event): void
+    {
+        try {
+            $this->progress_storage->failCurrentProcessIndicators();
+        } catch (\Throwable $e) {
+            /** @var \Psr\Log\LoggerInterface $PHPLOGGER */
+            global $PHPLOGGER;
+            $PHPLOGGER->error(
+                $e->getMessage(),
+                ['exception' => $e]
+            );
+        }
+    }
+}

--- a/src/Glpi/Progress/AbstractProgressIndicator.php
+++ b/src/Glpi/Progress/AbstractProgressIndicator.php
@@ -43,37 +43,37 @@ abstract class AbstractProgressIndicator
     /**
      * Operation start datetime.
      */
-    private readonly DateTimeInterface $started_at;
+    protected readonly DateTimeInterface $started_at;
 
     /**
      * Operation last update datetime.
      */
-    private DateTimeInterface $updated_at;
+    protected DateTimeInterface $updated_at;
 
     /**
      * Operation end datetime.
      */
-    private ?DateTimeInterface $ended_at = null;
+    protected ?DateTimeInterface $ended_at = null;
 
     /**
      * Indicates whether the operation failed.
      */
-    private bool $failed = false;
+    protected bool $failed = false;
 
     /**
      * Current step.
      */
-    private int $current_step = 0;
+    protected int $current_step = 0;
 
     /**
      * Max steps.
      */
-    private int $max_steps = 0;
+    protected int $max_steps = 0;
 
     /**
      * Progress bar message.
      */
-    private string $progress_bar_message = '';
+    protected string $progress_bar_message = '';
 
     public function __construct()
     {
@@ -126,6 +126,14 @@ abstract class AbstractProgressIndicator
     final public function getEndedAt(): ?DateTimeInterface
     {
         return $this->ended_at;
+    }
+
+    /**
+     * Indicates whether the operation is finished.
+     */
+    final public function isFinished(): bool
+    {
+        return $this->ended_at !== null;
     }
 
     /**


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] This change requires a documentation update.

## Description

Non recoverable  and uncaught exceptions during the install/update process were previously handled on client side by considering that a failure happened if no update was done on the server side in the last 60 seconds. The problem is that the operation process may take more than 60 seconds for some specific queries.

I changed the logic to use a `KernelEvents::EXCEPTION` listener to mark unfinished operations as failed when the PHP process exits due to an error.

It closes #20184.

I also moved a reusable of code into a trait to permit to plugins to easilly use the progress indicator JS module.