### PR TITLE
Fix DateTime exceptions on ticket stats tab

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -3292,7 +3292,9 @@ JS;
 
         // format dates
         foreach ($options['dates'] as &$data) {
-            $data['date'] = date("Y-m-d H:i:s", $data['timestamp']);
+            $data['date'] = $data['timestamp'] !== null
+                ? date("Y-m-d H:i:s", $data['timestamp'])
+                : null;
         }
 
         // get Html

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -45,7 +45,6 @@ use Glpi\Event;
 use Glpi\RichText\RichText;
 use Glpi\RichText\UserMention;
 use Safe\DateTime;
-use Safe\Exceptions\DatetimeException;
 
 use function Safe\preg_match;
 use function Safe\preg_match_all;
@@ -5454,7 +5453,7 @@ JAVASCRIPT;
     public function showStatsDates()
     {
         $now                      = time();
-        $date_creation            = strtotime($this->fields['date'] ?? '');
+        $date_creation            = strtotime($this->fields['date']);
         // Tickets created before 10.0.4 do not have takeintoaccountdate field, use old and incorrect computation for those cases
         $date_takeintoaccount     = 0;
         if ($this->fields['takeintoaccountdate'] !== null) {
@@ -5462,16 +5461,26 @@ JAVASCRIPT;
         } elseif ($this->fields['takeintoaccount_delay_stat'] > 0) {
             $date_takeintoaccount = $date_creation + $this->fields['takeintoaccount_delay_stat'];
         }
-        $internal_time_to_own     = strtotime($this->fields['internal_time_to_own'] ?? '');
-        $time_to_own              = strtotime($this->fields['time_to_own'] ?? '');
-        $internal_time_to_resolve = strtotime($this->fields['internal_time_to_resolve'] ?? '');
-        $time_to_resolve          = strtotime($this->fields['time_to_resolve'] ?? '');
-        try {
-            $solvedate = strtotime($this->fields['solvedate'] ?? '');
-        } catch (DatetimeException $e) {
-            $solvedate = '';
-        }
-        $closedate                = strtotime($this->fields['closedate'] ?? '');
+
+        $internal_time_to_own     = !empty($this->fields['internal_time_to_own'])
+            ? strtotime($this->fields['internal_time_to_own'])
+            : null;
+        $time_to_own              = !empty($this->fields['time_to_own'])
+            ? strtotime($this->fields['time_to_own'])
+            : null;
+        $internal_time_to_resolve = !empty($this->fields['internal_time_to_resolve'])
+            ? strtotime($this->fields['internal_time_to_resolve'])
+            : null;
+        $time_to_resolve          = !empty($this->fields['time_to_resolve'])
+            ? strtotime($this->fields['time_to_resolve'])
+            : null;
+        $solvedate                = !empty($this->fields['solvedate'])
+            ? strtotime($this->fields['solvedate'])
+            : null;
+        $closedate                = !empty($this->fields['closedate'])
+            ? strtotime($this->fields['closedate'])
+            : null;
+
         $goal_takeintoaccount     = ($date_takeintoaccount > 0 ? $date_takeintoaccount : $now);
         $goal_solvedate           = ($solvedate > 0 ? $solvedate : $now);
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

It fixes the following error:
```
An error occurred
In ./vendor/thecodingmachine/safe/generated/Exceptions/DatetimeException.php(9)
#0 ./vendor/thecodingmachine/safe/generated/8.4/datetime.php(1228): Safe\Exceptions\DatetimeException::createFromPhpError()
#1 ./src/Ticket.php(5465): Safe\strtotime('')
#2 ./src/CommonITILObject.php(5564): Ticket->showStatsDates()
#3 ./src/Ticket.php(823): CommonITILObject->showStats()
#4 ./src/CommonGLPI.php(683): Ticket::displayTabContentForItem(Object(Ticket), '4', 0)
#5 ./ajax/common.tabs.php(111): CommonGLPI::displayStandardTab(Object(Ticket), 'Ticket$4', 0, Array)
#6 ./src/Glpi/Controller/LegacyFileLoadController.php(63): require('./a...')
#7 ./vendor/symfony/http-kernel/HttpKernel.php(181): Glpi\Controller\LegacyFileLoadController->__invoke(Object(Symfony\Component\HttpFoundation\Request))
#8 ./vendor/symfony/http-kernel/HttpKernel.php(76): Symfony\Component\HttpKernel\HttpKernel->handleRaw(Object(Symfony\Component\HttpFoundation\Request), 1)
#9 ./vendor/symfony/http-kernel/Kernel.php(197): Symfony\Component\HttpKernel\HttpKernel->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#10 ./public/index.php(70): Symfony\Component\HttpKernel\Kernel->handle(Object(Symfony\Component\HttpFoundation\Request))
#11 {main}
```