### PR TITLE
[HLAPI] Add GraphQL scope and fix scope checks

### DIFF
--- a/phpunit/HLAPITestCase.php
+++ b/phpunit/HLAPITestCase.php
@@ -70,7 +70,7 @@ class HLAPITestCase extends DbTestCase
         return parent::login($user_name, $user_pass, $noauto, $expected);
     }
 
-    public function login(string $user_name = TU_USER, string $user_pass = TU_PASS, bool $noauto = true, bool $expected = true): Auth
+    public function login(string $user_name = TU_USER, string $user_pass = TU_PASS, bool $noauto = true, bool $expected = true, array $api_options = []): Auth
     {
         $request = new Request('POST', '/token', [
             'Content-Type' => 'application/json',
@@ -80,7 +80,7 @@ class HLAPITestCase extends DbTestCase
             'client_secret' => TU_OAUTH_CLIENT_SECRET,
             'username' => $user_name,
             'password' => $user_pass,
-            'scope' => 'api',
+            'scope' => $api_options['scope'] ?? 'email user api inventory status graphql',
         ]));
         $this->api->call($request, function ($call) {
             /** @var HLAPICallAsserter $call */

--- a/phpunit/functional/Glpi/Api/HL/Controller/AdministrationControllerTest.php
+++ b/phpunit/functional/Glpi/Api/HL/Controller/AdministrationControllerTest.php
@@ -535,4 +535,57 @@ class AdministrationControllerTest extends \HLAPITestCase
             });
         }
     }
+
+    public function testUserScope()
+    {
+        $this->login(api_options: ['scope' => 'api']);
+        $this->api->call(new Request('GET', '/Administration/User/Me'), function ($call) {
+            /** @var \HLAPICallAsserter $call */
+            $call->response
+                ->isAccessDenied();
+        });
+        $this->api->call(new Request('GET', '/Administration/User/Me/Emails/Default'), function ($call) {
+            /** @var \HLAPICallAsserter $call */
+            $call->response
+                ->isAccessDenied();
+        });
+        $this->login(api_options: ['scope' => 'user']);
+        $this->api->call(new Request('GET', '/Administration/User/Me'), function ($call) {
+            /** @var \HLAPICallAsserter $call */
+            $call->response
+                ->isOK();
+        });
+        $this->api->call(new Request('GET', '/Administration/User/Me/Emails/Default'), function ($call) {
+            /** @var \HLAPICallAsserter $call */
+            $call->response
+                ->isOK();
+        });
+    }
+
+    public function testEmailScope()
+    {
+        $this->login(api_options: ['scope' => 'api']);
+        $this->api->call(new Request('GET', '/Administration/User/me'), function ($call) {
+            /** @var \HLAPICallAsserter $call */
+            $call->response
+                ->isAccessDenied();
+        });
+        $this->api->call(new Request('GET', '/Administration/User/me/Emails/Default'), function ($call) {
+            /** @var \HLAPICallAsserter $call */
+            $call->response
+                ->isAccessDenied();
+        });
+        $this->login(api_options: ['scope' => 'email']);
+        // Access to email scope doesn't allow broad access to current user info
+        $this->api->call(new Request('GET', '/Administration/User/me'), function ($call) {
+            /** @var \HLAPICallAsserter $call */
+            $call->response
+                ->isAccessDenied();
+        });
+        $this->api->call(new Request('GET', '/Administration/User/me/Emails/Default'), function ($call) {
+            /** @var \HLAPICallAsserter $call */
+            $call->response
+                ->isOK();
+        });
+    }
 }

--- a/phpunit/functional/Glpi/Api/HL/Controller/CoreControllerTest.php
+++ b/phpunit/functional/Glpi/Api/HL/Controller/CoreControllerTest.php
@@ -374,4 +374,20 @@ class CoreControllerTest extends \HLAPITestCase
                 });
         });
     }
+
+    public function testStatusScope()
+    {
+        $this->login(api_options: ['scope' => 'api']);
+        $this->api->call(new Request('GET', '/Status'), function ($call) {
+            /** @var \HLAPICallAsserter $call */
+            $call->response
+                ->isAccessDenied();
+        });
+        $this->login(api_options: ['scope' => 'status']);
+        $this->api->call(new Request('GET', '/Status'), function ($call) {
+            /** @var \HLAPICallAsserter $call */
+            $call->response
+                ->isOK();
+        });
+    }
 }

--- a/phpunit/functional/Glpi/Api/HL/Controller/GraphQLControllerTest.php
+++ b/phpunit/functional/Glpi/Api/HL/Controller/GraphQLControllerTest.php
@@ -316,4 +316,22 @@ GRAPHQL);
                 });
         });
     }
+
+    public function testGraphQLScope()
+    {
+        $this->login(api_options: ['scope' => 'api']);
+        $request = new Request('POST', '/GraphQL', [], 'query { Ticket { id name } }');
+        $this->api->call($request, function ($call) {
+            /** @var \HLAPICallAsserter $call */
+            $call->response
+                ->isAccessDenied();
+        });
+        $this->login(api_options: ['scope' => 'graphql']);
+        $request = new Request('POST', '/GraphQL', [], 'query { Ticket { id name } }');
+        $this->api->call($request, function ($call) {
+            /** @var \HLAPICallAsserter $call */
+            $call->response
+                ->isOK();
+        });
+    }
 }

--- a/resources/api_doc.MD
+++ b/resources/api_doc.MD
@@ -30,7 +30,8 @@ When the client is created, there will be an automatically generated client ID a
 - `email`: Access to the user's own default email address
 - `user`: Access to the user's information
 - `status`: Access to the status endpoints (Does not apply when accessed via the CLI commands)
-- `inventory`: Access to submit inventory from the GLPI Agent via Client Credentials grant.
+- `inventory`: Access to submit inventory from the GLPI Agent via Client Credentials grant
+- `graphql`: Access to the GraphQL endpoint
 - `api`: Access to the API (All other endpoints not handled by their own scope)
 
 

--- a/src/Glpi/OAuth/Server.php
+++ b/src/Glpi/OAuth/Server.php
@@ -184,6 +184,7 @@ final class Server
             'api' => 'api',
             'inventory' => 'inventory',
             'status' => 'status',
+            'graphql' => 'graphql',
         ];
     }
 
@@ -195,6 +196,7 @@ final class Server
             'api' => __('Access to the API'),
             'inventory' => __('Access to submit inventory from an agent'),
             'status' => __('Access to the status endpoint'),
+            'graphql' => __('Access to the GraphQL endpoint'),
         ];
     }
 

--- a/tests/src/autoload/functions.php
+++ b/tests/src/autoload/functions.php
@@ -678,7 +678,7 @@ function loadDataset()
             [
                 'redirect_uri' => ["/api.php/oauth2/redirection"],
                 'grants' => ['password', 'client_credentials', 'authorization_code'],
-                'scopes' => ['api'],
+                'scopes' => ['email', 'user', 'api', 'inventory', 'status', 'graphql'],
                 'is_active' => 1,
                 'is_confidential' => 1,
                 'name' => 'Test OAuth Client',


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

- Separates access to the GraphQL endpoint from the generic `api` OAuth scope. The GraphQL endpoint is a little more capable than the regular Rest API of causing the server to process a lot of data. I think it is better to split this into its own scope now to let GLPI admins decide who really needs access to it.
- Fixes scope checks from within the test environment as it was being detected as CLI and bypassing them.
- Adds scope tests.

