### PR TITLE
Remove forced min button sizes

### DIFF
--- a/css/includes/_base.scss
+++ b/css/includes/_base.scss
@@ -204,6 +204,9 @@ body.in_modal {
 }
 
 .btn {
+    min-width: unset;
+    min-height: unset;
+
     .btn-group .select2-container ~ & {
         max-width: 25px;
     }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Latest Tabler updated added forced button animations and forces a minimum button width and height for all buttons which breaks our entity selector list at least. We shouldn't be using their animated buttons anyways, so this reverts the forced min sizes.

See https://github.com/tabler/tabler/pull/2401