### PR TITLE
fix(forms-migration): handle FormCreator zero range validation migration

### DIFF
--- a/phpunit/functional/Glpi/Form/Migration/FormMigrationTest.php
+++ b/phpunit/functional/Glpi/Form/Migration/FormMigrationTest.php
@@ -1752,6 +1752,108 @@ final class FormMigrationTest extends DbTestCase
                 ],
             ],
         ];
+
+        // FormCreator used 0 as default values when no validation was intended
+        yield 'QuestionTypeShortText - Zero range_min should be ignored' => [
+            'text',
+            [
+                [
+                    'range_min' => '0',
+                    'range_max' => null,
+                    'fieldname' => 'range',
+                ],
+            ],
+            ValidationStrategy::NO_VALIDATION,
+            [],
+        ];
+
+        yield 'QuestionTypeShortText - Zero range_max should be ignored' => [
+            'text',
+            [
+                [
+                    'range_min' => null,
+                    'range_max' => '0',
+                    'fieldname' => 'range',
+                ],
+            ],
+            ValidationStrategy::NO_VALIDATION,
+            [],
+        ];
+
+        yield 'QuestionTypeShortText - Both zero ranges should be ignored' => [
+            'text',
+            [
+                [
+                    'range_min' => '0',
+                    'range_max' => '0',
+                    'fieldname' => 'range',
+                ],
+            ],
+            ValidationStrategy::NO_VALIDATION,
+            [],
+        ];
+
+        yield 'QuestionTypeShortText - Valid range_min with zero range_max should only apply range_min' => [
+            'text',
+            [
+                [
+                    'range_min' => '5',
+                    'range_max' => '0',
+                    'fieldname' => 'range',
+                ],
+            ],
+            ValidationStrategy::VALID_IF,
+            [
+                [
+                    'value_operator' => ValueOperator::LENGTH_GREATER_THAN_OR_EQUALS,
+                    'value'          => '5',
+                    'logic_operator' => LogicOperator::AND,
+                ],
+            ],
+        ];
+
+        yield 'QuestionTypeShortText - Zero range_min with valid range_max should apply both conditions' => [
+            'text',
+            [
+                [
+                    'range_min' => '0',
+                    'range_max' => '50',
+                    'fieldname' => 'range',
+                ],
+            ],
+            ValidationStrategy::VALID_IF,
+            [
+                [
+                    'value_operator' => ValueOperator::LENGTH_GREATER_THAN_OR_EQUALS,
+                    'value'          => '0',
+                    'logic_operator' => LogicOperator::AND,
+                ],
+                [
+                    'value_operator' => ValueOperator::LENGTH_LESS_THAN_OR_EQUALS,
+                    'value'          => '50',
+                    'logic_operator' => LogicOperator::AND,
+                ],
+            ],
+        ];
+
+        yield 'QuestionTypeShortText - Invalid range 50-10 should only apply range_min' => [
+            'text',
+            [
+                [
+                    'range_min' => '50',
+                    'range_max' => '10',
+                    'fieldname' => 'range',
+                ],
+            ],
+            ValidationStrategy::VALID_IF,
+            [
+                [
+                    'value_operator' => ValueOperator::LENGTH_GREATER_THAN_OR_EQUALS,
+                    'value'          => '50',
+                    'logic_operator' => LogicOperator::AND,
+                ],
+            ],
+        ];
     }
 
     #[DataProvider('provideFormMigrationValidationConditionsForQuestions')]


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

- It fixes #20749

Fixes the migration of FormCreator validation ranges where zero default values were incorrectly applied as validation constraints.
