### PR TITLE
Fix issues with SMTP/IMAP oauth refresh tokens

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "laminas/laminas-mime": "^2.9",
         "laminas/laminas-servicemanager": "~3.10.0",
         "league/csv": "^9.7",
-        "league/oauth2-client": "^2.6",
+        "league/oauth2-client": "^2.8",
         "league/oauth2-google": "^4.0",
         "mexitek/phpcolors": "^1.0",
         "michelf/php-markdown": "^1.9",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a8e88493e35a97b7d0d43f8bd4fc7c8a",
+    "content-hash": "9ac26b6964acfc0f8f94da1d920f799d",
     "packages": [
         {
             "name": "brick/math",
@@ -1385,16 +1385,16 @@
         },
         {
             "name": "league/oauth2-client",
-            "version": "2.8.0",
+            "version": "2.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/oauth2-client.git",
-                "reference": "3d5cf8d0543731dfb725ab30e4d7289891991e13"
+                "reference": "9df2924ca644736c835fc60466a3a60390d334f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/oauth2-client/zipball/3d5cf8d0543731dfb725ab30e4d7289891991e13",
-                "reference": "3d5cf8d0543731dfb725ab30e4d7289891991e13",
+                "url": "https://api.github.com/repos/thephpleague/oauth2-client/zipball/9df2924ca644736c835fc60466a3a60390d334f9",
+                "reference": "9df2924ca644736c835fc60466a3a60390d334f9",
                 "shasum": ""
             },
             "require": {
@@ -1444,9 +1444,9 @@
             ],
             "support": {
                 "issues": "https://github.com/thephpleague/oauth2-client/issues",
-                "source": "https://github.com/thephpleague/oauth2-client/tree/2.8.0"
+                "source": "https://github.com/thephpleague/oauth2-client/tree/2.8.1"
             },
-            "time": "2024-12-11T05:05:52+00:00"
+            "time": "2025-02-26T04:37:30+00:00"
         },
         {
             "name": "league/oauth2-google",

--- a/src/Mail/SMTP/OauthProvider/Google.php
+++ b/src/Mail/SMTP/OauthProvider/Google.php
@@ -48,7 +48,7 @@ final class Google extends \League\OAuth2\Client\Provider\Google implements Prov
     public function getAuthorizationUrl(array $options = [])
     {
         $options = [
-            'prompt' => 'login', // ensure user will have to specify the account to use
+            'prompt' => 'consent select_account', // ensure user will have to specify the account to use
             'scope'  => $this->getScopes(),
         ];
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

To get PHP 8.4 support, the `league/oauth2-client` library has been updated in #19053. Unfortunately, it was containing a bug (fixed the next day #19053 has been made).

The result of this bug is that the refresh token is not provided anymore by the Oauth authentication provider. Without this token, the authentication expires and the SMTP login fails.

It fixes #20331.