### PR TITLE
Fix ITIL tabs count for Level agreements, Groups and Users

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -908,18 +908,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Certificate_Item.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Access to an undefined property CommonGLPI\\:\\:\\$fields\\.$#',
-	'identifier' => 'property.notFound',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Change.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Call to an undefined method CommonGLPI\\:\\:getID\\(\\)\\.$#',
-	'identifier' => 'method.notFound',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Change.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^PHPDoc tag @var with type CommonDBTM is not subtype of native type Group\\.$#',
 	'identifier' => 'varTag.nativeType',
 	'count' => 1,

--- a/src/Group.php
+++ b/src/Group.php
@@ -213,10 +213,10 @@ class Group extends CommonTreeDropdown
             isset($this->fields['is_requester'])
             && $this->fields['is_requester']
         ) {
-            $this->addStandardTab(Item_Ticket::class, $ong, $options);
+            $this->addStandardTab(Ticket::class, $ong, $options);
         }
-        $this->addStandardTab(Item_Problem::class, $ong, $options);
-        $this->addStandardTab(Change_Item::class, $ong, $options);
+        $this->addStandardTab(Problem::class, $ong, $options);
+        $this->addStandardTab(Change::class, $ong, $options);
         $this->addStandardTab(Notepad::class, $ong, $options);
         $this->addStandardTab(Log::class, $ong, $options);
         return $ong;

--- a/src/LevelAgreement.php
+++ b/src/LevelAgreement.php
@@ -112,7 +112,7 @@ abstract class LevelAgreement extends CommonDBChild
         $this->addDefaultFormTab($ong);
         $this->addStandardTab(static::$levelclass, $ong, $options);
         $this->addStandardTab(Rule::class, $ong, $options);
-        $this->addStandardTab(Item_Ticket::class, $ong, $options);
+        $this->addStandardTab(Ticket::class, $ong, $options);
 
         return $ong;
     }

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -824,9 +824,11 @@ class Ticket extends CommonITILObject
                 }
                 break;
 
+            case User::class:
             case Group::class:
             case SLA::class:
             case OLA::class:
+                return self::showListForItem($item, $withtemplate);
             default:
                 Toolbox::deprecated("You should register the `Item_Ticket` tab instead of the `Ticket` tab");
                 return Item_Ticket::displayTabContentForItem($item, $tabnum, $withtemplate);
@@ -4859,28 +4861,19 @@ JAVASCRIPT;
             'metacriteria' => [],
         ];
 
-        switch (get_class($item)) {
-            case SLA::class:
-                $criteria['ORDERBY'] = 'glpi_tickets.time_to_resolve DESC';
-                break;
-
-            case OLA::class:
-                $criteria['ORDERBY'] = 'glpi_tickets.internal_time_to_resolve DESC';
-                break;
-
-            case Group::class:
-                // Mini search engine
-                /** @var Group $item */
-                if ($item->haveChildren()) {
-                    $tree = (int) Session::getSavedOption(self::class, 'tree', 0);
-                    TemplateRenderer::getInstance()->display('components/form/item_itilobject_group.html.twig', [
-                        'tree' => $tree,
-                    ]);
-                } else {
-                    $tree = 0;
-                }
-                break;
+        if ($item instanceof Group) {
+            // Mini search engine
+            /** @var Group $item */
+            if ($item->haveChildren()) {
+                $tree = (int) Session::getSavedOption(self::class, 'tree', 0);
+                TemplateRenderer::getInstance()->display('components/form/item_itilobject_group.html.twig', [
+                    'tree' => $tree,
+                ]);
+            } else {
+                $tree = 0;
+            }
         }
+
         Item_Ticket::showListForItem($item, $withtemplate, $options);
     }
 

--- a/src/User.php
+++ b/src/User.php
@@ -420,9 +420,9 @@ class User extends CommonDBTM
         $this->addStandardTab(Config::class, $ong, $options);
         $this->addStandardTab(self::class, $ong, $options);
         $this->addStandardTab(Consumable::class, $ong, $options);
-        $this->addStandardTab(Item_Ticket::class, $ong, $options);
-        $this->addStandardTab(Item_Problem::class, $ong, $options);
-        $this->addStandardTab(Change_Item::class, $ong, $options);
+        $this->addStandardTab(Ticket::class, $ong, $options);
+        $this->addStandardTab(Problem::class, $ong, $options);
+        $this->addStandardTab(Change::class, $ong, $options);
         $this->addStandardTab(Document_Item::class, $ong, $options);
         $this->addStandardTab(Reservation::class, $ong, $options);
         $this->addStandardTab(Auth::class, $ong, $options);

--- a/tests/cypress/e2e/tabs.cy.js
+++ b/tests/cypress/e2e/tabs.cy.js
@@ -36,16 +36,16 @@ describe('Tabs', () => {
         cy.changeProfile('Super-Admin');
     });
     it('can use the "forcetab" URL parameter to land on a specific tab', () => {
-        cy.visit("/front/user.form.php?id=2&forcetab=Change_Item$1");
-        cy.findByRole('tab', { name: 'Changes' })
+        cy.visit("/front/user.form.php?id=2&forcetab=Change$1");
+        cy.findByRole('tab', { name: 'Created changes' })
             .should('have.attr', 'aria-selected', 'true');
-        cy.findByRole('tab', { name: 'Problems' })
+        cy.findByRole('tab', { name: 'Created problems' })
             .should('not.have.attr', 'aria-selected', 'true');
 
-        cy.visit("/front/user.form.php?id=2&forcetab=Item_Problem$1");
-        cy.findByRole('tab', { name: 'Problems' })
+        cy.visit("/front/user.form.php?id=2&forcetab=Problem$1");
+        cy.findByRole('tab', { name: 'Created problems' })
             .should('have.attr', 'aria-selected', 'true');
-        cy.findByRole('tab', { name: 'Changes' })
+        cy.findByRole('tab', { name: 'Created changes' })
             .should('not.have.attr', 'aria-selected', 'true');
     });
 });


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Since #16526, the count on ITIL OLA/SLA/User/Group tabs is broken. IMHO, registering tabs on `Item_XXX` should be reserved for asset classes. OLA/SAL/User/Group should register a Tickt/Problem/Change tab.