### PR TITLE
fix ItemTranslation not limiting sql criteria

### DIFF
--- a/phpunit/web/APIRestTest.php
+++ b/phpunit/web/APIRestTest.php
@@ -38,6 +38,12 @@ use APIClient;
 use Auth;
 use Computer;
 use Config;
+use Glpi\Form\Form;
+use Glpi\Form\FormTranslation;
+use Glpi\Form\Question;
+use Glpi\Form\Section;
+use Glpi\Helpdesk\HelpdeskTranslation;
+use Glpi\Helpdesk\Tile\GlpiPageTile;
 use Glpi\Tests\Api\Deprecated\Computer_Item;
 use Glpi\Tests\Api\Deprecated\Computer_SoftwareLicense;
 use Glpi\Tests\Api\Deprecated\Computer_SoftwareVersion;
@@ -3484,23 +3490,66 @@ class APIRestTest extends TestCase
         $this->assertEquals('Multi-update entity 2', $entity_obj->fields['comment']);
     }
 
-    public function testSystemSQLCriteria()
+    public static function testSystemSQLCriteriaProvider()
+    {
+        yield [
+            'type' => 'Glpi\\CustomAsset\\Test01Asset',
+            'field' => 'name',
+            'expected' => ['TestA', 'TestB'],
+            'not_expected' => ['Test02 A', 'Test02 B'],
+        ];
+        yield [
+            'type' => 'Glpi\\CustomAsset\\Test02Asset',
+            'field' => 'name',
+            'expected' => ['Test02 A', 'Test02 B'],
+            'not_expected' => ['TestA', 'TestB'],
+        ];
+
+        yield [
+            'type' => FormTranslation::class,
+            'field' => 'itemtype',
+            'expected' => [
+                Form::class,
+                Section::class,
+                Question::class,
+            ],
+            'not_expected' => [
+                GlpiPageTile::class,
+            ],
+        ];
+
+        yield [
+            'type' => HelpdeskTranslation::class,
+            'field' => 'itemtype',
+            'expected' => [
+                GlpiPageTile::class,
+            ],
+            'not_expected' => [
+                Form::class,
+                Section::class,
+                Question::class,
+            ],
+        ];
+    }
+
+    /**
+     * Some itemtypes share the same DB table and use `getSystemSQLCriteria` to specify criteria needed to limit DB queries to related types only.
+     * This test checks that the `getSystemSQLCriteria` method works correctly for these itemtypes in the legacy API.
+     */
+    #[DataProvider('testSystemSQLCriteriaProvider')]
+    public function testSystemSQLCriteria(string $type, string $field, array $expected, array $not_expected = []): void
     {
         $headers = ['Session-Token' => $this->session_token];
-        $data = json_decode($this->query('Glpi\\CustomAsset\\Test01Asset', [
+        $data = json_decode($this->query($type, [
             'headers' => $headers,
         ], no_decode: true));
-        $this->assertCount(2, $data);
-        $names = array_column($data, 'name');
-        $this->assertContains('TestA', $names);
-        $this->assertContains('TestB', $names);
-
-        $data = json_decode($this->query('Glpi\\CustomAsset\\Test02Asset', [
-            'headers' => $headers,
-        ], no_decode: true));
-        $this->assertCount(2, $data);
-        $names = array_column($data, 'name');
-        $this->assertContains('Test02 A', $names);
-        $this->assertContains('Test02 B', $names);
+        $this->assertCount(count($expected), $data);
+        $values = array_column($data, $field);
+        foreach ($expected as $v) {
+            $this->assertContains($v, $values);
+        }
+        foreach ($not_expected as $v) {
+            $this->assertNotContains($v, $values);
+        }
     }
 }

--- a/src/Glpi/Application/View/Extension/I18nExtension.php
+++ b/src/Glpi/Application/View/Extension/I18nExtension.php
@@ -36,6 +36,8 @@
 namespace Glpi\Application\View\Extension;
 
 use CommonDBTM;
+use Glpi\Form\FormTranslation;
+use Glpi\Helpdesk\HelpdeskTranslation;
 use Glpi\ItemTranslation\Context\ProvideTranslationsInterface;
 use Glpi\ItemTranslation\ItemTranslation;
 use Locale;
@@ -57,7 +59,8 @@ class I18nExtension extends AbstractExtension
             new TwigFunction('_nx', '_nx'),
             new TwigFunction('get_current_locale', [$this, 'getCurrentLocale']),
             new TwigFunction('get_plural_number', [Session::class, 'getPluralNumber']),
-            new TwigFunction('translate_item_key', [$this, 'translateItemKey']),
+            new TwigFunction('translate_form_item_key', $this->translateFormItemKey(...)),
+            new TwigFunction('translate_helpdesk_item_key', $this->translateHelpdeskItemKey(...)),
         ];
     }
 
