### PR TITLE
Fix closed change rendering

### DIFF
--- a/phpunit/functional/ChangeTest.php
+++ b/phpunit/functional/ChangeTest.php
@@ -207,7 +207,7 @@ class ChangeTest extends DbTestCase
         ]);
 
         // Initial status is new (incoming)
-        $this->assertSame(\CommonITILObject::INCOMING, $change->fields['status']);
+        $this->assertSame(CommonITILObject::INCOMING, $change->fields['status']);
 
         $change->update([
             'id' => $changes_id,
@@ -222,12 +222,12 @@ class ChangeTest extends DbTestCase
         // Verify user was assigned and status doesn't change
         $change->loadActors();
         $this->assertSame(1, $change->countUsers(\CommonITILActor::ASSIGN));
-        $this->assertSame(\CommonITILObject::INCOMING, $change->fields['status']);
+        $this->assertSame(CommonITILObject::INCOMING, $change->fields['status']);
 
         // Change status to accepted
         $change->update([
             'id' => $changes_id,
-            'status' => \CommonITILObject::ACCEPTED,
+            'status' => CommonITILObject::ACCEPTED,
         ]);
         // Unassign change and expect the status to stay accepted
         $change_user = new \Change_User();
@@ -238,7 +238,7 @@ class ChangeTest extends DbTestCase
         ]);
         $change->getFromDB($changes_id);
         $this->assertSame(0, $change->countUsers(\CommonITILActor::ASSIGN));
-        $this->assertSame(\CommonITILObject::ACCEPTED, $change->fields['status']);
+        $this->assertSame(CommonITILObject::ACCEPTED, $change->fields['status']);
     }
 
     public function testAddAdditionalActorsDuplicated()
@@ -288,7 +288,7 @@ class ChangeTest extends DbTestCase
         ]);
         $this->assertGreaterThan(0, $changes_id);
         // Even when automatically assigning a user, the initial status should be set to New
-        $this->assertSame(\CommonITILObject::INCOMING, $change->fields['status']);
+        $this->assertSame(CommonITILObject::INCOMING, $change->fields['status']);
     }
 
     public function testStatusWhenSolutionIsRefused()
@@ -300,7 +300,7 @@ class ChangeTest extends DbTestCase
             'content' => "test initial status",
             'entities_id' => getItemByTypeName('Entity', '_test_root_entity', true),
             '_users_id_assign' => getItemByTypeName('User', TU_USER, true),
-            'status'    => \CommonITILObject::SOLVED,
+            'status'    => CommonITILObject::SOLVED,
         ]);
         $this->assertGreaterThan(0, $changes_id);
 
@@ -312,13 +312,13 @@ class ChangeTest extends DbTestCase
             'users_id_editor' => getItemByTypeName('User', TU_USER, true),
             'content' => 'Test followup content',
             'requesttypes_id' => 1,
-            'timeline_position' => \CommonITILObject::TIMELINE_LEFT,
+            'timeline_position' => CommonITILObject::TIMELINE_LEFT,
             'add_reopen' => '',
         ]);
         $this->assertGreaterThan(0, $followup_id);
 
         $item = $change->getById($changes_id);
-        $this->assertSame(\CommonITILObject::INCOMING, $item->fields['status']);
+        $this->assertSame(CommonITILObject::INCOMING, $item->fields['status']);
     }
 
     public function testSearchOptions()

--- a/phpunit/functional/ChangeTest.php
+++ b/phpunit/functional/ChangeTest.php
@@ -35,6 +35,7 @@
 namespace tests\units;
 
 use Change;
+use CommonITILObject;
 use DbTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
@@ -480,6 +481,26 @@ class ChangeTest extends DbTestCase
         $html = ob_get_clean();
 
         // Assert: make sure some html was generated
+        $this->assertNotEmpty($html);
+    }
+
+    public function testShowFormClosedItem(): void
+    {
+        // Arrange: prepare an empty change
+        $change = $this->createItem(Change::class, [
+            'name'        => "My change",
+            'content'     => "My description",
+            'entities_id' => $this->getTestRootEntity(only_id: true),
+            'status'      => CommonITILObject::CLOSED,
+        ]);
+
+        // Act: render form for a new change
+        $this->login();
+        ob_start();
+        $change->showForm($change->getID());
+        $html = ob_get_clean();
+
+        // Assert: make sure some html was generated and no errors were thrown
         $this->assertNotEmpty($html);
     }
 

