### PR TITLE
fix midnight theme muted color

### DIFF
--- a/css/palettes/midnight.scss
+++ b/css/palettes/midnight.scss
@@ -48,7 +48,7 @@ $dark-mode-darken: #000;
 $color-contrast-dark: #1a1a1a;
 $light: #e6e6e6;
 $link-color: #b6c3e0;
-$text-muted: $dark;
+$text-muted: #c6cad2;
 $mainmenu_bg: #2f3f64;
 $mainmenu_fg: #f4f6fa;
 $logo: "../pics/logos/logo-GLPI-100-white.png";


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Partial revert of https://github.com/glpi-project/glpi/pull/16908 to fix several uses of muted text in Midnight including the breadcrumbs likes and some text in the debug bar. Since `$dark` is black and the main background color in this theme is also black, muted text is invisible.
