### PR TITLE
Throw an error when missing host or port on LDAP connection

### DIFF
--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -2872,6 +2872,17 @@ TWIG, $twig_params);
         self::$last_errno = null;
         self::$last_error = null;
 
+        if (!is_string($host) || empty($host) || $host === NOT_AVAILABLE) {
+            throw new \RuntimeException(
+                'No host provided for connection!'
+            );
+        }
+        if (!is_numeric($port) || empty($port) || $port === NOT_AVAILABLE) {
+            throw new \RuntimeException(
+                'No port provided for connection!'
+            );
+        }
+
         //Use an LDAP connection string
         $ldapuri = sprintf(
             '%s://%s:%s',


### PR DESCRIPTION
Both are required, but there is no typehint nor check before connection. 
UI should not permit to store a LDAP connection without host or port.