### PR TITLE
fix impact badge search criteria

### DIFF
--- a/js/impact.js
+++ b/js/impact.js
@@ -2838,16 +2838,26 @@ var GLPIImpact = {
                 hit = true;
 
                 if (trigger) {
-                    var target = badgeHitboxDetails.target;
+                    let target = badgeHitboxDetails.target;
 
-                    // Add items_id criteria
-                    target += "&criteria[0][link]=AND&criteria[0][field]=13&criteria[0][searchtype]=contains&criteria[0][value]=" + badgeHitboxDetails.id;
-                    // Add itemtype criteria
-                    target += "&criteria[1][link]=AND&criteria[1][field]=131&criteria[1][searchtype]=equals&criteria[1][value]=" + badgeHitboxDetails.itemtype;
+                    let next_criteria = 0;
+                    if (badgeHitboxDetails.id_option) {
+                        // Add items_id/itemtype metacriteria since we know the ID field for the asset type
+                        target += `&criteria[0][link]=AND&criteria[0][field]=${badgeHitboxDetails.id_option}&criteria[0][itemtype]=${badgeHitboxDetails.itemtype}&criteria[0][meta]=1&criteria[0][searchtype]=contains&criteria[0][value]=${badgeHitboxDetails.id}`;
+                        next_criteria = 1;
+                    } else {
+                        // Asset type doesn't have an ID metacriteria that we know of so fallback to the options directly on the ITIL item
+                        // Add items_id criteria
+                        target += `&criteria[0][link]=AND&criteria[0][field]=13&criteria[0][searchtype]=contains&criteria[0][value]=${badgeHitboxDetails.id}`;
+                        // Add itemtype criteria
+                        target += `&criteria[1][link]=AND&criteria[1][field]=131&criteria[1][searchtype]=equals&criteria[1][value]=${badgeHitboxDetails.itemtype}`;
+                        next_criteria = 2;
+                    }
+
                     // Add type criteria (incident)
-                    target += "&criteria[2][link]=AND&criteria[2][field]=14&criteria[2][searchtype]=equals&criteria[2][value]=1";
+                    target += `&criteria[${next_criteria}][link]=AND&criteria[${next_criteria}][field]=14&criteria[${next_criteria}][searchtype]=equals&criteria[${next_criteria}][value]=1`;
                     // Add status criteria (not solved)
-                    target += "&criteria[3][link]=AND&criteria[3][field]=12&criteria[3][searchtype]=equals&criteria[3][value]=notold";
+                    target += `&criteria[${next_criteria + 1}][link]=AND&criteria[${next_criteria + 1}][field]=12&criteria[${next_criteria + 1}][searchtype]=equals&criteria[${next_criteria + 1}][value]=notold`;
 
                     if (blank) {
                         window.open(target);
@@ -4170,6 +4180,7 @@ var GLPIImpact = {
                     target  : node.data('badge').target,
                     itemtype: node.data('id').split(GLPIImpact.NODE_ID_SEPERATOR)[0],
                     id      : node.data('id').split(GLPIImpact.NODE_ID_SEPERATOR)[1],
+                    id_option: node.data('id_option'),
                 });
 
                 // Draw the badge
@@ -4193,5 +4204,7 @@ var GLPIImpact = {
         });
     }
 };
+// Explicitly bind to the `window` object for Jest tests
+window.GLPIImpact = GLPIImpact;
 
-var searchAssetsDebounced = _.debounce(GLPIImpact.searchAssets, 400, false);
+var searchAssetsDebounced = _.debounce(window.GLPIImpact.searchAssets, 400, false);

--- a/src/Impact.php
+++ b/src/Impact.php
@@ -1367,7 +1367,7 @@ JS);
             'label'       => $item->getFriendlyName(),
             'image'       => self::getImpactIcon($item::class, $item->getID()),
             'ITILObjects' => $item->getITILTickets(true),
-            'id_option'   => !empty($id_field) ? array_keys($id_field)[0] : null,
+            'id_option'   => $id_field !== [] ? array_keys($id_field)[0] : null,
         ];
 
         // Only set GOTO link if the user have READ rights

--- a/src/Impact.php
+++ b/src/Impact.php
@@ -35,6 +35,8 @@
 
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\Plugin\Hooks;
+use Glpi\Search\SearchEngine;
+use Glpi\Search\SearchOption;
 use Glpi\Toolbox\URL;
 
 use function Safe\json_encode;
@@ -1349,11 +1351,23 @@ JS);
         }
 
         // Define basic data of the new node
+        $id_field = [];
+        if (in_array($item::class, SearchEngine::getMetaItemtypeAvailable(Ticket::class), true)) {
+            $search_options = SearchOption::getOptionsForItemtype($item::class);
+            $id_field = array_filter(
+                $search_options,
+                static fn($option, $id) => is_numeric($id)
+                    && $option['field'] === $item::getIndexName()
+                    && $option['table'] === $item::getTable(),
+                ARRAY_FILTER_USE_BOTH
+            );
+        }
         $new_node = [
             'id'          => $key,
             'label'       => $item->getFriendlyName(),
             'image'       => self::getImpactIcon($item::class, $item->getID()),
             'ITILObjects' => $item->getITILTickets(true),
+            'id_option'   => !empty($id_field) ? array_keys($id_field)[0] : null,
         ];
 
         // Only set GOTO link if the user have READ rights

