### PR TITLE
Fix sim pinpuk permission showing useless rights

### DIFF
--- a/src/Profile.php
+++ b/src/Profile.php
@@ -942,7 +942,7 @@ class Profile extends CommonDBTM
                                 'field' => 'devicesimcard_pinpuk',
                                 'rights'    => [
                                     READ    => __('Read'),
-                                    UPDATE  => __('Update')
+                                    UPDATE  => __('Update'),
                                 ]
                             ]),
                         ],

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -940,6 +940,10 @@ class Profile extends CommonDBTM
                             $fn_get_rights(DeviceSimcard::class, 'central', [
                                 'label' => __('Simcard PIN/PUK'),
                                 'field' => 'devicesimcard_pinpuk',
+                                'rights'    => [
+                                    READ    => __('Read'),
+                                    UPDATE  => __('Update')
+                                ]
                             ]),
                         ],
                     ],

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -943,7 +943,7 @@ class Profile extends CommonDBTM
                                 'rights'    => [
                                     READ    => __('Read'),
                                     UPDATE  => __('Update'),
-                                ]
+                                ],
                             ]),
                         ],
                     ],


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Since #14570, Simcard PIN/PUK permission was showing create and delete rights even though only read and update are valid.