### PR TITLE
Define unchecked exceptions to prepare future phpstan analysis

### DIFF
--- a/ajax/kanban.php
+++ b/ajax/kanban.php
@@ -146,10 +146,7 @@ if (($_POST['action'] ?? null) === 'update') {
         throw new AccessDeniedHttpException();
     }
 
-    $result = $item->add($inputs);
-    if (!$result) {
-        throw new BadRequestHttpException();
-    }
+    $item->safeAdd($inputs);
 } elseif (($_POST['action'] ?? null) === 'bulk_add_item') {
     $checkParams(['inputs']);
 

--- a/front/form/access_control.form.php
+++ b/front/form/access_control.form.php
@@ -57,12 +57,7 @@ try {
             $access_control->check($id, UPDATE, $input);
             $access_control->getFromDB($id);
             $input['_config'] = $access_control->createConfigFromUserInput($input);
-
-            if (!$access_control->update($input, true)) {
-                throw new RuntimeException(
-                    "Failed to update access control item"
-                );
-            }
+            $access_control->safeUpdate($input, true);
         }
     } else {
         // Unknown request

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -13,6 +13,66 @@ parameters:
         - install
         - src
     treatPhpDocTypesAsCertain: false
+    exceptions:
+        check:
+            # TODO: set these two parameters to true once we are ready to
+            # analyze our exceptions.
+            missingCheckedExceptionInThrows: false
+            tooWideThrowType: false
+        uncheckedExceptionRegexes:
+            # These represent HTTP errors, they must be uncheckeded as the top
+            # layer of the kernel will handle them appropriately.
+            - /^Glpi\\Exception\\Http\\/
+
+            # These represent unrecoverable errors in the CLI application, they
+            # must be uncheckeded as the top layer of the symfony console will
+            # handle them appropriately.
+            - /^Symfony\\Component\\Console\\Exception\\/
+            - /^Glpi\\Console\\Exception\\/
+        uncheckedExceptionClasses:
+            # These exceptions are always non recoverable by definition.
+            - RuntimeException
+            - LogicException
+
+            # This error happen when a regex is invalid.
+            # We consider this by default to be a non recoverable state but it can
+            # be handled in specific cases if needed (e.g. user supplied regex
+            # in the rule engine).
+            - Safe\Exceptions\PcreException
+
+            # This error happen when a json operation fails.
+            # We consider this by default to be a non recoverable state but it can
+            # be handled in specific cases if needed (e.g. user supplied JSON).
+            - Safe\Exceptions\JsonException
+
+            # This exception happen when operations like ini_get or init_set fails.
+            # We consider this to always be a non recoverable state as it shouldn't
+            # happen under normal conditions.
+            - Safe\Exceptions\InfoException
+
+            # These errors happen when a file or directory is missing.
+            # We consider this as non recoverable when it concerns GLPI's internal
+            # file structure that should always be present.
+            # It may be manually handled when dealing with non mandatory files
+            # and directories.
+            - Safe\Exceptions\FilesystemException
+            - Safe\Exceptions\DirException
+
+            # These errors happens when session operations fails.
+            # We consider this as always non recoverable.
+            - Safe\Exceptions\SessionException
+
+            # These errors happens when ob_* operations fails.
+            # We consider this as always non recoverable.
+            - Safe\Exceptions\OutcontrolException
+
+            # These errors happens when operations like sha1 or md5 fails.
+            # We consider this as always non recoverable.
+            - Safe\Exceptions\StringsException
+
+            # These errors happens when mb_* operations fails.
+            # We consider this as always non recoverable.
+            - Safe\Exceptions\MbstringException
     universalObjectCratesClasses:
         - Sabre\VObject\Node
     dynamicConstantNames:

--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -1355,7 +1355,6 @@ TWIG, ['authldaps_id' => $ID]);
      * @param integer $replicate_id use a replicate if > 0 (default -1)
      *
      * @return boolean connection succeeded?
-     * @throws SodiumException
      */
     public static function testLDAPConnection($auths_id, $replicate_id = -1)
     {
@@ -2619,7 +2618,6 @@ TWIG, $twig_params);
      * @param boolean $display display message information on redirect (false by default)
      *
      * @return array|boolean  with state, else false
