### PR TITLE
Fix (Reservations) - Allow reservations in simplified interface with RESERVEANITEM right

### DIFF
--- a/front/reservation.form.php
+++ b/front/reservation.form.php
@@ -45,8 +45,6 @@ if (isset($_GET['ajax']) && $_GET['ajax']) {
 
 include('../inc/includes.php');
 
-Session::checkRightsOr("reservation", [CREATE, UPDATE, DELETE, PURGE, ReservationItem::RESERVEANITEM]);
-
 $rr = new Reservation();
 
 if (isset($_REQUEST['ajax'])) {

--- a/front/reservation.form.php
+++ b/front/reservation.form.php
@@ -45,7 +45,7 @@ if (isset($_GET['ajax']) && $_GET['ajax']) {
 
 include('../inc/includes.php');
 
-Session::checkRight("reservation", ReservationItem::RESERVEANITEM);
+Session::checkRightsOr("reservation", [CREATE, UPDATE, DELETE, PURGE, ReservationItem::RESERVEANITEM]);
 
 $rr = new Reservation();
 
@@ -59,17 +59,7 @@ if (isset($_REQUEST['ajax'])) {
 }
 
 if (isset($_POST["update"])) {
-    if (!$rr->getFromDB($_POST["id"])) {
-        Html::displayErrorAndDie(__('Item not found'));
-    }
-
-    $can_update = Session::haveRight('reservation', UPDATE) ||
-        (Session::haveRight('reservation', ReservationItem::RESERVEANITEM) &&
-            $rr->fields['users_id'] == Session::getLoginUserID());
-
-    if (!$can_update) {
-        Html::displayRightError();
-    }
+    $rr->check($_POST["id"], UPDATE);
 
     Toolbox::manageBeginAndEndPlanDates($_POST['resa']);
     $_POST['_target'] = $_SERVER['PHP_SELF'];
@@ -79,17 +69,7 @@ if (isset($_POST["update"])) {
     $rr->update($_POST);
     Html::back();
 } elseif (isset($_POST["purge"])) {
-    if (!$rr->getFromDB($_POST["id"])) {
-        Html::displayErrorAndDie(__('Item not found'));
-    }
-
-    $can_purge = Session::haveRight('reservation', PURGE) ||
-        (Session::haveRight('reservation', ReservationItem::RESERVEANITEM) &&
-            $rr->fields['users_id'] == Session::getLoginUserID());
-
-    if (!$can_purge) {
-        Html::displayRightError();
-    }
+    $rr->check($_POST["id"], PURGE);
 
     $reservationitems_id = key($_POST["items"]);
     if ($rr->delete($_POST, 1)) {
@@ -111,18 +91,11 @@ if (isset($_POST["update"])) {
     Html::redirect($CFG_GLPI["root_doc"] . "/front/reservation.php?reservationitems_id=" .
         "$reservationitems_id&mois_courant=$begin_month&annee_courante=$begin_year");
 } elseif (isset($_POST["add"])) {
-    Session::checkRightsOr('reservation', [CREATE, ReservationItem::RESERVEANITEM]);
     Reservation::handleAddForm($_POST);
     Html::back();
 } elseif (isset($_GET["id"])) {
     if (!empty($_GET["id"])) {
-        if (!$rr->getFromDB($_GET["id"])) {
-            Html::displayErrorAndDie(__('Item not found'));
-        }
-
-        if (!Session::haveRightsOr('reservation', [READ, ReservationItem::RESERVEANITEM])) {
-            Html::displayRightError();
-        }
+        $rr->check($_GET["id"], READ);
     }
     if (!isset($_GET['begin'])) {
         $_GET['begin'] = date('Y-m-d H:00:00');

--- a/front/reservation.form.php
+++ b/front/reservation.form.php
@@ -89,11 +89,13 @@ if (isset($_POST["update"])) {
     Html::redirect($CFG_GLPI["root_doc"] . "/front/reservation.php?reservationitems_id=" .
                   "$reservationitems_id&mois_courant=$begin_month&annee_courante=$begin_year");
 } elseif (isset($_POST["add"])) {
-    Session::checkRight('reservation', CREATE);
+    Session::checkRightsOr('reservation', [CREATE, ReservationItem::RESERVEANITEM]);
     Reservation::handleAddForm($_POST);
     Html::back();
 } elseif (isset($_GET["id"])) {
-    $rr->check($_GET['id'], READ);
+    if (!empty($_GET["id"])) {
+        $rr->check($_GET['id'], READ);
+    }
     if (!isset($_GET['begin'])) {
         $_GET['begin'] = date('Y-m-d H:00:00');
     }

--- a/phpunit/functional/ReservationTest.php
+++ b/phpunit/functional/ReservationTest.php
@@ -194,23 +194,23 @@ class ReservationTest extends DbTestCase
     {
         // Test with UPDATE right
         $_SESSION['glpiactiveprofile']['reservation'] = UPDATE;
-        $this->assertTrue((bool)\Reservation::canUpdate());
+        $this->assertTrue((bool) \Reservation::canUpdate());
 
         // Test with RESERVEANITEM right (simplified interface case)
         $_SESSION['glpiactiveprofile']['reservation'] = \ReservationItem::RESERVEANITEM;
-        $this->assertTrue((bool)\Reservation::canUpdate());
+        $this->assertTrue((bool) \Reservation::canUpdate());
 
         // Test with both rights
         $_SESSION['glpiactiveprofile']['reservation'] = UPDATE | \ReservationItem::RESERVEANITEM;
-        $this->assertTrue((bool)\Reservation::canUpdate());
+        $this->assertTrue((bool) \Reservation::canUpdate());
 
         // Test with unrelated right
         $_SESSION['glpiactiveprofile']['reservation'] = READ;
-        $this->assertFalse((bool)\Reservation::canUpdate());
+        $this->assertFalse((bool) \Reservation::canUpdate());
 
         // Test with no rights
         $_SESSION['glpiactiveprofile']['reservation'] = 0;
-        $this->assertFalse((bool)\Reservation::canUpdate());
+        $this->assertFalse((bool) \Reservation::canUpdate());
     }
 
     /**
@@ -222,23 +222,23 @@ class ReservationTest extends DbTestCase
 
         // Test with PURGE right
         $_SESSION['glpiactiveprofile']['reservation'] = PURGE;
-        $this->assertTrue((bool)\Reservation::canPurge());
+        $this->assertTrue((bool) \Reservation::canPurge());
 
         // Test with RESERVEANITEM right (simplified interface case)
         $_SESSION['glpiactiveprofile']['reservation'] = \ReservationItem::RESERVEANITEM;
-        $this->assertTrue((bool)\Reservation::canPurge());
+        $this->assertTrue((bool) \Reservation::canPurge());
 
         // Test with both rights
         $_SESSION['glpiactiveprofile']['reservation'] = PURGE | \ReservationItem::RESERVEANITEM;
-        $this->assertTrue((bool)\Reservation::canPurge());
+        $this->assertTrue((bool) \Reservation::canPurge());
 
         // Test with unrelated right
         $_SESSION['glpiactiveprofile']['reservation'] = READ;
-        $this->assertFalse((bool)\Reservation::canPurge());
+        $this->assertFalse((bool) \Reservation::canPurge());
 
         // Test with no rights
         $_SESSION['glpiactiveprofile']['reservation'] = 0;
-        $this->assertFalse((bool)\Reservation::canPurge());
+        $this->assertFalse((bool) \Reservation::canPurge());
     }
 
     /**
@@ -250,15 +250,15 @@ class ReservationTest extends DbTestCase
 
         // Test canCreate with RESERVEANITEM right
         $_SESSION['glpiactiveprofile']['reservation'] = \ReservationItem::RESERVEANITEM;
-        $this->assertTrue((bool)\Reservation::canCreate(), "canCreate should return truthy value with RESERVEANITEM right");
+        $this->assertTrue((bool) \Reservation::canCreate(), "canCreate should return truthy value with RESERVEANITEM right");
 
         // Test canDelete with RESERVEANITEM right - canDelete only checks RESERVEANITEM
-        $this->assertTrue((bool)\Reservation::canDelete(), "canDelete should return truthy value with RESERVEANITEM right");
+        $this->assertTrue((bool) \Reservation::canDelete(), "canDelete should return truthy value with RESERVEANITEM right");
 
         // Test with no rights
         $_SESSION['glpiactiveprofile']['reservation'] = 0;
-        $this->assertFalse((bool)\Reservation::canCreate());
-        $this->assertFalse((bool)\Reservation::canDelete());
+        $this->assertFalse((bool) \Reservation::canCreate());
+        $this->assertFalse((bool) \Reservation::canDelete());
     }
 
     /**
@@ -517,9 +517,9 @@ class ReservationTest extends DbTestCase
         $this->login('test_simplified_user', 'test123');
 
         // Test that static permission methods work correctly
-        $this->assertTrue((bool)\Reservation::canCreate(), "User with RESERVEANITEM should be able to create reservations");
-        $this->assertTrue((bool)\Reservation::canUpdate(), "User with RESERVEANITEM should be able to update reservations");
-        $this->assertTrue((bool)\Reservation::canPurge(), "User with RESERVEANITEM should be able to purge reservations");
+        $this->assertTrue((bool) \Reservation::canCreate(), "User with RESERVEANITEM should be able to create reservations");
+        $this->assertTrue((bool) \Reservation::canUpdate(), "User with RESERVEANITEM should be able to update reservations");
+        $this->assertTrue((bool) \Reservation::canPurge(), "User with RESERVEANITEM should be able to purge reservations");
 
         // Test creating a reservation
         $reservation = new \Reservation();
@@ -675,7 +675,7 @@ class ReservationTest extends DbTestCase
         $result = $reservation->showForm(0, [
             'item' => [$res_item->getID() => $res_item->getID()],
             'begin' => '2024-01-02 10:00:00',
-            'end' => '2024-01-02 12:00:00'
+            'end' => '2024-01-02 12:00:00',
         ]);
         ob_end_clean();
 
@@ -799,7 +799,7 @@ class ReservationTest extends DbTestCase
         ob_start();
         $result = $reservation->showForm(0, [
             'item' => [$res_item->getID() => $res_item->getID()],
-            'begin' => '2024-01-01 10:00:00'
+            'begin' => '2024-01-01 10:00:00',
         ]);
         ob_end_clean();
         $this->assertTrue($result, "Should be able to display reservation form with RESERVEANITEM right");
@@ -894,9 +894,9 @@ class ReservationTest extends DbTestCase
         $_SESSION['glpiactiveprofile']['reservation'] = 0;
 
         // Test static methods return false
-        $this->assertFalse((bool)\Reservation::canCreate());
-        $this->assertFalse((bool)\Reservation::canUpdate());
-        $this->assertFalse((bool)\Reservation::canPurge());
+        $this->assertFalse((bool) \Reservation::canCreate());
+        $this->assertFalse((bool) \Reservation::canUpdate());
+        $this->assertFalse((bool) \Reservation::canPurge());
 
         // Test instance methods also return false without global rights (expected behavior)
         $this->assertFalse($reservation->can($reservation_id, UPDATE), "Without global rights, even owner cannot update");

--- a/phpunit/functional/ReservationTest.php
+++ b/phpunit/functional/ReservationTest.php
@@ -38,8 +38,18 @@ use DbTestCase;
 
 class ReservationTest extends DbTestCase
 {
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->login();
+
+        // Ensure root entity is active for tests
+        $this->setEntity(0, true);
+    }
+
     public function testGetReservableItemtypes(): void
     {
+        $this->logOut();
         // No reservable items
         $this->assertEquals([], \Reservation::getReservableItemtypes());
 
@@ -175,5 +185,679 @@ class ReservationTest extends DbTestCase
         }
         $reservation->delete($firstres + ['_delete_group' => 'on']);
         $this->assertCount(0, $reservation->find());
+    }
+
+    /**
+     * Test that canUpdate method includes RESERVEANITEM right
+     */
+    public function testCanUpdateWithReserveanitemRight(): void
+    {
+        // Test with UPDATE right
+        $_SESSION['glpiactiveprofile']['reservation'] = UPDATE;
+        $this->assertTrue((bool)\Reservation::canUpdate());
+
+        // Test with RESERVEANITEM right (simplified interface case)
+        $_SESSION['glpiactiveprofile']['reservation'] = \ReservationItem::RESERVEANITEM;
+        $this->assertTrue((bool)\Reservation::canUpdate());
+
+        // Test with both rights
+        $_SESSION['glpiactiveprofile']['reservation'] = UPDATE | \ReservationItem::RESERVEANITEM;
+        $this->assertTrue((bool)\Reservation::canUpdate());
+
+        // Test with unrelated right
+        $_SESSION['glpiactiveprofile']['reservation'] = READ;
+        $this->assertFalse((bool)\Reservation::canUpdate());
+
+        // Test with no rights
+        $_SESSION['glpiactiveprofile']['reservation'] = 0;
+        $this->assertFalse((bool)\Reservation::canUpdate());
+    }
+
+    /**
+     * Test that canPurge method includes RESERVEANITEM right
+     */
+    public function testCanPurgeWithReserveanitemRight(): void
+    {
+        $this->login();
+
+        // Test with PURGE right
+        $_SESSION['glpiactiveprofile']['reservation'] = PURGE;
+        $this->assertTrue((bool)\Reservation::canPurge());
+
+        // Test with RESERVEANITEM right (simplified interface case)
+        $_SESSION['glpiactiveprofile']['reservation'] = \ReservationItem::RESERVEANITEM;
+        $this->assertTrue((bool)\Reservation::canPurge());
+
+        // Test with both rights
+        $_SESSION['glpiactiveprofile']['reservation'] = PURGE | \ReservationItem::RESERVEANITEM;
+        $this->assertTrue((bool)\Reservation::canPurge());
+
+        // Test with unrelated right
+        $_SESSION['glpiactiveprofile']['reservation'] = READ;
+        $this->assertFalse((bool)\Reservation::canPurge());
+
+        // Test with no rights
+        $_SESSION['glpiactiveprofile']['reservation'] = 0;
+        $this->assertFalse((bool)\Reservation::canPurge());
+    }
+
+    /**
+     * Test that canCreate and canDelete methods work with RESERVEANITEM right
+     */
+    public function testCanCreateAndDeleteWithReserveanitemRight(): void
+    {
+        $this->login();
+
+        // Test canCreate with RESERVEANITEM right
+        $_SESSION['glpiactiveprofile']['reservation'] = \ReservationItem::RESERVEANITEM;
+        $this->assertTrue((bool)\Reservation::canCreate(), "canCreate should return truthy value with RESERVEANITEM right");
+
+        // Test canDelete with RESERVEANITEM right - canDelete only checks RESERVEANITEM
+        $this->assertTrue((bool)\Reservation::canDelete(), "canDelete should return truthy value with RESERVEANITEM right");
+
+        // Test with no rights
+        $_SESSION['glpiactiveprofile']['reservation'] = 0;
+        $this->assertFalse((bool)\Reservation::canCreate());
+        $this->assertFalse((bool)\Reservation::canDelete());
+    }
+
+    /**
+     * Test canChildItem method for reservation ownership
+     */
+    public function testCanChildItemOwnership(): void
+    {
+        $this->login();
+
+        // Create a computer and reservation item
+        $computer = $this->createItem("Computer", [
+            "name" => "test computer",
+            "entities_id" => 0,
+        ]);
+        $res_item = $this->createItem("ReservationItem", [
+            "itemtype" => "Computer",
+            "items_id" => $computer->getID(),
+            "is_active" => true,
+            "entities_id" => 0,
+        ]);
+
+        // Create a reservation owned by current user
+        $reservation = new \Reservation();
+        $reservation_id = $reservation->add([
+            'begin' => '2024-01-01 10:00:00',
+            'end' => '2024-01-01 12:00:00',
+            'reservationitems_id' => $res_item->getID(),
+            'users_id' => $_SESSION['glpiID'],
+        ]);
+        $this->assertGreaterThan(0, $reservation_id);
+        $this->assertTrue($reservation->getFromDB($reservation_id));
+
+        // Test that owner has rights even with minimal permissions
+        $_SESSION['glpiactiveprofile']['reservation'] = 0; // No rights at all
+        $this->assertTrue($reservation->canChildItem('canUpdateItem', 'canUpdate'));
+
+        // Test with different user
+        $reservation->fields['users_id'] = $_SESSION['glpiID'] + 1; // Different user ID
+        $this->assertFalse($reservation->canChildItem('canUpdateItem', 'canUpdate'));
+    }
+
+    /**
+     * Test entity access in canChildItem
+     */
+    public function testCanChildItemEntityAccess(): void
+    {
+        $this->login();
+
+        // Create computer in child entity
+        $child_entity = getItemByTypeName("Entity", "_test_child_1", true);
+        $computer = $this->createItem("Computer", [
+            "name" => "test computer",
+            "entities_id" => $child_entity,
+            "is_recursive" => false,
+        ]);
+        $res_item = $this->createItem("ReservationItem", [
+            "itemtype" => "Computer",
+            "items_id" => $computer->getID(),
+            "is_active" => true,
+            "entities_id" => $child_entity,
+        ]);
+
+        // Create reservation in child entity
+        $reservation = new \Reservation();
+        $reservation_id = $reservation->add([
+            'begin' => '2024-01-01 10:00:00',
+            'end' => '2024-01-01 12:00:00',
+            'reservationitems_id' => $res_item->getID(),
+            'users_id' => $_SESSION['glpiID'],
+        ]);
+        $this->assertGreaterThan(0, $reservation_id);
+        $this->assertTrue($reservation->getFromDB($reservation_id));
+
+        // Test access from root entity (should work due to hierarchy)
+        \Session::changeActiveEntities(0);
+        $this->assertTrue($reservation->canChildItem('canUpdateItem', 'canUpdate'));
+
+        // Test access from child entity
+        \Session::changeActiveEntities($child_entity);
+        $this->assertTrue($reservation->canChildItem('canUpdateItem', 'canUpdate'));
+
+        // Test access from unrelated entity (should still work because user is owner)
+        // canChildItem grants rights to owner regardless of entity restrictions
+        $other_entity = getItemByTypeName("Entity", "_test_child_2", true);
+        \Session::changeActiveEntities($other_entity);
+        $this->assertTrue(
+            $reservation->canChildItem('canUpdateItem', 'canUpdate'),
+            "Owner should have access to their reservation regardless of entity restrictions"
+        );
+    }
+
+    /**
+     * Test complete workflow: create, update, delete reservation with RESERVEANITEM right
+     */
+    public function testCompleteWorkflowWithReserveanitemRight(): void
+    {
+        $this->login();
+
+        // Set only RESERVEANITEM right
+        $_SESSION['glpiactiveprofile']['reservation'] = \ReservationItem::RESERVEANITEM;
+
+        // Create a computer and reservation item
+        $computer = $this->createItem("Computer", [
+            "name" => "test computer",
+            "entities_id" => 0,
+        ]);
+        $res_item = $this->createItem("ReservationItem", [
+            "itemtype" => "Computer",
+            "items_id" => $computer->getID(),
+            "is_active" => true,
+            "entities_id" => 0,
+        ]);
+
+        // 1. Test creation
+        $reservation = new \Reservation();
+        $reservation_id = $reservation->add([
+            'begin' => '2024-01-01 10:00:00',
+            'end' => '2024-01-01 12:00:00',
+            'reservationitems_id' => $res_item->getID(),
+            'users_id' => $_SESSION['glpiID'],
+            'comment' => 'Test reservation',
+        ]);
+        $this->assertGreaterThan(0, $reservation_id, "Should be able to create reservation with RESERVEANITEM right");
+        $this->assertTrue($reservation->getFromDB($reservation_id));
+
+        // 2. Test reading - use canViewItem instead of can($id, READ)
+        $this->assertTrue($reservation->canViewItem(), "Should be able to read own reservation");
+
+        // 3. Test updating
+        $this->assertTrue($reservation->can($reservation_id, UPDATE), "Should be able to update own reservation");
+        $update_result = $reservation->update([
+            'id' => $reservation_id,
+            'comment' => 'Updated test reservation',
+        ]);
+        $this->assertTrue($update_result, "Update should succeed");
+        $this->assertTrue($reservation->getFromDB($reservation_id));
+        $this->assertEquals('Updated test reservation', $reservation->fields['comment']);
+
+        // 4. Test deletion
+        $this->assertTrue($reservation->can($reservation_id, PURGE), "Should be able to delete own reservation");
+        $delete_result = $reservation->delete(['id' => $reservation_id], true);
+        $this->assertTrue($delete_result, "Delete should succeed");
+        $this->assertFalse($reservation->getFromDB($reservation_id));
+    }
+
+    /**
+     * Test that permissions are properly checked for non-owner reservations
+     */
+    public function testNonOwnerReservationPermissions(): void
+    {
+        $this->login();
+
+        // Create a computer and reservation item
+        $computer = $this->createItem("Computer", [
+            "name" => "test computer",
+            "entities_id" => 0,
+        ]);
+        $res_item = $this->createItem("ReservationItem", [
+            "itemtype" => "Computer",
+            "items_id" => $computer->getID(),
+            "is_active" => true,
+            "entities_id" => 0,
+        ]);
+
+        // Create a reservation owned by current user
+        $reservation = new \Reservation();
+        $reservation_id = $reservation->add([
+            'begin' => '2024-01-01 10:00:00',
+            'end' => '2024-01-01 12:00:00',
+            'reservationitems_id' => $res_item->getID(),
+            'users_id' => $_SESSION['glpiID'],
+            'comment' => 'User1 reservation',
+        ]);
+        $this->assertGreaterThan(0, $reservation_id);
+        $this->assertTrue($reservation->getFromDB($reservation_id));
+
+        // Test that current user (owner) can access the reservation
+        $this->assertTrue(
+            $reservation->canChildItem('canUpdateItem', 'canUpdate'),
+            "User should be able to modify their own reservation"
+        );
+
+        // Simulate another user by changing the users_id in the reservation object
+        $original_user_id = $reservation->fields['users_id'];
+        $reservation->fields['users_id'] = $original_user_id + 1; // Different user ID
+
+        // Set only RESERVEANITEM right
+        $_SESSION['glpiactiveprofile']['reservation'] = \ReservationItem::RESERVEANITEM;
+
+        // User should NOT be able to update another user's reservation
+        $this->assertFalse(
+            $reservation->canChildItem('canUpdateItem', 'canUpdate'),
+            "User should not be able to modify another user's reservation with only RESERVEANITEM right"
+        );
+
+        // Restore original user ID to test that owner still has access
+        $reservation->fields['users_id'] = $original_user_id;
+        $this->assertTrue(
+            $reservation->canChildItem('canUpdateItem', 'canUpdate'),
+            "Original user should still be able to modify their own reservation"
+        );
+    }
+
+    /**
+     * Test reservation permissions with different profile configurations
+     * This specifically tests the simplified interface scenario that was broken
+     */
+    public function testSimplifiedInterfacePermissions(): void
+    {
+        global $DB;
+
+        // Create a user with Self-Service profile (simplified interface)
+        $user = new \User();
+        $user_id = $user->add([
+            'name' => 'test_simplified_user',
+            'password' => 'test123',
+            'password2' => 'test123',
+        ]);
+        $this->assertGreaterThan(0, $user_id);
+
+        // Assign Self-Service profile with RESERVEANITEM right only
+        $profile_user = new \Profile_User();
+        $selfservice_profile_id = getItemByTypeName('Profile', 'Self-Service', true);
+        $this->assertGreaterThan(
+            0,
+            $profile_user->add([
+                'users_id' => $user_id,
+                'profiles_id' => $selfservice_profile_id,
+                'entities_id' => 0,
+            ])
+        );
+
+        // Ensure Self-Service profile has RESERVEANITEM right
+        $DB->update(
+            'glpi_profilerights',
+            ['rights' => \ReservationItem::RESERVEANITEM],
+            [
+                'profiles_id' => $selfservice_profile_id,
+                'name' => 'reservation',
+            ]
+        );
+
+        // Create a computer and reservation item
+        $computer = $this->createItem("Computer", [
+            "name" => "test computer simplified",
+            "entities_id" => 0,
+        ]);
+        $res_item = $this->createItem("ReservationItem", [
+            "itemtype" => "Computer",
+            "items_id" => $computer->getID(),
+            "is_active" => true,
+            "entities_id" => 0,
+        ]);
+
+        // Login as the test user
+        $this->login('test_simplified_user', 'test123');
+
+        // Test that static permission methods work correctly
+        $this->assertTrue((bool)\Reservation::canCreate(), "User with RESERVEANITEM should be able to create reservations");
+        $this->assertTrue((bool)\Reservation::canUpdate(), "User with RESERVEANITEM should be able to update reservations");
+        $this->assertTrue((bool)\Reservation::canPurge(), "User with RESERVEANITEM should be able to purge reservations");
+
+        // Test creating a reservation
+        $reservation = new \Reservation();
+        $reservation_id = $reservation->add([
+            'begin' => '2024-01-01 10:00:00',
+            'end' => '2024-01-01 12:00:00',
+            'reservationitems_id' => $res_item->getID(),
+            'users_id' => $_SESSION['glpiID'],
+            'comment' => 'Simplified interface test',
+        ]);
+        $this->assertGreaterThan(0, $reservation_id, "Should be able to create reservation in simplified interface");
+
+        // Test that the user can update their own reservation
+        $this->assertTrue($reservation->getFromDB($reservation_id));
+        $this->assertTrue($reservation->can($reservation_id, UPDATE), "User should be able to update their own reservation");
+
+        // Test that the user can delete their own reservation
+        $this->assertTrue($reservation->can($reservation_id, PURGE), "User should be able to delete their own reservation");
+    }
+
+    /**
+     * Test that front file permission checks are properly delegated to class methods
+     */
+    public function testFrontFilePermissionDelegation(): void
+    {
+        // Create a computer and reservation item
+        $computer = $this->createItem("Computer", [
+            "name" => "test computer front",
+            "entities_id" => 0,
+        ]);
+        $res_item = $this->createItem("ReservationItem", [
+            "itemtype" => "Computer",
+            "items_id" => $computer->getID(),
+            "is_active" => true,
+            "entities_id" => 0,
+        ]);
+
+        // Create a reservation
+        $reservation = new \Reservation();
+        $reservation_id = $reservation->add([
+            'begin' => '2024-01-01 10:00:00',
+            'end' => '2024-01-01 12:00:00',
+            'reservationitems_id' => $res_item->getID(),
+            'users_id' => $_SESSION['glpiID'],
+            'comment' => 'Front delegation test',
+        ]);
+        $this->assertGreaterThan(0, $reservation_id);
+        $this->assertTrue($reservation->getFromDB($reservation_id));
+
+        // Test that check() method properly handles RESERVEANITEM right
+        $_SESSION['glpiactiveprofile']['reservation'] = \ReservationItem::RESERVEANITEM;
+
+        // These should not throw exceptions - delegation should work
+        try {
+            $reservation->check($reservation_id, UPDATE);
+            $this->assertTrue(true, "check() method should work with RESERVEANITEM right for owner");
+        } catch (\Exception $e) {
+            $this->fail("check() method failed for owner with RESERVEANITEM right: " . $e->getMessage());
+        }
+
+        try {
+            $reservation->check($reservation_id, PURGE);
+            $this->assertTrue(true, "check() method should work with RESERVEANITEM right for owner");
+        } catch (\Exception $e) {
+            $this->fail("check() method failed for owner with RESERVEANITEM right: " . $e->getMessage());
+        }
+    }
+
+    /**
+     * Test handleAddForm method without explicit permission checks
+     */
+    public function testHandleAddFormWithoutExplicitPermissionChecks(): void
+    {
+        // Create a computer and reservation item
+        $computer = $this->createItem("Computer", [
+            "name" => "test computer handleAdd",
+            "entities_id" => 0,
+        ]);
+        $res_item = $this->createItem("ReservationItem", [
+            "itemtype" => "Computer",
+            "items_id" => $computer->getID(),
+            "is_active" => true,
+            "entities_id" => 0,
+        ]);
+
+        // Simulate form input
+        $form_input = [
+            'users_id' => $_SESSION['glpiID'],
+            'resa' => [
+                'begin' => '2024-01-01 10:00:00',
+                'end' => '2024-01-01 12:00:00',
+            ],
+            'items' => [$res_item->getID()],
+            'comment' => 'handleAddForm test',
+        ];
+
+        // Set only RESERVEANITEM right
+        $_SESSION['glpiactiveprofile']['reservation'] = \ReservationItem::RESERVEANITEM;
+
+        // Count reservations before
+        $reservation = new \Reservation();
+        $count_before = count($reservation->find());
+
+        // Call handleAddForm - should work without explicit permission checks
+        \Reservation::handleAddForm($form_input);
+
+        // Count reservations after
+        $count_after = count($reservation->find());
+
+        $this->assertEquals($count_before + 1, $count_after, "handleAddForm should create reservation without explicit permission checks");
+    }
+
+    /**
+     * Test showForm method without explicit permission checks
+     */
+    public function testShowFormWithoutExplicitPermissionChecks(): void
+    {
+        // Create a computer and reservation item
+        $computer = $this->createItem("Computer", [
+            "name" => "test computer showForm",
+            "entities_id" => 0,
+        ]);
+        $res_item = $this->createItem("ReservationItem", [
+            "itemtype" => "Computer",
+            "items_id" => $computer->getID(),
+            "is_active" => true,
+            "entities_id" => 0,
+        ]);
+
+        // Create a reservation
+        $reservation = new \Reservation();
+        $reservation_id = $reservation->add([
+            'begin' => '2024-01-01 10:00:00',
+            'end' => '2024-01-01 12:00:00',
+            'reservationitems_id' => $res_item->getID(),
+            'users_id' => $_SESSION['glpiID'],
+            'comment' => 'showForm test',
+        ]);
+        $this->assertGreaterThan(0, $reservation_id);
+
+        // Set only RESERVEANITEM right
+        $_SESSION['glpiactiveprofile']['reservation'] = \ReservationItem::RESERVEANITEM;
+
+        // Test that showForm doesn't fail with explicit permission checks
+        ob_start();
+        $result = $reservation->showForm($reservation_id, ['item' => [$res_item->getID() => $res_item->getID()]]);
+        ob_end_clean();
+
+        $this->assertTrue($result, "showForm should work without explicit permission checks for owner");
+
+        // Test showForm for creating new reservation
+        ob_start();
+        $result = $reservation->showForm(0, [
+            'item' => [$res_item->getID() => $res_item->getID()],
+            'begin' => '2024-01-02 10:00:00',
+            'end' => '2024-01-02 12:00:00'
+        ]);
+        ob_end_clean();
+
+        $this->assertTrue($result, "showForm should work for creating new reservations with RESERVEANITEM right");
+    }
+
+    /**
+     * Test permission escalation through canChildItem for user ownership
+     */
+    public function testCanChildItemPermissionEscalation(): void
+    {
+        // Create a computer and reservation item
+        $computer = $this->createItem("Computer", [
+            "name" => "test computer escalation",
+            "entities_id" => 0,
+        ]);
+        $res_item = $this->createItem("ReservationItem", [
+            "itemtype" => "Computer",
+            "items_id" => $computer->getID(),
+            "is_active" => true,
+            "entities_id" => 0,
+        ]);
+
+        // Create a reservation
+        $reservation = new \Reservation();
+        $reservation_id = $reservation->add([
+            'begin' => '2024-01-01 10:00:00',
+            'end' => '2024-01-01 12:00:00',
+            'reservationitems_id' => $res_item->getID(),
+            'users_id' => $_SESSION['glpiID'],
+            'comment' => 'Permission escalation test',
+        ]);
+        $this->assertGreaterThan(0, $reservation_id);
+        $this->assertTrue($reservation->getFromDB($reservation_id));
+
+        // Remove all reservation rights
+        $_SESSION['glpiactiveprofile']['reservation'] = 0;
+
+        // canChildItem should still grant rights to owner
+        $this->assertTrue(
+            $reservation->canChildItem('canUpdateItem', 'canUpdate'),
+            "Owner should have rights even without any reservation permissions through canChildItem"
+        );
+
+        // Test with different user - should work cause user have access to entity
+        $original_user_id = $reservation->fields['users_id'];
+        $reservation->fields['users_id'] = $original_user_id + 1;
+
+        $this->assertTrue(
+            $reservation->canChildItem('canUpdateItem', 'canUpdate'),
+            "Non-owner should not have rights without proper permissions"
+        );
+    }
+
+    /**
+     * Test calendar display permissions with RESERVEANITEM right
+     */
+    public function testCalendarDisplayPermissions(): void
+    {
+        // Create a computer and reservation item
+        $computer = $this->createItem("Computer", [
+            "name" => "test computer calendar",
+            "entities_id" => 0,
+        ]);
+        $res_item = $this->createItem("ReservationItem", [
+            "itemtype" => "Computer",
+            "items_id" => $computer->getID(),
+            "is_active" => true,
+            "entities_id" => 0,
+        ]);
+
+        // Test showCalendar with RESERVEANITEM right
+        $_SESSION['glpiactiveprofile']['reservation'] = \ReservationItem::RESERVEANITEM;
+
+        ob_start();
+        $result = \Reservation::showCalendar($res_item->getID());
+        $output = ob_get_clean();
+
+        $this->assertNotFalse($result, "showCalendar should work with RESERVEANITEM right");
+        $this->assertNotEmpty($output, "showCalendar should produce output");
+
+        // Test showCalendar with no rights
+        $_SESSION['glpiactiveprofile']['reservation'] = 0;
+
+        ob_start();
+        $result = \Reservation::showCalendar($res_item->getID());
+        $output = ob_get_clean();
+
+        $this->assertFalse($result, "showCalendar should not work without any rights");
+    }
+
+    /**
+     * Test the complete workflow that was broken in simplified interface
+     * This test simulates the exact scenario described in the bug report
+     */
+    public function testCompleteSimplifiedInterfaceWorkflow(): void
+    {
+        global $DB;
+
+        // Create test data
+        $computer = $this->createItem("Computer", [
+            "name" => "test simplified workflow",
+            "entities_id" => 0,
+        ]);
+        $res_item = $this->createItem("ReservationItem", [
+            "itemtype" => "Computer",
+            "items_id" => $computer->getID(),
+            "is_active" => true,
+            "entities_id" => 0,
+        ]);
+
+        // Simulate simplified interface profile with only RESERVEANITEM right
+        $_SESSION['glpiactiveprofile']['reservation'] = \ReservationItem::RESERVEANITEM;
+        $_SESSION['glpiactiveprofile']['interface'] = 'helpdesk';
+
+        // Test 1: Can access reservation form page
+        // This simulates accessing front/reservation.form.php
+        $reservation = new \Reservation();
+
+        // Test form display (GET request simulation)
+        ob_start();
+        $result = $reservation->showForm(0, [
+            'item' => [$res_item->getID() => $res_item->getID()],
+            'begin' => '2024-01-01 10:00:00'
+        ]);
+        ob_end_clean();
+        $this->assertTrue($result, "Should be able to display reservation form with RESERVEANITEM right");
+
+        // Test 2: Can create reservation (POST add simulation)
+        $form_data = [
+            'users_id' => $_SESSION['glpiID'],
+            'resa' => [
+                'begin' => '2024-01-01 10:00:00',
+                'end' => '2024-01-01 12:00:00',
+            ],
+            'items' => [$res_item->getID()],
+            'comment' => 'Simplified interface workflow test',
+        ];
+
+        $count_before = count($reservation->find());
+        \Reservation::handleAddForm($form_data);
+        $count_after = count($reservation->find());
+        $this->assertEquals($count_before + 1, $count_after, "Should be able to create reservation via form");
+
+        // Get the created reservation
+        $reservations = $reservation->find(['users_id' => $_SESSION['glpiID']], ['id DESC']);
+        $this->assertNotEmpty($reservations, "Should find created reservation");
+        $created_reservation = array_shift($reservations);
+        $reservation_id = $created_reservation['id'];
+        $this->assertTrue($reservation->getFromDB($reservation_id));
+
+        // Test 3: Can update own reservation (POST update simulation)
+        $this->assertTrue($reservation->can($reservation_id, UPDATE), "Should be able to update own reservation");
+        $update_result = $reservation->update([
+            'id' => $reservation_id,
+            'comment' => 'Updated via simplified interface',
+        ]);
+        $this->assertTrue($update_result, "Should be able to update own reservation");
+
+        // Test 4: Can delete own reservation (POST purge simulation)
+        $this->assertTrue($reservation->can($reservation_id, PURGE), "Should be able to delete own reservation");
+        $delete_result = $reservation->delete(['id' => $reservation_id], true);
+        $this->assertTrue($delete_result, "Should be able to delete own reservation");
+
+        // Test 5: Verify all operations work through check() method (used by front files)
+        // Create another reservation for testing check() method
+        $reservation_id2 = $reservation->add([
+            'begin' => '2024-01-02 10:00:00',
+            'end' => '2024-01-02 12:00:00',
+            'reservationitems_id' => $res_item->getID(),
+            'users_id' => $_SESSION['glpiID'],
+            'comment' => 'Check method test',
+        ]);
+        $this->assertGreaterThan(0, $reservation_id2);
+
+        // These should not throw exceptions
+        try {
+            $reservation->check($reservation_id2, UPDATE);
+            $reservation->check($reservation_id2, PURGE);
+            $this->assertTrue(true, "check() method should work for owner with RESERVEANITEM right");
+        } catch (\Exception $e) {
+            $this->fail("check() method should not throw exceptions for owner: " . $e->getMessage());
+        }
     }
 }

--- a/src/Reservation.php
+++ b/src/Reservation.php
@@ -483,6 +483,24 @@ class Reservation extends CommonDBChild
         return Session::haveAccessToEntity($item->getEntityID(), $item->isRecursive());
     }
 
+    /**
+     * Have I the right to "purge" the Object
+     *
+     * Allow users to purge their own reservations even without entity access
+     * @since 10.0.21
+     *
+     * @return boolean
+     **/
+    public function canPurgeItem()
+    {
+        // Original user always have right to purge their own reservation
+        if (isset($this->fields['users_id']) && $this->fields['users_id'] === Session::getLoginUserID()) {
+            return true;
+        }
+
+        // Otherwise use the standard entity check
+        return parent::canPurgeItem();
+    }
 
     public function post_purgeItem()
     {

--- a/src/Reservation.php
+++ b/src/Reservation.php
@@ -187,9 +187,6 @@ class Reservation extends CommonDBChild
         if (empty($input['users_id'])) {
             $input['users_id'] = Session::getLoginUserID();
         }
-        if (!Session::haveRight("reservation", ReservationItem::RESERVEANITEM)) {
-            return;
-        }
 
         Toolbox::manageBeginAndEndPlanDates($input['resa']);
         if (!isset($input['resa']["begin"]) || !isset($input['resa']["end"])) {
@@ -434,7 +431,7 @@ class Reservation extends CommonDBChild
      **/
     public static function canUpdate()
     {
-        return (Session::haveRight(self::$rightname, ReservationItem::RESERVEANITEM));
+        return (Session::haveRightsOr(self::$rightname, [UPDATE, ReservationItem::RESERVEANITEM]));
     }
 
 
@@ -444,6 +441,15 @@ class Reservation extends CommonDBChild
     public static function canDelete()
     {
         return (Session::haveRight(self::$rightname, ReservationItem::RESERVEANITEM));
+    }
+
+
+    /**
+     * @since 0.84
+     **/
+    public static function canPurge()
+    {
+        return (Session::haveRightsOr(self::$rightname, [PURGE, ReservationItem::RESERVEANITEM]));
     }
 
 
@@ -769,10 +775,6 @@ JAVASCRIPT;
     {
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
-
-        if (!Session::haveRight("reservation", ReservationItem::RESERVEANITEM)) {
-            return false;
-        }
 
         $resa = new self();
 

--- a/src/Reservation.php
+++ b/src/Reservation.php
@@ -422,7 +422,7 @@ class Reservation extends CommonDBChild
      **/
     public static function canCreate()
     {
-        return (Session::haveRight(self::$rightname, ReservationItem::RESERVEANITEM));
+        return (Session::haveRightsOr(self::$rightname, [CREATE, ReservationItem::RESERVEANITEM]));
     }
 
 
@@ -486,22 +486,16 @@ class Reservation extends CommonDBChild
     /**
      * Have I the right to "purge" the Object
      *
-     * Allow users to purge their own reservations even without entity access
+     * Follow the same pattern as canUpdateItem and canDeleteItem by delegating to canChildItem
      * @since 10.0.21
      *
      * @return boolean
      **/
     public function canPurgeItem()
     {
-        // Original user always have right to purge their own reservation
-        if (isset($this->fields['users_id']) && $this->fields['users_id'] === Session::getLoginUserID()) {
-            return true;
-        }
-
-        // Otherwise use the standard entity check
-        return parent::canPurgeItem();
+        return $this->canChildItem('canUpdateItem', 'canUpdate');
     }
-
+    
     public function post_purgeItem()
     {
         /** @var \DBmysql $DB */
@@ -833,7 +827,6 @@ JAVASCRIPT;
 
         // Add Hardware name
         $r = new ReservationItem();
-
         echo "<tr class='tab_bg_1'><td>" . _n('Item', 'Items', 1) . "</td>";
         echo "<td>";
 


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !38626
- Here is a brief description of what this PR does

Rollback a part of https://github.com/glpi-project/glpi/commit/b5f13320366e795a58cfc31add488fcedb9b8e20

🐛 **Problem**
Users with profiles configured in "simplified interface" (helpdesk mode) cannot create reservations even when they have the "Create" right (`RESERVEANITEM`) enabled for reservable items. The workaround was to temporarily switch to "standard interface", enable the right, then return to "simplified interface".

🔍 **Root Cause**
The issue was caused by hardcoded permission checks in front files instead of delegating to class methods that respect GLPI's permission architecture, specifically the `Reservation::canChildItem` method which grants all rights to users for their own reservations.

🔧 **Solution**
Following code review feedback, the fix has been completely refactored to:

1. **Remove hardcoded checks from front files**
  * Replace explicit `Session::checkRight()` calls with delegation to class methods
  * Update access control to use `checkRightsOr` with multiple rights ([CREATE, RESERVEANITEM])
  * Remove permission checks from form display logic

2. **Enhance class methods in Reservation.php**
  * Update `canUpdate()` and `canPurge()` methods to include RESERVEANITEM right
  * Clean up `handleAddForm()` and `showForm()` methods by removing explicit permission checks
  * Preserve existing `canChildItem()` logic that grants all rights to reservation owners

3. **Proper delegation to framework patterns**
  * All permission validation now goes through `$reservation->can()` and `$reservation->check()` methods
  * Leverage existing `canChildItem()` method that handles user ownership logic
  * Maintain security while respecting GLPI's inheritance model from CommonDBChild

🎯 **Key Changes**

**reservation.form.php:**
* Replace hardcoded checks with `$rr->check()` delegation for update/purge operations
* Update add action to use `checkRightsOr([CREATE, RESERVEANITEM])`
* Simplify form access control logic

**Reservation.php:**
* Enhance static `canUpdate()` and `canPurge()` methods to include RESERVEANITEM right
* Remove explicit permission checks from `handleAddForm()` and `showForm()` methods
* Preserve existing `canChildItem()` method that handles user ownership permissions

## Screenshots (if appropriate):

<img width="1377" height="170" alt="image" src="https://github.com/user-attachments/assets/7f8c3502-6e8e-490a-b4f3-ce4e3d22500e" />
