### PR TITLE
Categorize component type list page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ The present file will list all changes made to the project; according to the
 - User passwords are no longer wiped when the authentication source/server doesn't actually change during "Change of the authentication method" action.
 - Single item actions (Actions menu in item form) are now filtered by certain attributes of the item. For example, a Computer which has reservations enabled will not show the `Authorize reservations` action.
 - Improved labels in component link dropdown to only include textual information and hide normally hidden data.
+- Component types list is now categorized similar to the dropdown types list.
 
 ### Deprecated
 - Survey URL tags `TICKETCATEGORY_ID` and `TICKETCATEGORY_NAME` are deprecated and replaced by `ITILCATEGORY_ID` and `ITILCATEGORY_NAME` respectively.

--- a/front/devices.php
+++ b/front/devices.php
@@ -40,8 +40,7 @@ Session::checkRight("device", READ);
 Html::header(_n('Component', 'Components', Session::getPluralNumber()), '', "config", "commondevice");
 echo "<div class='text-center'>";
 
-$optgroup = Dropdown::getDeviceItemTypes();
-Dropdown::showItemTypeMenu(_n('Component', 'Components', Session::getPluralNumber()), $optgroup);
+$optgroup = Dropdown::getDeviceItemTypes(true);
 Dropdown::showItemTypeList($optgroup);
 
 echo "</div>";

--- a/phpunit/functional/DropdownTest.php
+++ b/phpunit/functional/DropdownTest.php
@@ -2487,4 +2487,32 @@ HTML;
             return $result['id'] === \Supplier::class . '_' . $inactive_supplier->getID();
         }));
     }
+
+    public function testGetDeviceItemTypes()
+    {
+        $this->login();
+        \Dropdown::resetItemtypesStaticCache();
+        $types = \Dropdown::getDeviceItemTypes();
+        // Not grouped by default (BC reasons)
+        $this->assertCount(1, $types);
+        $types = reset($types);
+        $this->assertGreaterThanOrEqual(2, $types);
+        foreach ($types as $type => $label) {
+            $this->assertTrue(is_subclass_of($type, \CommonDevice::class));
+            $this->assertIsString($label);
+        }
+
+        \Dropdown::resetItemtypesStaticCache();
+        $types = \Dropdown::getDeviceItemTypes(true);
+        $this->assertGreaterThanOrEqual(3, $types);
+        foreach ($types as $category => $types_list) {
+            $this->assertIsString($category);
+            $this->assertIsArray($types_list);
+            $this->assertGreaterThanOrEqual(1, $types_list);
+            foreach ($types_list as $type => $label) {
+                $this->assertTrue(is_subclass_of($type, \CommonDevice::class));
+                $this->assertIsString($label);
+            }
+        }
+    }
 }

--- a/phpunit/functional/Item_DevicesTest.php
+++ b/phpunit/functional/Item_DevicesTest.php
@@ -132,6 +132,6 @@ class Item_DevicesTest extends DbTestCase
     #[DataProvider('itemAffinitiesProvider')]
     public function testGetItemAffinities(string $itemtype, array $expected)
     {
-        $this->assertEquals($expected, Item_Devices::getItemAffinities($itemtype));
+        $this->assertEqualsCanonicalizing($expected, Item_Devices::getItemAffinities($itemtype));
     }
 }

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -67,6 +67,12 @@ class Dropdown
     private static $devices_itemtypes_options = null;
 
     /**
+     * List of devices itemtypes options grouped by category
+     * @var array|null
+     */
+    private static $devices_itemtypes_options_grouped = null;
+
+    /**
      * Print out an HTML "<select>" for a dropdown with preselected value
      *
      * @param string $itemtype  itemtype used for create dropdown
@@ -1183,23 +1189,36 @@ HTML;
     /**
      * Get the Device list name the user is allowed to edit
      *
+     * @param bool $grouped if true, group by category
      * @return array (group of dropdown) of array (itemtype => localized name)
      **/
