### PR TITLE
Fix printer graphs and infocom report charts

### DIFF
--- a/src/Glpi/Dashboard/Widget.php
+++ b/src/Glpi/Dashboard/Widget.php
@@ -751,24 +751,28 @@ HTML;
         // language=Twig
         $js = TemplateRenderer::getInstance()->renderFromStringTemplate(<<<TWIG
             <script type="module">
-                const target = GLPI.Dashboard.getActiveDashboard() ?
-                    GLPI.Dashboard.getActiveDashboard().element.find('#{{ chart_id }} .chart')
-                    : $('#{{ chart_id }} .chart');
-                const myChart = echarts.init(target[0]);
-                myChart.setOption({{ options|json_encode|raw }});
-                myChart
-                    .on('click', function (params) {
-                        const data_url = _.get(params, 'data.url', '');
-                        if (data_url.length > 0) {
-                            window.location.href = data_url;
-                        }
-                    });
+                (async () => {
+                    await import('/js/modules/Dashboard/Dashboard.js');
 
-                target.on('mouseover', () => {
-                    myChart.setOption({'toolbox': {'show': true}});
-                }).on('mouseout', () => {
-                    myChart.setOption({'toolbox': {'show': false}});
-                });
+                    const target = GLPI.Dashboard.getActiveDashboard() ?
+                        GLPI.Dashboard.getActiveDashboard().element.find('#{{ chart_id }} .chart')
+                        : $('#{{ chart_id }} .chart');
+                    const myChart = echarts.init(target[0]);
+                    myChart.setOption({{ options|json_encode|raw }});
+                    myChart
+                        .on('click', function (params) {
+                            const data_url = _.get(params, 'data.url', '');
+                            if (data_url.length > 0) {
+                                window.location.href = data_url;
+                            }
+                        });
+
+                    target.on('mouseover', () => {
+                        myChart.setOption({'toolbox': {'show': true}});
+                    }).on('mouseout', () => {
+                        myChart.setOption({'toolbox': {'show': false}});
+                    });
+                })();
             </script>
 TWIG, $twig_params);
 
