### PR TITLE
fix(rules): plural for assets rules tabs

### DIFF
--- a/src/RuleImportAssetCollection.php
+++ b/src/RuleImportAssetCollection.php
@@ -66,7 +66,7 @@ class RuleImportAssetCollection extends RuleCollection
                     $types = $CFG_GLPI['ruleimportasset_types'];
                     foreach ($types as $type) {
                         if (class_exists($type)) {
-                            $ong[$type] = $type::getTypeName();
+                            $ong[$type] = $type::getTypeName(Session::getPluralNumber());
                         }
                     }
                     $ong['_global'] = self::createTabEntry(__('Global'));


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] My feature works.

## Description

We’re talking about rules for asset**s**, so the tabs should all be in plural form by default.

## Screenshots (if appropriate):

Before
<img width="1979" height="305" alt="image" src="https://github.com/user-attachments/assets/252d2502-5963-4d34-910a-348039d4cf7a" />

After
<img width="1964" height="298" alt="image" src="https://github.com/user-attachments/assets/3810e160-5af0-4163-8735-53fc5352daa2" />
