### PR TITLE
remove margin from appliance relation list

### DIFF
--- a/src/Appliance_Item_Relation.php
+++ b/src/Appliance_Item_Relation.php
@@ -227,7 +227,7 @@ class Appliance_Item_Relation extends CommonDBRelation
             $relations_str .= "<li>$link $del</li>";
         }
 
-        return "<ul>$relations_str</ul>
+        return "<ul class='mb-0'>$relations_str</ul>
          <span class='cursor-pointer add_relation' data-appliances-items-id='{$appliances_items_id}'>
             <i class='ti ti-plus' title='" . __s('New relation') . "'></i>
             <span class='sr-only'>" . __s('New relation') . "</span>


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Remove bottom margin from the appliance relation list (Appliances tab of an asset). This is more of an annoyance if there are no relations yet but the `ul` element is still present which leaves a large gap above the add button.

## Screenshots (if appropriate):

Fixed:
<img width="875" height="256" alt="Selection_558" src="https://github.com/user-attachments/assets/85d9cc0e-ee05-4601-b059-8d9ed52b072c" />

