### PR TITLE
Ignore PHPStan errors related to unspecified iterable types

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -72,6 +72,9 @@ parameters:
         -
             message: '~/(xhprof_runs\.php|xhprof_lib\.php|downstream\.php|local_define\.php|config_db\.php|config_db_slave\.php)" is not a file or it does not exist.~'
             reportUnmatched: false
+        -
+            identifier: 'missingType.iterableValue'
+            reportUnmatched: false
 
 # Copy and uncomment this content into a "phpstan.neon" file to add your own config values
 #


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

With the PHPStan level 6, about 10700 error are reported, 6500 of them are corresponding to a lack of specification of the iterable types.

For instance, PHPStan reports `@return array` as an error, an requires to specify the content of the array, e.g. `@return list<CommonDBTM>`. Specifying all the array types could help to find issues, but I think we should focus on fixing other issues first, by adding type where the is no type documented.