### PR TITLE
Hide the GLPI-Network key behind a password field

### DIFF
--- a/templates/pages/setup/general/glpinetwork_setup.html.twig
+++ b/templates/pages/setup/general/glpinetwork_setup.html.twig
@@ -60,10 +60,15 @@
         </div>
     {% endif %}
 
-    {{ fields.textareaField('glpinetwork_registration_key', registration_key, __('Registration key'), {
-        full_width: true,
-        rows: 10
-    }) }}
+    {{ fields.passwordField(
+        'glpinetwork_registration_key',
+        registration_key,
+        __('Registration key'),
+        {
+            full_width: true,
+            'is_disclosable': true,
+        }
+    ) }}
 
     {% if registration_key is not empty %}
         {% if informations['validation_message'] is not empty %}


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

It closes #18964.

## Screenshots

Before (I altered the key to make it invalid on the screenshot):
<img width="1173" height="394" alt="image" src="https://github.com/user-attachments/assets/5b4fa3d0-c909-410a-8708-722537172830" />

After:
<img width="1173" height="394" alt="image" src="https://github.com/user-attachments/assets/1e97311d-42d2-4eac-ab81-ea9d831a6acb" />
