### PR TITLE
Fix remaining legitimate Psalm issues

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -16,16 +16,20 @@
     </projectFiles>
 
     <issueHandlers>
-        <!-- Suppress some errors for now, to make the report readable and handle error type one by one -->
+        <!--
+            Too many false positives.
+            - many are already secured by ForbidDynamicInstantiationRule, but Psalm does not seems to consider `is_a()` checks safe enough;
+            - many are related dynamic call to plugin functions/classes, we need a lot of refactor to indicate to Psalm these can be ignored;
+            - the rest is likely to not be exploitable, due to the really low probability to have a classname
+              that can be abused and that implements the specific static method called on a dynamic classname.
+        -->
         <TaintedCallable errorLevel="suppress" />
-        <TaintedCookie errorLevel="suppress" />
-        <TaintedFile errorLevel="suppress" />
-        <!-- <TaintedHeader errorLevel="suppress" /> -->
-        <!-- <TaintedHtml errorLevel="suppress" /> -->
-        <!-- <TaintedInclude errorLevel="suppress" /> -->
+
+        <!--
+            It is nearly impossible to conditionally suppress false-positive errors on the current code.
+            There is a lot of refactoring to do to be able to separate LDAP DN/filter definition from user input
+            between legitimate cases (filter defined by an admin, import by DN, ...) and the unexpected cases.
+        -->
         <TaintedLdap errorLevel="suppress" />
-        <TaintedSSRF errorLevel="suppress" />
-        <!-- <TaintedSql errorLevel="suppress" /> -->
-        <!-- <TaintedTextWithQuotes errorLevel="suppress" /> -->
     </issueHandlers>
 </psalm>

--- a/src/UploadHandler.php
+++ b/src/UploadHandler.php
@@ -1209,12 +1209,18 @@ class UploadHandler
         return substr($this->options['param_name'], 0, -1);
     }
 
+    /**
+     * @psalm-taint-escape file (`$this->basename()` forces path safeness)
+     */
     protected function get_file_name_param()
     {
         $name = $this->get_singular_param_name();
         return $this->basename(stripslashes($this->get_query_param($name)));
     }
 
+    /**
+     * @psalm-taint-escape file (`$this->basename()` forces path safeness)
+     */
     protected function get_file_names_params()
     {
         $params = $this->get_query_param($this->options['param_name']);


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

I keep the `TaintedCallable` and `TaintedLdap` errors suppression config. These are pretty hard to handle with our current code and with the current Psalm limitations.
Anyway, the initial purpose was to detect potential XSS, and lots of issues were detected. Maybe there are false negatives, but we may improve the configuration later.
