### PR TITLE
fix icon and plurals for certificate tab

### DIFF
--- a/src/Certificate_Item.php
+++ b/src/Certificate_Item.php
@@ -98,12 +98,10 @@ class Certificate_Item extends CommonDBRelation
                 && Certificate::canView()
             ) {
                 if ($_SESSION['glpishow_count_on_tabs']) {
-                    return self::createTabEntry(
-                        Certificate::getTypeName(2),
-                        self::countForItem($item)
-                    );
+                    $count = self::countForItem($item);
+                    return self::createTabEntry(text: Certificate::getTypeName(Session::getPluralNumber()), nb: $count, icon: Certificate::getIcon());
                 }
-                return Certificate::getTypeName(2);
+                return self::createTabEntry(text: Certificate::getTypeName(Session::getPluralNumber()), icon: Certificate::getIcon());
             }
         }
         return '';


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

- Fix missing icon in Certificates tab for assets
- Fix hard-coded use of "2" as a plural count