--- a/phpunit/functional/ProblemTest.php
+++ b/phpunit/functional/ProblemTest.php
@@ -329,8 +329,8 @@ class ProblemTest extends DbTestCase
     public function testShowFormClosedItem(): void
     {
         // Arrange: prepare an empty change
-        $change = $this->createItem(Problem::class, [
-            'name'        => "My change",
+        $problem = $this->createItem(Problem::class, [
+            'name'        => "My problem",
             'content'     => "My description",
             'entities_id' => $this->getTestRootEntity(only_id: true),
             'status'      => CommonITILObject::CLOSED,
@@ -339,7 +339,7 @@ class ProblemTest extends DbTestCase
         // Act: render form for a new change
         $this->login();
         ob_start();
-        $change->showForm($change->getID());
+        $problem->showForm($problem->getID());
         $html = ob_get_clean();
 
         // Assert: make sure some html was generated and no errors were thrown

--- a/phpunit/functional/ProblemTest.php
+++ b/phpunit/functional/ProblemTest.php
@@ -34,6 +34,7 @@
 
 namespace tests\units;
 
+use CommonITILObject;
 use DbTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Problem;
@@ -322,6 +323,26 @@ class ProblemTest extends DbTestCase
         $html = ob_get_clean();
 
         // Assert: make sure some html was generated
+        $this->assertNotEmpty($html);
+    }
+
+    public function testShowFormClosedItem(): void
+    {
+        // Arrange: prepare an empty change
+        $change = $this->createItem(Problem::class, [
+            'name'        => "My change",
+            'content'     => "My description",
+            'entities_id' => $this->getTestRootEntity(only_id: true),
+            'status'      => CommonITILObject::CLOSED,
+        ]);
+
+        // Act: render form for a new change
+        $this->login();
+        ob_start();
+        $change->showForm($change->getID());
+        $html = ob_get_clean();
+
+        // Assert: make sure some html was generated and no errors were thrown
         $this->assertNotEmpty($html);
     }
 

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -11242,8 +11242,8 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
     }
 
     /**
-     * Is the current user a requester of the current ticket and have the right
-     * to update it?
+     * Is the current user a requester of the current itil item and does he have
+     * the right to update it?
      *
      * @return bool
      */

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -668,6 +668,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
             'canupdate'               => $canupdate,
             'canpriority'             => $canupdate,
             'canassign'               => $canupdate,
+            'can_requester'           => $this->canRequesterUpdateItem(),
             'has_pending_reason'      => PendingReason_Item::getForItem($this) !== false,
         ]);
 
@@ -7914,10 +7915,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
 
     public static function showEditDescriptionForm(CommonITILObject $item)
     {
-        $can_requester = true;
-        if (method_exists($item, "canRequesterUpdateItem")) {
-            $can_requester = $item->canRequesterUpdateItem();
-        }
+        $can_requester = $item->canRequesterUpdateItem();
         TemplateRenderer::getInstance()->display('components/itilobject/timeline/simple_form.html.twig', [
             'item'          => $item,
             'canupdate'     => (Session::getCurrentInterface() == "central" && $item->canUpdateItem()),
@@ -11241,5 +11239,16 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
             'allow_auto_submit' => false,
             'main_rand' => mt_rand(),
         ]);
+    }
+
+    /**
+     * Is the current user a requester of the current ticket and have the right
+     * to update it?
+     *
+     * @return bool
+     */
+    public function canRequesterUpdateItem()
+    {
+        return true;
     }
 }

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -589,12 +589,7 @@ class Ticket extends CommonITILObject implements DefaultSearchRequestInterface
         return self::canupdate();
     }
 
-
-    /**
-     * Is the current user is a requester of the current ticket and have the right to update it ?
-     *
-     * @return boolean
-     */
+    #[Override]
     public function canRequesterUpdateItem()
     {
         return ($this->isUser(CommonITILActor::REQUESTER, Session::getLoginUserID())


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Fix a missing twig variable preventing a closed change or problem to be displayed.

After investigation, I saw that the missing variable was linked to some logic specific to the ticket but used in the parent itil object class.
I've improved it by moving the default behavior into a dedicated method than can then be overridden properly by the ticket class.

