### PR TITLE
Add falback color to FG color in Widget Bars/Lines Graph

### DIFF
--- a/src/Glpi/Dashboard/Widget.php
+++ b/src/Glpi/Dashboard/Widget.php
@@ -1418,7 +1418,7 @@ TWIG, $twig_params);
             $echart_serie = [
                 'name'            => $serie['name'],
                 'type'            => 'line',
-                'color'           => $palette[$serie_i],
+                'color'           => $palette[$serie_i] ?? Toolbox::getFgColor($p['color']),
                 'data'            => $serie['data'],
                 'smooth'          => 0.4,
                 'lineStyle'       => [


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
## Description
It fixes an undefined array key warning that could be thrown when the widget palette had no data.

In that case I've set a fallback to the FG Color so the series is visible with the main color.

The warning could also been thrown if it got too many series compared to the number of colors available in the palette.

## Screenshots
<img width="560" height="545" alt="image" src="https://github.com/user-attachments/assets/b08ae4bc-0adb-445b-b275-f92608d5ad9b" />
