### PR TITLE
fix(forms-migration): handle negative tree depth values for dropdown item questions

### DIFF
--- a/phpunit/functional/Glpi/Form/Migration/FormMigrationTest.php
+++ b/phpunit/functional/Glpi/Form/Migration/FormMigrationTest.php
@@ -2341,7 +2341,7 @@ final class FormMigrationTest extends DbTestCase
                 'itemtype'                       => 'ITILCategory',
                 'values'                         => json_encode([
                     'show_ticket_categories' => 'request',
-                    'show_tree_depth'        => '0',
+                    'show_tree_depth'        => '-1', // All levels
                     'show_tree_root'         => $itilcategory->getId(),
                     'selectable_tree_root'   => '0',
                     'entity_restrict'        => '3', // Entity restriction

--- a/src/Glpi/Form/QuestionType/QuestionTypeItemDropdown.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeItemDropdown.php
@@ -139,7 +139,11 @@ final class QuestionTypeItemDropdown extends QuestionTypeItem
         }
 
         $subtree_depth = 0;
-        if (isset($values['show_tree_depth']) && is_numeric($values['show_tree_depth'])) {
+        if (
+            isset($values['show_tree_depth'])
+            && is_numeric($values['show_tree_depth'])
+            && $values['show_tree_depth'] > 0
+        ) {
             $subtree_depth = (int) $values['show_tree_depth'];
         }
 


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Formcreator plugin migration fails to properly handle negative show_tree_depth values. A value of -1 (meaning "show all levels") was incorrectly processed as a valid depth restriction.