### PR TITLE
Add info alert about task templates creation order

### DIFF
--- a/src/ITILTemplatePredefinedField.php
+++ b/src/ITILTemplatePredefinedField.php
@@ -315,6 +315,9 @@ abstract class ITILTemplatePredefinedField extends ITILTemplateField
 
         if ($canedit) {
             echo "<div class='firstbloc'>";
+            echo "<tr class='tab_bg_2'><td><div class='alert alert-info'>" .
+                  __('Predefined task templates will be added according to their creation order') .
+                 "</div></td></tr>\n";
             echo "<form name='changeproblem_form$rand' id='changeproblem_form$rand' method='post'
                action='" . static::getFormURL() . "'>";
 
@@ -424,6 +427,8 @@ abstract class ITILTemplatePredefinedField extends ITILTemplateField
             Html::showMassiveActions($massiveactionparams);
             Html::closeForm();
         }
+                                                                echo "TEST";
+
         echo "</div>";
     }
 }


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !38451
- This PR adds an information alert to warn that the creation order of task templates corresponds to the creation order of tasks in the future ticket timeline

## Screenshots (if appropriate):
<img width="1311" height="638" alt="image" src="https://github.com/user-attachments/assets/c4e0712e-ad80-4620-ad51-59ebb7885f30" />



