### PR TITLE
Add missing canPurgeItem for CommonDBChild

### DIFF
--- a/src/CommonDBChild.php
+++ b/src/CommonDBChild.php
@@ -169,6 +169,11 @@ abstract class CommonDBChild extends CommonDBConnexity
         return $this->canChildItem('canUpdateItem', 'canUpdate');
     }
 
+    public function canPurgeItem(): bool
+    {
+        return $this->canChildItem('canUpdateItem', 'canUpdate');
+    }
+
 
     /**
      * @since 0.84


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.

## Description

As noticed with the recent reservation rights issues, CommonDBChild is missing a `canPurgeItem` method which delegates the check to the parent item's UPDATE permission.