### PR TITLE
Nested transactions

### DIFF
--- a/phpunit/DbTestCase.php
+++ b/phpunit/DbTestCase.php
@@ -59,6 +59,13 @@ class DbTestCase extends \GLPITestCase
     {
         global $DB;
         $DB->rollback();
+
+        // All transactions should be closed when a test is complete.
+        // If a transaction remains active, it mean there is a code somewhere
+        // that started it but forgot to commit/rollback.
+        $in_transaction = $this->callPrivateMethod($DB, 'isInTransaction');
+        $this->assertFalse($in_transaction);
+
         parent::tearDown();
     }
 

--- a/phpunit/functional/Glpi/Migration/AbstractPluginMigrationTest.php
+++ b/phpunit/functional/Glpi/Migration/AbstractPluginMigrationTest.php
@@ -164,7 +164,6 @@ class AbstractPluginMigrationTest extends DbTestCase
     {
         // Arrange
         $db = $this->createMock(DBmysql::class);
-        $db->method('inTransaction')->willReturn(true);
         $db->expects($this->once())->method('beginTransaction'); // A transtation will be started ...
         $db->expects($this->once())->method('rollBack'); // ... but a roll-back will be done.
         $db->expects($this->never())->method('commit');
@@ -243,7 +242,6 @@ class AbstractPluginMigrationTest extends DbTestCase
     {
         // Arrange
         $db = $this->createMock(DBmysql::class);
-        $db->method('inTransaction')->willReturn(true);
         $db->expects($this->once())->method('beginTransaction'); // A transtation will be started ...
         $db->expects($this->once())->method('rollBack'); // ... but a roll-back will be done.
         $db->expects($this->never())->method('commit');

--- a/src/Glpi/Form/AnswersHandler/AnswersHandler.php
+++ b/src/Glpi/Form/AnswersHandler/AnswersHandler.php
@@ -171,30 +171,19 @@ final class AnswersHandler
         /** @var \DBmysql $DB */
         global $DB;
 
-        if ($DB->inTransaction()) {
-            return $this->doSaveAnswers($form, $answers, $users_id, $delegation, $files);
-        } else {
-            // We do not want to commit the answers unless everything was processed
-            // correctly
-            $DB->beginTransaction();
+        // We do not want to commit the answers unless everything was processed
+        // correctly
+        $DB->beginTransaction();
 
-            try {
-                $answers_set = $this->doSaveAnswers($form, $answers, $users_id, $delegation, $files);
-                $DB->commit();
-                return $answers_set;
-            } catch (\Throwable $e) {
-                $DB->rollback();
+        try {
+            $answers_set = $this->doSaveAnswers($form, $answers, $users_id, $delegation, $files);
+            $DB->commit();
+            return $answers_set;
+        } catch (\Throwable $e) {
+            $DB->rollback();
 
-                /** @var \Psr\Log\LoggerInterface $PHPLOGGER */
-                global $PHPLOGGER;
-                $PHPLOGGER->error(
-                    "Failed to save answers: " . $e->getMessage(),
-                    ['exception' => $e]
-                );
-
-                // Propagate the exception
-                throw $e;
-            }
+            // Propagate the exception
+            throw $e;
         }
     }
 

--- a/src/Glpi/Form/Export/Serializer/FormSerializer.php
+++ b/src/Glpi/Form/Export/Serializer/FormSerializer.php
@@ -237,16 +237,14 @@ final class FormSerializer extends AbstractFormSerializer
         /** @var \DBmysql $DB */
         global $DB;
 
-        $use_transaction = !$DB->inTransaction();
-
-        if ($use_transaction) {
-            $DB->beginTransaction();
+        $DB->beginTransaction();
+        try {
             $forms = $this->doImportFormFormSpecs($form_spec, $mapper);
             $DB->commit();
-        } else {
-            $forms = $this->doImportFormFormSpecs($form_spec, $mapper);
+        } catch (\Throwable $e) {
+            $DB->rollback();
+            throw $e;
         }
-
         return $forms;
     }
 

--- a/src/Glpi/Inventory/Inventory.php
+++ b/src/Glpi/Inventory/Inventory.php
@@ -287,7 +287,7 @@ class Inventory
 
         $main_start = microtime(true); //bench
         try {
-            if (!$DB->inTransaction()) {
+            if (!defined('TU_USER')) {
                 $DB->beginTransaction();
             }
 
@@ -423,7 +423,9 @@ class Inventory
                 }
             }
         } catch (\Throwable $e) {
-            $DB->rollback();
+            if (!defined('TU_USER')) {
+                $DB->rollback();
+            }
             throw $e;
         } finally {
             unset($_SESSION['glpiinventoryuserrunning']);

--- a/src/Glpi/Migration/AbstractPluginMigration.php
+++ b/src/Glpi/Migration/AbstractPluginMigration.php
@@ -97,8 +97,11 @@ abstract class AbstractPluginMigration
 
         $fully_processed = false;
         try {
+            $need_rollback_on_throw = false;
+
             if ($this->validatePrerequisites()) {
                 $this->db->beginTransaction();
+                $need_rollback_on_throw = true;
 
                 $fully_processed = $this->processMigration();
 
@@ -118,7 +121,7 @@ abstract class AbstractPluginMigration
 
             $this->logger?->error($e->getMessage(), context: ['exception' => $e]);
 
-            if ($this->db->inTransaction()) {
+            if ($need_rollback_on_throw) {
                 $this->db->rollBack();
             }
         }

--- a/src/Group_User.php
+++ b/src/Group_User.php
@@ -794,10 +794,8 @@ class Group_User extends CommonDBRelation
             ]
         );
         $stmt = $DB->prepare($query);
-        $in_transaction = $DB->inTransaction();
-        if (!$in_transaction) {
-            $DB->beginTransaction();
-        }
+        $DB->beginTransaction();
+
         foreach ($users as $user) {
             $users_id  = $user['id'];
             $plannings = importArrayFromDB($user['plannings']);
@@ -821,9 +819,7 @@ class Group_User extends CommonDBRelation
             $DB->executeStatement($stmt);
         }
 
-        if (!$in_transaction) {
-            $DB->commit();
-        }
+        $DB->commit();
         $stmt->close();
 
         // Group cache must be invalidated when a user is added to a group
@@ -881,10 +877,7 @@ class Group_User extends CommonDBRelation
             ]
         );
         $stmt = $DB->prepare($query);
