### PR TITLE
Remove useless security warning related to `install.php`

### DIFF
--- a/src/Central.php
+++ b/src/Central.php
@@ -481,13 +481,6 @@ class Central extends CommonGLPI
                 );
             }
 
-            if (file_exists(GLPI_ROOT . "/install/install.php")) {
-                $messages['warnings'][] = sprintf(
-                    __('For security reasons, please remove file: %s'),
-                    "install/install.php"
-                );
-            }
-
             if (($myisam_count = $DB->getMyIsamTables()->count()) > 0) {
                 $messages['warnings'][] = sprintf(__('%d tables are using the deprecated MyISAM storage engine.'), $myisam_count)
                 . ' '


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Since commit a8109d4ee970a222faf48cf48fae2d2f06465796, it is not possible to access the installation process as long as the GLPI database configuration file exists. Therefore, it is not anymore necessary to display a security warning that says the file must be removed.

This change will permit to not have to handle a specific logic in our docker images, see https://github.com/glpi-project/docker-images/issues/189.