### PR TITLE
Detect unused vars with Rector

### DIFF
--- a/install/migrations/update_0.90.0_to_0.90.1.php
+++ b/install/migrations/update_0.90.0_to_0.90.1.php
@@ -47,7 +47,6 @@ function update0900to0901()
     global $DB, $migration;
 
     $updateresult     = true;
-    $ADDTODISPLAYPREF = [];
 
     $migration->setVersion('0.90.1');
 

--- a/install/migrations/update_0.90.1_to_0.90.5.php
+++ b/install/migrations/update_0.90.1_to_0.90.5.php
@@ -47,7 +47,6 @@ function update0901to0905()
     global $DB, $migration;
 
     $updateresult     = true;
-    $ADDTODISPLAYPREF = [];
 
     $migration->setVersion('0.90.5');
 

--- a/install/migrations/update_9.1.0_to_9.1.1.php
+++ b/install/migrations/update_9.1.0_to_9.1.1.php
@@ -45,9 +45,7 @@ function update910to911()
      */
     global $DB, $migration;
 
-    $current_config   = Config::getConfigurationValues('core');
     $updateresult     = true;
-    $ADDTODISPLAYPREF = [];
 
     $migration->setVersion('9.1.1');
 

--- a/install/migrations/update_9.1.1_to_9.1.3.php
+++ b/install/migrations/update_9.1.1_to_9.1.3.php
@@ -45,9 +45,7 @@ function update911to913()
      */
     global $DB, $migration;
 
-    $current_config   = Config::getConfigurationValues('core');
     $updateresult     = true;
-    $ADDTODISPLAYPREF = [];
 
     $migration->setVersion('9.1.3');
 

--- a/install/migrations/update_9.2.0_to_9.2.1.php
+++ b/install/migrations/update_9.2.0_to_9.2.1.php
@@ -45,9 +45,7 @@ function update920to921()
      */
     global $DB, $migration;
 
-    $current_config   = Config::getConfigurationValues('core');
     $updateresult     = true;
-    $ADDTODISPLAYPREF = [];
 
     $migration->setVersion('9.2.1');
 

--- a/install/migrations/update_9.2.1_to_9.2.2.php
+++ b/install/migrations/update_9.2.1_to_9.2.2.php
@@ -49,9 +49,7 @@ function update921to922()
      */
     global $DB, $migration;
 
-    $current_config   = Config::getConfigurationValues('core');
     $updateresult     = true;
-    $ADDTODISPLAYPREF = [];
 
     $migration->setVersion('9.2.2');
 

--- a/install/migrations/update_9.2.2_to_9.2.3.php
+++ b/install/migrations/update_9.2.2_to_9.2.3.php
@@ -49,9 +49,7 @@ function update922to923()
      */
     global $DB, $migration;
 
-    $current_config   = Config::getConfigurationValues('core');
     $updateresult     = true;
-    $ADDTODISPLAYPREF = [];
 
     $migration->setVersion('9.2.3');
 

--- a/install/migrations/update_9.2.x_to_9.3.0.php
+++ b/install/migrations/update_9.2.x_to_9.3.0.php
@@ -44,7 +44,6 @@ function update92xto930()
      * @var Migration $migration
      */
     global $DB, $migration;
-    $dbutils = new DbUtils();
 
     $current_config   = Config::getConfigurationValues('core');
     $updateresult     = true;

--- a/install/migrations/update_9.3.0_to_9.3.1.php
+++ b/install/migrations/update_9.3.0_to_9.3.1.php
@@ -48,9 +48,7 @@ function update930to931()
      */
     global $migration;
 
-    $current_config   = Config::getConfigurationValues('core');
     $updateresult     = true;
-    $ADDTODISPLAYPREF = [];
 
     $migration->setVersion('9.3.1');
 

--- a/install/migrations/update_9.3.1_to_9.3.2.php
+++ b/install/migrations/update_9.3.1_to_9.3.2.php
@@ -49,9 +49,7 @@ function update931to932()
      */
     global $DB, $migration;
 
-    $current_config   = Config::getConfigurationValues('core');
     $updateresult     = true;
-    $ADDTODISPLAYPREF = [];
 
     $migration->setVersion('9.3.2');
 

