### PR TITLE
fix(migration): handle unsupported value operators in form migration conditions

### DIFF
--- a/phpunit/functional/Glpi/Form/Migration/FormMigrationTest.php
+++ b/phpunit/functional/Glpi/Form/Migration/FormMigrationTest.php
@@ -3028,7 +3028,7 @@ final class FormMigrationTest extends DbTestCase
             'itemtype' => 'PluginFormcreatorQuestion',
             'items_id' => $sourceQuestionId,
             'plugin_formcreator_questions_id' => $targetQuestionId,
-            'show_condition' => 9, // Regex condition (unsupported)
+            'show_condition' => 4, // Greater than condition (unsupported)
             'show_value' => 'Test',
             'show_logic' => 1, // AND logic
         ]);
@@ -3053,7 +3053,7 @@ final class FormMigrationTest extends DbTestCase
         );
         $warnings = array_column($warnings, "message");
         $this->assertContains(
-            'A visibility condition used in "Question" "Source question with unsupported value operator" (Form "Form with unsupported value operator") with value operator "Match regular expression" is not supported by the question type. It will be ignored.',
+            'A visibility condition used in "Question" "Source question with unsupported value operator" (Form "Form with unsupported value operator") with value operator "Is greater than" is not supported by the question type. It will be ignored.',
             $warnings,
         );
     }

--- a/src/Glpi/Form/Migration/FormMigration.php
+++ b/src/Glpi/Form/Migration/FormMigration.php
@@ -1391,12 +1391,10 @@ class FormMigration extends AbstractPluginMigration
 
                 $condition_handler = current(array_filter(
                     $condition_handlers,
-                    function (ConditionHandlerInterface $handler) use ($value_operator) {
-                        return in_array(
-                            $value_operator,
-                            $handler->getSupportedValueOperators()
-                        );
-                    }
+                    fn(ConditionHandlerInterface $handler) => in_array(
+                        $value_operator,
+                        $handler->getSupportedValueOperators()
+                    )
                 ));
 
                 // If no condition handler is found for the value operator, we skip this condition

--- a/src/Glpi/Form/Migration/FormMigration.php
+++ b/src/Glpi/Form/Migration/FormMigration.php
@@ -1401,8 +1401,11 @@ class FormMigration extends AbstractPluginMigration
                 if ($condition_handler === false) {
                     /** @var Question|Comment|Section|FormDestination $item */
                     $item = getItemForItemtype($target_item['itemtype']);
-                    if ($item->getFromDB($target_item['items_id']) !== false) {
+                    if ($item !== false && $item->getFromDB($target_item['items_id']) !== false) {
                         $form = $item->getForm();
+                    } else {
+                        $item = null
+                        $form = null;
                     }
 
                     $this->result->addMessage(
@@ -1411,7 +1414,7 @@ class FormMigration extends AbstractPluginMigration
                             __('A visibility condition used in "%s" "%s" (Form "%s") with value operator "%s" is not supported by the question type. It will be ignored.'),
                             $item->getTypeName(1) ?? $target_item['itemtype'],
                             $item->getName() ?? $target_item['items_id'],
-                            $form?->getName() ?? NOT_AVAILABLE,
+                            $form->getName() ?? NOT_AVAILABLE,
                             $value_operator->getLabel()
                         )
                     );

--- a/src/Glpi/Form/Migration/FormMigration.php
+++ b/src/Glpi/Form/Migration/FormMigration.php
@@ -1404,7 +1404,7 @@ class FormMigration extends AbstractPluginMigration
                     if ($item !== false && $item->getFromDB($target_item['items_id']) !== false) {
                         $form = $item->getForm();
                     } else {
-                        $item = null
+                        $item = null;
                         $form = null;
                     }
 

--- a/src/Glpi/Form/Migration/FormMigration.php
+++ b/src/Glpi/Form/Migration/FormMigration.php
@@ -1401,23 +1401,17 @@ class FormMigration extends AbstractPluginMigration
                 if ($condition_handler === false) {
                     /** @var Question|Comment|Section|FormDestination $item */
                     $item = getItemForItemtype($target_item['itemtype']);
-                    if ($item->getFromDB($target_item['items_id']) === false) {
-                        throw new LogicException(
-                            sprintf(
-                                'Target item %s with ID %d not found for visibility condition.',
-                                $target_item['itemtype'],
-                                $target_item['items_id']
-                            )
-                        );
+                    if ($item->getFromDB($target_item['items_id']) !== false) {
+                        $form = $item->getForm();
                     }
 
                     $this->result->addMessage(
                         MessageType::Warning,
                         sprintf(
                             __('A visibility condition used in "%s" "%s" (Form "%s") with value operator "%s" is not supported by the question type. It will be ignored.'),
-                            $item->getTypeName(1),
-                            $item->getName(),
-                            $item->getForm()->getName(),
+                            $item->getTypeName(1) ?? $target_item['itemtype'],
+                            $item->getName() ?? $target_item['items_id'],
+                            $form?->getName() ?? NOT_AVAILABLE,
                             $value_operator->getLabel()
                         )
                     );


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

- It partially fixes #20205

Check whether the operator is supported by the question type when migrating conditions on questions.
Some operators are not supported by the new form integration.

Warning displayed if conditions are not imported.