### PR TITLE
Make DBConnection inherit CommonGLPI instead of CommonDBTM

### DIFF
--- a/phpunit/functional/CommonDBTMTest.php
+++ b/phpunit/functional/CommonDBTMTest.php
@@ -206,7 +206,6 @@ class CommonDBTMTest extends DbTestCase
     public static function getTableProvider()
     {
         return [
-            [\DBConnection::class, ''], // "static protected $notable = true;" case
             [\Item_Devices::class, ''], // "static protected $notable = true;" case
             [\Config::class, 'glpi_configs'],
             [Computer::class, 'glpi_computers'],

--- a/src/DBConnection.php
+++ b/src/DBConnection.php
@@ -42,7 +42,7 @@ use function Safe\unlink;
 /**
  *  Database class for Mysql
  **/
-class DBConnection extends CommonDBTM
+class DBConnection extends CommonGLPI
 {
     /**
      * "Use timezones" property name.


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.

## Description

`DBConnection` do not have a database table and thus has no reason to be a `CommonDBTM`.

## References

Fix #20545.

Note: I did not test the exact scenario from the issue, but I see that the relevant code from the stack trace check explicitly the `CommonDBTM` type so there is no reason the issue should persist after this.

<img width="706" height="270" alt="image" src="https://github.com/user-attachments/assets/3d35ad38-225f-461c-99b1-49f2e687a018" />

