### PR TITLE
Fix (SoftwareLicense_User) - Affected items counter for deleted users

### DIFF
--- a/src/SoftwareLicense_User.php
+++ b/src/SoftwareLicense_User.php
@@ -86,7 +86,27 @@ class SoftwareLicense_User extends CommonDBRelation
 
     public static function countForLicense(int $softwarelicenses_id): int
     {
-        return countElementsInTable(static::getTable(), ['softwarelicenses_id' => $softwarelicenses_id]);
+        /** @var \DBmysql $DB */
+        global $DB;
+
+        $iterator = $DB->request([
+            'COUNT' => 'cpt',
+            'FROM'  => static::getTable(),
+            'INNER JOIN' => [
+                User::getTable() => [
+                    'FKEY' => [
+                        static::getTable() => 'users_id',
+                        User::getTable() => 'id'
+                    ]
+                ]
+            ],
+            'WHERE' => [
+                static::getTable() . '.softwarelicenses_id' => $softwarelicenses_id,
+                User::getTable() . '.is_deleted' => 0
+            ]
+        ]);
+
+        return $iterator->current()['cpt'];
     }
 
     private static function showForUser(CommonDBTM $item, $withtemplate = 0): void

--- a/src/SoftwareLicense_User.php
+++ b/src/SoftwareLicense_User.php
@@ -96,14 +96,14 @@ class SoftwareLicense_User extends CommonDBRelation
                 User::getTable() => [
                     'FKEY' => [
                         static::getTable() => 'users_id',
-                        User::getTable() => 'id'
-                    ]
-                ]
+                        User::getTable() => 'id',
+                    ],
+                ],
             ],
             'WHERE' => [
                 static::getTable() . '.softwarelicenses_id' => $softwarelicenses_id,
-                User::getTable() . '.is_deleted' => 0
-            ]
+                User::getTable() . '.is_deleted' => 0,
+            ],
         ]);
 
         return $iterator->current()['cpt'];


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !38398
- Here is a brief description of what this PR does

Fixed an issue where the counter badge for "Affected items" in software licenses was not properly updated when users were moved to trash.

### Problem
When users linked to a software license were moved to trash (`is_deleted = 1`), the counter badge displayed next to "Affected items" was not updated accordingly. The list correctly showed only active users, but the counter included deleted users.

### Solution
Modified the `countForLicense` method in `SoftwareLicense_User` class to exclude deleted users from the count by adding a JOIN condition with `User::getTable() . '.is_deleted' => 0`.


## Screenshots (if appropriate):

![Licenses](https://github.com/user-attachments/assets/7bdb9b07-b356-4b9d-8ee5-f5460210c7e3)
