### PR TITLE
[HLAPI] Restrict GraphQL errors to 300+ statuses

### DIFF
--- a/src/Glpi/Api/HL/GraphQL.php
+++ b/src/Glpi/Api/HL/GraphQL.php
@@ -83,13 +83,13 @@ final class GraphQL
 
                         if (isset($args['id'])) {
                             $result = ResourceAccessor::getOneBySchema($completed_schema, ['id' => $args['id']], []);
-                            if ($result->getStatusCode() !== 200) {
+                            if ($result->getStatusCode() >= 300) {
                                 throw new Error($result->getBody());
                             }
                             return [json_decode($result->getBody(), true)];
                         }
                         $result = ResourceAccessor::searchBySchema($completed_schema, $args);
-                        if ($result->getStatusCode() !== 200) {
+                        if ($result->getStatusCode() >= 300) {
                             throw new Error($result->getBody());
                         }
                         return json_decode($result->getBody(), true);


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

In some cases the HLAPI may return a 206 status for a GraphQL query and it was mistakenly treating it as an error response.