### PR TITLE
Remove `nikic/php-parser` from dev requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -111,7 +111,6 @@
         "glpi-project/phpstan-glpi": "^1.0",
         "glpi-project/tools": "^0.7",
         "mikey179/vfsstream": "^1.6",
-        "nikic/php-parser": "^5.5",
         "php-parallel-lint/php-parallel-lint": "^1.4",
         "phpstan/extension-installer": "^1.4",
         "phpstan/phpstan": "^2.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b51b67512d6d9a33ccb7fb095504e20b",
+    "content-hash": "bd561cb7e83a00d18023b93a604d4f0d",
     "packages": [
         {
             "name": "apereo/phpcas",


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

This lib was required when GLPI PHPStan rules classes were embed in GLPI (see #19510). Now that they have been moved into a dedicated lib, it is not required anymore.