### PR TITLE
[HLAPI] Handle GraphQL errors and schema expansion limitation

### DIFF
--- a/phpunit/HLAPITestCase.php
+++ b/phpunit/HLAPITestCase.php
@@ -48,11 +48,13 @@ class HLAPITestCase extends \DbTestCase
 {
     private $bearer_token = null;
 
-    public function afterTestMethod($method)
+    public function tearDown(): void
     {
         // kill session
         Session::destroy();
-        parent::afterTestMethod($method);
+        // Reset the router
+        Router::resetInstance();
+        parent::tearDown();
     }
 
     public function resetSession()

--- a/phpunit/functional/Glpi/Api/HL/Controller/GraphQLControllerTest.php
+++ b/phpunit/functional/Glpi/Api/HL/Controller/GraphQLControllerTest.php
@@ -34,6 +34,7 @@
 
 namespace tests\units\Glpi\Api\HL\Controller;
 
+use Glpi\Api\HL\Middleware\InternalAuthMiddleware;
 use Glpi\Http\Request;
 
 class GraphQLControllerTest extends \HLAPITestCase
@@ -227,6 +228,44 @@ GRAPHQL);
                     $this->assertArrayHasKey('name', $content['data']['Computer'][0]['status']);
                     $this->assertTrue($content['data']['Computer'][0]['status']['visibilities']['computer']);
                     $this->assertFalse($content['data']['Computer'][0]['status']['visibilities']['monitor']);
+                });
+        });
+    }
+
+    public function testGetTicketIndirectlyWithoutRight()
+    {
+        /** @var \DBmysql $DB */
+        global $DB;
+
+        $this->assertTrue($DB->insert('glpi_tickets', [
+            'name' => __FUNCTION__,
+            'content' => __FUNCTION__,
+            'entities_id' => $this->getTestRootEntity(true),
+        ]));
+        $this->assertTrue($DB->update('glpi_entities', [
+            'comment' => 'Should not be visible',
+        ], [
+            'id' => $this->getTestRootEntity(true),
+        ]));
+
+        $this->loginWeb();
+        $this->api->getRouter()->registerAuthMiddleware(new InternalAuthMiddleware());
+
+        $_SESSION['glpi_use_mode'] = 2;
+
+        // Can see no entities
+        $_SESSION['glpiactiveprofile']['entity'] = 0;
+        $this->api->call(new Request('POST', '/GraphQL', [], 'query { Ticket { id name entity { id name comment } } }'), function ($call) {
+            /** @var \HLAPICallAsserter $call */
+            $call->response
+                ->status(fn($status) => $this->assertEquals(200, $status))
+                ->jsonContent(function ($content) {
+                    foreach ($content['data']['Ticket'] as $ticket) {
+                        // The name is part of the partial schema, so it is always visible
+                        $this->assertNotNull($ticket['entity']['name']);
+                        // The comment comes from the full schema which the user has no right to see
+                        $this->assertNull($ticket['entity']['comment']);
+                    }
                 });
         });
     }

--- a/src/Glpi/Api/HL/GraphQL.php
+++ b/src/Glpi/Api/HL/GraphQL.php
@@ -36,6 +36,7 @@
 namespace Glpi\Api\HL;
 
 use Glpi\Http\Request;
+use GraphQL\Error\Error;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Utils\BuildSchema;
 
@@ -75,10 +76,17 @@ final class GraphQL
                         $completed_schema = self::expandSchemaFromRequestedFields($schema, $field_selection, null, $api_version);
 
                         if (isset($args['id'])) {
-                            $result = json_decode(Search::getOneBySchema($completed_schema, ['id' => $args['id']], [])->getBody(), true);
-                            return [$result];
+                            $result = Search::getOneBySchema($completed_schema, ['id' => $args['id']], []);
+                            if ($result->getStatusCode() !== 200) {
+                                throw new Error($result->getBody());
+                            }
+                            return [json_decode($result->getBody(), true)];
                         }
-                        return json_decode(Search::searchBySchema($completed_schema, $args)->getBody(), true);
+                        $result = Search::searchBySchema($completed_schema, $args);
+                        if ($result->getStatusCode() !== 200) {
+                            throw new Error($result->getBody());
+                        }
+                        return json_decode($result->getBody(), true);
                     }
 
                     return $source[$info->fieldName] ?? null;
@@ -101,6 +109,10 @@ final class GraphQL
     {
         $is_schema_array = array_key_exists('items', $schema) && !array_key_exists('properties', $schema);
         $itemtype = self::getSchemaItemtype($schema, $api_version);
+        if (is_subclass_of($itemtype, \CommonDBTM::class) && !$itemtype::canView()) {
+            // Cannot view this itemtype so we shouldn't expand it further
+            return $schema;
+        }
         if ($is_schema_array) {
             $properties = $schema['items']['properties'];
         } else {


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

 Split from https://github.com/glpi-project/glpi/pull/19678
 
 - Implements GraphQL error responses when an error occurs during the search.
 - Prevents expanding a schema when the user has no right to see the itemtype
 Example:
 A User can read tickets but not entities.
The ticket schema includes a partial schema for the `entity` property which includes the ID and name while the full schema includes some other fields like `comment`.
When the user makes a request like:
```graphql
query {
    Ticket {
        id
        name
        entity {
            id
            name
            comment
        }
    }
}
```
The response schema will match the original request but the `comment` property will be null.