-    public static function getDeviceItemTypes()
+    public static function getDeviceItemTypes(bool $grouped = false)
     {
+        //TODO After GLPI 11.0, make this always return grouped values
         if (!Session::haveRight('device', READ)) {
             return [];
         }
 
-        if (self::$devices_itemtypes_options === null) {
+        $cache_prop = $grouped ? 'devices_itemtypes_options_grouped' : 'devices_itemtypes_options';
+        if (self::$$cache_prop === null) {
             $devices = [];
-            foreach (CommonDevice::getDeviceTypes() as $device_type) {
-                $devices[$device_type] = $device_type::getTypeName(Session::getPluralNumber());
+            foreach (CommonDevice::getDeviceTypes($grouped) as $category => $device_type) {
+                if (is_array($device_type)) {
+                    foreach ($device_type as $type) {
+                        $devices[$category][$type] = $type::getTypeName(Session::getPluralNumber());
+                    }
+                    asort($devices[$category]);
+                } else {
+                    $devices[$device_type] = $device_type::getTypeName(Session::getPluralNumber());
+                }
             }
-            asort($devices);
-            self::$devices_itemtypes_options = [_n('Component', 'Components', Session::getPluralNumber()) => $devices];
+            if (!$grouped) {
+                asort($devices);
+                $devices = [_n('Component', 'Components', Session::getPluralNumber()) => $devices];
+            }
+            self::$$cache_prop = $devices;
         }
-        return self::$devices_itemtypes_options;
+        return self::$$cache_prop;
     }
 
 
@@ -1451,6 +1470,7 @@ HTML;
      **/
     public static function showItemTypeMenu(string $title, array $optgroup, string $value = '', array $options = []): void
     {
+        Toolbox::deprecated(version: '11.1.0');
         $params = [
             'on_change'             => "var _value = this.options[this.selectedIndex].value; if (_value != 0) {window.location.href=_value;}",
             'width'                 => '300px',
@@ -1490,9 +1510,10 @@ HTML;
 
 
     /**
-     * Display a list to select a itemtype with link to search form
+     * Display a list to select an itemtype with link to search form
      *
-     * @param $optgroup array (group of dropdown) of array (itemtype => localized name)
+     * @param array $optgroup (group of dropdown) of array (itemtype => localized name)
+     * @return void
      */
     public static function showItemTypeList($optgroup)
     {
@@ -4541,6 +4562,7 @@ HTML;
     public static function resetItemtypesStaticCache(): void
     {
         self::$devices_itemtypes_options  = null;
+        self::$devices_itemtypes_options_grouped = null;
         self::$standard_itemtypes_options = null;
     }
 }

--- a/templates/pages/setup/dropdowns_list.html.twig
+++ b/templates/pages/setup/dropdowns_list.html.twig
@@ -40,12 +40,12 @@
          <div class="accordion accordion-flush">
             <div class="accordion-item">
                <div class="accordion-header">
-                  <button class="accordion-button {{ nb_opt > 1 ? "collapsed" : "" }}" type="button"
+                  <button class="accordion-button {{ nb_opt > 3 ? "collapsed" : "" }}" type="button"
                      data-bs-toggle="collapse" data-bs-target="#{{ card_id }}" aria-expanded="true" aria-controls="collapseOne">
                      {{ label }}
                   </button>
                </div>
-               <div id="{{ card_id }}" class="accordion-collapse {{ nb_opt > 1 ? "collapse" : "" }}" style="transition: none">
+               <div id="{{ card_id }}" class="accordion-collapse {{ nb_opt > 3 ? "collapse" : "" }}" style="transition: none">
                   <div class="list-group list-group-flush list-group-hoverable">
                      {% for itemtype, dropdown_label in dropdown %}
                         {% set is_entity_assign = itemtype|itemtype_class.isEntityAssign() %}
@@ -62,7 +62,7 @@
                                  {% if is_entity_assign %}
                                     <i class="{{ 'Entity'|itemtype_icon }} fs-4"
                                        data-bs-toggle="tooltip"
-                                       title="{{ __('Dropdown with entity management') }}"></i>
+                                       title="{{ __('Entity management') }}"></i>
                                  {% endif %}
                               </div>
                            </div>
@@ -83,7 +83,7 @@
 
 <div class="container-fluid text-start mb-4 dropdowns-list">
    <div class="input-icon mb-3">
-      <input class="form-control" placeholder="{{ __('Filter dropdowns') }}" id="filter-dropdown" />
+      <input class="form-control" placeholder="{{ __('Search') }}" id="filter-dropdown" />
       <span class="input-icon-addon">
          <i class="ti ti-search"></i>
       </span>


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

Fixes #19942

- Removes the dropdown that was present and plans the related `Dropdown::showItemTypeMenu` method to be deprecated starting in 11.1 as it isn't used anywhere else.
- Categorizes the component type list page. They are now categorized into "Input/Output", "Power Management" and "Others". Any devices not hard-coded into a category will end up under "Others".
- Change auto-expand count from 1 to 3. This means if the component or dropdown lists page has 3 or less lists, they will be expanded. This lines up with the number of lists which would appear in a single row on the vast majority of screens (1200px+ wide). This reduces the number of clicks needed.
- Change Search placeholder from "Filter dropdowns" to "Search". Affects dropdown and component lists.
- Change entity tooltip from "Dropdown with entity management" to simply "Entity management". Affects dropdown and component lists.
- `CommonDevice::getDeviceTypes` and `Dropdown::getDeviceItemTypes` now accept a `grouped` parameter. For backwards-compatibility this defaults to false. In the future, the parameter should be removed and have the returned values always categorized.

## Screenshots (if appropriate):

<img width="1018" height="680" alt="Selection_545" src="https://github.com/user-attachments/assets/35bfccef-176f-49ea-b7c9-ce927440c573" />