-     * @throws SodiumException
      */
     public static function ldapImportUserByServerId(
         array $params,
@@ -2781,7 +2779,6 @@ TWIG, $twig_params);
      *             - is_recursive
      *
      * @return integer|false
-     * @throws SodiumException
      */
     public static function ldapImportGroup($group_dn, $options = [])
     {
@@ -2819,7 +2816,6 @@ TWIG, $twig_params);
      * Open LDAP connection to current server
      *
      * @return boolean|Connection
-     * @throws SodiumException
      */
     public function connect()
     {
@@ -3025,7 +3021,6 @@ TWIG, $twig_params);
      * @param string $password User Password
      *
      * @return Connection|boolean link to the LDAP server : false if connection failed
-     * @throws SodiumException
      */
     public static function tryToConnectToServer($ldap_method, $login, $password)
     {
@@ -3146,7 +3141,6 @@ TWIG, $twig_params);
      *                 array('name'=>'glpi') or array('email' => 'test at test.com')
      *
      * @return array|boolean false if fail
-     * @throws SodiumException
      */
     public static function importUserFromServers($options = [])
     {
@@ -3809,7 +3803,6 @@ TWIG, $twig_params);
      * @param AuthLDAP $authldap AuthLDAP object
      *
      * @return void
-     * @throws SodiumException
      */
     public static function searchUser(AuthLDAP $authldap)
     {

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -1285,6 +1285,21 @@ class CommonDBTM extends CommonGLPI
         }
     }
 
+    /**
+     * Should be used instead of the add() method when you don't expect the
+     * add operation to possibly fail.
+     */
+    public function safeAdd(array $input, array $options = [], bool $history = true): int
+    {
+        $id = $this->add($input, $options, $history);
+        if ($id === false) {
+            $class = $this::class;
+            throw new RuntimeException("Failed to create item of class '$class'");
+        }
+
+        return $id;
+    }
+
     // Common functions
     /**
      * Add an item in the database with all it's items.
@@ -1643,6 +1658,23 @@ class CommonDBTM extends CommonGLPI
         UserMention::handleUserMentions($this);
     }
 
+    /**
+     * Should be used instead of the update() method when you don't expect the
+     * update operation to possibly fail.
+     */
+    public function safeUpdate(array $input, bool $history = true, array $options = []): void
+    {
+        $result = $this->update($input, $history, $options);
+        if (!$result) {
+            $message = sprintf(
+                "Failed to update item of class '%s' with id '%s'",
+                $this::class,
+                $input[$this::getForeignKeyField()] ?? "unknown",
+            );
+
+            throw new RuntimeException($message);
+        }
+    }
 
     /**
      * Update some elements of an item in the database.
@@ -2100,6 +2132,23 @@ class CommonDBTM extends CommonGLPI
     **/
     public function pre_updateInDB() {}
 
