### PR TITLE
Multiple form migrations fixes

### DIFF
--- a/phpunit/functional/Glpi/Form/Migration/FormMigrationTest.php
+++ b/phpunit/functional/Glpi/Form/Migration/FormMigrationTest.php
@@ -2544,7 +2544,7 @@ final class FormMigrationTest extends DbTestCase
         );
         $errors = array_column($errors, "message");
         $this->assertContains(
-            "Unable to import question with unknown type 'my_unknown_type'",
+            "Unable to import question 'question from unknown plugin' with unknown type 'my_unknown_type'",
             $errors,
         );
     }

--- a/src/Glpi/Form/Destination/CommonITILField/ValidationField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ValidationField.php
@@ -236,6 +236,11 @@ final class ValidationField extends AbstractConfigField implements DestinationFi
             $actors = [];
 
             foreach ($input[$this->getKey()][ValidationFieldConfig::SPECIFIC_ACTORS] as $actor) {
+                if (is_array($actor)) {
+                    // Input is already formatted correctly.
+                    continue;
+                }
+
                 $actor_parts = explode('-', $actor);
                 if (
                     count($actor_parts) !== 2
@@ -285,7 +290,6 @@ final class ValidationField extends AbstractConfigField implements DestinationFi
                             json_decode($rawData['commonitil_validation_question'], true)['values'] ?? []
                         );
                     }
-
                     return new ValidationFieldConfig(
                         strategies: [ValidationFieldStrategy::SPECIFIC_ACTORS],
                         specific_actors: $actors_ids ?? []

--- a/src/Glpi/Form/Migration/FormMigration.php
+++ b/src/Glpi/Form/Migration/FormMigration.php
@@ -573,6 +573,14 @@ class FormMigration extends AbstractPluginMigration
             $fieldtype = $raw_question['fieldtype'];
             $type_class = $this->getTypesConvertMap()[$fieldtype] ?? null;
 
+            if ($type_class === null) {
+                $this->result->addMessage(
+                    MessageType::Error,
+                    "Unable to import question '{$raw_question['name']}' with unknown type '$fieldtype'"
+                );
+                continue;
+            }
+
             $default_value = null;
             $extra_data = null;
             if (is_a($type_class, FormQuestionDataConverterInterface::class, true)) {

--- a/src/Glpi/Migration/AbstractPluginMigration.php
+++ b/src/Glpi/Migration/AbstractPluginMigration.php
@@ -108,7 +108,7 @@ abstract class AbstractPluginMigration
                 if ($simulate === false && $fully_processed === true) {
                     $this->db->commit();
                 } else {
-                    $fully_processed = $this->processMigration();
+                    $this->db->rollBack();
                 }
             } else {
                 $this->result->addMessage(MessageType::Error, __('Migration cannot be done.'));

--- a/src/Glpi/Migration/AbstractPluginMigration.php
+++ b/src/Glpi/Migration/AbstractPluginMigration.php
@@ -108,7 +108,7 @@ abstract class AbstractPluginMigration
                 if ($simulate === false && $fully_processed === true) {
                     $this->db->commit();
                 } else {
-                    $this->db->rollBack();
+                    $fully_processed = $this->processMigration();
                 }
             } else {
                 $this->result->addMessage(MessageType::Error, __('Migration cannot be done.'));


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

* Do no import questions with an invalid type (a warning will be emitted)
* Handle already formatted values in `ValidationField::prepareInput()`

## References

Fix #20249.
