### PR TITLE
Remove useless usage of the `html_attr` escape strategy

### DIFF
--- a/src/Glpi/Form/QuestionType/AbstractQuestionTypeShortAnswer.php
+++ b/src/Glpi/Form/QuestionType/AbstractQuestionTypeShortAnswer.php
@@ -116,7 +116,7 @@ abstract class AbstractQuestionTypeShortAnswer extends AbstractQuestionType impl
                 value="{{ question is not null ? question.fields.default_value : '' }}"
                 aria-label="{{ aria_label }}"
                 {% for key, value in attributes %}
-                    {{ key }}="{{ value|e('html_attr') }}"
+                    {{ key }}="{{ value }}"
                 {% endfor %}
             />
 TWIG;
@@ -153,7 +153,7 @@ TWIG;
                 aria-label="{{ label }}"
                 {{ question.fields.is_mandatory ? 'required' : '' }}
                 {% for key, value in attributes %}
-                    {{ key }}="{{ value|e('html_attr') }}"
+                    {{ key }}="{{ value }}"
                 {% endfor %}
             >
 TWIG;


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

This strategy is required only when there is no quotes surrounding the attribute value.