### PR TITLE
fix(delegators): incorrect rights for filtering users

### DIFF
--- a/templates/pages/admin/user.substitute.html.twig
+++ b/templates/pages/admin/user.substitute.html.twig
@@ -80,7 +80,10 @@
                               'multiple': 'multiple',
                               'used': [user.fields['id']],
                               'value': substitutes,
-                              'right': 'create_ticket_validate',
+                              'right': [
+                                 'validate_request',
+                                 'validate_incident'
+                              ]
                         }
                      ) }}
 

--- a/tests/cypress/e2e/Admin/user.cy.js
+++ b/tests/cypress/e2e/Admin/user.cy.js
@@ -101,10 +101,10 @@ describe('User form', () => {
     it('can add and remove my substitutes', () => {
         cy.visit('/front/preference.php');
         cy.findByRole('tab', { name: /Authorized substitutes/ }).click();
-        cy.getDropdownByLabelText('Approval substitutes').selectDropdownValue('tech');
+        cy.getDropdownByLabelText('Approval substitutes').selectDropdownValue('normal');
         cy.findByRole('button', { name: 'Save' }).click();
         cy.findByRole('tab', { name: /Authorized substitutes/ }).click();
-        cy.getDropdownByLabelText('Approval substitutes').should('contain.text', 'tech');
+        cy.getDropdownByLabelText('Approval substitutes').should('contain.text', 'normal');
         cy.getDropdownByLabelText('Approval substitutes').closest('.select2-container').find('.select2-selection__choice__remove').click();
         cy.findByRole('button', { name: 'Save' }).click();
         cy.findByRole('tab', { name: /Authorized substitutes/ }).click();


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] My feature works.

## Description

The validation delegation feature allows you to designate one or more users who can validate a ticket on your behalf.

However, this was not what was reflected in the code — only users with the right to “create a validation request” were selectable.

This fix corrects it :)

## Screenshots (if appropriate):

<img width="1020" height="514" alt="image" src="https://github.com/user-attachments/assets/2b90a571-09d8-47a3-96bd-17f85f5706a9" />

