### PR TITLE
Fix(SQLProvider): fix parseJoinString Call

### DIFF
--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -2833,7 +2833,10 @@ final class SQLProvider implements SearchProviderInterface
                     }
                     return [];
                 };
-                $specific_leftjoin_criteria = self::parseJoinString(Plugin::doOneHook($plugin_name, $hook_closure));
+                $specific_plugin_leftjoin_criteria = Plugin::doOneHook($plugin_name, $hook_closure);
+                if (!is_array($specific_plugin_leftjoin_criteria)){
+                    $specific_leftjoin_criteria = self::parseJoinString($specific_plugin_leftjoin_criteria);
+                }
             }
         }
         if (!empty($linkfield)) {


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

since https://github.com/glpi-project/glpi/pull/20206

When the `SQLProvider` class handles the `plugin_myplugin_addLeftJoin` hook, an issue occurs if the plugin does not implement this hook.

By default, the function returns an array, whereas a string is expected.
This mismatch leads to the following error (extract from tag plugin see https://github.com/pluginsGLPI/tag/pull/249#issuecomment-3188282553 ):

```
[2025-08-19 12:39:59] glpi.CRITICAL:   *** Uncaught PHP Exception Twig\Error\RuntimeError: "An exception has been thrown during the rendering of a template ("Glpi\Search\Provider\SQLProvider::parseJoinString(): Argument #1 ($raw_joins) must be of type string, array given, called in ./src/Glpi/Search/Provider/SQLProvider.php on line 2837") in "pages/generic_list.html.twig" at line 37." at generic_list.html.twig line 37
  Backtrace :
  ./templates/pages/generic_list.html.twig:37        
  ./vendor/twig/twig/src/Template.php:358            Twig\Template->yield()
  ./vendor/twig/twig/src/Template.php:373            Twig\Template->display()
  ./vendor/twig/twig/src/TemplateWrapper.php:51      Twig\Template->render()
  .../Glpi/Application/View/TemplateRenderer.php:168 Twig\TemplateWrapper->render()
  ./src/Glpi/Controller/AbstractController.php:68    Glpi\Application\View\TemplateRenderer->render()
  ./src/Glpi/Controller/GenericListController.php:51 Glpi\Controller\AbstractController->render()
  ./vendor/symfony/http-kernel/HttpKernel.php:181    Glpi\Controller\GenericListController->__invoke()
  ./vendor/symfony/http-kernel/HttpKernel.php:76     Symfony\Component\HttpKernel\HttpKernel->handleRaw()
  ./vendor/symfony/http-kernel/Kernel.php:197        Symfony\Component\HttpKernel\HttpKernel->handle()
  ./public/index.php:70                              Symfony\Component\HttpKernel\Kernel->handle()
  Previous: Glpi\Search\Provider\SQLProvider::parseJoinString(): Argument #1 ($raw_joins) must be of type string, array given, called in ./src/Glpi/Search/Provider/SQLProvider.php on line 2837
  ./src/Glpi/Search/Provider/SQLProvider.php:2652    
  ./src/Glpi/Search/Provider/SQLProvider.php:2837    Glpi\Search\Provider\SQLProvider::parseJoinString()
  ./src/Search.php:715                               Glpi\Search\Provider\SQLProvider::getLeftJoinCriteria()
  ./src/Glpi/Search/Provider/SQLProvider.php:4160    Search::addLeftJoin()
  ./src/Glpi/Search/SearchEngine.php:653             Glpi\Search\Provider\SQLProvider::constructSQL()
  ./src/Glpi/Search/SearchEngine.php:669             Glpi\Search\SearchEngine::getData()
  ./src/Glpi/Search/SearchEngine.php:626             Glpi\Search\SearchEngine::showOutput()
  :                                                  Glpi\Search\SearchEngine::show()
  .../Application/View/Extension/PhpExtension.php:93 call_user_func_array()
  ...ates/f6/f61fdcd24308d4a7e506cfe2e49cd0dd.php:55 Glpi\Application\View\Extension\PhpExtension->call()
  ./vendor/twig/twig/src/Template.php:402            __TwigTemplate_b16525d39795b98b0885d3f48dccb85d->doDisplay()
  ./vendor/twig/twig/src/Template.php:358            Twig\Template->yield()
  ./vendor/twig/twig/src/Template.php:373            Twig\Template->display()
  ./vendor/twig/twig/src/TemplateWrapper.php:51      Twig\Template->render()
  .../Glpi/Application/View/TemplateRenderer.php:168 Twig\TemplateWrapper->render()
  ./src/Glpi/Controller/AbstractController.php:68    Glpi\Application\View\TemplateRenderer->render()
  ./src/Glpi/Controller/GenericListController.php:51 Glpi\Controller\AbstractController->render()
  ./vendor/symfony/http-kernel/HttpKernel.php:181    Glpi\Controller\GenericListController->__invoke()
  ./vendor/symfony/http-kernel/HttpKernel.php:76     Symfony\Component\HttpKernel\HttpKernel->handleRaw()
  ./vendor/symfony/http-kernel/Kernel.php:197        Symfony\Component\HttpKernel\HttpKernel->handle()
  ./public/index.php:70                              Symfony\Component\HttpKernel\Kernel->handle()

```


## Screenshots (if appropriate):


