### PR TITLE
fix initial impact settings load

### DIFF
--- a/src/Impact.php
+++ b/src/Impact.php
@@ -395,11 +395,11 @@ JS);
         echo '</div>';
 
         // Settings dialog
-        $setting_dialog = "";
+        $setting_dialog = "''";
         if ($can_update && $impact_context) {
             $rand = mt_rand();
 
-            $setting_dialog .= '<form id="list_depth_form" action="' . htmlescape($CFG_GLPI['root_doc']) . '/front/impactitem.form.php" method="POST">';
+            $setting_dialog = '<form id="list_depth_form" action="' . htmlescape($CFG_GLPI['root_doc']) . '/front/impactitem.form.php" method="POST">';
             $setting_dialog .= '<table class="tab_cadre_fixe">';
             $setting_dialog .= '<tr>';
             $setting_dialog .= '<td><label for="impact_max_depth_' . $rand . '">' . __s("Max depth") . '</label></td>';


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Bug from https://github.com/glpi-project/glpi/pull/20324 causing initial JS for impact settings dialog to generate a JS error because the parameter is empty:
```JS
glpi_html_dialog({
    title: "Settings",
    body: ,
});
```
Not sure it matters much in practice since the settings get set immediately somewhere else. I don't have time for an in-depth review of the Impact feature though.

## Screenshots (if appropriate):


