### PR TITLE
Ignore `exit()`/`http_response_code()` PHPStan reports in API

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -608,32 +608,8 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Api/API.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^You should not use the `exit` function\\. It prevents the execution of post\\-request/post\\-command routines\\.$#',
-	'identifier' => 'glpi.forbidExit',
-	'count' => 3,
-	'path' => __DIR__ . '/src/Glpi/Api/API.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^You should not use the `http_response_code` function to change the response code\\. Due to a PHP bug, it may not provide the expected result \\(see https\\://bugs\\.php\\.net/bug\\.php\\?id\\=81451\\)\\.$#',
-	'identifier' => 'glpi.forbidHttpResponseCode',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/API.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$user_id of method Glpi\\\\Api\\\\API\\:\\:userPicture\\(\\) expects bool\\|int, string given\\.$#',
 	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/APIRest.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^You should not use the `exit` function\\. It prevents the execution of post\\-request/post\\-command routines\\.$#',
-	'identifier' => 'glpi.forbidExit',
-	'count' => 3,
-	'path' => __DIR__ . '/src/Glpi/Api/APIRest.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^You should not use the `http_response_code` function to change the response code\\. Due to a PHP bug, it may not provide the expected result \\(see https\\://bugs\\.php\\.net/bug\\.php\\?id\\=81451\\)\\.$#',
-	'identifier' => 'glpi.forbidHttpResponseCode',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Glpi/Api/APIRest.php',
 ];

--- a/src/Glpi/Api/API.php
+++ b/src/Glpi/Api/API.php
@@ -251,7 +251,7 @@ abstract class API
                 header("Access-Control-Allow-Headers: " .
                    "origin, content-type, accept, session-token, authorization, app-token");
             }
-            exit(0);
+            exit(0); // @phpstan-ignore glpi.forbidExit (API response is streamed)
         }
     }
 
@@ -2520,7 +2520,7 @@ abstract class API
 TWIG, ['md' => (new MarkdownRenderer())->render($documentation)]);
 
         Html::nullFooter();
-        exit();
+        exit(); // @phpstan-ignore glpi.forbidExit (API response is streamed)
     }
 
 
@@ -3149,9 +3149,9 @@ TWIG, ['md' => (new MarkdownRenderer())->render($documentation)]);
             Toolbox::getFileAsResponse($file, $user->fields['picture'])->send();
         } else {
             // No content
-            http_response_code(204);
+            http_response_code(204); // @phpstan-ignore glpi.forbidHttpResponseCode (API response is streamed)
         }
-        exit();
+        exit(); // @phpstan-ignore glpi.forbidExit (API response is streamed)
     }
 
     /**

--- a/src/Glpi/Api/APIRest.php
+++ b/src/Glpi/Api/APIRest.php
@@ -303,7 +303,7 @@ class APIRest extends API
                             $this->messageRightError();
                         }
                         $document->getAsResponse()->send();
-                        exit();
+                        exit(); // @phpstan-ignore glpi.forbidExit (API response is streamed)
                     }
 
                     if ($id !== false) {
@@ -649,7 +649,7 @@ class APIRest extends API
             header("$key: $value");
         }
 
-        http_response_code($httpcode);
+        http_response_code($httpcode); // @phpstan-ignore glpi.forbidHttpResponseCode (API response is streamed)
         $this->header($this->debug);
 
         if ($response !== null) {
@@ -669,7 +669,7 @@ class APIRest extends API
         } else {
             echo $json;
         }
-        exit();
+        exit(); // @phpstan-ignore glpi.forbidExit (API response is streamed)
     }
 
 
@@ -688,6 +688,6 @@ class APIRest extends API
         } elseif ($this->format == "json") {
             echo file_get_contents(GLPI_ROOT . '/' . $file);
         }
-        exit();
+        exit(); // @phpstan-ignore glpi.forbidExit (API response is streamed)
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

The API response is streamed and is compatible with usage of these functions.
The whole API response handling will have to be refactored in a future GLPI version.