+    /**
+     * Should be used instead of the delete() method when you don't expect the
+     * delete operation to possibly fail.
+     */
+    public function safeDelete(array $input, bool $force = false, bool $history = true): void
+    {
+        $result = $this->delete($input, $force, $history);
+        if (!$result) {
+            $message = sprintf(
+                "Failed to delete item of class '%s' with id '%s'",
+                $this::class,
+                $input[$this::getForeignKeyField()] ?? "unknown",
+            );
+
+            throw new RuntimeException($message);
+        }
+    }
 
     /**
      * Delete an item in the database.

--- a/src/CommonITILValidation.php
+++ b/src/CommonITILValidation.php
@@ -552,9 +552,7 @@ abstract class CommonITILValidation extends CommonDBChild
                 '_from_itilvalidation'  => true,
             ];
 
-            if (!$item->update($input)) {
-                throw new RuntimeException(sprintf('Failed to update related `%s` approval status.', $item::class));
-            }
+            $item->safeUpdate($input);
         }
     }
 
@@ -2071,9 +2069,7 @@ HTML;
                 'minimal_required_validation_percent' => $validationstep->fields['minimal_required_validation_percent'],
             ];
 
-            if (!$itil_validationstep->add($step_input)) {
-                throw new RuntimeException();
-            }
+            $itil_validationstep->safeAdd($step_input);
         }
 
         $input['itils_validationsteps_id'] = $itil_validationstep->getID();
@@ -2099,9 +2095,7 @@ HTML;
         }
 
         $itil_validationstep = static::getItilObjectItemType()::getValidationStepInstance();
-        if (!$itil_validationstep->delete(['id' => $itils_validationsteps_id])) {
-            throw new RuntimeException('Failed to delete unused approval step.');
-        };
+        $itil_validationstep->safeDelete(['id' => $itils_validationsteps_id]);
     }
 
     public function recomputeItilStatus(): void
@@ -2111,13 +2105,10 @@ HTML;
             throw new RuntimeException();
         }
 
-        $update = $itil_object->update([
+        $itil_object->safeUpdate([
             'id' => $itil_object->getID(),
             'global_validation' => self::computeValidationStatus($itil_object),
             '_from_itilvalidation' => true,
         ]);
-        if (!$update) {
-            throw new RuntimeException('Failed to update Itil global approval status.');
-        }
     }
 }

--- a/src/GLPIKey.php
+++ b/src/GLPIKey.php
@@ -388,13 +388,21 @@ class GLPIKey
         }
 
         $nonce = random_bytes(SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_NPUBBYTES); // NONCE = Number to be used ONCE, for each message
-        $encrypted = sodium_crypto_aead_xchacha20poly1305_ietf_encrypt(
-            $string,
-            $nonce,
-            $nonce,
-            $key
-        );
-        return base64_encode($nonce . $encrypted);
+        try {
+            $encrypted = sodium_crypto_aead_xchacha20poly1305_ietf_encrypt(
+                $string,
+                $nonce,
+                $nonce,
+                $key
+            );
+            return base64_encode($nonce . $encrypted);
+        } catch (SodiumException $e) {
+            throw new RuntimeException(
+                message: "Failed to encrypt GLPI key.",
+                code : $e->getCode(),
+                previous: $e,
+            );
+        }
     }
 
     /**
@@ -404,7 +412,6 @@ class GLPIKey
      * @param string|null $key Key to use, fallback to default key if null.
      *
      * @return string|null
-     * @throws SodiumException
      */
     public function decrypt(?string $string, $key = null): ?string
     {

--- a/src/Glpi/CalDAV/Backend/Calendar.php
+++ b/src/Glpi/CalDAV/Backend/Calendar.php
@@ -271,9 +271,7 @@ class Calendar extends AbstractBackend
             throw new Forbidden();
         }
 
