### PR TITLE
Mark the `showItem` Twig function as safe for HTML

### DIFF
--- a/src/Glpi/Application/View/Extension/SearchExtension.php
+++ b/src/Glpi/Application/View/Extension/SearchExtension.php
@@ -47,7 +47,7 @@ class SearchExtension extends AbstractExtension
     public function getFunctions(): array
     {
         return [
-            new TwigFunction('showItem', [$this, 'showItem']),
+            new TwigFunction('showItem', [$this, 'showItem'], ['is_safe' => ['html']]),
         ];
     }
 

--- a/templates/components/search/table.html.twig
+++ b/templates/components/search/table.html.twig
@@ -148,10 +148,10 @@
                      {% set colkey = col['itemtype'] ~ '_' ~ col['id'] %}
                      {# showItem function returns "<td ...>...</td>" #}
                      {% if col['meta'] is defined and col['meta'] %}
-                        {{ showItem(0, row[colkey]['displayname'], 0, 0)|raw }}
+                        {{ showItem(0, row[colkey]['displayname'], 0, 0) }}
                      {% else %}
                         {# Add a data-searchopt-content-id to each td to allow easy css selectors for a whole column #}
-                        {{ showItem(0, row[colkey]['displayname'], 0, 0, "data-searchopt-content-id=\"" ~ col['id'] ~ "\" " ~ call('Search::displayConfigItem', [itemtype, col['id'], row]))|raw }}
+                        {{ showItem(0, row[colkey]['displayname'], 0, 0, "data-searchopt-content-id=\"" ~ col['id'] ~ "\" " ~ call('Search::displayConfigItem', [itemtype, col['id'], row])) }}
                      {% endif %}
                   {% endfor %}
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Instead of using the `|raw` filter for every usage, it is preferable to directly use the `'is_safe' => ['html']` option.