### PR TITLE
Add ability to reset dashboards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The present file will list all changes made to the project; according to the
 ## [11.0.6] 2026-03-03
 
 ### Added
+- Dashboards can now be reset to the state it would have after a clean install. This is only available for dashboards added by GLPI itself.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The present file will list all changes made to the project; according to the
 ## [11.0.7] unreleased
 
 ### Added
+- Dashboards can now be reset to the state it would have after a clean install. This is only available for dashboards added by GLPI itself.
 
 ### Changed
 
@@ -27,7 +28,6 @@ The present file will list all changes made to the project; according to the
 ## [11.0.6] 2026-03-03
 
 ### Added
-- Dashboards can now be reset to the state it would have after a clean install. This is only available for dashboards added by GLPI itself.
 
 ### Changed
 

--- a/ajax/dashboard.php
+++ b/ajax/dashboard.php
@@ -39,6 +39,7 @@ use Glpi\Debug\Profiler;
 use Glpi\Error\ErrorHandler;
 use Glpi\Exception\Http\AccessDeniedHttpException;
 
+use Glpi\Exception\Http\UnprocessableEntityHttpException;
 use function Safe\json_decode;
 use function Safe\json_encode;
 
@@ -141,6 +142,21 @@ switch ($_POST['action'] ?? null) {
         }
         Config::setConfigurationValues('core', ['is_demo_dashboards' => 0]);
         return;
+
+    case 'prepare_reset':
+        if (!Session::haveRight(Config::$rightname, UPDATE)) {
+            throw new AccessDeniedHttpException();
+        }
+        $dashboard->showResetForm();
+        return;
+
+    case 'reset':
+        if (!Session::haveRight(Config::$rightname, UPDATE) || !isset($_POST['default_dashboard_key'])) {
+            throw new AccessDeniedHttpException();
+        }
+        if (!$dashboard->resetToDefault($_POST['default_dashboard_key'])) {
+            throw new UnprocessableEntityHttpException();
+        }
 }
 
 switch ($_GET['action'] ?? null) {

--- a/ajax/dashboard.php
+++ b/ajax/dashboard.php
@@ -38,8 +38,8 @@ use Glpi\Dashboard\Grid;
 use Glpi\Debug\Profiler;
 use Glpi\Error\ErrorHandler;
 use Glpi\Exception\Http\AccessDeniedHttpException;
-
 use Glpi\Exception\Http\UnprocessableEntityHttpException;
+
 use function Safe\json_decode;
 use function Safe\json_encode;
 

--- a/js/modules/Dashboard/Dashboard.js
+++ b/js/modules/Dashboard/Dashboard.js
@@ -33,7 +33,7 @@
 
 /* eslint prefer-template: 0 */
 /* global GridStack, GoInFullscreen, GoOutFullscreen, EasyMDE, getUuidV4, _, sortable */
-/* global glpi_ajax_dialog, glpi_close_all_dialogs */
+/* global glpi_ajax_dialog, glpi_close_all_dialogs, glpi_toast_info, glpi_toast_error */
 
 window.GLPI = window.GLPI || {};
 window.GLPI.Dashboard = {
@@ -469,6 +469,40 @@ class GLPIDashboard {
                 .show('fade').delay(2000).hide('fade');
         });
 
+        // reset dashboard
+        $(document).on('click', 'button.reset-dashboard ', (event) => {
+            event.preventDefault();
+            this.resetDashboard();
+        });
+        $(document).on('click', 'button[name="confirm-reset-dashboard"]', (event) => {
+            event.preventDefault();
+            const btn = $(event.target);
+            const selected_dashboard = btn
+                .closest('.dashboard-reset-container')
+                .find('select[name="default_dashboard_key"]');
+            $.ajax({
+                url: CFG_GLPI.root_doc+"/ajax/dashboard.php",
+                method: 'POST',
+                data: {
+                    action: 'reset',
+                    dashboard: this.current_name,
+                    default_dashboard_key: selected_dashboard.val(),
+                }
+            }).then(() => {
+                glpi_toast_info(__('Dashboard has been reset to default'));
+                if (window.reloadTab !== undefined) {
+                    window.reloadTab();
+                } else {
+                    this.initFilters();
+                    this.refreshDashboard();
+                }
+            }, () => {
+                glpi_toast_error(__('An error occurred while resetting the dashboard'));
+            }, () => {
+                glpi_close_all_dialogs();
+            });
+        });
+
         // display widget types after selecting a card
         $(document).on('select2:select', '.display-widget-form select[name=card_id]', (event) => {
             const select2_data      = event.params.data;
@@ -789,6 +823,17 @@ class GLPIDashboard {
         }).then(() => {
             if (force_refresh) {
                 this.refreshDashboard();
+            }
+        });
+    }
+
+    resetDashboard() {
+        glpi_ajax_dialog({
+            title: __("Reset to default"),
+            url: `${CFG_GLPI.root_doc}/ajax/dashboard.php`,
+            params: {
+                action: 'prepare_reset',
+                dashboard: this.current_name,
             }
         });
     }

--- a/js/modules/Dashboard/Dashboard.js
+++ b/js/modules/Dashboard/Dashboard.js
@@ -491,14 +491,15 @@ class GLPIDashboard {
             }).then(() => {
                 glpi_toast_info(__('Dashboard has been reset to default'));
                 if (window.reloadTab !== undefined) {
+                    window.glpi_close_all_dialogs();
                     window.reloadTab();
                 } else {
                     this.initFilters();
                     this.refreshDashboard();
+                    window.glpi_close_all_dialogs();
                 }
             }, () => {
                 glpi_toast_error(__('An error occurred while resetting the dashboard'));
-            }, () => {
                 glpi_close_all_dialogs();
             });
         });

