### PR TITLE
deduplicate default search columns logic

### DIFF
--- a/phpunit/functional/Glpi/Search/SearchOptionTest.php
+++ b/phpunit/functional/Glpi/Search/SearchOptionTest.php
@@ -35,6 +35,8 @@
 namespace tests\units\Glpi\Search;
 
 use DbTestCase;
+use Glpi\Asset\AssetDefinition;
+use Glpi\Search\SearchOption;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 class SearchOptionTest extends DbTestCase
@@ -48,7 +50,7 @@ class SearchOptionTest extends DbTestCase
             [\KnowbaseItem::class, [1, 80]], // Name, Entity Target
             [\RSSFeed::class, [1]], // Name (Not Entity assignable)
             [\AllAssets::class, [1, 80]], // Name, Entity
-            [\Glpi\Asset\AssetDefinition::class, [2]], // Label (Not Entity assignable)
+            [AssetDefinition::class, [2]], // Label (Not Entity assignable)
         ];
     }
 
@@ -58,7 +60,7 @@ class SearchOptionTest extends DbTestCase
         $this->login();
         $this->assertEquals(
             $expected,
-            \Glpi\Search\SearchOption::getDefaultToView($itemtype)
+            SearchOption::getDefaultToView($itemtype)
         );
     }
 }

--- a/phpunit/functional/Glpi/Search/SearchOptionTest.php
+++ b/phpunit/functional/Glpi/Search/SearchOptionTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Search;
+
+use DbTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+class SearchOptionTest extends DbTestCase
+{
+    public static function getDefaultToViewProvider(): array
+    {
+        return [
+            [\Computer::class, [1, 80]], // Name, Entity
+            [\Item_DeviceSimcard::class, [10, 80]], // Serial (marked as the name field), Entity
+            [\Ticket::class, [2, 1, 80]], // ID (Always shown for ITIL Objects), Name, Entity
+            [\KnowbaseItem::class, [1, 80]], // Name, Entity Target
+            [\RSSFeed::class, [1]], // Name (Not Entity assignable)
+            [\AllAssets::class, [1, 80]], // Name, Entity
+            [\Glpi\Asset\AssetDefinition::class, [2]], // Label (Not Entity assignable)
+        ];
+    }
+
+    #[DataProvider('getDefaultToViewProvider')]
+    public function testGetDefaultToView(string $itemtype, array $expected): void
+    {
+        $this->login();
+        $this->assertEquals(
+            $expected,
+            \Glpi\Search\SearchOption::getDefaultToView($itemtype)
+        );
+    }
+}

--- a/src/DisplayPreference.php
+++ b/src/DisplayPreference.php
@@ -313,7 +313,7 @@ class DisplayPreference extends CommonDBTM
         global $DB;
 
         // Fixed columns are not kept in the DB, so we should remove them from the order
-        $fixed_cols = $this->getFixedColumns($itemtype);
+        $fixed_cols = SearchOption::getDefaultToView($itemtype);
         $official_order = array_diff($order, $fixed_cols);
 
         // Remove duplicates (in case of UI bug not preventing them)
@@ -432,49 +432,6 @@ class DisplayPreference extends CommonDBTM
     }
 
     /**
-     * Get the fixed columns for a given itemtype
-     * A fixed columns is :
-     * - Always displayed before the normal columns
-     * - Can't be moved
-     * - Must not be shown in the search option dropdown (can't be added to the list)
-     */
-    protected function getFixedColumns(string $itemtype): array
-    {
-        /** @var array $CFG_GLPI */
-        global $CFG_GLPI;
-
-        $fixed_columns = [];
-
-        // Get item for itemtype
-        $item = null;
-        if ($itemtype != AllAssets::getType()) {
-            $item = getItemForItemtype($itemtype);
-        }
-
-        // ID is fixed for CommonITILObjects
-        if ($item instanceof CommonITILObject) {
-            $fixed_columns[] = 2;
-        }
-
-        // Name is always fixed
-        $fixed_columns[] = 1;
-
-        // Entity may be fixed
-        if (
-            Session::isMultiEntitiesMode()
-            && (
-                isset($CFG_GLPI["union_search_type"][$itemtype])
-                || ($item && $item->maybeRecursive())
-                || count($_SESSION["glpiactiveentities"]) > 1
-            )
-        ) {
-            $fixed_columns[] = 80;
-        }
-
-        return $fixed_columns;
-    }
-
-    /**
      * @param string $itemtype The itemtype
      * @param bool $global True if global config, false if personal config
      * @return void|false
@@ -512,7 +469,7 @@ class DisplayPreference extends CommonDBTM
         }
 
         // Get fixed columns
-        $fixed_columns = $this->getFixedColumns($itemtype);
+        $fixed_columns = SearchOption::getDefaultToView($itemtype);
         $group  = '';
         $already_added = self::getForTypeUser($itemtype, $IDuser, $interface);
         $available_to_add = [];

--- a/src/Glpi/Search/SearchOption.php
+++ b/src/Glpi/Search/SearchOption.php
@@ -40,6 +40,7 @@ use Appliance;
 use ArrayAccess;
 use Change;
 use CommonDBTM;
+use CommonITILObject;
 use CommonTreeDropdown;
 use Contract;
 use Document;
@@ -707,7 +708,7 @@ final class SearchOption implements ArrayAccess
      * @param array $params
      * @return array
      */
-    public static function getDefaultToView(string $itemtype, array $params): array
+    public static function getDefaultToView(string $itemtype, array $params = []): array
     {
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
@@ -730,6 +731,11 @@ final class SearchOption implements ArrayAccess
         } else {
             $id_field = [];
             $name_field = [];
+        }
+
+        // ID is fixed for CommonITILObjects
+        if ($item instanceof CommonITILObject && count($id_field) > 0) {
+            $toview[] = array_keys($id_field)[0];
         }
 
         if (count($name_field) > 0) {
@@ -771,7 +777,7 @@ final class SearchOption implements ArrayAccess
             }
         }
 
-        return $toview;
+        return array_unique($toview);
     }
 
     /**


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

Part of #20533
There was logic in both `DisplayPreference::getFixedColumns` and `SearchOption::getDefaultToView` to handle the columns always shown in search results. `SearchOption` was using newer, more flexible logic. I replaced uses of `DisplayPreference::getFixedColumns` with the newer method and fixed an issue with Ticket/Change/Problem IDs not being forced shown like was expected.