### PR TITLE
Fix legacy API ignoring getSystemSQLCriteria

### DIFF
--- a/phpunit/web/APIRestTest.php
+++ b/phpunit/web/APIRestTest.php
@@ -3483,4 +3483,24 @@ class APIRestTest extends TestCase
         $this->assertTrue($entity_obj->getFromDB($entity_2_id));
         $this->assertEquals('Multi-update entity 2', $entity_obj->fields['comment']);
     }
+
+    public function testSystemSQLCriteria()
+    {
+        $headers = ['Session-Token' => $this->session_token];
+        $data = json_decode($this->query('Glpi\\CustomAsset\\Test01Asset', [
+            'headers' => $headers,
+        ], no_decode: true));
+        $this->assertCount(2, $data);
+        $names = array_column($data, 'name');
+        $this->assertContains('TestA', $names);
+        $this->assertContains('TestB', $names);
+
+        $data = json_decode($this->query('Glpi\\CustomAsset\\Test02Asset', [
+            'headers' => $headers,
+        ], no_decode: true));
+        $this->assertCount(2, $data);
+        $names = array_column($data, 'name');
+        $this->assertContains('Test02 A', $names);
+        $this->assertContains('Test02 B', $names);
+    }
 }

--- a/src/Glpi/Api/API.php
+++ b/src/Glpi/Api/API.php
@@ -1159,6 +1159,7 @@ abstract class API
         $already_linked_table = [];
         $criteria = SQLProvider::getDefaultJoinCriteria($itemtype, $table, $already_linked_table);
         $criteria['WHERE'] = SQLProvider::getDefaultWhereCriteria($itemtype);
+        $criteria['WHERE'] += $itemtype::getSystemSQLCriteria();
         if (!isset($criteria['LEFT JOIN'])) {
             $criteria['LEFT JOIN'] = [];
         }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

A request for `Glpi\\CustomAsset\\Test01Asset` for example was returning assets of every definition because of the way the legacy API pieces together SQL criteria from the search engine.
Also affected `ItemTranslation` which I noticed while troubleshooting a different issue.
