### PR TITLE
fix overflow of long entity names in selector

### DIFF
--- a/templates/layout/parts/profile_selector.html.twig
+++ b/templates/layout/parts/profile_selector.html.twig
@@ -132,7 +132,7 @@
                 </button>
             </div>
 
-            <div class="fancytree-grid-container flexbox-item-grow entity_tree">
+            <div class="fancytree-grid-container flexbox-item-grow entity_tree overflow-x-auto">
                 <table id="tree_entity{{ rand }}" aria-label="{{ __('Entity tree') }}">
                 <colgroup>
                     <col></col>


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Long entity names could overflow the entity selector.