--- a/src/Glpi/Dashboard/Dashboard.php
+++ b/src/Glpi/Dashboard/Dashboard.php
@@ -338,17 +338,11 @@ class Dashboard extends CommonDBTM
             return false;
         }
 
-        $default_dashboards = require(GLPI_ROOT . '/install/migrations/update_9.4.x_to_9.5.0/dashboards.php');
-
         $target_dashboard = null;
 
-        foreach ($default_dashboards as $dashboard) {
-            if ($dashboard['key'] === $default_dashboard_key) {
+        foreach (self::getDefaults() as $dashboard) {
+            if ($dashboard['key'] === $default_dashboard_key && $dashboard['context'] === $this->fields['context']) {
                 $target_dashboard = $dashboard;
-                $target_dashboard['_items'] = array_map(static function ($item) {
-                    $item['card_options'] = json_decode($item['card_options'], true);
-                    return $item;
-                }, $target_dashboard['_items']);
                 break;
             }
         }
@@ -359,7 +353,7 @@ class Dashboard extends CommonDBTM
 
         $this->saveFilter('');
         $this->saveRights([]);
-        $this->saveItems($target_dashboard['_items']);
+        $this->saveItems($target_dashboard['items']);
 
         return true;
     }
@@ -367,9 +361,8 @@ class Dashboard extends CommonDBTM
     public function showResetForm(): void
     {
         $this->load();
-        $default_dashboard_data = require(GLPI_ROOT . '/install/migrations/update_9.4.x_to_9.5.0/dashboards.php');
         $default_dashboards = [];
-        foreach ($default_dashboard_data as $dashboard) {
+        foreach (self::getDefaults() as $dashboard) {
             if ($dashboard['context'] !== $this->fields['context']) {
                 continue;
             }

--- a/src/Glpi/Dashboard/Grid.php
+++ b/src/Glpi/Dashboard/Grid.php
@@ -305,6 +305,7 @@ HTML;
         $filter_label     = __s("Toggle filter mode");
         $add_dash_label   = __s("Add a new dashboard");
         $save_label       = _sx('button', "Save");
+        $reset_label      = __s("Reset dashboard to default");
 
         $gridstack_items = $this->getGridItemsHtml(!$mini);
 
@@ -339,9 +340,24 @@ HTML;
                 $r_tb_icons .= "<i class='btn btn-sm btn-icon btn-ghost-secondary ti ti-share fs-toggle open-embed' data-bs-toggle='tooltip' data-bs-placement='bottom' title='$embed_label'></i>";
                 $rename = "<div class='edit-dashboard-properties'>
                <input type='text' class='dashboard-name form-control' value='{$dashboard_title}' size='1'>
-               <i class='btn btn-ghost-secondary ti ti-device-floppy ms-1 save-dashboard-name' data-bs-toggle='tooltip' data-bs-placement='bottom' title='{$save_label}'></i>
+               <button class='btn btn-ghost-secondary btn-icon btn-sm fs-2 ms-1 save-dashboard-name' data-bs-toggle='tooltip' data-bs-placement='bottom' title='{$save_label}'>
+                   <i class='ti ti-device-floppy' ></i>
+               </button>
+               <button class='btn btn-ghost-danger btn-icon btn-sm fs-2 ms-1 reset-dashboard' data-bs-toggle='tooltip' data-bs-placement='bottom' title='{$reset_label}'>
+                   <i class='ti ti-refresh' ></i>
+               </button>
                <span class='display-message'></span>
             </div>";
+            }
+            if ($mini && $can_edit) {
+                $rename = <<<HTML
+                    <div class='edit-dashboard-properties'>
+                        <button class='btn btn-ghost-danger btn-icon btn-sm fs-2 ms-1 reset-dashboard' title='{$reset_label}'>
+                           <i class='ti ti-refresh' ></i>
+                       </button>
+                    </div>
+HTML;
+
             }
             if (!$mini && $can_purge) {
                 $r_tb_icons .= "<i class='btn btn-sm btn-icon btn-ghost-secondary ti ti-trash fs-toggle delete-dashboard' data-bs-toggle='tooltip' data-bs-placement='bottom' title='$delete_label'></i>";
@@ -365,6 +381,17 @@ HTML;
                   </div>
                   $rename
                </span>
+HTML;
+            } else {
+                $left_toolbar = <<<HTML
+                    <div class="toolbar left-toolbar mb-3 position-relative">
+                        <div class='edit-dashboard-properties'>
+                            <button class='btn btn-ghost-danger btn-sm ms-1 reset-dashboard'>
+                               <i class='ti ti-refresh' ></i>
+                               {$reset_label}
+                           </button>
+                        </div>
+                    </div>
 HTML;
             }
 

--- a/templates/components/dashboard/reset.html.twig
+++ b/templates/components/dashboard/reset.html.twig
@@ -5,7 +5,7 @@
  #
  # http://glpi-project.org
  #
- # @copyright 2015-2025 Teclib' and contributors.
+ # @copyright 2015-2026 Teclib' and contributors.
  # @licence   https://www.gnu.org/licenses/gpl-3.0.html
  #
  # ---------------------------------------------------------------------

--- a/templates/components/dashboard/reset.html.twig
+++ b/templates/components/dashboard/reset.html.twig
@@ -1,0 +1,54 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2025 Teclib' and contributors.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+{% import 'components/form/fields_macros.html.twig' as fields %}
+{% import 'components/alerts_macros.html.twig' as alerts %}
+
+<div class="dashboard-reset-container">
+    {% if dashboard.fields['context'] == 'core' or dashboard.fields['context'] == 'mini_core' %}
+        <div>
+            {{ alerts.alert_danger(__('This will reset all filters, cards, and sharing options in this dashboard with the one selected!')) }}
+            {{ fields.dropdownArrayField('default_dashboard_key', null, default_dashboards, __('Default dashboard to reset to'), {
+                full_width: true,
+                is_horizontal: false,
+            }) }}
+        </div>
+        <div class="flex-row-reverse">
+            <button type="button" class="btn btn-danger" name="confirm-reset-dashboard">
+                <i class="ti ti-refresh-alert me-1 alert-icon"></i>
+                {{ __('Reset to default') }}
+            </button>
+        </div>
+    {% else %}
+        {{ alerts.alert_danger(__('Resetting this dashboard is not currently supported.')) }}
+    {% endif %}
+</div>


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] This change requires a documentation update.

## Description

This has been frequently requested on the community forum at least for a while, and is even useful for developers and testers.
Similar to the new ability to reset display preferences also added in GLPI 11, this adds the ability to reset dashboards based on the data used during the initial install of GLPI.

This is only supported for "core" and "mini_core" dashboards. When choosing the dashboard to reset to, the choice is limited to initial dashboards of the same context. For example, the mini ticket dashboard will not offer to reset to the default Assets dashboard.

## Screenshots (if appropriate):

<img width="481" height="164" alt="Selection_582" src="https://github.com/user-attachments/assets/5f8a3563-2b9e-4076-ac77-b18a9db36045" />
<img width="674" height="170" alt="Selection_584" src="https://github.com/user-attachments/assets/1f76059e-9e1e-4206-a1ea-76a36d5895c1" />
<img width="567" height="348" alt="Selection_583" src="https://github.com/user-attachments/assets/becad935-7c0c-467f-bd69-adc66363122f" />
<img width="544" height="192" alt="Selection_585" src="https://github.com/user-attachments/assets/599e0dbd-d171-425e-9222-7fef78e81cc4" />

