### PR TITLE
Fix unsaved form state on load

### DIFF
--- a/src/Glpi/Form/QuestionType/AbstractQuestionTypeSelectable.php
+++ b/src/Glpi/Form/QuestionType/AbstractQuestionTypeSelectable.php
@@ -136,6 +136,10 @@ abstract class AbstractQuestionTypeSelectable extends AbstractQuestionType imple
                         }
                     });
                 {% endif %}
+
+                // The module above will trigger some input changes, we need
+                // to reset the global unsaved form state after this.
+                window.setHasUnsavedChanges(false);
             });
 TWIG;
 


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.

## Description

Some js code related to the dropdown questiontype trigger a change event on initialization (probably to fix some rendering issues related to select2 if I recall correctly), thus marking the form as unsaved.
Fixed by correcting the state manually after this code is finished.

## References

Fix #20663.


