### PR TITLE
set .grid-guide top position to avoid overlap; fix #20179

### DIFF
--- a/css/standalone/dashboard.scss
+++ b/css/standalone/dashboard.scss
@@ -562,6 +562,7 @@ $break_tablet: 1400px;
     .grid-guide {
         display: none;
         position: absolute;
+        top: 0;
         bottom: var(--gs-cell-height);
         width: calc(100% + 1px);
         border: 1px solid var(--tblr-body-bg);


### PR DESCRIPTION
## Description

It fixes #20719.
Previously in 10.0, top position was set with some calculation to match GLPI headers.
This part was cleaned and top position was removed by error I think


