### PR TITLE
Cleaner error handling on console when DB is unavailable

### DIFF
--- a/src/DBmysql.php
+++ b/src/DBmysql.php
@@ -249,13 +249,13 @@ class DBmysql
         $hostport = explode(":", $host);
         if (count($hostport) < 2) {
             // Host
-            $this->dbh->real_connect($host, $this->dbuser, rawurldecode($this->dbpassword), $this->dbdefault);
+            @$this->dbh->real_connect($host, $this->dbuser, rawurldecode($this->dbpassword), $this->dbdefault);
         } elseif (intval($hostport[1]) > 0) {
             // Host:port
-            $this->dbh->real_connect($hostport[0], $this->dbuser, rawurldecode($this->dbpassword), $this->dbdefault, $hostport[1]);
+            @$this->dbh->real_connect($hostport[0], $this->dbuser, rawurldecode($this->dbpassword), $this->dbdefault, $hostport[1]);
         } else {
             // :Socket
-            $this->dbh->real_connect($hostport[0], $this->dbuser, rawurldecode($this->dbpassword), $this->dbdefault, ini_get('mysqli.default_port'), $hostport[1]);
+            @$this->dbh->real_connect($hostport[0], $this->dbuser, rawurldecode($this->dbpassword), $this->dbdefault, ini_get('mysqli.default_port'), $hostport[1]);
         }
 
         if (!$this->dbh->connect_error) {

--- a/src/Glpi/Console/AbstractCommand.php
+++ b/src/Glpi/Console/AbstractCommand.php
@@ -113,7 +113,10 @@ abstract class AbstractCommand extends Command implements GlpiCommandInterface
         global $DB;
 
         if ($this->requires_db && (!($DB instanceof DBmysql) || !$DB->connected)) {
-            throw new \Symfony\Component\Console\Exception\RuntimeException(__('Unable to connect to database.'));
+            throw new \Glpi\Console\Exception\EarlyExitException(
+                '<error>' . __('Unable to connect to database.') . '</error>',
+                Application::ERROR_DB_UNAVAILABLE
+            );
         }
 
         $this->db = $DB;

--- a/src/Glpi/Console/Application.php
+++ b/src/Glpi/Console/Application.php
@@ -76,11 +76,18 @@ class Application extends BaseApplication
     public const ERROR_CONFIG_WRITE_ACCESS_DENIED = 129;
 
     /**
+     * Error code returned when DB is not available.
+     *
+     * @var integer
+     */
+    public const ERROR_DB_UNAVAILABLE = 130;
+
+    /**
      * Error code returned when DB is not up-to-date.
      *
      * @var integer
      */
-    public const ERROR_DB_OUTDATED = 129;
+    public const ERROR_DB_OUTDATED = 131;
 
     /**
      * Pointer to $CFG_GLPI.


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

1. It prevent the DB connection to trigger warnings that will break the session initialization.
2. It prevent outputing the full stack trace in the console output when DB is not available.

## Screenshots

Before 1:
![image](https://github.com/user-attachments/assets/b820c67b-4e76-4eba-ad92-dcee9ba99d7b)

Before 2:
![image](https://github.com/user-attachments/assets/861ccd63-02ca-42c4-a272-384b87bb39ad)

After:
![image](https://github.com/user-attachments/assets/85eecd14-5cc4-47f3-bab2-9e71ff721e08)
