### PR TITLE
Take completenames into acount in form export/import

### DIFF
--- a/phpunit/functional/Glpi/Form/Export/FormSerializerAccessPoliciesTest.php
+++ b/phpunit/functional/Glpi/Form/Export/FormSerializerAccessPoliciesTest.php
@@ -301,7 +301,7 @@ final class FormSerializerAccessPoliciesTest extends \DbTestCase
         $data = json_decode($json, true);
         $requirements = $data['forms'][0]['data_requirements'];
         $this->assertEquals([
-            ['itemtype' => Entity::class,  'name' => "_test_root_entity"],
+            ['itemtype' => Entity::class,  'name' => "Root entity > _test_root_entity"],
             ['itemtype' => User::class,    'name' => "User 1"],
             ['itemtype' => User::class,    'name' => "User 2"],
             ['itemtype' => Group::class,   'name' => "Group 1"],

--- a/src/Glpi/Form/AccessControl/ControlType/AllowList.php
+++ b/src/Glpi/Form/AccessControl/ControlType/AllowList.php
@@ -227,12 +227,9 @@ final class AllowList implements ControlTypeInterface
                 }
 
                 // Replace id with name and add a requirement
-                $name = $item->getName();
-                $data[$data_key][$i] = $name;
-                $requirements[] = new DataRequirementSpecification(
-                    $itemtype,
-                    $name
-                );
+                $requirement = DataRequirementSpecification::fromItem($item);
+                $requirements[] = $requirement;
+                $data[$data_key][$i] = $requirement->name;
             }
         }
 

--- a/src/Glpi/Form/Destination/CommonITILField/AssociatedItemsField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/AssociatedItemsField.php
@@ -329,11 +329,9 @@ final class AssociatedItemsField extends AbstractConfigField implements Destinat
                 $item = getItemForItemtype($itemtype);
                 if ($item->getFromDB($item_id)) {
                     // Insert name instead of id and register requirement
-                    $items[$itemtype][$i] = $item->getName();
-                    $requirements[] = new DataRequirementSpecification(
-                        $itemtype,
-                        $item->getName(),
-                    );
+                    $requirement = DataRequirementSpecification::fromItem($item);
+                    $requirements[] = $requirement;
+                    $items[$itemtype][$i] = $requirement->name;
                 }
             }
         }

--- a/src/Glpi/Form/Destination/CommonITILField/EntityField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/EntityField.php
@@ -262,9 +262,8 @@ final class EntityField extends AbstractConfigField implements DestinationFieldC
         }
 
         // Insert entity name and requirement
-        $name = $entity->getName();
-        $config[EntityFieldConfig::SPECIFIC_ENTITY_ID] = $name;
-        $requirement = new DataRequirementSpecification(Entity::class, $name);
+        $requirement = DataRequirementSpecification::fromItem($entity);
+        $config[EntityFieldConfig::SPECIFIC_ENTITY_ID] = $requirement->name;
 
         return new DynamicExportDataField($config, [$requirement]);
     }

--- a/src/Glpi/Form/Destination/CommonITILField/ITILActorField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ITILActorField.php
@@ -388,11 +388,9 @@ abstract class ITILActorField extends AbstractConfigField implements Destination
                 $item = getItemForItemtype($itemtype);
                 if ($item->getFromDB($item_id)) {
                     // Insert name instead of id and register requirement
-                    $items[$itemtype][$i] = $item->getName();
-                    $requirements[] = new DataRequirementSpecification(
-                        $itemtype,
-                        $item->getName(),
-                    );
+                    $requirement = DataRequirementSpecification::fromItem($item);
+                    $requirements[] = $requirement;
+                    $items[$itemtype][$i] = $requirement->name;
                 }
             }
         }

--- a/src/Glpi/Form/Destination/CommonITILField/ITILCategoryField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ITILCategoryField.php
@@ -228,9 +228,8 @@ final class ITILCategoryField extends AbstractConfigField implements Destination
         }
 
         // Insert category name and requirement
-        $name = $category->getName();
-        $config[ITILCategoryFieldConfig::SPECIFIC_ITILCATEGORY_ID] = $name;
-        $requirement = new DataRequirementSpecification(ITILCategory::class, $name);
+        $requirement = DataRequirementSpecification::fromItem($category);
+        $config[ITILCategoryFieldConfig::SPECIFIC_ITILCATEGORY_ID] = $requirement->name;
 
         return new DynamicExportDataField($config, [$requirement]);
     }

