### PR TITLE
Fix kanban state loading

### DIFF
--- a/src/Item_Kanban.php
+++ b/src/Item_Kanban.php
@@ -166,7 +166,7 @@ class Item_Kanban extends CommonDBRelation
 
         if (count($iterator)) {
             $data = $iterator->current();
-            if ($timestamp !== null) {
+            if (!empty($timestamp)) {
                 if (strtotime($timestamp) < strtotime($data['date_mod'])) {
                     return json_decode($data['state'], true);
                 } else {


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Changing PHP function usages to "Safe" implementations broke the loading of the Kanban because when the JS sends the `timestamp` of the last fetch, the `null` value is automatically converted to an empty string which makes the "Safe" `strtotime` throw an exception instead of returning false (implied 0) which would have made GLPI send the state data like it was expected to do.

The Kanban loading already had a E2E test, but it wasn't catching this even though it completely blocks the loading for me (Suspense component never resolves).