### PR TITLE
Fix long info in user card squashing pictures

### DIFF
--- a/templates/components/user/info_card.html.twig
+++ b/templates/components/user/info_card.html.twig
@@ -34,7 +34,7 @@
 
 <div class="p-0 user-info-card">
    <div class="row">
-      <div class="col pt-1">
+      <div class="col-auto pt-1">
          {% if user['id'] %}
             {{ include('components/user/picture.html.twig', {
                'users_id': user['id'],
@@ -43,7 +43,7 @@
             }) }}
          {% endif %}
       </div>
-      <div class="col-auto ms-2">
+      <div class="col ms-2">
          <h4 class="card-title mb-1">
             {% if user['id'] %}
                <a href="{{ 'User'|itemtype_form_path(user['id']) }}">{{ user['user_name'] }}</a>


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Fixes #13880
Only an issue in rare cases where information like an email or location is very long.

Switch the columns inside the user card so that the avatar column uses `col-auto` and the info uses `col`. This makes the info resize to accommodate the max-width of the qtip while the avatar maintains its own size.
This matches the user card seen on the Tabler template preview here:
https://preview.tabler.io/widgets.html

## Screenshots (if appropriate):
<img src="https://user-images.githubusercontent.com/5399964/214692690-ce67af26-db2f-480a-b081-ef211678d97a.png"/>
<img width="641" height="189" alt="Selection_536" src="https://github.com/user-attachments/assets/c86cd774-d19e-49c4-8cf3-8d42c6395c12" />

