### PR TITLE
fix date format preference

### DIFF
--- a/phpunit/functional/HtmlTest.php
+++ b/phpunit/functional/HtmlTest.php
@@ -68,6 +68,12 @@ class HtmlTest extends \DbTestCase
         $expected = date('m-d-Y');
         $this->assertSame($expected, \Html::convDate($mydate, 2));
 
+        // Check type casting when session property is not an int
+        $_SESSION['glpidate_format'] = '1';
+        $this->assertSame(date('d-m-Y'), \Html::convDate($mydate, 1));
+        $_SESSION['glpidate_format'] = '2';
+        $this->assertSame(date('m-d-Y'), \Html::convDate($mydate, 2));
+
         $expected_error = 'Failed to parse time string (not a date) at position 0 (n): The timezone could not be found in the database';
         $this->assertSame('not a date', \Html::convDate('not a date', 2));
         $this->hasPhpLogRecordThatContains($expected_error, LogLevel::ERROR);

--- a/src/Html.php
+++ b/src/Html.php
@@ -149,8 +149,8 @@ class Html
         if (!isset($_SESSION["glpidate_format"])) {
             $_SESSION["glpidate_format"] = 0;
         }
-        if (!$format) {
-            $format = $_SESSION["glpidate_format"];
+        if ($format === null) {
+            $format = (int) $_SESSION["glpidate_format"];
         }
 
         try {


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

Poor handling of the `date_format` preference in the Session was causing every date format to be treated as `Y-m-d`. When the session values were reloaded based on user preferences, the format was a string instead of an integer.