### PR TITLE
Initialize default form translations

### DIFF
--- a/src/Session.php
+++ b/src/Session.php
@@ -905,6 +905,54 @@ class Session
     }
 
     /**
+     * Loads all locales from the core for the translation system.
+     * Should only be used during the install or update process to allow initialization of text in multiple languages.
+     * @return void
+     */
+    public static function loadAllCoreLocales(): void
+    {
+        /**
+         * @var array $CFG_GLPI
+         * @var Translator $TRANSLATE
+         */
+        global $CFG_GLPI, $TRANSLATE;
+
+        $core_folders = is_dir(GLPI_LOCAL_I18N_DIR) ? scandir(GLPI_LOCAL_I18N_DIR) : [];
+        $core_folders = array_filter($core_folders, static function ($dir) {
+            if (!is_dir(GLPI_LOCAL_I18N_DIR . "/$dir")) {
+                return false;
+            }
+
+            if ($dir === 'core') {
+                return true;
+            }
+
+            return str_starts_with($dir, 'core_');
+        });
+        $core_folders = array_map(static function ($dir) {
+            return GLPI_LOCAL_I18N_DIR . "/$dir";
+        }, $core_folders);
+        $core_folders = [GLPI_I18N_DIR, ...$core_folders];
+
+        foreach ($core_folders as $core_folder) {
+            foreach ($CFG_GLPI['languages'] as $lang => $data) {
+                $mofile = "$core_folder/" . $data['1'];
+                $phpfile = str_replace('.mo', '.php', $mofile);
+
+                // Load local PHP file if it exists
+                if (file_exists($phpfile)) {
+                    $TRANSLATE->addTranslationFile('phparray', $phpfile, 'glpi', $lang);
+                }
+
+                // Load local MO file if it exists -- keep last so it gets precedence
+                if (file_exists($mofile)) {
+                    $TRANSLATE->addTranslationFile('gettext', $mofile, 'glpi', $lang);
+                }
+            }
+        }
+    }
+
+    /**
      * Return preffered language (from HTTP headers, fallback to default GLPI lang).
      *
      * @return string

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -2210,6 +2210,7 @@ class Toolbox
         }
         $progress_indicator?->addMessage(MessageType::Success, __('Default data imported.'));
 
+        Session::loadAllCoreLocales();
         $progress_indicator?->setProgressBarMessage(__('Creating default forms…'));
         $default_forms_manager = new DefaultDataManager();
         $default_forms_manager->initializeData();

--- a/src/Update.php
+++ b/src/Update.php
@@ -290,6 +290,7 @@ class Update
             $progress_indicator?->advance();
         }
 
+        Session::loadAllCoreLocales();
         // Create default forms
         $progress_indicator?->setProgressBarMessage(__('Creating default forms…'));
         $helpdesk_data_manager = new DefaultDataManager();


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Proposed solution for #19802.
As stated in the issue, the default forms and questions are initialized in whatever the current language happens to be during the install/update while previous versions always used the correct translated labels when ticket forms are displayed. This makes the migration to GLPI 11 difficult for existing multi-language users who would be forced to manually translate these forms.

This solution will load all of the core locales during the installation and update process before the default data is added. The Form `DefaultDataManager` will loop through the known languages and add the needed translations to the DB if a translation exists.

Known issue I haven't addressed:
- If question translations exist but not form name translations, the language doesn't show in the Form translations tab until you "Add" the language.

Expanding on this further in the future:
- The GLPI installation/update wizard could prompt for a list of languages to initialize data with, in addition to the default language chosen, instead of loading and filling data in all known languages. This could also be an ENV constant.

## Screenshots (if appropriate):


