### PR TITLE
Ensure Item_Device* classes have an itemlink in default columns

### DIFF
--- a/phpunit/functional/Item_DevicesTest.php
+++ b/phpunit/functional/Item_DevicesTest.php
@@ -38,6 +38,7 @@ use DbTestCase;
 use Glpi\Asset\Capacity;
 use Glpi\Asset\Capacity\HasDevicesCapacity;
 use Glpi\Features\Clonable;
+use Glpi\Search\SearchOption;
 use Item_Devices;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Toolbox;
@@ -133,5 +134,29 @@ class Item_DevicesTest extends DbTestCase
     public function testGetItemAffinities(string $itemtype, array $expected)
     {
         $this->assertEqualsCanonicalizing($expected, Item_Devices::getItemAffinities($itemtype));
+    }
+
+    /**
+     * Test that the default search result columns for Item_Device* include an itemlink to the device
+     * @return void
+     */
+    public function testDeviceSearchHasItemlinkByDefault()
+    {
+        foreach (\Item_Devices::getDeviceTypes() as $device_type) {
+            $search_options = SearchOption::getOptionsForItemtype($device_type);
+            $default_columns = SearchOption::getDefaultToView($device_type);
+            $has_itemlink = false;
+            $this->assertNotEmpty($default_columns, "Device type $device_type has no default search result columns");
+            foreach ($default_columns as $column) {
+                if (($search_options[$column]['datatype'] ?? '') === 'itemlink') {
+                    $has_itemlink = true;
+                    break;
+                }
+            }
+            $this->assertTrue(
+                $has_itemlink,
+                "Device type $device_type does not have an itemlink in its default search result columns"
+            );
+        }
     }
 }

--- a/src/Glpi/Search/SearchOption.php
+++ b/src/Glpi/Search/SearchOption.php
@@ -707,7 +707,7 @@ final class SearchOption implements ArrayAccess
      * @param array $params
      * @return array
      */
-    public static function getDefaultToView(string $itemtype, array $params): array
+    public static function getDefaultToView(string $itemtype, array $params = []): array
     {
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;

--- a/src/Item_DeviceSimcard.php
+++ b/src/Item_DeviceSimcard.php
@@ -63,7 +63,7 @@ class Item_DeviceSimcard extends Item_Devices implements AssignableItemInterface
     public static function getSpecificities($specif = '')
     {
         return [
-            'serial'         => parent::getSpecificities('serial'),
+            'serial'         => parent::getSpecificities('serial') + ['datatype' => 'itemlink'],
             'otherserial'    => parent::getSpecificities('otherserial'),
             'locations_id'   => parent::getSpecificities('locations_id'),
             'states_id'      => parent::getSpecificities('states_id'),


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

Fixes #20533
Fixes missing itemlink option for Item_DeviceSimcard and adds a test to ensure that all component classes have a search option shown by default which would let the user go to the component's form.