--- a/src/Glpi/Form/Destination/CommonITILField/ITILFollowupField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ITILFollowupField.php
@@ -175,12 +175,9 @@ final class ITILFollowupField extends AbstractConfigField
             $template = ITILFollowupTemplate::getById($template_id);
             if ($template) {
                 // Insert template name and requirement
-                $name = $template->getName();
-                $config[ITILFollowupFieldConfig::ITILFOLLOWUPTEMPLATE_IDS][$i] = $name;
-                $requirements[] = new DataRequirementSpecification(
-                    ITILFollowupTemplate::class,
-                    $name
-                );
+                $requirement = DataRequirementSpecification::fromItem($template);
+                $requirements[] = $requirement;
+                $config[ITILFollowupFieldConfig::ITILFOLLOWUPTEMPLATE_IDS][$i] = $requirement->name;
             }
         }
 

--- a/src/Glpi/Form/Destination/CommonITILField/ITILTaskField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ITILTaskField.php
@@ -175,12 +175,9 @@ final class ITILTaskField extends AbstractConfigField
             $template = TaskTemplate::getById($template_id);
             if ($template) {
                 // Insert template name and requirement
-                $name = $template->getName();
-                $config[ITILTaskFieldConfig::TASKTEMPLATE_IDS][$i] = $name;
-                $requirements[] = new DataRequirementSpecification(
-                    TaskTemplate::class,
-                    $name
-                );
+                $requirement = DataRequirementSpecification::fromItem($template);
+                $requirements[] = $requirement;
+                $config[ITILTaskFieldConfig::TASKTEMPLATE_IDS][$i] = $requirement->name;
             }
         }
 

--- a/src/Glpi/Form/Destination/CommonITILField/LinkedITILObjectsField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/LinkedITILObjectsField.php
@@ -414,11 +414,9 @@ final class LinkedITILObjectsField extends AbstractConfigField implements Destin
                     $item = getItemForItemtype($specific_object['itemtype']);
                     if ($item && $item->getFromDB($specific_object['items_id'])) {
                         // Insert name instead of id and register requirement
-                        $strategy_config[LinkedITILObjectsFieldStrategyConfig::SPECIFIC_ITILOBJECT]['items_id'] = $item->getName();
-                        $requirements[] = new DataRequirementSpecification(
-                            $specific_object['itemtype'],
-                            $item->getName(),
-                        );
+                        $requirement = DataRequirementSpecification::fromItem($item);
+                        $requirements[] = $requirement;
+                        $strategy_config[LinkedITILObjectsFieldStrategyConfig::SPECIFIC_ITILOBJECT]['items_id'] = $requirement->name;
                     }
                 }
             }

--- a/src/Glpi/Form/Destination/CommonITILField/LocationField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/LocationField.php
@@ -234,9 +234,8 @@ final class LocationField extends AbstractConfigField implements DestinationFiel
         }
 
         // Insert location name and requirement
-        $name = $location->getName();
-        $config[LocationFieldConfig::SPECIFIC_LOCATION_ID] = $name;
-        $requirement = new DataRequirementSpecification(Location::class, $name);
+        $requirement = DataRequirementSpecification::fromItem($location);
+        $config[LocationFieldConfig::SPECIFIC_LOCATION_ID] = $requirement->name;
 
         return new DynamicExportDataField($config, [$requirement]);
     }

--- a/src/Glpi/Form/Destination/CommonITILField/SLMField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/SLMField.php
@@ -180,9 +180,8 @@ abstract class SLMField extends AbstractConfigField implements DestinationFieldC
         }
 
         // Insert service level name and requirement
-        $name = $slm->getName();
-        $config[SLMFieldConfig::SLM_ID] = $name;
-        $requirement = new DataRequirementSpecification($this->getSLM()::class, $name);
+        $requirement = DataRequirementSpecification::fromItem($slm);
+        $config[SLMFieldConfig::SLM_ID] = $requirement->name;
 
         return new DynamicExportDataField($config, [$requirement]);
     }

--- a/src/Glpi/Form/Destination/CommonITILField/TemplateField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/TemplateField.php
@@ -207,9 +207,8 @@ final class TemplateField extends AbstractConfigField implements DestinationFiel
         }
 
         // Insert template name and requirement
