### PR TITLE
in tests

### DIFF
--- a/phpunit/InventoryTestCase.php
+++ b/phpunit/InventoryTestCase.php
@@ -139,7 +139,7 @@ class InventoryTestCase extends DbTestCase
         $inventory = new Inventory($source);
 
         if ($inventory->inError()) {
-            $this->dump($inventory->getErrors());
+            dump($inventory->getErrors());
         }
         $this->assertFalse($inventory->inError());
         $this->assertEmpty($inventory->getErrors());

--- a/phpunit/functional/AgentTest.php
+++ b/phpunit/functional/AgentTest.php
@@ -170,7 +170,7 @@ class AgentTest extends DbTestCase
 
         if ($inventory->inError()) {
             foreach ($inventory->getErrors() as $error) {
-                var_dump($error);
+                dump($error);
             }
         }
         $this->assertFalse($inventory->inError());
@@ -274,7 +274,7 @@ class AgentTest extends DbTestCase
 
         if ($inventory->inError()) {
             foreach ($inventory->getErrors() as $error) {
-                var_dump($error);
+                dump($error);
             }
         }
         $this->assertFalse($inventory->inError());
@@ -324,7 +324,7 @@ class AgentTest extends DbTestCase
 
         if ($inventory->inError()) {
             foreach ($inventory->getErrors() as $error) {
-                var_dump($error);
+                dump($error);
             }
         }
         $this->assertFalse($inventory->inError());
@@ -378,7 +378,7 @@ class AgentTest extends DbTestCase
 
         if ($inventory->inError()) {
             foreach ($inventory->getErrors() as $error) {
-                var_dump($error);
+                dump($error);
             }
         }
         $this->assertFalse($inventory->inError());
@@ -411,7 +411,7 @@ class AgentTest extends DbTestCase
 
         if ($inventory->inError()) {
             foreach ($inventory->getErrors() as $error) {
-                var_dump($error);
+                dump($error);
             }
         }
         $this->assertFalse($inventory->inError());

--- a/phpunit/functional/Glpi/Inventory/Assets/NetworkEquipmentTest.php
+++ b/phpunit/functional/Glpi/Inventory/Assets/NetworkEquipmentTest.php
@@ -385,7 +385,7 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
 
         if ($inventory->inError()) {
             foreach ($inventory->getErrors() as $error) {
-                var_dump($error);
+                dump($error);
             }
         }
         $this->assertFalse($inventory->inError());
@@ -511,7 +511,7 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
 
         if ($inventory->inError()) {
             foreach ($inventory->getErrors() as $error) {
-                var_dump($error);
+                dump($error);
             }
         }
         $this->assertFalse($inventory->inError());
@@ -598,7 +598,7 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
 
         if ($inventory->inError()) {
             foreach ($inventory->getErrors() as $error) {
-                var_dump($error);
+                dump($error);
             }
         }
         $this->assertFalse($inventory->inError());
@@ -666,7 +666,7 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
 
         if ($inventory->inError()) {
             foreach ($inventory->getErrors() as $error) {
-                var_dump($error);
+                dump($error);
             }
         }
         $this->assertFalse($inventory->inError());
@@ -783,7 +783,7 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
 
         if ($inventory->inError()) {
             foreach ($inventory->getErrors() as $error) {
-                var_dump($error);
+                dump($error);
             }
         }
         $this->assertFalse($inventory->inError());
@@ -888,7 +888,7 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
 
         if ($inventory->inError()) {
             foreach ($inventory->getErrors() as $error) {
-                var_dump($error);
+                dump($error);
             }
         }
         $this->assertFalse($inventory->inError());
@@ -997,7 +997,7 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
 
         if ($inventory->inError()) {
             foreach ($inventory->getErrors() as $error) {
-                var_dump($error);
+                dump($error);
             }
         }
         $this->assertFalse($inventory->inError());
@@ -1093,7 +1093,7 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
 
         if ($inventory->inError()) {
             foreach ($inventory->getErrors() as $error) {
-                var_dump($error);
+                dump($error);
             }
         }
         $this->assertFalse($inventory->inError());
@@ -1216,7 +1216,7 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
 
         if ($inventory->inError()) {
             foreach ($inventory->getErrors() as $error) {
-                var_dump($error);
+                dump($error);
             }
         }
         $this->assertFalse($inventory->inError());
