### PR TITLE
Prevent non-administrators from enabling debug mode from preferences

### DIFF
--- a/phpunit/functional/UserTest.php
+++ b/phpunit/functional/UserTest.php
@@ -2359,4 +2359,43 @@ class UserTest extends \DbTestCase
         $this->assertEquals(\Auth::LDAP, $it['authtype']);
         $this->assertEquals(2, $it['auths_id']);
     }
+
+    public static function onlyAdministatorsCanEnableDebugModeInPreferencesProvider(): iterable
+    {
+        yield [
+            'user' => 'glpi',
+            'can_toggle_debug_mode' => true
+        ];
+        yield [
+            'user' => 'tech',
+            'can_toggle_debug_mode' => false
+        ];
+        yield [
+            'user' => 'normal',
+            'can_toggle_debug_mode' => false
+        ];
+        yield [
+            'user' => 'post-only',
+            'can_toggle_debug_mode' => false
+        ];
+    }
+
+    #[DataProvider('onlyAdministatorsCanEnableDebugModeInPreferencesProvider')]
+    public function testOnlyAdministatorsCanEnableDebugModeInPreferences(
+        string $user,
+        bool $can_toggle_debug_mode
+    ): void {
+        // Act: login as user and edit user preferences
+        $this->login($user);
+        (new User())->update([
+            'id' => \Session::getLoginUserID(),
+            'use_mode' => \Session::DEBUG_MODE,
+        ]);
+
+        // Assert: check if debug mode was enabled
+        $this->assertEquals(
+            $can_toggle_debug_mode,
+            $_SESSION['glpi_use_mode'] === \Session::DEBUG_MODE
+        );
+    }
 }

--- a/src/User.php
+++ b/src/User.php
@@ -2888,6 +2888,7 @@ HTML;
 
         $anonymize_config = Entity::getAnonymizeConfig();
         TemplateRenderer::getInstance()->display('pages/admin/user/user.html.twig', [
+            'is_administrator' => Config::canUpdate(),
             'item' => $this,
             'is_preference_form' => true,
             'timezones' => $DB->getTimezones(),

--- a/src/User.php
+++ b/src/User.php
@@ -1302,6 +1302,7 @@ class User extends CommonDBTM implements TreeBrowseInterface
             if (
                 isset($input['use_mode'])
                 && ($_SESSION['glpi_use_mode'] !=  $input['use_mode'])
+                && Config::canUpdate()
             ) {
                 $_SESSION['glpi_use_mode'] = $input['use_mode'];
                 unset($_SESSION['glpimenu']); // Force menu regeneration

--- a/templates/pages/admin/user/user.html.twig
+++ b/templates/pages/admin/user/user.html.twig
@@ -237,10 +237,13 @@
                                     }]) %}
                                 {% endset %}
                                 {{ fields.htmlField('lang_dropdown', lang_dropdown, __('Language')) }}
-                                {{ fields.dropdownArrayField('use_mode', item.fields['use_mode'], {
-                                    (constant('Session::NORMAL_MODE')): __('Normal'),
-                                    (constant('Session::DEBUG_MODE')): __('Debug'),
-                                }, __('Use GLPI in mode')) }}
+
+                                {% if is_administrator %}
+                                    {{ fields.dropdownArrayField('use_mode', item.fields['use_mode'], {
+                                        (constant('Session::NORMAL_MODE')): __('Normal'),
+                                        (constant('Session::DEBUG_MODE')): __('Debug'),
+                                    }, __('Use GLPI in mode')) }}
+                                {% endif %}
                             {% endif %}
 
                             {{ fields.smallTitle(__('Contact information')) }}


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Prevent non-administrators from enabling debug mode from preferences and remove the "Use glpi in mode" setting from the user preferences.

## Reference 

Fix #20561.

