### PR TITLE
fix(forms-migration): Fixed invalid active state during form migration

### DIFF
--- a/phpunit/functional/Glpi/Form/Migration/FormMigrationTest.php
+++ b/phpunit/functional/Glpi/Form/Migration/FormMigrationTest.php
@@ -205,6 +205,21 @@ final class FormMigrationTest extends DbTestCase
                 'forms_categories_id' => fn() => getItemByTypeName(Category::class, 'My test form category', true),
             ],
         ];
+
+        yield 'Basic properties with inactive form' => [
+            [
+                'name'                => 'Test form migration for sections',
+                'entities_id'         => 0,
+                'is_recursive'        => 0,
+                'is_active'           => 0,
+                'is_deleted'          => 0,
+                'is_draft'            => 0,
+                'header'              => '',
+                'illustration'        => '',
+                'description'         => '',
+                'forms_categories_id' => 0,
+            ],
+        ];
     }
 
     #[DataProvider('provideFormMigrationBasicProperties')]

--- a/src/Glpi/Form/Migration/FormMigration.php
+++ b/src/Glpi/Form/Migration/FormMigration.php
@@ -455,7 +455,7 @@ class FormMigration extends AbstractPluginMigration
                 'plugin_formcreator_categories_id',
                 'entities_id',
                 'is_recursive',
-                'is_visible AS is_active',
+                'is_active',
                 'is_deleted',
             ],
             'FROM'   => 'glpi_plugin_formcreator_forms',


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

When migrating a form, the ‘activated’ status is not retained.
This change takes into account whether the form is ‘activated’.