### PR TITLE
fix(forms): Remove unnecessary margin from accordion body in form destination configuration

### DIFF
--- a/templates/pages/admin/form/form_destination_commonitil_config.html.twig
+++ b/templates/pages/admin/form/form_destination_commonitil_config.html.twig
@@ -347,7 +347,7 @@
                             aria-labelledby="heading-item-{{ rand }}-{{ loop.index }}"
                             data-bs-parent="#glpi-itil-destinations-accordion-{{ rand }}"
                         >
-                            <div class="accordion-body d-flex flex-column space-y-3 mt-n2">
+                            <div class="accordion-body d-flex flex-column space-y-3">
                                 {% for field in fields %}
                                     {{ _self.field_config_section(item, field, form, config) }}
                                 {% endfor %}


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.

## Description

Remove bad margin in form destination acccordion.
### Before
![Capture vidéo du 08-07-2025 16:50:51](https://github.com/user-attachments/assets/cd350878-65e2-4d7d-8bfe-14efc256d0b1)
### After
![Capture vidéo du 08-07-2025 16:50:34](https://github.com/user-attachments/assets/92568e9e-9927-4c7b-8c75-4f86c6dca9e0)
