### PR TITLE
Add Psalm annotations to detect unescaped translations

### DIFF
--- a/src/autoload/i18n.php
+++ b/src/autoload/i18n.php
@@ -50,6 +50,9 @@ $DEFAULT_PLURAL_NUMBER = 2;
  * @param string $domain domain used (default is glpi, may be plugin name)
  *
  * @return string translated string
+ *
+ * @psalm-taint-source html (translated message can contain unexpected HTML special chars)
+ * @psalm-taint-source has_quotes (translated message can contain quotes not present in the translation key)
  */
 function __($str, $domain = 'glpi')
 {
@@ -120,6 +123,9 @@ function _sx($ctx, $str, $domain = 'glpi')
  * @param string  $domain domain used (default is glpi, may be plugin name)
  *
  * @return string translated string
+ *
+ * @psalm-taint-source html (translated message can contain unexpected HTML special chars)
+ * @psalm-taint-source has_quotes (translated message can contain quotes not present in the translation key)
  */
 function _n($sing, $plural, $nb, $domain = 'glpi')
 {


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Psalm does not understand that the result of `__()` and `_n()` can contain quotes or HTML special chars.
I did not investigate to find the reason behind that, as I am not willing to start some kind of reverse engineering to find the root cause of this.
To indicate that `__()` and `_n()` are not safe, I added the proper Psalm annotations.

I will push a second commit later to fix the detected issues.