### PR TITLE
Fix tabs text escaping and add some missing icons

### DIFF
--- a/phpunit/functional/NotificationAjaxSettingTest.php
+++ b/phpunit/functional/NotificationAjaxSettingTest.php
@@ -55,13 +55,16 @@ class NotificationAjaxSettingTest extends DbTestCase
     {
         $instance = new \NotificationAjaxSetting();
         $tabs = $instance->defineTabs();
+        $tabs = array_map('strip_tags', $tabs);
         $this->assertSame(['NotificationAjaxSetting$1' => 'Setup'], $tabs);
     }
 
     public function testGetTabNameForItem()
     {
         $instance = new \NotificationAjaxSetting();
-        $this->assertSame(['1' => 'Setup'], $instance->getTabNameForItem($instance));
+        $tabs = $instance->getTabNameForItem($instance);
+        $tabs = array_map('strip_tags', $tabs);
+        $this->assertSame(['1' => 'Setup'], $tabs);
     }
 
     public function testDisplayTabContentForItem()

--- a/phpunit/functional/NotificationMailingSettingTest.php
+++ b/phpunit/functional/NotificationMailingSettingTest.php
@@ -55,6 +55,7 @@ class NotificationMailingSettingTest extends DbTestCase
     {
         $instance = new \NotificationMailingSetting();
         $tabs = $instance->defineTabs();
+        $tabs = array_map('strip_tags', $tabs);
         $this->assertSame(
             ['NotificationMailingSetting$1' => 'Setup'],
             $tabs
@@ -64,10 +65,9 @@ class NotificationMailingSettingTest extends DbTestCase
     public function testGetTabNameForItem()
     {
         $instance = new \NotificationMailingSetting();
-        $this->assertSame(
-            ['1' => 'Setup'],
-            $instance->getTabNameForItem($instance)
-        );
+        $tabs = $instance->getTabNameForItem($instance);
+        $tabs = array_map('strip_tags', $tabs);
+        $this->assertSame(['1' => 'Setup'], $tabs);
     }
 
     public function testDisplayTabContentForItem()

--- a/src/AuthMail.php
+++ b/src/AuthMail.php
@@ -383,7 +383,7 @@ TWIG, $twig_params);
         /** @var CommonDBTM $item */
         if (!$withtemplate && $item->can($item->getField('id'), READ)) {
             $ong = [];
-            $ong[1] = _sx('button', 'Test');    // test connection
+            $ong[1] = self::createTabEntry(_x('button', 'Test'), icon: 'ti ti-stethoscope');
 
             return $ong;
         }

--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -407,8 +407,8 @@ class CommonGLPI implements CommonGLPIInterface
         if (method_exists(static::class, 'getIcon')) {
             $icon = static::getIcon();
         }
-        $icon = $icon ? "<i class='$icon me-2'></i>" : '';
-        $ong[static::getType() . '$main'] = '<span>' . $icon . static::getTypeName(1) . '</span>';
+        $icon = $icon ? "<i class='" . htmlescape($icon) . " me-2'></i>" : '';
+        $ong[static::getType() . '$main'] = '<span>' . $icon . htmlescape(static::getTypeName(1)) . '</span>';
         return $this;
     }
 
@@ -759,7 +759,7 @@ class CommonGLPI implements CommonGLPIInterface
         $counter_html = '';
         if ($nb > 0) {
             $badge_content = $total_nb !== null ? "$nb/$total_nb" : "$nb";
-            $counter_html = sprintf(' <span class="badge glpi-badge">%s</span>', $badge_content);
+            $counter_html = sprintf(' <span class="badge glpi-badge">%s</span>', htmlescape($badge_content));
         }
 
         return sprintf(

--- a/src/CommonITILRecurrent.php
+++ b/src/CommonITILRecurrent.php
@@ -104,7 +104,7 @@ abstract class CommonITILRecurrent extends CommonDropdown
         // Tabs on CommonITILRecurrent items
         if ($item instanceof self) {
             $ong = [];
-            $ong[1] = _n('Information', 'Information', Session::getPluralNumber());
+            $ong[1] = self::createTabEntry(_n('Information', 'Information', Session::getPluralNumber()), icon: 'ti ti-info-circle');
             return $ong;
         }
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -969,7 +969,7 @@ class Config extends CommonDBTM
                 return self::createTabEntry(GLPINetwork::getTypeName(), 0, $item::getType(), GLPINetwork::getIcon());
 
             case Impact::getType():
-                return Impact::getTypeName();
+                return self::createTabEntry(Impact::getTypeName());
         }
         return '';
     }

