### PR TITLE
[HLAPI] Fix parsing != and valueless filters

### DIFF
--- a/phpunit/functional/Glpi/Api/HL/RSQL/LexerTest.php
+++ b/phpunit/functional/Glpi/Api/HL/RSQL/LexerTest.php
@@ -61,6 +61,74 @@ class LexerTest extends GLPITestCase
                 'name==(test', // In this case, "(test" is a valid value
                 [[5, 'name'], [6, '=='], [7, '(test']],
             ],
+            [
+                'name!=test', // Only operator that doesn't start with '='
+                [[5, 'name'], [6, '!='], [7, 'test']],
+            ],
+            [
+                'name=in=test',
+                [[5, 'name'], [6, '=in='], [7, 'test']],
+            ],
+            [
+                'name=out=test',
+                [[5, 'name'], [6, '=out='], [7, 'test']],
+            ],
+            [
+                'name=lt=test',
+                [[5, 'name'], [6, '=lt='], [7, 'test']],
+            ],
+            [
+                'name=le=test',
+                [[5, 'name'], [6, '=le='], [7, 'test']],
+            ],
+            [
+                'name=gt=test',
+                [[5, 'name'], [6, '=gt='], [7, 'test']],
+            ],
+            [
+                'name=ge=test',
+                [[5, 'name'], [6, '=ge='], [7, 'test']],
+            ],
+            [
+                'name=like=test',
+                [[5, 'name'], [6, '=like='], [7, 'test']],
+            ],
+            [
+                'name=ilike=test',
+                [[5, 'name'], [6, '=ilike='], [7, 'test']],
+            ],
+            [
+                'name=isnull=test',
+                [[5, 'name'], [6, '=isnull='], [7, 'test']],
+            ],
+            [
+                'name=isnull=',
+                [[5, 'name'], [6, '=isnull='], [8, '']],
+            ],
+            [
+                'name=notnull=test',
+                [[5, 'name'], [6, '=notnull='], [7, 'test']],
+            ],
+            [
+                'name=notnull=',
+                [[5, 'name'], [6, '=notnull='], [8, '']],
+            ],
+            [
+                'name=empty=test',
+                [[5, 'name'], [6, '=empty='], [7, 'test']],
+            ],
+            [
+                'name=empty=',
+                [[5, 'name'], [6, '=empty='], [8, '']],
+            ],
+            [
+                'name=notempty=test',
+                [[5, 'name'], [6, '=notempty='], [7, 'test']],
+            ],
+            [
+                'name=notempty=',
+                [[5, 'name'], [6, '=notempty='], [8, '']],
+            ],
         ];
     }
 
@@ -92,13 +160,6 @@ class LexerTest extends GLPITestCase
         $this->expectException(RSQLException::class);
         $this->expectExceptionMessage('RSQL query has an incomplete operator in filter for property "id"');
         Lexer::tokenize($query);
-    }
-
-    public function testMissingValue()
-    {
-        $this->expectException(RSQLException::class);
-        $this->expectExceptionMessage('RSQL query is missing a value in filter for property "id"');
-        Lexer::tokenize('id=like=');
     }
 
     public static function unclosedGroupProvider()

--- a/phpunit/functional/Glpi/Api/HL/RSQL/ParserTest.php
+++ b/phpunit/functional/Glpi/Api/HL/RSQL/ParserTest.php
@@ -37,59 +37,16 @@ namespace tests\units\Glpi\Api\HL\RSQL;
 use Glpi\Api\HL\Doc\Schema;
 use Glpi\Api\HL\RSQL\Error;
 use Glpi\Api\HL\RSQL\Parser;
