### PR TITLE
Fix homepage title line height

### DIFF
--- a/css/helpdesk_home.scss
+++ b/css/helpdesk_home.scss
@@ -89,6 +89,10 @@ header {
 
     h1 {
         font-size:3.7rem;
+
+        // The default `--tblr-line-height-h1` line height does not play well
+        // with the font size we apply here, it is better to remove it.
+        line-height: unset !important;
     }
 
     .search-bar-container {

--- a/templates/pages/helpdesk/index.html.twig
+++ b/templates/pages/helpdesk/index.html.twig
@@ -45,7 +45,7 @@
                 {{ render_scene(scene_left) }}
             </div>
             <div class="container-narrow search-banner-content">
-                <h1 class="text-center" data-testid="home-title">
+                <h1 class="text-center mb-0" data-testid="home-title">
                     {{ entity.getHelpdeskHomeTitle() }}
                 </h1>
 


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.

## Description

The line height used for the helpdesk home page search title did not play well with long multi line text.

Before:

<img width="1061" height="366" alt="image" src="https://github.com/user-attachments/assets/f872347a-16d3-4b81-a77e-5b863b96558f" />

After:

<img width="1089" height="455" alt="image" src="https://github.com/user-attachments/assets/1b9646fb-6f9e-45a5-ada1-2c2cebdf5981" />