--- a/src/DisplayPreference.php
+++ b/src/DisplayPreference.php
@@ -644,9 +644,9 @@ class DisplayPreference extends CommonDBTM
                 $global_only = $forced_tab === 'DisplayPreference$1' && !$allow_tab_switch;
                 $personal_only = $forced_tab === 'DisplayPreference$2' && !$allow_tab_switch;
                 $ong = [];
-                $ong[1] = $personal_only ? null : __('Global View');
+                $ong[1] = $personal_only ? null : self::createTabEntry(__('Global View'));
                 if (Session::haveRight(self::$rightname, self::PERSONAL)) {
-                    $ong[2] = $global_only ? null : __('Personal View');
+                    $ong[2] = $global_only ? null : self::createTabEntry(__('Personal View'));
                 }
 
                 $itemtype = $_GET["itemtype"] ?? null;
@@ -654,7 +654,7 @@ class DisplayPreference extends CommonDBTM
                     is_a($itemtype, CommonDBTM::class, true)
                     && $itemtype::supportHelpdeskDisplayPreferences()
                 ) {
-                    $ong[3] = __('Helpdesk View');
+                    $ong[3] = self::createTabEntry(__('Helpdesk View'));
                 }
 
                 return $ong;

--- a/src/DomainRecord.php
+++ b/src/DomainRecord.php
@@ -66,10 +66,11 @@ class DomainRecord extends CommonDBChild implements AssignableItemInterface
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
         if ($item::class === Domain::class) {
+            $nb = 0;
             if ($_SESSION['glpishow_count_on_tabs']) {
-                return self::createTabEntry(_n('Record', 'Records', Session::getPluralNumber()), self::countForDomain($item), $item::class);
+                $nb =  self::countForDomain($item);
             }
-            return _n('Record', 'Records', Session::getPluralNumber());
+            return self::createTabEntry(_n('Record', 'Records', Session::getPluralNumber()), $nb, $item::class);
         }
         return '';
     }

--- a/src/Glpi/Inventory/Conf.php
+++ b/src/Glpi/Inventory/Conf.php
@@ -334,9 +334,7 @@ class Conf extends CommonGLPI
                 $tabs[1] = self::createTabEntry(__('Configuration'), 0, $item::getType());
             }
             if ($item->enabled_inventory && Session::haveRight(self::$rightname, self::IMPORTFROMFILE)) {
-                $icon = "<i class='ti ti-upload me-2'></i>";
-                $text = '<span>' . $icon . __s('Import from file') . '</span>';
-                $tabs[2] = $text;
+                $tabs[2] = self::createTabEntry(__('Import from file'), icon: 'ti ti-upload');
             }
             return $tabs;
         }

--- a/src/Knowbase.php
+++ b/src/Knowbase.php
@@ -58,8 +58,8 @@ class Knowbase extends CommonGLPI
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
         if ($item::class === self::class) {
-            $tabs[1] = _x('button', 'Search');
-            $tabs[2] = _x('button', 'Browse');
+            $tabs[1] = self::createTabEntry(_x('button', 'Search'), icon: 'ti ti-search');
+            $tabs[2] = self::createTabEntry(_x('button', 'Browse'), icon: 'ti ti-list-tree');
 
             return $tabs;
         }

--- a/src/KnowbaseItemTranslation.php
+++ b/src/KnowbaseItemTranslation.php
@@ -85,9 +85,9 @@ class KnowbaseItemTranslation extends CommonDBChild
         if (!$withtemplate) {
             switch ($item::class) {
                 case self::class:
-                    $ong[1] = self::getTypeName(1);
+                    $ong[1] = self::createTabEntry(self::getTypeName(1));
                     if ($item->canUpdateItem()) {
-                        $ong[3] = __('Edit');
+                        $ong[3] = self::createTabEntry(__('Edit'), icon: 'ti ti-edit');
                     }
                     return $ong;
             }

--- a/src/Location.php
+++ b/src/Location.php
@@ -416,8 +416,8 @@ class Location extends CommonTreeDropdown
             switch ($item::class) {
                 case self::class:
                     $ong    = [];
-                    $ong[1] = self::getTypeName(Session::getPluralNumber());
-                    $ong[2] = _n('Item', 'Items', Session::getPluralNumber());
+                    $ong[1] = self::createTabEntry(self::getTypeName(Session::getPluralNumber()));
+                    $ong[2] = self::createTabEntry(_n('Item', 'Items', Session::getPluralNumber()), icon: 'ti ti-package');
                     return $ong;
             }
         }

