### PR TITLE
Lazy load form editor dropdowns

### DIFF
--- a/js/modules/Forms/EditorController.js
+++ b/js/modules/Forms/EditorController.js
@@ -938,7 +938,6 @@ export class GlpiFormEditorController
             } else if (config.type === "adapt") {
                 setupAdaptDropdown(config);
             }
-            tinyMCE.init(config);
             $(this).attr('data-glpi-loaded', "true");
         });
 

--- a/js/modules/Forms/EditorController.js
+++ b/js/modules/Forms/EditorController.js
@@ -928,6 +928,20 @@ export class GlpiFormEditorController
             $(this).attr('data-glpi-loaded', "true");
         });
 
+        // Lazy load dropdowns
+        item_container.find('select[data-glpi-loaded=false]').each(function() {
+            // Get editor config for this field
+            const id = $(this).attr("id");
+            const config = window.select2_configs[id];
+            if (config.type === "ajax") {
+                setupAjaxDropdown(config);
+            } else if (config.type === "adapt") {
+                setupAdaptDropdown(config);
+            }
+            tinyMCE.init(config);
+            $(this).attr('data-glpi-loaded', "true");
+        });
+
         /**
          * Delay the activation of the new item to avoid a rendering bug.
          * I can't explain it, but without this delay,

--- a/templates/pages/admin/form/form_question.html.twig
+++ b/templates/pages/admin/form/form_question.html.twig
@@ -227,6 +227,9 @@
                 data-glpi-form-editor-question-extra-details
                 data-fix-dropdown-flex
             >
+                {# Setup "glpi-loaded" attribute for questions, not for the template #}
+                {% set base_attributes = question is null ? {} : {'glpi-loaded' : "false"} %}
+
                 <div class="question-type-dropdown-group">
                     {{ fields.dropdownArrayField(
                         '_type_category',
@@ -234,7 +237,7 @@
                         question_types_manager.getCategoriesDropdownValues(),
                         '',
                         {
-                            'init'                 : question is not null,
+                            'init'                 : false,
                             'no_label'             : true,
                             'mb'                   : '',
                             'field_class'          : '',
@@ -243,8 +246,8 @@
                             'dropdownCssClass'     : 'question-type-dropdown-group-dropdown-select',
                             'aria_label'           : __('Question type'),
                             'add_data_attributes'  : {
-                                'glpi-form-editor-on-change': 'change-question-type-category'
-                            },
+                                'glpi-form-editor-on-change': 'change-question-type-category',
+                            }|merge(base_attributes),
                             'templateSelection'    : question_types_manager.getTemplateSelectionForCategories(),
                             'templateResult'       : question_types_manager.getTemplateResultForCategories(),
                         }
@@ -258,7 +261,7 @@
                         types,
                         question_type.getName(),
                         {
-                            'init'                 : question is not null,
+                            'init'                 : false,
                             'no_label'             : true,
                             'mb'                   : '',
                             'field_class'          : types|length == 1 ? ' d-none' : '',
@@ -267,8 +270,9 @@
                             'aria_label'           : __('Question sub type'),
                             'add_data_attributes'  : {
                                 'glpi-form-editor-on-change'             : 'change-question-type',
-                                'glpi-form-editor-question-type-selector': ''
-                            },
+                                'glpi-form-editor-question-type-selector': '',
+
+                            }|merge(base_attributes),
                             'templateSelection'    : question_types_manager.getTemplateSelectionForQuestionTypes(),
                             'templateResult'       : question_types_manager.getTemplateResultForQuestionTypes(),
                         }
@@ -281,7 +285,7 @@
                         question_type.getSubTypes(),
                         '',
                         {
-                            'init'                 : question is not null,
+                            'init'                 : false,
                             'no_label'             : true,
                             'mb'                   : '',
                             'field_class'          : sub_types is empty ? ' d-none' : '',
@@ -292,8 +296,8 @@
                             'add_data_attributes'  : {
                                 'glpi-form-editor-on-change'                   : 'change-question-sub-type',
                                 'glpi-form-editor-question-sub-type-selector'  : '',
-                                'glpi-form-editor-specific-question-extra-data': ''
-                            }
+                                'glpi-form-editor-specific-question-extra-data': '',
+                            }|merge(base_attributes),
                         }
                     ) }}
                 </div>


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.

## Description

Similar to #20431 but for select2 instead of tinymce.

Each form questions have dropdowns (to select the question type) but they are not shown until a question is selected.
To speed up initial load, we can delay initializing the dropdowns of a question until it is selected.

Partial improvement for https://github.com/glpi-project/glpi/issues/20416.
