### PR TITLE
fix(forms): Delete helpdesk translations after parent item deleted

### DIFF
--- a/phpunit/functional/Glpi/Helpdesk/Translation/HelpdeskTranslationTest.php
+++ b/phpunit/functional/Glpi/Helpdesk/Translation/HelpdeskTranslationTest.php
@@ -222,7 +222,7 @@ class HelpdeskTranslationTest extends \DbTestCase
                 'items_id'     => $entity->getID(),
                 'language'     => 'fr_FR',
                 'key'          => Entity::TRANSLATION_KEY_CUSTOM_HELPDESK_HOME_TITLE,
-                'translations' => ['one' => 'Titre personnalisé du centre d\'aide'],
+                'translations' => ['one' => 'custom_helpdesk_home_title in fr_FR'],
             ],
             ['translations']
         );
@@ -233,7 +233,7 @@ class HelpdeskTranslationTest extends \DbTestCase
                 'items_id'     => $entity->getID(),
                 'language'     => 'es_ES',
                 'key'          => Entity::TRANSLATION_KEY_CUSTOM_HELPDESK_HOME_TITLE,
-                'translations' => ['one' => 'Título personalizado del centro de ayuda'],
+                'translations' => ['one' => 'custom_helpdesk_home_title in es_ES'],
             ],
             ['translations']
         );

--- a/src/Entity.php
+++ b/src/Entity.php
@@ -38,6 +38,7 @@ use Glpi\DBAL\QueryFunction;
 use Glpi\Debug\Profiler;
 use Glpi\Event;
 use Glpi\Features\Clonable;
+use Glpi\Helpdesk\HelpdeskTranslation;
 use Glpi\Helpdesk\Tile\LinkableToTilesInterface;
 use Glpi\Helpdesk\Tile\TilesManager;
 use Glpi\ItemTranslation\Context\ProvideTranslationsInterface;
@@ -814,6 +815,7 @@ class Entity extends CommonTreeDropdown implements LinkableToTilesInterface, Pro
                 Entity_KnowbaseItem::class,
                 Entity_Reminder::class,
                 Entity_RSSFeed::class,
+                HelpdeskTranslation::class,
             ]
         );
     }

--- a/src/Glpi/Helpdesk/HelpdeskTranslation.php
+++ b/src/Glpi/Helpdesk/HelpdeskTranslation.php
@@ -132,10 +132,9 @@ final class HelpdeskTranslation extends ItemTranslation implements ProvideTransl
             $entities
         );
 
-        $tiles_handlers = array_map(
-            fn($tile) => $tile->listTranslationsHandlers(),
-            $tiles_manager->getAllTiles()
-        );
+        $tiles = $tiles_manager->getAllTiles();
+        $tiles = array_filter($tiles, fn($tile) => $tile instanceof ProvideTranslationsInterface);
+        $tiles_handlers = array_map(fn(ProvideTranslationsInterface $tile) => $tile->listTranslationsHandlers(), $tiles);
 
         return array_merge(...$entities_handlers, ...$tiles_handlers);
     }

--- a/src/Glpi/Helpdesk/Tile/ExternalPageTile.php
+++ b/src/Glpi/Helpdesk/Tile/ExternalPageTile.php
@@ -35,14 +35,18 @@
 namespace Glpi\Helpdesk\Tile;
 
 use CommonDBTM;
+use Glpi\ItemTranslation\Context\ProvideTranslationsInterface;
 use Glpi\ItemTranslation\Context\TranslationHandler;
 use Glpi\Session\SessionInfo;
 use Glpi\UI\IllustrationManager;
 use Override;
 
-final class ExternalPageTile extends CommonDBTM implements TileInterface
+final class ExternalPageTile extends CommonDBTM implements TileInterface, ProvideTranslationsInterface
 {
     public static $rightname = 'config';
+
+    public const TRANSLATION_KEY_TITLE = 'title';
+    public const TRANSLATION_KEY_DESCRIPTION = 'description';
 
     #[Override]
     public function getLabel(): string

--- a/src/Glpi/Helpdesk/Tile/FormTile.php
+++ b/src/Glpi/Helpdesk/Tile/FormTile.php
@@ -154,16 +154,6 @@ final class FormTile extends CommonDBChild implements TileInterface
         );
     }
 
