### PR TITLE
Prevent custom definitions to be loaded when DB is not up-to-date

### DIFF
--- a/phpunit/GLPITestCase.php
+++ b/phpunit/GLPITestCase.php
@@ -456,9 +456,13 @@ class GLPITestCase extends TestCase
         Log::$use_queue = false;
         CommonDBTM::clearSearchOptionCache();
         \Glpi\Search\SearchOption::clearSearchOptionCache();
-        AssetDefinitionManager::unsetInstance();
-        DropdownDefinitionManager::unsetInstance();
         Dropdown::resetItemtypesStaticCache();
+
+        // Reboot assets definitions
+        AssetDefinitionManager::unsetInstance();
+        AssetDefinitionManager::getInstance()->bootDefinitions();
+        DropdownDefinitionManager::unsetInstance();
+        DropdownDefinitionManager::getInstance()->bootDefinitions();
     }
 
     /**

--- a/phpunit/functional/Glpi/Asset/CustomFieldDefinitionTest.php
+++ b/phpunit/functional/Glpi/Asset/CustomFieldDefinitionTest.php
@@ -79,6 +79,8 @@ class CustomFieldDefinitionTest extends DbTestCase
             'default_value' => 'default text',
         ]);
 
+        $this->assertTrue($asset_definition->getFromDB($asset_definition->getID()));
+
         $this->assertTrue($asset_definition->update([
             'id' => $asset_definition->getID(),
             'fields_display' => [

--- a/src/Glpi/Api/HL/Controller/CustomAssetController.php
+++ b/src/Glpi/Api/HL/Controller/CustomAssetController.php
@@ -287,7 +287,7 @@ final class CustomAssetController extends AbstractController
     public static function getCustomAssetTypes(bool $types_only = true): array
     {
         $assets = [];
-        $definitions = AssetDefinitionManager::getInstance()->getDefinitions();
+        $definitions = AssetDefinitionManager::getInstance()->getDefinitions(true);
         foreach ($definitions as $definition) {
             $assets[$definition->fields['system_name']] = $definition->getAssetClassName()::getTypeName(1);
         }

--- a/src/Glpi/Asset/CustomFieldDefinition.php
+++ b/src/Glpi/Asset/CustomFieldDefinition.php
@@ -294,6 +294,36 @@ final class CustomFieldDefinition extends CommonDBChild
         parent::post_getFromDB();
     }
 
+    public function post_addItem()
+    {
+        parent::post_addItem();
+
+        $this->refreshAssetDefinition();
+    }
+
+    public function post_updateItem($history = true)
+    {
+        parent::post_updateItem($history);
+
+        $this->refreshAssetDefinition();
+    }
+
+    public function post_purgeItem()
+    {
+        parent::post_purgeItem();
+
+        $this->refreshAssetDefinition();
+    }
+
+    /**
+     * Refresh the asset definition to get force its custom fields definitions to be updated.
+     */
+    private function refreshAssetDefinition(): void
+    {
+        $definition = AssetDefinition::getById($this->fields['assets_assetdefinitions_id']);
+        AssetDefinitionManager::getInstance()->registerDefinition($definition);
+    }
+
     public function computeFriendlyName(): string
     {
         return $this->getDecodedTranslationsField()[Session::getLanguage()] ?? $this->fields['label'];

--- a/src/Glpi/CustomObject/AbstractDefinitionManager.php
+++ b/src/Glpi/CustomObject/AbstractDefinitionManager.php
@@ -42,9 +42,9 @@ abstract class AbstractDefinitionManager
 {
     /**
      * Definitions cache.
-     * @var array<int, mixed>
+     * @var array<int, ConcreteDefinition>
      */
-    private ?array $definitions_data = null;
+    private array $definitions = [];
 
     abstract public static function getInstance(): self;
 
@@ -83,13 +83,33 @@ abstract class AbstractDefinitionManager
     abstract public function autoloadClass(string $classname): void;
 
     /**
-     * Boostrap all the active definitions.
+     * Boot the definitions.
      */
-    final public function bootstrapDefinitions(): void
+    final public function bootDefinitions(): void
     {
+        $definition_object = static::getDefinitionClassInstance();
+
+        $this->definitions = [];
+
+        $definitions_data = getAllDataFromTable($definition_object::getTable());
+        foreach ($definitions_data as $definition_data) {
+            $definition = new $definition_object();
+            $definition->getFromResultSet($definition_data);
+            $this->registerDefinition($definition);
+        }
+
+        // Bootstrap definitions
         foreach ($this->getDefinitions(true) as $definition) {
             $this->bootstrapDefinition($definition);
         }
+    }
+
+    /**
+     * Register a definition.
+     */
+    public function registerDefinition(AbstractDefinition $definition): void
+    {
+        $this->definitions[$definition->fields['system_name']] = $definition;
     }
 
     /**
@@ -104,10 +124,7 @@ abstract class AbstractDefinitionManager
     {
         $classes = [];
 
-        foreach ($this->getDefinitions() as $definition) {
-            if (!$definition->isActive()) {
-                continue;
-            }
+        foreach ($this->getDefinitions(true) as $definition) {
             $classes[] = $definition->getCustomObjectClassName($with_namespace);
         }
 
@@ -130,7 +147,7 @@ abstract class AbstractDefinitionManager
      */
     final public function clearDefinitionsCache(): void
     {
-        $this->definitions_data = null;
+        $this->definitions = [];
     }
 
     /**
@@ -142,24 +159,13 @@ abstract class AbstractDefinitionManager
      */
     final public function getDefinitions(bool $only_active = false): array
     {
-        $definition_object = static::getDefinitionClassInstance();
-
-        if ($this->definitions_data === null) {
-            $this->definitions_data = getAllDataFromTable($definition_object::getTable());
+        if (!$only_active) {
+            return $this->definitions;
         }
 
-        $definitions = [];
-        foreach ($this->definitions_data as $definition_data) {
-            if ($only_active && (bool) $definition_data['is_active'] !== true) {
-                continue;
-            }
-
-            $system_name = $definition_data['system_name'];
-            $definition = new $definition_object();
-            $definition->getFromResultSet($definition_data);
-            $definitions[$system_name] = $definition;
-        }
-
-        return $definitions;
+        return \array_filter(
+            $this->definitions,
+            fn(AbstractDefinition $definition) => $definition->isActive()
+        );
     }
 }

--- a/src/Glpi/Kernel/Listener/PostBootListener/CustomObjectsBoot.php
+++ b/src/Glpi/Kernel/Listener/PostBootListener/CustomObjectsBoot.php
@@ -42,7 +42,7 @@ use Glpi\Kernel\ListenersPriority;
 use Glpi\Kernel\PostBootEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-final readonly class CustomObjectsBootstrap implements EventSubscriberInterface
+final readonly class CustomObjectsBoot implements EventSubscriberInterface
 {
     use KernelListenerTrait;
 
@@ -60,11 +60,11 @@ final readonly class CustomObjectsBootstrap implements EventSubscriberInterface
             return;
         }
 
-        Profiler::getInstance()->start('CustomObjectsBootstrap::execute', Profiler::CATEGORY_BOOT);
+        Profiler::getInstance()->start('CustomObjectsBoot::execute', Profiler::CATEGORY_BOOT);
 
-        AssetDefinitionManager::getInstance()->bootstrapDefinitions();
-        DropdownDefinitionManager::getInstance()->bootstrapDefinitions();
+        AssetDefinitionManager::getInstance()->bootDefinitions();
+        DropdownDefinitionManager::getInstance()->bootDefinitions();
 
-        Profiler::getInstance()->stop('CustomObjectsBootstrap::execute');
+        Profiler::getInstance()->stop('CustomObjectsBoot::execute');
     }
 }

