### PR TITLE
[HLAPI] Fix array properties not returning all elements

### DIFF
--- a/src/Glpi/Api/HL/Search.php
+++ b/src/Glpi/Api/HL/Search.php
@@ -549,11 +549,12 @@ final class Search
 
     private function getJoinNameForProperty(string $prop_name): string
     {
-        if (array_key_exists(str_replace(chr(0x1F), '.', $prop_name), $this->context->getJoins())) {
-            $join_name = str_replace(chr(0x1F), '.', $prop_name);
+        $joins = $this->context->getJoins();
+        $prop_name = str_replace(chr(0x1F), '.', $prop_name);
+        if (array_key_exists($prop_name, $joins)) {
+            $join_name = $prop_name;
         } else {
-            $join_name = substr($prop_name, 0, strrpos($prop_name, chr(0x1F)));
-            $join_name = str_replace(chr(0x1F), '.', $join_name);
+            $join_name = substr($prop_name, 0, strrpos($prop_name, '.'));
         }
         return $join_name;
     }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

Fixes #20017
A misidentification of joined properties was causing the search to skip grouping array property results and thus only returning a single result.