### PR TITLE
Fix $tabnum being a string instead of an integer

### DIFF
--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -679,7 +679,7 @@ class CommonGLPI implements CommonGLPIInterface
                     $options['itemtype'] = $itemtype;
                     Plugin::doHook(Hooks::PRE_SHOW_TAB, [ 'item' => $item, 'options' => &$options]);
                     Profiler::getInstance()->start(get_class($obj) . '::displayTabContentForItem');
-                    $ret = $obj->displayTabContentForItem($item, $tabnum, $withtemplate);
+                    $ret = $obj->displayTabContentForItem($item, (int) $tabnum, $withtemplate);
                     Profiler::getInstance()->stop(get_class($obj) . '::displayTabContentForItem');
 
                     Plugin::doHook(Hooks::POST_SHOW_TAB, ['item' => $item, 'options' => $options]);

--- a/src/Webhook.php
+++ b/src/Webhook.php
@@ -796,27 +796,27 @@ class Webhook extends CommonDBTM implements FilterableInterface
             return false;
         }
 
-        if ((int) $tabnum === 1) {
+        if ($tabnum === 1) {
             $item->showSecurityForm();
             return true;
         }
 
-        if ((int) $tabnum === 2) {
+        if ($tabnum === 2) {
             $item->showPayloadEditor();
             return true;
         }
 
-        if ((int) $tabnum === 3) {
+        if ($tabnum === 3) {
             $item->showCustomHeaders();
             return true;
         }
 
-        if ((int) $tabnum === 4) {
+        if ($tabnum === 4) {
             $item->showSentQueries();
             return true;
         }
 
-        if ((int) $tabnum === 5) {
+        if ($tabnum === 5) {
             $item->showPreviewForm();
             return true;
         }


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.

## Description

According to its documentation, `displayTabContentForItem` accept only `int` for its `tabnum` property.

<img width="903" height="337" alt="image" src="https://github.com/user-attachments/assets/c9a9aca2-6bba-4da6-bb43-9c6900832711" />

However, this is not what happens in reality because we use the result of `explode`, which is a string:

<img width="815" height="642" alt="image" src="https://github.com/user-attachments/assets/e990b9dd-97b0-407b-9097-9b08e0128e70" />

This lead to issue for two tabs on itil templates and documents as they try to do some strict comparison:

<img width="890" height="253" alt="image" src="https://github.com/user-attachments/assets/36d6f58c-96e7-4595-95af-3b34fd71b8df" />

<img width="970" height="184" alt="image" src="https://github.com/user-attachments/assets/079a418a-4344-40b5-8034-94f939d5374c" />

Rather than casting the two values in these two methods, I've fixed the main method call to make sure we send the expected `int` value as this is what the phpdoc suggest.

I've also removed cast for the webhook class as they are no longer needed after this change.

## References

Fix #20536.


