### PR TITLE
Remove `phpstan/extension-installer`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -85,7 +85,6 @@
         "maglnet/composer-require-checker": "^3.5",
         "mikey179/vfsstream": "^1.6",
         "php-parallel-lint/php-parallel-lint": "^1.4",
-        "phpstan/extension-installer": "^1.4",
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-deprecation-rules": "^2.0",
         "phpunit/phpunit": "^9.6",
@@ -112,9 +111,6 @@
             "php": "7.4.0"
         },
         "sort-packages": true,
-        "allow-plugins": {
-            "phpstan/extension-installer": true
-        },
         "audit": {
             "abandoned": "report"
         }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9ac26b6964acfc0f8f94da1d920f799d",
+    "content-hash": "2f9dea7a47817eecc239443f2c492bc6",
     "packages": [
         {
             "name": "brick/math",
@@ -6395,54 +6395,6 @@
                 "source": "https://github.com/php-parallel-lint/PHP-Parallel-Lint/tree/v1.4.0"
             },
             "time": "2024-03-27T12:14:49+00:00"
-        },
-        {
-            "name": "phpstan/extension-installer",
-            "version": "1.4.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpstan/extension-installer.git",
-                "reference": "85e90b3942d06b2326fba0403ec24fe912372936"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/extension-installer/zipball/85e90b3942d06b2326fba0403ec24fe912372936",
-                "reference": "85e90b3942d06b2326fba0403ec24fe912372936",
-                "shasum": ""
-            },
-            "require": {
-                "composer-plugin-api": "^2.0",
-                "php": "^7.2 || ^8.0",
-                "phpstan/phpstan": "^1.9.0 || ^2.0"
-            },
-            "require-dev": {
-                "composer/composer": "^2.0",
-                "php-parallel-lint/php-parallel-lint": "^1.2.0",
-                "phpstan/phpstan-strict-rules": "^0.11 || ^0.12 || ^1.0"
-            },
-            "type": "composer-plugin",
-            "extra": {
-                "class": "PHPStan\\ExtensionInstaller\\Plugin"
-            },
-            "autoload": {
-                "psr-4": {
-                    "PHPStan\\ExtensionInstaller\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "Composer plugin for automatic installation of PHPStan extensions",
-            "keywords": [
-                "dev",
-                "static analysis"
-            ],
-            "support": {
-                "issues": "https://github.com/phpstan/extension-installer/issues",
-                "source": "https://github.com/phpstan/extension-installer/tree/1.4.3"
-            },
-            "time": "2024-09-04T20:21:43+00:00"
         },
         {
             "name": "phpstan/phpstan",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,4 +1,5 @@
 includes:
+    - vendor/phpstan/phpstan-deprecation-rules/rules.neon
     - .phpstan-baseline.php
     - .phpstan-baseline.specific.php
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

For the moment, if a plugin executes PHPStan using the binary provided by GLPI itself, it will automatically load all installed PHPStan extensions. It means that adding an extension in GLPI may result in PHPStan failures in plugins.

Removing `phpstan/extension-installer` permit to disable this behaviour. Either GLPI and plugins will have to "include" each extension manually, but it gives a better control on what configuration is actually used.

As far as I know, only the `glpiinventory` plugin in its GLPI 11.0 branch uses the binary from GLPI, but we want to extends this way to do to most of our plugins to remove the necessity to have PHPStan installed in every plugin dir.