### PR TITLE
feat(forms): Added the regex operator to all question types + some missing operators in specific cases

### DIFF
--- a/phpunit/functional/Glpi/Form/Condition/ConditionHandler/ActorConditionHandlerTest.php
+++ b/phpunit/functional/Glpi/Form/Condition/ConditionHandler/ActorConditionHandlerTest.php
@@ -44,6 +44,14 @@ use tests\units\Glpi\Form\Condition\AbstractConditionHandler;
 
 final class ActorConditionHandlerTest extends AbstractConditionHandler
 {
+    public static function getConditionHandler(): ConditionHandlerInterface
+    {
+        return new ActorConditionHandler(
+            new QuestionTypeRequester(),
+            new QuestionTypeActorsExtraDataConfig()
+        );
+    }
+
     public static function conditionHandlerProvider(): iterable
     {
         /** @var class-string<AbstractQuestionTypeActors>[] $types */

--- a/phpunit/functional/Glpi/Form/Condition/ConditionHandler/DateConditionHandlerTest.php
+++ b/phpunit/functional/Glpi/Form/Condition/ConditionHandler/DateConditionHandlerTest.php
@@ -42,6 +42,11 @@ use tests\units\Glpi\Form\Condition\AbstractConditionHandler;
 
 final class DateConditionHandlerTest extends AbstractConditionHandler
 {
+    public static function getConditionHandler(): ConditionHandlerInterface
+    {
+        return new DateConditionHandler();
+    }
+
     #[Override]
     public static function conditionHandlerProvider(): iterable
     {

--- a/phpunit/functional/Glpi/Form/Condition/ConditionHandler/DateTimeConditionHandlerTest.php
+++ b/phpunit/functional/Glpi/Form/Condition/ConditionHandler/DateTimeConditionHandlerTest.php
@@ -42,6 +42,11 @@ use tests\units\Glpi\Form\Condition\AbstractConditionHandler;
 
 final class DateTimeConditionHandlerTest extends AbstractConditionHandler
 {
+    public static function getConditionHandler(): ConditionHandlerInterface
+    {
+        return new DateAndTimeConditionHandler();
+    }
+
     #[Override]
     public static function conditionHandlerProvider(): iterable
     {

--- a/phpunit/functional/Glpi/Form/Condition/ConditionHandler/ItemAsTextConditionHandlerTest.php
+++ b/phpunit/functional/Glpi/Form/Condition/ConditionHandler/ItemAsTextConditionHandlerTest.php
@@ -1,0 +1,124 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Form\Condition\ConditionHandler;
+
+use Computer;
+use Glpi\Form\Condition\ValueOperator;
+use Glpi\Form\QuestionType\QuestionTypeItem;
+use Glpi\Form\QuestionType\QuestionTypeItemDropdown;
+use Glpi\Form\QuestionType\QuestionTypeItemDropdownExtraDataConfig;
+use Glpi\Form\QuestionType\QuestionTypeItemExtraDataConfig;
+use Override;
+use SoftwareCategory;
+use tests\units\Glpi\Form\Condition\AbstractConditionHandler;
+
+final class ItemAsTextConditionHandlerTest extends AbstractConditionHandler
+{
+    public static function getConditionHandler(): ConditionHandlerInterface
+    {
+        return new ItemAsTextConditionHandler('Computer');
+    }
+
+    private static function getDefaultExtraDataConfig(string $question_type): QuestionTypeItemExtraDataConfig
+    {
+        switch ($question_type) {
+            case QuestionTypeItem::class:
+                return new QuestionTypeItemExtraDataConfig(
+                    itemtype: Computer::class,
+                );
+            case QuestionTypeItemDropdown::class:
+                return new QuestionTypeItemDropdownExtraDataConfig(
+                    itemtype: SoftwareCategory::class,
+                );
+            default:
+                throw new \InvalidArgumentException("Unsupported question type: $question_type");
+        }
+    }
+
+    #[Override]
+    public static function conditionHandlerProvider(): iterable
+    {
+        $extra_data = self::getDefaultExtraDataConfig(QuestionTypeItem::class);
+        $type = QuestionTypeItem::class;
+
+        // Test item answers with the CONTAINS operator
+        yield "Contains check - case 1 for $type" => [
+            'question_type'       => $type,
+            'condition_operator'  => ValueOperator::CONTAINS,
+            'condition_value'     => '_test_pc0',
+            'submitted_answer'    => [
+                'itemtype' => Computer::class,
+                'items_id' => getItemByTypeName(Computer::class, "_test_pc01", true),
+            ],
+            'expected_result'     => true,
+            'question_extra_data' => $extra_data,
+        ];
+        yield "Contains check - case 2 for $type" => [
+            'question_type'       => $type,
+            'condition_operator'  => ValueOperator::CONTAINS,
+            'condition_value'     => '_test_pc02',
+            'submitted_answer'    => [
+                'itemtype' => Computer::class,
+                'items_id' => getItemByTypeName(Computer::class, "_test_pc01", true),
+            ],
+            'expected_result'     => false,
+            'question_extra_data' => $extra_data,
+        ];
+
+        // Test item answers with the NOT_CONTAINS operator
+        yield "Not contains check - case 1 for $type" => [
+            'question_type'       => $type,
+            'condition_operator'  => ValueOperator::NOT_CONTAINS,
+            'condition_value'     => '_test_pc0',
+            'submitted_answer'    => [
+                'itemtype' => Computer::class,
+                'items_id' => getItemByTypeName(Computer::class, "_test_pc01", true),
+            ],
+            'expected_result'     => false,
+            'question_extra_data' => $extra_data,
+        ];
+        yield "Not contains check - case 2 for $type" => [
+            'question_type'       => $type,
+            'condition_operator'  => ValueOperator::NOT_CONTAINS,
+            'condition_value'     => '_test_pc02',
+            'submitted_answer'    => [
+                'itemtype' => Computer::class,
+                'items_id' => getItemByTypeName(Computer::class, "_test_pc01", true),
+            ],
+            'expected_result'     => true,
+            'question_extra_data' => $extra_data,
+        ];
+    }
+}

--- a/phpunit/functional/Glpi/Form/Condition/ConditionHandler/ItemConditionHandlerTest.php
+++ b/phpunit/functional/Glpi/Form/Condition/ConditionHandler/ItemConditionHandlerTest.php
@@ -46,6 +46,11 @@ use tests\units\Glpi\Form\Condition\AbstractConditionHandler;
 
 final class ItemConditionHandlerTest extends AbstractConditionHandler
 {
+    public static function getConditionHandler(): ConditionHandlerInterface
+    {
+        return new ItemConditionHandler('Computer');
+    }
+
     private static function getDefaultExtraDataConfig(string $question_type): QuestionTypeItemExtraDataConfig
     {
         switch ($question_type) {
@@ -109,56 +114,5 @@ final class ItemConditionHandlerTest extends AbstractConditionHandler
                 'question_extra_data' => $extra_data,
             ];
         }
-
-        $extra_data = self::getDefaultExtraDataConfig(QuestionTypeItem::class);
-        $type = QuestionTypeItem::class;
-
-        // Test item answers with the CONTAINS operator
-        yield "Contains check - case 1 for $type" => [
-            'question_type'       => $type,
-            'condition_operator'  => ValueOperator::CONTAINS,
-            'condition_value'     => '_test_pc0',
-            'submitted_answer'    => [
-                'itemtype' => Computer::class,
-                'items_id' => getItemByTypeName(Computer::class, "_test_pc01", true),
-            ],
-            'expected_result'     => true,
-            'question_extra_data' => $extra_data,
-        ];
-        yield "Contains check - case 2 for $type" => [
-            'question_type'       => $type,
-            'condition_operator'  => ValueOperator::EQUALS,
-            'condition_value'     => '_test_pc02',
-            'submitted_answer'    => [
-                'itemtype' => Computer::class,
-                'items_id' => getItemByTypeName(Computer::class, "_test_pc01", true),
-            ],
-            'expected_result'     => false,
-            'question_extra_data' => $extra_data,
-        ];
-
-        // Test item answers with the NOT_CONTAINS operator
-        yield "Not contains check - case 1 for $type" => [
-            'question_type'       => $type,
-            'condition_operator'  => ValueOperator::NOT_CONTAINS,
-            'condition_value'     => '_test_pc0',
-            'submitted_answer'    => [
-                'itemtype' => Computer::class,
-                'items_id' => getItemByTypeName(Computer::class, "_test_pc01", true),
-            ],
-            'expected_result'     => false,
-            'question_extra_data' => $extra_data,
-        ];
-        yield "Not contains check - case 2 for $type" => [
-            'question_type'       => $type,
-            'condition_operator'  => ValueOperator::NOT_CONTAINS,
-            'condition_value'     => '_test_pc02',
-            'submitted_answer'    => [
-                'itemtype' => Computer::class,
-                'items_id' => getItemByTypeName(Computer::class, "_test_pc01", true),
-            ],
-            'expected_result'     => true,
-            'question_extra_data' => $extra_data,
-        ];
     }
 }

--- a/phpunit/functional/Glpi/Form/Condition/ConditionHandler/MultipleChoiceFromValuesConditionHandlerTest.php
+++ b/phpunit/functional/Glpi/Form/Condition/ConditionHandler/MultipleChoiceFromValuesConditionHandlerTest.php
@@ -44,6 +44,11 @@ use tests\units\Glpi\Form\Condition\AbstractConditionHandler;
 
 final class MultipleChoiceFromValuesConditionHandlerTest extends AbstractConditionHandler
 {
+    public static function getConditionHandler(): ConditionHandlerInterface
+    {
+        return new MultipleChoiceFromValuesConditionHandler(['opt']);
+    }
+
     #[Override]
     public static function conditionHandlerProvider(): iterable
     {

--- a/phpunit/functional/Glpi/Form/Condition/ConditionHandler/NumberConditionHandlerTest.php
+++ b/phpunit/functional/Glpi/Form/Condition/ConditionHandler/NumberConditionHandlerTest.php
@@ -41,6 +41,11 @@ use tests\units\Glpi\Form\Condition\AbstractConditionHandler;
 
 final class NumberConditionHandlerTest extends AbstractConditionHandler
 {
+    public static function getConditionHandler(): ConditionHandlerInterface
+    {
+        return new NumberConditionHandler();
+    }
+
     #[Override]
     public static function conditionHandlerProvider(): iterable
     {

--- a/phpunit/functional/Glpi/Form/Condition/ConditionHandler/RegexConditionHandlerTest.php
+++ b/phpunit/functional/Glpi/Form/Condition/ConditionHandler/RegexConditionHandlerTest.php
@@ -1,0 +1,361 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Form\Condition\ConditionHandler;
+
+use Computer;
+use Glpi\DBAL\JsonFieldInterface;
+use Glpi\Form\Condition\ValueOperator;
+use Glpi\Form\QuestionType\QuestionTypeActorsExtraDataConfig;
+use Glpi\Form\QuestionType\QuestionTypeAssignee;
+use Glpi\Form\QuestionType\QuestionTypeCheckbox;
+use Glpi\Form\QuestionType\QuestionTypeDateTime;
+use Glpi\Form\QuestionType\QuestionTypeDateTimeExtraDataConfig;
+use Glpi\Form\QuestionType\QuestionTypeDropdown;
+use Glpi\Form\QuestionType\QuestionTypeDropdownExtraDataConfig;
+use Glpi\Form\QuestionType\QuestionTypeEmail;
+use Glpi\Form\QuestionType\QuestionTypeFile;
+use Glpi\Form\QuestionType\QuestionTypeItem;
+use Glpi\Form\QuestionType\QuestionTypeItemDropdown;
+use Glpi\Form\QuestionType\QuestionTypeItemDropdownExtraDataConfig;
+use Glpi\Form\QuestionType\QuestionTypeItemExtraDataConfig;
+use Glpi\Form\QuestionType\QuestionTypeLongText;
+use Glpi\Form\QuestionType\QuestionTypeNumber;
+use Glpi\Form\QuestionType\QuestionTypeObserver;
+use Glpi\Form\QuestionType\QuestionTypeRadio;
+use Glpi\Form\QuestionType\QuestionTypeRequester;
+use Glpi\Form\QuestionType\QuestionTypeRequestType;
+use Glpi\Form\QuestionType\QuestionTypeSelectableExtraDataConfig;
+use Glpi\Form\QuestionType\QuestionTypeShortText;
+use Glpi\Form\QuestionType\QuestionTypeUrgency;
+use Glpi\Form\QuestionType\QuestionTypeUserDevice;
+use Glpi\Form\QuestionType\QuestionTypeUserDevicesConfig;
+use Location;
+use Override;
+use PHPUnit\Framework\Attributes\DataProvider;
+use tests\units\Glpi\Form\Condition\AbstractConditionHandler;
+
+final class RegexConditionHandlerTest extends AbstractConditionHandler
+{
+    public static function getConditionHandler(): ConditionHandlerInterface
+    {
+        return new RegexConditionHandler(new QuestionTypeShortText(), null);
+    }
+
+    #[Override]
+    public static function conditionHandlerProvider(): iterable
+    {
+        $types = [
+            QuestionTypeShortText::class => [[
+                'regex'          => '/^test$/',
+                'valid_answer'   => 'test',
+                'invalid_answer' => 'not_test',
+            ]],
+            QuestionTypeNumber::class => [[
+                'regex'          => '/^[0-9]+$/',
+                'valid_answer'   => '123',
+                'invalid_answer' => 'not_a_number',
+            ]],
+            QuestionTypeEmail::class => [[
+                'regex'         => '/^[\w\.-]+@[\w\.-]+\.[a-zA-Z]{2,}$/',
+                'valid_answer'  => 'test@example.com',
+                'invalid_answer' => 'not_an_email',
+            ]],
+            QuestionTypeLongText::class => [[
+                'regex'          => '/^test$/',
+                'valid_answer'   => '<p>test</p>',
+                'invalid_answer' => '<p>not_test</p>',
+            ]],
+            QuestionTypeDateTime::class => [
+                [
+                    'regex'               => '/^2024-02/',
+                    'valid_answer'        => '2024-02-29',
+                    'invalid_answer'      => '2024-03-28',
+                    'question_extra_data' => new QuestionTypeDateTimeExtraDataConfig(
+                        is_date_enabled: true,
+                        is_time_enabled: false,
+                    ),
+                ],
+                [
+                    'regex'               => '/^14:/',
+                    'valid_answer'        => '14:00',
+                    'invalid_answer'      => '13:59',
+                    'question_extra_data' => new QuestionTypeDateTimeExtraDataConfig(
+                        is_date_enabled: false,
+                        is_time_enabled: true,
+                    ),
+                ],
+                [
+                    'regex'               => '/^2024-02/',
+                    'valid_answer'        => '2024-02-28 15:30:00',
+                    'invalid_answer'      => '2024-03-28 15:29:59',
+                    'question_extra_data' => new QuestionTypeDateTimeExtraDataConfig(
+                        is_date_enabled: true,
+                        is_time_enabled: true,
+                    ),
+                ],
+            ],
+            QuestionTypeUrgency::class => [[
+                'regex'          => '/^3$/',
+                'valid_answer'   => 3,
+                'invalid_answer' => 1,
+            ]],
+            QuestionTypeRequestType::class => [[
+                'regex'          => '/^1$/',
+                'valid_answer'   => 1,
+                'invalid_answer' => 2,
+            ]],
+            QuestionTypeFile::class => [[
+                'regex'          => '/^file_[0-9]+\.txt$/',
+                'valid_answer'   => ['file_1.txt'],
+                'invalid_answer' => ['file_2.doc'],
+            ]],
+            QuestionTypeRadio::class => [[
+                'regex'               => '/^Radio 1$/',
+                'valid_answer'        => 'radio_1',
+                'invalid_answer'      => 'radio_2',
+                'question_extra_data' => new QuestionTypeSelectableExtraDataConfig([
+                    'radio_1' => 'Radio 1',
+                    'radio_2' => 'Radio 2',
+                ]),
+            ]],
+            QuestionTypeCheckbox::class => [[
+                'regex'              => '/^Checkbox 1|Checkbox 2$/',
+                'valid_answer'        => ['checkbox_1', 'checkbox_2'],
+                'invalid_answer'      => ['checkbox_3', 'checkbox_4'],
+                'question_extra_data' => new QuestionTypeSelectableExtraDataConfig([
+                    'checkbox_1' => 'Checkbox 1',
+                    'checkbox_2' => 'Checkbox 2',
+                    'checkbox_3' => 'Checkbox 3',
+                    'checkbox_4' => 'Checkbox 4',
+                ]),
+            ]],
+            QuestionTypeDropdown::class => [
+                [
+                    'regex'               => '/^Dropdown 1$/',
+                    'valid_answer'        => ['dropdown_1'],
+                    'invalid_answer'      => ['dropdown_2'],
+                    'question_extra_data' => new QuestionTypeDropdownExtraDataConfig([
+                        'dropdown_1' => 'Dropdown 1',
+                        'dropdown_2' => 'Dropdown 2',
+                    ], false),
+                ],
+                [
+                    'regex'               => '/^Dropdown 1|Dropdown 2$/',
+                    'valid_answer'        => ['dropdown_1', 'dropdown_2'],
+                    'invalid_answer'      => ['dropdown_3', 'dropdown_4'],
+                    'question_extra_data' => new QuestionTypeDropdownExtraDataConfig([
+                        'dropdown_1' => 'Dropdown 1',
+                        'dropdown_2' => 'Dropdown 2',
+                        'dropdown_3' => 'Dropdown 3',
+                        'dropdown_4' => 'Dropdown 4',
+                    ], true),
+                ],
+            ],
+            QuestionTypeItem::class => [
+                [
+                    'regex' => '/^_test_pc01+$/',
+                    'valid_answer' => fn() => [
+                        'itemtype' => Computer::class,
+                        'items_id' => getItemByTypeName(Computer::class, "_test_pc01", true),
+                    ],
+                    'invalid_answer' => fn() => [
+                        'itemtype' => Computer::class,
+                        'items_id' => getItemByTypeName(Computer::class, "_test_pc02", true),
+                    ],
+                    'question_extra_data' => new QuestionTypeItemExtraDataConfig(Computer::class),
+                ],
+            ],
+            QuestionTypeItemDropdown::class => [
+                [
+                    'regex'        => '/^_location01$/',
+                    'valid_answer' => fn() => [
+                        'itemtype' => Location::class,
+                        'items_id' => getItemByTypeName(Location::class, "_location01", true),
+                    ],
+                    'invalid_answer' => fn() => [
+                        'itemtype' => Location::class,
+                        'items_id' => getItemByTypeName(Location::class, "_location02", true),
+                    ],
+                    'question_extra_data' => new QuestionTypeItemDropdownExtraDataConfig(Location::class),
+                ],
+            ],
+            QuestionTypeUserDevice::class => [
+                [
+                    'regex'          => '/^_test_pc01$/',
+                    'valid_answer'   => fn() => Computer::getType() . '_' . getItemByTypeName(Computer::class, "_test_pc01", true),
+                    'invalid_answer' => fn() => Computer::getType() . '_' . getItemByTypeName(Computer::class, "_test_pc02", true),
+                    'question_extra_data' => new QuestionTypeUserDevicesConfig(false),
+                ],
+                [
+                    'regex'          => '/^_test_pc01$/',
+                    'valid_answer'   => fn() => [Computer::getType() . '_' . getItemByTypeName(Computer::class, "_test_pc01", true)],
+                    'invalid_answer' => fn() => [Computer::getType() . '_' . getItemByTypeName(Computer::class, "_test_pc02", true)],
+                    'question_extra_data' => new QuestionTypeUserDevicesConfig(true),
+                ],
+            ],
+        ];
+
+        $types = array_merge($types, self::actorsConditionHandlerProvider());
+
+        foreach ($types as $type => $datas) {
+            foreach ($datas as $key => $data) {
+                foreach ([
+                    ValueOperator::MATCH_REGEX,
+                    ValueOperator::NOT_MATCH_REGEX,
+                ] as $operator) {
+                    yield $operator->getLabel() . " for $type - regex matches #$key" => [
+                        'question_type'       => $type,
+                        'condition_operator'  => $operator,
+                        'condition_value'     => $data['regex'],
+                        'submitted_answer'    => $data['valid_answer'],
+                        'expected_result'     => ValueOperator::MATCH_REGEX === $operator,
+                        'question_extra_data' => $data['question_extra_data'] ?? null,
+                    ];
+                    yield $operator->getLabel() . " for $type - regex does not match #$key" => [
+                        'question_type'       => $type,
+                        'condition_operator'  => $operator,
+                        'condition_value'     => $data['regex'],
+                        'submitted_answer'    => $data['invalid_answer'],
+                        'expected_result'     => ValueOperator::NOT_MATCH_REGEX === $operator,
+                        'question_extra_data' => $data['question_extra_data'] ?? null,
+                    ];
+                    yield $operator->getLabel() . " for $type - empty answer #$key" => [
+                        'question_type'       => $type,
+                        'condition_operator'  => $operator,
+                        'condition_value'     => $data['regex'],
+                        'submitted_answer'    => is_array($data['valid_answer']) ? [] : '',
+                        'expected_result'     => ValueOperator::NOT_MATCH_REGEX === $operator,
+                        'question_extra_data' => $data['question_extra_data'] ?? null,
+                    ];
+                    yield $operator->getLabel() . " for $type - invalid regex #$key" => [
+                        'question_type'       => $type,
+                        'condition_operator'  => $operator,
+                        'condition_value'     => '/invalid_regex',
+                        'submitted_answer'    => $data['valid_answer'],
+                        'expected_result'     => ValueOperator::NOT_MATCH_REGEX === $operator,
+                        'question_extra_data' => $data['question_extra_data'] ?? null,
+                    ];
+                }
+            }
+        }
+    }
+
+    private static function actorsConditionHandlerProvider(): array
+    {
+        /** @var class-string<AbstractQuestionTypeActors>[] $types */
+        $types = [
+            QuestionTypeRequester::class,
+            QuestionTypeAssignee::class,
+            QuestionTypeObserver::class,
+        ];
+
+        $datas = [];
+        foreach ($types as $type) {
+            $type_name           = (new $type())->getName();
+            $allowed_actor_types = (new $type())->getAllowedActorTypes();
+            foreach ($allowed_actor_types as $actor_type) {
+                $first_actor_name = sprintf('%s-%s-1', $type_name, getForeignKeyFieldForItemType($actor_type));
+                $second_actor_name = sprintf('%s-%s-2', $type_name, getForeignKeyFieldForItemType($actor_type));
+                $datas[$type][] = [
+                    'regex'          => '/^' . $first_actor_name . '$/',
+                    'valid_answer'   => fn() => [
+                        sprintf('%s-%s', getForeignKeyFieldForItemType($actor_type), getItemByTypeName($actor_type, $first_actor_name, true)),
+                    ],
+                    'invalid_answer' => fn() => [
+                        sprintf('%s-%s', getForeignKeyFieldForItemType($actor_type), getItemByTypeName($actor_type, $second_actor_name, true)),
+                    ],
+                    'question_extra_data' => new QuestionTypeActorsExtraDataConfig(
+                        is_multiple_actors: true
+                    ),
+                ];
+            }
+        }
+
+        return $datas;
+    }
+
+    #[DataProvider('conditionHandlerProvider')]
+    public function testConditionHandlerProvider(
+        string $question_type,
+        ValueOperator $condition_operator,
+        mixed $condition_value,
+        mixed $submitted_answer,
+        bool $expected_result,
+        ?JsonFieldInterface $question_extra_data = null,
+    ): void {
+        /** @var class-string<AbstractQuestionTypeActors>[] $types */
+        $types = [
+            QuestionTypeRequester::class,
+            QuestionTypeObserver::class,
+            QuestionTypeAssignee::class,
+        ];
+
+        foreach ($types as $type) {
+            $allowed_actor_types = (new $type())->getAllowedActorTypes();
+            foreach ($allowed_actor_types as $actor_type) {
+                $this->createItem($actor_type, [
+                    'entities_id' => $this->getTestRootEntity(true),
+                    'name'        => sprintf(
+                        '%s-%s-1',
+                        (new $type())->getName(),
+                        getForeignKeyFieldForItemType($actor_type)
+                    ),
+                ]);
+                $this->createItem($actor_type, [
+                    'entities_id' => $this->getTestRootEntity(true),
+                    'name'        => sprintf(
+                        '%s-%s-2',
+                        (new $type())->getName(),
+                        getForeignKeyFieldForItemType($actor_type)
+                    ),
+                ]);
+            }
+        }
+
+        // Submited answers must be a callable
+        if (is_callable($submitted_answer)) {
+            $submitted_answer = $submitted_answer();
+        }
+
+        parent::testConditionHandlerProvider(
+            question_type: $question_type,
+            condition_operator: $condition_operator,
+            condition_value: $condition_value,
+            submitted_answer: $submitted_answer,
+            expected_result: $expected_result,
+            question_extra_data: $question_extra_data,
+        );
+    }
+}

--- a/phpunit/functional/Glpi/Form/Condition/ConditionHandler/RequestTypeConditionHandlerTest.php
+++ b/phpunit/functional/Glpi/Form/Condition/ConditionHandler/RequestTypeConditionHandlerTest.php
@@ -42,6 +42,11 @@ use Ticket;
 
 final class RequestTypeConditionHandlerTest extends AbstractConditionHandler
 {
+    public static function getConditionHandler(): ConditionHandlerInterface
+    {
+        return new RequestTypeConditionHandler();
+    }
+
     #[Override]
     public static function conditionHandlerProvider(): iterable
     {
@@ -75,6 +80,36 @@ final class RequestTypeConditionHandlerTest extends AbstractConditionHandler
             'condition_value'    => Ticket::DEMAND_TYPE,
             'submitted_answer'   => Ticket::DEMAND_TYPE,
             'expected_result'    => true,
+        ];
+
+        // Test request type answers with the NOT_EQUALS operator
+        yield "Not equals check - case 1 for $type" => [
+            'question_type'      => $type,
+            'condition_operator' => ValueOperator::NOT_EQUALS,
+            'condition_value'    => Ticket::INCIDENT_TYPE,
+            'submitted_answer'   => Ticket::DEMAND_TYPE,
+            'expected_result'    => true,
+        ];
+        yield "Not equals check - case 2 for $type" => [
+            'question_type'      => $type,
+            'condition_operator' => ValueOperator::NOT_EQUALS,
+            'condition_value'    => Ticket::INCIDENT_TYPE,
+            'submitted_answer'   => Ticket::INCIDENT_TYPE,
+            'expected_result'    => false,
+        ];
+        yield "Not equals check - case 3 for $type" => [
+            'question_type'      => $type,
+            'condition_operator' => ValueOperator::NOT_EQUALS,
+            'condition_value'    => Ticket::DEMAND_TYPE,
+            'submitted_answer'   => Ticket::INCIDENT_TYPE,
+            'expected_result'    => true,
+        ];
+        yield "Not equals check - case 4 for $type" => [
+            'question_type'      => $type,
+            'condition_operator' => ValueOperator::NOT_EQUALS,
+            'condition_value'    => Ticket::DEMAND_TYPE,
+            'submitted_answer'   => Ticket::DEMAND_TYPE,
+            'expected_result'    => false,
         ];
     }
 }

--- a/phpunit/functional/Glpi/Form/Condition/ConditionHandler/RichTextConditionHandlerTest.php
+++ b/phpunit/functional/Glpi/Form/Condition/ConditionHandler/RichTextConditionHandlerTest.php
@@ -41,6 +41,11 @@ use tests\units\Glpi\Form\Condition\AbstractConditionHandler;
 
 final class RichTextConditionHandlerTest extends AbstractConditionHandler
 {
+    public static function getConditionHandler(): ConditionHandlerInterface
+    {
+        return new RichTextConditionHandler();
+    }
+
     #[Override]
     public static function conditionHandlerProvider(): iterable
     {
@@ -192,6 +197,112 @@ final class RichTextConditionHandlerTest extends AbstractConditionHandler
             'condition_value'    => "Exact answer",
             'submitted_answer'   => "<p>exact ANSWER</p>",
             'expected_result'    => false,
+        ];
+
+        // Test string answers with the LENGTH_GREATER_THAN operator
+        yield "Length greater than check - case 1 for $type" => [
+            'question_type'      => $type,
+            'condition_operator' => ValueOperator::LENGTH_GREATER_THAN,
+            'condition_value'    => 10,
+            'submitted_answer'   => "<p>short</p>",
+            'expected_result'    => false,
+        ];
+        yield "Length greater than check - case 2 for $type" => [
+            'question_type'      => $type,
+            'condition_operator' => ValueOperator::LENGTH_GREATER_THAN,
+            'condition_value'    => 10,
+            'submitted_answer'   => "<p>longer than ten characters</p>",
+            'expected_result'    => true,
+        ];
+        yield "Length greater than check - case 3 for $type" => [
+            'question_type'      => $type,
+            'condition_operator' => ValueOperator::LENGTH_GREATER_THAN,
+            'condition_value'    => 10,
+            'submitted_answer'   => "<p>exactlyten</p>",
+            'expected_result'    => false,
+        ];
+
+        // Test string answers with the LENGTH_GREATER_THAN_OR_EQUALS operator
+        yield "Length greater than or equals check - case 1 for $type" => [
+            'question_type'      => $type,
+            'condition_operator' => ValueOperator::LENGTH_GREATER_THAN_OR_EQUALS,
+            'condition_value'    => 10,
+            'submitted_answer'   => "<p>short</p>",
+            'expected_result'    => false,
+        ];
+        yield "Length greater than or equals check - case 2 for $type" => [
+            'question_type'      => $type,
+            'condition_operator' => ValueOperator::LENGTH_GREATER_THAN_OR_EQUALS,
+            'condition_value'    => 10,
+            'submitted_answer'   => "<p>longer than ten characters</p>",
+            'expected_result'    => true,
+        ];
+        yield "Length greater than or equals check - case 3 for $type" => [
+            'question_type'      => $type,
+            'condition_operator' => ValueOperator::LENGTH_GREATER_THAN_OR_EQUALS,
+            'condition_value'    => 10,
+            'submitted_answer'   => "<p>exactly ten</p>",
+            'expected_result'    => true,
+        ];
+        yield "Length greater than or equals check - case 4 for $type" => [
+            'question_type'      => $type,
+            'condition_operator' => ValueOperator::LENGTH_GREATER_THAN_OR_EQUALS,
+            'condition_value'    => 10,
+            'submitted_answer'   => "<p>nine</p>",
+            'expected_result'    => false,
+        ];
+
+        // Test string answers with the LENGTH_LESS_THAN operator
+        yield "Length less than check - case 1 for $type" => [
+            'question_type'      => $type,
+            'condition_operator' => ValueOperator::LENGTH_LESS_THAN,
+            'condition_value'    => 10,
+            'submitted_answer'   => "<p>longer than ten characters</p>",
+            'expected_result'    => false,
+        ];
+        yield "Length less than check - case 2 for $type" => [
+            'question_type'      => $type,
+            'condition_operator' => ValueOperator::LENGTH_LESS_THAN,
+            'condition_value'    => 10,
+            'submitted_answer'   => "<p>short</p>",
+            'expected_result'    => true,
+        ];
+        yield "Length less than check - case 3 for $type" => [
+            'question_type'      => $type,
+            'condition_operator' => ValueOperator::LENGTH_LESS_THAN,
+            'condition_value'    => 10,
+            'submitted_answer'   => "<p>exactly ten</p>",
+            'expected_result'    => false,
+        ];
+
+        // Test string answers with the LENGTH_LESS_THAN_OR_EQUALS operator
+        yield "Length less than or equals check - case 1 for $type" => [
+            'question_type'      => $type,
+            'condition_operator' => ValueOperator::LENGTH_LESS_THAN_OR_EQUALS,
+            'condition_value'    => 10,
+            'submitted_answer'   => "<p>longer than ten characters</p>",
+            'expected_result'    => false,
+        ];
+        yield "Length less than or equals check - case 2 for $type" => [
+            'question_type'      => $type,
+            'condition_operator' => ValueOperator::LENGTH_LESS_THAN_OR_EQUALS,
+            'condition_value'    => 10,
+            'submitted_answer'   => "<p>short</p>",
+            'expected_result'    => true,
+        ];
+        yield "Length less than or equals check - case 3 for $type" => [
+            'question_type'      => $type,
+            'condition_operator' => ValueOperator::LENGTH_LESS_THAN_OR_EQUALS,
+            'condition_value'    => 10,
+            'submitted_answer'   => "<p>exactlyten</p>",
+            'expected_result'    => true,
+        ];
+        yield "Length less than or equals check - case 4 for $type" => [
+            'question_type'      => $type,
+            'condition_operator' => ValueOperator::LENGTH_LESS_THAN_OR_EQUALS,
+            'condition_value'    => 10,
+            'submitted_answer'   => "<p>nine</p>",
+            'expected_result'    => true,
         ];
     }
 }

--- a/phpunit/functional/Glpi/Form/Condition/ConditionHandler/SingleChoiceFromValuesConditionHandlerTest.php
+++ b/phpunit/functional/Glpi/Form/Condition/ConditionHandler/SingleChoiceFromValuesConditionHandlerTest.php
@@ -44,6 +44,11 @@ use tests\units\Glpi\Form\Condition\AbstractConditionHandler;
 
 final class SingleChoiceFromValuesConditionHandlerTest extends AbstractConditionHandler
 {
+    public static function getConditionHandler(): ConditionHandlerInterface
+    {
+        return new SingleChoiceFromValuesConditionHandler(['opt']);
+    }
+
     #[Override]
     public static function conditionHandlerProvider(): iterable
     {

--- a/phpunit/functional/Glpi/Form/Condition/ConditionHandler/StringConditionHandlerTest.php
+++ b/phpunit/functional/Glpi/Form/Condition/ConditionHandler/StringConditionHandlerTest.php
@@ -42,6 +42,11 @@ use tests\units\Glpi\Form\Condition\AbstractConditionHandler;
 
 final class StringConditionHandlerTest extends AbstractConditionHandler
 {
+    public static function getConditionHandler(): ConditionHandlerInterface
+    {
+        return new StringConditionHandler();
+    }
+
     #[Override]
     public static function conditionHandlerProvider(): iterable
     {
@@ -199,49 +204,109 @@ final class StringConditionHandlerTest extends AbstractConditionHandler
                 'expected_result'    => false,
             ];
 
-            // Test string answers with the MATCH_REGEX operator
-            yield "Match regex check - case 1 for $type" => [
+            // Test string answers with the LENGTH_GREATER_THAN operator
+            yield "Length greater than check - case 1 for $type" => [
                 'question_type'      => $type,
-                'condition_operator' => ValueOperator::MATCH_REGEX,
-                'condition_value'    => "/[09]+/",
-                'submitted_answer'   => "Invalid format",
+                'condition_operator' => ValueOperator::LENGTH_GREATER_THAN,
+                'condition_value'    => 10,
+                'submitted_answer'   => "short",
                 'expected_result'    => false,
             ];
-            yield "Match regex check - case 2 for $type" => [
+            yield "Length greater than check - case 2 for $type" => [
                 'question_type'      => $type,
-                'condition_operator' => ValueOperator::MATCH_REGEX,
-                'condition_value'    => "/[09]+/",
-                'submitted_answer'   => "0124511",
+                'condition_operator' => ValueOperator::LENGTH_GREATER_THAN,
+                'condition_value'    => 10,
+                'submitted_answer'   => "longer than ten characters",
                 'expected_result'    => true,
             ];
-            yield "Match regex check - case 3 for $type" => [
+            yield "Length greater than check - case 3 for $type" => [
                 'question_type'      => $type,
-                'condition_operator' => ValueOperator::MATCH_REGEX,
-                'condition_value'    => "not a regex", // Invalid regex should not trigger errors
-                'submitted_answer'   => "answer",
+                'condition_operator' => ValueOperator::LENGTH_GREATER_THAN,
+                'condition_value'    => 10,
+                'submitted_answer'   => "exactlyten",
                 'expected_result'    => false,
             ];
 
-            // Test string answers with the NOT_MATCH_REGEX operator
-            yield "Not match regex check - case 1 for $type" => [
+            // Test string answers with the LENGTH_GREATER_THAN_OR_EQUALS operator
+            yield "Length greater than or equals check - case 1 for $type" => [
                 'question_type'      => $type,
-                'condition_operator' => ValueOperator::NOT_MATCH_REGEX,
-                'condition_value'    => "/[09]+/",
-                'submitted_answer'   => "Invalid format",
-                'expected_result'    => true,
-            ];
-            yield "Not match regex check - case 2 for $type" => [
-                'question_type'      => $type,
-                'condition_operator' => ValueOperator::NOT_MATCH_REGEX,
-                'condition_value'    => "/[09]+/",
-                'submitted_answer'   => "0124511",
+                'condition_operator' => ValueOperator::LENGTH_GREATER_THAN_OR_EQUALS,
+                'condition_value'    => 10,
+                'submitted_answer'   => "short",
                 'expected_result'    => false,
             ];
-            yield "Not match regex check - case 3 for $type" => [
+            yield "Length greater than or equals check - case 2 for $type" => [
                 'question_type'      => $type,
-                'condition_operator' => ValueOperator::NOT_MATCH_REGEX,
-                'condition_value'    => "not a regex", // Invalid regex should not trigger errors
-                'submitted_answer'   => "answer",
+                'condition_operator' => ValueOperator::LENGTH_GREATER_THAN_OR_EQUALS,
+                'condition_value'    => 10,
+                'submitted_answer'   => "longer than ten characters",
+                'expected_result'    => true,
+            ];
+            yield "Length greater than or equals check - case 3 for $type" => [
+                'question_type'      => $type,
+                'condition_operator' => ValueOperator::LENGTH_GREATER_THAN_OR_EQUALS,
+                'condition_value'    => 10,
+                'submitted_answer'   => "exactlyten",
+                'expected_result'    => true,
+            ];
+            yield "Length greater than or equals check - case 4 for $type" => [
+                'question_type'      => $type,
+                'condition_operator' => ValueOperator::LENGTH_GREATER_THAN_OR_EQUALS,
+                'condition_value'    => 10,
+                'submitted_answer'   => "nine",
+                'expected_result'    => false,
+            ];
+
+            // Test string answers with the LENGTH_LESS_THAN operator
+            yield "Length less than check - case 1 for $type" => [
+                'question_type'      => $type,
+                'condition_operator' => ValueOperator::LENGTH_LESS_THAN,
+                'condition_value'    => 10,
+                'submitted_answer'   => "longer than ten characters",
+                'expected_result'    => false,
+            ];
+            yield "Length less than check - case 2 for $type" => [
+                'question_type'      => $type,
+                'condition_operator' => ValueOperator::LENGTH_LESS_THAN,
+                'condition_value'    => 10,
+                'submitted_answer'   => "short",
+                'expected_result'    => true,
+            ];
+            yield "Length less than check - case 3 for $type" => [
+                'question_type'      => $type,
+                'condition_operator' => ValueOperator::LENGTH_LESS_THAN,
+                'condition_value'    => 10,
+                'submitted_answer'   => "exactlyten",
+                'expected_result'    => false,
+            ];
+
+            // Test string answers with the LENGTH_LESS_THAN_OR_EQUALS operator
+            yield "Length less than or equals check - case 1 for $type" => [
+                'question_type'      => $type,
+                'condition_operator' => ValueOperator::LENGTH_LESS_THAN_OR_EQUALS,
+                'condition_value'    => 10,
+                'submitted_answer'   => "longer than ten characters",
+                'expected_result'    => false,
+            ];
+            yield "Length less than or equals check - case 2 for $type" => [
+                'question_type'      => $type,
+                'condition_operator' => ValueOperator::LENGTH_LESS_THAN_OR_EQUALS,
+                'condition_value'    => 10,
+                'submitted_answer'   => "short",
+                'expected_result'    => true,
+            ];
+            yield "Length less than or equals check - case 3 for $type" => [
+                'question_type'      => $type,
+                'condition_operator' => ValueOperator::LENGTH_LESS_THAN_OR_EQUALS,
+                'condition_value'    => 10,
+                'submitted_answer'   => "exactlyten",
+                'expected_result'    => true,
+            ];
+            yield "Length less than or equals check - case 4 for $type" => [
+                'question_type'      => $type,
+                'condition_operator' => ValueOperator::LENGTH_LESS_THAN_OR_EQUALS,
+                'condition_value'    => 10,
+                'submitted_answer'   => "nine",
                 'expected_result'    => true,
             ];
         }

--- a/phpunit/functional/Glpi/Form/Condition/ConditionHandler/TimeConditionHandlerTest.php
+++ b/phpunit/functional/Glpi/Form/Condition/ConditionHandler/TimeConditionHandlerTest.php
@@ -42,6 +42,11 @@ use tests\units\Glpi\Form\Condition\AbstractConditionHandler;
 
 final class TimeConditionHandlerTest extends AbstractConditionHandler
 {
+    public static function getConditionHandler(): ConditionHandlerInterface
+    {
+        return new TimeConditionHandler();
+    }
+
     #[Override]
     public static function conditionHandlerProvider(): iterable
     {

--- a/phpunit/functional/Glpi/Form/Condition/ConditionHandler/UrgencyConditionHandlerTest.php
+++ b/phpunit/functional/Glpi/Form/Condition/ConditionHandler/UrgencyConditionHandlerTest.php
@@ -42,6 +42,11 @@ use tests\units\Glpi\Form\Condition\AbstractConditionHandler;
 
 final class UrgencyConditionHandlerTest extends AbstractConditionHandler
 {
+    public static function getConditionHandler(): ConditionHandlerInterface
+    {
+        return new UrgencyConditionHandler();
+    }
+
     #[Override]
     public static function conditionHandlerProvider(): iterable
     {

--- a/phpunit/functional/Glpi/Form/Condition/ConditionHandler/UserDevicesAsTextConditionHandlerTest.php
+++ b/phpunit/functional/Glpi/Form/Condition/ConditionHandler/UserDevicesAsTextConditionHandlerTest.php
@@ -1,0 +1,190 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Form\Condition\ConditionHandler;
+
+use Glpi\Form\Condition\ValueOperator;
+use Glpi\Form\QuestionType\QuestionTypeUserDevice;
+use Glpi\Form\QuestionType\QuestionTypeUserDevicesConfig;
+use Override;
+use tests\units\Glpi\Form\Condition\AbstractConditionHandler;
+
+final class UserDevicesAsTextConditionHandlerTest extends AbstractConditionHandler
+{
+    public static function getConditionHandler(): ConditionHandlerInterface
+    {
+        return new UserDevicesAsTextConditionHandler(new QuestionTypeUserDevicesConfig(
+            is_multiple_devices: false,
+        ));
+    }
+
+    #[Override]
+    public static function conditionHandlerProvider(): iterable
+    {
+        $type = QuestionTypeUserDevice::class;
+
+        // Test with single device config
+        $single_device_config = new QuestionTypeUserDevicesConfig(
+            is_multiple_devices: false,
+        );
+
+        // Test with multiple devices config
+        $multiple_devices_config = new QuestionTypeUserDevicesConfig(
+            is_multiple_devices: true,
+        );
+
+        yield from self::getCasesForConfig($type, $single_device_config, 'single device');
+        yield from self::getCasesForConfig($type, $multiple_devices_config, 'multiple devices');
+    }
+
+    private static function getCasesForConfig(
+        string $type,
+        QuestionTypeUserDevicesConfig $extra_data,
+        string $config_type
+    ): iterable {
+        $is_multiple = $extra_data->isMultipleDevices();
+
+        // Get real test computer IDs
+        $computer_id = getItemByTypeName(\Computer::class, "_test_pc01", true);
+        $monitor_id = getItemByTypeName(\Monitor::class, "_test_monitor_1", true);
+
+        // Test user devices with the CONTAINS operator
+        yield "Contains check - case 1 for $type ($config_type)" => [
+            'question_type'       => $type,
+            'condition_operator'  => ValueOperator::CONTAINS,
+            'condition_value'     => 'test',
+            'submitted_answer'    => $is_multiple ? ["Computer_$computer_id"] : "Computer_$computer_id",
+            'expected_result'     => true,
+            'question_extra_data' => $extra_data,
+        ];
+        yield "Contains check - case 2 for $type ($config_type)" => [
+            'question_type'       => $type,
+            'condition_operator'  => ValueOperator::CONTAINS,
+            'condition_value'     => 'monitor',
+            'submitted_answer'    => $is_multiple ? ["Computer_$computer_id"] : "Computer_$computer_id",
+            'expected_result'     => false,
+            'question_extra_data' => $extra_data,
+        ];
+        yield "Contains check - case 3 for $type ($config_type)" => [
+            'question_type'       => $type,
+            'condition_operator'  => ValueOperator::CONTAINS,
+            'condition_value'     => 'nonexistent',
+            'submitted_answer'    => $is_multiple ? ["Computer_$computer_id", "Monitor_$monitor_id"] : "Computer_$computer_id",
+            'expected_result'     => false,
+            'question_extra_data' => $extra_data,
+        ];
+
+        if ($is_multiple) {
+            yield "Contains check - case 4 for $type ($config_type)" => [
+                'question_type'       => $type,
+                'condition_operator'  => ValueOperator::CONTAINS,
+                'condition_value'     => 'test',
+                'submitted_answer'    => ["Computer_$computer_id", "Monitor_$monitor_id"],
+                'expected_result'     => true,
+                'question_extra_data' => $extra_data,
+            ];
+            yield "Contains check - case 5 for $type ($config_type)" => [
+                'question_type'       => $type,
+                'condition_operator'  => ValueOperator::CONTAINS,
+                'condition_value'     => 'phone',
+                'submitted_answer'    => ["Computer_$computer_id", "Monitor_$monitor_id"],
+                'expected_result'     => false,
+                'question_extra_data' => $extra_data,
+            ];
+        }
+
+        // Test user devices with the NOT_CONTAINS operator
+        yield "Not contains check - case 1 for $type ($config_type)" => [
+            'question_type'       => $type,
+            'condition_operator'  => ValueOperator::NOT_CONTAINS,
+            'condition_value'     => 'monitor',
+            'submitted_answer'    => $is_multiple ? ["Computer_$computer_id"] : "Computer_$computer_id",
+            'expected_result'     => true,
+            'question_extra_data' => $extra_data,
+        ];
+        yield "Not contains check - case 2 for $type ($config_type)" => [
+            'question_type'       => $type,
+            'condition_operator'  => ValueOperator::NOT_CONTAINS,
+            'condition_value'     => 'test',
+            'submitted_answer'    => $is_multiple ? ["Computer_$computer_id"] : "Computer_$computer_id",
+            'expected_result'     => false,
+            'question_extra_data' => $extra_data,
+        ];
+        yield "Not contains check - case 3 for $type ($config_type)" => [
+            'question_type'       => $type,
+            'condition_operator'  => ValueOperator::NOT_CONTAINS,
+            'condition_value'     => 'nonexistent',
+            'submitted_answer'    => $is_multiple ? ["Computer_$computer_id", "Monitor_$monitor_id"] : "Computer_$computer_id",
+            'expected_result'     => true,
+            'question_extra_data' => $extra_data,
+        ];
+
+        if ($is_multiple) {
+            yield "Not contains check - case 4 for $type ($config_type)" => [
+                'question_type'       => $type,
+                'condition_operator'  => ValueOperator::NOT_CONTAINS,
+                'condition_value'     => 'test',
+                'submitted_answer'    => ["Computer_$computer_id", "Monitor_$monitor_id"],
+                'expected_result'     => false,
+                'question_extra_data' => $extra_data,
+            ];
+            yield "Not contains check - case 5 for $type ($config_type)" => [
+                'question_type'       => $type,
+                'condition_operator'  => ValueOperator::NOT_CONTAINS,
+                'condition_value'     => 'phone',
+                'submitted_answer'    => ["Computer_$computer_id", "Monitor_$monitor_id"],
+                'expected_result'     => true,
+                'question_extra_data' => $extra_data,
+            ];
+        }
+
+        // Test empty answers
+        yield "Empty answer test - contains for $type ($config_type)" => [
+            'question_type'       => $type,
+            'condition_operator'  => ValueOperator::CONTAINS,
+            'condition_value'     => 'Computer',
+            'submitted_answer'    => $is_multiple ? [] : '',
+            'expected_result'     => false,
+            'question_extra_data' => $extra_data,
+        ];
+        yield "Empty answer test - not contains for $type ($config_type)" => [
+            'question_type'       => $type,
+            'condition_operator'  => ValueOperator::NOT_CONTAINS,
+            'condition_value'     => 'Computer',
+            'submitted_answer'    => $is_multiple ? [] : '',
+            'expected_result'     => true,
+            'question_extra_data' => $extra_data,
+        ];
+    }
+}

--- a/phpunit/functional/Glpi/Form/Condition/ConditionHandler/UserDevicesConditionHandlerTest.php
+++ b/phpunit/functional/Glpi/Form/Condition/ConditionHandler/UserDevicesConditionHandlerTest.php
@@ -43,6 +43,14 @@ use tests\units\Glpi\Form\Condition\AbstractConditionHandler;
 
 final class UserDevicesConditionHandlerTest extends AbstractConditionHandler
 {
+    public static function getConditionHandler(): array
+    {
+        return [
+            new UserDevicesConditionHandler(is_multiple_devices: false),
+            new UserDevicesConditionHandler(is_multiple_devices: true),
+        ];
+    }
+
     #[Override]
     public static function conditionHandlerProvider(): iterable
     {

--- a/phpunit/functional/Glpi/Form/Condition/ConditionHandler/VisibilityConditionHandlerTest.php
+++ b/phpunit/functional/Glpi/Form/Condition/ConditionHandler/VisibilityConditionHandlerTest.php
@@ -72,6 +72,11 @@ use tests\units\Glpi\Form\Condition\AbstractConditionHandler;
 
 final class VisibilityConditionHandlerTest extends AbstractConditionHandler
 {
+    public static function getConditionHandler(): ConditionHandlerInterface
+    {
+        return new VisibilityConditionHandler();
+    }
+
     #[Override]
     public static function conditionHandlerProvider(): iterable
     {

--- a/phpunit/functional/Glpi/Form/Condition/EditorManagerTest.php
+++ b/phpunit/functional/Glpi/Form/Condition/EditorManagerTest.php
@@ -416,7 +416,7 @@ final class EditorManagerTest extends GLPITestCase
                 [
                     'uuid' => 2,
                     'name' => 'Question 2',
-                    'type' => QuestionTypeFile::class, // only support visibility conditions
+                    'type' => QuestionTypeFile::class, // only support visibility and regex conditions
                 ],
             ],
         ]);
@@ -427,8 +427,10 @@ final class EditorManagerTest extends GLPITestCase
 
         // Assert: no operators should be found.
         $this->assertEquals([
-            'visible'     => __("Is visible"),
-            'not_visible' => __("Is not visible"),
+            'visible'         => __("Is visible"),
+            'not_visible'     => __("Is not visible"),
+            'match_regex'     => __("Match regular expression"),
+            'not_match_regex' => __("Do not match regular expression"),
         ], $dropdown_values);
     }
 

--- a/phpunit/functional/Glpi/Form/Migration/FormMigrationTest.php
+++ b/phpunit/functional/Glpi/Form/Migration/FormMigrationTest.php
@@ -1743,7 +1743,14 @@ final class FormMigrationTest extends DbTestCase
                     'fieldname' => 'range',
                 ],
             ],
-            ValidationStrategy::NO_VALIDATION,
+            ValidationStrategy::VALID_IF,
+            [
+                [
+                    'value_operator' => ValueOperator::MATCH_REGEX,
+                    'value'          => '/^[A-Za-z0-9]+$/',
+                    'logic_operator' => LogicOperator::AND,
+                ],
+            ],
         ];
     }
 

--- a/src/Glpi/Form/Condition/ConditionHandler/RegexConditionHandler.php
+++ b/src/Glpi/Form/Condition/ConditionHandler/RegexConditionHandler.php
@@ -1,0 +1,115 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Form\Condition\ConditionHandler;
+
+use Glpi\DBAL\JsonFieldInterface;
+use Glpi\Form\Condition\ConditionData;
+use Glpi\Form\Condition\ConditionValueAsStringProviderInterface;
+use Glpi\Form\Condition\ValueOperator;
+use Glpi\Form\QuestionType\QuestionTypeInterface;
+use Override;
+
+class RegexConditionHandler implements ConditionHandlerInterface
+{
+    public function __construct(
+        private QuestionTypeInterface $questionType,
+        private ?JsonFieldInterface $question_config
+    ) {}
+
+    #[Override]
+    public function getSupportedValueOperators(): array
+    {
+        return [
+            ValueOperator::MATCH_REGEX,
+            ValueOperator::NOT_MATCH_REGEX,
+        ];
+    }
+
+    #[Override]
+    public function getTemplate(): string
+    {
+        return '/pages/admin/form/condition_handler_templates/input.html.twig';
+    }
+
+    #[Override]
+    public function getTemplateParameters(ConditionData $condition): array
+    {
+        return [];
+    }
+
+    #[Override]
+    public function applyValueOperator(
+        mixed $a,
+        ValueOperator $operator,
+        mixed $b,
+    ): bool {
+        if ($this->questionType instanceof ConditionValueAsStringProviderInterface) {
+            $a = $this->questionType->getConditionValueAsString($a, $this->question_config);
+        }
+
+        $a = is_array($a) ? $a : [$a];
+        $b = strtolower(strval($b));
+
+        // Handle empty array input: empty values don't match any regex,
+        // so MATCH_REGEX returns false and NOT_MATCH_REGEX returns true
+        if ($a === []) {
+            return $operator === ValueOperator::NOT_MATCH_REGEX;
+        }
+
+        $matches_count = 0;
+        foreach ($a as $value) {
+            $value = strtolower(strval($value));
+
+            // Note: we do not want to throw warnings here if an invalid regex
+            // is configured by the user.
+            // There is no clean way to test that a regex is valid in PHP,
+            // therefore the simplest way to deal with that is to ignore
+            // warnings using the "@" prefix.
+            $result = @preg_match($b, $value); // @phpstan-ignore theCodingMachineSafe.function
+
+            if ($result) {
+                $matches_count++;
+            }
+        }
+
+        // MATCH_REGEX: returns true if ALL values match the regex
+        // NOT_MATCH_REGEX: returns true if NO values match the regex
+        if ($operator === ValueOperator::MATCH_REGEX) {
+            return $matches_count === count($a);
+        } else {
+            return $matches_count === 0;
+        }
+    }
+}

--- a/src/Glpi/Form/Condition/ConditionHandler/RegexConditionHandler.php
+++ b/src/Glpi/Form/Condition/ConditionHandler/RegexConditionHandler.php
@@ -36,7 +36,7 @@ namespace Glpi\Form\Condition\ConditionHandler;
 
 use Glpi\DBAL\JsonFieldInterface;
 use Glpi\Form\Condition\ConditionData;
-use Glpi\Form\Condition\ConditionValueAsStringProviderInterface;
+use Glpi\Form\Condition\ConditionValueTransformerInterface;
 use Glpi\Form\Condition\ValueOperator;
 use Glpi\Form\QuestionType\QuestionTypeInterface;
 use Override;
@@ -75,8 +75,8 @@ class RegexConditionHandler implements ConditionHandlerInterface
         ValueOperator $operator,
         mixed $b,
     ): bool {
-        if ($this->questionType instanceof ConditionValueAsStringProviderInterface) {
-            $a = $this->questionType->getConditionValueAsString($a, $this->question_config);
+        if ($this->questionType instanceof ConditionValueTransformerInterface) {
+            $a = $this->questionType->transformConditionValueForComparisons($a, $this->question_config);
         }
 
         $a = is_array($a) ? $a : [$a];

--- a/src/Glpi/Form/Condition/ConditionHandler/RequestTypeConditionHandler.php
+++ b/src/Glpi/Form/Condition/ConditionHandler/RequestTypeConditionHandler.php
@@ -44,7 +44,10 @@ class RequestTypeConditionHandler implements ConditionHandlerInterface
     #[Override]
     public function getSupportedValueOperators(): array
     {
-        return [ValueOperator::EQUALS];
+        return [
+            ValueOperator::EQUALS,
+            ValueOperator::NOT_EQUALS,
+        ];
     }
 
     #[Override]
@@ -70,7 +73,8 @@ class RequestTypeConditionHandler implements ConditionHandlerInterface
         $b = (int) $b;
 
         return match ($operator) {
-            ValueOperator::EQUALS => $a === $b,
+            ValueOperator::EQUALS     => $a === $b,
+            ValueOperator::NOT_EQUALS => $a !== $b,
 
             // Unsupported operators
             default => false,

--- a/src/Glpi/Form/Condition/ConditionHandler/UserDevicesAsTextConditionHandler.php
+++ b/src/Glpi/Form/Condition/ConditionHandler/UserDevicesAsTextConditionHandler.php
@@ -85,7 +85,7 @@ final class UserDevicesAsTextConditionHandler implements ConditionHandlerInterfa
         }
 
         // Get valid item names from the raw answer
-        $a = (new QuestionTypeUserDevice())->getConditionValueAsString($a, $this->question_config);
+        $a = (new QuestionTypeUserDevice())->transformConditionValueForComparisons($a, $this->question_config);
 
         // Normalize values
         $a = array_map(fn(string $item) => strtolower(strval($item)), $a);

--- a/src/Glpi/Form/Condition/ConditionValueAsStringProviderInterface.php
+++ b/src/Glpi/Form/Condition/ConditionValueAsStringProviderInterface.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Form\Condition;
+
+use Glpi\DBAL\JsonFieldInterface;
+
+/**
+ * Items that implements this interface can provide a string representation of their value to be used in conditions.
+ */
+interface ConditionValueAsStringProviderInterface
+{
+    /**
+     * Get the value of the answer as a string or an array of strings to be used in conditions.
+     *
+     * @param mixed $value The value of the answer
+     *
+     * @return string|array<string>
+     */
+    public function getConditionValueAsString(mixed $value, ?JsonFieldInterface $question_config): string|array;
+}

--- a/src/Glpi/Form/Condition/ConditionValueTransformerInterface.php
+++ b/src/Glpi/Form/Condition/ConditionValueTransformerInterface.php
@@ -37,16 +37,16 @@ namespace Glpi\Form\Condition;
 use Glpi\DBAL\JsonFieldInterface;
 
 /**
- * Items that implements this interface can provide a string representation of their value to be used in conditions.
+ * Items that implements this interface can transform their values for use in condition comparisons.
  */
-interface ConditionValueAsStringProviderInterface
+interface ConditionValueTransformerInterface
 {
     /**
-     * Get the value of the answer as a string or an array of strings to be used in conditions.
+     * Transform the value of the answer to a format suitable for condition comparisons.
      *
      * @param mixed $value The value of the answer
      *
-     * @return string|array<string>
+     * @return string|array<string> A string or an array of strings for comparison
      */
-    public function getConditionValueAsString(mixed $value, ?JsonFieldInterface $question_config): string|array;
+    public function transformConditionValueForComparisons(mixed $value, ?JsonFieldInterface $question_config): string|array;
 }

--- a/src/Glpi/Form/QuestionType/AbstractQuestionType.php
+++ b/src/Glpi/Form/QuestionType/AbstractQuestionType.php
@@ -37,6 +37,7 @@ namespace Glpi\Form\QuestionType;
 
 use Glpi\DBAL\JsonFieldInterface;
 use Glpi\Form\Condition\ConditionHandler\ConditionHandlerInterface;
+use Glpi\Form\Condition\ConditionHandler\RegexConditionHandler;
 use Glpi\Form\Condition\ConditionHandler\VisibilityConditionHandler;
 use Glpi\Form\Export\Context\DatabaseMapper;
 use Glpi\Form\Export\Serializer\DynamicExportDataField;
@@ -245,6 +246,9 @@ abstract class AbstractQuestionType implements QuestionTypeInterface
     public function getConditionHandlers(
         ?JsonFieldInterface $question_config
     ): array {
-        return [new VisibilityConditionHandler()];
+        return [
+            new VisibilityConditionHandler(),
+            new RegexConditionHandler($this, $question_config),
+        ];
     }
 }

--- a/src/Glpi/Form/QuestionType/AbstractQuestionTypeActors.php
+++ b/src/Glpi/Form/QuestionType/AbstractQuestionTypeActors.php
@@ -40,7 +40,7 @@ use Exception;
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\JsonFieldInterface;
 use Glpi\Form\Condition\ConditionHandler\ActorConditionHandler;
-use Glpi\Form\Condition\ConditionValueAsStringProviderInterface;
+use Glpi\Form\Condition\ConditionValueTransformerInterface;
 use Glpi\Form\Condition\UsedAsCriteriaInterface;
 use Glpi\Form\Export\Context\DatabaseMapper;
 use Glpi\Form\Export\Serializer\DynamicExportDataField;
@@ -64,7 +64,7 @@ use function Safe\json_encode;
 abstract class AbstractQuestionTypeActors extends AbstractQuestionType implements
     FormQuestionDataConverterInterface,
     UsedAsCriteriaInterface,
-    ConditionValueAsStringProviderInterface
+    ConditionValueTransformerInterface
 {
     /**
      * Retrieve the allowed actor types
@@ -466,7 +466,7 @@ TWIG;
     }
 
     #[Override]
-    public function getConditionValueAsString(mixed $value, ?JsonFieldInterface $question_config): array
+    public function transformConditionValueForComparisons(mixed $value, ?JsonFieldInterface $question_config): array
     {
         // Handle empty cases first
         if (empty($value)) {

--- a/src/Glpi/Form/QuestionType/AbstractQuestionTypeActors.php
+++ b/src/Glpi/Form/QuestionType/AbstractQuestionTypeActors.php
@@ -40,6 +40,7 @@ use Exception;
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\JsonFieldInterface;
 use Glpi\Form\Condition\ConditionHandler\ActorConditionHandler;
+use Glpi\Form\Condition\ConditionValueAsStringProviderInterface;
 use Glpi\Form\Condition\UsedAsCriteriaInterface;
 use Glpi\Form\Export\Context\DatabaseMapper;
 use Glpi\Form\Export\Serializer\DynamicExportDataField;
@@ -48,6 +49,7 @@ use Glpi\Form\Migration\FormQuestionDataConverterInterface;
 use Glpi\Form\Question;
 use Group;
 use InvalidArgumentException;
+use LogicException;
 use Override;
 use Safe\Exceptions\JsonException;
 use Supplier;
@@ -59,7 +61,10 @@ use function Safe\json_encode;
 /**
  * "Actors" questions represent an input field for actors (requesters, ...)
  */
-abstract class AbstractQuestionTypeActors extends AbstractQuestionType implements FormQuestionDataConverterInterface, UsedAsCriteriaInterface
+abstract class AbstractQuestionTypeActors extends AbstractQuestionType implements
+    FormQuestionDataConverterInterface,
+    UsedAsCriteriaInterface,
+    ConditionValueAsStringProviderInterface
 {
     /**
      * Retrieve the allowed actor types
@@ -458,6 +463,53 @@ TWIG;
             parent::getConditionHandlers($question_config),
             [new ActorConditionHandler($this, $question_config)]
         );
+    }
+
+    #[Override]
+    public function getConditionValueAsString(mixed $value, ?JsonFieldInterface $question_config): array
+    {
+        // Handle empty cases first
+        if (empty($value)) {
+            return [];
+        }
+
+        // If it's a JSON string (from database), decode it
+        if (is_string($value) && json_validate($value)) {
+            $value = json_decode($value, true);
+        } elseif (is_array($value)) {
+            $value = json_decode($this->formatDefaultValueForDB($value), true);
+        }
+
+        $config = $this->getDefaultValueConfig($value);
+        if (!($config instanceof QuestionTypeActorsDefaultValueConfig)) {
+            throw new LogicException(
+                'Expected QuestionTypeActorsDefaultValueConfig, got ' . get_class($config)
+            );
+        }
+
+        $actors = [];
+        foreach ($config->getUsersIds() as $user_id) {
+            $user = User::getById($user_id);
+            if ($user) {
+                $actors[] = $user->getName();
+            }
+        }
+
+        foreach ($config->getGroupsIds() as $group_id) {
+            $group = Group::getById($group_id);
+            if ($group) {
+                $actors[] = $group->getName();
+            }
+        }
+
+        foreach ($config->getSuppliersIds() as $supplier_id) {
+            $supplier = Supplier::getById($supplier_id);
+            if ($supplier) {
+                $actors[] = $supplier->getName();
+            }
+        }
+
+        return $actors;
     }
 
     #[Override]

--- a/src/Glpi/Form/QuestionType/AbstractQuestionTypeSelectable.php
+++ b/src/Glpi/Form/QuestionType/AbstractQuestionTypeSelectable.php
@@ -37,7 +37,7 @@ namespace Glpi\Form\QuestionType;
 
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\JsonFieldInterface;
-use Glpi\Form\Condition\ConditionValueAsStringProviderInterface;
+use Glpi\Form\Condition\ConditionValueTransformerInterface;
 use Glpi\Form\Migration\FormQuestionDataConverterInterface;
 use Glpi\Form\Question;
 use Glpi\ItemTranslation\Context\TranslationHandler;
@@ -50,7 +50,7 @@ use function Safe\json_decode;
 /**
  * Short answers are single line inputs used to answer simple questions.
  */
-abstract class AbstractQuestionTypeSelectable extends AbstractQuestionType implements FormQuestionDataConverterInterface, TranslationAwareQuestionType, ConditionValueAsStringProviderInterface
+abstract class AbstractQuestionTypeSelectable extends AbstractQuestionType implements FormQuestionDataConverterInterface, TranslationAwareQuestionType, ConditionValueTransformerInterface
 {
     public const TRANSLATION_KEY_OPTION = 'option';
 
@@ -476,7 +476,7 @@ TWIG;
     }
 
     #[Override]
-    public function getConditionValueAsString(mixed $value, ?JsonFieldInterface $question_config): array
+    public function transformConditionValueForComparisons(mixed $value, ?JsonFieldInterface $question_config): array
     {
         // Handle empty cases first
         if (empty($value)) {

--- a/src/Glpi/Form/QuestionType/QuestionTypeDropdown.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeDropdown.php
@@ -39,7 +39,7 @@ use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\JsonFieldInterface;
 use Glpi\Form\Condition\ConditionHandler\MultipleChoiceFromValuesConditionHandler;
 use Glpi\Form\Condition\ConditionHandler\SingleChoiceFromValuesConditionHandler;
-use Glpi\Form\Condition\ConditionValueAsStringProviderInterface;
+use Glpi\Form\Condition\ConditionValueTransformerInterface;
 use Glpi\Form\Condition\UsedAsCriteriaInterface;
 use Glpi\Form\Question;
 use InvalidArgumentException;
@@ -49,7 +49,7 @@ use function Safe\json_decode;
 
 final class QuestionTypeDropdown extends AbstractQuestionTypeSelectable implements
     UsedAsCriteriaInterface,
-    ConditionValueAsStringProviderInterface
+    ConditionValueTransformerInterface
 {
     #[Override]
     public function getInputType(?Question $question): string

--- a/src/Glpi/Form/QuestionType/QuestionTypeDropdown.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeDropdown.php
@@ -39,6 +39,7 @@ use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\JsonFieldInterface;
 use Glpi\Form\Condition\ConditionHandler\MultipleChoiceFromValuesConditionHandler;
 use Glpi\Form\Condition\ConditionHandler\SingleChoiceFromValuesConditionHandler;
+use Glpi\Form\Condition\ConditionValueAsStringProviderInterface;
 use Glpi\Form\Condition\UsedAsCriteriaInterface;
 use Glpi\Form\Question;
 use InvalidArgumentException;
@@ -46,7 +47,9 @@ use Override;
 
 use function Safe\json_decode;
 
-final class QuestionTypeDropdown extends AbstractQuestionTypeSelectable implements UsedAsCriteriaInterface
+final class QuestionTypeDropdown extends AbstractQuestionTypeSelectable implements
+    UsedAsCriteriaInterface,
+    ConditionValueAsStringProviderInterface
 {
     #[Override]
     public function getInputType(?Question $question): string

--- a/src/Glpi/Form/QuestionType/QuestionTypeItem.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeItem.php
@@ -43,7 +43,7 @@ use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\JsonFieldInterface;
 use Glpi\Form\Condition\ConditionHandler\ItemAsTextConditionHandler;
 use Glpi\Form\Condition\ConditionHandler\ItemConditionHandler;
-use Glpi\Form\Condition\ConditionValueAsStringProviderInterface;
+use Glpi\Form\Condition\ConditionValueTransformerInterface;
 use Glpi\Form\Condition\UsedAsCriteriaInterface;
 use Glpi\Form\Export\Context\DatabaseMapper;
 use Glpi\Form\Export\Serializer\DynamicExportDataField;
@@ -66,7 +66,7 @@ use function Safe\json_encode;
 class QuestionTypeItem extends AbstractQuestionType implements
     FormQuestionDataConverterInterface,
     UsedAsCriteriaInterface,
-    ConditionValueAsStringProviderInterface
+    ConditionValueTransformerInterface
 {
     protected string $itemtype_aria_label;
     protected string $items_id_aria_label;
@@ -326,7 +326,7 @@ class QuestionTypeItem extends AbstractQuestionType implements
     }
 
     #[Override]
-    public function getConditionValueAsString(mixed $value, ?JsonFieldInterface $question_config): string
+    public function transformConditionValueForComparisons(mixed $value, ?JsonFieldInterface $question_config): string
     {
         // Handle empty cases first
         if (empty($value)) {

--- a/src/Glpi/Form/QuestionType/QuestionTypeLongText.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeLongText.php
@@ -38,6 +38,7 @@ namespace Glpi\Form\QuestionType;
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\JsonFieldInterface;
 use Glpi\Form\Condition\ConditionHandler\RichTextConditionHandler;
+use Glpi\Form\Condition\ConditionValueAsStringProviderInterface;
 use Glpi\Form\Condition\UsedAsCriteriaInterface;
 use Glpi\Form\FormTranslation;
 use Glpi\Form\Migration\FormQuestionDataConverterInterface;
@@ -52,7 +53,8 @@ use Session;
 final class QuestionTypeLongText extends AbstractQuestionType implements
     FormQuestionDataConverterInterface,
     UsedAsCriteriaInterface,
-    TranslationAwareQuestionType
+    TranslationAwareQuestionType,
+    ConditionValueAsStringProviderInterface
 {
     #[Override]
     public function getFormEditorJsOptions(): string
@@ -198,6 +200,12 @@ TWIG;
         ?JsonFieldInterface $question_config
     ): array {
         return array_merge(parent::getConditionHandlers($question_config), [new RichTextConditionHandler()]);
+    }
+
+    #[Override]
+    public function getConditionValueAsString(mixed $value, ?JsonFieldInterface $question_config): string
+    {
+        return strip_tags(strval($value));
     }
 
     #[Override]

--- a/src/Glpi/Form/QuestionType/QuestionTypeLongText.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeLongText.php
@@ -38,7 +38,7 @@ namespace Glpi\Form\QuestionType;
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\JsonFieldInterface;
 use Glpi\Form\Condition\ConditionHandler\RichTextConditionHandler;
-use Glpi\Form\Condition\ConditionValueAsStringProviderInterface;
+use Glpi\Form\Condition\ConditionValueTransformerInterface;
 use Glpi\Form\Condition\UsedAsCriteriaInterface;
 use Glpi\Form\FormTranslation;
 use Glpi\Form\Migration\FormQuestionDataConverterInterface;
@@ -54,7 +54,7 @@ final class QuestionTypeLongText extends AbstractQuestionType implements
     FormQuestionDataConverterInterface,
     UsedAsCriteriaInterface,
     TranslationAwareQuestionType,
-    ConditionValueAsStringProviderInterface
+    ConditionValueTransformerInterface
 {
     #[Override]
     public function getFormEditorJsOptions(): string
@@ -203,7 +203,7 @@ TWIG;
     }
 
     #[Override]
-    public function getConditionValueAsString(mixed $value, ?JsonFieldInterface $question_config): string
+    public function transformConditionValueForComparisons(mixed $value, ?JsonFieldInterface $question_config): string
     {
         return strip_tags(strval($value));
     }

--- a/src/Glpi/Form/QuestionType/QuestionTypeUrgency.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeUrgency.php
@@ -39,12 +39,13 @@ use CommonITILObject;
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\JsonFieldInterface;
 use Glpi\Form\Condition\ConditionHandler\UrgencyConditionHandler;
+use Glpi\Form\Condition\ConditionValueAsStringProviderInterface;
 use Glpi\Form\Condition\UsedAsCriteriaInterface;
 use Glpi\Form\Migration\FormQuestionDataConverterInterface;
 use Glpi\Form\Question;
 use Override;
 
-final class QuestionTypeUrgency extends AbstractQuestionType implements UsedAsCriteriaInterface, FormQuestionDataConverterInterface
+final class QuestionTypeUrgency extends AbstractQuestionType implements UsedAsCriteriaInterface, FormQuestionDataConverterInterface, ConditionValueAsStringProviderInterface
 {
     /**
      * Retrieve the default value for the urgency question type
@@ -188,6 +189,12 @@ TWIG;
         ?JsonFieldInterface $question_config
     ): array {
         return array_merge(parent::getConditionHandlers($question_config), [new UrgencyConditionHandler()]);
+    }
+
+    #[Override]
+    public function getConditionValueAsString(mixed $value, ?JsonFieldInterface $question_config): string
+    {
+        return strval($value);
     }
 
     #[Override]

--- a/src/Glpi/Form/QuestionType/QuestionTypeUrgency.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeUrgency.php
@@ -39,13 +39,13 @@ use CommonITILObject;
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\JsonFieldInterface;
 use Glpi\Form\Condition\ConditionHandler\UrgencyConditionHandler;
-use Glpi\Form\Condition\ConditionValueAsStringProviderInterface;
+use Glpi\Form\Condition\ConditionValueTransformerInterface;
 use Glpi\Form\Condition\UsedAsCriteriaInterface;
 use Glpi\Form\Migration\FormQuestionDataConverterInterface;
 use Glpi\Form\Question;
 use Override;
 
-final class QuestionTypeUrgency extends AbstractQuestionType implements UsedAsCriteriaInterface, FormQuestionDataConverterInterface, ConditionValueAsStringProviderInterface
+final class QuestionTypeUrgency extends AbstractQuestionType implements UsedAsCriteriaInterface, FormQuestionDataConverterInterface, ConditionValueTransformerInterface
 {
     /**
      * Retrieve the default value for the urgency question type
@@ -192,7 +192,7 @@ TWIG;
     }
 
     #[Override]
-    public function getConditionValueAsString(mixed $value, ?JsonFieldInterface $question_config): string
+    public function transformConditionValueForComparisons(mixed $value, ?JsonFieldInterface $question_config): string
     {
         return strval($value);
     }

--- a/src/Glpi/Form/QuestionType/QuestionTypeUserDevice.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeUserDevice.php
@@ -41,7 +41,7 @@ use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\JsonFieldInterface;
 use Glpi\Form\Condition\ConditionHandler\UserDevicesAsTextConditionHandler;
 use Glpi\Form\Condition\ConditionHandler\UserDevicesConditionHandler;
-use Glpi\Form\Condition\ConditionValueAsStringProviderInterface;
+use Glpi\Form\Condition\ConditionValueTransformerInterface;
 use Glpi\Form\Condition\UsedAsCriteriaInterface;
 use Glpi\Form\Question;
 use InvalidArgumentException;
@@ -54,7 +54,7 @@ use function Safe\preg_match;
 
 final class QuestionTypeUserDevice extends AbstractQuestionType implements
     UsedAsCriteriaInterface,
-    ConditionValueAsStringProviderInterface
+    ConditionValueTransformerInterface
 {
     #[Override]
     public function validateExtraDataInput(array $input): bool
@@ -314,7 +314,7 @@ TWIG;
     }
 
     #[Override]
-    public function getConditionValueAsString(mixed $value, ?JsonFieldInterface $question_config): array
+    public function transformConditionValueForComparisons(mixed $value, ?JsonFieldInterface $question_config): array
     {
         if (!is_array($value)) {
             $value = [$value];

--- a/templates/pages/admin/form/conditional_visibility_dropdown.html.twig
+++ b/templates/pages/admin/form/conditional_visibility_dropdown.html.twig
@@ -45,7 +45,7 @@
 
         {% set hide = question_strategy == enum('Glpi\\Form\\Condition\\VisibilityStrategy').ALWAYS_VISIBLE %}
         {% set force_show = force_show|default(false) %}
-        class="btn-group ms-1 {{ (hide and not force_show) ? 'd-none' : '' }}"
+        class="dropdown-center btn-group ms-1 {{ (hide and not force_show) ? 'd-none' : '' }}"
 
         {# May be displayed on section, comment and question #}
         {# We can't use instanceOf here as `item` may be null #}

--- a/tests/cypress/e2e/form/editor/conditions.cy.js
+++ b/tests/cypress/e2e/form/editor/conditions.cy.js
@@ -1206,6 +1206,18 @@ describe ('Conditions', () => {
                         value: 10,
                         valueType: 'number'
                     },
+                    {
+                        logic: 'Or',
+                        operator: 'Match regular expression',
+                        value: '/^[0-9]$/',
+                        valueType: 'string'
+                    },
+                    {
+                        logic: 'Or',
+                        operator: 'Do not match regular expression',
+                        value: '/^[0-9]$/',
+                        valueType: 'string'
+                    },
                 ]
             },
         ],
@@ -1423,6 +1435,18 @@ describe ('Conditions', () => {
                         value: '2021-01-01',
                         valueType: 'date'
                     },
+                    {
+                        logic: 'Or',
+                        operator: 'Match regular expression',
+                        value: '/^2021-01-01$/',
+                        valueType: 'date'
+                    },
+                    {
+                        logic: 'Or',
+                        operator: 'Do not match regular expression',
+                        value: '/^2021-01-01$/',
+                        valueType: 'date'
+                    },
                 ]
             },
         ],
@@ -1478,6 +1502,18 @@ describe ('Conditions', () => {
                         logic: 'Or',
                         operator: 'Is less than or equals to',
                         value: '12:00',
+                        valueType: 'date'
+                    },
+                    {
+                        logic: 'Or',
+                        operator: 'Match regular expression',
+                        value: '/^12:00$/',
+                        valueType: 'date'
+                    },
+                    {
+                        logic: 'Or',
+                        operator: 'Do not match regular expression',
+                        value: '/^12:00$/',
                         valueType: 'date'
                     },
                 ]
@@ -1537,6 +1573,18 @@ describe ('Conditions', () => {
                         value: '2021-01-01T12:00',
                         valueType: 'date'
                     },
+                    {
+                        logic: 'Or',
+                        operator: 'Match regular expression',
+                        value: '/^2021-01-01T12:00$/',
+                        valueType: 'date'
+                    },
+                    {
+                        logic: 'Or',
+                        operator: 'Do not match regular expression',
+                        value: '/^2021-01-01T12:00$/',
+                        valueType: 'date'
+                    },
                 ]
             },
         ],
@@ -1580,7 +1628,19 @@ describe ('Conditions', () => {
                         operator: 'Do not contains',
                         value: 'glpi',
                         valueType: 'dropdown'
-                    }
+                    },
+                    {
+                        logic: 'Or',
+                        operator: 'Match regular expression',
+                        value: '/glpi/',
+                        valueType: 'string'
+                    },
+                    {
+                        logic: 'Or',
+                        operator: 'Do not match regular expression',
+                        value: '/glpi/',
+                        valueType: 'string'
+                    },
                 ],
             }
         ],
@@ -1624,7 +1684,19 @@ describe ('Conditions', () => {
                         operator: 'Do not contains',
                         value: 'glpi',
                         valueType: 'dropdown'
-                    }
+                    },
+                    {
+                        logic: 'Or',
+                        operator: 'Match regular expression',
+                        value: '/glpi/',
+                        valueType: 'string'
+                    },
+                    {
+                        logic: 'Or',
+                        operator: 'Do not match regular expression',
+                        value: '/glpi/',
+                        valueType: 'string'
+                    },
                 ],
             }
         ],
@@ -1668,7 +1740,19 @@ describe ('Conditions', () => {
                         operator: 'Do not contains',
                         value: 'glpi',
                         valueType: 'dropdown'
-                    }
+                    },
+                    {
+                        logic: 'Or',
+                        operator: 'Match regular expression',
+                        value: '/glpi/',
+                        valueType: 'string'
+                    },
+                    {
+                        logic: 'Or',
+                        operator: 'Do not match regular expression',
+                        value: '/glpi/',
+                        valueType: 'string'
+                    },
                 ],
             }
         ],
@@ -1725,6 +1809,18 @@ describe ('Conditions', () => {
                         value: 'High',
                         valueType: 'dropdown'
                     },
+                    {
+                        logic: 'Or',
+                        operator: 'Match regular expression',
+                        value: '/^1$/',
+                        valueType: 'string'
+                    },
+                    {
+                        logic: 'Or',
+                        operator: 'Do not match regular expression',
+                        value: '/^1$/',
+                        valueType: 'string'
+                    }
                 ],
             },
         ],
@@ -1751,6 +1847,24 @@ describe ('Conditions', () => {
                         value: 'Request',
                         valueType: 'dropdown'
                     },
+                    {
+                        logic: 'Or',
+                        operator: 'Is not equal to',
+                        value: 'Request',
+                        valueType: 'dropdown'
+                    },
+                    {
+                        logic: 'Or',
+                        operator: 'Match regular expression',
+                        value: '/^1$/',
+                        valueType: 'string'
+                    },
+                    {
+                        logic: 'Or',
+                        operator: 'Do not match regular expression',
+                        value: '/^1$/',
+                        valueType: 'string'
+                    }
                 ],
             },
         ],
@@ -1771,6 +1885,18 @@ describe ('Conditions', () => {
                         value: null,
                         valueType: null
                     },
+                    {
+                        logic: 'Or',
+                        operator: 'Match regular expression',
+                        value: '/^file_[0-9]+\\.txt$/',
+                        valueType: 'string'
+                    },
+                    {
+                        logic: 'Or',
+                        operator: 'Do not match regular expression',
+                        value: '/^file_[0-9]+\\.txt$/',
+                        valueType: 'string'
+                    }
                 ],
             },
         ],
@@ -1803,6 +1929,18 @@ describe ('Conditions', () => {
                         operator: 'Is not equal to',
                         value: 'Option 2',
                         valueType: 'dropdown'
+                    },
+                    {
+                        logic: 'Or',
+                        operator: 'Match regular expression',
+                        value: '^Option [1-4]$',
+                        valueType: 'string'
+                    },
+                    {
+                        logic: 'Or',
+                        operator: 'Do not match regular expression',
+                        value: '^Option [1-4]$',
+                        valueType: 'string'
                     }
                 ]
             }
@@ -1848,6 +1986,18 @@ describe ('Conditions', () => {
                         operator: 'Do not contains',
                         value: ['Option 1', 'Option 3'],
                         valueType: 'dropdown_multiple'
+                    },
+                    {
+                        logic: 'Or',
+                        operator: 'Match regular expression',
+                        value: '^Option [1-4]$',
+                        valueType: 'string'
+                    },
+                    {
+                        logic: 'Or',
+                        operator: 'Do not match regular expression',
+                        value: '^Option [1-4]$',
+                        valueType: 'string'
                     }
                 ]
             },
@@ -1881,6 +2031,18 @@ describe ('Conditions', () => {
                         operator: 'Is not equal to',
                         value: 'Option 2',
                         valueType: 'dropdown'
+                    },
+                    {
+                        logic: 'Or',
+                        operator: 'Match regular expression',
+                        value: '^Option [1-4]$',
+                        valueType: 'string'
+                    },
+                    {
+                        logic: 'Or',
+                        operator: 'Do not match regular expression',
+                        value: '^Option [1-4]$',
+                        valueType: 'string'
                     }
                 ]
             },
@@ -1926,6 +2088,18 @@ describe ('Conditions', () => {
                         operator: 'Do not contains',
                         value: ['Option 2', 'Option 4'],
                         valueType: 'dropdown_multiple'
+                    },
+                    {
+                        logic: 'Or',
+                        operator: 'Match regular expression',
+                        value: '^Option [1-4]$',
+                        valueType: 'string'
+                    },
+                    {
+                        logic: 'Or',
+                        operator: 'Do not match regular expression',
+                        value: '^Option [1-4]$',
+                        valueType: 'string'
                     }
                 ]
             },
@@ -1970,6 +2144,18 @@ describe ('Conditions', () => {
                         logic: 'Or',
                         operator: 'Do not contains',
                         value: 'Computer - {uuid}',
+                        valueType: 'string'
+                    },
+                    {
+                        logic: 'Or',
+                        operator: 'Match regular expression',
+                        value: '/Computer/',
+                        valueType: 'string'
+                    },
+                    {
+                        logic: 'Or',
+                        operator: 'Do not match regular expression',
+                        value: '/Computer/',
                         valueType: 'string'
                     }
                 ]
@@ -2016,7 +2202,19 @@ describe ('Conditions', () => {
                         operator: 'Do not contains',
                         value: 'Location - {uuid}',
                         valueType: 'string'
-                    }
+                    },
+                    {
+                        logic: 'Or',
+                        operator: 'Match regular expression',
+                        value: '/Location/',
+                        valueType: 'string'
+                    },
+                    {
+                        logic: 'Or',
+                        operator: 'Do not match regular expression',
+                        value: '/Location/',
+                        valueType: 'string'
+                    },
                 ]
             },
         ],
@@ -2050,6 +2248,30 @@ describe ('Conditions', () => {
                         value: 'Computer',
                         valueType: 'dropdown'
                     },
+                    {
+                        logic: 'Or',
+                        operator: 'Contains',
+                        value: 'Computer',
+                        valueType: 'string'
+                    },
+                    {
+                        logic: 'Or',
+                        operator: 'Do not contains',
+                        value: 'Computer',
+                        valueType: 'string'
+                    },
+                    {
+                        logic: 'Or',
+                        operator: 'Match regular expression',
+                        value: '/Computer/',
+                        valueType: 'string'
+                    },
+                    {
+                        logic: 'Or',
+                        operator: 'Do not match regular expression',
+                        value: '/Computer/',
+                        valueType: 'string'
+                    },
                 ]
             },
         ],
@@ -2082,6 +2304,30 @@ describe ('Conditions', () => {
                         operator: 'All items of itemtype',
                         value: ['Computer'],
                         valueType: 'dropdown_multiple'
+                    },
+                    {
+                        logic: 'Or',
+                        operator: 'Contains',
+                        value: 'Computer',
+                        valueType: 'string'
+                    },
+                    {
+                        logic: 'Or',
+                        operator: 'Do not contains',
+                        value: 'Computer',
+                        valueType: 'string'
+                    },
+                    {
+                        logic: 'Or',
+                        operator: 'Match regular expression',
+                        value: '/Computer/',
+                        valueType: 'string'
+                    },
+                    {
+                        logic: 'Or',
+                        operator: 'Do not match regular expression',
+                        value: '/Computer/',
+                        valueType: 'string'
                     },
                 ]
             }


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

- It partially fixes #20205

Added the regex operator to all question types
Added some missing operators for specific question types :
-  QuestionTypeRequestType => Adding `NOT_EQUALS` operator
- QuestionTypeUserDevices => Adding `CONTAINS`, `NOT_CONTAINS` operators