### PR TITLE
Fix (ImpactAnalysis) - Resolve node overlap when adding elements to shared groups

### DIFF
--- a/js/impact.js
+++ b/js/impact.js
@@ -877,6 +877,9 @@ var GLPIImpact = {
                 if (!node.isParent() && positions[node.data('id')] !== undefined) {
                     x = parseFloat(positions[node.data('id')].x);
                     y = parseFloat(positions[node.data('id')].y);
+                } else if (!node.isParent()) {
+                    // Add node to no_positions list if it doesn't have a saved position
+                    GLPIImpact.no_positions.push(node);
                 }
 
                 return {
@@ -1989,10 +1992,12 @@ var GLPIImpact = {
         var eles = this.cy.add(toAdd);
 
         var options;
+        var savedPositions = null;
         if (params.positions === undefined) {
             options = this.getDagreLayout();
         } else {
-            options = this.getPresetLayout(JSON.parse(params.positions));
+            savedPositions = JSON.parse(params.positions);
+            options = this.getPresetLayout(savedPositions);
         }
 
         // Place the layout anywhere to compute it's bounding box
@@ -2000,29 +2005,75 @@ var GLPIImpact = {
         layout.run();
         this.generateMissingPositions();
 
-        // First, position the graph on the clicked areaa
-        var newGraphBoundingBox = eles.boundingBox();
-        var center = {
-            x: (newGraphBoundingBox.x1 + newGraphBoundingBox.x2) / 2,
-            y: (newGraphBoundingBox.y1 + newGraphBoundingBox.y2) / 2,
-        };
+        // Check if any of the new nodes have saved positions
+        var hasNodesWithSavedPositions = false;
+        if (savedPositions) {
+            eles.nodes().forEach(function(node) {
+                if (!node.isParent() && savedPositions[node.data('id')] !== undefined) {
+                    hasNodesWithSavedPositions = true;
+                }
+            });
+        }
 
-        var centerToClickVector = [
-            startNode.x - center.x,
-            startNode.y - center.y,
-        ];
+        // Only apply positioning logic if we don't have saved positions for the new nodes
+        if (!hasNodesWithSavedPositions) {
+            // First, position the graph on the clicked area
+            var newGraphBoundingBox = eles.boundingBox();
+            var center = {
+                x: (newGraphBoundingBox.x1 + newGraphBoundingBox.x2) / 2,
+                y: (newGraphBoundingBox.y1 + newGraphBoundingBox.y2) / 2,
+            };
 
-        // Apply vector to each node
-        eles.nodes().forEach(function(node) {
-            if (!node.isParent()) {
-                node.position({
-                    x: node.position().x + centerToClickVector[0],
-                    y: node.position().y + centerToClickVector[1],
-                });
-            }
-        });
+            var centerToClickVector = [
+                startNode.x - center.x,
+                startNode.y - center.y,
+            ];
 
-        newGraphBoundingBox = eles.boundingBox();
+            // Apply vector to each node
+            eles.nodes().forEach(function(node) {
+                if (!node.isParent()) {
+                    node.position({
+                        x: node.position().x + centerToClickVector[0],
+                        y: node.position().y + centerToClickVector[1],
+                    });
+                }
+            });
+
+            newGraphBoundingBox = eles.boundingBox();
+        } else {
+            // If we have saved positions, just finish and don't apply collision detection
+            this.cy.animate({
+                center: {
+                    eles : GLPIImpact.cy.filter(""),
+                },
+            });
+
+            this.cy.getElementById(startNode.id).data("highlight", 1);
+
+            // Set undo/redo data
+            var data = {
+                edges: eles.edges().map(function(edge){ return edge.data(); }),
+                compounds: [],
+                nodes: [],
+            };
+            eles.nodes().forEach(function(node) {
+                if (node.isParent()) {
+                    data.compounds.push({
+                        compoundData    : _.clone(node.data()),
+                        compoundChildren: node.children().map(function(n) {
+                            return n.data('id');
+                        }),
+                    });
+                } else {
+                    data.nodes.push({
+                        nodeData    : _.clone(node.data()),
+                        nodePosition: _.clone(node.position()),
+                    });
+                }
+            });
+            this.addToUndo(this.ACTION_ADD_GRAPH, data);
+            return;
+        }
 
         // If the two bouding box overlap
         if (!(mainBoundingBox.x1 > newGraphBoundingBox.x2

--- a/js/impact.js
+++ b/js/impact.js
@@ -2051,27 +2051,27 @@ var GLPIImpact = {
             this.cy.getElementById(startNode.id).data("highlight", 1);
 
             // Set undo/redo data
-            var data = {
+            var undoData = {
                 edges: eles.edges().map(function(edge){ return edge.data(); }),
                 compounds: [],
                 nodes: [],
             };
             eles.nodes().forEach(function(node) {
                 if (node.isParent()) {
-                    data.compounds.push({
+                    undoData.compounds.push({
                         compoundData    : _.clone(node.data()),
                         compoundChildren: node.children().map(function(n) {
                             return n.data('id');
                         }),
                     });
                 } else {
-                    data.nodes.push({
+                    undoData.nodes.push({
                         nodeData    : _.clone(node.data()),
                         nodePosition: _.clone(node.position()),
                     });
                 }
             });
-            this.addToUndo(this.ACTION_ADD_GRAPH, data);
+            this.addToUndo(this.ACTION_ADD_GRAPH, undoData);
             return;
         }
 


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does

### Problem
When adding elements to a group in impact analysis A, then viewing impact analysis B that shares common elements, new elements appear overlapped instead of taking intelligent positions.

### Root Cause
1. `getPresetLayout()` wasn't adding nodes without saved positions to `no_positions` array
2. `insertGraph()` was applying automatic repositioning even for nodes with saved positions, overriding user-defined layouts

### Solution
- **getPresetLayout**: Add nodes without saved positions to `GLPIImpact.no_positions`
- **insertGraph**: Check if nodes have saved positions before applying automatic repositioning logic
- Preserve user-defined positions while ensuring new nodes get intelligent placement

## Screenshots (if appropriate):

<img width="764" height="545" alt="image" src="https://github.com/user-attachments/assets/3ef128de-151d-43ba-934e-75fc5103e89e" />
