### PR TITLE
hide images being removed from gallery

### DIFF
--- a/templates/components/form/fields_macros.html.twig
+++ b/templates/components/form/fields_macros.html.twig
@@ -365,8 +365,17 @@
          {% endif %}
          {% if clearable %}
             <input type="hidden" name="_blank_{{ name }}" />
+             {%- set clear_js -%}
+                 const blank_input = $('input[name=\'_blank_{{ name }}\']');
+                 blank_input.val(blank_input.val() ? '' : true);
+                 if ($(this).closest('.picture_gallery_item').length) {
+                    $(this).closest('.picture_gallery_item').hide();
+                 } else {
+                    $(this).closest('.img-overlay-wrapper').hide();
+                 }
+             {%- endset -%}
             <button type="button" class="btn p-2 position-absolute top-0 start-0" title="{{ __('Delete') }}"
-                    onclick="const blank_input = $('input[name=\'_blank_{{ name }}\']'); blank_input.val(blank_input.val() ? '' : true); $(this).toggleClass('btn-danger')">
+                    onclick="{{ clear_js }}">
                <i class="ti ti-x"></i>
             </button>
          {% endif %}
@@ -382,7 +391,7 @@
    {% set field %}
       <div class="picture_gallery d-flex flex-wrap overflow-auto p-3">
          {% for i, picture in value %}
-            <div style="position: relative; width: fit-content">
+            <div class="picture_gallery_item" style="position: relative; width: fit-content">
                {{ _self.imageField(name ~ '_' ~ i, picture, '', {
                   'style': 'max-width: 300px; max-height: 150px',
                   'class': 'picture_square',


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Fixes #19586
Instead of changing the "X" color to red/danger color to indicate pending removal, the images are now hidden. In the past, there was a checkbox that could be toggled to indicate if you want to remove the image and the current UI worked in a similar way where you could toggle the removal by clicking the "X". Now, it is no longer able to be toggled. Maybe support could be added for Ctrl-Z to work seamlessly with the browser's handling of text fields but that is a complex task, if it is possible at all. For now, if a user makes a mistake with removing images, they must refresh the page and start all changes over again.