### PR TITLE
remove img usage in supplier links

### DIFF
--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -403,14 +403,8 @@ class Dropdown
             }
 
             // Supplier Links
-            if ($itemtype == "Supplier") {
-                /** @var Supplier $item */
-                if ($item->getFromDB($params['value'])) {
-                    $link_icon = '<div>';
-                    $link_icon .= $item->getLinks();
-                    $link_icon .= '</div>';
-                    $icon_array[] = $link_icon;
-                }
+            if ($item instanceof Supplier && $item->getFromDB($params['value'])) {
+                $icon_array[] = $item->getLinks();
             }
 
             // Location icon

--- a/src/Supplier.php
+++ b/src/Supplier.php
@@ -380,25 +380,13 @@ class Supplier extends CommonDBTM
      **/
     public function getLinks($withname = false)
     {
-        global $CFG_GLPI;
-
-        $ret = '&nbsp;&nbsp;&nbsp;&nbsp;';
-
-        if ($withname) {
-            $ret .= htmlescape($this->fields["name"]);
-            $ret .= "&nbsp;&nbsp;";
-        }
+        $ret = $withname ? ('<span class="ms-3 me-1">' . htmlescape($this->fields["name"]) . '</span>') : '';
 
         if (!empty($this->fields['website'])) {
-            $ret .= "<a href='" . Toolbox::formatOutputWebLink($this->fields['website']) . "' target='_blank'>
-                  <img src='" . $CFG_GLPI["root_doc"] . "/pics/web.png' class='middle' alt=\"" .
-                   __s('Web') . "\" title=\"" . __s('Web') . "\"></a>&nbsp;&nbsp;";
-        }
-
-        if ($this->can($this->fields['id'], READ)) {
-            $ret .= "<a href='" . self::getFormURLWithID($this->fields['id']) . "'>
-                  <img src='" . $CFG_GLPI["root_doc"] . "/pics/edit.png' class='middle' alt=\"" .
-                   __s('Update') . "\" title=\"" . __s('Update') . "\"></a>";
+            $ret .= "<a class='btn btn-icon btn-outline-secondary' href='" . htmlescape(Toolbox::formatOutputWebLink($this->fields['website'])) . "'
+                target='_blank' title=\"" . __s('Web') . "\">
+                <i class='ti ti-world' ></i>
+                </a>";
         }
         return $ret;
     }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Fix display of the extra dropdown links for Supplier dropdowns.

## Screenshots (if appropriate):

| Old Dark  | Old Light |
| ------------- | ------------- |
| <img width="374" height="56" alt="Selection_586" src="https://github.com/user-attachments/assets/9e8a6e75-9304-42e3-9cec-eeedda38d758" />  | <img width="603" height="54" alt="Selection_587" src="https://github.com/user-attachments/assets/84481e31-9ae4-4a35-8a45-1bbdc9a8866e" />  |

New:
<img width="355" height="53" alt="Selection_588" src="https://github.com/user-attachments/assets/730f79d7-dc76-4a6f-984d-eca2ab65d6f3" />

