### PR TITLE
Reduce unneeded interactions in form e2e tests

### DIFF
--- a/templates/pages/admin/form/form_section.html.twig
+++ b/templates/pages/admin/form/form_section.html.twig
@@ -51,6 +51,8 @@
 <section
     data-glpi-form-editor-section
     data-glpi-form-editor-condition-type="{{ enum('Glpi\\Form\\Condition\\Type').SECTION.value }}"
+    {{ section is not null ? 'data-glpi-form-editor-section-id=' ~ section.getID() : '' }}
+    {{ section is not null ? 'data-glpi-form-editor-section-uuid=' ~ section.fields['uuid'] : '' }}
     class="mt-4"
     aria-label="{{ __("Form section") }}"
 >

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -47,8 +47,6 @@ Cypress.Commands.add('login', (username = 'e2e_tests', password = 'glpi') => {
 
         // Parse page
         const csrf = $html.find('input[name=_glpi_csrf_token]').val();
-        const username_input = $html.find('#login_name').prop('name');
-        const password_input = $html.find('#login_password').prop('name');
 
         // Send login request
         cy.request({
@@ -56,8 +54,8 @@ Cypress.Commands.add('login', (username = 'e2e_tests', password = 'glpi') => {
             url: '/front/login.php',
             form: true,
             body: {
-                [username_input]: username,
-                [password_input]: password,
+                login_name: username,
+                login_password: password,
                 _glpi_csrf_token: csrf,
             }
         });

--- a/tests/cypress/support/commands/form.d.ts
+++ b/tests/cypress/support/commands/form.d.ts
@@ -34,7 +34,7 @@
 declare namespace Cypress {
     interface Chainable<Subject> {
         createFormWithAPI(fields: Object): Chainable<any>
-        visitFormTab(tab_name: string): Chainable<any>
+        visitFormTab(form_id: number, tab_name: string): Chainable<any>
         saveFormEditorAndReload(): Chainable<any>
         addQuestion(name: string): Chainable<any>
         addSection(name: string): Chainable<any>

--- a/tests/cypress/support/commands/form.js
+++ b/tests/cypress/support/commands/form.js
@@ -40,10 +40,7 @@ Cypress.Commands.add('createFormWithAPI', (
     });
 });
 
-Cypress.Commands.add('visitFormTab', {prevSubject: true}, (
-    form_id,
-    tab_name
-) => {
+Cypress.Commands.add('visitFormTab', (form_id, tab_name) => {
     const fully_qualified_tabs = new Map([
         ['Form', 'Glpi\\Form\\Form\\Form$main'],
         ['Policies', 'Glpi\\Form\\AccessControl\\FormAccessControl$1'],


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.

## Description

*To continue whenever I get some time*

As much as we can blame Cypress for being flaky and slow, there are things with the actual test code which are slowing these tests down a lot. Waiting on slow tests is not a great use of time, and just pushing to GitHub often just wastes hours of runner time just for it to fail again.

Testing form conditions takes 15 minutes on its own (8 minutes in headless mode), even without any retries.

In form tests, creating a new form interactively when we aren't specifically testing the form creation is wasted time. It is faster to create the form using the API.
Creating new items in every test when it isn't needed, even through the API, is a slow process. It is better to create items once before the tests run and reuse them when possible. An update call to reset some of the item is faster than recreating items in some cases.
Using `type`, especially with longer inputs, is not needed if you don't need to test key events.