### PR TITLE
fix(forms): Bad translation for dropdown question type (add context)

### DIFF
--- a/src/Glpi/Form/QuestionType/QuestionTypeCategory.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeCategory.php
@@ -110,7 +110,7 @@ enum QuestionTypeCategory: string implements QuestionTypeCategoryInterface
             self::FILE => __("File"),
             self::RADIO => __("Radio"),
             self::CHECKBOX => __("Checkbox"),
-            self::DROPDOWN => _n('Dropdown', 'Dropdowns', 1),
+            self::DROPDOWN => _nx('form_editor', 'Dropdown', 'Dropdowns', 1),
             self::ITEM => _n('Item', 'Items', 1)
         };
     }


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

This pull request makes a small update to the label translation for the `DROPDOWN` question type in the `QuestionTypeCategory` class. The change uses a more specific translation function to provide better context for translators.

- Changed the `DROPDOWN` label to use `_nx` with the context `'form_editor'` for improved translation accuracy in `QuestionTypeCategory.php`.