### PR TITLE
Fix(Anonymisation): clarify ambiguous option label

### DIFF
--- a/src/Entity.php
+++ b/src/Entity.php
@@ -3561,7 +3561,7 @@ class Entity extends CommonTreeDropdown
             self::CONFIG_PARENT => __('Inheritance of the parent entity'),
             self::ANONYMIZE_DISABLED => __('Disabled'),
             self::ANONYMIZE_USE_GENERIC => __("Replace the agent and group name with a generic name"),
-            self::ANONYMIZE_USE_NICKNAME => __("Replace the agent and group name with a customisable nickname"),
+            self::ANONYMIZE_USE_NICKNAME => __("Replace the agent name with a customisable nickname and the group name with a generic name"),
             self::ANONYMIZE_USE_GENERIC_USER => __("Replace the agent's name with a generic name"),
             self::ANONYMIZE_USE_NICKNAME_USER => __("Replace the agent's name with a customisable nickname"),
             self::ANONYMIZE_USE_GENERIC_GROUP => __("Replace the group's name with a generic name"),


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !38481

The option `Replace the agent and group name with a customizable nickname` is ambiguous.

Currently, there is no option to specify a custom name for groups.

In fact, this option uses a generic name for groups.

```php
public static function getAnonymizedName(?int $entities_id = null): ?string
{
    switch (Entity::getAnonymizeConfig($entities_id)) {
        default:
        case Entity::ANONYMIZE_DISABLED:
            return null;

        case Entity::ANONYMIZE_USE_GENERIC:
        case Entity::ANONYMIZE_USE_NICKNAME: // Here
        case Entity::ANONYMIZE_USE_GENERIC_GROUP:
            return __("Helpdesk group");
    }
}
```


## Screenshots (if appropriate):


