### PR TITLE
Fix home search results displaying escaped html

### DIFF
--- a/templates/pages/helpdesk/search.html.twig
+++ b/templates/pages/helpdesk/search.html.twig
@@ -47,10 +47,10 @@
                     <div class="col-auto">
                         {{ render_illustration("browse-kb", 60) }}
                     </div>
-                    <div class="col text-truncate">
-                        <span class="text-body d-block">{{ faq.name }}</span>
-                        <div class="d-block text-secondary text-truncate richtext-strip-margin">
-                            {{ faq.answer|safe_html }}
+                    <div class="col">
+                        <span class="text-body d-block mb-1">{{ faq.name }}</span>
+                        <div class="text-secondary text-truncate richtext-strip-margin">
+                            {{ faq.answer|striptags }}
                         </div>
                     </div>
                 </a>
@@ -81,10 +81,10 @@
                     <div class="col-auto">
                         {{ render_illustration(form.fields.illustration, 60) }}
                     </div>
-                    <div class="col text-truncate">
-                        <span class="text-body d-block"> {{ form.fields.name }} </span>
-                        <div class="d-block text-secondary text-truncate">
-                            {{ form.fields.description }}
+                    <div class="col">
+                        <span class="text-body d-block mb-1"> {{ form.fields.name }} </span>
+                        <div class="text-secondary text-truncate">
+                            {{ form.fields.description|striptags }}
                         </div>
                     </div>
                 </a>


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.

## Description

We strip tags here because we don't want the html to be rendered, there isn't enough space.

Before:
<img width="1113" height="415" alt="image" src="https://github.com/user-attachments/assets/a1a76639-9953-47b2-920b-1588a82c092f" />

After:
<img width="1120" height="418" alt="image" src="https://github.com/user-attachments/assets/367d5c1a-67e4-43e2-b407-b413169a9f77" />

