### PR TITLE
Replace #LBBR# #LBHR# values in CSV/PDF/... exports

### DIFF
--- a/phpunit/functional/Glpi/Toolbox/DataExportTest.php
+++ b/phpunit/functional/Glpi/Toolbox/DataExportTest.php
@@ -132,6 +132,16 @@ HTML,
             'value'           => 'Some value' . "\xE5\x8A\xA0",
             'expected_result' => 'Some value' . "\xE5\x8A\xA0",
         ];
+
+        // LBBR/LBHR values
+        yield [
+            'value'           => 'first#LBBR#second#LBBR#third',
+            'expected_result' => 'first' . "\n" . 'second' . "\n" . 'third',
+        ];
+        yield [
+            'value'           => 'first#LBHR#second#LBHR#third',
+            'expected_result' => 'first' . "\n\n---\n\n" . 'second' . "\n\n---\n\n" . 'third',
+        ];
     }
 
     #[DataProvider('normalizeValueForTextExportProvider')]

--- a/src/Glpi/Toolbox/DataExport.php
+++ b/src/Glpi/Toolbox/DataExport.php
@@ -38,6 +38,7 @@ namespace Glpi\Toolbox;
 use DOMDocument;
 use DOMXPath;
 use Glpi\RichText\RichText;
+use Search;
 
 use function Safe\preg_replace;
 
@@ -89,6 +90,9 @@ class DataExport
             $value = preg_replace('/^' . $spacing_chars_pattern . '/u', '', $value);
             $value = preg_replace('/' . $spacing_chars_pattern . '$/u', '', $value);
         }
+
+        $value = preg_replace('/' . Search::LBBR . '/', "\n", $value);
+        $value = preg_replace('/' . Search::LBHR . '/', "\n\n---\n\n", $value);
 
         return $value;
     }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

It fixes #14476.

This changes was not done in the 10.0/bugfixes branch to be sure to not break existing scripts. However, I think the export format should be enhanced to make it easier to read for end-users, whereas automated scripts should use the API.

## Screenshots

### Before

#### CSV
<img width="906" height="156" alt="image" src="https://github.com/user-attachments/assets/2767ae9d-3759-433d-916a-749d532b773d" />

#### PDF
<img width="1085" height="261" alt="image" src="https://github.com/user-attachments/assets/b30359f7-1a53-4943-af3e-ce05e7b3c3bf" />


### After

#### CSV
<img width="748" height="258" alt="image" src="https://github.com/user-attachments/assets/1c28194b-00bb-4930-964d-0d2091474a09" />

#### PDF
<img width="1085" height="261" alt="image" src="https://github.com/user-attachments/assets/f246276f-75e9-4374-a218-22b4395ee059" />


