### PR TITLE
Document hook check_config & activate

### DIFF
--- a/src/Glpi/Plugin/Hooks.php
+++ b/src/Glpi/Plugin/Hooks.php
@@ -1335,6 +1335,14 @@ class Hooks
      */
     public const CHECK_CONFIG = 'check_config';
 
+
+    /**
+     * Automatic hook function called to allow plugin activation.
+     * The function is called with no parameters.
+     * The function must return a boolean: false to prevent the plugin from being activated, true to allow it.
+     */
+    public const ACTIVATE = 'activate';
+
     /**
      * Get file hooks
      *

--- a/src/Glpi/Plugin/Hooks.php
+++ b/src/Glpi/Plugin/Hooks.php
@@ -1325,6 +1325,17 @@ class Hooks
     public const AUTO_STATUS = 'status';
 
     /**
+     * Register a function to perform a configuration check.
+     * It can be used to :
+     * - set the plugin in `TOBECONFIGURED` state (installation & checkPluginState())
+     * - prevent the plugin from being activated
+     *
+     * The function is called with no parameters.
+     * The function must return a boolean. Returning true has the same effect as not implementing the hook, returning false will have the effects described above.
+     */
+    public const CHECK_CONFIG = 'check_config';
+
+    /**
      * Get file hooks
      *
      * @return array

--- a/tests/functional/Plugin.php
+++ b/tests/functional/Plugin.php
@@ -720,7 +720,7 @@ class Plugin extends DbTestCase
     /**
      * Test state checking on a valid directory corresponding to a known active plugin with no modifications
      * having nor check_prerequisites nor check_config function.
-     * Should results in no changes.
+     * Shouldn't trigger changes.
      */
     public function testCheckPluginStateForActiveAndNotUpdatedPluginHavingNoCheckFunctions()
     {


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] This change requires a documentation update.

## Description

Added php constants to document `check_config` & `activate` hooks.
The constants are not used anywhere.
This is for the `./bin/console tools:generate_hooks_documentation` command (to later update the documentation repository).

(Not sure about on which branch to merge.)