### PR TITLE
Fix ItemVirtualMachine showForm rights

### DIFF
--- a/src/ItemVirtualMachine.php
+++ b/src/ItemVirtualMachine.php
@@ -144,10 +144,6 @@ class ItemVirtualMachine extends CommonDBChild
      **/
     public function showForm($ID, array $options = [])
     {
-        if (!Session::haveRight("computer", UPDATE)) {
-            return false;
-        }
-
         if ($ID > 0) {
             $asset = getItemForItemtype($this->fields['itemtype']);
             $this->check($ID, READ);

--- a/src/ItemVirtualMachine.php
+++ b/src/ItemVirtualMachine.php
@@ -163,7 +163,7 @@ class ItemVirtualMachine extends CommonDBChild
             }
         }
 
-        $options['canedit'] = Session::haveRight($asset::$rightname, UPDATE);
+        $options['canedit'] = $asset->can($asset->getID(), UPDATE);
         $this->initForm($ID, $options);
         TemplateRenderer::getInstance()->display('components/form/itemvirtualmachine.html.twig', [
             'item'                      => $this,


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

The permission to update Computers should not be a blocker in viewing ItemVirtualMachine. This is also not related to the actual parent itemtype since this is a generic class now instead of ComputerVirtualMachine. The second commit changes the `canedit` check to check the ability to update the specific parent asset.