--- a/src/Glpi/Kernel/ListenersPriority.php
+++ b/src/Glpi/Kernel/ListenersPriority.php
@@ -50,7 +50,7 @@ final class ListenersPriority
         PostBootListener\SessionStart::class =>                        130,
         PostBootListener\LoadLanguage::class =>                        120,
         PostBootListener\InitializePlugins::class =>                   110,
-        PostBootListener\CustomObjectsBootstrap::class =>              100,
+        PostBootListener\CustomObjectsBoot::class =>                   100,
     ];
 
     public const REQUEST_LISTENERS_PRIORITIES = [

--- a/src/Glpi/Migration/GenericobjectPluginMigration.php
+++ b/src/Glpi/Migration/GenericobjectPluginMigration.php
@@ -474,6 +474,9 @@ class GenericobjectPluginMigration extends AbstractPluginMigration
                 );
             }
 
+            // Reload the definition to refresh its custom fields definition cache
+            $asset_definition->getFromDB($asset_definition->getID());
+
             // Update the fields display options
             $form_fields = array_keys($asset_definition->getAllFields());
 

--- a/tests/src/autoload/functions.php
+++ b/tests/src/autoload/functions.php
@@ -808,11 +808,11 @@ function loadDataset()
     global $GLPI_CACHE;
     $GLPI_CACHE->clear();
 
