### PR TITLE
Allow usage of `/` routes in plugins

### DIFF
--- a/src/Glpi/Kernel/Listener/RequestListener/PluginsRouterListener.php
+++ b/src/Glpi/Kernel/Listener/RequestListener/PluginsRouterListener.php
@@ -78,7 +78,7 @@ final readonly class PluginsRouterListener implements EventSubscriberInterface
         }
 
         $route_matches = [];
-        if (preg_match('#^/plugins/(?<plugin_key>[^\/]+)(?<plugin_resource>/.+)$#', $request->getPathInfo(), $route_matches) !== 1) {
+        if (preg_match('#^/plugins/(?<plugin_key>[^\/]+)(?<plugin_resource>/.*)$#', $request->getPathInfo(), $route_matches) !== 1) {
             return;
         }
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

The plugin route pattern was `/.+`, but that was not allowing the definition of a `/` route inside a plugin (e.g. `https://glpi.domain.tld/plugins/glpiinventory/`). With a `/.*` pattern, this will be possible.

I did not find a way to test this, as it depends on the Symfony router component that is pretty hard to mock.