### PR TITLE
Fix form editor drag and drop on chrome based browsers

### DIFF
--- a/css/includes/components/form/_form-editor.scss
+++ b/css/includes/components/form/_form-editor.scss
@@ -51,7 +51,6 @@
 
             [data-glpi-form-editor-question-drag-merge] {
                 position: relative;
-                width: 15%;
             }
 
             [data-glpi-form-editor-toolbar] {

--- a/js/modules/Forms/EditorController.js
+++ b/js/modules/Forms/EditorController.js
@@ -919,6 +919,11 @@ export class GlpiFormEditorController
                 .removeAttr(`data-glpi-form-editor-active-${type}`);
         });
 
+        // Nothing selected, stop here to avoid triggering lazy loading on null.
+        if (item_container === null) {
+            return;
+        }
+
         // Lazy load descriptions
         item_container.find('textarea[data-glpi-loaded=false]').each(function() {
             // Get editor config for this field


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.

## Description

Drag and drop wasn't working on chrome due to a CSS directive (width: 15%).

@ccailly Can you check with this CSS was needed? What do we lose by removing it?

## References

Fix #19737.