-    // Force bootstraping of the created custom assets/dropdowns
+    // Force reboot of the created custom assets/dropdowns
     AssetDefinitionManager::unsetInstance();
-    AssetDefinitionManager::getInstance()->bootstrapDefinitions();
+    AssetDefinitionManager::getInstance()->bootDefinitions();
     DropdownDefinitionManager::unsetInstance();
-    DropdownDefinitionManager::getInstance()->bootstrapDefinitions();
+    DropdownDefinitionManager::getInstance()->bootDefinitions();
 }
 
 /**


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

When a DB update is required, the custom objects autoloader is not registered and the definitions are not booted. However, the `AssetDefinitionManager::getDefinitions()` method returns all the definitions founds in the database, due to its "on demand" loading mechanism.

It can cause issues. For instance, when the plugins are deactivated when a DB update is required, `Plugin->unactivateAll()` is executed and indirectly tries to load the asset definitions (`Glpi\Event::log()` -> ` CommonDBTM->add()` -> `Webhook::raise()`  -> `Webhook::getAPIItemtypeData()` -> `Glpi\Api\HL\Controller\CustomAssetController::getCustomAssetTypes()` -> `Glpi\Asset\AssetDefinitionManager->getDefinitions()`), and then tries to call the `getTypeName()` method on corresponding classes, than cannot be loaded because the custom asset classes autoloader is not registered.

```
glpi.CRITICAL:   *** Uncaught Error: Class "Glpi\CustomAsset\PortableAsset" not found
  Backtrace :
  ...Api/HL/Controller/CustomAssetController.php:292 
  ./src/Webhook.php:363                              Glpi\Api\HL\Controller\CustomAssetController::getCustomAssetTypes()
  ./src/Webhook.php:1104                             Webhook::getAPIItemtypeData()
  ./src/CommonDBTM.php:1442                          Webhook::raise()
  ./src/Glpi/Event.php:129                           CommonDBTM->add()
  ./src/Plugin.php:1304                              Glpi\Event::log()
  ...ener/PostBootListener/CheckPluginsStates.php:76 Plugin->unactivateAll()
  .../event-dispatcher/Debug/WrappedListener.php:116 Glpi\Kernel\Listener\PostBootListener\CheckPluginsStates->onPostBoot()
  ...ymfony/event-dispatcher/EventDispatcher.php:220 Symfony\Component\EventDispatcher\Debug\WrappedListener->__invoke()
  ...symfony/event-dispatcher/EventDispatcher.php:56 Symfony\Component\EventDispatcher\EventDispatcher->callListeners()
  ...spatcher/Debug/TraceableEventDispatcher.php:139 Symfony\Component\EventDispatcher\EventDispatcher->dispatch()
  ./src/Glpi/Kernel/Kernel.php:144                   Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcher->dispatch()
  ./vendor/symfony/http-kernel/Kernel.php:192        Glpi\Kernel\Kernel->boot()
  ./public/index.php:70                              Symfony\Component\HttpKernel\Kernel->handle()
```

I think the root issue here is that `CommonDBTM::add()` is executed on a GLPI instance that requires an update. However, changing this is probably complex, and probably requires some specifications. Indeed, we want to keep the event log (both in DB and in files) for the changes made on the plugins states during the GLPI bootstrap. A solution could be to disable the add/update/delete hooks on the event log, but it is too late to do it in GLPI 11.0.