### PR TITLE
Toolbox getGuzzleClient: Remove phpdoc throws that is never throws

### DIFF
--- a/src/Agent.php
+++ b/src/Agent.php
@@ -62,10 +62,6 @@ class Agent extends CommonDBTM
     /** @var string */
     public const ACTION_INVENTORY = 'inventory';
 
-
-    /** @var integer */
-    protected const TIMEOUT  = 5;
-
     /** @var boolean */
     public $dohistory = true;
 
@@ -705,7 +701,6 @@ class Agent extends CommonDBTM
         foreach ($addresses as $address) {
             $options = [
                 'base_uri'        => $address,
-                'connect_timeout' => self::TIMEOUT,
             ];
 
             // init guzzle client with base options

--- a/src/Glpi/Marketplace/Api/Plugins.php
+++ b/src/Glpi/Marketplace/Api/Plugins.php
@@ -54,7 +54,6 @@ class Plugins
     protected $last_error  = null;
 
     public const COL_PAGE    = 200;
-    protected const TIMEOUT     = 5;
 
     /**
      * Max request attemps on READ operations.
@@ -77,7 +76,6 @@ class Plugins
         // init guzzle client with base options
         $this->httpClient = Toolbox::getGuzzleClient([
             'base_uri'        => GLPI_MARKETPLACE_PLUGINS_API_URI,
-            'connect_timeout' => self::TIMEOUT,
         ]);
     }
 

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -1327,7 +1327,7 @@ class Toolbox
      * @param array $extra_options Extra options to pass to the Guzzle client constructor
      * @return Client Guzzle client
      */
-    public static function getGuzzleClient(array $extra_options): Client
+    public static function getGuzzleClient(array $extra_options = []): Client
     {
         global $CFG_GLPI;
 

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -1331,7 +1331,7 @@ class Toolbox
     {
         global $CFG_GLPI;
 
-        $options = $extra_options;
+        $options = $extra_options + ['connect_timeout' => 5];
         // add proxy string if configured in glpi
         if (!empty($CFG_GLPI["proxy_name"])) {
             $proxy_creds      = !empty($CFG_GLPI["proxy_user"])

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -1326,7 +1326,6 @@ class Toolbox
      * Get a new Guzzle client with proxy if configured and the specified other options.
      * @param array $extra_options Extra options to pass to the Guzzle client constructor
      * @return Client Guzzle client
-     * @throws SodiumException
      */
     public static function getGuzzleClient(array $extra_options): Client
     {


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

- It removes a throws in the phpdoc that was never thrown (catched inside the glpi decrypt function)
- Also add the parameter default value to empty array @cedric-anne will this cause any issue since the method signature is changed ??