+use Glpi\Api\HL\RSQL\RSQLException;
 use Glpi\Api\HL\Search;
 use GLPITestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 class ParserTest extends GLPITestCase
 {
-    public static function parseProvider()
+    private function getParserInstance($schema = null)
     {
-        return [
-            [
-                [[5, 'id'], [6, '=='], [7, '20']], /** Tokens. First element is the token type. See T_* consts in {@link \Glpi\Api\HL\RSQL\Lexer} */
-                "(`_`.`id` = '20')",
-            ],
-            [
-                [
-                    [3, "("], [3, "("], [5, "model.name"], [6, "=in="], [7, "(A2696,A2757,A2777)"], [1, ";"],
-                    [5, "name"], [6, "=like="], [7, "*Staff*"], [4, ")"], [2, ","], [3, "("], [5, "model.name"],
-                    [6, "=in="], [7, "(A2602,A2604,A2603,A2605)"], [1, ";"], [5, "name"], [6, "=like="], [7, "*Student*"],
-                    [4, ")"], [4, ")"], [2, ","], [5, "name"], [6, "=in="], [7, "(A2436,A2764,A2437,A2766)"],
-                ],
-                "(((`model`.`name` IN ('A2696', 'A2757', 'A2777')) AND (`_`.`name` LIKE CAST('%Staff%' AS BINARY))) OR ((`model`.`name` IN ('A2602', 'A2604', 'A2603', 'A2605')) AND (`_`.`name` LIKE CAST('%Student%' AS BINARY)))) OR (`_`.`name` IN ('A2436', 'A2764', 'A2437', 'A2766'))",
-            ],
-            [
-                [[5, 'name'], [6, '=='], [7, '(test']],
-                "(`_`.`name` = '(test')",
-            ],
-            [
-                [[5, 'scalar_join'], [6, '=='], [7, '1']],
-                "(`scalar_join`.`external_prop` = '1')", // While the property is 'scalar_join', that is also the join name. The field it points to is 'external_prop', so the resolved SQL is `scalar_join`.`external_prop`.
-            ],
-            [
-                [[5, 'scalar_join'], [6, '=='], [7, 'true']],
-                "(`scalar_join`.`external_prop` = '1')",
-            ],
-            [
-                [[5, 'scalar_join'], [6, '=='], [7, '0']],
-                "(`scalar_join`.`external_prop` = '0')",
-            ],
-            [
-                [[5, 'scalar_join'], [6, '=='], [7, 'false']],
-                "(`scalar_join`.`external_prop` = '0')",
-            ],
-            [
-                [[5, 'extra_fields.extra1'], [6, '=='], [7, 'test']],
-                "(`extra_fieldsextra1`.`extra1` = 'test')",
-            ],
-        ];
-    }
-
-    #[DataProvider('parseProvider')]
-    public function testParse(array $tokens, string $expected)
-    {
-        $schema = [
+        $schema ??= [
             'properties' => [
                 'id' => ['type' => 'integer'],
                 'name' => ['type' => 'string'],
@@ -132,8 +89,120 @@ class ParserTest extends GLPITestCase
         $context_class->getProperty('flattened_properties')->setValue($context, Schema::flattenProperties($schema['properties']));
         $context_class->getProperty('joins')->setValue($context, Schema::getJoins($schema['properties']));
         $search_class->getProperty('context')->setValue($search, $context);
-        $parser = new Parser($search);
-        $this->assertEquals($expected, (string) $parser->parse($tokens)->getSQLWhereCriteria());
+        return new Parser($search);
+    }
+
+    public static function parseProvider()
+    {
+        return [
+            [
+                [[5, 'id'], [6, '=='], [7, '20']], /** Tokens. First element is the token type. See T_* consts in {@link \Glpi\Api\HL\RSQL\Lexer} */
+                "(`_`.`id` = '20')",
+            ],
+            [
+                [
+                    [3, "("], [3, "("], [5, "model.name"], [6, "=in="], [7, "(A2696,A2757,A2777)"], [1, ";"],
+                    [5, "name"], [6, "=like="], [7, "*Staff*"], [4, ")"], [2, ","], [3, "("], [5, "model.name"],
+                    [6, "=in="], [7, "(A2602,A2604,A2603,A2605)"], [1, ";"], [5, "name"], [6, "=like="], [7, "*Student*"],
+                    [4, ")"], [4, ")"], [2, ","], [5, "name"], [6, "=in="], [7, "(A2436,A2764,A2437,A2766)"],
+                ],
+                "(((`model`.`name` IN ('A2696', 'A2757', 'A2777')) AND (`_`.`name` LIKE CAST('%Staff%' AS BINARY))) OR ((`model`.`name` IN ('A2602', 'A2604', 'A2603', 'A2605')) AND (`_`.`name` LIKE CAST('%Student%' AS BINARY)))) OR (`_`.`name` IN ('A2436', 'A2764', 'A2437', 'A2766'))",
+            ],
+            [
+                [[5, 'name'], [6, '=='], [7, '(test']],
+                "(`_`.`name` = '(test')",
+            ],
+            [
+                [[5, 'scalar_join'], [6, '=='], [7, '1']],
+                "(`scalar_join`.`external_prop` = '1')", // While the property is 'scalar_join', that is also the join name. The field it points to is 'external_prop', so the resolved SQL is `scalar_join`.`external_prop`.
+            ],
+            [
+                [[5, 'scalar_join'], [6, '=='], [7, 'true']],
+                "(`scalar_join`.`external_prop` = '1')",
+            ],
+            [
+                [[5, 'scalar_join'], [6, '=='], [7, '0']],
+                "(`scalar_join`.`external_prop` = '0')",
+            ],
+            [
+                [[5, 'scalar_join'], [6, '=='], [7, 'false']],
+                "(`scalar_join`.`external_prop` = '0')",
+            ],
+            [
+                [[5, 'extra_fields.extra1'], [6, '=='], [7, 'test']],
+                "(`extra_fieldsextra1`.`extra1` = 'test')",
+            ],
+            [
+                [[5, 'id'], [6, '=in='], [7, '(4,7)']],
+                "(`_`.`id` IN ('4', '7'))",
+            ],
+            [
+                [[5, 'id'], [6, '=out='], [7, '(4,7)']],
+                "( NOT (`_`.`id` IN ('4', '7')))",
+            ],
+            [
+                [[5, 'id'], [6, '=gt='], [7, '4']],
+                "(`_`.`id` > '4')",
+            ],
+            [
+                [[5, 'id'], [6, '=ge='], [7, '4']],
+                "(`_`.`id` >= '4')",
+            ],
+            [
+                [[5, 'id'], [6, '=lt='], [7, '4']],
+                "(`_`.`id` < '4')",
+            ],
+            [
+                [[5, 'id'], [6, '=le='], [7, '4']],
+                "(`_`.`id` <= '4')",
+            ],
+            [
+                [[5, 'name'], [6, '=like='], [7, '*test*']],
+                "(`_`.`name` LIKE CAST('%test%' AS BINARY))",
+            ],
+            [
+                [[5, 'name'], [6, '=ilike='], [7, '%Test*']],
+                "(`_`.`name` LIKE '_Test%')",
+            ],
+            [
+                [[5, 'name'], [6, '=isnull='], [7, 'test']],
+                "(`_`.`name` IS NULL)",
+            ],
+            [
+                [[5, 'name'], [6, '=isnull='], [8, '']],
+                "(`_`.`name` IS NULL)",
+            ],
+            [
+                [[5, 'name'], [6, '=notnull='], [7, 'test']],
+                "( NOT (`_`.`name` IS NULL))",
+            ],
+            [
+                [[5, 'name'], [6, '=notnull='], [8, '']],
+                "( NOT (`_`.`name` IS NULL))",
+            ],
+            [
+                [[5, 'name'], [6, '=empty='], [7, 'test']],
+                "(((`_`.`name` = '') OR (`_`.`name` IS NULL)))",
+            ],
+            [
+                [[5, 'name'], [6, '=empty='], [8, '']],
+                "(((`_`.`name` = '') OR (`_`.`name` IS NULL)))",
+            ],
+            [
+                [[5, 'name'], [6, '=notempty='], [7, 'test']],
+                "(((`_`.`name` <> '') AND (`_`.`name` <> NULL)))",
+            ],
+            [
+                [[5, 'name'], [6, '=notempty='], [8, '']],
+                "(((`_`.`name` <> '') AND (`_`.`name` <> NULL)))",
+            ],
+        ];
+    }
+
+    #[DataProvider('parseProvider')]
+    public function testParse(array $tokens, string $expected)
+    {
+        $this->assertEquals($expected, (string) $this->getParserInstance()->parse($tokens)->getSQLWhereCriteria());
     }
 
     /**
@@ -142,7 +211,7 @@ class ParserTest extends GLPITestCase
      */
     public function testIgnoreInvalidProperties()
     {
-        $schema = [
+        $parser = $this->getParserInstance([
             'properties' => [
                 'id' => ['type' => 'integer'],
                 'name' => ['type' => 'string'],
@@ -152,17 +221,7 @@ class ParserTest extends GLPITestCase
                     'x-mapper' => static fn() => 'mapped',
                 ],
             ],
-        ];
-
-        $search_class = new \ReflectionClass(Search::class);
-        $search = $search_class->newInstanceWithoutConstructor();
-        $context_class = new \ReflectionClass(Search\SearchContext::class);
-        $context = $context_class->newInstanceWithoutConstructor();
-        $context_class->getProperty('schema')->setValue($context, $schema);
-        $context_class->getProperty('flattened_properties')->setValue($context, Schema::flattenProperties($schema['properties']));
-        $context_class->getProperty('joins')->setValue($context, Schema::getJoins($schema['properties']));
-        $search_class->getProperty('context')->setValue($search, $context);
-        $parser = new Parser($search);
+        ]);
 
         $result = $parser->parse([[5, 'test'], [6, '=='], [7, 'test']]);
         $this->assertEquals('1', (string) $result->getSQLWhereCriteria());
@@ -181,5 +240,13 @@ class ParserTest extends GLPITestCase
         $result = $parser->parse([[5, 'mapped'], [6, '=='], [7, 'test']]);
         $this->assertEquals('1', (string) $result->getSQLWhereCriteria());
         $this->assertEquals(Error::MAPPED_PROPERTY, $result->getInvalidFilters()['mapped']);
+    }
+
+    public function testMissingValue()
+    {
+        $this->expectException(RSQLException::class);
+        $this->expectExceptionMessage('RSQL query is missing a value in filter for property "id"');
+        $parser = $this->getParserInstance();
+        $parser->parse([[5, 'id'], [6, '=='], [8, '']]);
     }
 }

--- a/src/Glpi/Api/HL/RSQL/Parser.php
+++ b/src/Glpi/Api/HL/RSQL/Parser.php
@@ -96,6 +96,7 @@ final class Parser
                 [
                     'operator' => '==',
                     'description' => 'equivalent to',
+                    'value_expected' => true,
                     'sql_where_callable' => fn($a, $b) => [
                         [$this->db::quoteName($a) => $b],
                     ],
@@ -103,6 +104,7 @@ final class Parser
                 [
                     'operator' => '!=',
                     'description' => 'not equivalent to',
+                    'value_expected' => true,
                     'sql_where_callable' => fn($a, $b) => [
                         [$this->db::quoteName($a) => ['<>', $b]],
                     ],
@@ -110,6 +112,7 @@ final class Parser
                 [
                     'operator' => '=in=',
                     'description' => 'in',
+                    'value_expected' => true,
                     'sql_where_callable' => fn($a, $b) => [
                         [$this->db::quoteName($a) => $this->rsqlGroupToArray($b)],
                     ],
@@ -117,6 +120,7 @@ final class Parser
                 [
                     'operator' => '=out=',
                     'description' => 'not in',
+                    'value_expected' => true,
                     'sql_where_callable' => fn($a, $b) => [
                         ['NOT' => [$this->db::quoteName($a) => $this->rsqlGroupToArray($b)]],
                     ],
@@ -124,6 +128,7 @@ final class Parser
                 [
                     'operator' => '=lt=',
                     'description' => 'less than',
+                    'value_expected' => true,
                     'sql_where_callable' => fn($a, $b) => [
                         [$this->db::quoteName($a) => ['<', $b]],
                     ],
@@ -131,6 +136,7 @@ final class Parser
                 [
                     'operator' => '=le=',
                     'description' => 'less than or equal to',
+                    'value_expected' => true,
                     'sql_where_callable' => fn($a, $b) => [
                         [$this->db::quoteName($a) => ['<=', $b]],
                     ],
@@ -138,6 +144,7 @@ final class Parser
                 [
                     'operator' => '=gt=',
                     'description' => 'greater than',
+                    'value_expected' => true,
                     'sql_where_callable' => fn($a, $b) => [
                         [$this->db::quoteName($a) => ['>', $b]],
                     ],
@@ -145,6 +152,7 @@ final class Parser
                 [
                     'operator' => '=ge=',
                     'description' => 'greater than or equal to',
+                    'value_expected' => true,
                     'sql_where_callable' => fn($a, $b) => [
                         [$this->db::quoteName($a) => ['>=', $b]],
                     ],
@@ -152,6 +160,7 @@ final class Parser
                 [
                     'operator' => '=like=',
                     'description' => 'like',
+                    'value_expected' => true,
                     'sql_where_callable' => function ($a, $b) {
                         $b = str_replace(['%', '*'], ['_', '%'], $b);
                         return [
@@ -164,6 +173,7 @@ final class Parser
                 [
                     'operator' => '=ilike=',
                     'description' => 'case insensitive like',
+                    'value_expected' => true,
                     'sql_where_callable' => function ($a, $b) {
                         $b = str_replace(['%', '*'], ['_', '%'], $b);
                         return [
@@ -174,6 +184,7 @@ final class Parser
                 [
                     'operator' => '=isnull=',
                     'description' => 'is null',
+                    'value_expected' => false,
                     'sql_where_callable' => fn($a, $b) => [
                         [$this->db::quoteName($a) => null],
                     ],
@@ -181,6 +192,7 @@ final class Parser
                 [
                     'operator' => '=notnull=',
                     'description' => 'is not null',
+                    'value_expected' => false,
                     'sql_where_callable' => fn($a, $b) => [
                         ['NOT' => [$this->db::quoteName($a) => null]],
                     ],
@@ -189,6 +201,7 @@ final class Parser
                     // Empty string or null
                     'operator' => '=empty=',
                     'description' => 'is empty',
+                    'value_expected' => false,
                     'sql_where_callable' => fn($a, $b) => [
                         [
                             'OR' => [
@@ -201,6 +214,7 @@ final class Parser
                 [
                     'operator' => '=notempty=',
                     'description' => 'is not empty',
+                    'value_expected' => false,
                     'sql_where_callable' => fn($a, $b) => [
                         [
                             'AND' => [
@@ -218,6 +232,7 @@ final class Parser
     /**
      * @param array $tokens Tokens from the RSQL lexer.
      * @return Result RSQL query result
+     * @throws RSQLException
      */
     public function parse(array $tokens): Result
     {
@@ -270,9 +285,13 @@ final class Parser
                     $buffer['operator'] = null;
                 } else {
                     $buffer['operator'] = $operators[$value]['sql_where_callable'];
+                    $buffer['value_expected'] = $operators[$value]['value_expected'];
                 }
-            } elseif ($type === Lexer::T_VALUE) {
+            } elseif ($type === Lexer::T_VALUE || $type === Lexer::T_UNSPECIFIED_VALUE) {
                 if ($buffer['property'] !== null && $buffer['operator'] !== null && $buffer['field'] !== null) {
+                    if ($buffer['value_expected'] && $type === Lexer::T_UNSPECIFIED_VALUE) {
+                        throw new RSQLException('', sprintf(__('RSQL query is missing a value in filter for property "%1$s"'), $buffer['property']));
+                    }
                     // Unquote value if it is quoted
                     if (preg_match('/^".*"$/', $value) || preg_match("/^'.*'$/", $value)) {
                         $value = substr($value, 1, -1);


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

Filters using the `!=` operator were not being lexed properly as the logic incorrectly assumed all filter operators begin with "=". Support for this was added to the lexer and the parser was changed to be in charge of handling missing values based on the operator token.
This also fixes issues with filters using operators where a value is not expected/needed like `=isnull=`.

RSQL tests were expanded to cover all operators.