-        $in_transaction = $DB->inTransaction();
-        if (!$in_transaction) {
-            $DB->beginTransaction();
-        }
+        $DB->beginTransaction();
         foreach ($users as $user) {
             $users_id  = $user['id'];
             $plannings = importArrayFromDB($user['plannings']);
@@ -903,9 +896,7 @@ class Group_User extends CommonDBRelation
             $DB->executeStatement($stmt);
         }
 
-        if (!$in_transaction) {
-            $DB->commit();
-        }
+        $DB->commit();
         $stmt->close();
 
         // Group cache must be invalidated when a user is remove from a group

--- a/src/SavedSearch.php
+++ b/src/SavedSearch.php
@@ -1069,10 +1069,8 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
                     $_SESSION['glpigroups'] = [];
                 }
 
-                $in_transaction = $DB->inTransaction();
-                if (!$in_transaction) {
-                    $DB->beginTransaction();
-                }
+                $DB->beginTransaction();
+
                 foreach ($iterator as $row) {
                     try {
                         $self->fields = $row;
@@ -1089,9 +1087,7 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
                 }
 
                 $stmt->close();
-                if (!$in_transaction) {
-                    $DB->commit();
-                }
+                $DB->commit();
 
                 $cron_status = 1;
             }

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -5764,14 +5764,13 @@ JAVASCRIPT;
             }
             return false;
         }
-        $in_transaction = $DB->inTransaction();
 
