### PR TITLE
Prevent automatic infocom generation during genericobject migration

### DIFF
--- a/phpunit/functional/Glpi/Migration/GenericobjectPluginMigrationTest.php
+++ b/phpunit/functional/Glpi/Migration/GenericobjectPluginMigrationTest.php
@@ -106,6 +106,10 @@ class GenericobjectPluginMigrationTest extends DbTestCase
         // Arrange
         global $DB;
 
+        // Forces the `auto_create_infocoms` config to validate that it is correctly supported by the migration.
+        global $CFG_GLPI;
+        $CFG_GLPI['auto_create_infocoms'] = true;
+
         $migration = new GenericobjectPluginMigration($DB);
         $result    = new PluginMigrationResult();
         $this->setPrivateProperty($migration, 'result', $result);

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -1275,6 +1275,7 @@ class CommonDBTM extends CommonGLPI
      * @param array   $input   the _POST vars returned by the item form when press add
      * @param array   $options with the insert options
      *   - unicity_message : do not display message if item it a duplicate (default is yes)
+     *   - disable_infocom_creation: do not automatically create infocom (default is false)
      * @param boolean $history do history log ? (true by default)
      *
      * @return false|integer the new ID of the added item (or false if fail)
@@ -1399,7 +1400,8 @@ class CommonDBTM extends CommonGLPI
 
                     // Auto create infocoms
                     if (
-                        isset($CFG_GLPI["auto_create_infocoms"]) && $CFG_GLPI["auto_create_infocoms"]
+                        ($options['disable_infocom_creation'] ?? false) !== true
+                        && isset($CFG_GLPI["auto_create_infocoms"]) && $CFG_GLPI["auto_create_infocoms"]
                         && (!isset($input['clone']) || !$input['clone'])
                         && Infocom::canApplyOn($this)
                     ) {

--- a/src/Glpi/Migration/AbstractPluginMigration.php
+++ b/src/Glpi/Migration/AbstractPluginMigration.php
@@ -251,13 +251,15 @@ abstract class AbstractPluginMigration
      * @param class-string<T> $itemtype             Target itemtype.
      * @param array $input                          Creation/update input.
      * @param array|null $reconciliation_criteria   Fields used to reconciliate input with a potential existing item.
+     * @param array $options                        Options to use during add/update operation.
      *
      * @return T    The created/reused item.
      */
     final protected function importItem(
         string $itemtype,
         array $input,
-        ?array $reconciliation_criteria = null
+        ?array $reconciliation_criteria = null,
+        array $options = []
     ): CommonDBTM {
         $item = \getItemForItemtype($itemtype);
         if ($item === false) {
@@ -330,7 +332,7 @@ abstract class AbstractPluginMigration
                 return $item;
             }
 
-            $updated = $item->update($input);
+            $updated = $item->update($input, options: $options);
             $this->addSessionMessagesToResult();
             if ($updated === false) {
                 throw new MigrationException(
@@ -359,7 +361,7 @@ abstract class AbstractPluginMigration
         }
 
         // Create a new item.
-        $created = $item->add($input);
+        $created = $item->add($input, options: $options);
         $this->addSessionMessagesToResult();
         if ($created === false) {
             throw new MigrationException(

--- a/src/Glpi/Migration/GenericobjectPluginMigration.php
+++ b/src/Glpi/Migration/GenericobjectPluginMigration.php
@@ -817,6 +817,9 @@ class GenericobjectPluginMigration extends AbstractPluginMigration
                     $asset = $this->importItem(
                         $asset_class,
                         input: $input,
+                        options: [
+                            'disable_infocom_creation' => true,
+                        ]
                     );
 
                     $this->mapItem(


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

The infocom entry must not be created automatically when importing a genericobject asset, as it will be created later during the migration, based on the existing infocom linked to this asset.
The infocom import is already tested here: https://github.com/glpi-project/glpi/blob/e95301ac690f9b30a8f02076d5ce5c886ae6340f/phpunit/functional/Glpi/Migration/GenericobjectPluginMigrationTest.php#L776-L798

It fixes #19668.