-    #[Override]
-    public function listTranslationsHandlers(): array
-    {
-        /**
-         * Title and description are already translated in the form
-         * so we don't need to add them here.
-         */
-        return [];
-    }
-
     public function getFormId(): int
     {
         return $this->fields['forms_forms_id'] ?? 0;

--- a/src/Glpi/Helpdesk/Tile/FormTile.php
+++ b/src/Glpi/Helpdesk/Tile/FormTile.php
@@ -158,7 +158,7 @@ final class FormTile extends CommonDBChild implements TileInterface
     public function listTranslationsHandlers(): array
     {
         /**
-         * Title and descriptioin are already translated in the form
+         * Title and description are already translated in the form
          * so we don't need to add them here.
          */
         return [];

--- a/src/Glpi/Helpdesk/Tile/FormTile.php
+++ b/src/Glpi/Helpdesk/Tile/FormTile.php
@@ -38,7 +38,6 @@ use CommonDBChild;
 use Glpi\Form\AccessControl\FormAccessControlManager;
 use Glpi\Form\AccessControl\FormAccessParameters;
 use Glpi\Form\Form;
-use Glpi\ItemTranslation\Context\TranslationHandler;
 use Glpi\Session\SessionInfo;
 use Html;
 use Override;
@@ -158,27 +157,11 @@ final class FormTile extends CommonDBChild implements TileInterface
     #[Override]
     public function listTranslationsHandlers(): array
     {
-        $handlers = [];
-        $key = sprintf('%s: %s', $this->getLabel(), $this->fields['title'] ?? NOT_AVAILABLE);
-        if (!empty($this->getTitle())) {
-            $handlers[$key][] = new TranslationHandler(
-                item: $this,
-                key: self::TRANSLATION_KEY_TITLE,
-                name: __('Title'),
-                value: $this->getTitle()
-            );
-        }
-        if (!empty($this->getDescription())) {
-            $handlers[$key][] = new TranslationHandler(
-                item: $this,
-                key: self::TRANSLATION_KEY_DESCRIPTION,
-                name: __('Description'),
-                value: $this->getDescription(),
-                is_rich_text: true,
-            );
-        }
-
-        return $handlers;
+        /**
+         * Title and descriptioin are already translated in the form
+         * so we don't need to add them here.
+         */
+        return [];
     }
 
     public function getFormId(): int

--- a/src/Glpi/Helpdesk/Tile/GlpiPageTile.php
+++ b/src/Glpi/Helpdesk/Tile/GlpiPageTile.php
@@ -35,6 +35,7 @@
 namespace Glpi\Helpdesk\Tile;
 
 use CommonDBTM;
+use Glpi\Helpdesk\HelpdeskTranslation;
 use Glpi\ItemTranslation\Context\ProvideTranslationsInterface;
 use Glpi\ItemTranslation\Context\TranslationHandler;
 use Glpi\Session\SessionInfo;
@@ -159,6 +160,7 @@ final class GlpiPageTile extends CommonDBTM implements TileInterface, ProvideTra
         $this->deleteChildrenAndRelationsFromDb(
             [
                 Item_Tile::class,
+                HelpdeskTranslation::class,
             ]
         );
     }

--- a/src/Glpi/Helpdesk/Tile/TileInterface.php
+++ b/src/Glpi/Helpdesk/Tile/TileInterface.php
@@ -34,14 +34,10 @@
 
 namespace Glpi\Helpdesk\Tile;
 
-use Glpi\ItemTranslation\Context\ProvideTranslationsInterface;
 use Glpi\Session\SessionInfo;
 
-interface TileInterface extends ProvideTranslationsInterface
+interface TileInterface
 {
-    public const TRANSLATION_KEY_TITLE = 'title';
-    public const TRANSLATION_KEY_DESCRIPTION = 'description';
-
     public function getLabel(): string;
 
     public function getTitle(): string;

--- a/templates/pages/helpdesk/index.html.twig
+++ b/templates/pages/helpdesk/index.html.twig
@@ -108,6 +108,10 @@
 
                 <div class="row">
                     {% for tile in tiles %}
+                        {# Check if the tile provides translations #}
+                        {# Actually, only FormTile does not provide translations because its title and description are already translated in the form itself #}
+                        {% set is_tile_provide_translations = tile is instanceof('Glpi\\ItemTranslation\\Context\\ProvideTranslationsInterface') %}
+
                         <div class="col-12 col-sm-6 col-md-4 d-flex">
                             <a
                                 class="card mx-1 my-2 flex-grow-1"
@@ -120,10 +124,19 @@
                                         </div>
                                         <div class="ms-4">
                                             <h2 class="card-title mb-2">
-                                                {{ translate_item_key(tile, constant('TRANSLATION_KEY_TITLE', tile)) }}
+                                                {% if is_tile_provide_translations %}
+                                                    {{ translate_item_key(tile, constant('TRANSLATION_KEY_TITLE', tile)) }}
+                                                {% else %}
+                                                    {{ tile.getTitle() }}
+                                                {% endif %}
                                             </h2>
                                             <div class="text-secondary remove-last-tinymce-margin">
-                                                {{ translate_item_key(tile, constant('TRANSLATION_KEY_DESCRIPTION', tile))|safe_html }}
+                                                {# If the tile provides translations, use the translation handler to get the description #}
+                                                {% if is_tile_provide_translations %}
+                                                    {{ translate_item_key(tile, constant('TRANSLATION_KEY_DESCRIPTION', tile))|safe_html }}
+                                                {% else %}
+                                                    {{ tile.getDescription()|safe_html }}
+                                                {% endif %}
                                             </div>
                                         </div>
                                     </div>


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Same as https://github.com/glpi-project/glpi/pull/20507 but for helpdesk translations.

I also took the opportunity to remove the "double translation" from the forms with `FormTile`.