-        if ($p['full_transaction'] && !$in_transaction) {
+        if ($p['full_transaction']) {
             $DB->beginTransaction();
         }
         foreach ($ticket_ids as $id) {
             try {
-                if (!$p['full_transaction'] && !$in_transaction) {
+                if (!$p['full_transaction']) {
                     $DB->beginTransaction();
                 }
                 if ($merge_target->canUpdateItem() && $ticket->can($id, DELETE)) {
@@ -5982,7 +5981,7 @@ JAVASCRIPT;
                     if (!$ticket->delete(['id' => $id, '_disablenotif' => true])) {
                         throw new \RuntimeException(sprintf(__('Failed to delete ticket %d'), $id), 1);
                     }
-                    if (!$p['full_transaction'] && !$in_transaction) {
+                    if (!$p['full_transaction']) {
                         $DB->commit();
                     }
                     $status[$id] = 0;
@@ -6008,15 +6007,13 @@ JAVASCRIPT;
                     $status[$id] = $e->getCode();
                 }
                 Toolbox::logDebug($e->getMessage());
-                if (!$in_transaction) {
-                    $DB->rollBack();
-                }
+                $DB->rollBack();
                 if ($p['full_transaction']) {
                     return false;
                 }
             }
         }
-        if ($p['full_transaction'] && !$in_transaction) {
+        if ($p['full_transaction']) {
             $DB->commit();
         }
         return true;

--- a/src/Transfer.php
+++ b/src/Transfer.php
@@ -233,11 +233,8 @@ final class Transfer extends CommonDBTM
         // Store to
         $this->to = $to;
 
-        $intransaction = $DB->inTransaction();
         try {
-            if (!$intransaction) {
-                $DB->beginTransaction();
-            }
+            $DB->beginTransaction();
 
             // Simulate transfers To know which items need to be transfer
             $this->simulateTransfer($items);
@@ -267,13 +264,9 @@ final class Transfer extends CommonDBTM
             // FIXME: only if Software or SoftwareLicense has been changed?
             $this->cleanSoftwareVersions();
             $this->cleanSoftwares();
-            if (!$intransaction && $DB->inTransaction()) {
-                $DB->commit();
-            }
+            $DB->commit();
         } catch (\Throwable $e) {
-            if (!$intransaction && $DB->inTransaction()) {
-                $DB->rollBack();
-            }
+            $DB->rollBack();
             ErrorHandler::logCaughtException($e);
             ErrorHandler::displayCaughtExceptionMessage($e);
         }

--- a/tests/functional/Glpi/System/Status/StatusChecker.php
+++ b/tests/functional/Glpi/System/Status/StatusChecker.php
@@ -37,10 +37,13 @@ namespace tests\units\Glpi\System\Status;
 use AuthLDAP;
 use AuthMail;
 use CronTask;
-use DbTestCase;
+use GlpiTestCase;
 use Glpi\System\Status\StatusChecker as GlpiStatusChecker;
 
-class StatusChecker extends DbTestCase
+// Must not extends DBTestCase as call to GlpiStatusChecker::getDBStatus
+// will instanciate a new database connection which will autocommit the transaction
+// started by DBTestCase before each tests
+class StatusChecker extends GlpiTestCase
 {
     public function testStatusFormat()
     {
@@ -105,7 +108,7 @@ class StatusChecker extends DbTestCase
         // Future checks won't re-run that check then, so the DB changes aren't lost.
         GlpiStatusChecker::getDBStatus();
 
-        // Manually start a transaction since this is a new connection
+        // Manually start a transaction since this test case extends GlpiTestCase, not DBTestCase
         $DB->beginTransaction();
 
         // Add a bunch of bad service items
@@ -165,7 +168,8 @@ class StatusChecker extends DbTestCase
         $this->string($status['crontasks']['status'])->isEqualTo(GlpiStatusChecker::STATUS_PROBLEM);
         $this->array($status['crontasks']['stuck'])->size->isEqualTo(2);
 
-        // afterTestMethod will rollback the DB changes for us
+        // Manually rollback data since this test case extends GlpiTestCase, not DBTestCase
+        $DB->rollBack();
     }
 
     protected function getCalculatedGlobalStatusProvider()


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

A common issue with our tests suite is that the sql transactions that wrap the tests cases conflicts with the transaction from the source code as our DB only support running one transaction at a time.

While searching for answers, I checked what popular tools like doctrine were doing for this kind of issue and found the following:

<img width="873" height="868" alt="image" src="https://github.com/user-attachments/assets/bfe36af2-d92b-48d3-ad06-901ace32e7f4" />

To sum up, doctrine supports it using SQL savepoint when the begin transaction method is called from inside a transaction.
This result in a seamless experience for developers as they don't have to worry about the current transaction level and can just call the begin transaction method anywhere from the code.

While looking into it, I found that we already support save points but only manually.
This is not ideal as it require a lot of boilerplate each time it is used and in fact there is 0 usage in our code base.

I've removed this manual methods and implemented the "doctrine way" in the main beginTransaction/commit/rollback methods.
