### PR TITLE
fix(forms): Delete form translations after parent item deleted

### DIFF
--- a/src/Glpi/Form/Comment.php
+++ b/src/Glpi/Form/Comment.php
@@ -104,6 +104,16 @@ final class Comment extends CommonDBChild implements
     }
 
     #[Override]
+    public function cleanDBonPurge()
+    {
+        $this->deleteChildrenAndRelationsFromDb(
+            [
+                FormTranslation::class,
+            ]
+        );
+    }
+
+    #[Override]
     public function prepareInputForAdd($input)
     {
         if (!isset($input['uuid'])) {

--- a/src/Glpi/Form/Form.php
+++ b/src/Glpi/Form/Form.php
@@ -390,6 +390,7 @@ final class Form extends CommonDBTM implements
                 FormDestination::class,
                 FormAccessControl::class,
                 FormTile::class,
+                FormTranslation::class,
             ]
         );
     }

--- a/src/Glpi/Form/Question.php
+++ b/src/Glpi/Form/Question.php
@@ -117,6 +117,16 @@ final class Question extends CommonDBChild implements BlockInterface, Conditiona
     }
 
     #[Override]
+    public function cleanDBonPurge()
+    {
+        $this->deleteChildrenAndRelationsFromDb(
+            [
+                FormTranslation::class,
+            ]
+        );
+    }
+
+    #[Override]
     public function listTranslationsHandlers(): array
     {
         $key = sprintf('%s: %s', self::getTypeName(), $this->getName());

--- a/src/Glpi/Form/Section.php
+++ b/src/Glpi/Form/Section.php
@@ -105,6 +105,7 @@ final class Section extends CommonDBChild implements ConditionableVisibilityInte
             [
                 Question::class,
                 Comment::class,
+                FormTranslation::class,
             ]
         );
     }


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

- It fixes #20495

Remove translations of form elements when deleting them.