@@ -1363,7 +1363,7 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
 
         if ($inventory->inError()) {
             foreach ($inventory->getErrors() as $error) {
-                var_dump($error);
+                dump($error);
             }
         }
         $this->assertFalse($inventory->inError());
@@ -1512,7 +1512,7 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
 
         if ($inventory->inError()) {
             foreach ($inventory->getErrors() as $error) {
-                var_dump($error);
+                dump($error);
             }
         }
         $this->assertFalse($inventory->inError());
@@ -1653,7 +1653,7 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
 
         if ($inventory->inError()) {
             foreach ($inventory->getErrors() as $error) {
-                var_dump($error);
+                dump($error);
             }
         }
 
@@ -1785,7 +1785,7 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
 
         if ($inventory->inError()) {
             foreach ($inventory->getErrors() as $error) {
-                var_dump($error);
+                dump($error);
             }
         }
 
@@ -3011,7 +3011,7 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
 
         if ($inventory->inError()) {
             foreach ($inventory->getErrors() as $error) {
-                var_dump($error);
+                dump($error);
             }
         }
         $this->assertFalse($inventory->inError());
@@ -3177,7 +3177,7 @@ Compiled Wed 25-Jan-23 16:15 by mcpre</COMMENTS>
 
         if ($inventory->inError()) {
             foreach ($inventory->getErrors() as $error) {
-                var_dump($error);
+                dump($error);
             }
         }
         $this->assertFalse($inventory->inError());
@@ -3219,7 +3219,7 @@ Compiled Wed 25-Jan-23 16:15 by mcpre</COMMENTS>
 
         if ($inventory->inError()) {
             foreach ($inventory->getErrors() as $error) {
-                var_dump($error);
+                dump($error);
             }
         }
         $this->assertFalse($inventory->inError());
@@ -3262,7 +3262,7 @@ Compiled Wed 25-Jan-23 16:15 by mcpre</COMMENTS>
 
         if ($inventory->inError()) {
             foreach ($inventory->getErrors() as $error) {
-                var_dump($error);
+                dump($error);
             }
         }
         $this->assertFalse($inventory->inError());
@@ -3307,7 +3307,7 @@ Compiled Wed 25-Jan-23 16:15 by mcpre</COMMENTS>
 
         if ($inventory->inError()) {
             foreach ($inventory->getErrors() as $error) {
-                var_dump($error);
+                dump($error);
             }
         }
         $this->assertFalse($inventory->inError());
@@ -3368,7 +3368,7 @@ Compiled Wed 25-Jan-23 16:15 by mcpre</COMMENTS>
 
         if ($inventory->inError()) {
             foreach ($inventory->getErrors() as $error) {
-                var_dump($error);
+                dump($error);
             }
         }
         $this->assertFalse($inventory->inError());
@@ -3417,7 +3417,7 @@ Compiled Wed 25-Jan-23 16:15 by mcpre</COMMENTS>
 
         if ($inventory->inError()) {
             foreach ($inventory->getErrors() as $error) {
-                var_dump($error);
+                dump($error);
             }
         }
         $this->assertFalse($inventory->inError());

--- a/phpunit/functional/Glpi/Inventory/Assets/NetworkPortTest.php
+++ b/phpunit/functional/Glpi/Inventory/Assets/NetworkPortTest.php
@@ -1436,7 +1436,7 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
 
         if ($inventory->inError()) {
             foreach ($inventory->getErrors() as $error) {
-                var_dump($error);
+                dump($error);
             }
         }
         $this->assertFalse($inventory->inError());
@@ -1476,7 +1476,7 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
 
         if ($inventory->inError()) {
             foreach ($inventory->getErrors() as $error) {
-                var_dump($error);
+                dump($error);
             }
         }
         $this->assertFalse($inventory->inError());
@@ -1509,7 +1509,7 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
 
         if ($inventory->inError()) {
             foreach ($inventory->getErrors() as $error) {
-                var_dump($error);
+                dump($error);
             }
         }
         $this->assertFalse($inventory->inError());
@@ -1558,7 +1558,7 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
 
         if ($inventory->inError()) {
             foreach ($inventory->getErrors() as $error) {
-                var_dump($error);
+                dump($error);
             }
         }
         $this->assertFalse($inventory->inError());

