### PR TITLE
handle non-json responses in debug middleware

### DIFF
--- a/src/Glpi/Api/HL/Middleware/DebugResponseMiddleware.php
+++ b/src/Glpi/Api/HL/Middleware/DebugResponseMiddleware.php
@@ -93,9 +93,11 @@ class DebugResponseMiddleware extends AbstractMiddleware implements ResponseMidd
 
         // Pretty print JSON responses
         if ($input->response instanceof JSONResponse) {
-            $content = $input->response->getBody();
-            $pretty_print_json = json_encode(json_decode($content), JSON_PRETTY_PRINT);
-            $input->response = $input->response->withBody(Utils::streamFor($pretty_print_json));
+            $content = (string) $input->response->getBody();
+            if (!empty($content)) {
+                $pretty_print_json = json_encode(json_decode($content), JSON_PRETTY_PRINT);
+                $input->response = $input->response->withBody(Utils::streamFor($pretty_print_json));
+            }
         }
 
         // Call the next middleware


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Fixes #20520 (real issue in comment).
For requests that return no body, like DELETE requests, the middleware used to work properly and got an empty result from the JSON functions. Changes to use the "safe" wrappers caused it to break because an empty body wasn't recognized as valid JSON and therefore triggered an exception to be thrown.

## Screenshots (if appropriate):


