### PR TITLE
Fix impact tab in some cases

### DIFF
--- a/phpunit/functional/ImpactTest.php
+++ b/phpunit/functional/ImpactTest.php
@@ -164,10 +164,15 @@ class ImpactTest extends \DbTestCase
         // Create an impact graph
         $this->addDbEdge($computer1, $computer2);
         $this->addDbEdge($computer2, $computer3);
-        $tab_name = $impact->getTabNameForItem($computer2);
+        $this->assertEquals("Impact analysis 2", strip_tags($impact->getTabNameForItem($computer2)));
+        $this->assertEquals("Impact analysis 2", strip_tags($impact->getTabNameForItem($computer2, '')));
+        $this->assertEquals("Impact analysis 2", strip_tags($impact->getTabNameForItem($computer2, '0')));
+        $this->assertEquals("Impact analysis 2", strip_tags($impact->getTabNameForItem($computer2, 0)));
+        $this->assertEquals('', $impact->getTabNameForItem($computer2, 1));
+        $this->assertEquals('', $impact->getTabNameForItem($computer2, '1'));
+        $this->assertEquals('', $impact->getTabNameForItem($computer2, 2));
+        $this->assertEquals('', $impact->getTabNameForItem($computer2, '2'));
         $_SESSION['glpishow_count_on_tabs'] = $old_session;
-
-        $this->assertEquals("Impact analysis 2", strip_tags($tab_name));
     }
 
     public function testGetTabNameForItem_ITILObject()

--- a/src/Impact.php
+++ b/src/Impact.php
@@ -86,7 +86,7 @@ class Impact extends CommonGLPI
         /** @var \DBmysql $DB */
         global $DB;
 
-        if ($withtemplate != 0) {
+        if ((int) $withtemplate > 0) {
             return '';
         }
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

In some cases, an empty string is passed to the `withtemplate` parameter which causes the check that the item is not a template to fail because an empty string doesn't loosely equal 0.

https://forum.glpi-project.org/viewtopic.php?id=292775