### PR TITLE
Filter home tiles on tickets rights

### DIFF
--- a/phpunit/DbTestCase.php
+++ b/phpunit/DbTestCase.php
@@ -696,4 +696,34 @@ class DbTestCase extends GLPITestCase
         }
         return $a === $b;
     }
+
+    protected function addRightToProfile(
+        string $profile,
+        string $right,
+        int $value
+    ): void {
+        $profile_right = new ProfileRight();
+        $profile_right->getFromDBByCrit([
+            'profiles_id' => getItemByTypeName(Profile::class, $profile, true),
+            'name' => $right,
+        ]);
+        $this->updateItem(ProfileRight::class, $profile_right->fields['id'], [
+            'rights' => $profile_right->fields['rights'] | $value,
+        ]);
+    }
+
+    protected function removeRightFromProfile(
+        string $profile,
+        string $right,
+        int $value
+    ): void {
+        $profile_right = new ProfileRight();
+        $profile_right->getFromDBByCrit([
+            'profiles_id' => getItemByTypeName(Profile::class, $profile, true),
+            'name' => $right,
+        ]);
+        $this->updateItem(ProfileRight::class, $profile_right->fields['id'], [
+            'rights' => $profile_right->fields['rights'] & ~$value,
+        ]);
+    }
 }

--- a/src/Glpi/Helpdesk/Tile/FormTile.php
+++ b/src/Glpi/Helpdesk/Tile/FormTile.php
@@ -41,6 +41,7 @@ use Glpi\Form\Form;
 use Glpi\Session\SessionInfo;
 use Html;
 use Override;
+use Ticket;
 
 final class FormTile extends CommonDBChild implements TileInterface
 {
@@ -107,6 +108,10 @@ final class FormTile extends CommonDBChild implements TileInterface
     public function isAvailable(SessionInfo $session_info): bool
     {
         $form_access_manager = FormAccessControlManager::getInstance();
+
+        if (!$session_info->hasRight(Ticket::$rightname, CREATE)) {
+            return false;
+        }
 
         // Form must be active
         if (!$this->form->isActive()) {

--- a/src/Glpi/Helpdesk/Tile/GlpiPageTile.php
+++ b/src/Glpi/Helpdesk/Tile/GlpiPageTile.php
@@ -127,7 +127,10 @@ final class GlpiPageTile extends CommonDBTM implements TileInterface, ProvideTra
     public function isAvailable(SessionInfo $session_info): bool
     {
         return match ($this->fields['page']) {
-            self::PAGE_SERVICE_CATALOG => true,
+            self::PAGE_SERVICE_CATALOG => $session_info->hasRight(
+                Ticket::$rightname,
+                CREATE,
+            ),
             self::PAGE_FAQ             => true,
             self::PAGE_RESERVATION     => $session_info->hasRight(
                 'reservation',
@@ -137,7 +140,10 @@ final class GlpiPageTile extends CommonDBTM implements TileInterface, ProvideTra
                 TicketValidation::VALIDATEINCIDENT,
                 TicketValidation::VALIDATEREQUEST,
             ]),
-            self::PAGE_ALL_TICKETS     => $session_info->hasRight('ticket', READ),
+            self::PAGE_ALL_TICKETS     => $session_info->hasRight(
+                Ticket::$rightname,
+                READ
+            ),
             default                    => false,
         };
     }


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Rarely, self service user may not be allowed to see or create tickets.

These change take this into account when picking which tiles to display:
* Form tiles are hidden if the user can't create tickets
* Service catalog tile is hidden if the user can't create tickets
* "See my tickets" tiles is hidden if the user can't read tickets

