### PR TITLE
Do not use `CommonDBTM` hooks on GLPI boot

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -463,6 +463,13 @@ class Plugin extends CommonDBTM
         if (($key = array_search($plugin_key, self::$loaded_plugins)) !== false) {
             unset(self::$loaded_plugins[$key]);
         }
+
+        // reset menu
+        if (isset($_SESSION['glpimenu'])) {
+            unset($_SESSION['glpimenu']);
+        }
+
+        $this->resetHookableCacheEntries($this->fields['directory']);
     }
 
 
@@ -651,12 +658,14 @@ class Plugin extends CommonDBTM
      */
     public function checkPluginState($plugin_key, bool $check_for_replacement = false)
     {
+        /** @var \DBmysql $DB */
+        global $DB;
+
         $plugin = new self();
 
         $information      = $this->getPluginInformation($plugin_key) ?? [];
-        $is_already_known = $plugin->getFromDBByCrit(['directory' => $plugin_key]);
         $is_loadable      = $information !== [];
-
+        $is_already_known = $plugin->getFromDBByCrit(['directory' => $plugin_key]);
         $new_specs        = $check_for_replacement ? $this->getNewInfoAndDirBasedOnOldName($plugin_key) : null;
         $is_replaced      = $new_specs !== null;
 
@@ -664,6 +673,19 @@ class Plugin extends CommonDBTM
             // Plugin is not known and we are unable to load information, we ignore it.
             return;
         }
+
+        // Filter information to keep only fields expected to be inserted/updated into the DB.
+        $information = array_filter(
+            $information,
+            function ($key) {
+                return in_array(
+                    $key,
+                    ['name', 'version', 'author', 'homepage', 'license'],
+                    true
+                );
+            },
+            ARRAY_FILTER_USE_KEY
+        );
 
         if ($is_already_known && $is_replaced) {
             // Filesystem contains both the checked plugin and the plugin that is supposed to replace it.
@@ -677,19 +699,17 @@ class Plugin extends CommonDBTM
                     ),
                     E_USER_WARNING
                 );
-                $this->update(
+                $DB->update(
+                    self::getTable(),
                     [
-                        'id'    => $plugin->fields['id'],
                         'state' => self::REPLACED,
-                    ] + $information
+                    ] + $information,
+                    [
+                        'id' => $plugin->fields['id'],
+                    ]
                 );
 
                 $this->unload($plugin_key);
-
-                // reset menu
-                if (isset($_SESSION['glpimenu'])) {
-                    unset($_SESSION['glpimenu']);
-                }
 
                 Event::log(
                     '',
@@ -721,14 +741,12 @@ class Plugin extends CommonDBTM
 
         if (!$is_already_known) {
             // Plugin not known, add it in DB
-            $this->add(
-                array_merge(
-                    $information,
-                    [
-                        'state'     => $is_replaced ? self::REPLACED : self::NOTINSTALLED,
-                        'directory' => $plugin_key,
-                    ]
-                )
+            $DB->insert(
+                self::getTable(),
+                [
+                    'state'     => $is_replaced ? self::REPLACED : self::NOTINSTALLED,
+                    'directory' => $plugin_key,
+                ] + $information
             );
             return;
         }
@@ -740,7 +758,6 @@ class Plugin extends CommonDBTM
             // Plugin known version differs from information or plugin has been renamed,
             // update information in database
             $input              = $information;
-            $input['id']        = $plugin->fields['id'];
             $input['directory'] = $plugin_key;
             if (!in_array($plugin->fields['state'], [self::ANEW, self::NOTINSTALLED, self::NOTUPDATED])) {
                 // mark it as 'updatable' unless it was not installed
@@ -766,13 +783,15 @@ class Plugin extends CommonDBTM
                 );
             }
 
-            $this->update($input);
+            $DB->update(
+                self::getTable(),
+                $input,
+                [
+                    'id' => $plugin->fields['id'],
+                ]
+            );
 
             $this->unload($plugin_key);
-            // reset menu
-            if (isset($_SESSION['glpimenu'])) {
-                unset($_SESSION['glpimenu']);
-            }
 
             return;
         }
