### PR TITLE
Check configuration entries on updated database

### DIFF
--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -139,6 +139,10 @@ $empty_data_builder = new class {
             'notifications_mailing' => '0',
             'admin_email' => 'admsys@localhost',
             'admin_email_name' => '',
+            'admin_email_noreply' => '',
+            'admin_email_noreply_name' => '',
+            'admin_reply' => '',
+            'admin_reply_name' => '',
             'from_email' => '',
             'from_email_name' => '',
             'noreply_email' => '',
@@ -368,6 +372,9 @@ $empty_data_builder = new class {
             'projecttask_completed_states_id' => 0,
             'non_reusable_passwords_count' => 1,
             'plugins_execution_mode' => Plugin::EXECUTION_MODE_ON,
+            'glpinetwork_registration_key' => null,
+            'impact_assets_list' => '[]',
+            'timezone' => null,
         ];
 
         $tables['glpi_configs'] = [];

--- a/install/migrations/update_10.0.x_to_11.0.0/configs.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/configs.php
@@ -56,3 +56,10 @@ $migration->addField(
 );
 
 $migration->removeConfig(['url_base_api']);
+
+// Add config entries that were missing from the default installation data since GLPI 9.5.
+$migration->addConfig([
+    'glpinetwork_registration_key' => null,
+    'impact_assets_list' => '[]',
+    'timezone' => null,
+]);

--- a/install/migrations/update_10.0.x_to_11.0.0/entity.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/entity.php
@@ -76,6 +76,7 @@ foreach ($fields as $field) {
         );
     }
 }
+$migration->removeConfig($fields);
 
 $fields = [
     'state_autoupdate_mode',
@@ -98,6 +99,7 @@ foreach ($fields as $field) {
         );
     }
 }
+$migration->removeConfig($fields);
 
 /** Add base url for entities to be used in notification */
 if (!$DB->fieldExists("glpi_entities", "url_base", false)) {

--- a/install/migrations/update_9.1.x_to_9.2.0.php
+++ b/install/migrations/update_9.1.x_to_9.2.0.php
@@ -1117,6 +1117,7 @@ function update91xto920()
             'notifications_ajax_sound' => null,
             'notifications_ajax_icon_url'       => '/pics/glpi.png',
         ]);
+        $migration->removeConfig(['use_mailing']);
     }
 
     if (!$DB->tableExists('glpi_notifications_notificationtemplates')) {


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

This check will permit to ensure that there are the same configuration entries on a freshly installed DB and on an updated DB. Only the configuration entries names are checked, not values.

Here are the results from a test commit (b456ab2cea9cfca909ec4bb6c718c4eafead1d7e).

<img width="834" height="335" alt="image" src="https://github.com/user-attachments/assets/63665a10-f3b8-46b7-9b30-b8cc59ca1f6c" />

