### PR TITLE
Migrate ticket details form plugin config option

### DIFF
--- a/install/migrations/update_10.0.x_to_11.0.0/form.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/form.php
@@ -293,7 +293,7 @@ if (!$DB->fieldExists("glpi_entities", $field)) {
     $migration->addPostQuery(
         $DB->buildUpdate(
             'glpi_entities',
-            [$field => 0],
+            [$field => 1], // Ticket details shown by default for upgraded installations to maintain previous behavior
             ['id' => 0]
         )
     );

--- a/src/Glpi/Form/Migration/FormMigration.php
+++ b/src/Glpi/Form/Migration/FormMigration.php
@@ -376,6 +376,9 @@ class FormMigration extends AbstractPluginMigration
             'targets_change' => $this->countRecords('glpi_plugin_formcreator_targetchanges') * 2,
             'translations' => $this->countRecords('glpi_plugin_formcreator_forms_languages'),
             'conditions' => $this->countRecords('glpi_plugin_formcreator_conditions'),
+            'configs' => $this->countRecords('glpi_plugin_formcreator_entityconfigs', [
+                'replace_helpdesk' => [-2, 2],
+            ]),
         ];
 
         // Set total progress steps
@@ -396,6 +399,7 @@ class FormMigration extends AbstractPluginMigration
         $this->processMigrationOfTranslations();
         $this->processMigrationOfVisibilityConditions();
         $this->processMigrationOfValidationConditions();
+        $this->processMigrationOfConfigs();
 
         $this->progress_indicator?->setProgressBarMessage('');
         $this->progress_indicator?->finish();
@@ -1798,6 +1802,31 @@ class FormMigration extends AbstractPluginMigration
             $targetTable,
             $sourceItemtype
         );
+    }
+
+    private function processMigrationOfConfigs(): void
+    {
+        $entity_configs = $this->db->request([
+            'SELECT' => [
+                'entities_id',
+                'replace_helpdesk',
+            ],
+            'FROM'   => 'glpi_plugin_formcreator_entityconfigs',
+            'WHERE'  => [
+                // Only need to update entities where it is inherited or full service catalog
+                'replace_helpdesk' => [-2, 2],
+            ],
+        ]);
+        foreach ($entity_configs as $entity_config) {
+            $this->db->update('glpi_entities', [
+                'show_tickets_properties_on_helpdesk' => match ($entity_config['replace_helpdesk']) {
+                    -2 => -2, // Inherit from parent entity
+                    2 => 1, // Full service catalog -> Show ticket properties
+                },
+            ], ['id' => $entity_config['entities_id']]);
+
+            $this->progress_indicator?->advance();
+        }
     }
 
     /**

--- a/tests/glpi-formcreator-migration-data.sql
+++ b/tests/glpi-formcreator-migration-data.sql
@@ -559,4 +559,25 @@ CREATE TABLE `glpi_plugin_formcreator_questionregexes` (
   KEY `plugin_formcreator_questions_id` (`plugin_formcreator_questions_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=297 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
+CREATE TABLE `glpi_plugin_formcreator_entityconfigs` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `entities_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `replace_helpdesk` int(11) NOT NULL DEFAULT -2,
+  `default_form_list_mode` int(11) NOT NULL DEFAULT -2,
+  `sort_order` int(11) NOT NULL DEFAULT -2,
+  `is_kb_separated` int(11) NOT NULL DEFAULT -2,
+  `is_search_visible` int(11) NOT NULL DEFAULT -2,
+  `is_dashboard_visible` int(11) NOT NULL DEFAULT -2,
+  `is_header_visible` int(11) NOT NULL DEFAULT -2,
+  `is_search_issue_visible` int(11) NOT NULL DEFAULT -2,
+  `tile_design` int(11) NOT NULL DEFAULT -2,
+  `home_page` int(11) NOT NULL DEFAULT -2,
+  `is_category_visible` int(11) NOT NULL DEFAULT -2,
+  `is_folded_menu` int(11) NOT NULL DEFAULT -2,
+  `header` text DEFAULT NULL,
+  `service_catalog_home` int(11) NOT NULL DEFAULT -2,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `unicity` (`entities_id`)
+) ENGINE=InnoDB AUTO_INCREMENT=8 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC
+
 -- Dump completed on 2025-01-21 11:41:32

--- a/tests/src/autoload/functions.php
+++ b/tests/src/autoload/functions.php
@@ -61,6 +61,9 @@ function loadDataset()
             ], [
                 'name'        => '_test_child_2',
                 'entities_id' => '_test_root_entity',
+            ], [
+                'name'        => '_test_child_3',
+                'entities_id' => '_test_root_entity',
             ],
         ], 'Computer' => [
             [


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

Fixes #19988
Changes the default values of `show_tickets_properties_on_helpdesk` to ease migrations from Form Creator as well as upgrades from previous versions where the plugin wasn't installed.

- For new installations, ticket details are hidden.
- If FC was installed, the equivalent entity config is used for the core option for every entity.
- If FC was not installed and this is an update, ticket details will remain shown by default as they were in every previous version of GLPI.
