### PR TITLE
Fix the request source field showing incorrect information

### DIFF
--- a/templates/components/itilobject/timeline/approbation_form.html.twig
+++ b/templates/components/itilobject/timeline/approbation_form.html.twig
@@ -47,7 +47,7 @@
                <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}" />
                <input type="hidden" name="itemtype" value="{{ item.getType() }}" />
                <input type="hidden" name="items_id" value="{{ item.fields['id'] }}" />
-               <input type="hidden" name="requesttypes_id" value="{{ 0 }}" />
+               <input type="hidden" name="requesttypes_id" value="0" />
 
                <div class="card-header">
                   {{ __('Approval of the solution') }}


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)

It fixes a GLPI’s ticket system bug that causes the request source field to show incorrect information due to wrong id quoted. The screenshot shows the example.

To solve this issue, we made a new function `getRequestTypesId()` in `src/CommonDBTM.phpto` get the request type id.

## Screenshots (if appropriate):
<img width="1907" height="1040" alt="スクリーンショット 2025-07-30 100457" src="https://github.com/user-attachments/assets/2ef64299-c780-4d92-bd14-fac65042e321" />


