### PR TITLE
Fix(GraphQL) Resolve GraphQL query invalid error with query key extraction

### DIFF
--- a/src/Glpi/Api/HL/GraphQL.php
+++ b/src/Glpi/Api/HL/GraphQL.php
@@ -37,6 +37,7 @@ namespace Glpi\Api\HL;
 
 use CommonDBTM;
 use Glpi\Debug\Profiler;
+use Glpi\Exception\Http\BadRequestHttpException;
 use Glpi\Http\Request;
 use GraphQL\Error\Error;
 use GraphQL\Type\Definition\ResolveInfo;
@@ -59,7 +60,11 @@ final class GraphQL
     public static function processRequest(Request $request): array
     {
         $api_version = $request->getHeaderLine('GLPI-API-Version') ?: Router::API_VERSION;
-        $query = (string) $request->getBody();
+        $bodyJson = json_decode((string) $request->getBody(), true);
+        if ($bodyJson === null || !isset($bodyJson['query'])) {
+            throw new BadRequestHttpException('Invalid GraphQL request: missing query');
+        }
+        $query = $bodyJson['query'];
         $generator = new GraphQLGenerator($api_version);
         Profiler::getInstance()->start('GraphQL::processRequest', Profiler::CATEGORY_HLAPI);
         Profiler::getInstance()->start('Build GraphQLSchema', Profiler::CATEGORY_HLAPI);


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

By integrating a connector using GraphQL, we encountered an issue in the processing of queries. During the execution of the `GraphQL::executeQuery` method, an exception was raised indicating that the GraphQL query was invalid due to the absence of the query key in the request body.

The implementation of GraphQL seems to have a problem in handling the body. Adding the extraction of the query when passing the `GraphQL::executeQuery` method resolves the issue.

## Screenshots (if appropriate):

Problem :

<img width="1748" height="775" alt="glpi-pr-1" src="https://github.com/user-attachments/assets/275a9709-4f87-4b5f-9424-313db2306e3e" />

After patch : 

<img width="1746" height="811" alt="glpi-pr-2" src="https://github.com/user-attachments/assets/cb488bad-d0bc-4513-a8ac-1e77787f632f" />