-        if (!$item->delete(['id' => $item->fields['id']], true)) {
-            throw new Exception('Error during object deletion');
-        }
+        $item->safeDelete(['id' => $item->fields['id']], true);
     }
 
     /**

--- a/src/Glpi/Controller/Config/Helpdesk/UpdateTileController.php
+++ b/src/Glpi/Controller/Config/Helpdesk/UpdateTileController.php
@@ -35,7 +35,6 @@
 namespace Glpi\Controller\Config\Helpdesk;
 
 use Glpi\Exception\Http\AccessDeniedHttpException;
-use RuntimeException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
@@ -66,9 +65,7 @@ final class UpdateTileController extends AbstractTileController
         unset($input['_itemtype']);
 
         // Update the tile
-        if (!$tile->update($input)) {
-            throw new RuntimeException();
-        }
+        $tile->safeUpdate($input);
 
         // Re-render the tile list
         $tiles = $this->tiles_manager->getTilesForItem($linked_item);

--- a/src/Glpi/Controller/Form/Destination/AddDestinationController.php
+++ b/src/Glpi/Controller/Form/Destination/AddDestinationController.php
@@ -36,7 +36,6 @@ namespace Glpi\Controller\Form\Destination;
 
 use Glpi\Controller\AbstractController;
 use Glpi\Exception\Http\AccessDeniedHttpException;
-use Glpi\Exception\Http\BadRequestHttpException;
 use Glpi\Form\Destination\FormDestination;
 use Glpi\Form\Form;
 use Glpi\Http\RedirectResponse;
@@ -58,10 +57,7 @@ final class AddDestinationController extends AbstractController
         }
 
         // Create destination item
-        $id = $destination->add($input);
-        if (!$id) {
-            throw new BadRequestHttpException();
-        }
+        $id = $destination->safeAdd($input);
 
         // Save the ID to reopen the correct accordion item
         $_SESSION['active_destination'] = $id;

--- a/src/Glpi/Controller/Form/Destination/PurgeDestinationController.php
+++ b/src/Glpi/Controller/Form/Destination/PurgeDestinationController.php
@@ -36,7 +36,6 @@ namespace Glpi\Controller\Form\Destination;
 
 use Glpi\Controller\AbstractController;
 use Glpi\Exception\Http\AccessDeniedHttpException;
-use Glpi\Exception\Http\BadRequestHttpException;
 use Glpi\Form\Destination\FormDestination;
 use Glpi\Form\Form;
 use Glpi\Http\RedirectResponse;
@@ -58,9 +57,7 @@ final class PurgeDestinationController extends AbstractController
         }
 
         // Delete destination item
-        if (!$destination->delete($input)) {
-            throw new BadRequestHttpException('Failed to delete destination item');
-        }
+        $destination->safeDelete($input);
 
         return new RedirectResponse(Form::getFormURLWithID($form_id));
     }

--- a/src/Glpi/Controller/Form/Destination/UpdateDestinationController.php
+++ b/src/Glpi/Controller/Form/Destination/UpdateDestinationController.php
@@ -36,7 +36,6 @@ namespace Glpi\Controller\Form\Destination;
 
 use Glpi\Controller\AbstractController;
 use Glpi\Exception\Http\AccessDeniedHttpException;
-use Glpi\Exception\Http\BadRequestHttpException;
 use Glpi\Form\Destination\FormDestination;
 use Glpi\Form\Form;
 use Glpi\Http\RedirectResponse;
@@ -64,9 +63,7 @@ final class UpdateDestinationController extends AbstractController
         }
 
         // Update destination item
-        if (!$destination->update($input)) {
-            throw new BadRequestHttpException('Failed to update destination item');
-        }
+        $destination->safeUpdate($input);
 
         // Save the ID to reopen the correct accordion item
         $_SESSION['active_destination'] = $destination_id;

--- a/src/Glpi/Form/AnswersHandler/AnswersHandler.php
+++ b/src/Glpi/Form/AnswersHandler/AnswersHandler.php
@@ -321,15 +321,7 @@ final class AnswersHandler
             'users_id'       => $users_id,
             'index'          => $next_index,
         ];
-        $id = $answers_set->add($input);
-
-        // If we can't save the answers, throw an exception as it make no sense
-        // to keep going
-        if (!$id) {
-            throw new Exception(
-                "Failed to save answers: " . json_encode($input)
-            );
-        }
+        $answers_set->safeAdd($input);
 
         return $answers_set;
     }
@@ -385,12 +377,7 @@ final class AnswersHandler
                     'itemtype'                       => $item::getType(),
                     'items_id'                       => $item->getID(),
                 ];
-                if (!$form_item->add($input)) {
-                    throw new Exception(
-                        "Failed to create destination item: "
-                        . json_encode($input)
-                    );
-                }
+                $form_item->safeAdd($input);
             }
 
             // Store created items for post-creation processing

--- a/src/Glpi/Form/Form.php
+++ b/src/Glpi/Form/Form.php
@@ -762,19 +762,13 @@ final class Form extends CommonDBTM implements
             if ($section === null) {
                 // Add new section
                 $section = new Section();
-                $id = $section->add($form_data);
-
-                if (!$id) {
-                    throw new RuntimeException("Failed to add section");
-                }
+                $id = $section->safeAdd($form_data);
             } else {
                 // Update existing section
                 $form_data['id'] = $section->getID();
 
-                $success = $section->update($form_data);
-                if (!$success) {
-                    throw new RuntimeException("Failed to update section");
-                }
+                $section->safeUpdate($form_data);
+
                 $id = $section->getID();
             }
 
@@ -823,10 +817,7 @@ final class Form extends CommonDBTM implements
 
             foreach ($missing_sections as $row) {
                 $section = new Section();
-                $success = $section->delete($row);
-                if (!$success) {
-                    throw new RuntimeException("Failed to delete section");
-                }
+                $section->safeDelete($row);
             }
         }
 
@@ -875,19 +866,12 @@ final class Form extends CommonDBTM implements
             if ($question === null) {
                 // Add new question
                 $question = new Question();
-                $id = $question->add($question_data);
-
-                if (!$id) {
-                    throw new RuntimeException("Failed to add question");
-                }
+                $id = $question->safeAdd($question_data);
             } else {
                 // Update existing question
                 $question_data['id'] = $question->getID();
 
-                $success = $question->update($question_data);
-                if (!$success) {
-                    throw new RuntimeException("Failed to update question");
-                }
+                $question->safeUpdate($question_data);
                 $id = $question->getID();
             }
 
@@ -941,10 +925,7 @@ final class Form extends CommonDBTM implements
 
             foreach ($missing_questions as $row) {
                 $question = new Question();
-                $success = $question->delete($row);
-                if (!$success) {
-                    throw new RuntimeException("Failed to delete question");
-                }
+                $question->safeDelete($row);
             }
         }
 
@@ -994,19 +975,12 @@ final class Form extends CommonDBTM implements
             if ($comment === null) {
                 // Add new question
                 $comment = new Comment();
-                $id = $comment->add($comment_data);
-
-                if (!$id) {
-                    throw new RuntimeException("Failed to add comment");
-                }
+                $id = $comment->safeAdd($comment_data);
             } else {
                 // Update existing comment
                 $comment_data['id'] = $comment->getID();
 
-                $success = $comment->update($comment_data);
-                if (!$success) {
-                    throw new RuntimeException("Failed to update comment");
-                }
+                $comment->safeUpdate($comment_data);
                 $id = $comment->getID();
             }
             // Keep track of its id
@@ -1059,10 +1033,7 @@ final class Form extends CommonDBTM implements
 
             foreach ($missing_comments as $row) {
                 $comment = new Comment();
-                $success = $comment->delete($row);
-                if (!$success) {
-                    throw new RuntimeException("Failed to delete comment");
-                }
+                $comment->safeDelete($row);
             }
         }
 
@@ -1141,14 +1112,11 @@ final class Form extends CommonDBTM implements
     private function addDefaultDestinations(): void
     {
         $destination = new FormDestination();
-        $id = $destination->add([
+        $destination->safeAdd([
             self::getForeignKeyField() => $this->getId(),
             'itemtype'                 => FormDestinationTicket::class,
             'name'                     => Ticket::getTypeName(1),
         ]);
-        if (!$id) {
-            throw new RuntimeException("Failed to initialize destinations");
-        }
     }
 
     private function addDefaultAccessPolicies(): void

--- a/src/Glpi/Form/Migration/FormMigration.php
+++ b/src/Glpi/Form/Migration/FormMigration.php
@@ -1185,14 +1185,10 @@ class FormMigration extends AbstractPluginMigration
                 }
             }
 
-            if (
-                !$destination->update([
-                    'id'     => $destination->getID(),
-                    'config' => $fields_config,
-                ])
-            ) {
-                throw new LogicException("Failed to update destination with id {$destination->getID()}");
-            }
+            $destination->safeUpdate([
+                'id'     => $destination->getID(),
+                'config' => $fields_config,
+            ]);
         }
     }
 

--- a/src/Glpi/Helpdesk/DefaultDataManager.php
+++ b/src/Glpi/Helpdesk/DefaultDataManager.php
@@ -294,11 +294,7 @@ final class DefaultDataManager
 
         // Create question
         $question = new Question();
-        if (!$question->add($question_data)) {
-            throw new RuntimeException(
-                "Failed to create question: " . json_encode($question_data)
-            );
-        }
+        $question->safeAdd($question_data);
 
         return $question;
     }
@@ -380,13 +376,9 @@ final class DefaultDataManager
     private function setDefaultDestinationConfig(Form $form, array $config): void
     {
         $destination = current($form->getDestinations());
-        $success = $destination->update([
+        $destination->safeUpdate([
             'id' => $destination->getID(),
             'config'   => $config,
         ]);
-
-        if (!$success) {
-            throw new RuntimeException("Failed configure destination");
-        }
     }
 }

--- a/src/Glpi/Helpdesk/Tile/TilesManager.php
+++ b/src/Glpi/Helpdesk/Tile/TilesManager.php
@@ -192,22 +192,16 @@ final class TilesManager
         }
 
         $tile = new $tile_class();
-        $id = $tile->add($params);
-        if (!$id) {
-            throw new RuntimeException("Failed to create tile");
-        }
+        $id = $tile->safeAdd($params);
 
         $item_tile = new Item_Tile();
-        $id = $item_tile->add([
+        $id = $item_tile->safeAdd([
             'items_id_item' => $item->getID(),
             'itemtype_item' => $item::class,
             'items_id_tile' => $id,
             'itemtype_tile' => $tile_class,
             'rank'          => $this->getMaxUsedRankForItem($item) + 1,
         ]);
-        if (!$id) {
-            throw new RuntimeException("Failed to link tile to item");
-        }
 
         return $id;
     }
@@ -273,15 +267,11 @@ final class TilesManager
             throw new RuntimeException("Failed to delete, missing Item_Tile data");
         }
         $id = $item_tile->getID();
-        if (!$item_tile->delete(['id' => $id])) {
-            throw new RuntimeException("Failed to delete item tile ($id)");
-        }
+        $item_tile->safeDelete(['id' => $id]);
 
         // Then delete the tile itself
         $items_id_tile = $tile->getDatabaseId();
-        if (!$tile->delete(['id' => $items_id_tile])) {
-            throw new RuntimeException("Failed to delete tile ($items_id_tile)");
-        }
+        $tile->safeDelete(['id' => $items_id_tile]);
     }
 
     public function showConfigFormForItem(

--- a/src/Glpi/Security/TOTPManager.php
+++ b/src/Glpi/Security/TOTPManager.php
@@ -44,13 +44,11 @@ use GLPIKey;
 use Group_User;
 use JsonException;
 use Profile_User;
-use Psr\Log\LoggerInterface;
 use RobThree\Auth\Algorithm;
 use RobThree\Auth\Providers\Qr\BaconQrCodeProvider;
 use RobThree\Auth\TwoFactorAuth;
 use RobThree\Auth\TwoFactorAuthException;
 use Safe\DateTimeImmutable;
-use SodiumException;
 
 use function Safe\json_encode;
 
@@ -209,27 +207,16 @@ final class TOTPManager
         if (count($it) === 0) {
             return null;
         }
-        try {
-            $config = $it->current()['2fa'];
-            if (empty($config)) {
-                return null;
-            }
-            $config = json_decode($config, true, 512, JSON_THROW_ON_ERROR);
-            if (!isset($config['secret'])) {
-                return null;
-            } else {
-                $config['secret'] = (new GLPIKey())->decrypt($config['secret']);
-                return $config;
-            }
-        } catch (SodiumException $e) {
-            /** @var LoggerInterface $PHPLOGGER */
-            global $PHPLOGGER;
-            $PHPLOGGER->error(
-                "Unreadable TOTP secret for user ID {$users_id}: " . $e->getMessage(),
-                ['exception' => $e]
-            );
-
+        $config = $it->current()['2fa'];
+        if (empty($config)) {
             return null;
+        }
+        $config = json_decode($config, true, 512, JSON_THROW_ON_ERROR);
+        if (!isset($config['secret'])) {
+            return null;
+        } else {
+            $config['secret'] = (new GLPIKey())->decrypt($config['secret']);
+            return $config;
         }
     }
 

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -5775,10 +5775,7 @@ JAVASCRIPT;
                         'date'            => $ticket->fields['date_creation'],
                         'sourceitems_id'  => $ticket->getID(),
                     ];
