### PR TITLE
fix(inventory): Import denied (no log) error when importing network equipment

### DIFF
--- a/src/Inventory/Asset/MainAsset.php
+++ b/src/Inventory/Asset/MainAsset.php
@@ -854,12 +854,11 @@ abstract class MainAsset extends InventoryAsset
             //Or printer that has not changed its IP
             //do not update to prevents discoveries to remove all ports, IPs and so on found with network inventory
             if (
-                $itemtype == NetworkEquipment::getType()
-                ||
                 (
-                    $itemtype == Printer::getType()
-                && !AssetPrinter::needToBeUpdatedFromDiscovery($this->item, $val)
+                    $itemtype == NetworkEquipment::getType()
+                    || $itemtype == Printer::getType()
                 )
+                && !(\Glpi\Inventory\Asset\NetworkEquipment::needToBeUpdatedFromDiscovery($this->item, $val))
             ) {
                 //only update autoupdatesystems_id, last_inventory_update, snmpcredentials_id
                 $input = $this->handleInput($val, $this->item);

--- a/src/Inventory/Asset/NetworkEquipment.php
+++ b/src/Inventory/Asset/NetworkEquipment.php
@@ -450,4 +450,34 @@ class NetworkEquipment extends MainAsset
     {
         return \NetworkEquipment::class;
     }
+
+    /**
+     * Try to know if networkEquipement need to be updated from discovery
+     * Only if IP has changed
+     * @return boolean
+     */
+    public static function needToBeUpdatedFromDiscovery(\CommonDBTM $item, $val)
+    {
+        if (property_exists($val, 'ips')) {
+            foreach ($val->ips as $ip) {
+                $blacklist = new Blacklist();
+                //exclude IP if needed
+                if ('' != $blacklist->process(Blacklist::IP, $ip)) {
+                    //try to find IP (get from discovery) from known IP of item
+                    //if found refuse update
+                    //if no, item IP have changed so  we allow the update from discovery
+                    $ipaddress = new \IPAddress($ip);
+                    $tmp['mainitems_id'] = $item->fields['id'];
+                    $tmp['mainitemtype'] = $item::getType();
+                    $tmp['is_dynamic']   = 1;
+                    $tmp['name']         = $ipaddress->getTextual();
+                    if ($ipaddress->getFromDBByCrit(Sanitizer::sanitize($tmp))) {
+                        return false;
+                    }
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
 }

--- a/src/Inventory/Asset/Printer.php
+++ b/src/Inventory/Asset/Printer.php
@@ -365,36 +365,6 @@ class Printer extends NetworkEquipment
         }
     }
 
-    /**
-     * Try to know if printer need to be updated from discovery
-     * Only if IP has changed
-     * @return boolean
-     */
-    public static function needToBeUpdatedFromDiscovery(CommonDBTM $item, $val)
-    {
-        if (property_exists($val, 'ips')) {
-            foreach ($val->ips as $ip) {
-                $blacklist = new Blacklist();
-                //exclude IP if needed
-                if ('' != $blacklist->process(Blacklist::IP, $ip)) {
-                    //try to find IP (get from discovery) from known IP of Printer
-                    //if found refuse update
-                    //if no, printer IP have changed so  we allow the update from discovery
-                    $ipaddress = new IPAddress($ip);
-                    $tmp['mainitems_id'] = $item->fields['id'];
-                    $tmp['mainitemtype'] = $item::getType();
-                    $tmp['is_dynamic']   = 1;
-                    $tmp['name']         = $ipaddress->getTextual();
-                    if ($ipaddress->getFromDBByCrit(Sanitizer::sanitize($tmp))) {
-                        return false;
-                    }
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
     public function getItemtype(): string
     {
         return \Printer::class;


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !38789
- When a network equipment is imported with a XML file and its IP address is changed, the equipment is updated correctly. However, if the IP address is not changed, the equipment can also be updated as expected.

## Screenshots (if appropriate):

Before (First Import)
<img width="1438" height="89" alt="image" src="https://github.com/user-attachments/assets/04e4236f-f6ab-40de-af22-8680f4d98f31" />

After fix
First Import: Item does not exist, so it should be imported.
<img width="1438" height="89" alt="image" src="https://github.com/user-attachments/assets/22fc8cdc-b5ef-4a0d-a42d-618ab7101e26" />

Second Import (without IP address change): Item is not re-imported unnecessarily.
<img width="1438" height="89" alt="image" src="https://github.com/user-attachments/assets/4ceffe5d-dace-49cc-a820-c577a02e3337" />

Third Import (with IP address change): Item is updated accordingly.
<img width="1438" height="89" alt="image" src="https://github.com/user-attachments/assets/cb781faf-92b2-4cfd-b131-eaa3b7eba60e" />