### PR TITLE
GLPIKey::decrypt: Fix invalid method throws and add missing catch for base64_decode

### DIFF
--- a/src/GLPIKey.php
+++ b/src/GLPIKey.php
@@ -393,13 +393,12 @@ class GLPIKey
     }
 
     /**
-     * Descrypt a string.
+     * Decrypt a string.
      *
      * @param string|null $string String to decrypt.
      * @param string|null $key Key to use, fallback to default key if null.
      *
      * @return string|null
-     * @throws SodiumException
      */
     public function decrypt(?string $string, $key = null): ?string
     {
@@ -417,7 +416,15 @@ class GLPIKey
             return $string;
         }
 
-        $string = base64_decode($string);
+        try {
+            $string = base64_decode($string);
+        } catch (\Safe\Exceptions\UrlException $e) {
+            trigger_error(
+                'Unable to base64_decode the string. The string was probably not encrypted using GLPIKey::encrypt',
+                E_USER_WARNING
+            );
+            return '';
+        }
 
         $nonce = mb_substr($string, 0, SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_NPUBBYTES, '8bit');
         if (mb_strlen($nonce, '8bit') !== SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_NPUBBYTES) {

--- a/src/GLPIKey.php
+++ b/src/GLPIKey.php
@@ -36,6 +36,7 @@ use Glpi\Plugin\Hooks;
 use Safe\Exceptions\FilesystemException;
 use Safe\Exceptions\SodiumException;
 
+use Safe\Exceptions\UrlException;
 use function Safe\base64_decode;
 use function Safe\file_put_contents;
 use function Safe\sodium_crypto_aead_xchacha20poly1305_ietf_decrypt;
@@ -418,7 +419,7 @@ class GLPIKey
 
         try {
             $string = base64_decode($string);
-        } catch (\Safe\Exceptions\UrlException $e) {
+        } catch (UrlException $e) {
             trigger_error(
                 'Unable to base64_decode the string. The string was probably not encrypted using GLPIKey::encrypt',
                 E_USER_WARNING

--- a/src/GLPIKey.php
+++ b/src/GLPIKey.php
@@ -35,8 +35,8 @@
 use Glpi\Plugin\Hooks;
 use Safe\Exceptions\FilesystemException;
 use Safe\Exceptions\SodiumException;
-
 use Safe\Exceptions\UrlException;
+
 use function Safe\base64_decode;
 use function Safe\file_put_contents;
 use function Safe\sodium_crypto_aead_xchacha20poly1305_ietf_decrypt;

--- a/src/GLPIKey.php
+++ b/src/GLPIKey.php
@@ -400,7 +400,7 @@ class GLPIKey
      *
      * @return string|null
      */
-    public function decrypt(?string $string, $key = null): ?string
+    public function decrypt(?string $string, ?string $key = null): ?string
     {
         if (empty($string)) {
             // Avoid sodium exception for blank content. Just return the null/empty value.


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.


## Description

- It fixes a wrong phpdoc throws (already catched in the method) and add a missing catch for base64_decode

