### PR TITLE
tell users the expected regex pattern format

### DIFF
--- a/src/Rule.php
+++ b/src/Rule.php
@@ -2569,6 +2569,9 @@ JS
             && ($rc = getItemForItemtype($this->rulecriteriaclass))
         ) {
             echo Html::input($name, ['value' => $value]);
+            if (in_array($condition, [self::REGEX_MATCH, self::REGEX_NOT_MATCH])) {
+                echo '<span class="text-muted">' . __s('Patterns must include delimiters, e.g. /pattern/') . '</span>';
+            }
         }
     }
 

--- a/templates/pages/admin/rules/criteria.html.twig
+++ b/templates/pages/admin/rules/criteria.html.twig
@@ -41,7 +41,7 @@
         {{ inputs.hidden(rule.getRuleIdField, item.fields[rules_id_field]) }}
         {% set criteria_dropdown %}
             <div class="d-flex">
-                <div class="btn-group">
+                <div>
                     {% do call([rule, 'dropdownCriteria'], [{
                         value: item.fields['criteria'],
                         rand: rand


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Fixes #20611
Fixes #19308
Add a note under criteria value inputs when the condition type is REGEX or NOT REGEX to tell users that they need to include the delimiters around the pattern.

The GLPI user documentation doesn't explicitly say this, but it does include an example regular expression pattern that includes the delimiters.

This could be backported to 10.0/bugfixes if desired except the change in the Twig template since it doesn't exist in GLPI 10 and only fixes a UI issue with a box shadow in GLPI 11.

## Screenshots (if appropriate):

<img width="847" height="99" alt="Selection_579" src="https://github.com/user-attachments/assets/c987f3b0-4fb8-494c-b84f-aec20a819263" />