-                    if (!$fup->add($input)) {
-                        //Cannot add followup. Abort/fail the merge
-                        throw new RuntimeException(sprintf(__('Failed to add followup to ticket %d'), $merge_target_id), 1);
-                    }
+                    $fup->safeAdd($input);
                     if (in_array('ITILFollowup', $p['linktypes'])) {
                         // Copy any followups to the ticket
                         $tomerge = $fup->find([
@@ -5790,10 +5787,7 @@ JAVASCRIPT;
                             $fup2['sourceitems_id'] = $id;
                             $fup2['content'] = $fup2['content'];
                             unset($fup2['id']);
-                            if (!$fup->add($fup2)) {
-                                // Cannot add followup. Abort/fail the merge
-                                throw new RuntimeException(sprintf(__('Failed to add followup to ticket %d'), $merge_target_id), 1);
-                            }
+                            $fup->safeAdd($fup2);
                         }
                     }
                     if (in_array('TicketTask', $p['linktypes'])) {
@@ -5811,10 +5805,7 @@ JAVASCRIPT;
                             $task2['content'] = $task2['content'];
                             unset($task2['id']);
                             unset($task2['uuid']);
-                            if (!$task->add($task2)) {
-                                //Cannot add followup. Abort/fail the merge
-                                throw new RuntimeException(sprintf(__('Failed to add task to ticket %d'), $merge_target_id), 1);
-                            }
+                            $task->safeAdd($task2);
                         }
                     }
                     if (in_array('Document', $p['linktypes'])) {
@@ -5839,10 +5830,7 @@ JAVASCRIPT;
                         foreach ($tomerge as $document_item2) {
                             $document_item2['items_id'] = $merge_target_id;
                             unset($document_item2['id']);
-                            if (!$document_item->add($document_item2)) {
-                                //Cannot add document. Abort/fail the merge
-                                throw new RuntimeException(sprintf(__('Failed to add document to ticket %d'), $merge_target_id), 1);
-                            }
+                            $document_item->safeAdd($document_item2);
                         }
                     }
                     if ($p['link_type'] > 0 && $p['link_type'] < 5) {
@@ -5869,10 +5857,7 @@ JAVASCRIPT;
                                 ],
                             ],
                         ]);
