### PR TITLE
Remove unexpected `</table>` tag

### DIFF
--- a/src/CommonDBVisible.php
+++ b/src/CommonDBVisible.php
@@ -297,8 +297,6 @@ abstract class CommonDBVisible extends CommonDBTM
             }
         }
 
-        echo "</table>";
-
         $massiveactionparams = [
             'num_displayed' => count($entries),
             'container' => 'mass' . static::class . $rand,


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

There is no opening `<table>` tag corresponding to this closing `</table>` tag.