### PR TITLE
try to add e2e artifiacts on cancellation too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,7 +225,7 @@ jobs:
     if: github.repository == 'glpi-project/glpi' || github.event_name != 'schedule'
     name: "E2E and web tests using latest PHP and MariaDB versions"
     runs-on: "ubuntu-latest"
-    timeout-minutes: 90
+    timeout-minutes: 5
     env:
       COMPOSE_FILE: ".github/actions/docker-compose-app.yml:.github/actions/docker-compose-services.yml"
       APPLICATION_ROOT: "${{ github.workspace }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,7 +225,7 @@ jobs:
     if: github.repository == 'glpi-project/glpi' || github.event_name != 'schedule'
     name: "E2E and web tests using latest PHP and MariaDB versions"
     runs-on: "ubuntu-latest"
-    timeout-minutes: 5
+    timeout-minutes: 90
     env:
       COMPOSE_FILE: ".github/actions/docker-compose-app.yml:.github/actions/docker-compose-services.yml"
       APPLICATION_ROOT: "${{ github.workspace }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,13 +271,13 @@ jobs:
         run: |
           docker compose exec -T app .github/actions/test_tests-e2e.sh
       - name: "Upload Cypress screenshots"
-        if: "${{ steps.e2e.conclusion == 'failure' || steps.e2e.conclusion == 'cancelled' }}"
+        if: "${{ always() && (steps.e2e.conclusion == 'failure' || steps.e2e.conclusion == 'cancelled') }}"
         uses: actions/upload-artifact@v4
         with:
           name: cypress-screenshots
           path: tests/cypress/screenshots
       - name: "Upload GLPI logs"
-        if: "${{ steps.e2e.conclusion == 'failure' || steps.e2e.conclusion == 'cancelled' }}"
+        if: "${{ always() && (steps.e2e.conclusion == 'failure' || steps.e2e.conclusion == 'cancelled') }}"
         uses: actions/upload-artifact@v4
         with:
             name: glpi-logs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,13 +271,13 @@ jobs:
         run: |
           docker compose exec -T app .github/actions/test_tests-e2e.sh
       - name: "Upload Cypress screenshots"
-        if: "${{ failure() && steps.e2e.conclusion == 'failure' }}"
+        if: "${{ steps.e2e.conclusion == 'failure' || steps.e2e.conclusion == 'cancelled' }}"
         uses: actions/upload-artifact@v4
         with:
           name: cypress-screenshots
           path: tests/cypress/screenshots
       - name: "Upload GLPI logs"
-        if: "${{ failure() && steps.e2e.conclusion == 'failure' }}"
+        if: "${{ steps.e2e.conclusion == 'failure' || steps.e2e.conclusion == 'cancelled' }}"
         uses: actions/upload-artifact@v4
         with:
             name: glpi-logs


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

E2E timeouts occasionally happen due to how slow the tests are and the fact they can all retry up to 3 times, so in some cases a bug may cause them to get cancelled for exceeding 90 minutes. In that case, the Cypress screenshots and GLPI logs were not being attached because a cancelled test isn't considered failed.

I think this will fix that, but I don't know how to reliably test it.