### PR TITLE
Lazy load form questions descriptions

### DIFF
--- a/js/modules/Forms/EditorController.js
+++ b/js/modules/Forms/EditorController.js
@@ -919,6 +919,15 @@ export class GlpiFormEditorController
                 .removeAttr(`data-glpi-form-editor-active-${type}`);
         });
 
+        // Lazy load descriptions
+        item_container.find('textarea[data-glpi-loaded=false]').each(function() {
+            // Get editor config for this field
+            const id = $(this).attr("id");
+            const config = window.tinymce_editor_configs[id];
+            tinyMCE.init(config);
+            $(this).attr('data-glpi-loaded', "true");
+        });
+
         /**
          * Delay the activation of the new item to avoid a rendering bug.
          * I can't explain it, but without this delay,

--- a/templates/components/form/basic_inputs_macros.html.twig
+++ b/templates/components/form/basic_inputs_macros.html.twig
@@ -333,6 +333,7 @@
         'statusbar': true,
         'content_style': "",
         'input_addclass': '',
+        'additional_attributes': [],
     }|merge(options) %}
 
     {% if options.fields_template.isMandatoryField(name)|default(false) %}
@@ -346,6 +347,9 @@
     <textarea class="form-control {{ options.input_addclass }}"
             id="{{ options.id }}" name="{{ name }}" rows="{{ options.rows }}"
             style="width: 100%;"
+            {% for attr, value in options.additional_attributes %}
+               {{ attr }}="{{ value }}"
+            {% endfor %}
             {% if not options.aria_label is empty %}
                 aria-label="{{ options.aria_label }}"
             {% endif %}

--- a/templates/pages/admin/form/form_comment.html.twig
+++ b/templates/pages/admin/form/form_comment.html.twig
@@ -146,6 +146,7 @@
                 {# Mark as secondary if empty #}
                 {{ comment is null or comment.fields.description|length == 0 ? "data-glpi-form-editor-active-comment-extra-details" : "" }}
             >
+                {% set load_editor = comment is not null and comment.fields.description|length > 0 %}
                 {{ fields.textareaField(
                     'description',
                     comment is not null ? comment.fields.description : '',
@@ -158,9 +159,12 @@
                         'editor_height': "0",
                         'rows' : 1,
                         'toolbar_location': 'bottom',
-                        'init': comment is not null ? true : false,
+                        'init': load_editor,
                         'mb': 'mb-0',
-                })
+                        'additional_attributes': {
+                            'data-glpi-loaded': load_editor ? "true" : "false"
+                        }
+                    })
                 ) }}
             </div>
         </div>

--- a/templates/pages/admin/form/form_question.html.twig
+++ b/templates/pages/admin/form/form_question.html.twig
@@ -200,6 +200,7 @@
                 {# Mark as secondary if empty #}
                 {{ question is null or question.fields.description|length == 0 ? "data-glpi-form-editor-question-extra-details" : "" }}
             >
+                {% set load_editor = question is not null and question.fields.description|length > 0 %}
                 {{ fields.textareaField(
                     'description',
                     question is not null ? question.fields.description : '',
@@ -212,9 +213,12 @@
                         'editor_height': "0",
                         'rows' : 1,
                         'toolbar_location': 'bottom',
-                        'init': question is not null ? true : false,
+                        'init': load_editor,
                         'mb': 'mb-0',
-                })
+                        'additional_attributes': {
+                            'data-glpi-loaded': load_editor ? "true" : "false"
+                        }
+                    })
                 ) }}
             </div>
 


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

In the form editor, questions can have a description, which is a tinymce editor.
This mean we load one editor per question, which slow down the loading of the page (I think tinymce isn't made to be loaded with a lot of instances, it doesn't handle it very well).

To avoid this, I've added a lazy loading mechanism for question that have an empty description.
As a reminder, the editor only show the description if it is not empty or if the question is selected.
Thus, if the description is empty we can wait for the user to select the question before loading the tinymce editor.

Partial improvement for #20416.
