### PR TITLE
Fix `getItemForItemtype()` PHPDoc

### DIFF
--- a/ajax/timeline.php
+++ b/ajax/timeline.php
@@ -43,11 +43,12 @@ use function Safe\json_encode;
 if (($_POST['action'] ?? null) === 'change_task_state') {
     header("Content-Type: application/json; charset=UTF-8");
 
-    if (
-        !isset($_POST['tasks_id'], $_POST['parenttype'])
-        || ($parent = getItemForItemtype($_POST['parenttype'])) === false
-        || !is_a($parent, CommonITILObject::class, true)
-    ) {
+    if (!isset($_POST['tasks_id'], $_POST['parenttype'])) {
+        return;
+    }
+
+    $parent = getItemForItemtype($_POST['parenttype']);
+    if (!($parent instanceof CommonITILObject)) {
         return;
     }
 

--- a/front/commonitilobject_commonitilobject.form.php
+++ b/front/commonitilobject_commonitilobject.form.php
@@ -48,7 +48,7 @@ if (isset($_POST['purge'], $_POST['id'])) {
     [$link_class_1, $link_class_2, $link_id] = explode('_', $_POST['id'], 3);
     $link_class = $link_class_1 . '_' . $link_class_2;
     $itil_itil = getItemForItemtype($link_class);
-    $_POST['id'] = $link_id;
+    $_POST['id'] = (int) $link_id;
     $itil_itil->check($_POST['id'], PURGE);
 
     $itil_itil->delete($_POST, true);

--- a/front/itilsolution.form.php
+++ b/front/itilsolution.form.php
@@ -36,13 +36,20 @@
 require_once(__DIR__ . '/_check_webserver_config.php');
 
 use Glpi\Event;
+use Glpi\Exception\Http\NotFoundHttpException;
 
 /** @var DBmysql $DB */
 global $DB;
 
 $solution = new ITILSolution();
 $track = getItemForItemtype($_POST['itemtype']);
-$track->getFromDB($_POST['items_id']);
+
+if (
+    !($track instanceof CommonITILObject)
+    || !$track->getFromDB($_POST['items_id'])
+) {
+    throw new NotFoundHttpException();
+}
 
 $redirect = null;
 $handled = false;

--- a/front/lock.form.php
+++ b/front/lock.form.php
@@ -46,7 +46,6 @@ global $CFG_GLPI;
 
 if (isset($_POST['itemtype'])) {
     $source_item = getItemForItemtype($_POST['itemtype']);
-    $itemtype = $source_item::class;
     if ($source_item->can($_POST['id'], UPDATE)) {
         $devices = Item_Devices::getDeviceTypes();
         $actions = array_merge($CFG_GLPI['inventory_lockable_objects'], array_values($devices));
@@ -94,7 +93,7 @@ if (isset($_POST['itemtype'])) {
                         }
 
                         //Force unlock
-                        $item->delete(['id' => $key], 1);
+                        $item->delete(['id' => $key], true);
                     }
                 }
             }

--- a/phpunit/functional/Notification_NotificationTemplateTest.php
+++ b/phpunit/functional/Notification_NotificationTemplateTest.php
@@ -182,17 +182,17 @@ class Notification_NotificationTemplateTest extends DbTestCase
         \Notification_NotificationTemplate::registerMode(
             'testmode',
             'A test label',
-            'anyplugin'
+            'tester'
         );
 
         $class = \Notification_NotificationTemplate::getModeClass('testmode');
-        $this->assertSame('PluginAnypluginNotificationTestmode', $class);
+        $this->assertSame('PluginTesterNotificationTestmode', $class);
 
         $class = \Notification_NotificationTemplate::getModeClass('testmode', 'event');
-        $this->assertSame('PluginAnypluginNotificationEventTestmode', $class);
+        $this->assertSame('PluginTesterNotificationEventTestmode', $class);
 
         $class = \Notification_NotificationTemplate::getModeClass('testmode', 'setting');
-        $this->assertSame('PluginAnypluginNotificationTestmodeSetting', $class);
+        $this->assertSame('PluginTesterNotificationTestmodeSetting', $class);
     }
 
     public function testHasActiveMode()

--- a/phpunit/functional/StateTest.php
+++ b/phpunit/functional/StateTest.php
@@ -38,10 +38,10 @@ use CommonDBTM;
 use Computer;
 use DbTestCase;
 use DropdownVisibility;
+use Glpi\Features\StateInterface;
 use Phone;
 use Printer;
 use ReflectionClass;
-use Toolbox;
 
 class StateTest extends DbTestCase
 {
@@ -194,8 +194,8 @@ class StateTest extends DbTestCase
 
         foreach ($CFG_GLPI['state_types'] as $itemtype) {
             $this->assertTrue(
-                Toolbox::hasTrait($itemtype, \Glpi\Features\State::class),
-                $itemtype . ' misses ' . \Glpi\Features\State::class . ' trait!'
+                is_a($itemtype, StateInterface::class, true),
+                $itemtype . ' must implement ' . StateInterface::class
             );
         }
     }

--- a/src/Appliance.php
+++ b/src/Appliance.php
@@ -37,11 +37,12 @@ use Glpi\Features\AssetImage;
 use Glpi\Features\AssignableItem;
 use Glpi\Features\AssignableItemInterface;
 use Glpi\Features\Clonable;
+use Glpi\Features\StateInterface;
 
 /**
  * Appliances Class
  **/
-class Appliance extends CommonDBTM implements AssignableItemInterface
+class Appliance extends CommonDBTM implements AssignableItemInterface, StateInterface
 {
     use Clonable;
     use Glpi\Features\State;

--- a/src/Cable.php
+++ b/src/Cable.php
@@ -36,13 +36,14 @@ use Glpi\Application\View\TemplateRenderer;
 use Glpi\Features\AssignableItem;
 use Glpi\Features\AssignableItemInterface;
 use Glpi\Features\Clonable;
+use Glpi\Features\StateInterface;
 use Glpi\Socket;
 use Glpi\SocketModel;
 
 /**
  * Class Cable
  */
-class Cable extends CommonDBTM implements AssignableItemInterface
+class Cable extends CommonDBTM implements AssignableItemInterface, StateInterface
 {
     use AssignableItem;
     use Clonable;

--- a/src/Certificate.php
+++ b/src/Certificate.php
@@ -37,6 +37,7 @@ use Glpi\DBAL\QueryFunction;
 use Glpi\Features\AssignableItem;
 use Glpi\Features\AssignableItemInterface;
 use Glpi\Features\Clonable;
+use Glpi\Features\StateInterface;
 
 use function Safe\strtotime;
 
@@ -44,7 +45,7 @@ use function Safe\strtotime;
  * Class to declare a certificate
  * @since 9.2
  */
-class Certificate extends CommonDBTM implements AssignableItemInterface
+class Certificate extends CommonDBTM implements AssignableItemInterface, StateInterface
 {
     use Clonable;
     use Glpi\Features\State;

--- a/src/Cluster.php
+++ b/src/Cluster.php
@@ -35,11 +35,12 @@
 use Glpi\Features\AssignableItem;
 use Glpi\Features\AssignableItemInterface;
 use Glpi\Features\Clonable;
+use Glpi\Features\StateInterface;
 
 /**
  * Cluster Class
  **/
-class Cluster extends CommonDBTM implements AssignableItemInterface
+class Cluster extends CommonDBTM implements AssignableItemInterface, StateInterface
 {
     use Clonable;
     use Glpi\Features\State;

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -1983,7 +1983,7 @@ class CommonDBTM extends CommonGLPI
                 foreach ($iterator as $data) {
                     $input['id'] = $data['id'];
                     // No history for such update
-                    $item->update($input, 0);
+                    $item->update($input, false);
                 }
             }
         }

--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -50,6 +50,8 @@ class CommonGLPI implements CommonGLPIInterface
 {
     /**
      * Show the title of the item in the navigation header ?
+     *
+     * @var bool
      */
     protected static $showTitleInNavigationHeader = false;
 
@@ -342,9 +344,9 @@ class CommonGLPI implements CommonGLPIInterface
     /**
      * Add standard define tab
      *
-     * @param string $itemtype itemtype link to the tab
-     * @param array  $ong      defined tabs
-     * @param array  $options  options (for withtemplate)
+     * @param class-string<CommonGLPI> $itemtype itemtype link to the tab
+     * @param array                    $ong      defined tabs
+     * @param array                    $options  options (for withtemplate)
      *
      * @return CommonGLPI
      **/
@@ -672,10 +674,7 @@ class CommonGLPI implements CommonGLPIInterface
                     return $ret;
                 }
 
-                if (
-                    !is_numeric($itemtype) && ($itemtype != 'empty')
-                    && ($obj = getItemForItemtype($itemtype))
-                ) {
+                if ($obj = getItemForItemtype($itemtype)) {
                     $options['tabnum'] = $tabnum;
                     $options['itemtype'] = $itemtype;
                     Plugin::doHook(Hooks::PRE_SHOW_TAB, [ 'item' => $item, 'options' => &$options]);
@@ -1284,7 +1283,9 @@ class CommonGLPI implements CommonGLPIInterface
 
     /**
      * Get links to Faq
-     **/
+     *
+     * @return string
+     */
     public function getKBLinks()
     {
         /**

--- a/src/CommonITILActor.php
+++ b/src/CommonITILActor.php
@@ -1,5 +1,6 @@
 <?php
 
+
 /**
  * ---------------------------------------------------------------------
  *
@@ -252,6 +253,10 @@ abstract class CommonITILActor extends CommonDBRelation
     public function post_addItem()
     {
         $item = getItemForItemtype(static::$itemtype_1);
+
+        if (!($item instanceof CommonITILObject)) {
+            throw new RuntimeException();
+        }
 
         $no_stat_computation = true;
         if ($this->input['type'] == CommonITILActor::ASSIGN) {

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -43,6 +43,7 @@ use Glpi\Features\Clonable;
 use Glpi\Features\Kanban;
 use Glpi\Features\KanbanInterface;
 use Glpi\Features\Teamwork;
+use Glpi\Features\TeamworkInterface;
 use Glpi\Features\Timeline;
 use Glpi\Form\AnswersSet;
 use Glpi\Form\Destination\AnswersSet_FormDestinationItem;
@@ -66,7 +67,7 @@ use function Safe\strtotime;
  * @property-read array $groups
  * @property-read array $suppliers
  **/
-abstract class CommonITILObject extends CommonDBTM implements KanbanInterface
+abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, TeamworkInterface
 {
     use Clonable;
     use Timeline;
@@ -9421,7 +9422,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface
         };
 
         $actor = getItemForItemtype($actor_class);
-        if (!is_a($actor, CommonITILActor::class)) {
+        if (!($actor instanceof CommonITILActor)) {
             throw new RuntimeException(
                 'The actor class for item type ' . $itemtype . ' must extend CommonITILActor.'
             );
@@ -10366,6 +10367,9 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface
         return $validation_class_name ? getItemForItemtype($validation_class_name) : null;
     }
 
+    /**
+     * @return class-string<CommonITILValidation>|null
+     */
     public static function getValidationClassName(): ?string
     {
         $validation_class = static::class . 'Validation';
@@ -11208,8 +11212,12 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface
         return false;
     }
 
-    public static function getTeamMemberForm(CommonITILObject $item): string
+    public static function getTeamMemberForm(CommonDBTM $item): string
     {
+        if (!($item instanceof CommonITILObject)) {
+            throw new RuntimeException();
+        }
+
         $itiltemplate = $item->getITILTemplateToUse(
             0,
             $item instanceof Ticket ? $item->fields['type'] : null,

--- a/src/CommonITILObject_CommonITILObject.php
+++ b/src/CommonITILObject_CommonITILObject.php
@@ -264,7 +264,9 @@ abstract class CommonITILObject_CommonITILObject extends CommonDBRelation
         $item_2 = getItemForItemtype(static::$itemtype_2);
 
         if (
-            $item_1->getFromDB($this->fields[static::$items_id_1])
+            $item_1 instanceof CommonITILObject
+            && $item_2 instanceof CommonITILObject
+            && $item_1->getFromDB($this->fields[static::$items_id_1])
             && $item_2->getFromDB($this->fields[static::$items_id_2])
         ) {
             $item_1->updateDateMod($this->fields[static::$items_id_1]);

--- a/src/Computer.php
+++ b/src/Computer.php
@@ -39,12 +39,13 @@ use Glpi\Features\Clonable;
 use Glpi\Features\DCBreadcrumb;
 use Glpi\Features\DCBreadcrumbInterface;
 use Glpi\Features\Inventoriable;
+use Glpi\Features\StateInterface;
 use Glpi\Socket;
 
 /**
  *  Computer class
  **/
-class Computer extends CommonDBTM implements AssignableItemInterface, DCBreadcrumbInterface
+class Computer extends CommonDBTM implements AssignableItemInterface, DCBreadcrumbInterface, StateInterface
 {
     use DCBreadcrumb;
     use Clonable;

--- a/src/Contract.php
+++ b/src/Contract.php
@@ -36,13 +36,14 @@ use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
 use Glpi\Features\Clonable;
+use Glpi\Features\StateInterface;
 
 use function Safe\strtotime;
 
 /**
  *  Contract class
  */
-class Contract extends CommonDBTM
+class Contract extends CommonDBTM implements StateInterface
 {
     use Clonable;
     use Glpi\Features\State;

--- a/src/DatabaseInstance.php
+++ b/src/DatabaseInstance.php
@@ -37,8 +37,9 @@ use Glpi\Features\AssignableItem;
 use Glpi\Features\AssignableItemInterface;
 use Glpi\Features\Clonable;
 use Glpi\Features\Inventoriable;
+use Glpi\Features\StateInterface;
 
-class DatabaseInstance extends CommonDBTM implements AssignableItemInterface
+class DatabaseInstance extends CommonDBTM implements AssignableItemInterface, StateInterface
 {
     use Clonable;
     use Inventoriable;

--- a/src/DbUtils.php
+++ b/src/DbUtils.php
@@ -541,12 +541,9 @@ final class DbUtils
     /**
      * Get new item objet for an itemtype
      *
-     * @param string $itemtype itemtype
-     *
-     * @return CommonDBTM|false itemtype instance or false if class does not exists
-     * @template T
-     * @phpstan-param class-string<T> $itemtype
-     * @phpstan-return T|false
+     * @template T of CommonDBTM
+     * @param class-string<T>|string $itemtype
+     * @return ($itemtype is class-string<T> ? T : false)
      */
     public function getItemForItemtype($itemtype)
     {
@@ -568,6 +565,7 @@ final class DbUtils
             return false;
         }
 
+        // @phpstan-ignore return.type (Template should be `of CommonGLPI`, but it result in about 1000 errors due to usage of `CommonDBTM` properties and methods on the result without checking it is a `CommonDBTM`)
         return new $classname();
     }
 

--- a/src/Enclosure.php
+++ b/src/Enclosure.php
@@ -38,11 +38,12 @@ use Glpi\Features\AssignableItemInterface;
 use Glpi\Features\Clonable;
 use Glpi\Features\DCBreadcrumb;
 use Glpi\Features\DCBreadcrumbInterface;
+use Glpi\Features\StateInterface;
 
 /**
  * Enclosure Class
  **/
-class Enclosure extends CommonDBTM implements AssignableItemInterface, DCBreadcrumbInterface
+class Enclosure extends CommonDBTM implements AssignableItemInterface, DCBreadcrumbInterface, StateInterface
 {
     use DCBreadcrumb;
     use Clonable;

--- a/src/Glpi/Application/View/Extension/TeamExtension.php
+++ b/src/Glpi/Application/View/Extension/TeamExtension.php
@@ -35,8 +35,7 @@
 
 namespace Glpi\Application\View\Extension;
 
-use Glpi\Features\Teamwork;
-use Toolbox;
+use Glpi\Features\TeamworkInterface;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
 
@@ -54,7 +53,7 @@ class TeamExtension extends AbstractExtension
 
     public function getTeamRoleName($itemtype, int $role, int $nb = 1): string
     {
-        if (Toolbox::hasTrait($itemtype, Teamwork::class)) {
+        if (is_a($itemtype, TeamworkInterface::class, true)) {
             return $itemtype::getTeamRoleName($role, $nb);
         }
         return '';

--- a/src/Glpi/Asset/Asset.php
+++ b/src/Glpi/Asset/Asset.php
@@ -45,6 +45,7 @@ use Glpi\Features\AssignableItem;
 use Glpi\Features\AssignableItemInterface;
 use Glpi\Features\Clonable;
 use Glpi\Features\Inventoriable;
+use Glpi\Features\StateInterface;
 use Group;
 use Group_Item;
 use InvalidArgumentException;
@@ -60,7 +61,7 @@ use User;
 use function Safe\json_decode;
 use function Safe\json_encode;
 
-abstract class Asset extends CommonDBTM implements AssignableItemInterface
+abstract class Asset extends CommonDBTM implements AssignableItemInterface, StateInterface
 {
     use CustomObjectTrait;
 

--- a/src/Glpi/Features/State.php
+++ b/src/Glpi/Features/State.php
@@ -61,11 +61,7 @@ trait State
     }
 
     /**
-     * Get the visibility of the state field for the item
-     *
-     * @param int $id State ID
-     *
-     * @return bool
+     * @see StateInterface::isStateVisible()
      */
     public function isStateVisible(int $id): bool
     {
@@ -80,9 +76,7 @@ trait State
     }
 
     /**
-     * Get the visibility criteria of the state field to use a filter condition
-     *
-     * @return array
+     * @see StateInterface::getStateVisibilityCriteria()
      */
     public function getStateVisibilityCriteria(): array
     {

--- a/src/Glpi/Features/StateInterface.php
+++ b/src/Glpi/Features/StateInterface.php
@@ -35,26 +35,21 @@
 
 namespace Glpi\Features;
 
-use CommonDBTM;
-use Glpi\Application\View\TemplateRenderer;
-use ProjectTeam;
-
-/**
- * Trait for itemtypes that can have a team
- * @since 10.0.0
- */
-trait Teamwork
+interface StateInterface
 {
     /**
-     * @see TeamworkInterface::getTeamMemberForm()
+     * Get the visibility of the state field for the item
+     *
+     * @param int $id State ID
+     *
+     * @return bool
      */
-    public static function getTeamMemberForm(CommonDBTM $item): string
-    {
-        $members_types = ProjectTeam::$available_types;
+    public function isStateVisible(int $id): bool;
 
-        return TemplateRenderer::getInstance()->render('components/kanban/teammember.html.twig', [
-            'item' => $item,
-            'members_types' => $members_types,
-        ]);
-    }
+    /**
+     * Get the visibility criteria of the state field to use a filter condition
+     *
+     * @return array
+     */
+    public function getStateVisibilityCriteria(): array;
 }

--- a/src/Glpi/Features/TeamworkInterface.php
+++ b/src/Glpi/Features/TeamworkInterface.php
@@ -36,25 +36,52 @@
 namespace Glpi\Features;
 
 use CommonDBTM;
-use Glpi\Application\View\TemplateRenderer;
-use ProjectTeam;
 
-/**
- * Trait for itemtypes that can have a team
- * @since 10.0.0
- */
-trait Teamwork
+interface TeamworkInterface
 {
     /**
-     * @see TeamworkInterface::getTeamMemberForm()
+     * Get an array of all possible roles
+     * @return array
      */
-    public static function getTeamMemberForm(CommonDBTM $item): string
-    {
-        $members_types = ProjectTeam::$available_types;
+    public static function getTeamRoles(): array;
 
-        return TemplateRenderer::getInstance()->render('components/kanban/teammember.html.twig', [
-            'item' => $item,
-            'members_types' => $members_types,
-        ]);
-    }
+    /**
+     * Get the localized name for a team role
+     * @param int $role
+     * @param int $nb
+     * @return string
+     */
+    public static function getTeamRoleName(int $role, int $nb = 1): string;
+
+    /**
+     * Get all types of team members that are supported by this item type
+     * @return array
+     */
+    public static function getTeamItemtypes(): array;
+
+    /**
+     * Add a team member to this item
+     * @param string $itemtype
+     * @param int $items_id
+     * @param array $params
+     * @return bool
+     */
+    public function addTeamMember(string $itemtype, int $items_id, array $params = []): bool;
+
+    /**
+     * Remove a team member to this item
+     * @param string $itemtype
+     * @param int $items_id
+     * @param array $params
+     * @return bool
+     */
+    public function deleteTeamMember(string $itemtype, int $items_id, array $params = []): bool;
+
+    /**
+     * Get all team members
+     * @return array
+     */
+    public function getTeam(): array;
+
+    public static function getTeamMemberForm(CommonDBTM $item): string;
 }

--- a/src/Glpi/Form/Destination/CommonITILField/LinkedITILObjectsField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/LinkedITILObjectsField.php
@@ -190,7 +190,7 @@ final class LinkedITILObjectsField extends AbstractConfigField implements Destin
             }
 
             $target = getItemForItemtype($linked_itilobject['itemtype']);
-            if (!$target || !$target->getFromDB($linked_itilobject['items_id'])) {
+            if (!($target instanceof CommonITILObject) || !$target->getFromDB($linked_itilobject['items_id'])) {
                 continue;
             }
 

--- a/src/Glpi/Inventory/Conf.php
+++ b/src/Glpi/Inventory/Conf.php
@@ -58,6 +58,7 @@ use Entity;
 use finfo;
 use Glpi\Agent\Communication\AbstractRequest;
 use Glpi\Application\View\TemplateRenderer;
+use Glpi\Features\StateInterface;
 use Glpi\Plugin\Hooks;
 use Glpi\Toolbox\ArrayNormalizer;
 use GLPIKey;
@@ -1035,10 +1036,8 @@ class Conf extends CommonGLPI
             echo "<td width='20%'>";
             $condition = [];
             foreach ($CFG_GLPI['inventory_types'] as $inv_type) {
-                if (
-                    Toolbox::hasTrait($inv_type, \Glpi\Features\State::class)
-                    && $inv_item = getItemForItemtype($inv_type)
-                ) {
+                $inv_item = getItemForItemtype($inv_type);
+                if ($inv_item instanceof StateInterface) {
                     $condition[] = $inv_item->getStateVisibilityCriteria();
                 }
             }

--- a/src/Glpi/ItemTranslation/ItemTranslation.php
+++ b/src/Glpi/ItemTranslation/ItemTranslation.php
@@ -76,8 +76,11 @@ class ItemTranslation extends CommonDBChild
             && isset($input['itemtype'])
             && isset($input['items_id'])
         ) {
-            $item = getItemForItemtype($input['itemtype'])?->getById($input['items_id']);
-            if ($item instanceof ProvideTranslationsInterface) {
+            $item = getItemForItemtype($input['itemtype']);
+            if (
+                $item instanceof ProvideTranslationsInterface
+                && $item->getFromDB($input['items_id'])
+            ) {
                 foreach ($item->listTranslationsHandlers() as $handlers) {
                     foreach ($handlers as $handler) {
                         if ($handler->getKey() === $input['key']) {
@@ -121,8 +124,11 @@ class ItemTranslation extends CommonDBChild
      */
     public function isPossiblyObsolete(): bool
     {
-        $item = getItemForItemtype($this->fields[static::$itemtype])?->getById($this->fields[static::$items_id]);
-        if ($item instanceof ProvideTranslationsInterface) {
+        $item = getItemForItemtype($this->fields[static::$itemtype]);
+        if (
+            $item instanceof ProvideTranslationsInterface
+            && $item->getFromDB($this->fields[static::$items_id])
+        ) {
             foreach ($item->listTranslationsHandlers() as $handlers) {
                 foreach ($handlers as $handler) {
                     if ($handler->getKey() === $this->fields['key'] && $this->getTranslation() != null) {

--- a/src/ITILFollowup.php
+++ b/src/ITILFollowup.php
@@ -352,7 +352,14 @@ class ITILFollowup extends CommonDBChild
         }
 
         $job = getItemForItemtype($this->fields['itemtype']);
-        $job->getFromDB($this->fields[self::$items_id]);
+
+        if (
+            !($job instanceof CommonITILObject)
+            || !$job->getFromDB($this->fields[self::$items_id])
+        ) {
+            return;
+        }
+
         $job->updateDateMod($this->fields[self::$items_id]);
 
         // Add log entry in the ITIL Object
@@ -383,7 +390,7 @@ class ITILFollowup extends CommonDBChild
     {
         $parent_item = isset($input['itemtype']) ? getItemForItemtype($input['itemtype']) : null;
         if (
-            $parent_item === null
+            !($parent_item instanceof CommonITILObject)
             || !array_key_exists('items_id', $input)
             || $parent_item->getFromDB((int) $input['items_id']) === false
         ) {
@@ -526,7 +533,10 @@ class ITILFollowup extends CommonDBChild
 
         $job      = getItemForItemtype($this->fields['itemtype']);
 
-        if (!$job->getFromDB($this->fields['items_id'])) {
+        if (
+            !($job instanceof CommonITILObject)
+            || !$job->getFromDB($this->fields['items_id'])
+        ) {
             return;
         }
 
@@ -1119,7 +1129,13 @@ class ITILFollowup extends CommonDBChild
 
         // Get parent item
         $commonITILObject = getItemForItemtype($this->fields['itemtype']);
-        $commonITILObject->getFromDB($this->fields['items_id']);
+
+        if (
+            !($commonITILObject instanceof CommonITILObject)
+            || !$commonITILObject->getFromDB($this->fields['items_id'])
+        ) {
+            return false;
+        }
 
         $actors = $commonITILObject->getITILActors();
         $user_id = $this->fields['users_id'];

--- a/src/ITILSolution.php
+++ b/src/ITILSolution.php
@@ -111,6 +111,11 @@ class ITILSolution extends CommonDBChild
     public function canCreateItem(): bool
     {
         $item = getItemForItemtype($this->fields['itemtype']);
+
+        if (!($item instanceof CommonITILObject)) {
+            return false;
+        }
+
         $item->getFromDB($this->fields['items_id']);
         return $item->canSolve();
     }
@@ -188,7 +193,7 @@ class ITILSolution extends CommonDBChild
 
         $parent_item = isset($input['itemtype']) ? getItemForItemtype($input['itemtype']) : null;
         if (
-            $parent_item === null
+            !($parent_item instanceof CommonITILObject)
             || !array_key_exists('items_id', $input)
             || $parent_item->getFromDB((int) $input['items_id']) === false
         ) {

--- a/src/ITILTemplate.php
+++ b/src/ITILTemplate.php
@@ -87,8 +87,14 @@ abstract class ITILTemplate extends CommonDropdown
             $itiltype = static::getITILObjectClass();
             $itil_object  = getItemForItemtype($itiltype);
             $itemstable = $itil_object->getItemsTable();
+
             $tth_class = $itiltype . 'TemplateHiddenField';
-            $tth          = getItemForItemtype($tth_class);
+            $tth = getItemForItemtype($tth_class);
+            if (!($tth instanceof ITILTemplateHiddenField)) {
+                throw new RuntimeException(
+                    sprintf('`%s` is not an instance of `%s`.', $tth_class, ITILTemplateHiddenField::class)
+                );
+            }
             $this->hidden = $tth->getHiddenFields($ID, $withtypeandcategory);
 
             // Force items_id if itemtype is defined
@@ -104,7 +110,12 @@ abstract class ITILTemplate extends CommonDropdown
             }
             // Always get all mandatory fields
             $ttm_class = $itiltype . 'TemplateMandatoryField';
-            $ttm             = getItemForItemtype($ttm_class);
+            $ttm = getItemForItemtype($ttm_class);
+            if (!($ttm instanceof ITILTemplateMandatoryField)) {
+                throw new RuntimeException(
+                    sprintf('`%s` is not an instance of `%s`.', $ttm_class, ITILTemplateMandatoryField::class)
+                );
+            }
             $this->mandatory = $ttm->getMandatoryFields($ID);
 
             // Force items_id if itemtype is defined
@@ -121,7 +132,12 @@ abstract class ITILTemplate extends CommonDropdown
 
             // Always get all read only fields
             $ttr_class = $itiltype . 'TemplateReadonlyField';
-            $ttr             = getItemForItemtype($ttr_class);
+            $ttr = getItemForItemtype($ttr_class);
+            if (!($ttr instanceof ITILTemplateReadonlyField)) {
+                throw new RuntimeException(
+                    sprintf('`%s` is not an instance of `%s`.', $ttr_class, ITILTemplateReadonlyField::class)
+                );
+            }
             $this->readonly = $ttr->getReadonlyFields($ID);
 
             // Force items_id if itemtype is defined
@@ -137,8 +153,14 @@ abstract class ITILTemplate extends CommonDropdown
             }
 
             $ttp_class = $itiltype . 'TemplatePredefinedField';
-            $ttp              = getItemForItemtype($ttp_class);
+            $ttp = getItemForItemtype($ttp_class);
+            if (!($ttp instanceof ITILTemplatePredefinedField)) {
+                throw new RuntimeException(
+                    sprintf('`%s` is not an instance of `%s`.', $ttp_class, ITILTemplatePredefinedField::class)
+                );
+            }
             $this->predefined = $ttp->getPredefinedFields($ID, $withtypeandcategory);
+
             // Compute time_to_resolve
             if (isset($this->predefined['time_to_resolve'])) {
                 $this->predefined['time_to_resolve']

--- a/src/ITILTemplateField.php
+++ b/src/ITILTemplateField.php
@@ -45,8 +45,16 @@ use Glpi\Search\SearchOption;
  **/
 abstract class ITILTemplateField extends CommonDBChild
 {
+    /**
+     * @var class-string<ITILTemplate>
+     */
     public static $itemtype; //to be filled in subclass
+
     public static $items_id; //to be filled in subclass
+
+    /**
+     * @var class-string<CommonITILObject>
+     */
     public static $itiltype; //to be filled in subclass
 
     private $all_fields;

--- a/src/LevelAgreement.php
+++ b/src/LevelAgreement.php
@@ -54,7 +54,7 @@ abstract class LevelAgreement extends CommonDBChild
 
     protected static $prefix            = '';
     protected static $prefixticket      = '';
-    /** @var string|class-string<LevelAgreementLevel> */
+    /** @var ''|class-string<LevelAgreementLevel> */
     protected static $levelclass        = '';
     /** @var string|class-string<CommonDBTM> */
     protected static $levelticketclass  = '';

--- a/src/Line.php
+++ b/src/Line.php
@@ -36,13 +36,14 @@
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\Features\AssignableItem;
 use Glpi\Features\AssignableItemInterface;
+use Glpi\Features\StateInterface;
 
 /**
  * @since 9.2
  */
 
 
-class Line extends CommonDBTM implements AssignableItemInterface
+class Line extends CommonDBTM implements AssignableItemInterface, StateInterface
 {
     use Glpi\Features\State;
     use AssignableItem;

--- a/src/Monitor.php
+++ b/src/Monitor.php
@@ -40,11 +40,12 @@ use Glpi\Features\Clonable;
 use Glpi\Features\DCBreadcrumb;
 use Glpi\Features\DCBreadcrumbInterface;
 use Glpi\Features\Inventoriable;
+use Glpi\Features\StateInterface;
 
 /**
  * Monitor Class
  **/
-class Monitor extends CommonDBTM implements AssignableItemInterface, DCBreadcrumbInterface
+class Monitor extends CommonDBTM implements AssignableItemInterface, DCBreadcrumbInterface, StateInterface
 {
     use DCBreadcrumb;
     use Clonable;

--- a/src/NetworkEquipment.php
+++ b/src/NetworkEquipment.php
@@ -40,12 +40,13 @@ use Glpi\Features\Clonable;
 use Glpi\Features\DCBreadcrumb;
 use Glpi\Features\DCBreadcrumbInterface;
 use Glpi\Features\Inventoriable;
+use Glpi\Features\StateInterface;
 use Glpi\Socket;
 
 /**
  * Network equipment Class
  **/
-class NetworkEquipment extends CommonDBTM implements AssignableItemInterface, DCBreadcrumbInterface
+class NetworkEquipment extends CommonDBTM implements AssignableItemInterface, DCBreadcrumbInterface, StateInterface
 {
     use DCBreadcrumb;
     use Clonable;

--- a/src/NotificationEventMailing.php
+++ b/src/NotificationEventMailing.php
@@ -227,17 +227,14 @@ class NotificationEventMailing extends NotificationEventAbstract
                         ];
 
                         if (is_a($current->fields['itemtype'], CommonITILObject::class, true)) {
-                            // Main item is a `CommonITILObject`.
-                            // Adapt documents filtering to attach child items documents (if needed)
-                            // and exclude inline images.
-                            $main_item = new $current->fields['itemtype']();
+                            // Attach documents from child, unless only documents from trigger should be attached
                             if (
-                                $current->fields['attach_documents'] !== NotificationSetting::ATTACH_FROM_TRIGGER_ONLY
-                                && $main_item->getFromDB($current->fields['items_id'])
+                                $item_for_docs instanceof CommonITILObject
+                                && $current->fields['attach_documents'] !== NotificationSetting::ATTACH_FROM_TRIGGER_ONLY
                             ) {
-                                // Attach documents from child, unless only documents from trigger should be attached
                                 $doc_crit = $item_for_docs->getAssociatedDocumentsCriteria(true);
                             }
+
                             if ($is_html) {
                                 // Remove documents having "NO_TIMELINE" position if mail is HTML, as
                                 // these documents corresponds to inlined images.

--- a/src/NotificationTargetCommonITILObject.php
+++ b/src/NotificationTargetCommonITILObject.php
@@ -1163,7 +1163,7 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
     public function addDataForTemplate($event, $options = [])
     {
         $events    = $this->getAllEvents();
-        $objettype = strtolower($this->obj->getType());
+        $objettype = strtolower($this->obj::class);
 
         // Get data from ITIL objects
         if ($event != 'alertnotclosed') {
@@ -1178,7 +1178,8 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
                     $this->data["##$objettype.entity##"]      = $entity->getField('completename');
                     $this->data["##$objettype.shortentity##"] = $entity->getField('name');
                 }
-                if ($item = getItemForItemtype($objettype)) {
+                $item = getItemForItemtype($objettype);
+                if ($item instanceof CommonITILObject) {
                     $objettypes = Toolbox::strtolower(getPlural($objettype));
                     $items      = [];
                     foreach ($options['items'] as $object) {

--- a/src/Notification_NotificationTemplate.php
+++ b/src/Notification_NotificationTemplate.php
@@ -491,7 +491,15 @@ TWIG, $twig_params);
      * @param string $mode      Requested mode
      * @param 'event'|'setting'|'' $extratype Extra type
      *
-     * @return string
+     * @return (
+     *      $extratype is 'event'
+     *          ? class-string<NotificationEventInterface>
+     *          : (
+     *              $extratype is 'setting'
+     *                  ? class-string<NotificationSetting>
+     *                  : class-string<NotificationInterface>
+     *          )
+     *      )
      */
     public static function getModeClass($mode, $extratype = '')
     {
@@ -509,6 +517,26 @@ TWIG, $twig_params);
         if ($conf['from'] !== 'core') {
             $classname = 'Plugin' . ucfirst($conf['from']) . $classname;
         }
+
+
+        switch ($extratype) {
+            case 'event':
+                $expected_class = NotificationEventInterface::class;
+                break;
+            case 'setting':
+                $expected_class = NotificationSetting::class;
+                break;
+            default:
+                $expected_class = NotificationInterface::class;
+                break;
+        }
+
+        if (!is_a($classname, $expected_class, true)) {
+            throw new RuntimeException(
+                sprintf('`%s` is not an instance of `%s`.', $classname, $expected_class)
+            );
+        }
+
         return $classname;
     }
 

--- a/src/PDU.php
+++ b/src/PDU.php
@@ -38,11 +38,12 @@ use Glpi\Features\AssignableItemInterface;
 use Glpi\Features\Clonable;
 use Glpi\Features\DCBreadcrumb;
 use Glpi\Features\DCBreadcrumbInterface;
+use Glpi\Features\StateInterface;
 
 /**
  * PDU Class
  **/
-class PDU extends CommonDBTM implements AssignableItemInterface, DCBreadcrumbInterface
+class PDU extends CommonDBTM implements AssignableItemInterface, DCBreadcrumbInterface, StateInterface
 {
     use AssignableItem {
         prepareInputForAdd as prepareInputForAddAssignableItem;

--- a/src/PassiveDCEquipment.php
+++ b/src/PassiveDCEquipment.php
@@ -37,12 +37,13 @@ use Glpi\Features\AssignableItemInterface;
 use Glpi\Features\Clonable;
 use Glpi\Features\DCBreadcrumb;
 use Glpi\Features\DCBreadcrumbInterface;
+use Glpi\Features\StateInterface;
 use Glpi\Socket;
 
 /**
  * PassiveDCEquipment Class
  **/
-class PassiveDCEquipment extends CommonDBTM implements AssignableItemInterface, DCBreadcrumbInterface
+class PassiveDCEquipment extends CommonDBTM implements AssignableItemInterface, DCBreadcrumbInterface, StateInterface
 {
     use AssignableItem;
     use Clonable;

--- a/src/Peripheral.php
+++ b/src/Peripheral.php
@@ -39,12 +39,13 @@ use Glpi\Features\Clonable;
 use Glpi\Features\DCBreadcrumb;
 use Glpi\Features\DCBreadcrumbInterface;
 use Glpi\Features\Inventoriable;
+use Glpi\Features\StateInterface;
 use Glpi\Socket;
 
 /**
  * Peripheral Class
  **/
-class Peripheral extends CommonDBTM implements AssignableItemInterface, DCBreadcrumbInterface
+class Peripheral extends CommonDBTM implements AssignableItemInterface, DCBreadcrumbInterface, StateInterface
 {
     use DCBreadcrumb;
     use Clonable;

--- a/src/Phone.php
+++ b/src/Phone.php
@@ -38,12 +38,13 @@ use Glpi\Features\AssignableItem;
 use Glpi\Features\AssignableItemInterface;
 use Glpi\Features\Clonable;
 use Glpi\Features\Inventoriable;
+use Glpi\Features\StateInterface;
 use Glpi\Socket;
 
 /**
  * Phone Class
  **/
-class Phone extends CommonDBTM implements AssignableItemInterface
+class Phone extends CommonDBTM implements AssignableItemInterface, StateInterface
 {
     use Clonable;
     use Inventoriable;

--- a/src/Planning.php
+++ b/src/Planning.php
@@ -444,22 +444,21 @@ JAVASCRIPT;
                 $users[$item->getID()] = $item->getName();
                 break;
 
-            default:
-                if (is_a($item, 'CommonITILObject', true)) {
-                    foreach ($item->getUsers(CommonITILActor::ASSIGN) as $data) {
-                        $users[$data['users_id']] = getUserName($data['users_id']);
-                    }
-                    foreach ($item->getGroups(CommonITILActor::ASSIGN) as $data) {
-                        foreach (Group_User::getGroupUsers($data['groups_id']) as $data2) {
-                            $users[$data2['id']] = formatUserName(
-                                $data2["id"],
-                                $data2["name"],
-                                $data2["realname"],
-                                $data2["firstname"]
-                            );
-                        }
+            case CommonITILObject::class:
+                foreach ($item->getUsers(CommonITILActor::ASSIGN) as $data) {
+                    $users[$data['users_id']] = getUserName($data['users_id']);
+                }
+                foreach ($item->getGroups(CommonITILActor::ASSIGN) as $data) {
+                    foreach (Group_User::getGroupUsers($data['groups_id']) as $data2) {
+                        $users[$data2['id']] = formatUserName(
+                            $data2["id"],
+                            $data2["name"],
+                            $data2["realname"],
+                            $data2["firstname"]
+                        );
                     }
                 }
+
                 $task = getItemForItemtype($item::getTaskClass());
                 if ($task->getFromDBByCrit(['tickets_id' => $item->fields['id']])) {
                     $users[$task->fields['users_id_tech']] = getUserName($task->fields['users_id_tech']);
@@ -1271,7 +1270,7 @@ TWIG, $twig_params);
         $params['res_itemtype'] ??= '';
         $params['res_items_id'] ??= 0;
         if ($item = getItemForItemtype($params['itemtype'])) {
-            $item->showForm('', [
+            $item->showForm(-1, [
                 'from_planning_ajax' => true,
                 'begin'              => $params['begin'],
                 'end'                => $params['end'],

--- a/src/Printer.php
+++ b/src/Printer.php
@@ -40,12 +40,13 @@ use Glpi\Features\AssignableItem;
 use Glpi\Features\AssignableItemInterface;
 use Glpi\Features\Clonable;
 use Glpi\Features\Inventoriable;
+use Glpi\Features\StateInterface;
 use Glpi\Socket;
 
 /**
  * Printer Class
  **/
-class Printer extends CommonDBTM implements AssignableItemInterface
+class Printer extends CommonDBTM implements AssignableItemInterface, StateInterface
 {
     use Clonable;
     use Inventoriable;

--- a/src/Project.php
+++ b/src/Project.php
@@ -41,6 +41,7 @@ use Glpi\Features\Clonable;
 use Glpi\Features\Kanban;
 use Glpi\Features\KanbanInterface;
 use Glpi\Features\Teamwork;
+use Glpi\Features\TeamworkInterface;
 use Glpi\Plugin\Hooks;
 use Glpi\RichText\RichText;
 use Glpi\Team\Team;
@@ -50,7 +51,7 @@ use Glpi\Team\Team;
  *
  * @since 0.85
  **/
-class Project extends CommonDBTM implements ExtraVisibilityCriteria, KanbanInterface
+class Project extends CommonDBTM implements ExtraVisibilityCriteria, KanbanInterface, TeamworkInterface
 {
     use Kanban;
     use Clonable;

--- a/src/ProjectTask.php
+++ b/src/ProjectTask.php
@@ -40,6 +40,7 @@ use Glpi\DBAL\QueryFunction;
 use Glpi\DBAL\QuerySubQuery;
 use Glpi\Features\PlanningEvent;
 use Glpi\Features\Teamwork;
+use Glpi\Features\TeamworkInterface;
 use Glpi\RichText\RichText;
 use Ramsey\Uuid\Uuid;
 use Sabre\VObject\Component\VCalendar;
@@ -54,7 +55,7 @@ use function Safe\strtotime;
  *
  * @since 0.85
  **/
-class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
+class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface, TeamworkInterface
 {
     use PlanningEvent;
     use VobjectConverterTrait;

--- a/src/Rack.php
+++ b/src/Rack.php
@@ -37,11 +37,12 @@ use Glpi\Features\AssignableItem;
 use Glpi\Features\AssignableItemInterface;
 use Glpi\Features\DCBreadcrumb;
 use Glpi\Features\DCBreadcrumbInterface;
+use Glpi\Features\StateInterface;
 
 /**
  * Rack Class
  **/
-class Rack extends CommonDBTM implements AssignableItemInterface, DCBreadcrumbInterface
+class Rack extends CommonDBTM implements AssignableItemInterface, DCBreadcrumbInterface, StateInterface
 {
     use DCBreadcrumb;
     use Glpi\Features\State;

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -65,7 +65,13 @@ class Rule extends CommonDBTM
     public $restrict_matching     = false;
 
     protected $rules_id_field     = 'rules_id';
+    /**
+     * @var class-string<RuleAction>
+     */
     protected $ruleactionclass    = RuleAction::class;
+    /**
+     * @var class-string<RuleCriteria>
+     */
     protected $rulecriteriaclass  = RuleCriteria::class;
 
     public $specific_parameters   = false;
@@ -675,7 +681,10 @@ class Rule extends CommonDBTM
                 $input          = $ma->getInput();
                 $collectionname = $input['rule_class_name'] . 'Collection';
                 $rulecollection = getItemForItemtype($collectionname);
-                if ($rulecollection->canUpdate()) {
+                if (!($rulecollection instanceof RuleCollection)) {
+                    $ma->itemDone($item->getType(), $ids, MassiveAction::ACTION_KO);
+                    $ma->addMessage($item->getErrorMessage(ERROR_NOT_FOUND));
+                } elseif ($rulecollection->canUpdate()) {
                     foreach ($ids as $id) {
                         if ($item->getFromDB($id)) {
                             if ($rulecollection->moveRule($id, $input['ranking'], $input['move_type'])) {
@@ -2895,7 +2904,7 @@ JS
     }
 
     /**
-     * @param string $sub_type
+     * @param class-string<Rule> $sub_type
      *
      * @return array
      **/

--- a/src/RuleAction.php
+++ b/src/RuleAction.php
@@ -43,7 +43,10 @@ use function Safe\preg_replace;
 class RuleAction extends CommonDBChild
 {
     // From CommonDBChild
-    public static $itemtype        = "Rule";
+    /**
+     * @var class-string<Rule>
+     */
+    public static $itemtype        = Rule::class;
     public static $items_id        = 'rules_id';
     public $dohistory              = true;
     public $auto_message_on_action = false;
@@ -56,7 +59,7 @@ class RuleAction extends CommonDBChild
 
         if (isset($_POST['rule_class_name']) && is_subclass_of(Rule::class, $_POST['rule_class_name'])) {
             $rule = getItemForItemtype($_POST['rule_class_name']);
-            if ($rule->maxActionsCount() == 1) {
+            if ($rule instanceof Rule && $rule->maxActionsCount() == 1) {
                 $forbidden[] = 'clone';
             }
         }
@@ -196,8 +199,9 @@ class RuleAction extends CommonDBChild
                     && !empty($values['rules_id'])
                     && $generic_rule->getFromDB($values['rules_id'])
                 ) {
-                    if ($rule = getItemForItemtype($generic_rule->fields["sub_type"])) {
-                        return $rule->getAction($values[$field]);
+                    $rule = getItemForItemtype($generic_rule->fields["sub_type"]);
+                    if ($rule instanceof Rule) {
+                        return $rule->getActionName($values[$field]);
                     }
                 }
                 break;
@@ -215,7 +219,8 @@ class RuleAction extends CommonDBChild
                     && !empty($values['rules_id'])
                     && $generic_rule->getFromDB($values['rules_id'])
                 ) {
-                    if ($rule = getItemForItemtype($generic_rule->fields["sub_type"])) {
+                    $rule = getItemForItemtype($generic_rule->fields["sub_type"]);
+                    if ($rule instanceof Rule) {
                         return $rule->getCriteriaDisplayPattern(
                             $values["criteria"],
                             $values["condition"],
@@ -242,7 +247,8 @@ class RuleAction extends CommonDBChild
                     && !empty($values['rules_id'])
                     && $generic_rule->getFromDB($values['rules_id'])
                 ) {
-                    if ($rule = getItemForItemtype($generic_rule->fields["sub_type"])) {
+                    $rule = getItemForItemtype($generic_rule->fields["sub_type"]);
+                    if ($rule instanceof Rule) {
                         $options['value'] = $values[$field];
                         $options['name']  = $name;
                         return $rule->dropdownActions($options);
@@ -276,9 +282,10 @@ class RuleAction extends CommonDBChild
                     && !empty($values['rules_id'])
                     && $generic_rule->getFromDB($values['rules_id'])
                 ) {
-                    if ($rule = getItemForItemtype($generic_rule->fields["sub_type"])) {
+                    $rule = getItemForItemtype($generic_rule->fields["sub_type"]);
+                    if ($rule instanceof Rule) {
                         /// TODO review it : need to pass display param and others...
-                        return $rule->displayActionSelectPattern($values);
+                        return (new static())->displayActionSelectPattern($values);
                     }
                 }
                 break;
@@ -335,7 +342,7 @@ class RuleAction extends CommonDBChild
     /**
      * Display a dropdown with all the possible actions
      *
-     * @param array{subtype: string, name: string, field?: string, value?: string, alreadyused: bool, display?: bool} $options
+     * @param array{subtype: class-string<Rule>, name: string, field?: string, value?: string, alreadyused: bool, display?: bool} $options
      * <ul>
      *     <li>subtype: the itemtype of the rule</li>
      *     <li>name: the name of the dropdown</li>
@@ -445,7 +452,7 @@ class RuleAction extends CommonDBChild
 
     /**
      * @param integer $rules_id
-     * @param string $sub_type
+     * @param class-string<Rule> $sub_type
      **/
     public function getAlreadyUsedForRuleID($rules_id, $sub_type)
     {
@@ -599,7 +606,8 @@ class RuleAction extends CommonDBChild
 
                         case "dropdown_users_validate":
                             $used = [];
-                            if ($item = getItemForItemtype($options["sub_type"])) {
+                            $item = getItemForItemtype($options["sub_type"]);
+                            if ($item instanceof Rule) {
                                 $rule_data = getAllDataFromTable(
                                     self::getTable(),
                                     [
@@ -622,7 +630,8 @@ class RuleAction extends CommonDBChild
 
                         case "dropdown_groups_validate":
                             $used = [];
-                            if ($item = getItemForItemtype($options["sub_type"])) {
+                            $item = getItemForItemtype($options["sub_type"]);
+                            if ($item instanceof Rule) {
                                 $rule_data = getAllDataFromTable(
                                     self::getTable(),
                                     [
@@ -662,7 +671,8 @@ class RuleAction extends CommonDBChild
                             break;
 
                         default:
-                            if ($rule = getItemForItemtype($options["sub_type"])) {
+                            $rule = getItemForItemtype($options["sub_type"]);
+                            if ($rule instanceof Rule) {
                                 $display = $rule->displayAdditionalRuleAction($actions[$options["field"]], $param['value']);
                             }
                             break;

--- a/src/RuleCollection.php
+++ b/src/RuleCollection.php
@@ -1899,7 +1899,8 @@ TWIG, $twig_params);
             ($check_dictionnary_type && in_array($itemtype, $CFG_GLPI["dictionnary_types"], true))
             || !$check_dictionnary_type
         ) {
-            if ($item = getItemForItemtype($typeclass)) {
+            $item = getItemForItemtype($typeclass);
+            if ($item instanceof RuleCollection) {
                 return $item;
             }
         }

--- a/src/RuleCriteria.php
+++ b/src/RuleCriteria.php
@@ -46,7 +46,10 @@ use function Safe\preg_replace;
 class RuleCriteria extends CommonDBChild
 {
     // From CommonDBChild
-    public static $itemtype        = 'Rule';
+    /**
+     * @var class-string<Rule>
+     */
+    public static $itemtype        = Rule::class;
     public static $items_id        = 'rules_id';
     public $dohistory              = true;
     public $auto_message_on_action = false;
@@ -193,7 +196,8 @@ class RuleCriteria extends CommonDBChild
                     !empty($values['rules_id'])
                     && $generic_rule->getFromDB($values['rules_id'])
                 ) {
-                    if ($rule = getItemForItemtype($generic_rule->fields["sub_type"])) {
+                    $rule = getItemForItemtype($generic_rule->fields["sub_type"]);
+                    if ($rule instanceof Rule) {
                         return $rule->getCriteriaName($values[$field]);
                     }
                 }
@@ -223,7 +227,8 @@ class RuleCriteria extends CommonDBChild
                     && !empty($values['rules_id'])
                     && $generic_rule->getFromDB($values['rules_id'])
                 ) {
-                    if ($rule = getItemForItemtype($generic_rule->fields["sub_type"])) {
+                    $rule = getItemForItemtype($generic_rule->fields["sub_type"]);
+                    if ($rule instanceof Rule) {
                         return $rule->getCriteriaDisplayPattern(
                             $values["criteria"],
                             $values["condition"],
@@ -250,7 +255,8 @@ class RuleCriteria extends CommonDBChild
                     && !empty($values['rules_id'])
                     && $generic_rule->getFromDB($values['rules_id'])
                 ) {
-                    if ($rule = getItemForItemtype($generic_rule->fields["sub_type"])) {
+                    $rule = getItemForItemtype($generic_rule->fields["sub_type"]);
+                    if ($rule instanceof Rule) {
                         $options['value'] = $values[$field];
                         $options['name']  = $name;
                         return $rule->dropdownCriteria($options);
@@ -265,7 +271,8 @@ class RuleCriteria extends CommonDBChild
                     && !empty($values['rules_id'])
                     && $generic_rule->getFromDB($values['rules_id'])
                 ) {
-                    if ($rule = getItemForItemtype($generic_rule->fields["sub_type"])) {
+                    $rule = getItemForItemtype($generic_rule->fields["sub_type"]);
+                    if ($rule instanceof Rule) {
                         if (isset($values['criteria']) && !empty($values['criteria'])) {
                             $options['criterion'] = $values['criteria'];
                         }
@@ -286,7 +293,8 @@ class RuleCriteria extends CommonDBChild
                     && !empty($values['rules_id'])
                     && $generic_rule->getFromDB($values['rules_id'])
                 ) {
-                    if ($rule = getItemForItemtype($generic_rule->fields["sub_type"])) {
+                    $rule = getItemForItemtype($generic_rule->fields["sub_type"]);
+                    if ($rule instanceof Rule) {
                         /// TODO : manage display param to this function : need to send ot to all under functions
                         $rule->displayCriteriaSelectPattern(
                             $name,

--- a/src/SoftwareLicense.php
+++ b/src/SoftwareLicense.php
@@ -39,11 +39,12 @@ use Glpi\Features\AssetImage;
 use Glpi\Features\AssignableItem;
 use Glpi\Features\AssignableItemInterface;
 use Glpi\Features\Clonable;
+use Glpi\Features\StateInterface;
 
 /**
  * SoftwareLicense Class
  **/
-class SoftwareLicense extends CommonTreeDropdown implements AssignableItemInterface
+class SoftwareLicense extends CommonTreeDropdown implements AssignableItemInterface, StateInterface
 {
     use Clonable;
     use Glpi\Features\State;

--- a/src/SoftwareVersion.php
+++ b/src/SoftwareVersion.php
@@ -34,11 +34,12 @@
  */
 
 use Glpi\Application\View\TemplateRenderer;
+use Glpi\Features\StateInterface;
 
 /**
  * SoftwareVersion Class
  **/
-class SoftwareVersion extends CommonDBChild
+class SoftwareVersion extends CommonDBChild implements StateInterface
 {
     use Glpi\Features\State;
 

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -1667,7 +1667,7 @@ class Toolbox
                                 // force redirect to timeline when timeline is enabled
                                 $forcetab = str_replace(['TicketFollowup$1', 'TicketTask$1', 'ITILFollowup$1'], 'Ticket$1', $forcetab);
 
-                                return $item::getFormURLWithID($data[1]) . "&$forcetab";
+                                return $item::getFormURLWithID((int) $data[1]) . "&$forcetab";
                             }
                         } elseif (
                             !empty($data[0])

--- a/src/Transfer.php
+++ b/src/Transfer.php
@@ -2553,7 +2553,8 @@ final class Transfer extends CommonDBTM
                 break;
         }
 
-        if (!($link_item = getItemForItemtype($link_type))) {
+        $link_item = getItemForItemtype($link_type);
+        if (!($link_item instanceof CommonDBTM)) {
             return;
         }
 
@@ -2641,7 +2642,8 @@ final class Transfer extends CommonDBTM
                                     unset($link_item->fields['id']);
                                     $input                = $link_item->fields;
                                     $input['entities_id'] = $this->to;
-                                    unset($link_item->fields);
+
+                                    $link_item = new $link_item();
                                     $newID = $link_item->add($input);
                                     // 2 - transfer as copy
                                     $this->transferItem($link_type, $item_ID, $newID);
@@ -3539,6 +3541,11 @@ final class Transfer extends CommonDBTM
                     $fk              = getForeignKeyFieldForTable($devicetable);
 
                     $device          = getItemForItemtype($devicetype);
+
+                    if (!($device instanceof CommonDevice)) {
+                        continue;
+                    }
+
                     // Get contracts for the item
                     $criteria = [
                         'FROM'   => $itemdevicetable,
@@ -3643,7 +3650,8 @@ final class Transfer extends CommonDBTM
                                             }
                                         }
                                         $input['entities_id'] = $this->to;
-                                        unset($device->fields);
+
+                                        $device = new $device();
                                         $newdeviceID = $device->add($input);
                                         // 2 - transfer as copy
                                         $this->transferItem($devicetype, $item_ID, $newdeviceID);

--- a/src/Unmanaged.php
+++ b/src/Unmanaged.php
@@ -37,11 +37,12 @@ use Glpi\Application\View\TemplateRenderer;
 use Glpi\Features\AssignableItem;
 use Glpi\Features\AssignableItemInterface;
 use Glpi\Features\Inventoriable;
+use Glpi\Features\StateInterface;
 
 /**
  * Not managed devices from inventory
  */
-class Unmanaged extends CommonDBTM implements AssignableItemInterface
+class Unmanaged extends CommonDBTM implements AssignableItemInterface, StateInterface
 {
     use Inventoriable;
     use Glpi\Features\State;

--- a/src/autoload/dbutils-aliases.php
+++ b/src/autoload/dbutils-aliases.php
@@ -155,12 +155,10 @@ function getTableForItemType($itemtype)
  *
  * @since 0.83
  *
- * @param string $itemtype itemtype
- * @return CommonDBTM|false itemtype object or false if class does not exists
- * @template T
- * @phpstan-param class-string<T> $itemtype
- * @phpstan-return T|false
- **/
+ * @template T of CommonDBTM
+ * @param class-string<T>|string $itemtype
+ * @return ($itemtype is class-string<T> ? T : false)
+ */
 function getItemForItemtype($itemtype)
 {
     $dbu = new DbUtils();

--- a/templates/components/kanban/item_panels/default_panel.html.twig
+++ b/templates/components/kanban/item_panels/default_panel.html.twig
@@ -72,7 +72,7 @@
          </h5>
          {% if team is not empty %}
             {% set item = itemtype|itemtype_class %}
-            {% if item is usingtrait('Glpi\\Features\\Teamwork') %}
+            {% if item is instanceof('Glpi\\Features\\TeamworkInterface') %}
                {% for team_role in item.getTeamRoles() %}
                   {% set role_members = team|filter(m => m.role == team_role) %}
                   {% if role_members|length > 0 %}

--- a/tests/fixtures/plugins/tester/src/PluginTesterNotificationEventTestmode.php
+++ b/tests/fixtures/plugins/tester/src/PluginTesterNotificationEventTestmode.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2025 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -33,28 +32,27 @@
  * ---------------------------------------------------------------------
  */
 
-namespace Glpi\Features;
-
-use CommonDBTM;
-use Glpi\Application\View\TemplateRenderer;
-use ProjectTeam;
-
-/**
- * Trait for itemtypes that can have a team
- * @since 10.0.0
- */
-trait Teamwork
+class PluginTesterNotificationEventTestmode implements NotificationEventInterface
 {
-    /**
-     * @see TeamworkInterface::getTeamMemberForm()
-     */
-    public static function getTeamMemberForm(CommonDBTM $item): string
-    {
-        $members_types = ProjectTeam::$available_types;
+    public static function getAdminData()
+    {}
 
-        return TemplateRenderer::getInstance()->render('components/kanban/teammember.html.twig', [
-            'item' => $item,
-            'members_types' => $members_types,
-        ]);
-    }
+    public static function getTargetField(&$data)
+    {}
+
+    public static function canCron()
+    {}
+
+    public static function getTargetFieldName()
+    {}
+
+    public static function getEntityAdminsData($entity)
+    {}
+
+    public static function send(array $data)
+    {}
+
+    public static function raise($event, CommonGLPI $item, array $options, $label, array $data, NotificationTarget $notificationtarget, NotificationTemplate $template, $notify_me, $emitter = null, ?CommonDBTM $trigger = null)
+    {}
+
 }

--- a/tests/fixtures/plugins/tester/src/PluginTesterNotificationTestmode.php
+++ b/tests/fixtures/plugins/tester/src/PluginTesterNotificationTestmode.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2025 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -33,28 +32,15 @@
  * ---------------------------------------------------------------------
  */
 
-namespace Glpi\Features;
-
-use CommonDBTM;
-use Glpi\Application\View\TemplateRenderer;
-use ProjectTeam;
-
-/**
- * Trait for itemtypes that can have a team
- * @since 10.0.0
- */
-trait Teamwork
+class PluginTesterNotificationTestmode implements NotificationInterface
 {
-    /**
-     * @see TeamworkInterface::getTeamMemberForm()
-     */
-    public static function getTeamMemberForm(CommonDBTM $item): string
-    {
-        $members_types = ProjectTeam::$available_types;
+    public static function testNotification()
+    {}
 
-        return TemplateRenderer::getInstance()->render('components/kanban/teammember.html.twig', [
-            'item' => $item,
-            'members_types' => $members_types,
-        ]);
-    }
+    public function sendNotification($options = [])
+    {}
+
+    public static function check($value, $options = [])
+    {}
+
 }

--- a/tests/fixtures/plugins/tester/src/PluginTesterNotificationTestmodeSetting.php
+++ b/tests/fixtures/plugins/tester/src/PluginTesterNotificationTestmodeSetting.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2025 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -33,28 +32,12 @@
  * ---------------------------------------------------------------------
  */
 
-namespace Glpi\Features;
-
-use CommonDBTM;
-use Glpi\Application\View\TemplateRenderer;
-use ProjectTeam;
-
-/**
- * Trait for itemtypes that can have a team
- * @since 10.0.0
- */
-trait Teamwork
+class PluginTesterNotificationTestmodeSetting extends NotificationSetting
 {
-    /**
-     * @see TeamworkInterface::getTeamMemberForm()
-     */
-    public static function getTeamMemberForm(CommonDBTM $item): string
-    {
-        $members_types = ProjectTeam::$available_types;
+    protected function showFormConfig()
+    {}
 
-        return TemplateRenderer::getInstance()->render('components/kanban/teammember.html.twig', [
-            'item' => $item,
-            'members_types' => $members_types,
-        ]);
-    }
+    public function getEnableLabel()
+    {}
+
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

While investigating on PHPStan level 6 errors, I figured out that there was a few `Unable to resolve the template type T in call to function getItemForItemtype` errors. Reworking the PHPDoc helps to improve the evaluation of `getItemForItemtype()` result, and to detect new errors.