### PR TITLE
Add extra context to form import issues

### DIFF
--- a/templates/pages/admin/form/import/step3_resolve_issues.html.twig
+++ b/templates/pages/admin/form/import/step3_resolve_issues.html.twig
@@ -49,8 +49,9 @@
             <table class="table table-card mb-0">
                 <thead>
                     <tr>
-                        <th class="w-25 px-4">{{ __("Original value") }}</th>
-                        <th class="w-75 px-4">{{ __("Replacement value") }}</th>
+                        <th class="w-30 px-4">{{ __("Itemtype") }}</th>
+                        <th class="w-20 px-4">{{ __("Original value") }}</th>
+                        <th class="w-50 px-4">{{ __("Replacement value") }}</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -58,6 +59,12 @@
                         {% set original_name = issue.default_name ?? issue.name %}
 
                         <tr>
+                            <td class="px-4 align-middle">
+                                <div class="d-flex align-items-center">
+                                    <i class="me-2 {{ issue.itemtype|itemtype_icon }}"></i>
+                                    <span>{{ issue.itemtype|itemtype_name }}</span>
+                                </div>
+                            </td>
                             <td class="px-4 align-middle">
                                 <span>{{ original_name }}</span>
                             </td>


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.

## Description

While checking out an issue related to this feature, I've noticed that some extra context in the "Resolve issue" step indicating clearly the target itemtype would be helpful.

Before:
<img width="1008" height="341" alt="image" src="https://github.com/user-attachments/assets/4806162a-c002-488f-9c55-4585a223ab4b" />

After:
<img width="1016" height="372" alt="image" src="https://github.com/user-attachments/assets/f0acc682-3b75-4272-8048-933b23ff4dc6" />

