### PR TITLE
Fix(NetworkPort): disconnect related socket id needed

### DIFF
--- a/phpunit/functional/Glpi/SocketTest.php
+++ b/phpunit/functional/Glpi/SocketTest.php
@@ -35,6 +35,8 @@
 namespace tests\units\Glpi;
 
 use DbTestCase;
+use NetworkPort;
+use NetworkPortEthernet;
 
 class SocketTest extends DbTestCase
 {
@@ -50,4 +52,89 @@ class SocketTest extends DbTestCase
         $this->assertSame(null, $socket->fields['itemtype']);
         $this->assertSame(0, $socket->fields['items_id']);
     }
+
+
+    public function testSocketDisconnect()
+    {
+        // Create socket
+        $socket = new \Glpi\Socket();
+        $socketId = $socket->add([
+            'name'      => __FUNCTION__,
+            'items_id'  => '',
+            'itemtype'  => '',
+        ]);
+
+        $this->assertTrue($socket->getFromDB($socketId));
+        $this->assertNull($socket->fields['itemtype']);
+        $this->assertSame(0, $socket->fields['items_id']);
+
+        // Retrieve test computer
+        $computer = getItemByTypeName('Computer', '_test_pc01');
+        $this->assertNotFalse($computer);
+
+        // Create NetworkPortEthernet
+        $networkPort = new NetworkPort();
+        $networkPortId = $networkPort->add([
+            'items_id'                    => $computer->getID(),
+            'itemtype'                    => 'Computer',
+            'entities_id'                 => $computer->fields['entities_id'],
+            'is_recursive'                => 0,
+            'logical_number'              => 3,
+            'mac'                         => '00:24:81:eb:c6:d2',
+            'instantiation_type'          => 'NetworkPortEthernet',
+            'name'                        => 'eth1',
+            'comment'                     => 'Comment me!',
+            'items_devicenetworkcards_id' => 0,
+            'type'                        => 'T',
+            'speed'                       => 1000,
+            'speed_other_value'           => '',
+            'NetworkName_name'            => 'test1',
+            'NetworkName_comment'         => 'test1 comment',
+            'NetworkName_fqdns_id'        => 0,
+            'NetworkName__ipaddresses'    => ['-1' => '192.168.20.1'],
+            '_create_children'            => true,
+        ]);
+
+        // Verify NetworkPort creation
+        $this->assertTrue($networkPort->getFromDBByCrit([
+            'itemtype'           => 'Computer',
+            'items_id'           => $computer->getID(),
+            'name'               => 'eth1',
+            'instantiation_type' => 'NetworkPortEthernet',
+        ]));
+
+        // Get NetworkPortEthernet instantiation
+        $ethernetPort = new NetworkPortEthernet();
+        $this->assertTrue($ethernetPort->getFromDBByCrit([
+            'networkports_id' => $networkPort->getID(),
+        ]));
+
+        // Connect socket to ethernet port
+        $this->assertTrue($ethernetPort->update([
+            'id'               => $ethernetPort->getID(),
+            'sockets_id'       => $socketId,
+            'networkports_id'  => $networkPortId,
+        ]));
+
+        // Check that socket is correctly linked
+        $this->assertTrue($socket->getFromDB($socketId));
+        $this->assertSame('Computer', $socket->fields['itemtype']);
+        $this->assertSame($computer->getID(), $socket->fields['items_id']);
+        $this->assertSame($networkPortId, $socket->fields['networkports_id']);
+
+        // Disconnect socket
+        $this->assertTrue($ethernetPort->update([
+            'id'               => $ethernetPort->getID(),
+            'sockets_id'       => 0,
+            'networkports_id'  => $networkPortId,
+        ]));
+
+        // Verify socket is disconnected from network port but still linked to main item
+        $this->assertTrue($socket->getFromDB($socketId));
+        $this->assertSame('Computer', $socket->fields['itemtype']);
+        $this->assertSame($computer->getID(), $socket->fields['items_id']);
+        $this->assertSame(0, $socket->fields['networkports_id']);
+    }
+
+
 }

--- a/src/NetworkPortInstantiation.php
+++ b/src/NetworkPortInstantiation.php
@@ -122,6 +122,8 @@ class NetworkPortInstantiation extends CommonDBChild
 
     public function manageSocket()
     {
+
+        Toolbox::logDebug($this->input, $this->fields);
         //add link to define
         if (isset($this->input['sockets_id']) && $this->input['sockets_id'] > 0) {
             $networkport = new NetworkPort();
@@ -135,6 +137,15 @@ class NetworkPortInstantiation extends CommonDBChild
                     "position"        => $networkport->fields['logical_number'],
                     "items_id"        => $networkport->fields['items_id'],
                     "networkports_id" => $this->fields['networkports_id'],
+                ]);
+            }
+        } else {
+            // Retrieve the associated socket to disconnect it from the NetworkPortEthernet
+            $socket = new Socket();
+            if ($socket->getFromDBByCrit(["networkports_id" => $this->fields['networkports_id']])) {
+                $socket->update([
+                    "id" => $socket->getID(),
+                    "networkports_id" => 0,
                 ]);
             }
         }

--- a/src/NetworkPortInstantiation.php
+++ b/src/NetworkPortInstantiation.php
@@ -122,8 +122,6 @@ class NetworkPortInstantiation extends CommonDBChild
 
     public function manageSocket()
     {
-
-        Toolbox::logDebug($this->input, $this->fields);
         //add link to define
         if (isset($this->input['sockets_id']) && $this->input['sockets_id'] > 0) {
             $networkport = new NetworkPort();


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !38472

When editing a `NetworkPortEthernet`, the displayed socket is retrieved through the `Socket` object, as it's the one maintaining the actual link:

```php
$socket = new Socket();
$value = 0;
if ($netport->getID() && $socket->getFromDBByCrit(['networkports_id' => $netport->getID()])) {
    $value = $socket->getID();
}
```

However, when attempting to **remove** the linked socket (i.e. disconnect it), the operation silently fails. The socket is never actually disconnected, because the current code only handles socket **assignment** if a `sockets_id` is explicitly provided and greater than zero:

```php
if (isset($this->input['sockets_id']) && $this->input['sockets_id'] > 0) {
    // Handle socket link
}
```

**What Works**

* Adding a new socket
* Replacing an existing socket with another one

**What Fails**

* Removing the socket (setting `sockets_id = 0`) does not trigger the disconnection logic

**Fix Proposal**
Update the socket-handling logic in the `NetworkPortEthernet` update process to correctly handle the case where `sockets_id` is set to `0` or explicitly removed.


## Screenshots (if appropriate):


