### PR TITLE
Catch new deprecations in DBmysqliterator tests

### DIFF
--- a/phpunit/functional/DBmysqlIteratorTest.php
+++ b/phpunit/functional/DBmysqlIteratorTest.php
@@ -529,11 +529,10 @@ class DBmysqlIteratorTest extends DbTestCase
     {
         $it = $this->it->execute(['FROM' => 'foo', 'WHERE' => 'id=1']);
         $this->assertSame('SELECT * FROM `foo` WHERE id=1', $it->getSql());
-        // Uncomment in GLPI 11.1
-        // $this->hasPhpLogRecordThatContains(
-        //    'Passing SQL request criteria as strings is deprecated for security reasons.',
-        //    LogLevel::INFO
-        // );
+        $this->hasPhpLogRecordThatContains(
+            'Passing SQL request criteria as strings is deprecated for security reasons.',
+            LogLevel::INFO
+        );
 
         $it = $this->it->execute(['FROM' => 'foo', 'WHERE' => ['bar' => null]]);
         $this->assertSame('SELECT * FROM `foo` WHERE `bar` IS NULL', $it->getSql());
@@ -568,21 +567,19 @@ class DBmysqlIteratorTest extends DbTestCase
         foreach ([false, 0, '0'] as $false) {
             $it = $this->it->execute(['FROM' => 'foo', 'WHERE' => [$false]]);
             $this->assertSame('SELECT * FROM `foo` WHERE false', $it->getSql());
-            // Uncomment in GLPI 11.1
-            // $this->hasPhpLogRecordThatContains(
-            //     'Passing SQL request criteria as booleans is deprecated. Please use `new \Glpi\DBAL\QueryExpression("false");`',
-            //     LogLevel::INFO
-            // );
+            $this->hasPhpLogRecordThatContains(
+                'Passing SQL request criteria as booleans is deprecated. Please use `new \Glpi\DBAL\QueryExpression("false");`',
+                LogLevel::INFO
+            );
         }
 
         foreach ([true, 1, '1'] as $true) {
             $it = $this->it->execute(['FROM' => 'foo', 'WHERE' => [$true]]);
             $this->assertSame('SELECT * FROM `foo` WHERE true', $it->getSql());
-            // Uncomment in GLPI 11.1
-            // $this->hasPhpLogRecordThatContains(
-            //     'Passing SQL request criteria as booleans is deprecated. Please use `new \Glpi\DBAL\QueryExpression("true");`',
-            //     LogLevel::INFO
-            // );
+            $this->hasPhpLogRecordThatContains(
+                'Passing SQL request criteria as booleans is deprecated. Please use `new \Glpi\DBAL\QueryExpression("true");`',
+                LogLevel::INFO
+            );
         }
     }
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

It follows the merge of #20510 in the main branch. I forgot to uncomment the corresponding deprecation checks in tests.