### PR TITLE
fix(forms-migration): Handle invalid DropdownItem configs

### DIFF
--- a/phpunit/functional/Glpi/Form/Migration/FormMigrationTest.php
+++ b/phpunit/functional/Glpi/Form/Migration/FormMigrationTest.php
@@ -2265,11 +2265,10 @@ final class FormMigrationTest extends DbTestCase
         $this->assertTrue($this->callPrivateMethod($migration, 'processMigration'));
 
         // Verify that the question has not been migrated
-        countElementsInTable(
+        this->assertEquals(0, countElementsInTable(
             'glpi_forms_questions',
             ['name' => $question_name],
-            0
-        );
+        ));
 
         // Verify that the migration result contains an error
         $this->assertTrue($result->hasErrors());

--- a/phpunit/functional/Glpi/Form/Migration/FormMigrationTest.php
+++ b/phpunit/functional/Glpi/Form/Migration/FormMigrationTest.php
@@ -2168,6 +2168,126 @@ final class FormMigrationTest extends DbTestCase
         );
     }
 
+    public function testFormMigrationQuestionDropdownItemWithEmptyValues(): void
+    {
+        /**
+         * @var \DBmysql $DB
+         */
+        global $DB;
+
+        // Create a form
+        $this->assertTrue($DB->insert(
+            'glpi_plugin_formcreator_forms',
+            [
+                'name' => 'Test form migration question for dropdown item question with empty values',
+            ]
+        ));
+        $form_id = $DB->insertId();
+
+        // Insert a section for the form
+        $this->assertTrue($DB->insert(
+            'glpi_plugin_formcreator_sections',
+            [
+                'plugin_formcreator_forms_id' => $form_id,
+            ]
+        ));
+
+        $section_id = $DB->insertId();
+
+        // Insert a question for the form
+        $this->assertTrue($DB->insert(
+            'glpi_plugin_formcreator_questions',
+            [
+                'name'                           => 'Test form migration question for dropdown item question with empty values',
+                'plugin_formcreator_sections_id' => $section_id,
+                'fieldtype'                      => 'dropdown',
+                'itemtype'                       => 'ITILCategory',
+                'values'                         => '', // Empty values
+            ]
+        ));
+
+        // Process migration
+        $migration = new FormMigration($DB, FormAccessControlManager::getInstance());
+        $this->setPrivateProperty($migration, 'result', new PluginMigrationResult());
+        $this->assertTrue($this->callPrivateMethod($migration, 'processMigration'));
+
+        // Verify that the question has been migrated correctly
+        /** @var Question $question */
+        $question = getItemByTypeName(Question::class, 'Test form migration question for dropdown item question with empty values');
+        /** @var QuestionTypeItemDropdown $question_type */
+        $question_type = $question->getQuestionType();
+        $this->assertEquals(\ITILCategory::getType(), $question_type->getDefaultValueItemtype($question));
+        $this->assertEquals([], $question_type->getCategoriesFilter($question));
+        $this->assertEquals(0, $question_type->getRootItemsId($question));
+        $this->assertEquals(0, $question_type->getSubtreeDepth($question));
+    }
+
+    public function testFormMigrationQuestionDropdownItemWithInvalidItemtype(): void
+    {
+        /**
+         * @var \DBmysql $DB
+         */
+        global $DB;
+
+        $form_name     = 'Test form migration question for dropdown item question with invalid itemtype';
+        $question_name = 'Test form migration question for dropdown item question with invalid itemtype';
+
+        // Create a form
+        $this->assertTrue($DB->insert('glpi_plugin_formcreator_forms', ['name' => $form_name]));
+        $form_id = $DB->insertId();
+
+        // Insert a section for the form
+        $this->assertTrue($DB->insert(
+            'glpi_plugin_formcreator_sections',
+            [
+                'plugin_formcreator_forms_id' => $form_id,
+            ]
+        ));
+
+        $section_id = $DB->insertId();
+
+        // Insert a question for the form with an invalid itemtype
+        $this->assertTrue($DB->insert(
+            'glpi_plugin_formcreator_questions',
+            [
+                'name'                           => $question_name,
+                'plugin_formcreator_sections_id' => $section_id,
+                'fieldtype'                      => 'dropdown',
+                'itemtype'                       => 'InvalidItemType', // Invalid itemtype
+                'values'                         => '', // Empty values
+            ]
+        ));
+
+        // Process migration
+        $migration = new FormMigration($DB, FormAccessControlManager::getInstance());
+        $result = new PluginMigrationResult();
+        $this->setPrivateProperty($migration, 'result', $result);
+        $this->assertTrue($this->callPrivateMethod($migration, 'processMigration'));
+
+        // Verify that the question has not been migrated
+        countElementsInTable(
+            'glpi_forms_questions',
+            ['name' => $question_name],
+            0
+        );
+
+        // Verify that the migration result contains an error
+        $this->assertTrue($result->hasErrors());
+        $errors = array_filter(
+            $result->getMessages(),
+            fn($m) => $m['type'] == MessageType::Error
+        );
+        $errors = array_column($errors, "message");
+        $this->assertContains(
+            sprintf(
+                'Error while importing question "%s" in section "N/A" and form "%s": Invalid extra data for question',
+                $question_name,
+                $form_name
+            ),
+            $errors
+        );
+    }
+
     public function testFormMigrationQuestionDropdownItemWithAdvancedOptions(): void
     {
         global $DB;

--- a/phpunit/functional/Glpi/Form/Migration/FormMigrationTest.php
+++ b/phpunit/functional/Glpi/Form/Migration/FormMigrationTest.php
@@ -2265,7 +2265,7 @@ final class FormMigrationTest extends DbTestCase
         $this->assertTrue($this->callPrivateMethod($migration, 'processMigration'));
 
         // Verify that the question has not been migrated
-        this->assertEquals(0, countElementsInTable(
+        $this->assertEquals(0, countElementsInTable(
             'glpi_forms_questions',
             ['name' => $question_name],
         ));

--- a/src/Glpi/Form/QuestionType/QuestionTypeItemDropdown.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeItemDropdown.php
@@ -115,7 +115,12 @@ final class QuestionTypeItemDropdown extends QuestionTypeItem
     #[Override]
     public function convertExtraData(array $rawData): mixed
     {
-        $values = json_decode($rawData['values'] ?? '', true) ?? [];
+        // Decode JSON string to array
+        $values = [];
+        if (!empty($rawData['values']) && is_string($rawData['values'])) {
+            $values = json_decode($rawData['values'], true);
+        }
+
         $categories_filter = [];
         if (isset($values['show_ticket_categories'])) {
             $categories_filter = match ($values['show_ticket_categories']) {


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Fixed `convertExtraData` method in `QuestionTypeItemDropdown` to handle empty or non-string `values` fields.