### PR TITLE
Allow sending mail notifications immediately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -549,6 +549,7 @@ The present file will list all changes made to the project; according to the
 - `ProjectTask::showDebug()`
 - `QuerySubQuery` class. Replaced by `Glpi\DBAL\QuerySubQuery`.
 - `QueryUnion` class. Replaced by `Glpi\DBAL\QueryUnion`.
+- `QueuedNotification::forceSendFor()`
 - `Reminder::addVisibilityJoins()`
 - `ReminderTranslation::canBeTranslated()`. Translations are now always active.
 - `ReminderTranslation::isReminderTranslationActive()`. Translations are now always active.

--- a/phpunit/GLPITestCase.php
+++ b/phpunit/GLPITestCase.php
@@ -261,6 +261,37 @@ class GLPITestCase extends TestCase
         $this->has_failed = false;
     }
 
+    /**
+     * Check that the session contains the given message.
+     */
+    protected function hasSessionMessageThatContains(string $message, string $level): void
+    {
+        $this->has_failed = true;
+        $this->assertTrue(
+            isset($_SESSION['MESSAGE_AFTER_REDIRECT'][$level]),
+            'No messages for selected level!'
+        );
+
+        $found = false;
+        foreach ($_SESSION['MESSAGE_AFTER_REDIRECT'][$level] as $key => $record) {
+            if (str_contains($record, $message)) {
+                $found = true;
+                unset($_SESSION['MESSAGE_AFTER_REDIRECT'][$level][$key]);
+                break;
+            }
+        }
+
+        if ($found) {
+            foreach ($_SESSION['MESSAGE_AFTER_REDIRECT'] as $level => $records) {
+                if ($records === []) {
+                    unset($_SESSION['MESSAGE_AFTER_REDIRECT'][$level]);
+                }
+            }
+        }
+
+        $this->has_failed = !$found;
+    }
+
     protected function hasNoSessionMessages(array $levels)
     {
         foreach ($levels as $level) {

--- a/src/CronTask.php
+++ b/src/CronTask.php
@@ -575,7 +575,6 @@ class CronTask extends CommonDBTM
         if ($error_count >= $threshold) {
             // No alert has been sent within last day, so we can send one without bothering administrator
             NotificationEvent::raiseEvent('alert', $this, ['items' => [$this->fields['id'] => $this->fields]]);
-            QueuedNotification::forceSendFor(self::class, $this->fields['id']);
 
             // Delete existing outdated alerts
             $alert = new Alert();
@@ -1858,7 +1857,6 @@ TWIG, ['msg' => __('Last run list')]);
             if (NotificationEvent::raiseEvent("alert", $task, ['items' => $crontasks])) {
                 $task->addVolume(1);
             }
-            QueuedNotification::forceSendFor(self::class, $task->fields['id']);
         }
 
         return 1;

--- a/src/NotificationMailing.php
+++ b/src/NotificationMailing.php
@@ -201,6 +201,12 @@ class NotificationMailing implements NotificationInterface
                     $options['subject'] . "\n"
                 )
             );
+
+            $itemtype = (string) $queue->fields['itemtype'];
+            $event    = (string) $queue->fields['event'];
+            if (NotificationTarget::shouldNotificationBeSentImmediately($itemtype, $event)) {
+                NotificationEventMailing::send([$queue->fields]);
+            }
         }
 
         return true;

--- a/src/NotificationTarget.php
+++ b/src/NotificationTarget.php
@@ -964,6 +964,34 @@ class NotificationTarget extends CommonDBChild
     }
 
     /**
+     * Return list of notification events for which the notifications should be sent immediately.
+     *
+     * @return array
+     */
+    public function getEventsToSendImmediately(): array
+    {
+        return [];
+    }
+
+    /**
+     * Indicates whether the notification should be sent immediately.
+     *
+     * @param class-string<CommonDBTM> $itemtype
+     */
+    public static function shouldNotificationBeSentImmediately(string $itemtype, string $event): bool
+    {
+        $target_class = NotificationTarget::getInstanceClass($itemtype);
+
+        if (!is_a($target_class, NotificationTarget::class, true)) {
+            return false;
+        }
+
+        $target = new $target_class();
+
+        return in_array($event, $target->getEventsToSendImmediately(), true);
+    }
+
+    /**
      * Return whether the notification content corresponding to the given event can be disclosed.
      *
      * @return bool

--- a/src/NotificationTargetCronTask.php
+++ b/src/NotificationTargetCronTask.php
@@ -43,6 +43,13 @@ class NotificationTargetCronTask extends NotificationTarget
         return ['alert' => __('Monitoring of automatic actions')];
     }
 
+    #[Override()]
+    public function getEventsToSendImmediately(): array
+    {
+        return [
+            'alert',
+        ];
+    }
 
     public function addDataForTemplate($event, $options = [])
     {

--- a/src/NotificationTargetUser.php
+++ b/src/NotificationTargetUser.php
@@ -47,6 +47,16 @@ class NotificationTargetUser extends NotificationTarget
         ];
     }
 
+    #[Override()]
+    public function getEventsToSendImmediately(): array
+    {
+        return [
+            'passwordexpires',
+            'passwordforget',
+            'passwordinit',
+        ];
+    }
+
     public function canNotificationContentBeDisclosed(string $event): bool
     {
         if ($event === 'passwordforget') {

--- a/src/QueuedNotification.php
+++ b/src/QueuedNotification.php
@@ -723,32 +723,6 @@ class QueuedNotification extends CommonDBTM
     }
 
     /**
-     * Force sending all mails in queue for a specific item
-     *
-     * @param string  $itemtype item type
-     * @param integer $items_id id of the item
-     *
-     * @return void
-     **/
-    public static function forceSendFor($itemtype, $items_id)
-    {
-        if (!empty($itemtype) && !empty($items_id)) {
-            $pendings = self::getPendings(
-                limit: 1,
-                extra_where: [
-                    'itemtype'  => $itemtype,
-                    'items_id'  => $items_id,
-                ]
-            );
-
-            foreach ($pendings as $mode => $data) {
-                $eventclass = Notification_NotificationTemplate::getModeClass($mode, 'event');
-                $eventclass::send($data);
-            }
-        }
-    }
-
-    /**
      * Print the queued mail form
      *
      * @param integer $ID      ID of the item

--- a/src/User.php
+++ b/src/User.php
@@ -5360,7 +5360,6 @@ HTML;
         NotificationEvent::raiseEvent($event, $this, [
             'entities_id' => $entities_id,
         ]);
-        QueuedNotification::forceSendFor($this->getType(), $this->fields['id']);
 
         return true;
     }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] This change requires a documentation update.

## Description

It fixes #12773 and replaces #16314.

A new `getEventsToSendImmediately()` method has been added to the `NotificationTarget` class. It permit to indicates which event should trigger instant notifications. The notification queue is still used in order to be able to use the retry process and also to have access to the notification content and logs.
