### PR TITLE
Add config to allow unauthenticated files upload

### DIFF
--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -173,6 +173,7 @@ $empty_data_builder = new class {
             'planning_end' => '20:00:00',
             'utf8_conv' => '1',
             'use_public_faq' => '0',
+            'allow_unauthenticated_uploads' => '0',
             'url_base' => 'http://localhost',
             'show_link_in_mail' => '0',
             'text_login' => '',

--- a/install/migrations/update_10.0.x_to_11.0.0/configs.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/configs.php
@@ -35,13 +35,14 @@
  * @var Migration $migration
  */
 $migration->addConfig([
-    'password_init_token_delay' => '86400',
-    'toast_location'    => 'bottom-right',
-    'set_followup_tech' => '0',
-    'set_solution_tech' => '0',
-    'is_demo_dashboards' => '0',
-    'planned_task_state' => '1',
-    'plugins_execution_mode' => 'on', // Plugin::EXECUTION_MODE_ON
+    'password_init_token_delay'     => '86400',
+    'toast_location'                => 'bottom-right',
+    'set_followup_tech'             => '0',
+    'set_solution_tech'             => '0',
+    'is_demo_dashboards'            => '0',
+    'planned_task_state'            => '1',
+    'plugins_execution_mode'        => 'on', // Plugin::EXECUTION_MODE_ON
+    'allow_unauthenticated_uploads' => '0',
 ]);
 $migration->addField('glpi_users', 'toast_location', 'string');
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -2036,4 +2036,12 @@ class Config extends CommonDBTM
         }
         return null;
     }
+
+    public static function allowUnauthenticatedUploads(): bool
+    {
+        /** @var array $CFG_GLPI */
+        global $CFG_GLPI;
+
+        return (bool) ($CFG_GLPI['allow_unauthenticated_uploads'] ?? false);
+    }
 }

--- a/src/Glpi/Form/QuestionType/QuestionTypeFile.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeFile.php
@@ -35,6 +35,7 @@
 
 namespace Glpi\Form\QuestionType;
 
+use Config;
 use Document;
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\Form\Question;
@@ -135,6 +136,6 @@ TWIG;
     #[Override]
     public function isAllowedForUnauthenticatedAccess(): bool
     {
-        return false;
+        return Config::allowUnauthenticatedUploads();
     }
 }

--- a/src/Glpi/Form/QuestionType/QuestionTypeLongText.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeLongText.php
@@ -35,6 +35,7 @@
 
 namespace Glpi\Form\QuestionType;
 
+use Config;
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\JsonFieldInterface;
 use Glpi\Form\Condition\ConditionHandler\RichTextConditionHandler;
@@ -157,7 +158,7 @@ TWIG;
                 "",
                 {
                     'enable_richtext': true,
-                    'enable_images'  : is_authenticated,
+                    'enable_images'  : enable_images,
                     'init'           : question is not null ? true   : false,
                     'is_horizontal'  : false,
                     'full_width'     : true,
@@ -171,7 +172,7 @@ TWIG;
         return $twig->renderFromStringTemplate($template, [
             'question'      => $question,
             'default_value' => $translated_default_value,
-            'is_authenticated' => Session::isAuthenticated(),
+            'enable_images' => Session::isAuthenticated() || Config::allowUnauthenticatedUploads(),
         ]);
     }
 

--- a/src/Glpi/Http/Firewall.php
+++ b/src/Glpi/Http/Firewall.php
@@ -211,6 +211,11 @@ final class Firewall
             '/install/' => self::STRATEGY_NO_CHECK, // No check during install/update
         ];
 
+        if (Config::allowUnauthenticatedUploads()) {
+            $paths['/ajax/fileupload.php'] = self::STRATEGY_NO_CHECK;
+            $paths['/ajax/getFileTag.php'] = self::STRATEGY_NO_CHECK;
+        }
+
         foreach ($paths as $checkPath => $strategy) {
             if (\str_starts_with($path, $checkPath)) {
                 return $strategy;

--- a/templates/pages/setup/general/general_setup.html.twig
+++ b/templates/pages/setup/general/general_setup.html.twig
@@ -93,6 +93,15 @@
         field_options
     ) }}
 
+    {{ fields.checkboxField(
+        'allow_unauthenticated_uploads',
+        config['allow_unauthenticated_uploads'] ?? false,
+        __('Allow unauthenticated uploads'),
+        field_options|merge({
+            helper: __("Do not use this option if your GLPI is reachable from the internet. Use at your own risk."),
+        })
+    ) }}
+
 </div>
 
 <div class="hr-text">


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.

## Description

Possible solution for #19834.

Still not sure this is the way forward but opening it for discussion.

Maybe we should try to understand better the needs of the users that require this feature and offer an alternative? Open to suggestions.
I am conflicted about opening a potential security breach, even if it is "opt in".

On a side note, we have others form fields that are disallowed for public forms (like assets dropdown).
If we accept that public fileupload is safe if the GLPI instance is inside a private network, then maybe theses questions types should also be allowed in this case.
