### PR TITLE
Fix(Monaco): fix undefined lang loader

### DIFF
--- a/js/modules/Monaco/MonacoEditor.js
+++ b/js/modules/Monaco/MonacoEditor.js
@@ -60,6 +60,10 @@ export default class MonacoEditor {
 
         // Can't just specify the loader when registering the language apparently...
         async function registerNewLangLoaderData() {
+            // If the language is not registered or does not have a loader, we can't set language configuration
+            if (!existing_lang || typeof existing_lang.loader !== "function") {
+                return;
+            }
             const loader = await existing_lang.loader();
             window.monaco.languages.setMonarchTokensProvider(new_lang_id, loader.language);
             window.monaco.languages.setLanguageConfiguration(new_lang_id, loader.conf);


### PR DESCRIPTION

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

During the initialization of the Monaco editor, we attempt to load the language configuration through the language-specific loader.

For example, when using **Twig**, the loader references the following file:

```
webpack://glpi/glpi/node_modules/monaco-editor/esm/vs/basic-languages/twig/twig.contribution.js
```

However, for **JSON** (used by the `Ansible` plugin), the language configuration file does not exist — which is expected.

As a result, the following error occurs:

<img width="585" height="130" alt="image" src="https://github.com/user-attachments/assets/a634e2e2-5817-4106-a408-df2b28510d36" />



This PR ensures that we properly check for the existence of the loader before attempting to call it, preventing unnecessary errors during editor initialization.



## Screenshots (if appropriate):


