### PR TITLE
fix TOC overflow on smaller screen sizes

### DIFF
--- a/css/includes/components/_documentation.scss
+++ b/css/includes/components/_documentation.scss
@@ -154,14 +154,14 @@
     }
 }
 
-@include media-breakpoint-down(lg) {
-    .documentation {
-        margin-left: 200px;
+@include media-breakpoint-down(xxl) {
+    .documentation-large {
+        margin-left: 240px;
     }
 }
 
-@include media-breakpoint-down(xl) {
+@include media-breakpoint-down(sm) {
     .documentation-large {
-        margin-left: 200px;
+        margin-left: 0;
     }
 }


### PR DESCRIPTION
On "medium-ish" screen sizes, TOC of "getting started" HLAPI documentation overlaps the content.

<img width="755" height="429" alt="image" src="https://github.com/user-attachments/assets/ad3bb461-cccf-4cf4-b637-6347bdcee5da" />

I increased the size to 240px to match the TOC width and move the breakpoint on `xxl` where the issue disappears.