@@ -66,11 +69,19 @@ class I18nExtension extends AbstractExtension
         return Locale::parseLocale($_SESSION['glpilanguage'] ?? 'en_GB');
     }
 
-    public function translateItemKey(
+    public function translateFormItemKey(
         CommonDBTM&ProvideTranslationsInterface $item,
         string $key,
         int $count = 1
     ): ?string {
-        return ItemTranslation::translate($item, $key, $count);
+        return FormTranslation::translate($item, $key, $count);
+    }
+
+    public function translateHelpdeskItemKey(
+        CommonDBTM&ProvideTranslationsInterface $item,
+        string $key,
+        int $count = 1
+    ): ?string {
+        return HelpdeskTranslation::translate($item, $key, $count);
     }
 }

--- a/src/Glpi/Application/View/Extension/I18nExtension.php
+++ b/src/Glpi/Application/View/Extension/I18nExtension.php
@@ -39,7 +39,6 @@ use CommonDBTM;
 use Glpi\Form\FormTranslation;
 use Glpi\Helpdesk\HelpdeskTranslation;
 use Glpi\ItemTranslation\Context\ProvideTranslationsInterface;
-use Glpi\ItemTranslation\ItemTranslation;
 use Locale;
 use Session;
 use Twig\Extension\AbstractExtension;

--- a/src/Glpi/Form/FormTranslation.php
+++ b/src/Glpi/Form/FormTranslation.php
@@ -156,4 +156,12 @@ final class FormTranslation extends ItemTranslation
             )
         );
     }
+
+    public static function getSystemSQLCriteria(?string $tablename = null): array
+    {
+        $criteria = [
+            'itemtype' => [Form::class, Section::class, Question::class, Comment::class],
+        ];
+        return [crc32(serialize($criteria)) => $criteria];
+    }
 }

--- a/src/Glpi/Form/QuestionType/AbstractQuestionTypeSelectable.php
+++ b/src/Glpi/Form/QuestionType/AbstractQuestionTypeSelectable.php
@@ -419,7 +419,7 @@ TWIG;
                         class="form-check-input" {{ value.checked ? 'checked' : '' }}
                     >
                     <span class="form-check-label">