--- a/install/migrations/update_9.3.x_to_9.4.0.php
+++ b/install/migrations/update_9.3.x_to_9.4.0.php
@@ -44,9 +44,7 @@ function update93xto940()
      * @var Migration $migration
      */
     global $DB, $migration;
-    $dbutils = new DbUtils();
 
-    $current_config   = Config::getConfigurationValues('core');
     $updateresult     = true;
     $ADDTODISPLAYPREF = [];
     $config_to_drop = [];

--- a/install/migrations/update_9.5.5_to_9.5.6.php
+++ b/install/migrations/update_9.5.5_to_9.5.6.php
@@ -49,9 +49,7 @@ function update955to956()
      */
     global $DB, $migration, $CFG_GLPI;
 
-    $current_config   = Config::getConfigurationValues('core');
     $updateresult     = true;
-    $ADDTODISPLAYPREF = [];
 
     $migration->setVersion('9.5.6');
 

--- a/install/migrations/update_9.5.6_to_9.5.7.php
+++ b/install/migrations/update_9.5.6_to_9.5.7.php
@@ -48,9 +48,7 @@ function update956to957()
      */
     global $DB, $migration, $CFG_GLPI;
 
-    $current_config   = Config::getConfigurationValues('core');
     $updateresult     = true;
-    $ADDTODISPLAYPREF = [];
 
     $migration->setVersion('9.5.7');
 

--- a/rector.php
+++ b/rector.php
@@ -35,6 +35,7 @@
 use Rector\Caching\ValueObject\Storage\FileCacheStorage;
 use Rector\CodeQuality\Rector as CodeQuality;
 use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector as DeadCode;
 use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
 use Rector\ValueObject\PhpVersion;
 
@@ -104,6 +105,7 @@ return RectorConfig::configure()
         CodeQuality\LogicalAnd\LogicalToBooleanRector::class,
         CodeQuality\NotEqual\CommonNotEqualRector::class,
         CodeQuality\Ternary\UnnecessaryTernaryExpressionRector::class,
+        DeadCode\Assign\RemoveUnusedVariableAssignRector::class,
     ])
     ->withPhpSets(php74: true) // apply PHP sets up to PHP 7.4
 ;

--- a/src/Auth.php
+++ b/src/Auth.php
@@ -801,7 +801,6 @@ class Auth extends CommonGLPI
 
         // manage the $login_auth (force the auth source of the user account)
         $this->user->fields["auths_id"] = 0;
