### PR TITLE
Fix detected Psalm `TaintedInclude` issues

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -22,7 +22,7 @@
         <TaintedFile errorLevel="suppress" />
         <TaintedHeader errorLevel="suppress" />
         <!-- <TaintedHtml errorLevel="suppress" /> -->
-        <TaintedInclude errorLevel="suppress" />
+        <!-- <TaintedInclude errorLevel="suppress" /> -->
         <TaintedLdap errorLevel="suppress" />
         <TaintedSSRF errorLevel="suppress" />
         <TaintedSql errorLevel="suppress" />

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -1954,6 +1954,10 @@ class Plugin extends CommonDBTM
             if (!is_dir($base_dir)) {
                 continue;
             }
+            /**
+             * Plugin setup file is safe for inclusion.
+             * @psalm-taint-escape include
+             */
             $file_path = sprintf('%s/%s/setup.php', $base_dir, $plugin_key);
 
             if (file_exists($file_path)) {
@@ -2033,9 +2037,20 @@ class Plugin extends CommonDBTM
             throw new RuntimeException('Including plugin hook files is forbidden when plugins execution is suspended.');
         }
 
+        if (preg_match(self::PLUGIN_KEY_PATTERN, $plugin_key) !== 1) {
+            // Prevent issues with illegal chars
+            return;
+        }
+
         foreach (GLPI_PLUGINS_DIRECTORIES as $base_dir) {
-            if (file_exists("$base_dir/$plugin_key/hook.php")) {
-                include_once("$base_dir/$plugin_key/hook.php");
+            /**
+             * Plugin hook file is safe for inclusion.
+             * @psalm-taint-escape include
+             */
+            $path = "$base_dir/$plugin_key/hook.php";
+
+            if (file_exists($path)) {
+                include_once($path);
                 break;
             }
         }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Existing includes were safe. I just added a check on the `$plugin_key` parameter of the `Plugin::includeHook()` method to be sure that it cannot be used to include a file outside the expected plugin directory tree.