### PR TITLE
Fix tiles cascade deletion + hide invalid tiles

### DIFF
--- a/src/Glpi/Helpdesk/Tile/ExternalPageTile.php
+++ b/src/Glpi/Helpdesk/Tile/ExternalPageTile.php
@@ -102,4 +102,14 @@ final class ExternalPageTile extends CommonDBTM implements TileInterface
     {
         return "pages/admin/external_page_tile_config_fields.html.twig";
     }
+
+    #[Override]
+    public function cleanDBonPurge()
+    {
+        $this->deleteChildrenAndRelationsFromDb(
+            [
+                Item_Tile::class,
+            ]
+        );
+    }
 }

--- a/src/Glpi/Helpdesk/Tile/GlpiPageTile.php
+++ b/src/Glpi/Helpdesk/Tile/GlpiPageTile.php
@@ -138,6 +138,16 @@ final class GlpiPageTile extends CommonDBTM implements TileInterface
         return "pages/admin/glpi_page_tile_config_fields.html.twig";
     }
 
+    #[Override]
+    public function cleanDBonPurge()
+    {
+        $this->deleteChildrenAndRelationsFromDb(
+            [
+                Item_Tile::class,
+            ]
+        );
+    }
+
     public function getPage(): string
     {
         return $this->fields['page'] ?? "";

--- a/src/Glpi/Helpdesk/Tile/InvalidTileException.php
+++ b/src/Glpi/Helpdesk/Tile/InvalidTileException.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Helpdesk\Tile;
+
+use RuntimeException;
+
+final class InvalidTileException extends RuntimeException {}

--- a/src/Glpi/Helpdesk/Tile/TilesManager.php
+++ b/src/Glpi/Helpdesk/Tile/TilesManager.php
@@ -114,7 +114,14 @@ final class TilesManager
             }
 
             // Try to load tile from database
-            if (!$tile->getFromDb($row['items_id_tile'])) {
+            try {
+                if (!$tile->getFromDb($row['items_id_tile'])) {
+                    continue;
+                }
+            } catch (InvalidTileException $e) {
+                // Should not happen unless the database is manually edited
+                // Log the error but do not block the exectuion.
+                trigger_error("Unable to load linked form", E_USER_WARNING);
                 continue;
             }
 


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Two fixes:

1\) Fix tiles cascade deletion.

Deleting a tile from `glpi_helpdesks_tiles_items_tiles` would not delete the linked items in `glpi_helpdesks_tiles_formtiles`, `glpi_helpdesks_tiles_externalpagetiles` or `glpi_helpdesks_tiles_glpipagetiles`.

This has been fixed and tested.

2\) Hide invalid tiles

A form tile may be invalid it is linked to a deleted form.
This was already fixed in another PR (deleting a form also delete the tile) but to be extra safe I've made sure invalid tiles are ignored and do no appears.
