### PR TITLE
Update SNMP v3 protocols definitions

### DIFF
--- a/src/SNMPCredential.php
+++ b/src/SNMPCredential.php
@@ -152,6 +152,14 @@ class SNMPCredential extends CommonDBTM
                 return 'MD5';
             case 2:
                 return 'SHA';
+            case 3:
+                return 'SHA224';
+            case 4:
+                return 'SHA256';
+            case 5:
+                return 'SHA384';
+            case 6:
+                return 'SHA512';
             default:
                 return '';
         }
@@ -170,8 +178,12 @@ class SNMPCredential extends CommonDBTM
                 return 'DES';
             case 2:
                 return 'AES';
-            case 5:
+            case 3:
                 return '3DES';
+            case 4:
+                return 'AES192C';
+            case 5:
+                return 'AES256C';
             default:
                 return '';
         }

--- a/templates/components/form/snmpcredential.html.twig
+++ b/templates/components/form/snmpcredential.html.twig
@@ -72,7 +72,7 @@
    {{ fields.dropdownArrayField(
       'authentication',
       item.fields['authentication'],
-      {0: '-----', 1: 'MD5', 2: 'SHA'},
+      {0: '-----', 1: 'MD5', 2: 'SHA', 3: 'SHA224', 4: 'SHA256', 5: 'SHA384', 6: 'SHA512'},
       __('Encryption protocol for authentication '),
       {
          add_field_attribs: {
@@ -99,7 +99,7 @@
    {{ fields.dropdownArrayField(
       'encryption',
       item.fields['encryption'],
-      {0: '-----', 1: 'DES', 2: 'AES128', 3: 'Triple-DES'},
+      {0: '-----', 1: 'DES', 2: 'AES128', 3: 'Triple-DES', 4: 'Cisco AES192', 5: 'Cisco AES256'},
       __('Encryption protocol for data'),
       {
          add_field_attribs: {


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] This change requires a documentation update.

## Description

- First it fixes triple-DES support as getEncryption() API wasn't reporting it for value "3". As far I can see this bug was still present in FusionInventory plugin.
- Secondly it adds definitions for new auth protocols (sha224, sha256, sha384 and sha512) and priv protocols (Cisco AES192 & AES256). The use of these protocols will actually requires to use current glpi-agent nightly build. It also requires Net::SNMP v6.0.1 perl library on the system, but this is the case for all recent linux distro and glpi-agent MacOS & Windows builds. These conditions may require a documentation update.
- Here is a brief description of what this PR does:
  - `getEncryption()` method now returns "3DES" as expected for value "3" as it should
  - Twig templates includes new values for new protocols and `getEncryption()` & `getAuthProtocol()` APIs returns the string expected by glpi-agent.

## Screenshots:

Dropdown for Authentication protocols:
<img width="1870" height="574" alt="image" src="https://github.com/user-attachments/assets/42c08333-828e-4d7c-afa8-512c019593df" />

Dropdown for Private protocols:
<img width="1170" height="528" alt="image" src="https://github.com/user-attachments/assets/4735bc0e-33c0-42b3-a4fd-f21776af2e4a" />

GLPI-Agent debug2 output showing it receives expected protocols for a SHA256/AES256 netdiscovery task in response to PROLOG request:
```
[debug2] [http client] sending message:
<?xml version="1.0" encoding="UTF-8"?>
<REQUEST>
  <DEVICEID>rog-2025-06-23-13-06-29</DEVICEID>
  <QUERY>PROLOG</QUERY>
  <TOKEN>12345678</TOKEN>
</REQUEST>
...
[debug2] format: Zlib
[debug2] [http client] receiving message:
<?xml version="1.0"?>
<REPLY><PROLOG_FREQ>24</PROLOG_FREQ><RESPONSE>SEND</RESPONSE><OPTION><NAME>NETDISCOVERY</NAME><PARAM THREADS_DISCOVERY="20" TIMEOUT="1" PID="8"/><RANGEIP ID="1" IPSTART="192.168.7.1" IPEND="192.168.7.2" ENTITY="0"/><AUTHENTICATION><ID>3</ID><VERSION>3</VERSION><USERNAME>test</USERNAME><AUTHPROTOCOL>SHA256</AUTHPROTOCOL><AUTHPASSPHRASE>********</AUTHPASSPHRASE><PRIVPROTOCOL>AES256C</PRIVPROTOCOL><PRIVPASSPHRASE>********</PRIVPASSPHRASE></AUTHENTICATION></OPTION></REPLY>
...
[info] running task NetDiscovery
```