-        $authtype = null;
         if ($login_auth === 'local') {
             $this->auth_type = self::DB_GLPI;
             $this->user->fields["authtype"] = self::DB_GLPI;

--- a/src/Change_Problem.php
+++ b/src/Change_Problem.php
@@ -230,7 +230,6 @@ class Change_Problem extends CommonITILObject_CommonITILObject
 
         $problems = [];
         $used     = [];
-        $numrows = count($iterator);
         foreach ($iterator as $data) {
             $problems[$data['id']] = $data;
             $used[$data['id']]     = $data['id'];

--- a/src/CommonDBVisible.php
+++ b/src/CommonDBVisible.php
@@ -174,7 +174,6 @@ abstract class CommonDBVisible extends CommonDBTM
         $ID      = (int) $this->fields['id'];
         $canedit = $this->canEdit($ID);
         $rand    = mt_rand();
-        $nb      = $this->countVisibilities();
 
         if ($canedit) {
             TemplateRenderer::getInstance()->display('components/add_visibility_target.html.twig', [

--- a/src/CommonItilObject_Item.php
+++ b/src/CommonItilObject_Item.php
@@ -392,7 +392,6 @@ abstract class CommonItilObject_Item extends CommonDBRelation
         $rand    = mt_rand();
 
         $types_iterator = static::getDistinctTypes($instID);
-        $number = count($types_iterator);
         $is_closed = $obj instanceof CommonITILObject
             && in_array(
                 $obj->fields['status'],
@@ -803,7 +802,6 @@ TWIG, $twig_params);
         $entity_restrict = Session::getMatchingActiveEntities($entity_restrict);
 
         $rand        = (int) $params['rand'];
-        $already_add = $params['used'];
 
         if (
             $_SESSION["glpiactiveprofile"]["helpdesk_hardware"]

--- a/src/Contract_Supplier.php
+++ b/src/Contract_Supplier.php
@@ -251,7 +251,6 @@ TWIG, $twig_params);
         $rand    = mt_rand();
 
         $iterator = self::getListForItem($contract);
-        $number = count($iterator);
 
         $suppliers = [];
         $used      = [];

--- a/src/CronTask.php
+++ b/src/CronTask.php
@@ -246,7 +246,7 @@ class CronTask extends CommonDBTM
             pcntl_signal(SIGTERM, [$this, 'signal']);
         }
 
-        $result = $DB->update(
+        $DB->update(
             self::getTable(),
             [
                 'state'  => self::STATE_RUNNING,
@@ -1150,15 +1150,6 @@ class CronTask extends CommonDBTM
         }
 
         $start = (int) ($_GET["start"] ?? 0);
-
-        // Total Number of events
-        $number = countElementsInTable(
-            'glpi_crontasklogs',
-            [
-                'crontasks_id' => $this->fields['id'],
-                'state'        => [CronTaskLog::STATE_STOP, CronTaskLog::STATE_ERROR],
-            ]
-        );
 
         $criteria = [
             'FROM'   => 'glpi_crontasklogs',

--- a/src/DBmysql.php
+++ b/src/DBmysql.php
@@ -1985,9 +1985,6 @@ class DBmysql
     {
         $lines = explode("\n", $sql);
 
-        // try to keep mem. use down
-        $sql = "";
-
         $linecount = count($lines);
         $output = "";
 

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -4539,7 +4539,6 @@ HTML;
         ]);
 
         $results = $hook_results['actors'] ?? [];
-        $total_results = count($results);
 
         $start = ($post['page'] - 1) * $post['page_limit'];
         $results = array_slice($results, $start, $post['page_limit']);

--- a/src/Entity.php
+++ b/src/Entity.php
@@ -1882,9 +1882,6 @@ class Entity extends CommonTreeDropdown implements LinkableToTilesInterface, Pro
             );
         }
 
-        // Notification right applied
-        $canedit = (Notification::canUpdate()
-                  && Session::haveAccessToEntity($ID));
         TemplateRenderer::getInstance()->display('pages/admin/entity/notifications.html.twig', [
             'item' => $entity,
             'params' => [

--- a/src/Glpi/Agent/Communication/Headers/Common.php
+++ b/src/Glpi/Agent/Communication/Headers/Common.php
@@ -208,8 +208,6 @@ class Common
      */
     final public function getHeaderName(string $prop): string
     {
-        $name = $prop;
-
         if (isset($this->getHeadersNames()[$prop])) {
             return $this->getHeadersNames()[$prop];
         }

--- a/src/Glpi/Api/HL/RoutePath.php
+++ b/src/Glpi/Api/HL/RoutePath.php
@@ -212,7 +212,6 @@ final class RoutePath
         $attributes = [];
         $placeholders = [];
         preg_match_all('/\{([^}]+)\}/', $this->getRoutePath(), $placeholders);
-        $placeholders = $placeholders[1];
         $path_parts = explode('/', $path);
         $route_parts = explode('/', $this->getRoutePath());
         foreach ($route_parts as $i => $part) {
@@ -317,7 +316,6 @@ final class RoutePath
         );
         /** @var Doc\Route $controller_doc_attr */
         $controller_doc_attr = count($controller_doc_attrs) ? reset($controller_doc_attrs)->newInstance() : null;
-        $t = $this->getMethod()->getAttributes();
         $doc_attrs = array_filter(
             $this->getMethod()->getAttributes(),
             static fn($attr) => is_a($attr->getName(), Doc\Route::class, true)

--- a/src/Glpi/Controller/ApiController.php
+++ b/src/Glpi/Controller/ApiController.php
@@ -78,7 +78,6 @@ final class ApiController extends AbstractController
             });
         }
 
-        $supported_versions = Router::getAPIVersions();
         // Extract the requested API version (if any) and then remove it from the URI
         $version = Router::API_VERSION;
         if (preg_match('/^\/v(\d+(?:\.\d+)*)\//', $relative_uri, $matches)) {

--- a/src/Glpi/Dashboard/Grid.php
+++ b/src/Glpi/Dashboard/Grid.php
@@ -951,9 +951,6 @@ HTML;
         /** @var CacheInterface $GLPI_CACHE */
         global $GLPI_CACHE;
 
-        $gridstack_id = $card_options['args']['gridstack_id'] ?? $card_id;
-        $dashboard    = $card_options['dashboard'] ?? "";
-
         $force = ($card_options['args']['force'] ?? $card_options['force'] ?? false);
 
         // retrieve card
@@ -968,7 +965,6 @@ HTML;
             \htmlescape($card_id) .
             "</div>";
 
-        $start = microtime(true);
         Profiler::getInstance()->start(__METHOD__ . ' get card data');
         try {
             $cards = $this->getAllDasboardCards();

--- a/src/Glpi/Dashboard/Widget.php
+++ b/src/Glpi/Dashboard/Widget.php
@@ -48,7 +48,6 @@ use Search;
 use Symfony\Component\DomCrawler\Crawler;
 use Toolbox;
 
-use function Safe\json_encode;
 use function Safe\ob_get_clean;
 use function Safe\ob_start;
 
@@ -627,22 +626,18 @@ HTML;
             return $html;
         }
 
-        $labels = [];
         $series = [];
         $total = 0;
         foreach ($p['data'] as $entry) {
             $entry = array_merge($default_entry, $entry);
             $total += $entry['number'];
 
-            $labels[] = $entry['label'];
             $series[] = [
                 'name'  => $entry['label'],
                 'value' => $entry['number'],
                 'url'   => $entry['url'],
             ];
         }
-
-        $labels = json_encode($labels);
 
         $colors = self::getPalette($p['palette'], $nb_series);
         if ($p['use_gradient']) {

--- a/src/Glpi/Features/TreeBrowse.php
+++ b/src/Glpi/Features/TreeBrowse.php
@@ -66,7 +66,6 @@ trait TreeBrowse
 
         $ajax_url    = $CFG_GLPI["root_doc"] . "/ajax/treebrowse.php";
 
-        $loading_txt = __s('Loading...');
         $start       = isset($params['start'])
                             ? (int) $params['start']
                             : 0;

--- a/src/Glpi/Form/Destination/AbstractCommonITILFormDestination.php
+++ b/src/Glpi/Form/Destination/AbstractCommonITILFormDestination.php
@@ -163,7 +163,7 @@ abstract class AbstractCommonITILFormDestination implements FormDestinationInter
         );
 
         // Compute input from fields configuration
-        foreach ($this->getConfigurableFields() as $field) {
+        foreach ($fields_to_apply as $field) {
             $input = $field->applyConfiguratedValueToInputUsingAnswers(
                 $field->getConfig($form, $config),
                 $input,

--- a/src/Glpi/Inventory/Asset/VirtualMachine.php
+++ b/src/Glpi/Inventory/Asset/VirtualMachine.php
@@ -226,7 +226,6 @@ class VirtualMachine extends InventoryAsset
     {
         $value = $this->data;
         $itemVirtualmachine = new ItemVirtualMachine();
-        $computer = new Computer();
 
         $db_vms = $this->getExisting();
 

--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -4328,7 +4328,6 @@ final class SQLProvider implements SearchProviderInterface
         }
 
         $LIMIT   = "";
-        $numrows = 0;
         //No search: count number of items using a simple count(ID) request and LIMIT search
         if ($data['search']['no_search']) {
             $LIMIT = " LIMIT " . (int) $data['search']['start'] . ", " . (int) $data['search']['list_limit'];

--- a/src/Glpi/System/Requirement/IntegerSize.php
+++ b/src/Glpi/System/Requirement/IntegerSize.php
@@ -47,8 +47,6 @@ final class IntegerSize extends AbstractRequirement
 
     protected function check()
     {
-        $extension_loaded = $this->isExtensionLoaded();
-        $driver_is_mysqlnd = $this->isMysqlND();
         if (PHP_INT_SIZE < 8) {
             $this->validated = false;
             $this->validation_messages[] = __('OS or PHP is not relying on 64 bits integers.');
@@ -56,15 +54,5 @@ final class IntegerSize extends AbstractRequirement
             $this->validated = true;
             $this->validation_messages[] = __('OS and PHP are relying on 64 bits integers.');
         }
-    }
-
-    protected function isExtensionLoaded(): bool
-    {
-        return extension_loaded('mysqli');
-    }
-
-    protected function isMysqlND(): bool
-    {
-        return defined('MYSQLI_OPT_INT_AND_FLOAT_NATIVE');
     }
 }

--- a/src/Html.php
+++ b/src/Html.php
@@ -4509,7 +4509,6 @@ JS;
         $multiple = $params['multiple'];
         $templateResult = $params['templateResult'];
         $templateSelection = $params['templateSelection'];
-        $container_css_class = $params['container_css_class'];
         $aria_label = $params['aria_label'];
         unset($params["on_change"], $params["width"]);
 

--- a/src/IPAddress.php
+++ b/src/IPAddress.php
@@ -241,7 +241,6 @@ class IPAddress extends CommonDBChild
             return;
         }
 
-        $rand = mt_rand();
         $start       = (int) ($_GET["start"] ?? 0);
         $sort        = $_GET["sort"] ?? "";
         $order       = strtoupper($_GET["order"] ?? "");

--- a/src/IPNetwork_Vlan.php
+++ b/src/IPNetwork_Vlan.php
@@ -174,8 +174,6 @@ class IPNetwork_Vlan extends CommonDBRelation
         $header_end .= "<th>" . __s('ID TAG') . "</th>";
         $header_end .= "</tr>";
         echo $header_begin . $header_top . $header_end;
-
-        $used = [];
         foreach ($vlans as $data) {
             echo "<tr class='tab_bg_1'>";
             if ($canedit) {

--- a/src/Infocom.php
+++ b/src/Infocom.php
@@ -1271,7 +1271,6 @@ JS;
             $date_i2,
             $date_s2
         );
-        $date_Y2 = date("Y");
 
         switch ($type_amort) {
             case "1":

--- a/src/Item_Environment.php
+++ b/src/Item_Environment.php
@@ -142,9 +142,6 @@ final class Item_Environment extends CommonDBChild
             $envs[$env['id']] = $env;
         }
 
-        $users = array_unique(array_column($all_data, 'user'));
-        $users = array_combine($users, $users);
-
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'start' => $start,
             'sort' => $sort,

--- a/src/Item_Line.php
+++ b/src/Item_Line.php
@@ -304,7 +304,6 @@ class Item_Line extends CommonDBRelation
 
         $itemtype = $item::getType();
         $ID = $item->fields['id'];
-        $rand = mt_rand();
 
         if (
             !$item->getFromDB($ID)

--- a/src/Item_Rack.php
+++ b/src/Item_Rack.php
@@ -539,8 +539,6 @@ JAVASCRIPT;
          */
         global $CFG_GLPI, $DB;
 
-        $colspan = 4;
-
         echo "<div class='center'>";
 
         $this->initForm($ID, $options);

--- a/src/Itil_Project.php
+++ b/src/Itil_Project.php
@@ -264,7 +264,6 @@ TWIG, $twig_params);
         }
 
         $canedit = $itil->canEdit($ID);
-        $rand    = mt_rand();
 
         $selfTable = self::getTable();
         $projectTable = Project::getTable();

--- a/src/NetworkPortInstantiation.php
+++ b/src/NetworkPortInstantiation.php
@@ -447,7 +447,6 @@ TWIG, $twig_params);
         $lastItem = $recursiveItems[count($recursiveItems) - 1];
 
         echo "<td>" . __s('Origin port') . "</td><td>\n";
-        $links_id      = [];
         $netport_types = ['NetworkPortEthernet', 'NetworkPortWifi'];
         $selectOptions = [];
         $possible_ports = [];

--- a/src/NetworkPort_Vlan.php
+++ b/src/NetworkPort_Vlan.php
@@ -100,7 +100,6 @@ class NetworkPort_Vlan extends CommonDBRelation
         }
 
         $canedit = $port->canEdit($ID);
-        $rand    = mt_rand();
 
         $iterator = $DB->request([
             'SELECT'    => [

--- a/src/NotificationEvent.php
+++ b/src/NotificationEvent.php
@@ -229,7 +229,6 @@ class NotificationEvent extends CommonDBTM
                 }
             }
         }
-        $template = null;
         return true;
     }
 }

--- a/src/NotificationTarget.php
+++ b/src/NotificationTarget.php
@@ -489,7 +489,6 @@ class NotificationTarget extends CommonDBChild
     {
 
         $type   = "";
-        $action = "";
         $target = self::getInstanceByType($input['itemtype']);
 
         if (!isset($input['notifications_id'])) {
@@ -582,8 +581,6 @@ class NotificationTarget extends CommonDBChild
     {
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
-
-        $new_target = null;
         $new_lang = '';
 
         // Default USER TYPE is ANONYMOUS

--- a/src/NotificationTargetSavedSearch_Alert.php
+++ b/src/NotificationTargetSavedSearch_Alert.php
@@ -74,8 +74,6 @@ class NotificationTargetSavedSearch_Alert extends NotificationTarget
         global $CFG_GLPI;
 
         $events = $this->getEvents();
-
-        $savedsearch_alert = $options['item'];
         /** @var SavedSearch $savedsearch */
         $savedsearch = $options['savedsearch'];
 

--- a/src/NotificationTemplate.php
+++ b/src/NotificationTemplate.php
@@ -351,10 +351,6 @@ class NotificationTemplate extends CommonDBTM
     public static function process($string, $data)
     {
 
-        $offset = $new_offset = 0;
-        //Template processed
-        $output = "";
-
         $cleandata = [];
         // clean data for strtr
         foreach ($data as $field => $value) {
@@ -609,7 +605,6 @@ class NotificationTemplate extends CommonDBTM
     public function getDataToSend(NotificationTarget $target, $tid, $to, array $user_infos, array $options)
     {
 
-        $language   = $user_infos['language'];
         $user_name  = $user_infos['username'];
 
         $sender     = $target->getSender();

--- a/src/PDU_Rack.php
+++ b/src/PDU_Rack.php
@@ -365,8 +365,6 @@ class PDU_Rack extends CommonDBRelation
 
         $pdu   = new PDU();
         $pdu_m = new PDUModel();
-        $pra   = new self();
-        $sides = self::getSides();
 
         $found_pdus = [];
         // find pdus from this relation

--- a/src/RuleCollection.php
+++ b/src/RuleCollection.php
@@ -1153,7 +1153,6 @@ TWIG, $twig_params);
         if (!$xmlE = simplexml_load_string($xml)) {
             Session::addMessageAfterRedirect(__s('Unauthorized file type'), false, ERROR);
         }
-        $errors = libxml_get_errors();
         // convert SimpleXml object into an array and store it in session
         $rules         = json_decode(json_encode((array) $xmlE), true);
         // check rules (check if entities, criteria and actions is always good in this glpi)

--- a/src/Search.php
+++ b/src/Search.php
@@ -948,7 +948,6 @@ class Search
     public static function showItem($type, $value, &$num, $row, $extraparam = '')
     {
 
-        $out = "";
         // Handle null values
         if ($value === null) {
             $value = '';

--- a/src/Software.php
+++ b/src/Software.php
@@ -964,7 +964,6 @@ class Software extends CommonDBTM implements TreeBrowseInterface, AssignableItem
             ),
             'ORDERBY'   => 'entity',
         ]);
-        $nb = count($iterator);
 
         $entries = [];
         $software = new self();

--- a/src/Ticket_Contract.php
+++ b/src/Ticket_Contract.php
@@ -110,7 +110,6 @@ class Ticket_Contract extends CommonDBRelation
             return $entry;
         }, iterator_to_array(self::getListForItem($item), false));
         $twig_params['used'] = [];
-        $numrows = count($linked_items);
         foreach ($linked_items as $linked_item) {
             $twig_params['used'][$linked_item['id']] = $linked_item['id'];
         }

--- a/src/Transfer.php
+++ b/src/Transfer.php
@@ -3022,7 +3022,6 @@ final class Transfer extends CommonDBTM
     {
 
         $input               = [];
-        $suppliers_id_assign = 0;
 
         //TODO Is there a replacement needed for this commented code or is it obsolete?
         // if ($data['suppliers_id_assign'] > 0) {

--- a/src/User.php
+++ b/src/User.php
@@ -2877,13 +2877,6 @@ HTML;
             return false;
         }
 
-        $authtype = $this->getAuthMethodsByID();
-
-        $extauth  = !(($this->fields["authtype"] == Auth::DB_GLPI)
-                   || (($this->fields["authtype"] == Auth::NOT_YET_AUTHENTIFIED)
-                       && !empty($this->fields["password"])));
-
-
         $profiles = [];
         if (count($_SESSION['glpiprofiles']) > 1) {
             $profiles = Dropdown::getDropdownArrayNames(
@@ -6288,7 +6281,6 @@ HTML;
         $options['candel'] = false;
         $options['canedit'] = self::canUpdate();
         $this->showFormHeader($options);
-        $rand = mt_rand();
 
         echo "<tr class='tab_bg_1'>";
         $surnamerand = mt_rand();

--- a/src/Webhook.php
+++ b/src/Webhook.php
@@ -1119,10 +1119,6 @@ class Webhook extends CommonDBTM implements FilterableInterface
             return;
         }
 
-        $entity_criteria = [
-            'entities_id' => 0,
-        ];
-
         $it = $DB->request([
             'SELECT' => ['id', 'entities_id', 'is_recursive'],
             'FROM' => self::getTable(),


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Unused vars are most of the time dead code that stay here after a refactoring (or a bad copy/paste).

It can also sometimes be a bug. For instance, I had to manually adapt the result of the diff proposed by rector from something like:

```diff
diff --git a/src/Glpi/Form/Destination/AbstractCommonITILFormDestination.php b/src/Glpi/Form/Destination/AbstractCommonITILFormDestination.php
index bb26fe3270..324acad02a 100644
--- a/src/Glpi/Form/Destination/AbstractCommonITILFormDestination.php
+++ b/src/Glpi/Form/Destination/AbstractCommonITILFormDestination.php
@@ -114,8 +114,6 @@ abstract class AbstractCommonITILFormDestination implements FormDestinationInter
     ): array {
         $typename               = $this->getLabel();
         $itil_object            = $this->getTarget();
-        $fields_to_apply        = $this->getConfigurableFields();
-        $already_applied_fields = [];
 
         // Mandatory values, we must preset defaults values as it can't be
         // missing from the input.
@@ -131,7 +129,6 @@ abstract class AbstractCommonITILFormDestination implements FormDestinationInter
             $input,
             $answers_set
         );
-        $already_applied_fields[] = EntityField::class;
 
         // Template field must be computed before applying predefined fields
         $target_itemtype = $this->getTarget();
@@ -142,7 +139,6 @@ abstract class AbstractCommonITILFormDestination implements FormDestinationInter
             $input,
             $answers_set
         );
-        $already_applied_fields[] = TemplateField::class;
 
         // ITILCategory field must be computed before applying predefined fields
         $itilcategory_field = new ITILCategoryField();
@@ -151,17 +147,10 @@ abstract class AbstractCommonITILFormDestination implements FormDestinationInter
             $input,
             $answers_set
         );
-        $already_applied_fields[] = ITILCategoryField::class;
 
         // Compute and apply template predefined template fields
         $input = $this->applyPredefinedTemplateFields($input);
 
-        // Remove already applied fields from fields to apply
-        $fields_to_apply = array_filter(
-            $fields_to_apply,
-            fn($field) => !in_array(get_class($field), $already_applied_fields)
-        );
-
         // Compute input from fields configuration
         foreach ($this->getConfigurableFields() as $field) {
             $input = $field->applyConfiguratedValueToInputUsingAnswers(

```

to this:
```diff
diff --git a/src/Glpi/Form/Destination/AbstractCommonITILFormDestination.php b/src/Glpi/Form/Destination/AbstractCommonITILFormDestination.php
index bb26fe3270..a17e12c65f 100644
--- a/src/Glpi/Form/Destination/AbstractCommonITILFormDestination.php
+++ b/src/Glpi/Form/Destination/AbstractCommonITILFormDestination.php
@@ -163,7 +163,7 @@ abstract class AbstractCommonITILFormDestination implements FormDestinationInter
         );
 
         // Compute input from fields configuration
-        foreach ($this->getConfigurableFields() as $field) {
+        foreach ($fields_to_apply as $field) {
             $input = $field->applyConfiguratedValueToInputUsingAnswers(
                 $field->getConfig($form, $config),
                 $input,
```

I hope my fix is correct.