### PR TITLE
Form import: fix conflicts when resolving issues for multiple forms

### DIFF
--- a/src/Glpi/Controller/Form/Import/Step3ResolveIssuesController.php
+++ b/src/Glpi/Controller/Form/Import/Step3ResolveIssuesController.php
@@ -62,10 +62,12 @@ final class Step3ResolveIssuesController extends AbstractController
         $mapper = new DatabaseMapper(Session::getActiveEntities());
 
         $replacements = $request->request->all()["replacements"] ?? [];
-        foreach ($replacements as $itemtype => $replacements_for_itemtype) {
-            foreach ($replacements_for_itemtype as $original_name => $items_id) {
-                $mapper->addMappedItem($itemtype, $original_name, (int) $items_id);
-            }
+        foreach ($replacements as $replacements_data) {
+            $mapper->addMappedItem(
+                $replacements_data['itemtype'],
+                $replacements_data['original_name'],
+                (int) $replacements_data['replacement_id'],
+            );
         }
 
         $issues = $serializer->listIssues($mapper, $json)->getIssues()[$form_id];

--- a/src/Glpi/Controller/Form/Import/Step3ResolveIssuesController.php
+++ b/src/Glpi/Controller/Form/Import/Step3ResolveIssuesController.php
@@ -64,7 +64,7 @@ final class Step3ResolveIssuesController extends AbstractController
         $replacements = $request->request->all()["replacements"] ?? [];
         foreach ($replacements as $itemtype => $replacements_for_itemtype) {
             foreach ($replacements_for_itemtype as $original_name => $items_id) {
-                $mapper->addMappedItem($itemtype, $original_name, $items_id);
+                $mapper->addMappedItem($itemtype, $original_name, (int) $items_id);
             }
         }
 

--- a/templates/pages/admin/form/import/step3_resolve_issues.html.twig
+++ b/templates/pages/admin/form/import/step3_resolve_issues.html.twig
@@ -55,9 +55,10 @@
                     </tr>
                 </thead>
                 <tbody>
+                    {% set existing_replacements = replacements|length %}
                     {% for issue in issues %}
                         {% set original_name = issue.default_name ?? issue.name %}
-
+                        {% set replacement_index = loop.index0 + existing_replacements %}
                         <tr>
                             <td class="px-4 align-middle">
                                 <div class="d-flex align-items-center">
@@ -69,11 +70,11 @@
                                 <span>{{ original_name }}</span>
                             </td>
                             <td class="px-4">
-                                <input type="hidden" name="replacements[{{ loop.index0 }}][itemtype]" value="{{ issue.itemtype }}"/>
-                                <input type="hidden" name="replacements[{{ loop.index0 }}][original_name]" value="{{ original_name }}"/>
+                                <input type="hidden" name="replacements[{{ replacement_index }}][itemtype]" value="{{ issue.itemtype }}"/>
+                                <input type="hidden" name="replacements[{{ replacement_index }}][original_name]" value="{{ original_name }}"/>
                                 {{ fields.dropdownField(
                                     issue.itemtype,
-                                    'replacements[' ~ loop.index0 ~ '][replacement_id]',
+                                    'replacements[' ~ replacement_index ~ '][replacement_id]',
                                     issue.replacement_id|default(''),
                                     '',
                                     {


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works. -> don't want to add new e2e tests on this


## Description

First commit is form another PR, I'll rebase once it is merged.

When resolving issues on form import, the selected values are stored in temporary inputs like this:

<img width="817" height="274" alt="image" src="https://github.com/user-attachments/assets/955ff978-551e-43e1-86c3-4ab466150780" />

There was a conflict on the array input used as new values would also be put at the start of the `replacements` array (so resolving issues on a form would erases resolved issues form another form).
I've fixed it by making sure we are always adding new values at the end of the array.

There was also an issue regarding types, the ids needs to be casted to int as they are stored as strings in $_POST.