### PR TITLE
fix(forms): Fixed incorrect display for the render layout selection option

### DIFF
--- a/templates/pages/admin/form/form_editor.html.twig
+++ b/templates/pages/admin/form/form_editor.html.twig
@@ -210,6 +210,9 @@
                                                 'full_width'    : true,
                                                 'templateSelection': 'renderLayoutTemplateSelection',
                                                 'templateResult': 'renderLayoutTemplateResult',
+                                                'add_field_attribs': {
+                                                    'data-fix-dropdown-flex': '',
+                                                },
                                             }
                                         ) }}
 


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.

## Description

This pull request makes a small change to the `form_editor.html.twig` file to enhance the layout's behavior. Specifically, it adds a `data-fix-dropdown-flex` attribute to the `accordion-body` element to address potential issues with dropdown alignment in flexible layouts.

## Screenshots (if appropriate):

### Before
<img width="313" height="144" alt="image" src="https://github.com/user-attachments/assets/1e297e42-1b6d-4c32-af2d-9b3a76646968" />

### After
<img width="393" height="228" alt="image" src="https://github.com/user-attachments/assets/78c9daf7-9edb-456e-8c9d-714ab54945ae" />
