### PR TITLE
Fix error during `diagnostic:check_html_encoding` command execution

### DIFF
--- a/src/Glpi/Console/Diagnostic/CheckHtmlEncodingCommand.php
+++ b/src/Glpi/Console/Diagnostic/CheckHtmlEncodingCommand.php
@@ -40,6 +40,7 @@ use DBmysql;
 use Glpi\Console\AbstractCommand;
 use Glpi\Console\Exception\EarlyExitException;
 use ITILFollowup;
+use ReflectionClass;
 use Safe\Exceptions\FilesystemException;
 use Search;
 use Session;
@@ -367,6 +368,13 @@ final class CheckHtmlEncodingCommand extends AbstractCommand
             $itemtype = getItemTypeForTable($table);
 
             if (!is_a($itemtype, CommonDBTM::class, true)) {
+                continue;
+            }
+
+            if ((new ReflectionClass($itemtype))->isAbstract()) {
+                // Cannot retrieve search options of an abstract class.
+                // Anyway, corresponding classes were introduced in GLPI 11.0 and corresponding tables
+                // are not even supposed to contain encoded data. They can be ignored safely.
                 continue;
             }
 

--- a/src/Glpi/Search/SearchOption.php
+++ b/src/Glpi/Search/SearchOption.php
@@ -174,6 +174,8 @@ final class SearchOption implements ArrayAccess
             $search[$itemtype] += $new_options;
         };
 
+        $search[$itemtype] = [];
+
         // standard type first
         switch ($itemtype) {
             case 'Internet':


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

While trying to reproduce #15410 on GLPI 11.0, I figured out that the command was failing due to the introduction in GLPI 11.0 of tables that corresponds to abstract classes. For them, `getItemTypeForTable()` returns an abstract class and trying to instanciate them result in error.

The error was:
```
PHP User Warning (512): Cannot instanciate "Glpi\Asset\AssetModel" as it is an abstract class. at DbUtils.php line 561 in ./src/DbUtils.php at line 561
PHP Warning (2): Undefined array key "Glpi\Asset\AssetModel" at SearchOption.php line 373 in ./src/Glpi/Search/SearchOption.php at line 373
PHP Warning (2): foreach() argument must be of type array|object, null given at SearchOption.php line 373 in ./src/Glpi/Search/SearchOption.php at line 373
PHP Warning (2): Undefined array key "Glpi\Asset\AssetModel" at SearchOption.php line 400 in ./src/Glpi/Search/SearchOption.php at line 400
PHP Warning (2): Undefined array key "Glpi\Asset\AssetModel" at SearchOption.php line 401 in ./src/Glpi/Search/SearchOption.php at line 401

In SearchOption.php line 401:
                                                                                                        
  [TypeError]                                                                                           
  Glpi\Search\SearchOption::getOptionsForItemtype(): Return value must be of type array, null returned  
                                                                                                        

Exception trace:
  at /var/www/glpi/src/Glpi/Search/SearchOption.php:401
 Glpi\Search\SearchOption::getOptionsForItemtype() at /var/www/glpi/src/Search.php:883
 Search::getOptions() at /var/www/glpi/src/Glpi/Console/Diagnostic/CheckHtmlEncodingCommand.php:373
 Glpi\Console\Diagnostic\CheckHtmlEncodingCommand->findTextFields() at /var/www/glpi/src/Glpi/Console/Diagnostic/CheckHtmlEncodingCommand.php:130
 Glpi\Console\Diagnostic\CheckHtmlEncodingCommand->execute() at /var/www/glpi/vendor/symfony/console/Command/Command.php:326
 Symfony\Component\Console\Command\Command->run() at /var/www/glpi/vendor/symfony/console/Application.php:1096
 Symfony\Component\Console\Application->doRunCommand() at /var/www/glpi/src/Glpi/Console/Application.php:325
 Glpi\Console\Application->doRunCommand() at /var/www/glpi/vendor/symfony/console/Application.php:324
 Symfony\Component\Console\Application->doRun() at /var/www/glpi/vendor/symfony/console/Application.php:175
 Symfony\Component\Console\Application->run() at /var/www/glpi/bin/console:144

diagnostic:check_html_encoding [-f|--fix|--no-fix] [-d|--dump DUMP]
```