-        $name = $template->getName();
-        $config[TemplateFieldConfig::TEMPLATE_ID] = $name;
-        $requirement = new DataRequirementSpecification($template_type, $name);
+        $requirement = DataRequirementSpecification::fromItem($template);
+        $config[TemplateFieldConfig::TEMPLATE_ID] = $requirement->name;
 
         return new DynamicExportDataField($config, [$requirement]);
     }

--- a/src/Glpi/Form/Destination/CommonITILField/ValidationField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ValidationField.php
@@ -416,13 +416,11 @@ final class ValidationField extends AbstractConfigField implements DestinationFi
                         $item = getItemForItemtype($itemtype);
                         if ($item->getFromDB($item_id)) {
                             // Register requirement with item name
-                            $requirements[] = new DataRequirementSpecification(
-                                $itemtype,
-                                $item->getName(),
-                            );
+                            $requirement = DataRequirementSpecification::fromItem($item);
+                            $requirements[] = $requirement;
 
                             // Replace item ID with name in config
-                            $config[ValidationFieldConfig::STRATEGY_CONFIGS][$index][ValidationFieldStrategyConfig::SPECIFIC_ACTORS][$itemtype][$id_index] = $item->getName();
+                            $config[ValidationFieldConfig::STRATEGY_CONFIGS][$index][ValidationFieldStrategyConfig::SPECIFIC_ACTORS][$itemtype][$id_index] = $requirement->name;
                         }
                     }
                 }

--- a/src/Glpi/Form/Export/Context/DatabaseMapper.php
+++ b/src/Glpi/Form/Export/Context/DatabaseMapper.php
@@ -36,6 +36,7 @@
 namespace Glpi\Form\Export\Context;
 
 use CommonDBTM;
+use CommonTreeDropdown;
 use Glpi\Form\Comment;
 use Glpi\Form\Export\Specification\DataRequirementSpecification;
 use Glpi\Form\Question;
@@ -161,9 +162,12 @@ final class DatabaseMapper
         $query = [
             'FROM' => $item::getTable(),
         ];