--- a/phpunit/functional/Glpi/Inventory/Assets/PrinterTest.php
+++ b/phpunit/functional/Glpi/Inventory/Assets/PrinterTest.php
@@ -1821,7 +1821,7 @@ class PrinterTest extends AbstractInventoryAsset
         $inventory = new Inventory($source);
 
         if ($inventory->inError()) {
-            $this->dump($inventory->getErrors());
+            dump($inventory->getErrors());
         }
         $this->assertFalse($inventory->inError());
         $this->assertEmpty($inventory->getErrors());
@@ -2058,7 +2058,7 @@ class PrinterTest extends AbstractInventoryAsset
         $inventory = new Inventory($source);
 
         if ($inventory->inError()) {
-            $this->dump($inventory->getErrors());
+            dump($inventory->getErrors());
         }
         $this->assertFalse($inventory->inError());
         $this->assertEmpty($inventory->getErrors());
@@ -2169,7 +2169,7 @@ class PrinterTest extends AbstractInventoryAsset
         $inventory = new Inventory($source);
 
         if ($inventory->inError()) {
-            $this->dump($inventory->getErrors());
+            dump($inventory->getErrors());
         }
         $this->assertFalse($inventory->inError());
         $this->assertEmpty($inventory->getErrors());

--- a/phpunit/functional/IPAddressTest.php
+++ b/phpunit/functional/IPAddressTest.php
@@ -257,7 +257,6 @@ class IPAddressTest extends DbTestCase
             unset($currentIP['is_dynamic']);
             unset($currentIP['mainitems_id']);
             unset($currentIP['mainitemtype']);
-            //var_dump($currentIP);
             $this->assertSame($expected, $currentIP);
         }
 

--- a/phpunit/functional/LockedfieldTest.php
+++ b/phpunit/functional/LockedfieldTest.php
@@ -266,7 +266,7 @@ class LockedfieldTest extends DbTestCase
         $inventory = new Inventory($json);
 
         if ($inventory->inError()) {
-            $this->dump($inventory->getErrors());
+            dump($inventory->getErrors());
         }
         $this->assertFalse($inventory->inError());
         $this->assertEmpty($inventory->getErrors());
@@ -338,7 +338,7 @@ class LockedfieldTest extends DbTestCase
         $inventory = new Inventory($json);
 
         if ($inventory->inError()) {
-            $this->dump($inventory->getErrors());
+            dump($inventory->getErrors());
         }
         $this->assertFalse($inventory->inError());
         $this->assertEmpty($inventory->getErrors());
@@ -391,7 +391,7 @@ class LockedfieldTest extends DbTestCase
         $inventory = new Inventory($json);
 
         if ($inventory->inError()) {
-            $this->dump($inventory->getErrors());
+            dump($inventory->getErrors());
         }
         $this->assertFalse($inventory->inError());
         $this->assertEmpty($inventory->getErrors());
@@ -440,7 +440,7 @@ class LockedfieldTest extends DbTestCase
         $inventory = new Inventory($json);
 
         if ($inventory->inError()) {
-            $this->dump($inventory->getErrors());
+            dump($inventory->getErrors());
         }
         $this->assertFalse($inventory->inError());
         $this->assertEmpty($inventory->getErrors());
@@ -510,7 +510,7 @@ class LockedfieldTest extends DbTestCase
         $inventory = new Inventory($json);
 
         if ($inventory->inError()) {
-            $this->dump($inventory->getErrors());
+            dump($inventory->getErrors());
         }
         $this->assertFalse($inventory->inError());
         $this->assertEmpty($inventory->getErrors());
@@ -563,7 +563,7 @@ class LockedfieldTest extends DbTestCase
         $inventory = new Inventory($json);
 
         if ($inventory->inError()) {
-            $this->dump($inventory->getErrors());
+            dump($inventory->getErrors());
         }
         $this->assertFalse($inventory->inError());
         $this->assertEmpty($inventory->getErrors());
@@ -710,7 +710,7 @@ class LockedfieldTest extends DbTestCase
 
         $inventory = new Inventory($json);
         if ($inventory->inError()) {
-            $this->dump($inventory->getErrors());
+            dump($inventory->getErrors());
         }
         $this->assertFalse($inventory->inError());
         $this->assertEmpty($inventory->getErrors());
@@ -747,7 +747,7 @@ class LockedfieldTest extends DbTestCase
 
         $inventory = new Inventory($json);
         if ($inventory->inError()) {
-            $this->dump($inventory->getErrors());
+            dump($inventory->getErrors());
         }
         $this->assertFalse($inventory->inError());
         $this->assertEmpty($inventory->getErrors());
