### PR TITLE
Fix detected Psalm `TaintedSql` issues

### DIFF
--- a/phpunit/functional/DBTest.php
+++ b/phpunit/functional/DBTest.php
@@ -90,6 +90,8 @@ class DBTest extends \GLPITestCase
             ['field AS f', '`field` AS `f`'],
             ['field as f', '`field` AS `f`'],
             ['table.field as f', '`table`.`field` AS `f`'],
+            ['ta`ble', '`ta``ble`'],
+            ['ta`ble.f`i`e`l`d', '`ta``ble`.`f``i``e``l``d`'],
         ];
     }
 
@@ -152,13 +154,7 @@ class DBTest extends \GLPITestCase
                     'WHERE' => ['NOT' => ['name' => null]],
                 ]),
                 'INSERT INTO `table` (SELECT `id`, `name` FROM `other` WHERE NOT (`name` IS NULL))',
-            ],/*, [
-                'table', [
-                    'field'  => new \QueryParam('field'),
-                    'other'  => new \QueryParam('other')
-                ],
-                'INSERT INTO `table` (`field`, `other`) VALUES (:field, :other)'
-            ]*/ //mysqli does not support named parameters
+            ],
         ];
     }
 
@@ -206,14 +202,6 @@ class DBTest extends \GLPITestCase
                 [],
                 'UPDATE `table` SET `field` = ? WHERE  NOT (`id` IN (?, ?))',
             ], [
-                /*'table', [
-                    'field'  => new \QueryParam('field')
-                ], [
-                    'NOT' => ['id' => [new \QueryParam('idone'), new \QueryParam('idtwo')]]
-                ],
-                [],
-                'UPDATE `table` SET `field` = :field WHERE  NOT (`id` IN (:idone, :idtwo))'
-            ], [*/
                 'table', [
                     'field'  => new QueryExpression(\DBmysql::quoteName('field') . ' + 1'),
                 ], [
@@ -301,12 +289,6 @@ class DBTest extends \GLPITestCase
                 [],
                 'DELETE `table` FROM `table` WHERE  NOT (`id` IN (?, ?))',
             ], [
-                /*'table', [
-                    'NOT'  => ['id' => [new \QueryParam('idone'), new \QueryParam('idtwo')]]
-                ],
-                [],
-                'DELETE `table` FROM `table` WHERE  NOT (`id` IN (:idone, :idtwo))'
-            ], [*/
                 'table', [
                     'id'  => 1,
                 ],

--- a/phpunit/functional/DBmysqlIteratorTest.php
+++ b/phpunit/functional/DBmysqlIteratorTest.php
@@ -529,6 +529,10 @@ class DBmysqlIteratorTest extends DbTestCase
     {
         $it = $this->it->execute(['FROM' => 'foo', 'WHERE' => 'id=1']);
         $this->assertSame('SELECT * FROM `foo` WHERE id=1', $it->getSql());
+        $this->hasPhpLogRecordThatContains(
+            'Passing SQL request criteria as strings is deprecated for security reasons.',
+            LogLevel::INFO
+        );
 
         $it = $this->it->execute(['FROM' => 'foo', 'WHERE' => ['bar' => null]]);
         $this->assertSame('SELECT * FROM `foo` WHERE `bar` IS NULL', $it->getSql());
@@ -559,9 +563,6 @@ class DBmysqlIteratorTest extends DbTestCase
 
         $it = $this->it->execute(['FROM' => 'foo', 'WHERE' => ['bar' => new QueryParam()]]);
         $this->assertSame('SELECT * FROM `foo` WHERE `bar` = ?', $it->getSql());
-
-        /*$it = $this->it->execute(['FROM' => 'foo', 'WHERE' => ['bar' => new \QueryParam('myparam')]]);
-        $this->assertSame('SELECT * FROM `foo` WHERE `bar` = :myparam', $it->getSql());*/
     }
 
     public function testEmptyIn(): void

--- a/phpunit/functional/Glpi/DBAL/QueryParamTest.php
+++ b/phpunit/functional/Glpi/DBAL/QueryParamTest.php
@@ -36,29 +36,9 @@ namespace tests\units\Glpi\DBAL;
 
 use DbTestCase;
 use Glpi\DBAL\QueryParam;
-use PHPUnit\Framework\Attributes\DataProvider;
 
 class QueryParamTest extends DbTestCase
 {
-    public static function dataParamsProvider()
-    {
-
-        return [
-            [null, '?'],
-            ['', '?'],
-            ['?', '?'],
-            ['myparam', ':myparam'],
-            [':myparam', ':myparam'],
-        ];
-    }
-
-    #[DataProvider('dataParamsProvider')]
-    public function testQueryParam($value, $expected)
-    {
-        $qpa = new QueryParam($value);
-        $this->assertSame($expected, $qpa->getValue());
-    }
-
     public function testEmptyQueryParam()
     {
         $qpa = new QueryParam();

--- a/psalm.xml
+++ b/psalm.xml
@@ -25,7 +25,7 @@
         <!-- <TaintedInclude errorLevel="suppress" /> -->
         <TaintedLdap errorLevel="suppress" />
         <TaintedSSRF errorLevel="suppress" />
-        <TaintedSql errorLevel="suppress" />
+        <!-- <TaintedSql errorLevel="suppress" /> -->
         <!-- <TaintedTextWithQuotes errorLevel="suppress" /> -->
     </issueHandlers>
 </psalm>

--- a/src/AbstractQuery.php
+++ b/src/AbstractQuery.php
@@ -65,6 +65,8 @@ abstract class AbstractQuery
      * Get SQL query
      *
      * @return string
+     *
+     * @psalm-taint-escape sql
      */
     abstract public function getQuery();
 

--- a/src/Glpi/DBAL/QueryExpression.php
+++ b/src/Glpi/DBAL/QueryExpression.php
@@ -66,6 +66,8 @@ class QueryExpression
      * Query expression value
      *
      * @return string
+     *
+     * @psalm-taint-escape sql
      */
     public function getValue()
     {

--- a/src/Glpi/DBAL/QueryParam.php
+++ b/src/Glpi/DBAL/QueryParam.php
@@ -35,39 +35,17 @@
 
 namespace Glpi\DBAL;
 
-/**
- *  Database iterator class for Mysql
- **/
 class QueryParam
 {
-    private $value;
-
     /**
-     * Create a query param with a value
-     *
-     * @param string $value Query parameter value, defaults to '?'
-     */
-    public function __construct($value = '?')
-    {
-        if ($value == null || trim($value) == '') {
-            $value = '?';
-        }
-        if ($value != '?' && !str_starts_with($value, ':')) {
-            $value = ':' . $value;
-        }
-        $this->value = $value;
-    }
-
-    /**
-     * Query parameter value
+     * Query parameter value.
      *
      * @return string
      */
     public function getValue()
     {
-        return $this->value;
+        return '?';
     }
-
 
     public function __toString()
     {

--- a/src/QueryParam.php
+++ b/src/QueryParam.php
@@ -38,9 +38,11 @@
  */
 class QueryParam extends Glpi\DBAL\QueryParam
 {
+    /**
+     * @phpstan-ignore constructor.unusedParameter
+     */
     public function __construct($expression = '?')
     {
         Toolbox::deprecated('\QueryParam is deprecated, use \Glpi\DBAL\QueryParam instead');
-        parent::__construct($expression);
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

1. I securized the `DBmysql::quoteName()` to handle the presence of backtick in names. They are now escaped by doubling them (e.g. ``` SELECT * FROM `my``table`; ```).

2. I deprecated the possibility to use string criteria (e.g. `['FROM' => 'glpi_computers', 'WHERE' => 'is_deleted=0']`). I hope this is not used anymore in GLPI, as we should have removed the usage of queries bases on string concatenations.

3. I removed the possibility to define a specific identifier to query parameters. This had never worked, as explained in the tests comments.

4. I adapted some code lines to ensure Psalm understand that the built quety is safe.