### PR TITLE
Improve search config UI

### DIFF
--- a/templates/components/search/displaypreference_list.html.twig
+++ b/templates/components/search/displaypreference_list.html.twig
@@ -61,7 +61,7 @@
                                         {% do call('Html::showMassiveActionCheckBox', ['DisplayPreference', pref['itemtype']]) %}
                                     </span>
                                 {% endif %}
-                                <button type="button" class="btn btn-ghost-secondary p-0 btn-itemtype-pref overflow-hidden" data-itemtype="{{ pref['itemtype'] }}">
+                                <button type="button" class="btn btn-ghost-secondary p-0 btn-itemtype-pref overflow-hidden" data-itemtype="{{ pref['itemtype'] }}" title="{{ name }}">
                                     <i class="{{ pref['itemtype']|itemtype_icon }} me-1"></i>
                                     <span class="text-truncate">
                                         {{ name }}

--- a/templates/components/search/displaypreference_list.html.twig
+++ b/templates/components/search/displaypreference_list.html.twig
@@ -54,16 +54,18 @@
                 <div class="display-prefs-list row g-2 mt-1">
                     {% for pref in preferences %}
                         {% set name = pref['itemtype']|itemtype_name(1)|default(pref['itemtype']) %}
-                        <div class="col-3 displayed-itemtype">
-                            <div class="bg-gray-300 border border-gray-200 p-3 rounded-2">
+                        <div class="col-12 col-sm-6 col-xl-4 col-xxl-3 displayed-itemtype">
+                            <div class="bg-gray-300 border border-gray-200 p-3 rounded-2 d-flex">
                                 {% if massiveactionparams['specific_actions']|length > 0 %}
                                     <span class="me-2">
                                         {% do call('Html::showMassiveActionCheckBox', ['DisplayPreference', pref['itemtype']]) %}
                                     </span>
                                 {% endif %}
-                                <button type="button" class="btn btn-ghost-secondary p-0 btn-itemtype-pref" data-itemtype="{{ pref['itemtype'] }}">
+                                <button type="button" class="btn btn-ghost-secondary p-0 btn-itemtype-pref overflow-hidden" data-itemtype="{{ pref['itemtype'] }}">
                                     <i class="{{ pref['itemtype']|itemtype_icon }} me-1"></i>
-                                    {{ name }}
+                                    <span class="text-truncate">
+                                        {{ name }}
+                                    </span>
                                 </button>
                             </div>
                         </div>


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.

## Description

Add breakpoints to display one/two/three/four items per line depending on screen size:

<img width="535" height="523" alt="image" src="https://github.com/user-attachments/assets/6d1051ac-3ccb-4a8f-a57e-09bc43a96020" />

  
  
Hide long content behind text ellipsis:

<img width="1264" height="235" alt="image" src="https://github.com/user-attachments/assets/99b3146c-c640-45be-8923-be9b68214dd2" />


## References

Fix #20553

