### PR TITLE
Enable filtering massive actions in single item mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ The present file will list all changes made to the project; according to the
 - Renamed `From email header` and `To email header` criteria in the mails receiver rules to `From email address` and `To email address` respectively.
 - Replaced text mentions of "Validations" with "Approvals" to unify the terminology used.
 - User passwords are no longer wiped when the authentication source/server doesn't actually change during "Change of the authentication method" action.
+- Single item actions (Actions menu in item form) are now filtered by certain attributes of the item. For example, a Computer which has reservations enabled will not show the `Authorize reservations` action.
 
 ### Deprecated
 - Survey URL tags `TICKETCATEGORY_ID` and `TICKETCATEGORY_NAME` are deprecated and replaced by `ITILCATEGORY_ID` and `ITILCATEGORY_NAME` respectively.
@@ -243,6 +244,8 @@ The present file will list all changes made to the project; according to the
 - The `PLUGINS_DIRECTORIES` constant has been renamed to `GLPI_PLUGINS_DIRECTORIES`.
 - Most of the `Profile::show*()` methods have been made private.
 - `server` parameter of `User::changeAuthMethod()` now defaults to '0' instead of '-1' which was an invalid value when using unsigned integers.
+- `checkitem` parameter of `CommonDBTM::getMassiveActionsForItemtype()` is now the actual item being acted on when in single item mode.
+  To identify the difference between the generic item instance given for multi-item mode, use the `isNewItem()` method.
 
 #### Deprecated
 - Usage of the `/marketplace` path for plugins URLs. All plugins URLs should now start with `/plugins`.

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -6318,6 +6318,7 @@ TWIG, $twig_params);
     public function getMassiveActionsForItem(): MassiveAction
     {
         $params = [
+            '_from_single_item' => true,
             'item' => [
                 static::class => [
                     $this->fields['id'] => 1,

--- a/src/MassiveAction.php
+++ b/src/MassiveAction.php
@@ -171,10 +171,20 @@ class MassiveAction
      **/
     public function __construct(array $POST, array $GET, $stage, ?int $items_id = null)
     {
-        /** @var array $CFG_GLPI */
-        global $CFG_GLPI;
-
-        $this->from_single_item = $GET['_from_single_item'] ?? false;
+        if (isset($GET['_single_item'])) {
+            $item = getItemForItemtype($GET['_single_item']['itemtype']);
+            if ($item->getFromDB($GET['_single_item']['id'])) {
+                $this->from_single_item = true;
+                $this->check_item = $item;
+            }
+        } elseif (($POST['_from_single_item'] ?? false) && isset($POST['item'])) {
+            $itemtype = array_keys($POST['item'])[0];
+            $item = getItemForItemtype($itemtype);
+            if ($item->getFromDB(array_keys($POST['item'][$itemtype])[0])) {
+                $this->from_single_item = true;
+                $this->check_item = $item;
+            }
+        }
 
         if ($POST !== []) {
             if (!isset($POST['is_deleted'])) {

--- a/src/Reservation.php
+++ b/src/Reservation.php
@@ -1164,10 +1164,31 @@ JAVASCRIPT;
 
         $action_prefix = 'Reservation' . MassiveAction::CLASS_ACTION_SEPARATOR;
         if (in_array($itemtype, $CFG_GLPI["reservation_types"], true)) {
-            $actions[$action_prefix . 'enable'] = "<i class='" . self::getIcon() . "'></i>" . __s('Authorize reservations');
-            $actions[$action_prefix . 'disable'] = "<i class='ti ti-calendar-off'></i>" . __s('Prohibit reservations');
-            $actions[$action_prefix . 'available'] = "<i class='" . self::getIcon() . "'></i>" . __s('Make available for reservations');
-            $actions[$action_prefix . 'unavailable'] = "<i class='ti ti-calendar-off'></i>" . __s('Make unavailable for reservations');
+            $show_all = $checkitem === null || $checkitem->isNewItem();
+            $reservable = false;
+            $available = false;
+            if (!$show_all) {
+                if ($checkitem->isTemplate()) {
+                    return;
+                }
+                $ri = new ReservationItem();
+                $reservable = $ri->getFromDBbyItem($checkitem::class, $checkitem->getID());
+                if ($reservable) {
+                    $available = (bool) $ri->fields['is_active'];
+                }
+            }
+            if ($show_all || !$reservable) {
+                $actions[$action_prefix . 'enable'] = "<i class='" . self::getIcon() . "'></i>" . __s('Authorize reservations');
+            }
+            if ($show_all || $reservable) {
+                $actions[$action_prefix . 'disable'] = "<i class='ti ti-calendar-off'></i>" . __s('Prohibit reservations');
+            }
+            if ($show_all || ($reservable && !$available)) {
+                $actions[$action_prefix . 'available'] = "<i class='" . self::getIcon() . "'></i>" . __s('Make available for reservations');
+            }
+            if ($show_all || $available) {
+                $actions[$action_prefix . 'unavailable'] = "<i class='ti ti-calendar-off'></i>" . __s('Make unavailable for reservations');
+            }
         }
     }
 

--- a/templates/components/form/header_content.html.twig
+++ b/templates/components/form/header_content.html.twig
@@ -66,7 +66,7 @@
 
 {% if item.canEdit(item.fields['id']) %}
    <form name="massaction_{{ rand }}" id="massaction_{{ rand }}" method="post"
-         action="{{ path('/front/massiveaction.php') }}?_from_single_item=1" data-submit-once>
+         action="{{ path('/front/massiveaction.php') }}?_single_item[itemtype]={{ item.getType() }}&_single_item[id]={{ item.getID() }}" data-submit-once>
       <div id="massive_container_{{ rand }}"></div>
       <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}" />
    </form>

--- a/templates/components/itilobject/layout.html.twig
+++ b/templates/components/itilobject/layout.html.twig
@@ -111,7 +111,7 @@
 {% endfor %}
 
 <form name="massaction_{{ rand }}" id="massaction_{{ rand }}" method="post"
-      action="{{ path('/front/massiveaction.php') }}?_from_single_item=1" data-submit-once>
+      action="{{ path('/front/massiveaction.php') }}?_single_item[itemtype]={{ item.getType() }}&_single_item[id]={{ item.getID() }}" data-submit-once>
    <div id="massive_container_{{ rand }}"></div>
    <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}" />
 </form>


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

Fixes #20316
Initial work, and more of a short-term solution, for filtering the shown massive actions when in single-item mode by utilizing the `checkitem` parameter. This PR removes the reservation actions completely for templates since they are no relevant and also allows showing only the related actions for regular items depending on the current reservable state.

A breaking change for a future version could be a refactor of the Massive Action system as there are a few issues:
`getAllMassiveActions` can call `getMassiveActionsForItemtype` on some itemtypes like `Reservation` to get related actions if the itemtype is reservable but it has three different parameters related to an item, `item`, `checkitem`, `items_id` which is confusing and their usage doesn't seem aligned unless I missed something.
Filtering of actions in single-action mode was completely done by a later call to `getForbiddenSingleMassiveActions` on the specific item instance. The item wouldn't know about the extra actions added by common itemtypes like `Reservation` or plugins. The responsibility of filtering the actions should be with the source that added them to begin with.