### PR TITLE
fix(license): users not counted in usage bar

### DIFF
--- a/src/Item_SoftwareLicense.php
+++ b/src/Item_SoftwareLicense.php
@@ -124,7 +124,7 @@ class Item_SoftwareLicense extends CommonDBRelation
             case '164':
                 $softlicense = new SoftwareLicense();
                 $softlicense->getFromDB($options['raw_data']['id']);
-                $assign_item = self::countForLicense($options['raw_data']['id']);
+                $assign_item = self::countForLicense($options['raw_data']['id']) + SoftwareLicense_User::countForLicense($options['raw_data']['id']);
                 return TemplateRenderer::getInstance()->render(
                     'pages/management/license_progressbar.html.twig',
                     [

--- a/src/SoftwareLicense.php
+++ b/src/SoftwareLicense.php
@@ -271,7 +271,8 @@ class SoftwareLicense extends CommonTreeDropdown implements AssignableItemInterf
         TemplateRenderer::getInstance()->display('pages/management/softwarelicense.html.twig', [
             'item'   => $this,
             'params' => $options,
-            'licences_assigned' => Item_SoftwareLicense::countForLicense($this->getID()),
+            'licences_assigned' => Item_SoftwareLicense::countForLicense($this->getID())
+                + SoftwareLicense_User::countForLicense($this->getID()),
         ]);
 
         return true;


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes #20422 
- Users were not included in the total number of items assigned by a license in the progress bar.
## Screenshots (if appropriate):

**Affected items:**
<img width="708" height="303" alt="image" src="https://github.com/user-attachments/assets/565a71c7-3ff7-4901-b958-89268c6ce48d" />

**Before fix:**
<img width="695" height="148" alt="image" src="https://github.com/user-attachments/assets/2e31a999-cb18-4714-9966-1236178b9bab" />

**After fix:**
<img width="695" height="148" alt="image" src="https://github.com/user-attachments/assets/13d8251b-941a-4a16-8818-98a451debcba" />