@@ -1019,7 +1019,7 @@ class LockedfieldTest extends DbTestCase
 
         // Output inventory errors if any are present (for debugging purposes)
         if ($inventory->inError()) {
-            $this->dump($inventory->getErrors());
+            dump($inventory->getErrors());
         }
 
         // Assert no error occurred during inventory conversion or import

--- a/phpunit/functional/RuleImportEntityTest.php
+++ b/phpunit/functional/RuleImportEntityTest.php
@@ -387,7 +387,7 @@ class RuleImportEntityTest extends DbTestCase
         $inventory = new Inventory($json);
 
         if ($inventory->inError()) {
-            $this->dump($inventory->getErrors());
+            dump($inventory->getErrors());
         }
         $this->assertFalse($inventory->inError());
         $this->assertEmpty($inventory->getErrors());
@@ -518,7 +518,7 @@ class RuleImportEntityTest extends DbTestCase
         $inventory = new Inventory($json);
 
         if ($inventory->inError()) {
-            $this->dump($inventory->getErrors());
+            dump($inventory->getErrors());
         }
         $this->assertFalse($inventory->inError());
         $this->assertEmpty($inventory->getErrors());

--- a/phpunit/functional/RuleLocationTest.php
+++ b/phpunit/functional/RuleLocationTest.php
@@ -326,7 +326,7 @@ class RuleLocationTest extends DbTestCase
         $inventory = new Inventory($json);
 
         if ($inventory->inError()) {
-            $this->dump($inventory->getErrors());
+            dump($inventory->getErrors());
         }
         $this->assertFalse($inventory->inError());
         $this->assertEmpty($inventory->getErrors());

--- a/phpunit/functional/RuleMatchedLogTest.php
+++ b/phpunit/functional/RuleMatchedLogTest.php
@@ -103,7 +103,7 @@ class RuleMatchedLogTest extends DbTestCase
         $date_add = $_SESSION['glpi_currenttime'];
 
         if ($inventory->inError()) {
-            $this->dump($inventory->getErrors());
+            dump($inventory->getErrors());
         }
         $this->assertFalse($inventory->inError());
         $this->assertEmpty($inventory->getErrors());
@@ -153,7 +153,7 @@ class RuleMatchedLogTest extends DbTestCase
         $inventoryupdate = new Inventory($jsonupdate);
         $date_update = $_SESSION['glpi_currenttime'];
         if ($inventoryupdate->inError()) {
-            $this->dump($inventoryupdate->getErrors());
+            dump($inventoryupdate->getErrors());
         }
         $this->assertFalse($inventoryupdate->inError());
         $this->assertEmpty($inventoryupdate->getErrors());

--- a/phpunit/functional/RuleTest.php
+++ b/phpunit/functional/RuleTest.php
@@ -651,7 +651,7 @@ class RuleTest extends DbTestCase
 
         //FIXME: missing tests?
         /*$result = $rule->getCriteriaDisplayPattern(9, \Rule::PATTERN_IS, 1);
-        var_dump($result);*/
+        dump($result);*/
     }
 
     public function testRanking()

--- a/phpunit/functional/SearchTest.php
+++ b/phpunit/functional/SearchTest.php
@@ -6097,9 +6097,6 @@ class SearchTest extends DbTestCase
         sort($names);
         sort($expected);
 
-        //var_dump($data['sql']['search']);ob_flush();
-        //var_dump(getAllDataFromTable('glpi_tickets'));ob_flush();
-
         // Validate results
         $this->assertEquals(
             $expected,

--- a/phpunit/functional/UnmanagedTest.php
+++ b/phpunit/functional/UnmanagedTest.php
@@ -122,7 +122,7 @@ Compiled Fri 26-Mar-10 09:14 by prod_rel_team</DESCRIPTION>
 
         if ($inventory->inError()) {
             foreach ($inventory->getErrors() as $error) {
-                var_dump($error);
+                dump($error);
             }
         }
         $this->assertFalse($inventory->inError());
@@ -174,7 +174,7 @@ Compiled Fri 26-Mar-10 09:14 by prod_rel_team</DESCRIPTION>
 
         if ($inventory->inError()) {
             foreach ($inventory->getErrors() as $error) {
-                var_dump($error);
+                dump($error);
             }
         }
         $this->assertFalse($inventory->inError());


### PR DESCRIPTION
$this->dump() function doesn't exist.
+ replaced var_dump
+ removed comments

<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

