### PR TITLE
only show warranty valid to when there is a warranty

### DIFF
--- a/templates/components/infocom.html.twig
+++ b/templates/components/infocom.html.twig
@@ -302,7 +302,7 @@
                               'toadd'          : {'-1': __('Lifelong')},
                               'unit'           : 'month',
                               'disabled'       : disabled,
-                              'add_field_html' : '<span class="text-muted">' ~ __('Valid to %s')|format(warrantyexpir) ~ '</span>'
+                              'add_field_html' : warrantyexpir is not empty ? ('<span class="text-muted">' ~ __('Valid to %s')|format(warrantyexpir) ~ '</span>') : ''
                            }
                         ) }}
                      {% endif %}


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Avoid showing the text "Valid to" under the warranty duration selection when there is no warranty expiration.

## Screenshots (if appropriate):
<img width="435" height="77" alt="Selection_589" src="https://github.com/user-attachments/assets/36cb1d86-220a-4766-be60-92bedd0ab958" />