@@ -1198,55 +1202,59 @@ HTML;
         // language=Twig
         $js = TemplateRenderer::getInstance()->renderFromStringTemplate(<<<TWIG
             <script type="module">
-                const target = GLPI.Dashboard.getActiveDashboard() ?
-                    GLPI.Dashboard.getActiveDashboard().element.find('#{{ chart_id }} .chart')
-                    : $('#{{ chart_id }} .chart');
-                const chart_options = {{ options|json_encode|raw }};
-                const palette = {{ palette|json_encode|raw }};
-                $.each(chart_options.series, function (index, serie) {
-                    if ({{ distributed ? 'true' : 'false' }}) {
-                        serie['itemStyle'] = {
-                            ...serie['itemStyle'],
-                            'color': (param) => palette[param.dataIndex]
-                        }
-                    }
-                    serie['label'] = {
-                        ...serie['label'],
-                        'formatter': (param) => param.data.value == 0 ? '' : param.data.value
-                    };
-                });
-                if ({{ horizontal ? 'true' : 'false' }}) {
-                    chart_options['xAxis'] = {
-                        ...chart_options['xAxis'],
-                        'axisLabel': {
-                            'formatter': (value) => {
-                                if (value < 1e3) {
-                                    return value;
-                                } else if (value < 1e6) {
-                                    return value / 1e3 + "K";
-                                } else {
-                                    return value / 1e6 + "M";
-                                }
+                (async () => {
+                    await import('/js/modules/Dashboard/Dashboard.js');
+
+                    const target = GLPI.Dashboard.getActiveDashboard() ?
+                        GLPI.Dashboard.getActiveDashboard().element.find('#{{ chart_id }} .chart')
+                        : $('#{{ chart_id }} .chart');
+                    const chart_options = {{ options|json_encode|raw }};
+                    const palette = {{ palette|json_encode|raw }};
+                    $.each(chart_options.series, function (index, serie) {
+                        if ({{ distributed ? 'true' : 'false' }}) {
+                            serie['itemStyle'] = {
+                                ...serie['itemStyle'],
+                                'color': (param) => palette[param.dataIndex]
                             }
                         }
-                    };
-                }
-
-                const myChart = echarts.init(target[0]);
-                myChart.setOption(chart_options);
-                myChart
-                    .on('click', function (params) {
-                        const data_url = _.get(params, 'data.url', '');
-                        if (data_url.length > 0) {
-                            window.location.href = data_url;
-                        }
+                        serie['label'] = {
+                            ...serie['label'],
+                            'formatter': (param) => param.data.value == 0 ? '' : param.data.value
+                        };
                     });
+                    if ({{ horizontal ? 'true' : 'false' }}) {
+                        chart_options['xAxis'] = {
+                            ...chart_options['xAxis'],
+                            'axisLabel': {
+                                'formatter': (value) => {
+                                    if (value < 1e3) {
+                                        return value;
+                                    } else if (value < 1e6) {
+                                        return value / 1e3 + "K";
+                                    } else {
+                                        return value / 1e6 + "M";
+                                    }
+                                }
+                            }
+                        };
+                    }
 
-                target.on('mouseover', () => {
-                    myChart.setOption({'toolbox': {'show': true}});
-                }).on('mouseout', () => {
-                    myChart.setOption({'toolbox': {'show': false}});
-                });
+                    const myChart = echarts.init(target[0]);
+                    myChart.setOption(chart_options);
+                    myChart
+                        .on('click', function (params) {
+                            const data_url = _.get(params, 'data.url', '');
+                            if (data_url.length > 0) {
+                                window.location.href = data_url;
+                            }
+                        });
+
+                    target.on('mouseover', () => {
+                        myChart.setOption({'toolbox': {'show': true}});
+                    }).on('mouseout', () => {
+                        myChart.setOption({'toolbox': {'show': false}});
+                    });
+                })();
             </script>
 TWIG, $twig_params);
 
@@ -1532,35 +1540,40 @@ HTML;
         // language=Twig
         $js = TemplateRenderer::getInstance()->renderFromStringTemplate(<<<TWIG
             <script type="module">
-                const target = GLPI.Dashboard.getActiveDashboard() ?
-                    GLPI.Dashboard.getActiveDashboard().element.find('#{{ chart_id }} .chart')
-                    : $('#{{ chart_id }} .chart');
-                const chart_options = {{ options|json_encode|raw }};
-                
-                $.each(chart_options.series, function (index, serie) {
-                    if ({{ show_points ? 'true' : 'false' }}) {
-                        serie['symbol'] = (value) => value > 0 ? 'circle': 'none';
-                    }
-                    if ({{ point_labels ? 'true' : 'false' }}) {
-                        serie['label']['formatter'] = (param) => param.data.value == 0 ? '': param.data.value;
-                    }
-                });
+                (async () => {
+                    await import('/js/modules/Dashboard/Dashboard.js');
 
-                const myChart = echarts.init(target[0]);
-                myChart.setOption(chart_options);
-                myChart
-                    .on('click', function (params) {
-                        const data_url = _.get(params, 'data.url', '');
-                        if (data_url.length > 0) {
-                            window.location.href = data_url;
+                    const target = GLPI.Dashboard.getActiveDashboard() ?
+                        GLPI.Dashboard.getActiveDashboard().element.find('#{{ chart_id }} .chart')
+                        : $('#{{ chart_id }} .chart');
+                    const chart_options = {{ options|json_encode|raw }};
+
+                    $.each(chart_options.series, function (index, serie) {
+                        if ({{ show_points ? 'true' : 'false' }}) {
+                            serie['symbol'] = (value) => value > 0 ? 'circle': 'none';
+                        }
+                        if ({{ point_labels ? 'true' : 'false' }}) {
+                            serie['label']['formatter'] = (param) => param.data.value == 0 ? '': param.data.value;
                         }
                     });
 
-                target.on('mouseover', () => {
-                    myChart.setOption({'toolbox': {'show': true}});
-                }).on('mouseout', () => {
-                    myChart.setOption({'toolbox': {'show': false}});
-                });
+                    const myChart = echarts.init(target[0]);
+                    myChart.setOption(chart_options);
+                    myChart
+                        .on('click', function (params) {
+                            const data_url = _.get(params, 'data.url', '');
+                            if (data_url.length > 0) {
+                                window.location.href = data_url;
+                            }
+                        });
+
+                    target.on('mouseover', () => {
+                        myChart.setOption({'toolbox': {'show': true}});
+                    }).on('mouseout', () => {
+                        myChart.setOption({'toolbox': {'show': false}});
+                    });
+
+                })();
             </script>
 TWIG, $twig_params);
 

--- a/src/PrinterLog.php
+++ b/src/PrinterLog.php
@@ -377,7 +377,7 @@ class PrinterLog extends CommonDBChild
         ]);
 
         // display graph
-        echo "<div class='dashboard printer_barchart pt-2'>";
+        echo "<div class='dashboard printer_barchart pt-2' data-testid='pages_barchart'>";
         echo Widget::multipleAreas($bar_conf);
         echo "</div>";
     }

--- a/tests/cypress/e2e/Asset/printer.cy.js
+++ b/tests/cypress/e2e/Asset/printer.cy.js
@@ -1,0 +1,46 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+describe("Printer", () => {
+    beforeEach(() => {
+        cy.login();
+    });
+
+    it('can view pages counter', () => {
+        cy.createWithAPI("Printer", {
+            name: 'Test printer',
+        }).then((id) => {
+            cy.visit(`/front/printer.form.php?id=${id}&forcetab=PrinterLog$0`);
+            cy.findByTestId('pages_barchart').find('canvas').should('exist');
+        });
+    });
+});


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

Fix missing scripts for the printer graph tab on printers and infocom reports.

This is caused by a bad practice, the code from the widgets class depends on some module that it doesn't load.
It works on the main dashboards page because we load the module there before loading the graphs in a separated ajax request, but it can't be replicated easily on the printer page because the graph and tab are in the same request and you can't make two independent scripts tags wait for each others.

I've fixed it by manually importing the module where it is needed.
This has no impact on the main dashboard page where the module was already loaded as browsers will only import modules once.

To review with whitespace change off, there are not much change but some code is wrapped in a anonymous methods so there is a lot of indentation changes.

## References

Fix #20530.
Fix #20543.


