### PR TITLE
Fix `Plugin::getWebDir()` results with customized `GLPI_MARKETPLACE_DIR`

### DIFF
--- a/phpunit/functional/PluginTest.php
+++ b/phpunit/functional/PluginTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units;
+
+use DbTestCase;
+use Plugin;
+
+class PluginTest extends DbTestCase
+{
+    public function testGetWebDir(): void
+    {
+        global $CFG_GLPI;
+
+        $this->assertEquals('plugins/tester', @Plugin::getWebDir('tester', false, false));
+        $this->assertEquals('marketplace/myplugin', @Plugin::getWebDir('myplugin', false, false));
+
+        foreach (['', '/glpi', '/path/to/app'] as $root_doc) {
+            $CFG_GLPI['root_doc'] = $root_doc;
+            $this->assertEquals($root_doc . '/plugins/tester', @Plugin::getWebDir('tester', true, false));
+            $this->assertEquals($root_doc . '/marketplace/myplugin', @Plugin::getWebDir('myplugin', true, false));
+        }
+
+        foreach (['http://localhost', 'https://www.example.org/glpi'] as $url_base) {
+            $CFG_GLPI['url_base'] = $url_base;
+            $this->assertEquals($url_base . '/plugins/tester', @Plugin::getWebDir('tester', true, true));
+            $this->assertEquals($url_base . '/marketplace/myplugin', @Plugin::getWebDir('myplugin', true, true));
+        }
+
+        $this->assertFalse(@Plugin::getWebDir('notaplugin', true, true));
+    }
+}

--- a/src/Glpi/Application/Environment.php
+++ b/src/Glpi/Application/Environment.php
@@ -163,8 +163,9 @@ enum Environment: string
                     // calendar mockups
                     '/^file:\/\/.*\.ics$/',
                 ],
+                'GLPI_MARKETPLACE_DIR'          => $root_dir . '/tests/fixtures/marketplace',
                 'GLPI_PLUGINS_DIRECTORIES'      => [
-                    $root_dir . '/plugins',
+                    '{GLPI_MARKETPLACE_DIR}',
                     $root_dir . '/tests/fixtures/plugins',
                 ],
             ],

--- a/tests/fixtures/marketplace/myplugin/setup.php
+++ b/tests/fixtures/marketplace/myplugin/setup.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+function plugin_version_myplugin()
+{
+    return [
+        'name'           => 'myplugin',
+        'version'        => '1.0.0',
+        'author'         => 'GLPI Test suite',
+        'license'        => 'GPL v2+',
+        'requirements'   => [
+            'glpi' => [
+                'min' => '9.5.0',
+            ]
+        ]
+    ];
+}
+
+function plugin_myplugin_install(): bool
+{
+    return true;
+}
+
+
+function plugin_myplugin_uninstall(): bool
+{
+    return true;
+}
+
+function plugin_init_myplugin(): void
+{}

--- a/tests/functional/Plugin.php
+++ b/tests/functional/Plugin.php
@@ -825,7 +825,7 @@ class Plugin extends DbTestCase
 
         return implode(
             DIRECTORY_SEPARATOR,
-            [GLPI_ROOT, 'plugins', $directory]
+            [GLPI_ROOT, 'tests', 'fixtures', 'plugins', $directory]
         );
     }
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

In GLPI 11.0, moving the marketplace directory outside the GLPI root directory is now possible. Even if the method is deprecated, `Plugin::getWebDir()` should handle it to provide a valid URL path.

See https://github.com/glpi-project/docker-images/issues/197