--- a/tests/js/bootstrap.mjs
+++ b/tests/js/bootstrap.mjs
@@ -40,6 +40,9 @@ await import('select2/dist/js/select2.full').then((select2) => {
     // Select2 exports a function that registers itself as a jQuery plugin
     select2.default();
 });
+await import('lodash').then((lodash) => {
+    window._ = lodash.default;
+});
 
 // Add a flag variable to know in other scripts if they are run in tests. Should not affect how they behave, just how functions/vars in non-modules are bound.
 window.GLPI_TEST_ENV = true;

--- a/tests/js/impact.test.js
+++ b/tests/js/impact.test.js
@@ -1,0 +1,90 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+require('@jest/globals');
+
+describe('Impact', () => {
+    //let window_href_spy;
+    beforeEach(() => {
+        require('/js/impact.js');
+        delete window.location;
+        Object.defineProperty(window, 'location', {
+            value: {
+                href: '',
+                reload: jest.fn().mockImplementation(() => {})
+            },
+            writable: true,
+            configurable: true,
+        });
+        //window_href_spy = jest.spyOn(window.location, 'href');
+    });
+    it('Sets globals', () => {
+        expect(window.GLPIImpact).toBeDefined();
+    });
+    it('Badge Hitbox Search Link Correct', () => {
+        window.GLPIImpact.cy = {
+            zoom: () => 1,
+        };
+        window.GLPIImpact.badgesHitboxes = [
+            {
+                "position": {
+                    "x": 600,
+                    "y": 420
+                },
+                "target": "/front/ticket.php?is_deleted=0&as_map=0&search=Search&itemtype=Ticket",
+                "itemtype": "Computer",
+                "id": "2",
+                "id_option": 2
+            },
+            {
+                "position": {
+                    "x": 700,
+                    "y": 420
+                },
+                "target": "/front/ticket.php?is_deleted=0&as_map=0&search=Search&itemtype=Ticket",
+                "itemtype": "Computer",
+                "id": "2",
+            }
+        ];
+        window.location.href = '';
+        window.GLPIImpact.checkBadgeHitboxes({x: 601, y: 421}, true, false);
+        // This badge has a known ID option, so we should be using the metacriteria
+        expect(window.location.href).toBe('/front/ticket.php?is_deleted=0&as_map=0&search=Search&itemtype=Ticket&criteria[0][link]=AND&criteria[0][field]=2&criteria[0][itemtype]=Computer&criteria[0][meta]=1&criteria[0][searchtype]=contains&criteria[0][value]=2&criteria[1][link]=AND&criteria[1][field]=14&criteria[1][searchtype]=equals&criteria[1][value]=1&criteria[2][link]=AND&criteria[2][field]=12&criteria[2][searchtype]=equals&criteria[2][value]=notold');
+        window.GLPIImpact.checkBadgeHitboxes({x: 701, y: 421}, true, false);
+        // This badge has no ID option, so we should be using a simple criteria as a fallback
+        expect(window.location.href).toBe('/front/ticket.php?is_deleted=0&as_map=0&search=Search&itemtype=Ticket&criteria[0][link]=AND&criteria[0][field]=13&criteria[0][searchtype]=contains&criteria[0][value]=2&criteria[1][link]=AND&criteria[1][field]=131&criteria[1][searchtype]=equals&criteria[1][value]=Computer&criteria[2][link]=AND&criteria[2][field]=14&criteria[2][searchtype]=equals&criteria[2][value]=1&criteria[3][link]=AND&criteria[3][field]=12&criteria[3][searchtype]=equals&criteria[3][value]=notold');
+        // Test outside hitbox
+        window.location.href = '';
+        window.GLPIImpact.checkBadgeHitboxes({x: 800, y: 421}, true, false);
+        expect(window.location.href).toBe('');
+    });
+});

--- a/tests/js/jest.config.js
+++ b/tests/js/jest.config.js
@@ -34,7 +34,7 @@ module.exports = {
     projects: [
         {
             displayName: 'units',
-            testMatch: ['<rootDir>/modules/**/*.test.js'],
+            testMatch: ['<rootDir>/*.test.js', '<rootDir>/modules/**/*.test.js'],
             setupFilesAfterEnv: ["<rootDir>/jest-setup.mjs"],
             setupFiles: ['<rootDir>/bootstrap.mjs'],
             moduleDirectories: ['js/modules', 'tests/js/modules', 'node_modules'],


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

Fixes #20528
Changes the search criteria used when clicking a badge in the impact graph so that the metacriteria for an asset's ID is used instead of the "Associated element" ID Ticket search option which is usually not meant to be searchable. If we cannot identify the correct metacriteria ID field, the previous behavior is used. If the metacriteria is not used, it shows a confusing criteria in the query builder "Items seen contains X" where X is the asset ID.

This PR also starts testing the Impact JS via Jest where there were no JS unit tests for this feature before.