### PR TITLE
Increase long answer default value size

### DIFF
--- a/src/Glpi/Form/QuestionType/QuestionTypeLongText.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeLongText.php
@@ -119,7 +119,7 @@ final class QuestionTypeLongText extends AbstractQuestionType implements
                 {
                     'placeholder'    : placeholder,
                     'enable_richtext': true,
-                    'editor_height'  : "0",
+                    'editor_height'  : "100",
                     'rows'           : 1,
                     'init'           : question is not null ? true: false,
                     'is_horizontal'  : false,


### PR DESCRIPTION
## Description

Not really sold on it tbh but it has been requested.

Before:

<img width="1246" height="626" alt="image" src="https://github.com/user-attachments/assets/b1ff750b-6f01-4318-aae2-e42f844ca80a" />

After:

<img width="1248" height="650" alt="image" src="https://github.com/user-attachments/assets/fb52b780-8156-40d9-978d-5724135dc82b" />


