### PR TITLE
Fix language column lengths

### DIFF
--- a/install/migrations/update_10.0.x_to_11.0.0/remindertranslations.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/remindertranslations.php
@@ -33,29 +33,7 @@
  */
 
 /**
- * @var DBmysql $DB
  * @var Migration $migration
  */
 
-$default_charset   = DBConnection::getDefaultCharset();
-$default_collation = DBConnection::getDefaultCollation();
-$default_key_sign  = DBConnection::getDefaultPrimaryKeySignOption();
-
-if (!$DB->tableExists('glpi_itemtranslations_itemtranslations')) {
-    $DB->doQuery(
-        "CREATE TABLE `glpi_itemtranslations_itemtranslations` (
-            `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
-            `items_id` int unsigned NOT NULL DEFAULT '0',
-            `itemtype` varchar(100) NOT NULL,
-            `key` varchar(255) NOT NULL,
-            `language` varchar(10) NOT NULL,
-            `translations` JSON NOT NULL,
-            `hash` varchar(32) DEFAULT NULL,
-            PRIMARY KEY (`id`),
-            UNIQUE KEY `unique_item_key` (`items_id`, `itemtype`, `key`, `language`),
-            KEY `item` (`itemtype`, `items_id`)
-        ) ENGINE=InnoDB DEFAULT CHARSET={$default_charset} COLLATE={$default_collation} ROW_FORMAT=DYNAMIC;"
-    );
-} else {
-    $migration->changeField('glpi_itemtranslations_itemtranslations', 'language', 'language', 'varchar(10) NOT NULL');
-}
+$migration->changeField('glpi_remindertranslations', 'language', 'language', 'varchar(10)');

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -6320,7 +6320,7 @@ DROP TABLE IF EXISTS `glpi_remindertranslations`;
 CREATE TABLE `glpi_remindertranslations` (
   `id` int unsigned NOT NULL AUTO_INCREMENT,
   `reminders_id` int unsigned NOT NULL DEFAULT '0',
-  `language` varchar(5) DEFAULT NULL,
+  `language` varchar(10) DEFAULT NULL,
   `name` text,
   `text` longtext,
   `users_id` int unsigned NOT NULL DEFAULT '0',
@@ -10198,7 +10198,7 @@ CREATE TABLE `glpi_itemtranslations_itemtranslations` (
   `items_id` int unsigned NOT NULL DEFAULT '0',
   `itemtype` varchar(100) NOT NULL,
   `key` varchar(255) NOT NULL,
-  `language` varchar(5) NOT NULL,
+  `language` varchar(10) NOT NULL,
   `translations` JSON NOT NULL,
   `hash` varchar(32) DEFAULT NULL,
   PRIMARY KEY (`id`),


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Typically, we have used 10 character length columns for storing language codes. For some reason, there are two exceptions currently:
1. Reminder translations which have existed since GLPI 9.5
2. Item Translations which were added for GLPI 11

Not every language code is 5 characters or less in our hard-coded languages. Currently, both of these limited columns would prevent adding translations for the Latin America Spanish language which has a code of `es_419`.