### PR TITLE
Handle 2FA issuer suffix and fix 2FA display issue

### DIFF
--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -367,6 +367,7 @@ $empty_data_builder = new class {
             '2fa_enforced' => 0,
             '2fa_grace_date_start' => null,
             '2fa_grace_days' => 0,
+            '2fa_suffix' => '',
             'is_notif_enable_default' => 1,
             'show_search_form' => 0,
             'search_pagination_on_top' => 0,

--- a/install/migrations/update_10.0.x_to_11.0.0/mfa.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/mfa.php
@@ -62,4 +62,5 @@ $migration->addConfig([
     '2fa_enforced' => 0,
     '2fa_grace_date_start' => null,
     '2fa_grace_days' => 0,
+    '2fa_suffix' => '',
 ]);

--- a/phpunit/functional/Glpi/Security/TOTPManagerTest.php
+++ b/phpunit/functional/Glpi/Security/TOTPManagerTest.php
@@ -240,4 +240,17 @@ class TOTPManagerTest extends \DbTestCase
         $CFG_GLPI['2fa_grace_days'] = 0;
         $this->assertEquals(0, $tfa->getGracePeriodDaysLeft());
     }
+
+    public function testGet2faIssuer()
+    {
+        global $CFG_GLPI;
+
+        $tfa = new TOTPManager();
+
+        // No custom suffix
+        $this->assertEquals('GLPI', $tfa->getIssuer());
+
+        $CFG_GLPI['2fa_suffix'] = 'test';
+        $this->assertEquals('GLPI (test)', $tfa->getIssuer());
+    }
 }

--- a/src/Glpi/Security/TOTPManager.php
+++ b/src/Glpi/Security/TOTPManager.php
@@ -111,6 +111,23 @@ final class TOTPManager
     public static string $brand_label = 'GLPI';
 
     /**
+     * Mainly used to get the displayed issuer for the TOTP in Authenticator app
+     * @return string
+     */
+    public function getIssuer(): string
+    {
+        global $CFG_GLPI;
+        $label = $CFG_GLPI['app_name'] ?? self::$brand_label;
+
+        $tfaSuffix = $CFG_GLPI['2fa_suffix'] ?? '';
+        if (!empty($tfaSuffix)) {
+            $label .= ' (' . $tfaSuffix . ')';
+        }
+
+        return $label;
+    }
+
+    /**
      * Get an instance of the TwoFactorAuth class
      * @param string $algorithm Algorithm used to generate the TOTP code.
      * @return TwoFactorAuth
@@ -122,7 +139,7 @@ final class TOTPManager
         if ($tfa === null) {
             $tfa = new TwoFactorAuth(
                 new BaconQrCodeProvider(4, '#ffffff', '#000000', 'svg'),
-                self::$brand_label,
+                $this->getIssuer(),
                 self::CODE_LENGTH_DIGITS,
                 self::CODE_VALIDITY_SECONDS,
                 Algorithm::from($algorithm)
@@ -529,7 +546,7 @@ final class TOTPManager
     {
         $secret = $this->createSecret();
         $tfa = $this->getTwoFactorAuth();
-        $name = self::$brand_label;
+        $name = $this->getIssuer();
         if (isset($_SESSION['mfa_pre_auth'])) {
             $name = $_SESSION['mfa_pre_auth']['user']['name'];
         } elseif (isset($_SESSION['glpiname'])) {

--- a/templates/pages/2fa/2fa_request.html.twig
+++ b/templates/pages/2fa/2fa_request.html.twig
@@ -38,7 +38,7 @@
 {% endblock %}
 
 {% block content_block %}
-   <form method="post" action="front/login.php" data-submit-once autocomplete="off" class="m-n4" data-code-type="code">
+   <form method="post" action="front/login.php" data-submit-once autocomplete="off" class="m-md-n4" data-code-type="code">
       <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}" />
       <input type="hidden" name="redirect" value="{{ redirect }}"/>
       <div>

--- a/templates/pages/2fa/macros.html.twig
+++ b/templates/pages/2fa/macros.html.twig
@@ -34,7 +34,7 @@
    <div class="d-flex justify-content-center">
       {% for i in 1..digits %}
          <input type="text" class="form-control text-center {{ i != 1 ? 'ms-2' : '' }} fw-bold" name="totp_code[]"
-             maxlength="1" pattern="[0-9]" inputmode="numeric" required style="width: 2em; font-size: 1.5em"
+             maxlength="1" pattern="[0-9]" inputmode="numeric" required style="width: 2.5em; font-size: 1.5em"
              aria-label="{{ __('2FA code digit %s of %s')|format(i, digits) }}">
       {% endfor %}
    </div>

--- a/templates/pages/setup/general/security_setup.html.twig
+++ b/templates/pages/setup/general/security_setup.html.twig
@@ -158,6 +158,14 @@
    ) }}
 
    {{ fields.largeTitle(__('Two-factor authentication (2FA)'), 'ti ti-2fa') }}
+    {{ fields.textField(
+        '2fa_suffix',
+        config['2fa_suffix'],
+        __('2FA Suffix'),
+        field_options|merge({
+            helper: __("This will be added in the issuer name for authenticator app."),
+        })
+    ) }}
 
    {{ fields.sliderField(
       '2fa_enforced',


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.


## Description

- It fixes #20728 and #20757 
- This fixes correct a 2fa input text overlap on mobile and also add the possibility to set a suffix for the 2fa issuer in the Authenticator app
