### PR TITLE
No need to escape illustrations translation file

### DIFF
--- a/phpunit/functional/Glpi/UI/IllustrationManagerTest.php
+++ b/phpunit/functional/Glpi/UI/IllustrationManagerTest.php
@@ -124,7 +124,7 @@ final class IllustrationManagerTest extends GLPITestCase
             "cellphone",
         ];
         foreach ($to_check as $string) {
-            $this->assertStringContainsString('_sx("Icon", "' . $string . '")', $content);
+            $this->assertStringContainsString('_x("Icon", "' . $string . '")', $content);
         }
     }
 }

--- a/tools/generateillustrationtranslationfilecommand.class.php
+++ b/tools/generateillustrationtranslationfilecommand.class.php
@@ -57,12 +57,12 @@ final class GenerateIllustrationTranslationFileCommand extends Command
         $manager = new IllustrationManager();
         foreach ($manager->getAllIconsTitles() as $title) {
             $title = addslashes($title);
-            $content .= '_sx("Icon", "' . $title . '");' . PHP_EOL;
+            $content .= '_x("Icon", "' . $title . '");' . PHP_EOL;
         }
 
         foreach ($manager->getAllIconsTags() as $tag) {
             $tag = addslashes($tag);
-            $content .= '_sx("Icon", "' . $tag . '");' . PHP_EOL;
+            $content .= '_x("Icon", "' . $tag . '");' . PHP_EOL;
         }
 
         $written_bytes = file_put_contents(


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

This file is only used to extract locales and calles to `_x()` are not used, escaping them is useless.