### PR TITLE
Prevent non blocking errors displaying to break GLPI boot

### DIFF
--- a/src/Glpi/Error/ErrorDisplayHandler/HtmlErrorDisplayHandler.php
+++ b/src/Glpi/Error/ErrorDisplayHandler/HtmlErrorDisplayHandler.php
@@ -49,7 +49,7 @@ final class HtmlErrorDisplayHandler implements ErrorDisplayHandler
 
     public function canOutput(): bool
     {
-        if (!self::$currentRequest) {
+        if (\isCommandLine()) {
             return false;
         }
 
@@ -63,7 +63,11 @@ final class HtmlErrorDisplayHandler implements ErrorDisplayHandler
             return false;
         }
 
-        return self::$currentRequest->getPreferredFormat() === 'html';
+        // Need to fallback to `Request::createFromGlobals()` for errors that appears before the
+        // `onRequest` event.
+        $request = self::$currentRequest ?? Request::createFromGlobals();
+
+        return $request->getPreferredFormat() === 'html';
     }
 
     public function displayErrorMessage(string $error_label, string $message, string $log_level): void

--- a/src/Glpi/Kernel/Listener/PostBootListener/FlushBootErrors.php
+++ b/src/Glpi/Kernel/Listener/PostBootListener/FlushBootErrors.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Kernel\Listener\PostBootListener;
+
+use Glpi\Debug\Profiler;
+use Glpi\Error\ErrorHandler;
+use Glpi\Kernel\ListenersPriority;
+use Glpi\Kernel\PostBootEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+final readonly class FlushBootErrors implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            PostBootEvent::class => ['onPostBoot', ListenersPriority::POST_BOOT_LISTENERS_PRIORITIES[self::class]],
+        ];
+    }
+
+    public function onPostBoot(): void
+    {
+        Profiler::getInstance()->start('FlushBootErrors::execute', Profiler::CATEGORY_BOOT);
+
+        ErrorHandler::disableBufferAndFlushMessages();
+
+        Profiler::getInstance()->stop('FlushBootErrors::execute');
+    }
+}

--- a/src/Glpi/Kernel/ListenersPriority.php
+++ b/src/Glpi/Kernel/ListenersPriority.php
@@ -38,6 +38,7 @@ use Glpi\Kernel\Listener\PostBootListener\BootPlugins;
 use Glpi\Kernel\Listener\PostBootListener\CheckPluginsStates;
 use Glpi\Kernel\Listener\PostBootListener\CustomObjectsAutoloaderRegistration;
 use Glpi\Kernel\Listener\PostBootListener\CustomObjectsBoot;
+use Glpi\Kernel\Listener\PostBootListener\FlushBootErrors;
 use Glpi\Kernel\Listener\PostBootListener\InitializeCache;
 use Glpi\Kernel\Listener\PostBootListener\InitializeDbConnection;
 use Glpi\Kernel\Listener\PostBootListener\InitializePlugins;
@@ -68,6 +69,10 @@ final class ListenersPriority
         CheckPluginsStates::class =>                  150,
         BootPlugins::class =>                         140,
         SessionStart::class =>                        130,
+
+        // Need to be after `SessionStart` to prevent headers to be sent before the session start.
+        FlushBootErrors::class =>                     125,
+
         LoadLanguage::class =>                        120,
         InitializePlugins::class =>                   110,
         CustomObjectsBoot::class =>                   100,


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

In CLI context or in dev/debug mode, any non blocking error generates an error message output. If this happens before the session is started, then the session start fails because response headers are already sent. With the proposed changes, the error messages are buffered during the GLPI boot sequence and flushed juste after the session is started.

It fixes #20266.