### PR TITLE
Fix helpdesk tiles description field length

### DIFF
--- a/install/migrations/update_10.0.x_to_11.0.0/form.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/form.php
@@ -263,11 +263,19 @@ if (!$DB->tableExists('glpi_helpdesks_tiles_glpipagetiles')) {
         "CREATE TABLE `glpi_helpdesks_tiles_glpipagetiles` (
             `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
             `title` varchar(255) DEFAULT NULL,
-            `description` varchar(255) DEFAULT NULL,
+            `description` text DEFAULT null,
             `illustration` varchar(255) DEFAULT NULL,
             `page` varchar(255) DEFAULT NULL,
             PRIMARY KEY (`id`)
         ) ENGINE=InnoDB DEFAULT CHARSET={$default_charset} COLLATE={$default_collation} ROW_FORMAT=DYNAMIC;"
+    );
+} else {
+    // Fix a bad type, description was created as varchar(255) when it should have been a text field.
+    $migration->changeField(
+        'glpi_helpdesks_tiles_glpipagetiles',
+        'description',
+        'description',
+        'text',
     );
 }
 if (!$DB->tableExists('glpi_helpdesks_tiles_externalpagetiles')) {
@@ -275,11 +283,19 @@ if (!$DB->tableExists('glpi_helpdesks_tiles_externalpagetiles')) {
         "CREATE TABLE `glpi_helpdesks_tiles_externalpagetiles` (
             `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
             `title` varchar(255) DEFAULT NULL,
-            `description` varchar(255) DEFAULT NULL,
+            `description` text DEFAULT null,
             `illustration` varchar(255) DEFAULT NULL,
             `url` text DEFAULT NULL,
             PRIMARY KEY (`id`)
         ) ENGINE=InnoDB DEFAULT CHARSET={$default_charset} COLLATE={$default_collation} ROW_FORMAT=DYNAMIC;"
+    );
+} else {
+    // Fix a bad type, description was created as varchar(255) when it should have been a text field.
+    $migration->changeField(
+        'glpi_helpdesks_tiles_externalpagetiles',
+        'description',
+        'description',
+        'text',
     );
 }
 

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -3201,7 +3201,7 @@ DROP TABLE IF EXISTS `glpi_helpdesks_tiles_glpipagetiles`;
 CREATE TABLE `glpi_helpdesks_tiles_glpipagetiles` (
   `id` int unsigned NOT NULL AUTO_INCREMENT,
   `title` varchar(255) DEFAULT NULL,
-  `description` varchar(255) DEFAULT NULL,
+  `description` text DEFAULT null,
   `illustration` varchar(255) DEFAULT NULL,
   `page` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`)
@@ -3213,7 +3213,7 @@ DROP TABLE IF EXISTS `glpi_helpdesks_tiles_externalpagetiles`;
 CREATE TABLE `glpi_helpdesks_tiles_externalpagetiles` (
   `id` int unsigned NOT NULL AUTO_INCREMENT,
   `title` varchar(255) DEFAULT NULL,
-  `description` varchar(255) DEFAULT NULL,
+  `description` text DEFAULT null,
   `illustration` varchar(255) DEFAULT NULL,
   `url` text DEFAULT NULL,
   PRIMARY KEY (`id`)


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.

## Description

This field was meant to be a `TEXT`,  255 chars can be filled very quickly with richtext tags.