-        $condition = [
-            'name' => $name,
-        ];
+
+        if ($item instanceof CommonTreeDropdown) {
+            $condition = ['completename' => $name];
+        } else {
+            $condition = ['name' => $name];
+        }
 
         // Check entities
         if ($item->isEntityAssign()) {

--- a/src/Glpi/Form/Export/Serializer/FormSerializer.php
+++ b/src/Glpi/Form/Export/Serializer/FormSerializer.php
@@ -53,6 +53,7 @@ use Glpi\Form\Export\Result\ImportResultPreview;
 use Glpi\Form\Export\Specification\AccesControlPolicyContentSpecification;
 use Glpi\Form\Export\Specification\CommentContentSpecification;
 use Glpi\Form\Export\Specification\ConditionDataSpecification;
+use Glpi\Form\Export\Specification\DataRequirementSpecification;
 use Glpi\Form\Export\Specification\DestinationContentSpecification;
 use Glpi\Form\Export\Specification\ExportContentSpecification;
 use Glpi\Form\Export\Specification\FormContentSpecification;
@@ -282,14 +283,16 @@ final class FormSerializer extends AbstractFormSerializer
 
         // Export entity
         $entity = Entity::getById($form->fields['entities_id']);
-        $spec->entity_name = $entity->fields['name'];
-        $spec->addDataRequirement(Entity::class, $entity->fields['name']);
+        $requirement = DataRequirementSpecification::fromItem($entity);
+        $spec->addDataRequirement($requirement);
+        $spec->entity_name = $requirement->name;
 
         // Export category
         $category = new Category();
         if ($category->getFromDB($form->fields[Category::getForeignKeyField()])) {
-            $spec->category_name = $category->fields['name'];
-            $spec->addDataRequirement(Category::class, $category->fields['name']);
+            $requirement = DataRequirementSpecification::fromItem($category);
+            $spec->addDataRequirement($requirement);
+            $spec->category_name = $requirement->name;
         }
 
         return $spec;

--- a/src/Glpi/Form/Export/Specification/DataRequirementSpecification.php
+++ b/src/Glpi/Form/Export/Specification/DataRequirementSpecification.php
@@ -36,6 +36,7 @@
 namespace Glpi\Form\Export\Specification;
 
 use CommonDBTM;
+use CommonTreeDropdown;
 
 final class DataRequirementSpecification
 {

--- a/src/Glpi/Form/Export/Specification/DataRequirementSpecification.php
+++ b/src/Glpi/Form/Export/Specification/DataRequirementSpecification.php
@@ -47,9 +47,9 @@ final class DataRequirementSpecification
     public static function fromItem(CommonDBTM $item): self
     {
         if ($item instanceof CommonTreeDropdown) {
-            $name = $item->getName();
-        } else {
             $name = $item->getName(['complete' => true]);
+        } else {
+            $name = $item->getName();
         }
         return new self($item::class, $name);
     }

--- a/src/Glpi/Form/Export/Specification/DataRequirementSpecification.php
+++ b/src/Glpi/Form/Export/Specification/DataRequirementSpecification.php
@@ -35,10 +35,22 @@
 
 namespace Glpi\Form\Export\Specification;
 
+use CommonDBTM;
+
 final class DataRequirementSpecification
 {
     public function __construct(
         public string $itemtype = "",
         public string $name = "",
     ) {}
+
+    public static function fromItem(CommonDBTM $item): self
+    {
+        if ($item instanceof CommonTreeDropdown) {
+            $name = $item->getName();
+        } else {
+            $name = $item->getName(['complete' => true]);
+        }
+        return new self($item::class, $name);
+    }
 }

--- a/src/Glpi/Form/Export/Specification/FormContentSpecification.php
+++ b/src/Glpi/Form/Export/Specification/FormContentSpecification.php
@@ -82,12 +82,8 @@ final class FormContentSpecification
     }
 
     public function addDataRequirement(
-        string $class,
-        string $name,
+        DataRequirementSpecification $requirement
     ): void {
-        $requirement = new DataRequirementSpecification();
-        $requirement->itemtype = $class;
-        $requirement->name = $name;
         $this->data_requirements[] = $requirement;
     }
 

--- a/src/Glpi/Form/QuestionType/AbstractQuestionTypeActors.php
+++ b/src/Glpi/Form/QuestionType/AbstractQuestionTypeActors.php
@@ -571,9 +571,9 @@ TWIG;
                     continue;
                 }
 
-                $name = $item->getName();
-                $default_value_config[$data_key][$i] = $name;
-                $requirements[] = new DataRequirementSpecification($itemtype, $name);
+                $requirement = DataRequirementSpecification::fromItem($item);
+                $requirements[] = $requirement;
+                $default_value_config[$data_key][$i] = $requirement->name;
             }
         }
 

--- a/src/Glpi/Form/QuestionType/QuestionTypeItem.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeItem.php
@@ -405,11 +405,9 @@ class QuestionTypeItem extends AbstractQuestionType implements
 
         // Replace id and register requirement
         $key = QuestionTypeItemDefaultValueConfig::KEY_ITEMS_ID;
-        $default_value_data[$key] = $item->getName();
-        $requirements[] = new DataRequirementSpecification(
-            $itemtype,
-            $item->getName(),
-        );
+        $requirement = DataRequirementSpecification::fromItem($item);
+        $requirements[] = $requirement;
+        $default_value_data[$key] = $requirement->name;
 
         return new DynamicExportDataField($default_value_data, $requirements);
     }

--- a/tests/fixtures/export-of-2-forms.json
+++ b/tests/fixtures/export-of-2-forms.json
@@ -6,7 +6,7 @@
             "uuid": "form-1",
             "name": "My valid form",
             "illustration": "report-issue",
-            "entity_name": "E2ETestEntity",
+            "entity_name": "Root entity > E2ETestEntity",
             "is_recursive": false,
             "is_active": false,
             "submit_button_visibility_strategy": "always_visible",
@@ -46,7 +46,7 @@
             "data_requirements": [
                 {
                     "itemtype": "Entity",
-                    "name": "E2ETestEntity"
+                    "name": "Root entity > E2ETestEntity"
                 },
                 {
                     "itemtype": "User",


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

When importing or exporting forms, we use the name of the required items (e.g. specific entities or categories).
This isn't ideal for `CommonTreeDropdown` items as they may have duplicated names, is it best to rely on the full completename to make sure we target the right item.


