### PR TITLE
Move dev cache files into files/_cache

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -49,7 +49,7 @@ $finder = (new PhpCsFixer\Finder())
 
 return (new PhpCsFixer\Config())
     ->setParallelConfig(PhpCsFixer\Runner\Parallel\ParallelConfigFactory::detect())
-    ->setCacheFile(sys_get_temp_dir() . '/php-cs-fixer.glpi.cache')
+    ->setCacheFile('files/_cache/php-cs-fixer/php-cs-fixer.cache')
     ->setRules([
         '@PER-CS2.0' => true,
         '@PHP84Migration' => true,

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,6 +4,7 @@
     xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
     bootstrap="phpunit/bootstrap.php"
     colors="true"
+    cacheDirectory="files/_cache/phpunit"
 >
   <source>
     <include>

--- a/rector.php
+++ b/rector.php
@@ -59,7 +59,7 @@ return RectorConfig::configure()
     ->withPhpVersion(PhpVersion::PHP_82)
     ->withCache(
         cacheClass: FileCacheStorage::class,
-        cacheDirectory: sys_get_temp_dir() . '/rector'
+        cacheDirectory: 'files/_cache/rector',
     )
     ->withParallel(timeoutSeconds: 300)
     // handled by PHP-CS-Fixer with `fully_qualified_strict_types` rule ->withImportNames()


### PR DESCRIPTION
## Checklist before requesting a review

Two of these caches (rector and php cs fixer) were stored in /tmp.
The issue is that if you run multiple dev instances on the same setup, the cache files will be identical for both.

I didn't run into the issue myself as I use docker so no conflicts are possible (/tmp is unique per GLPI instance) but it might be an issue for non-docker users.

I've moved them into `files/_cache` to avoid this, and also moved the phpunit cache there as it is currently polluting the root folder.
