### PR TITLE
Fix default OS dictionary rules

### DIFF
--- a/resources/Rules/RuleDictionnaryOperatingSystem.xml
+++ b/resources/Rules/RuleDictionnaryOperatingSystem.xml
@@ -26,7 +26,7 @@
         <condition>0</condition>
         <date_creation></date_creation>
         <rulecriteria>
-            <criteria>os_name</criteria>
+            <criteria>name</criteria>
             <condition>6</condition>
             <pattern>/(SUSE|SunOS|Red Hat|CentOS|Ubuntu|Debian|Fedora|AlmaLinux|Oracle|Amazon Linux)(?:\D+|)([\d.]*) ?(?:\(?([\w ]+)\)?)?/</pattern>
         </rulecriteria>
@@ -59,7 +59,7 @@
         <condition>0</condition>
         <date_creation></date_creation>
         <rulecriteria>
-            <criteria>os_name</criteria>
+            <criteria>name</criteria>
             <condition>6</condition>
             <pattern>/(Microsoft)(?&amp;#62;\(R\)|&#xAE;)? (Windows) (XP|\d\.\d|\d{1,4}|Vista)(&#x2122;)? ?(.*)/</pattern>
         </rulecriteria>
@@ -89,7 +89,7 @@
         <condition>0</condition>
         <date_creation></date_creation>
         <rulecriteria>
-            <criteria>os_name</criteria>
+            <criteria>name</criteria>
             <condition>6</condition>
             <pattern>/(Microsoft)(?&amp;#62;\(R\)|&#xAE;)? (?:(Hyper-V|Windows)(?:\(R\))?) ((?:Server|))(?:\(R\)|&#xAE;)? (\d{4}(?: R2)?)(?:[,\s]++)?([^\s]*)(?: Edition(?: x64)?)?$/</pattern>
         </rulecriteria>

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -3729,7 +3729,22 @@ class Rule extends CommonDBTM
                 continue;
             }
 
+            $available_criteria = $rule->getCriterias();
+            $available_actions   = $rule->getActions();
+
             foreach ($rulexml->xpath('./rulecriteria') as $criteriaxml) {
+                if (!array_key_exists((string) $criteriaxml->criteria, $available_criteria)) {
+                    trigger_error(
+                        sprintf(
+                            'Unknown criteria `%s` for rule `%s`.',
+                            (string) $criteriaxml->criteria,
+                            (string) $rulexml->uuid
+                        ),
+                        E_USER_WARNING
+                    );
+                    $has_errors = true;
+                    continue;
+                }
                 $criteria_input = [
                     'rules_id'  => $rule_id,
                     'criteria'  => (string) $criteriaxml->criteria,
@@ -3750,6 +3765,18 @@ class Rule extends CommonDBTM
             }
 
             foreach ($rulexml->xpath('./ruleaction') as $actionxml) {
+                if (!array_key_exists((string) $actionxml->field, $available_actions)) {
+                    trigger_error(
+                        sprintf(
+                            'Unknown action field `%s` for rule `%s`.',
+                            (string) $actionxml->field,
+                            (string) $rulexml->uuid
+                        ),
+                        E_USER_WARNING
+                    );
+                    $has_errors = true;
+                    continue;
+                }
                 $action_input = [
                     'rules_id'    => $rule_id,
                     'action_type' => (string) $actionxml->action_type,


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Fixes #20549
Fix criteria names in default OS dictionary rules.
Adds check during initialization that the criteria and action fields in the default rules XML is valid. This is tested by the install/update tests. You can validate manually by changing the criteria/action fields and running the install/update test.