-                        if (!$tt->add($linkparams)) {
-                            //Cannot link tickets. Abort/fail the merge
-                            throw new RuntimeException(sprintf(__('Failed to link tickets %d and %d'), $merge_target_id, $id), 1);
-                        }
+                        $tt->safeAdd($linkparams);
                     }
                     if (isset($p['append_actors'])) {
                         $tu = new Ticket_User();
@@ -5964,9 +5949,7 @@ JAVASCRIPT;
                         }
                     }
                     //Delete this ticket
-                    if (!$ticket->delete(['id' => $id, '_disablenotif' => true])) {
-                        throw new RuntimeException(sprintf(__('Failed to delete ticket %d'), $id), 1);
-                    }
+                    $ticket->safeDelete(['id' => $id, '_disablenotif' => true]);
                     if (!$p['full_transaction']) {
                         $DB->commit();
                     }

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -1333,7 +1333,6 @@ class Toolbox
      * Get a new Guzzle client with proxy if configured and the specified other options.
      * @param array $extra_options Extra options to pass to the Guzzle client constructor
      * @return Client Guzzle client
-     * @throws SodiumException
      */
     public static function getGuzzleClient(array $extra_options): Client
     {


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.

## Description

In order to be able to detect unhandled PHPStan exceptions in the future, we must first define unchecked exception for cases were we don't want the exception to be handled.

This is a first step in this direction + some fix for the Sodium exceptions (throw were declared on function that didn't really throw them).

I've also added new functions to avoid having the same boilerplate code everywhere:
- `CommonDBTM::safeAdd()`
- `CommonDBTM::safeDelete()`
- `CommonDBTM::safeUpdate()`

It should probably be used instead of add/delete/update for new usages.