### PR TITLE
Improve migration command

### DIFF
--- a/src/Glpi/Console/Traits/PluginMigrationTrait.php
+++ b/src/Glpi/Console/Traits/PluginMigrationTrait.php
@@ -65,7 +65,7 @@ trait PluginMigrationTrait
             if ($created_count > 0) {
                 $messages[] = [
                     'type'    => MessageType::Success,
-                    'message' => sprintf('%d items created.', $created_count),
+                    'message' => sprintf(__('%1$d items created.'), $created_count),
                 ];
             }
 
@@ -74,7 +74,7 @@ trait PluginMigrationTrait
             if ($reused_count > 0) {
                 $messages[] = [
                     'type'    => MessageType::Success,
-                    'message' => sprintf('%d items reused.', $reused_count),
+                    'message' => sprintf(__('%1$d items reused.'), $reused_count),
                 ];
             }
 
@@ -83,7 +83,7 @@ trait PluginMigrationTrait
             if ($ignored_count > 0) {
                 $messages[] = [
                     'type'    => MessageType::Notice,
-                    'message' => sprintf('%d items ignored.', $ignored_count),
+                    'message' => sprintf(__('%1$d items ignored.'), $ignored_count),
                 ];
             }
         } else {

--- a/src/Glpi/Console/Traits/PluginMigrationTrait.php
+++ b/src/Glpi/Console/Traits/PluginMigrationTrait.php
@@ -59,30 +59,37 @@ trait PluginMigrationTrait
 
         $messages = $result->getMessages();
 
-        $created_items_ids = $result->getCreatedItemsIds();
-        $created_count = \array_reduce($created_items_ids, static fn(int $count, array $ids): int => $count + count($ids), 0);
-        if ($created_count > 0) {
-            $messages[] = [
-                'type'    => MessageType::Success,
-                'message' => sprintf('%d items created.', $created_count),
-            ];
-        }
+        if ($result->isFullyProcessed()) {
+            $created_items_ids = $result->getCreatedItemsIds();
+            $created_count = \array_reduce($created_items_ids, static fn(int $count, array $ids): int => $count + count($ids), 0);
+            if ($created_count > 0) {
+                $messages[] = [
+                    'type'    => MessageType::Success,
+                    'message' => sprintf('%d items created.', $created_count),
+                ];
+            }
 
-        $reused_items_ids = $result->getReusedItemsIds();
-        $reused_count = \array_reduce($reused_items_ids, static fn(int $count, array $ids): int => $count + count($ids), 0);
-        if ($reused_count > 0) {
-            $messages[] = [
-                'type'    => MessageType::Success,
-                'message' => sprintf('%d items reused.', $reused_count),
-            ];
-        }
+            $reused_items_ids = $result->getReusedItemsIds();
+            $reused_count = \array_reduce($reused_items_ids, static fn(int $count, array $ids): int => $count + count($ids), 0);
+            if ($reused_count > 0) {
+                $messages[] = [
+                    'type'    => MessageType::Success,
+                    'message' => sprintf('%d items reused.', $reused_count),
+                ];
+            }
 
-        $ignored_items_ids = $result->getIgnoredItemsIds();
-        $ignored_count = \array_reduce($ignored_items_ids, static fn(int $count, array $ids): int => $count + count($ids), 0);
-        if ($ignored_count > 0) {
+            $ignored_items_ids = $result->getIgnoredItemsIds();
+            $ignored_count = \array_reduce($ignored_items_ids, static fn(int $count, array $ids): int => $count + count($ids), 0);
+            if ($ignored_count > 0) {
+                $messages[] = [
+                    'type'    => MessageType::Notice,
+                    'message' => sprintf('%d items ignored.', $ignored_count),
+                ];
+            }
+        } else {
             $messages[] = [
-                'type'    => MessageType::Notice,
-                'message' => sprintf('%d items ignored.', $ignored_count),
+                'type'    => MessageType::Error,
+                'message' => __("Migration was aborted due to errors, all changes have been reverted"),
             ];
         }
 

--- a/src/Glpi/Console/Traits/PluginMigrationTrait.php
+++ b/src/Glpi/Console/Traits/PluginMigrationTrait.php
@@ -89,7 +89,7 @@ trait PluginMigrationTrait
         } else {
             $messages[] = [
                 'type'    => MessageType::Error,
-                'message' => __("Migration was aborted due to errors, all changes have been reverted"),
+                'message' => __("Migration was aborted due to errors, all changes have been reverted."),
             ];
         }
 


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.

## Description

When the migration fail, the "%d items created" message is displayed which is a lie since we rollback the changes in this case. 
It might mislead users, I've made sure we display a "Migration was aborted due to errors, all changes have been reverted" instead message in this case.

Also, some messages were not translated.


