### PR TITLE
Improve some OAuth failure error messages

### DIFF
--- a/phpunit/functional/Glpi/Api/HL/Controller/AdministrationControllerTest.php
+++ b/phpunit/functional/Glpi/Api/HL/Controller/AdministrationControllerTest.php
@@ -542,12 +542,18 @@ class AdministrationControllerTest extends \HLAPITestCase
         $this->api->call(new Request('GET', '/Administration/User/Me'), function ($call) {
             /** @var \HLAPICallAsserter $call */
             $call->response
-                ->isAccessDenied();
+                ->isAccessDenied()
+                ->jsonContent(function ($content) {
+                    $this->assertEquals('You do not have the required scope(s) to access this endpoint.', $content['detail']);
+                });
         });
         $this->api->call(new Request('GET', '/Administration/User/Me/Emails/Default'), function ($call) {
             /** @var \HLAPICallAsserter $call */
             $call->response
-                ->isAccessDenied();
+                ->isAccessDenied()
+                ->jsonContent(function ($content) {
+                    $this->assertEquals('You do not have the required scope(s) to access this endpoint.', $content['detail']);
+                });
         });
         $this->login(api_options: ['scope' => 'user']);
         $this->api->call(new Request('GET', '/Administration/User/Me'), function ($call) {
@@ -568,19 +574,28 @@ class AdministrationControllerTest extends \HLAPITestCase
         $this->api->call(new Request('GET', '/Administration/User/me'), function ($call) {
             /** @var \HLAPICallAsserter $call */
             $call->response
-                ->isAccessDenied();
+                ->isAccessDenied()
+                ->jsonContent(function ($content) {
+                    $this->assertEquals('You do not have the required scope(s) to access this endpoint.', $content['detail']);
+                });
         });
         $this->api->call(new Request('GET', '/Administration/User/me/Emails/Default'), function ($call) {
             /** @var \HLAPICallAsserter $call */
             $call->response
-                ->isAccessDenied();
+                ->isAccessDenied()
+                ->jsonContent(function ($content) {
+                    $this->assertEquals('You do not have the required scope(s) to access this endpoint.', $content['detail']);
+                });
         });
         $this->login(api_options: ['scope' => 'email']);
         // Access to email scope doesn't allow broad access to current user info
         $this->api->call(new Request('GET', '/Administration/User/me'), function ($call) {
             /** @var \HLAPICallAsserter $call */
             $call->response
-                ->isAccessDenied();
+                ->isAccessDenied()
+                ->jsonContent(function ($content) {
+                    $this->assertEquals('You do not have the required scope(s) to access this endpoint.', $content['detail']);
+                });
         });
         $this->api->call(new Request('GET', '/Administration/User/me/Emails/Default'), function ($call) {
             /** @var \HLAPICallAsserter $call */

--- a/phpunit/functional/Glpi/Api/HL/Controller/CoreControllerTest.php
+++ b/phpunit/functional/Glpi/Api/HL/Controller/CoreControllerTest.php
@@ -250,12 +250,15 @@ class CoreControllerTest extends \HLAPITestCase
             'scope' => '',
         ];
 
-        // Expect 401 error if no grant is set
         $request = new Request('POST', '/Token', ['Content-Type' => 'application/json'], json_encode($auth_data));
         $this->api->call($request, function ($call) {
             /** @var \HLAPICallAsserter $call */
             $call->response
-                ->status(fn($status) => $this->assertEquals(401, $status));
+                ->status(fn($status) => $this->assertEquals(400, $status))
+                ->jsonContent(function ($content) {
+                    $this->assertEquals('unauthorized_client', $content['error']);
+                    $this->assertEquals('The authenticated client is not authorized to use this authorization grant type.', $content['error_description']);
+                });
         });
 
         $client->update([
@@ -348,12 +351,15 @@ class CoreControllerTest extends \HLAPITestCase
             'scope' => 'inventory',
         ];
 
-        // Expect 401 error if no grant is set
         $request = new Request('POST', '/Token', ['Content-Type' => 'application/json'], json_encode($auth_data));
         $this->api->call($request, function ($call) {
             /** @var \HLAPICallAsserter $call */
             $call->response
-                ->status(fn($status) => $this->assertEquals(401, $status));
+                ->status(fn($status) => $this->assertEquals(400, $status))
+                ->jsonContent(function ($content) {
+                    $this->assertEquals('unauthorized_client', $content['error']);
+                    $this->assertEquals('The authenticated client is not authorized to use this authorization grant type.', $content['error_description']);
+                });
         });
 
         $client->update([
@@ -381,7 +387,10 @@ class CoreControllerTest extends \HLAPITestCase
         $this->api->call(new Request('GET', '/Status'), function ($call) {
             /** @var \HLAPICallAsserter $call */
             $call->response
-                ->isAccessDenied();
+                ->isAccessDenied()
+                ->jsonContent(function ($content) {
+                    $this->assertEquals('You do not have the required scope(s) to access this endpoint.', $content['detail']);
+                });
         });
         $this->login(api_options: ['scope' => 'status']);
         $this->api->call(new Request('GET', '/Status'), function ($call) {

--- a/phpunit/functional/Glpi/Api/HL/Controller/GraphQLControllerTest.php
+++ b/phpunit/functional/Glpi/Api/HL/Controller/GraphQLControllerTest.php
@@ -324,7 +324,10 @@ GRAPHQL);
         $this->api->call($request, function ($call) {
             /** @var \HLAPICallAsserter $call */
             $call->response
-                ->isAccessDenied();
+                ->isAccessDenied()
+                ->jsonContent(function ($content) {
+                    $this->assertEquals('You do not have the required scope(s) to access this endpoint.', $content['detail']);
+                });
         });
         $this->login(api_options: ['scope' => 'graphql']);
         $request = new Request('POST', '/GraphQL', [], 'query { Ticket { id name } }');

--- a/src/Glpi/Api/HL/Controller/AbstractController.php
+++ b/src/Glpi/Api/HL/Controller/AbstractController.php
@@ -297,10 +297,14 @@ abstract class AbstractController
     /**
      * @return Response
      */
-    public static function getAccessDeniedErrorResponse(): Response
+    public static function getAccessDeniedErrorResponse(array|null|string $detail = null): Response
     {
         return new JSONResponse(
-            self::getErrorResponseBody(self::ERROR_RIGHT_MISSING, "You don't have permission to perform this action."),
+            self::getErrorResponseBody(
+                status: self::ERROR_RIGHT_MISSING,
+                title: "You don't have permission to perform this action.",
+                detail: $detail,
+            ),
             403
         );
     }

--- a/src/Glpi/Api/HL/Middleware/OAuthRequestMiddleware.php
+++ b/src/Glpi/Api/HL/Middleware/OAuthRequestMiddleware.php
@@ -87,6 +87,6 @@ class OAuthRequestMiddleware extends AbstractMiddleware implements RequestMiddle
             }
         }
 
-        $input->response = AbstractController::getAccessDeniedErrorResponse();
+        $input->response = AbstractController::getAccessDeniedErrorResponse('You do not have the required scope(s) to access this endpoint.');
     }
 }

--- a/src/Glpi/OAuth/ClientRepository.php
+++ b/src/Glpi/OAuth/ClientRepository.php
@@ -36,6 +36,7 @@
 namespace Glpi\OAuth;
 
 use League\OAuth2\Server\Entities\ClientEntityInterface;
+use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\Repositories\ClientRepositoryInterface;
 use OAuthClient;
 
@@ -65,6 +66,9 @@ class ClientRepository implements ClientRepositoryInterface
         return null;
     }
 
+    /**
+     * @throws OAuthServerException If the requested grant type is not allowed for the client
+     */
     public function validateClient($clientIdentifier, $clientSecret, $grantType): bool
     {
         $client = new OAuthClient();
@@ -78,6 +82,9 @@ class ClientRepository implements ClientRepositoryInterface
 
         $global_grants = ['refresh_token'];
         $allowed_grants = array_merge($client->fields['grants'], $global_grants);
-        return in_array($grantType, $allowed_grants, true);
+        if (!in_array($grantType, $allowed_grants, true)) {
+            throw OAuthServerException::unauthorizedClient();
+        }
+        return true;
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

Fixes #20736

Trying to use a grant not allowed for the client specified:
```json
{
	"error": "unauthorized_client",
	"error_description": "The authenticated client is not authorized to use this authorization grant type."
}
```
Originally I considered using the `OAuthServerException::invalidGrant` exception but after looking more, it seems like this is intended to be used in another situation and the `OAuthServerException::unauthorizedClient` exception is more correct.

Trying to access an endpoint without a required scope:
```json
{
	"status": "ERROR_RIGHT_MISSING",
	"title": "You don't have permission to perform this action.",
	"detail": "You do not have the required scope(s) to access this endpoint."
}
```
I considered the `OAuthServerException::invalidScope` exception but this seems more for if the client requests a scope that isn't supported rather than requesting a resource without the required scope. This exception is a 400 status code rather than 403, so that seems to verify my suspicion. Instead, I added a detail to the generic access denied error to indicate the required scope is missing.

Related RFC:
https://datatracker.ietf.org/doc/html/rfc6749#section-5.2