--- a/src/NotificationSetting.php
+++ b/src/NotificationSetting.php
@@ -98,7 +98,7 @@ abstract class NotificationSetting extends CommonDBTM
     {
         switch ($item->getType()) {
             case static::class:
-                $tabs[1] = __('Setup');
+                $tabs[1] = self::createTabEntry(__('Setup'));
                 return $tabs;
         }
         return '';

--- a/src/Planning.php
+++ b/src/Planning.php
@@ -189,7 +189,7 @@ class Planning extends CommonGLPI
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
         if ($item::class === self::class) {
-            $tabs[1] = self::getTypeName();
+            $tabs[1] = self::createTabEntry(self::getTypeName());
 
             return $tabs;
         }

--- a/src/ReservationItem.php
+++ b/src/ReservationItem.php
@@ -854,13 +854,13 @@ TWIG, $twig_params);
         if ($item::class === self::class) {
             $tabs = [];
             if (Session::haveRightsOr("reservation", [READ, self::RESERVEANITEM])) {
-                $tabs[1] = Reservation::getTypeName(Session::getPluralNumber());
+                $tabs[1] = self::createTabEntry(Reservation::getTypeName(Session::getPluralNumber()));
             }
             if (
                 (Session::getCurrentInterface() === "central")
                 && Session::haveRight("reservation", READ)
             ) {
-                $tabs[2] = __('Administration');
+                $tabs[2] = self::createTabEntry(__('Administration'), icon: 'ti ti-shield-check');
             }
             return $tabs;
         }

--- a/src/RuleCollection.php
+++ b/src/RuleCollection.php
@@ -1966,29 +1966,33 @@ TWIG, $twig_params);
         if ($item instanceof self) {
             $ong = [];
             if ($item->showInheritedTab()) {
-                //TRANS: %s is the entity name
-                $ong[1] = sprintf(
-                    __('Rules applied: %s'),
-                    Dropdown::getDropdownName(
-                        'glpi_entities',
-                        $_SESSION['glpiactive_entity']
+                $ong[1] = self::createTabEntry(
+                    sprintf(
+                        // TRANS: %s is the entity name
+                        __('Rules applied: %s'),
+                        Dropdown::getDropdownName(
+                            'glpi_entities',
+                            $_SESSION['glpiactive_entity']
+                        )
                     )
                 );
             }
             $title = $item->getMainTabLabel();
             if ($item->isRuleRecursive()) {
-                //TRANS: %s is the entity name
-                $title = sprintf(
-                    __('Local rules: %s'),
-                    Dropdown::getDropdownName(
-                        'glpi_entities',
-                        $_SESSION['glpiactive_entity']
+                $title = self::createTabEntry(
+                    sprintf(
+                        // TRANS: %s is the entity name
+                        __('Local rules: %s'),
+                        Dropdown::getDropdownName(
+                            'glpi_entities',
+                            $_SESSION['glpiactive_entity']
+                        )
                     )
                 );
             }
             $ong[2] = $title;
             if ($item->showChildrensTab()) {
-                $ong[3] = __('Rules applicable in the sub-entities');
+                $ong[3] = self::createTabEntry(__('Rules applicable in the sub-entities'));
             }
             return $ong;
         }

--- a/src/RuleImportAssetCollection.php
+++ b/src/RuleImportAssetCollection.php
@@ -69,7 +69,7 @@ class RuleImportAssetCollection extends RuleCollection
                             $ong[$type] = $type::getTypeName();
                         }
                     }
-                    $ong['_global'] = __('Global');
+                    $ong['_global'] = self::createTabEntry(__('Global'));
                     return $ong;
             }
         }

--- a/src/Software.php
+++ b/src/Software.php
@@ -104,7 +104,7 @@ class Software extends CommonDBTM implements TreeBrowseInterface, AssignableItem
             && $item->isRecursive()
             && $item->can($item->fields['id'], UPDATE)
         ) {
-            return __('Merging');
+            return self::createTabEntry(__('Merging'), icon: 'ti ti-arrow-merge');
         }
         return '';
     }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

`getTabNameForItem()` must return safe HTML. I did not found how to help Pslam to detect unescaped texts, so I just validate that every tab entry is created with `CommonDBTM::createTabEntry()`.

I added some icons that were missing.