### PR TITLE
Adjust display of reservation repitition fields

### DIFF
--- a/templates/components/form/reservation.html.twig
+++ b/templates/components/form/reservation.html.twig
@@ -159,7 +159,9 @@
             }
         ) }}
 
-        {{ fields.ajaxField('resaperiodcontent' ~ rand, '') }}
+        {{ fields.ajaxField('resaperiodcontent' ~ rand, '', '', {
+            full_width: true
+        }) }}
 
         {% do call('Ajax::updateItemOnSelectEvent', [
             'dropdown_periodicity_type_' ~ rand,


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Show repetition options as a full width field to avoid it being too small in the form.

PR in draft until the other part of the report can be verified/fixed.

## Screenshots (if appropriate):

<img width="701" height="618" alt="Selection_578" src="https://github.com/user-attachments/assets/6945d584-383d-4bd5-ae11-36ed5ad6933b" />
