### PR TITLE
Optimize counts in search queries

### DIFF
--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -2913,8 +2913,7 @@ final class SQLProvider implements SearchProviderInterface
                             $interlinkfield,
                             (bool) $meta,
                             $meta_type,
-                            $interjoinparams,
-                            $use_join_subquery
+                            $interjoinparams
                         ));
 
                         // No direct link with the previous joins

--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -2913,7 +2913,8 @@ final class SQLProvider implements SearchProviderInterface
                             $interlinkfield,
                             (bool) $meta,
                             $meta_type,
-                            $interjoinparams
+                            $interjoinparams,
+                            $use_join_subquery
                         ));
 
                         // No direct link with the previous joins
@@ -5047,7 +5048,8 @@ final class SQLProvider implements SearchProviderInterface
                 true,
                 $m_itemtype,
                 $sopt["joinparams"],
-                $sopt["field"]
+                $sopt["field"],
+                $sopt['use_join_subquery'] ?? false
             );
         }
     }

--- a/src/Search.php
+++ b/src/Search.php
@@ -701,6 +701,7 @@ class Search
      * @param string  $meta_type            Meta item type
      * @param array   $joinparams           Array join parameters (condition / joinbefore...)
      * @param string  $field                Field to display (needed for translation join) (default '')
+     * @param bool    $is_counter           Is it a counter join? (default false)
      *
      * @return string Left join string
      **/
@@ -713,7 +714,8 @@ class Search
         $meta = false,
         $meta_type = '',
         $joinparams = [],
-        $field = ''
+        $field = '',
+        bool $is_counter = false
     ) {
         global $DB;
         $criteria = SQLProvider::getLeftJoinCriteria(
@@ -725,7 +727,8 @@ class Search
             (bool) $meta,
             (string) $meta_type,
             $joinparams,
-            $field
+            $field,
+            $is_counter
         );
         $iterator = new DBmysqlIterator($DB);
         $iterator->buildQuery([

--- a/src/Search.php
+++ b/src/Search.php
@@ -701,7 +701,7 @@ class Search
      * @param string  $meta_type            Meta item type
      * @param array   $joinparams           Array join parameters (condition / joinbefore...)
      * @param string  $field                Field to display (needed for translation join) (default '')
-     * @param bool    $is_counter           Is it a counter join? (default false)
+     * @param bool    $use_join_subquery    Use a subquery for the join (default false)
      *
      * @return string Left join string
      **/
@@ -715,7 +715,7 @@ class Search
         $meta_type = '',
         $joinparams = [],
         $field = '',
-        bool $is_counter = false
+        $use_join_subquery = false
     ) {
         global $DB;
         $criteria = SQLProvider::getLeftJoinCriteria(
@@ -728,7 +728,7 @@ class Search
             (string) $meta_type,
             $joinparams,
             $field,
-            $is_counter
+            $use_join_subquery
         );
         $iterator = new DBmysqlIterator($DB);
         $iterator->buildQuery([

--- a/src/User.php
+++ b/src/User.php
@@ -3583,6 +3583,7 @@ HTML;
             'forcegroupby'       => true,
             'usehaving'          => true,
             'datatype'           => 'count',
+            'use_join_subquery'  => true,
             'massiveaction'      => false,
             'joinparams'         => [
                 'beforejoin'         => [
@@ -3603,6 +3604,7 @@ HTML;
             'forcegroupby'       => true,
             'usehaving'          => true,
             'datatype'           => 'count',
+            'use_join_subquery'  => true,
             'massiveaction'      => false,
             'joinparams'         => [
                 'jointype'           => 'child',
@@ -3618,6 +3620,7 @@ HTML;
             'forcegroupby'       => true,
             'usehaving'          => true,
             'datatype'           => 'count',
+            'use_join_subquery'  => true,
             'massiveaction'      => false,
             'joinparams'         => [
                 'beforejoin'         => [


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !38556

Attempts to optimize the SQL search query when performing a `COUNT`, especially in user-related searches. Currently, up to three `searchoptions` can be used to count tickets linked to a user. When the database contains a large number of tickets and multiple such columns are selected, the query consumes significant resources and can crash GLPI if it takes too long.

The issue stems from `LEFT JOIN`s being executed before the count, forcing the database to process a large number of rows. This PR refactors the query to move the calculation into a subquery, on which the `LEFT JOIN` is then performed. This avoids multiplying intermediate rows and significantly reduces query overhead.

## Screenshots (if appropriate):


