### PR TITLE
feat(forms-destination): Add support for specific approval templates in validation field

### DIFF
--- a/src/Glpi/Form/Destination/CommonITILField/ValidationField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ValidationField.php
@@ -91,11 +91,19 @@ final class ValidationField extends AbstractConfigField implements DestinationFi
         $twig = TemplateRenderer::getInstance();
         return $twig->render('pages/admin/form/itil_config_fields/validation.html.twig', [
             // Possible configuration constant that will be used to to hide/show additional fields
+            'CONFIG_SPECIFIC_VALUES'  => ValidationFieldStrategy::SPECIFIC_VALUES->value,
             'CONFIG_SPECIFIC_ACTORS'  => ValidationFieldStrategy::SPECIFIC_ACTORS->value,
             'CONFIG_SPECIFIC_ANSWERS' => ValidationFieldStrategy::SPECIFIC_ANSWERS->value,
 
             // General display options
             'options' => $display_options,
+
+            // Specific additional config for SPECIFIC_VALUES strategy
+            'specific_value_extra_field' => [
+                'aria_label'     => __("Select approval templates..."),
+                'value'           => $config->getSpecificValidationTemplateIds(),
+                'input_name'      => $input_name . "[" . ValidationFieldConfig::SPECIFIC_VALIDATION_TEMPLATE_IDS . "]",
+            ],
 
             // Specific additional config for SPECIFIC_ACTORS strategy
             'specific_values_extra_field' => [

--- a/src/Glpi/Form/Destination/CommonITILField/ValidationFieldConfig.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ValidationFieldConfig.php
@@ -43,9 +43,10 @@ final class ValidationFieldConfig implements
     ConfigFieldWithStrategiesInterface
 {
     // Unique reference to hardcoded names used for serialization and forms input names
-    public const STRATEGIES            = 'strategies';
-    public const SPECIFIC_QUESTION_IDS = 'specific_question_ids';
-    public const SPECIFIC_ACTORS       = 'specific_actors';
+    public const STRATEGIES                       = 'strategies';
+    public const SPECIFIC_VALIDATION_TEMPLATE_IDS = 'specific_validationtemplates_ids';
+    public const SPECIFIC_QUESTION_IDS            = 'specific_question_ids';
+    public const SPECIFIC_ACTORS                  = 'specific_actors';
 
     /**
      * @param array<ValidationFieldStrategy> $strategies
@@ -54,6 +55,7 @@ final class ValidationFieldConfig implements
      */
     public function __construct(
         private array $strategies,
+        private array $specific_validationtemplate_ids = [],
         private array $specific_question_ids = [],
         private array $specific_actors = [],
     ) {}
@@ -71,6 +73,7 @@ final class ValidationFieldConfig implements
 
         return new self(
             strategies: $strategies,
+            specific_validationtemplate_ids: $data[self::SPECIFIC_VALIDATION_TEMPLATE_IDS] ?? [],
             specific_question_ids: $data[self::SPECIFIC_QUESTION_IDS] ?? [],
             specific_actors: $data[self::SPECIFIC_ACTORS] ?? [],
         );
@@ -84,6 +87,7 @@ final class ValidationFieldConfig implements
                 fn(ValidationFieldStrategy $strategy) => $strategy->value,
                 $this->strategies
             ),
+            self::SPECIFIC_VALIDATION_TEMPLATE_IDS => $this->specific_validationtemplate_ids,
             self::SPECIFIC_QUESTION_IDS => $this->specific_question_ids,
             self::SPECIFIC_ACTORS => $this->specific_actors,
         ];
@@ -101,6 +105,11 @@ final class ValidationFieldConfig implements
     public function getStrategies(): array
     {
         return $this->strategies;
+    }
+
+    public function getSpecificValidationTemplateIds(): array
+    {
+        return $this->specific_validationtemplate_ids;
     }
 
     public function getSpecificQuestionIds(): array

--- a/src/Glpi/Form/Destination/CommonITILField/ValidationFieldStrategy.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ValidationFieldStrategy.php
@@ -36,10 +36,13 @@
 namespace Glpi\Form\Destination\CommonITILField;
 
 use Glpi\Form\AnswersSet;
+use ITILValidationTemplate;
+use ITILValidationTemplate_Target;
 
 enum ValidationFieldStrategy: string
 {
     case NO_VALIDATION    = 'no_validation';
+    case SPECIFIC_VALUES  = 'specific_values';
     case SPECIFIC_ACTORS  = 'specific_actors';
     case SPECIFIC_ANSWERS = 'specific_answers';
 
@@ -47,7 +50,8 @@ enum ValidationFieldStrategy: string
     {
         return match ($this) {
             self::NO_VALIDATION    => __("No approval"),
-            self::SPECIFIC_ACTORS   => __("Specific actors"),
+            self::SPECIFIC_VALUES  => __("Specific Approval templates"),
+            self::SPECIFIC_ACTORS  => __("Specific actors"),
             self::SPECIFIC_ANSWERS => __("Answer from specific questions"),
         };
     }
@@ -58,6 +62,9 @@ enum ValidationFieldStrategy: string
     ): ?array {
         return match ($this) {
             self::NO_VALIDATION    => null,
+            self::SPECIFIC_VALUES  => $this->getActorsForSpecificValues(
+                $config->getSpecificValidationTemplateIds()
+            ),
             self::SPECIFIC_ACTORS  => $this->getActorsFromSpecificActors(
                 $config->getSpecificActors()
             ),
@@ -100,6 +107,41 @@ enum ValidationFieldStrategy: string
                 $actors = array_merge($actors, $actors_to_add);
             } elseif ($actors_to_add !== null) {
                 $actors[] = $actors_to_add;
+            }
+        }
+
+        return $actors;
+    }
+
+    /**
+     * Get actors for specific validation templates
+     *
+     * @param ?array<int> $specific_values Validation template IDs
+     */
+    private function getActorsForSpecificValues(
+        ?array $specific_values,
+    ): ?array {
+        if (empty($specific_values)) {
+            return null;
+        }
+
+        $actors = [];
+        foreach ($specific_values as $validation_template_id) {
+            $validation_template = ITILValidationTemplate::getById($validation_template_id);
+            if (!$validation_template) {
+                continue;
+            }
+
+            $targets = ITILValidationTemplate_Target::getTargets($validation_template_id);
+            if (empty($targets)) {
+                continue;
+            }
+
+            foreach ($targets as $target) {
+                $actors[] = [
+                    'itemtype' => $target['itemtype'],
+                    'items_id' => $target['items_id'],
+                ];
             }
         }
 

--- a/templates/pages/admin/form/itil_config_fields/validation.html.twig
+++ b/templates/pages/admin/form/itil_config_fields/validation.html.twig
@@ -32,6 +32,22 @@
 
 {% import 'components/form/fields_macros.html.twig' as fields %}
 
+<div data-glpi-itildestination-field-config-display-condition="{{ CONFIG_SPECIFIC_VALUES }}">
+    {{ fields.dropdownField(
+        "ITILValidationTemplate",
+        specific_value_extra_field.input_name,
+        specific_value_extra_field.value,
+        "",
+        options|merge({
+            field_class: '',
+            mb: '',
+            multiple: true,
+            no_label: true,
+            aria_label: specific_value_extra_field.aria_label,
+        })
+    ) }}
+</div>
+
 <div data-glpi-itildestination-field-config-display-condition="{{ CONFIG_SPECIFIC_ACTORS }}">
     {% set actors_dropdown = call('Glpi\\Form\\Dropdown\\FormActorsDropdown::show', [
         specific_values_extra_field.input_name,

--- a/tests/cypress/e2e/form/destination_config_fields/validation.cy.js
+++ b/tests/cypress/e2e/form/destination_config_fields/validation.cy.js
@@ -62,6 +62,10 @@ describe('Validation configuration', () => {
             cy.createWithAPI('Group', {
                 'name': `Validation configuration test group - ${form_id}`,
             });
+
+            cy.createWithAPI('ITILValidationTemplate', {
+                'name': `Validation configuration test validation template - ${form_id}`
+            });
         });
     });
 
@@ -78,6 +82,18 @@ describe('Validation configuration', () => {
         // Make sure hidden dropdowns are not displayed
         cy.get('@config').getDropdownByLabelText('Select a request type...').should('not.exist');
         cy.get('@config').getDropdownByLabelText('Select a question...').should('not.exist');
+
+        // Switch to "Specific values"
+        cy.get('@validation_dropdown').selectDropdownValue('Specific Approval templates');
+        cy.get('@config').getDropdownByLabelText('Select approval templates...').as('specific_templates_dropdown');
+        cy.get('@form_id').then((form_id) => {
+            cy.get('@specific_templates_dropdown').selectDropdownValue(`Validation configuration test validation template - ${form_id}`);
+
+            cy.findByRole('button', {'name': 'Update item'}).click();
+            cy.checkAndCloseAlert('Item successfully updated');
+            cy.get('@validation_dropdown').hasDropdownValue('Specific Approval templates');
+            cy.get('@specific_templates_dropdown').hasDropdownValue(`Validation configuration test validation template - ${form_id}`);
+        });
 
         // Switch to "Specific actors"
         cy.get('@validation_dropdown').selectDropdownValue('Specific actors');


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Added a new strategy for the validation configuration field.
The `Specific Approval templates` strategy allows you to use approval templates that will be added to the target when it is created.

## Screenshots

![image](https://github.com/user-attachments/assets/507c429e-a2be-4034-b615-44f83247ae07)