@@ -780,10 +799,13 @@ class Plugin extends CommonDBTM
         // Check if replacement state changed
         if ((int) $plugin->fields['state'] === self::REPLACED && !$is_replaced) {
             // Reset plugin state as replacement plugin is not present anymore on filesystem
-            $this->update(
+            $DB->update(
+                self::getTable(),
                 [
-                    'id'    => $plugin->fields['id'],
                     'state' => self::NOTINSTALLED,
+                ],
+                [
+                    'id' => $plugin->fields['id'],
                 ]
             );
             return;
@@ -796,10 +818,13 @@ class Plugin extends CommonDBTM
 
             if ((int) $plugin->fields['state'] === self::TOBECONFIGURED && $is_config_ok) {
                 // Remove TOBECONFIGURED state if configuration is OK now
-                $this->update(
+                $DB->update(
+                    self::getTable(),
                     [
-                        'id'    => $plugin->fields['id'],
                         'state' => self::NOTACTIVATED,
+                    ],
+                    [
+                        'id' => $plugin->fields['id'],
                     ]
                 );
                 return;
@@ -812,10 +837,13 @@ class Plugin extends CommonDBTM
                     ),
                     E_USER_WARNING
                 );
-                $this->update(
+                $DB->update(
+                    self::getTable(),
                     [
-                        'id'    => $plugin->fields['id'],
                         'state' => self::TOBECONFIGURED,
+                    ],
+                    [
+                        'id' => $plugin->fields['id'],
                     ]
                 );
                 return;
@@ -858,7 +886,29 @@ class Plugin extends CommonDBTM
                 ),
                 E_USER_WARNING
             );
-            $this->unactivate($plugin->fields['id']);
+
+            $DB->update(
+                self::getTable(),
+                [
+                    'state' => self::NOTACTIVATED,
+                ],
+                [
+                    'id' => $plugin->fields['id'],
+                ]
+            );
+
+            $this->unload($plugin_key);
+
+            Event::log(
+                '',
+                Plugin::class,
+                3,
+                "setup",
+                sprintf(
+                    'Plugin "%s" prerequisites are not matched. It has been deactivated.',
+                    $plugin_key
+                )
+            );
         }
     }
 
@@ -950,8 +1000,6 @@ class Plugin extends CommonDBTM
                 'state'   => self::NOTINSTALLED,
             ]);
             $this->unload($this->fields['directory']);
-
-            $this->resetHookableCacheEntries($this->fields['directory']);
 
             self::doHook(Hooks::POST_PLUGIN_UNINSTALL, $this->fields['directory']);
 
@@ -1225,14 +1273,7 @@ class Plugin extends CommonDBTM
             ]);
             $this->unload($this->fields['directory']);
 
-            $this->resetHookableCacheEntries($this->fields['directory']);
-
             self::doHook(Hooks::POST_PLUGIN_DISABLE, $this->fields['directory']);
-
-            // reset menu
-            if (isset($_SESSION['glpimenu'])) {
-                unset($_SESSION['glpimenu']);
-            }
 
             Session::addMessageAfterRedirect(
                 sprintf(__('Plugin %1$s has been deactivated!'), $this->fields['name']),


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

As explained in #20246, changes made to plugins states during the GLPI boot are triggering `CommonDBTM` hooks before the end of the GLPI boot, and it may cause unexpected issues. Indeed, the logic behing business rules, unicity checks, webhooks, etc... can trigger execution of some pieces of code that are not expected to be executed during the GLPI boot.

For the plugins states updates, I propose to use `DBmysql::insert()`/`DBmysql::update()` for every operation made in the `Plugin::checkPluginState()` method.

Events logged when a plugin state change, are also triggering `CommonDBTM` hooks. I checked the GLPI code and all the code of all plugins from the plugin's catalog and I did not see any usage of the `add()`/`update()`/`delete()` methods on an `Event` object. The only method used to log events is `Event::log()`. I propose to "disable" the `add()`/`update()`/`delete()` methods and to insert data directly in DB without trigerring any `CommonDBTM` hook. It will prevent unexpected issues and will also ensure that plugins cannot alter/prevent the event when it is inserted into the DB.

I hope there is no more `CommonDBTM::add()`/`CommonDBTM::update()` operations made during the GLPI boot.

IMHO, if this solution is accepted, it may be included in GLPI 11.0.