### PR TITLE
Use absolute path for console execution in tests bootstrap

### DIFF
--- a/phpunit/bootstrap.php
+++ b/phpunit/bootstrap.php
@@ -54,7 +54,7 @@ require_once dirname(__DIR__) . '/src/Glpi/Application/ResourcesChecker.php';
 // It seems calling $cache_manager->resetAllCaches(); mess up with the kernel
 // leading to some issues. It is safer to use the console directly as it goes
 // throught another process.
-exec("bin/console cache:clear --env='testing'");
+exec(sprintf("php %s cache:clear --env='testing'", realpath(GLPI_ROOT . '/bin/console')));
 
 global $GLPI_CACHE;
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -52,7 +52,7 @@ require_once dirname(__DIR__) . '/src/Glpi/Application/ResourcesChecker.php';
 // It seems calling $cache_manager->resetAllCaches(); mess up with the kernel
 // leading to some issues. It is safer to use the console directly as it goes
 // throught another process.
-exec("bin/console cache:clear --env='testing'");
+exec(sprintf("php %s cache:clear --env='testing'", realpath(GLPI_ROOT . '/bin/console')));
 
 global $GLPI_CACHE;
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

It will permit to use this bootstrap file for plugins tests.