### PR TITLE
Fix form fields overflowing column

### DIFF
--- a/templates/generic_show_form.html.twig
+++ b/templates/generic_show_form.html.twig
@@ -54,7 +54,7 @@
    <div class="card-body d-flex flex-wrap">
       <div class="col-12 col-xxl-{{ item_has_pictures ? '9' : '12' }} flex-column">
          <div class="d-flex flex-row flex-wrap flex-xl-nowrap">
-            <div class="row flex-row align-items-start flex-grow-1">
+            <div class="row flex-row align-items-start flex-grow-1" style="min-width: 0;">
                <div class="row flex-row">
                   {% block form_fields %}
                      {% if item.isField('name') %}


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Fixes #14166
Issue is caused by the default value of `min-width`. Normally, this is "0" but for `flex` elements it becomes `auto`. In that case, the content can sometimes grow to overflow the parent container.

https://stackoverflow.com/questions/36230944/prevent-flex-items-from-overflowing-a-container

## Screenshots (if appropriate):

<img width="1384" height="681" alt="Selection_538" src="https://github.com/user-attachments/assets/21ac53e3-fb93-4760-80cb-3cd1c8c4bea4" />

<img width="1399" height="507" alt="Selection_539" src="https://github.com/user-attachments/assets/1415da69-ebfd-454f-9ddc-1bf16e25ee9b" />

