### PR TITLE
Fix breadcrumbs and type name for enclosure items

### DIFF
--- a/front/item_enclosure.form.php
+++ b/front/item_enclosure.form.php
@@ -76,5 +76,5 @@ if (isset($_REQUEST['id'])) {
     ];
 }
 
-$menus = ["management", "enclosure"];
+$menus = ["assets", Enclosure::class];
 Item_Enclosure::displayFullPageForItem($_REQUEST['id'] ?? 0, $menus, $params);

--- a/src/Item_Enclosure.php
+++ b/src/Item_Enclosure.php
@@ -47,7 +47,7 @@ class Item_Enclosure extends CommonDBRelation
 
     public static function getTypeName($nb = 0)
     {
-        return _n('Item', 'Item', $nb);
+        return _n('Enclosure item', 'Enclosure items', $nb);
     }
 
 


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.

## Description

Before:

<img width="613" height="263" alt="image" src="https://github.com/user-attachments/assets/558fae4f-2fe3-4577-9a6c-346220cecbc2" />

After:

<img width="604" height="292" alt="image" src="https://github.com/user-attachments/assets/cadd81ed-9ec3-4d40-8684-7904f57b8a95" />

As a side note, you might find the 'Add' and 'Template' menu suprising as they target the enclosure type, not the item enclosure type.
However, this is what we do for others similar types, see virtual machines on computers for example:

<img width="780" height="216" alt="image" src="https://github.com/user-attachments/assets/b9867dc3-45c2-448c-b5cf-607e5c3055d9" />


## References

Fix #20531.

