### PR TITLE
Fix plugins commands loading when plugins table is missing

### DIFF
--- a/src/Glpi/Kernel/Listener/PostBootListener/BootPlugins.php
+++ b/src/Glpi/Kernel/Listener/PostBootListener/BootPlugins.php
@@ -54,8 +54,12 @@ final readonly class BootPlugins implements EventSubscriberInterface
 
     public function onPostBoot(): void
     {
-        if (!$this->isDatabaseUsable()) {
-            // Requires the database to be available.
+        global $DB;
+
+        if (
+            !$this->isDatabaseUsable()
+            || !$DB->tableExists(Plugin::getTable())
+        ) {
             return;
         }
 

--- a/tests/functional/Glpi/Console/CommandLoader.php
+++ b/tests/functional/Glpi/Console/CommandLoader.php
@@ -278,8 +278,20 @@ PHP,
         $all_names_to_class = array_merge($core_names_to_class, $plugins_names_to_class);
 
         // Mock plugin
-        $plugin = $this->newMockInstance('Plugin');
-        $this->calling($plugin)->isActivated = true;
+        $plugin = new class extends \Plugin {
+            public static function getPlugins()
+            {
+                return ['awesome', 'random'];
+            }
+
+            public static function getPhpDir(string $plugin_key = "", $full = true)
+            {
+                return match ($plugin_key) {
+                    'awesome' => vfsStream::url('glpi/plugins/awesome'),
+                    'random' => vfsStream::url('glpi/tests/fixtures/plugins/random'),
+                };
+            }
+        };
 
         // Check with plugins
         $this->when(


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

When the `glpi_plugins` table is missing, the plugins boot logic and the plugins command loader are generating errors. This is an unexpected case, but it is prefarable to handle it to not break the whole GLPI application in this case. The GLPI admin will be warned that there is something wrong with its DB during the update process.

Fixed errors:
```
$ bin/console
RuntimeException {#44
  #message: "MySQL query error: Table 'glpi.11-0.glpi_plugins' doesn't exist (1146) in SQL query "SELECT * FROM `glpi_plugins` WHERE `state` IN ('1', '3')"."
  #code: 0
  #file: "./src/DBmysql.php"
  #line: 381
  trace: {
    ./src/DBmysql.php:381 {
      DBmysql->doQuery($query)^
      › if (!$res) {
      ›     throw new RuntimeException(
      ›         sprintf(
    }
    ./src/DBmysqlIterator.php:123 { …}
    ./src/DBmysql.php:1050 { …}
    ./src/CommonDBTM.php:628 { …}
    ./src/Plugin.php:326 { …}
    ./src/Glpi/Kernel/Listener/PostBootListener/BootPlugins.php:67 { …}
    ./vendor/symfony/event-dispatcher/Debug/WrappedListener.php:116 { …}
    ./vendor/symfony/event-dispatcher/EventDispatcher.php:220 { …}
    ./vendor/symfony/event-dispatcher/EventDispatcher.php:56 { …}
    ./vendor/symfony/event-dispatcher/Debug/TraceableEventDispatcher.php:139 { …}
    ./src/Glpi/Kernel/Kernel.php:147 { …}
    ./src/Glpi/Console/Application.php:114 { …}
    ./bin/console:143 { …}
  }
}
```
and
```
In DBmysql.php line 381:
                                                                                                                                                                   
  [RuntimeException]                                                                                                                                               
  MySQL query error: Table 'glpi.glpi_plugins' doesn't exist (1146) in SQL query "SELECT `id` FROM `glpi_plugins` WHERE `glpi_plugins`.`directory` = '.gitkeep'".  
                                                                                                                                                                   

Exception trace:
  at /var/www/glpi/src/DBmysql.php:381
 DBmysql->doQuery() at /var/www/glpi/src/DBmysqlIterator.php:123
 DBmysqlIterator->execute() at /var/www/glpi/src/DBmysql.php:1050
 DBmysql->request() at /var/www/glpi/src/CommonDBTM.php:425
 CommonDBTM->getFromDBByCrit() at /var/www/glpi/src/Plugin.php:298
 Plugin->getFromDBbyDir() at /var/www/glpi/src/Plugin.php:1427
 Plugin->isActivated() at /var/www/glpi/src/Glpi/Console/CommandLoader.php:247
 Glpi\Console\CommandLoader->findPluginCommands() at /var/www/glpi/src/Glpi/Console/CommandLoader.php:150
 Glpi\Console\CommandLoader->getCommands() at /var/www/glpi/src/Glpi/Console/CommandLoader.php:112
 Glpi\Console\CommandLoader->has() at /var/www/glpi/vendor/symfony/console/Application.php:617
 Symfony\Component\Console\Application->has() at /var/www/glpi/vendor/symfony/console/Application.php:704
 Symfony\Component\Console\Application->find() at /var/www/glpi/vendor/symfony/console/Application.php:266
 Symfony\Component\Console\Application->doRun() at /var/www/glpi/vendor/symfony/console/Application.php:175
 Symfony\Component\Console\Application->run() at /var/www/glpi/bin/console:144
```