### PR TITLE
load rule info once during inventory import

### DIFF
--- a/src/Glpi/Inventory/MainAsset/MainAsset.php
+++ b/src/Glpi/Inventory/MainAsset/MainAsset.php
@@ -548,6 +548,13 @@ abstract class MainAsset extends InventoryAsset
     {
         $blacklist = new Blacklist();
 
+        $ruleEntity = new RuleImportEntityCollection();
+        $ruleEntity->getCollectionPart();
+        $ruleLocation = new RuleLocationCollection();
+        $ruleLocation->getCollectionPart();
+        $ruleImportAsset = new RuleImportAssetCollection();
+        $ruleImportAsset->getCollectionPart();
+
         foreach ($this->data as $key => $data) {
             $blacklist->processBlackList($data);
 
@@ -556,9 +563,6 @@ abstract class MainAsset extends InventoryAsset
 
             if (!$this->isAccessPoint($data)) {
                 $entity_input = $this->prepareEntitiesRulesInput($data, $input);
-
-                $ruleEntity = new RuleImportEntityCollection();
-                $ruleEntity->getCollectionPart();
                 $dataEntity = $ruleEntity->processAllRules($entity_input, []);
 
                 if (isset($dataEntity['_ignore_import'])) {
@@ -591,8 +595,6 @@ abstract class MainAsset extends InventoryAsset
                     }
                 }
 
-                $ruleLocation = new RuleLocationCollection();
-                $ruleLocation->getCollectionPart();
                 $dataLocation = $ruleLocation->processAllRules($input, []);
 
                 if (isset($dataLocation['locations_id']) && $dataLocation['locations_id'] != -1) {
@@ -605,9 +607,7 @@ abstract class MainAsset extends InventoryAsset
 
             //call rules on current collected data to find item
             //a callback on rulepassed() will be done if one is found.
-            $rule = new RuleImportAssetCollection();
-            $rule->getCollectionPart();
-            $datarules = $rule->processAllRules($input, [], ['class' => $this]);
+            $datarules = $ruleImportAsset->processAllRules($input, [], ['class' => $this]);
 
             if (isset($datarules['_no_rule_matches']) && $datarules['_no_rule_matches'] == '1') {
                 //no rule matched, this is a new one


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Yesterday I wrote a quick profiling extension for PHPUnit to get an overview of the slowest unit tests to see if any performance could be gained in the tests, or more importantly within GLPI itself.

Real world performance impacts may not be too much, but I also don't know enough about native inventory to say for sure. I guess at the very least it should reduce server load when multiple agents are submitting inventories.

In tests though, loading rule lists once for the MainAsset handling reduced execution of `InventoryTest::testImportNetworkEquipmentWireless` from 33 seconds to 20 seconds. This test was the slowest except for `SearchTest::testSearchAllMeta`. There may be smaller performance improvements in the other inventory tests.

This should be a safe change since rules are not being modified within this process.