-                        {{ translate_item_key(
+                        {{ translate_form_item_key(
                             question,
                             '%s-%s'|format(
                                 constant('Glpi\\\\Form\\\\QuestionType\\\\AbstractQuestionTypeSelectable::TRANSLATION_KEY_OPTION'),

--- a/src/Glpi/Form/QuestionType/AbstractQuestionTypeShortAnswer.php
+++ b/src/Glpi/Form/QuestionType/AbstractQuestionTypeShortAnswer.php
@@ -39,7 +39,6 @@ use Glpi\Application\View\TemplateRenderer;
 use Glpi\Form\FormTranslation;
 use Glpi\Form\Migration\FormQuestionDataConverterInterface;
 use Glpi\Form\Question;
-use Glpi\ItemTranslation\ItemTranslation;
 use Override;
 
 /**

--- a/src/Glpi/Form/QuestionType/AbstractQuestionTypeShortAnswer.php
+++ b/src/Glpi/Form/QuestionType/AbstractQuestionTypeShortAnswer.php
@@ -36,6 +36,7 @@
 namespace Glpi\Form\QuestionType;
 
 use Glpi\Application\View\TemplateRenderer;
+use Glpi\Form\FormTranslation;
 use Glpi\Form\Migration\FormQuestionDataConverterInterface;
 use Glpi\Form\Question;
 use Glpi\ItemTranslation\ItemTranslation;
@@ -137,7 +138,7 @@ TWIG;
     ): string {
         $default_value = $question->fields['default_value'] ?? '';
         if ($this instanceof TranslationAwareQuestionType) {
-            $default_value = ItemTranslation::translate(
+            $default_value = FormTranslation::translate(
                 $question,
                 Question::TRANSLATION_KEY_DEFAULT_VALUE,
                 1

--- a/src/Glpi/Form/QuestionType/QuestionTypeLongText.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeLongText.php
@@ -43,7 +43,6 @@ use Glpi\Form\FormTranslation;
 use Glpi\Form\Migration\FormQuestionDataConverterInterface;
 use Glpi\Form\Question;
 use Glpi\ItemTranslation\Context\TranslationHandler;
-use Glpi\ItemTranslation\ItemTranslation;
 use Override;
 use Session;
 

--- a/src/Glpi/Form/QuestionType/QuestionTypeLongText.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeLongText.php
@@ -39,6 +39,7 @@ use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\JsonFieldInterface;
 use Glpi\Form\Condition\ConditionHandler\RichTextConditionHandler;
 use Glpi\Form\Condition\UsedAsCriteriaInterface;
+use Glpi\Form\FormTranslation;
 use Glpi\Form\Migration\FormQuestionDataConverterInterface;
 use Glpi\Form\Question;
 use Glpi\ItemTranslation\Context\TranslationHandler;
@@ -143,7 +144,7 @@ TWIG;
     public function renderEndUserTemplate(Question $question): string
     {
         // TODO: handle required
-        $translated_default_value = ItemTranslation::translate(
+        $translated_default_value = FormTranslation::translate(
             $question,
             Question::TRANSLATION_KEY_DEFAULT_VALUE,
             1

--- a/src/Glpi/Helpdesk/HelpdeskTranslation.php
+++ b/src/Glpi/Helpdesk/HelpdeskTranslation.php
@@ -189,7 +189,7 @@ final class HelpdeskTranslation extends ItemTranslation implements ProvideTransl
     public static function getSystemSQLCriteria(?string $tablename = null): array
     {
         return [
-            'itemtype' => array_map(static fn($tile) => $tile::class, (new TilesManager())->getTileTypes())
+            'itemtype' => array_map(static fn($tile) => $tile::class, (new TilesManager())->getTileTypes()),
         ];
     }
 }

--- a/src/Glpi/Helpdesk/HelpdeskTranslation.php
+++ b/src/Glpi/Helpdesk/HelpdeskTranslation.php
@@ -188,9 +188,8 @@ final class HelpdeskTranslation extends ItemTranslation implements ProvideTransl
 
     public static function getSystemSQLCriteria(?string $tablename = null): array
     {
-        $tiles = (new TilesManager())->getAllTiles();
         return [
-            'itemtype' => array_map(static fn($tile) => $tile::class, $tiles)
+            'itemtype' => array_map(static fn($tile) => $tile::class, (new TilesManager())->getTileTypes())
         ];
     }
 }

--- a/src/Glpi/Helpdesk/HelpdeskTranslation.php
+++ b/src/Glpi/Helpdesk/HelpdeskTranslation.php
@@ -185,4 +185,12 @@ final class HelpdeskTranslation extends ItemTranslation implements ProvideTransl
     {
         return $this->listTranslationsHandlers();
     }
+
+    public static function getSystemSQLCriteria(?string $tablename = null): array
+    {
+        $tiles = (new TilesManager())->getAllTiles();
+        return [
+            'itemtype' => array_map(static fn($tile) => $tile::class, $tiles)
+        ];
+    }
 }

--- a/src/Glpi/ItemTranslation/ItemTranslation.php
+++ b/src/Glpi/ItemTranslation/ItemTranslation.php
@@ -46,7 +46,7 @@ use Session;
 use function Safe\json_decode;
 use function Safe\json_encode;
 
-class ItemTranslation extends CommonDBChild
+abstract class ItemTranslation extends CommonDBChild
 {
     public static $rightname = 'config';
 
@@ -285,5 +285,10 @@ class ItemTranslation extends CommonDBChild
         );
 
         return $translations_to_review;
+    }
+
+    public static function getSystemSQLCriteria(?string $tablename = null): array
+    {
+        throw new LogicException('getSystemSQLCriteria must be implemented in subclasses of ItemTranslation');
     }
 }

--- a/templates/pages/form_renderer.html.twig
+++ b/templates/pages/form_renderer.html.twig
@@ -61,11 +61,11 @@
                 data-glpi-form-renderer-form-header
             >
                 <h1 class="form-title mb-2" aria-label="{{ __('Form title') }}">
-                    {{ translate_item_key(form, constant('TRANSLATION_KEY_NAME', form)) }}
+                    {{ translate_form_item_key(form, constant('TRANSLATION_KEY_NAME', form)) }}
                 </h1>
 
                 <div class="text-muted form-description" aria-label="{{ __('Form description') }}" role="note">
-                    {{ translate_item_key(form, constant('TRANSLATION_KEY_HEADER', form))|safe_html }}
+                    {{ translate_form_item_key(form, constant('TRANSLATION_KEY_HEADER', form))|safe_html }}
                 </div>
             </div>
 
@@ -93,7 +93,7 @@
                             style="width: fit-content; max-width: calc(100% - var(--tblr-border-radius) * 2);"
                         >
                             <h2 class="mb-0 {{ not section.fields.name ? "text-muted" : "" }}">
-                                {{ translate_item_key(section, constant('TRANSLATION_KEY_NAME', section))|default(__('Untitled section')) }}
+                                {{ translate_form_item_key(section, constant('TRANSLATION_KEY_NAME', section))|default(__('Untitled section')) }}
                             </h2>
                         </div>
                     {% endif %}
@@ -103,7 +103,7 @@
                         <div class="card-body">
                             {% if not is_single_section_form and section.fields.description is not empty %}
                                 <div class="text-muted section-description mb-3">
-                                    {{ translate_item_key(section, constant('TRANSLATION_KEY_DESCRIPTION', section))|safe_html }}
+                                    {{ translate_form_item_key(section, constant('TRANSLATION_KEY_DESCRIPTION', section))|safe_html }}
                                 </div>
                             {% endif %}
 
@@ -166,7 +166,7 @@
                                                 {% endif %}
                                             >
                                                 <h3 class="mb-2 {{ not form_block.fields.name ? "text-muted" : "" }}">
-                                                    {{ translate_item_key(form_block, constant('TRANSLATION_KEY_NAME', form_block))|default(form_block.getUntitledLabel()) }}
+                                                    {{ translate_form_item_key(form_block, constant('TRANSLATION_KEY_NAME', form_block))|default(form_block.getUntitledLabel()) }}
                                                     {% if form_block.fields.is_mandatory ?? false %}
                                                         <span class="text-danger">*</span>
                                                     {% endif %}
@@ -179,7 +179,7 @@
                                                 {% endif %}
 
                                                 <div class="text-muted block-description" role="note" aria-label="{{ __('%s description')|format(form_block.getTypeName(1)) }}">
-                                                    {{ translate_item_key(form_block, constant('TRANSLATION_KEY_DESCRIPTION', form_block))|safe_html }}
+                                                    {{ translate_form_item_key(form_block, constant('TRANSLATION_KEY_DESCRIPTION', form_block))|safe_html }}
                                                 </div>
                                             </section>
                                         {% endif %}

--- a/templates/pages/helpdesk/index.html.twig
+++ b/templates/pages/helpdesk/index.html.twig
@@ -125,7 +125,7 @@
                                         <div class="ms-4">
                                             <h2 class="card-title mb-2">
                                                 {% if is_tile_provide_translations %}
-                                                    {{ translate_item_key(tile, constant('TRANSLATION_KEY_TITLE', tile)) }}
+                                                    {{ translate_helpdesk_item_key(tile, constant('TRANSLATION_KEY_TITLE', tile)) }}
                                                 {% else %}
                                                     {{ tile.getTitle() }}
                                                 {% endif %}
@@ -133,7 +133,7 @@
                                             <div class="text-secondary remove-last-tinymce-margin">
                                                 {# If the tile provides translations, use the translation handler to get the description #}
                                                 {% if is_tile_provide_translations %}
-                                                    {{ translate_item_key(tile, constant('TRANSLATION_KEY_DESCRIPTION', tile))|safe_html }}
+                                                    {{ translate_helpdesk_item_key(tile, constant('TRANSLATION_KEY_DESCRIPTION', tile))|safe_html }}
                                                 {% else %}
                                                     {{ tile.getDescription()|safe_html }}
                                                 {% endif %}

--- a/tests/src/autoload/functions.php
+++ b/tests/src/autoload/functions.php
@@ -35,6 +35,12 @@
 
 use Glpi\Asset\AssetDefinitionManager;
 use Glpi\Dropdown\DropdownDefinitionManager;
+use Glpi\Form\Form;
+use Glpi\Form\FormTranslation;
+use Glpi\Form\Question;
+use Glpi\Form\Section;
+use Glpi\Helpdesk\HelpdeskTranslation;
+use Glpi\Helpdesk\Tile\GlpiPageTile;
 use Glpi\Socket;
 
 function loadDataset()
@@ -807,6 +813,7 @@ function loadDataset()
                 }
             }
         }
+        initFormTranslationFixtures();
         Search::$search = [];
         Config::setConfigurationValues('phpunit', ['dataset' => $data['_version']]);
     }
@@ -842,4 +849,61 @@ function getItemByTypeName(string $type, string $name, bool $onlyid = false): Co
         throw new RuntimeException(sprintf('Unable to load a single `%s` item with the name `%s` (none or many exist may exist).', $type, $name));
     }
     return ($onlyid ? $item->getID() : $item);
+}
+
+function initFormTranslationFixtures()
+{
+    /** @var \DBmysql $DB */
+    global $DB;
+
+    $form = getItemByTypeName(Form::class, 'Request a service');
+    $section = new Section();
+    $section->getFromDBByCrit([
+        'forms_forms_id' => $form->getID(),
+        'name' => 'First Section',
+    ]);
+    $question = new Question();
+    $question->getFromDBByCrit([
+        'forms_sections_id' => $section->getID(),
+        'name' => 'Title',
+    ]);
+
+    $DB->insert(FormTranslation::getTable(), [
+        'itemtype' => Form::class,
+        'items_id' => $form->getID(),
+        'key' => 'form_name',
+        'language' => 'en_XX',
+        'translations' => '{"one": "Request a service translated"}',
+        'hash' => md5('Request a service')
+    ]);
+    $DB->insert(FormTranslation::getTable(), [
+        'itemtype' => Section::class,
+        'items_id' => $section->getID(),
+        'key' => 'section_name',
+        'language' => 'en_XX',
+        'translations' => '{"one": "First Section translated"}',
+        'hash' => md5('First Section')
+    ]);
+    $DB->insert(FormTranslation::getTable(), [
+        'itemtype' => Question::class,
+        'items_id' => $question->getID(),
+        'key' => 'question_name',
+        'language' => 'en_XX',
+        'translations' => '{"one": "Title translated"}',
+        'hash' => md5('Title')
+    ]);
+
+    $glpi_tile = new GlpiPageTile();
+    $glpi_tile->getFromDBByCrit([
+        'title' => 'Browse help articles',
+    ]);
+
+    $DB->insert(HelpdeskTranslation::getTable(), [
+        'itemtype' => GlpiPageTile::class,
+        'items_id' => $question->getID(),
+        'key' => 'title',
+        'language' => 'en_XX',
+        'translations' => '{"one": "Browse help articles translated"}',
+        'hash' => md5('Browse help articles')
+    ]);
 }

--- a/tests/src/autoload/functions.php
+++ b/tests/src/autoload/functions.php
@@ -853,7 +853,7 @@ function getItemByTypeName(string $type, string $name, bool $onlyid = false): Co
 
 function initFormTranslationFixtures()
 {
-    /** @var \DBmysql $DB */
+    /** @var DBmysql $DB */
     global $DB;
 
     $form = getItemByTypeName(Form::class, 'Request a service');
@@ -874,7 +874,7 @@ function initFormTranslationFixtures()
         'key' => 'form_name',
         'language' => 'en_XX',
         'translations' => '{"one": "Request a service translated"}',
-        'hash' => md5('Request a service')
+        'hash' => md5('Request a service'),
     ]);
     $DB->insert(FormTranslation::getTable(), [
         'itemtype' => Section::class,
@@ -882,7 +882,7 @@ function initFormTranslationFixtures()
         'key' => 'section_name',
         'language' => 'en_XX',
         'translations' => '{"one": "First Section translated"}',
-        'hash' => md5('First Section')
+        'hash' => md5('First Section'),
     ]);
     $DB->insert(FormTranslation::getTable(), [
         'itemtype' => Question::class,
@@ -890,7 +890,7 @@ function initFormTranslationFixtures()
         'key' => 'question_name',
         'language' => 'en_XX',
         'translations' => '{"one": "Title translated"}',
-        'hash' => md5('Title')
+        'hash' => md5('Title'),
     ]);
 
     $glpi_tile = new GlpiPageTile();
@@ -904,6 +904,6 @@ function initFormTranslationFixtures()
         'key' => 'title',
         'language' => 'en_XX',
         'translations' => '{"one": "Browse help articles translated"}',
-        'hash' => md5('Browse help articles')
+        'hash' => md5('Browse help articles'),
     ]);
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

Since `ItemTranslation` was designed to use a generic table for translations while also accessing that table through child classes `FormTranslation` and `HelpdeskTranslation`, there must be a `getSystemSQLCriteria` defined for each to limit relevant results. Also, since it was designed this way, the `ItemTranslation` class itself must be abstract so it isn't used directly.