### PR TITLE
Extract translations from inline Twig template

### DIFF
--- a/locales/ar_SA.po
+++ b/locales/ar_SA.po
@@ -13,17 +13,17 @@
 # Roshan Roche <roshan6@gmail.com>, 2025
 # ahmed h, 2025
 # Virus Al-Karar, 2025
-# alexandre delaunay <delaunay.alexandre@gmail.com>, 2025
 # Mohammad Mousa <mm84010@gmail.com>, 2025
+# alexandre delaunay <delaunay.alexandre@gmail.com>, 2025
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-26 10:20+0000\n"
+"POT-Creation-Date: 2025-08-26 12:21+0000\n"
 "PO-Revision-Date: 2022-09-16 06:53+0000\n"
-"Last-Translator: Mohammad Mousa <mm84010@gmail.com>, 2025\n"
+"Last-Translator: alexandre delaunay <delaunay.alexandre@gmail.com>, 2025\n"
 "Language-Team: Arabic (Saudi Arabia) (https://app.transifex.com/glpi/teams/1637/ar_SA/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -805,7 +805,7 @@ msgstr ""
 #: templates/components/itilobject/timeline/main_description.html.twig
 #: templates/components/user/info_card.html.twig
 #: templates/pages/tools/kb/comments.html.twig src/KnowbaseItem.php:245
-#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1188
+#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1191
 #: js/src/vue/CustomObject/FieldPreview/Field.vue:30
 msgid "Edit"
 msgstr "تحرير"
@@ -1455,7 +1455,7 @@ msgid "Cancel"
 msgstr "إلغاء"
 
 #: templates/components/form/basic_inputs_macros.html.twig
-#: src/CommonITILValidation.php:1773
+#: src/CommonITILValidation.php:1776
 msgid "Validate"
 msgstr ""
 
@@ -1978,7 +1978,7 @@ msgstr "رقم المخزون"
 #: src/Computer.php:461 src/ProjectTask_Ticket.php:336 src/Certificate.php:278
 #: src/CronTask.php:1274 src/CronTask.php:1412
 #: src/CommonItilObject_Item.php:506 src/PDU.php:203 src/CommonDBTM.php:3513
-#: src/CommonITILValidation.php:1356 src/Plugin.php:2657
+#: src/CommonITILValidation.php:1359 src/Plugin.php:2657
 msgid "Status"
 msgstr "الحالة"
 
@@ -3508,7 +3508,7 @@ msgstr[5] ""
 #: src/CommonITILObject.php:4737 src/CommonITILObject.php:4746
 #: src/CommonITILObject.php:6847 src/CommonITILObject.php:6894
 #: src/CommonITILObject.php:10159 src/NotificationTargetChange.php:308
-#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1498
+#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1501
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] ""
@@ -3522,7 +3522,7 @@ msgstr[5] ""
 #: src/NotificationTargetTicket.php:676 src/NotificationTargetTicket.php:706
 #: src/NotificationTargetCommonITILObject.php:976
 #: src/ITILValidationTemplate.php:81 src/NotificationTargetChange.php:327
-#: src/CommonITILValidation.php:1391 src/CommonITILValidation.php:1518
+#: src/CommonITILValidation.php:1394 src/CommonITILValidation.php:1521
 msgid "Approver"
 msgstr ""
 
@@ -4276,7 +4276,7 @@ msgstr ""
 #: src/OAuthClient.php:94 src/Item_RemoteManagement.php:207
 #: src/Item_RemoteManagement.php:238 src/Certificate.php:125
 #: src/CronTask.php:1391 src/Contact.php:282 src/PDU.php:114
-#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1329
+#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1332
 #: src/Domain.php:233 src/Domain.php:257 src/ConsumableItem.php:167
 msgid "ID"
 msgstr "رقم التعريف"
@@ -5856,7 +5856,7 @@ msgstr ""
 #: src/Project.php:904 src/ProjectTask.php:963
 #: src/NotificationTargetProjectTask.php:553
 #: src/NotificationTargetProjectTask.php:568 src/Cartridge.php:895
-#: src/CommonITILValidation.php:1252
+#: src/CommonITILValidation.php:1255
 msgctxt "item"
 msgid "State"
 msgstr "الحالة"
@@ -17612,7 +17612,7 @@ msgid "Observer group except manager users"
 msgstr ""
 
 #: src/NotificationTargetCommonITILObject.php:973
-#: src/CommonITILValidation.php:1254 src/CommonITILValidation.php:1381
+#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1384
 msgid "Approval requester"
 msgstr ""
 
@@ -26231,12 +26231,12 @@ msgstr ""
 msgctxt "form_editor"
 msgid "Dropdown"
 msgid_plural "Dropdowns"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
-msgstr[5] ""
+msgstr[0] "القوائم المنسدلة"
+msgstr[1] "القوائم المنسدلة"
+msgstr[2] "القوائم المنسدلة"
+msgstr[3] "القوائم المنسدلة"
+msgstr[4] "القوائم المنسدلة"
+msgstr[5] "القوائم المنسدلة"
 
 #: src/Glpi/Form/QuestionType/QuestionTypeUserDevice.php:148
 #: src/Glpi/Form/QuestionType/QuestionTypeUserDevice.php:149
@@ -33913,7 +33913,7 @@ msgstr ""
 msgid "Granted + Not subject to approval"
 msgstr ""
 
-#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1836
+#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1839
 msgid "Group user(s)"
 msgstr ""
 
@@ -33926,77 +33926,89 @@ msgstr ""
 msgid "Progress: %1$s%% of %2$s%% required"
 msgstr ""
 
-#: src/CommonITILValidation.php:1253 src/CommonITILValidation.php:1365
-#: src/CommonITILValidation.php:1472
+#: src/CommonITILValidation.php:1127
+msgid "Approval step accepted"
+msgstr ""
+
+#: src/CommonITILValidation.php:1128
+msgid "Approval step refused"
+msgstr ""
+
+#: src/CommonITILValidation.php:1129
+msgid "Approval step pending"
+msgstr ""
+
+#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1368
+#: src/CommonITILValidation.php:1475
 msgid "Request date"
 msgstr "تاريخ الطلب"
 
-#: src/CommonITILValidation.php:1255 src/CommonITILValidation.php:1338
-#: src/CommonITILValidation.php:1430
+#: src/CommonITILValidation.php:1258 src/CommonITILValidation.php:1341
+#: src/CommonITILValidation.php:1433
 msgid "Request comments"
 msgstr "ملاحظات الطلب"
 
-#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1373
-#: src/CommonITILValidation.php:1485
+#: src/CommonITILValidation.php:1259 src/CommonITILValidation.php:1376
+#: src/CommonITILValidation.php:1488
 msgid "Approval date"
 msgstr "تاريخ الموافقة"
 
-#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1400
+#: src/CommonITILValidation.php:1260 src/CommonITILValidation.php:1403
 msgid "Requested approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1258
+#: src/CommonITILValidation.php:1261
 msgid "Requested approver"
 msgstr ""
 
-#: src/CommonITILValidation.php:1259
+#: src/CommonITILValidation.php:1262
 msgid "Approval Comment"
 msgstr ""
 
-#: src/CommonITILValidation.php:1260
+#: src/CommonITILValidation.php:1263
 #: src/NotificationTargetKnowbaseItem.php:218
 msgid "Documents"
 msgstr "وثائق"
 
-#: src/CommonITILValidation.php:1347 src/CommonITILValidation.php:1444
+#: src/CommonITILValidation.php:1350 src/CommonITILValidation.php:1447
 msgid "Approval comments"
 msgstr "ملاحظات الموافقة"
 
-#: src/CommonITILValidation.php:1459
+#: src/CommonITILValidation.php:1462
 msgid "Approval status"
 msgstr "حالة الطلب"
 
-#: src/CommonITILValidation.php:1541
+#: src/CommonITILValidation.php:1544
 msgid "Approver substitute"
 msgstr ""
 
-#: src/CommonITILValidation.php:1601
+#: src/CommonITILValidation.php:1604
 msgid "Approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1623
+#: src/CommonITILValidation.php:1626
 msgid "Substitute of a member of approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1694
+#: src/CommonITILValidation.php:1697
 msgid "Approval status by users"
 msgstr ""
 
-#: src/CommonITILValidation.php:1849
+#: src/CommonITILValidation.php:1852
 msgid "Approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1954
+#: src/CommonITILValidation.php:1957
 msgid ""
 "This item is waiting for approval, do you really want to resolve or close "
 "it?"
 msgstr ""
 
-#: src/CommonITILValidation.php:1995
+#: src/CommonITILValidation.php:1998
 msgid "This item is waiting for approval."
 msgstr ""
 
-#: src/CommonITILValidation.php:1996
+#: src/CommonITILValidation.php:1999
 msgid "Do you really want to resolve or close it?"
 msgstr ""
 
@@ -35106,7 +35118,7 @@ msgstr ""
 
 #: js/src/vue/Kanban/Kanban.vue:1339
 msgid "Search or filter results"
-msgstr ""
+msgstr "أبحث أو أحصر النتائج"
 
 #: js/src/vue/Kanban/Kanban.vue:1342
 msgid "Add column"

--- a/locales/be_BY.po
+++ b/locales/be_BY.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-26 10:20+0000\n"
+"POT-Creation-Date: 2025-08-26 12:21+0000\n"
 "PO-Revision-Date: 2022-09-16 06:53+0000\n"
 "Last-Translator: alexandre delaunay <delaunay.alexandre@gmail.com>, 2025\n"
 "Language-Team: Belarusian (Belarus) (https://app.transifex.com/glpi/teams/1637/be_BY/)\n"
@@ -793,7 +793,7 @@ msgstr ""
 #: templates/components/itilobject/timeline/main_description.html.twig
 #: templates/components/user/info_card.html.twig
 #: templates/pages/tools/kb/comments.html.twig src/KnowbaseItem.php:245
-#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1188
+#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1191
 #: js/src/vue/CustomObject/FieldPreview/Field.vue:30
 msgid "Edit"
 msgstr ""
@@ -1437,7 +1437,7 @@ msgid "Cancel"
 msgstr ""
 
 #: templates/components/form/basic_inputs_macros.html.twig
-#: src/CommonITILValidation.php:1773
+#: src/CommonITILValidation.php:1776
 msgid "Validate"
 msgstr ""
 
@@ -1959,7 +1959,7 @@ msgstr "Інвентарны нумар"
 #: src/Computer.php:461 src/ProjectTask_Ticket.php:336 src/Certificate.php:278
 #: src/CronTask.php:1274 src/CronTask.php:1412
 #: src/CommonItilObject_Item.php:506 src/PDU.php:203 src/CommonDBTM.php:3513
-#: src/CommonITILValidation.php:1356 src/Plugin.php:2657
+#: src/CommonITILValidation.php:1359 src/Plugin.php:2657
 msgid "Status"
 msgstr ""
 
@@ -3469,7 +3469,7 @@ msgstr[3] ""
 #: src/CommonITILObject.php:4737 src/CommonITILObject.php:4746
 #: src/CommonITILObject.php:6847 src/CommonITILObject.php:6894
 #: src/CommonITILObject.php:10159 src/NotificationTargetChange.php:308
-#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1498
+#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1501
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] ""
@@ -3481,7 +3481,7 @@ msgstr[3] ""
 #: src/NotificationTargetTicket.php:676 src/NotificationTargetTicket.php:706
 #: src/NotificationTargetCommonITILObject.php:976
 #: src/ITILValidationTemplate.php:81 src/NotificationTargetChange.php:327
-#: src/CommonITILValidation.php:1391 src/CommonITILValidation.php:1518
+#: src/CommonITILValidation.php:1394 src/CommonITILValidation.php:1521
 msgid "Approver"
 msgstr ""
 
@@ -4225,7 +4225,7 @@ msgstr ""
 #: src/OAuthClient.php:94 src/Item_RemoteManagement.php:207
 #: src/Item_RemoteManagement.php:238 src/Certificate.php:125
 #: src/CronTask.php:1391 src/Contact.php:282 src/PDU.php:114
-#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1329
+#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1332
 #: src/Domain.php:233 src/Domain.php:257 src/ConsumableItem.php:167
 msgid "ID"
 msgstr "ID"
@@ -5783,7 +5783,7 @@ msgstr ""
 #: src/Project.php:904 src/ProjectTask.php:963
 #: src/NotificationTargetProjectTask.php:553
 #: src/NotificationTargetProjectTask.php:568 src/Cartridge.php:895
-#: src/CommonITILValidation.php:1252
+#: src/CommonITILValidation.php:1255
 msgctxt "item"
 msgid "State"
 msgstr "Стан"
@@ -17417,7 +17417,7 @@ msgid "Observer group except manager users"
 msgstr ""
 
 #: src/NotificationTargetCommonITILObject.php:973
-#: src/CommonITILValidation.php:1254 src/CommonITILValidation.php:1381
+#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1384
 msgid "Approval requester"
 msgstr ""
 
@@ -33401,7 +33401,7 @@ msgstr ""
 msgid "Granted + Not subject to approval"
 msgstr ""
 
-#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1836
+#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1839
 msgid "Group user(s)"
 msgstr ""
 
@@ -33414,77 +33414,89 @@ msgstr ""
 msgid "Progress: %1$s%% of %2$s%% required"
 msgstr ""
 
-#: src/CommonITILValidation.php:1253 src/CommonITILValidation.php:1365
-#: src/CommonITILValidation.php:1472
+#: src/CommonITILValidation.php:1127
+msgid "Approval step accepted"
+msgstr ""
+
+#: src/CommonITILValidation.php:1128
+msgid "Approval step refused"
+msgstr ""
+
+#: src/CommonITILValidation.php:1129
+msgid "Approval step pending"
+msgstr ""
+
+#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1368
+#: src/CommonITILValidation.php:1475
 msgid "Request date"
 msgstr ""
 
-#: src/CommonITILValidation.php:1255 src/CommonITILValidation.php:1338
-#: src/CommonITILValidation.php:1430
+#: src/CommonITILValidation.php:1258 src/CommonITILValidation.php:1341
+#: src/CommonITILValidation.php:1433
 msgid "Request comments"
 msgstr ""
 
-#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1373
-#: src/CommonITILValidation.php:1485
+#: src/CommonITILValidation.php:1259 src/CommonITILValidation.php:1376
+#: src/CommonITILValidation.php:1488
 msgid "Approval date"
 msgstr ""
 
-#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1400
+#: src/CommonITILValidation.php:1260 src/CommonITILValidation.php:1403
 msgid "Requested approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1258
+#: src/CommonITILValidation.php:1261
 msgid "Requested approver"
 msgstr ""
 
-#: src/CommonITILValidation.php:1259
+#: src/CommonITILValidation.php:1262
 msgid "Approval Comment"
 msgstr ""
 
-#: src/CommonITILValidation.php:1260
+#: src/CommonITILValidation.php:1263
 #: src/NotificationTargetKnowbaseItem.php:218
 msgid "Documents"
 msgstr ""
 
-#: src/CommonITILValidation.php:1347 src/CommonITILValidation.php:1444
+#: src/CommonITILValidation.php:1350 src/CommonITILValidation.php:1447
 msgid "Approval comments"
 msgstr ""
 
-#: src/CommonITILValidation.php:1459
+#: src/CommonITILValidation.php:1462
 msgid "Approval status"
 msgstr ""
 
-#: src/CommonITILValidation.php:1541
+#: src/CommonITILValidation.php:1544
 msgid "Approver substitute"
 msgstr ""
 
-#: src/CommonITILValidation.php:1601
+#: src/CommonITILValidation.php:1604
 msgid "Approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1623
+#: src/CommonITILValidation.php:1626
 msgid "Substitute of a member of approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1694
+#: src/CommonITILValidation.php:1697
 msgid "Approval status by users"
 msgstr ""
 
-#: src/CommonITILValidation.php:1849
+#: src/CommonITILValidation.php:1852
 msgid "Approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1954
+#: src/CommonITILValidation.php:1957
 msgid ""
 "This item is waiting for approval, do you really want to resolve or close "
 "it?"
 msgstr ""
 
-#: src/CommonITILValidation.php:1995
+#: src/CommonITILValidation.php:1998
 msgid "This item is waiting for approval."
 msgstr ""
 
-#: src/CommonITILValidation.php:1996
+#: src/CommonITILValidation.php:1999
 msgid "Do you really want to resolve or close it?"
 msgstr ""
 

--- a/locales/bg_BG.po
+++ b/locales/bg_BG.po
@@ -18,7 +18,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-26 10:20+0000\n"
+"POT-Creation-Date: 2025-08-26 12:21+0000\n"
 "PO-Revision-Date: 2022-09-16 06:53+0000\n"
 "Last-Translator: alexandre delaunay <delaunay.alexandre@gmail.com>, 2025\n"
 "Language-Team: Bulgarian (Bulgaria) (https://app.transifex.com/glpi/teams/1637/bg_BG/)\n"
@@ -795,7 +795,7 @@ msgstr ""
 #: templates/components/itilobject/timeline/main_description.html.twig
 #: templates/components/user/info_card.html.twig
 #: templates/pages/tools/kb/comments.html.twig src/KnowbaseItem.php:245
-#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1188
+#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1191
 #: js/src/vue/CustomObject/FieldPreview/Field.vue:30
 msgid "Edit"
 msgstr "Редактирай"
@@ -1440,7 +1440,7 @@ msgid "Cancel"
 msgstr "Отказ"
 
 #: templates/components/form/basic_inputs_macros.html.twig
-#: src/CommonITILValidation.php:1773
+#: src/CommonITILValidation.php:1776
 msgid "Validate"
 msgstr "Потвърди"
 
@@ -1958,7 +1958,7 @@ msgstr "Инвентарен номер"
 #: src/Computer.php:461 src/ProjectTask_Ticket.php:336 src/Certificate.php:278
 #: src/CronTask.php:1274 src/CronTask.php:1412
 #: src/CommonItilObject_Item.php:506 src/PDU.php:203 src/CommonDBTM.php:3513
-#: src/CommonITILValidation.php:1356 src/Plugin.php:2657
+#: src/CommonITILValidation.php:1359 src/Plugin.php:2657
 msgid "Status"
 msgstr "Статус"
 
@@ -3436,7 +3436,7 @@ msgstr[1] ""
 #: src/CommonITILObject.php:4737 src/CommonITILObject.php:4746
 #: src/CommonITILObject.php:6847 src/CommonITILObject.php:6894
 #: src/CommonITILObject.php:10159 src/NotificationTargetChange.php:308
-#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1498
+#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1501
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "Заявител"
@@ -3446,7 +3446,7 @@ msgstr[1] "Заявители"
 #: src/NotificationTargetTicket.php:676 src/NotificationTargetTicket.php:706
 #: src/NotificationTargetCommonITILObject.php:976
 #: src/ITILValidationTemplate.php:81 src/NotificationTargetChange.php:327
-#: src/CommonITILValidation.php:1391 src/CommonITILValidation.php:1518
+#: src/CommonITILValidation.php:1394 src/CommonITILValidation.php:1521
 msgid "Approver"
 msgstr "Одобряващ"
 
@@ -4182,7 +4182,7 @@ msgstr "Няма история"
 #: src/OAuthClient.php:94 src/Item_RemoteManagement.php:207
 #: src/Item_RemoteManagement.php:238 src/Certificate.php:125
 #: src/CronTask.php:1391 src/Contact.php:282 src/PDU.php:114
-#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1329
+#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1332
 #: src/Domain.php:233 src/Domain.php:257 src/ConsumableItem.php:167
 msgid "ID"
 msgstr "ID"
@@ -5717,7 +5717,7 @@ msgstr ""
 #: src/Project.php:904 src/ProjectTask.php:963
 #: src/NotificationTargetProjectTask.php:553
 #: src/NotificationTargetProjectTask.php:568 src/Cartridge.php:895
-#: src/CommonITILValidation.php:1252
+#: src/CommonITILValidation.php:1255
 msgctxt "item"
 msgid "State"
 msgstr "Състояние"
@@ -17180,7 +17180,7 @@ msgid "Observer group except manager users"
 msgstr ""
 
 #: src/NotificationTargetCommonITILObject.php:973
-#: src/CommonITILValidation.php:1254 src/CommonITILValidation.php:1381
+#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1384
 msgid "Approval requester"
 msgstr "Заявяващ одобрение"
 
@@ -25296,8 +25296,8 @@ msgstr ""
 msgctxt "form_editor"
 msgid "Dropdown"
 msgid_plural "Dropdowns"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Падащо меню"
+msgstr[1] "Падащи менюта"
 
 #: src/Glpi/Form/QuestionType/QuestionTypeUserDevice.php:148
 #: src/Glpi/Form/QuestionType/QuestionTypeUserDevice.php:149
@@ -32739,7 +32739,7 @@ msgstr "Не подлежи на одобрение"
 msgid "Granted + Not subject to approval"
 msgstr "Предоставено + Не подлежи на одобрение"
 
-#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1836
+#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1839
 msgid "Group user(s)"
 msgstr ""
 
@@ -32752,67 +32752,79 @@ msgstr ""
 msgid "Progress: %1$s%% of %2$s%% required"
 msgstr ""
 
-#: src/CommonITILValidation.php:1253 src/CommonITILValidation.php:1365
-#: src/CommonITILValidation.php:1472
+#: src/CommonITILValidation.php:1127
+msgid "Approval step accepted"
+msgstr ""
+
+#: src/CommonITILValidation.php:1128
+msgid "Approval step refused"
+msgstr ""
+
+#: src/CommonITILValidation.php:1129
+msgid "Approval step pending"
+msgstr ""
+
+#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1368
+#: src/CommonITILValidation.php:1475
 msgid "Request date"
 msgstr "Дата на заявка"
 
-#: src/CommonITILValidation.php:1255 src/CommonITILValidation.php:1338
-#: src/CommonITILValidation.php:1430
+#: src/CommonITILValidation.php:1258 src/CommonITILValidation.php:1341
+#: src/CommonITILValidation.php:1433
 msgid "Request comments"
 msgstr "Заявка за коментари"
 
-#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1373
-#: src/CommonITILValidation.php:1485
+#: src/CommonITILValidation.php:1259 src/CommonITILValidation.php:1376
+#: src/CommonITILValidation.php:1488
 msgid "Approval date"
 msgstr "Дата на одобряване"
 
-#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1400
+#: src/CommonITILValidation.php:1260 src/CommonITILValidation.php:1403
 msgid "Requested approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1258
+#: src/CommonITILValidation.php:1261
 msgid "Requested approver"
 msgstr ""
 
-#: src/CommonITILValidation.php:1259
+#: src/CommonITILValidation.php:1262
 msgid "Approval Comment"
 msgstr ""
 
-#: src/CommonITILValidation.php:1260
+#: src/CommonITILValidation.php:1263
 #: src/NotificationTargetKnowbaseItem.php:218
 msgid "Documents"
 msgstr "Документи"
 
-#: src/CommonITILValidation.php:1347 src/CommonITILValidation.php:1444
+#: src/CommonITILValidation.php:1350 src/CommonITILValidation.php:1447
 msgid "Approval comments"
 msgstr "Коментари към одобрение"
 
-#: src/CommonITILValidation.php:1459
+#: src/CommonITILValidation.php:1462
 msgid "Approval status"
 msgstr "Статус на одобрение"
 
-#: src/CommonITILValidation.php:1541
+#: src/CommonITILValidation.php:1544
 msgid "Approver substitute"
 msgstr ""
 
-#: src/CommonITILValidation.php:1601
+#: src/CommonITILValidation.php:1604
 msgid "Approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1623
+#: src/CommonITILValidation.php:1626
 msgid "Substitute of a member of approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1694
+#: src/CommonITILValidation.php:1697
 msgid "Approval status by users"
 msgstr ""
 
-#: src/CommonITILValidation.php:1849
+#: src/CommonITILValidation.php:1852
 msgid "Approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1954
+#: src/CommonITILValidation.php:1957
 msgid ""
 "This item is waiting for approval, do you really want to resolve or close "
 "it?"
@@ -32820,11 +32832,11 @@ msgstr ""
 "Този елемент очаква одобрение. Наистина ли искате да го решите или "
 "затворите?"
 
-#: src/CommonITILValidation.php:1995
+#: src/CommonITILValidation.php:1998
 msgid "This item is waiting for approval."
 msgstr ""
 
-#: src/CommonITILValidation.php:1996
+#: src/CommonITILValidation.php:1999
 msgid "Do you really want to resolve or close it?"
 msgstr ""
 
@@ -33844,7 +33856,7 @@ msgstr ""
 
 #: js/src/vue/CustomObject/FieldPreview/Sidebar.vue:49
 msgid "Custom fields"
-msgstr ""
+msgstr "Персонализирани полета"
 
 #: js/src/vue/FuzzySearch/Modal.vue:10
 msgid "Go to menu"
@@ -33914,7 +33926,7 @@ msgstr ""
 
 #: js/src/vue/Kanban/Kanban.vue:1339
 msgid "Search or filter results"
-msgstr ""
+msgstr "Търси или филтрирай резултатите"
 
 #: js/src/vue/Kanban/Kanban.vue:1342
 msgid "Add column"

--- a/locales/ca_ES.po
+++ b/locales/ca_ES.po
@@ -19,8 +19,8 @@
 # David Marti, 2025
 # Joan F, 2025
 # DOMBRE Julien <moyo@indepnet.net>, 2025
-# alexandre delaunay <delaunay.alexandre@gmail.com>, 2025
 # Oriol Lladó, 2025
+# alexandre delaunay <delaunay.alexandre@gmail.com>, 2025
 # Nuria Costa <nuria.costa@uvic.cat>, 2025
 # 
 #, fuzzy
@@ -28,7 +28,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-26 10:20+0000\n"
+"POT-Creation-Date: 2025-08-26 12:21+0000\n"
 "PO-Revision-Date: 2022-09-16 06:53+0000\n"
 "Last-Translator: Nuria Costa <nuria.costa@uvic.cat>, 2025\n"
 "Language-Team: Catalan (Spain) (https://app.transifex.com/glpi/teams/1637/ca_ES/)\n"
@@ -809,7 +809,7 @@ msgstr ""
 #: templates/components/itilobject/timeline/main_description.html.twig
 #: templates/components/user/info_card.html.twig
 #: templates/pages/tools/kb/comments.html.twig src/KnowbaseItem.php:245
-#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1188
+#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1191
 #: js/src/vue/CustomObject/FieldPreview/Field.vue:30
 msgid "Edit"
 msgstr "Edita"
@@ -1455,7 +1455,7 @@ msgid "Cancel"
 msgstr "Cancel·la"
 
 #: templates/components/form/basic_inputs_macros.html.twig
-#: src/CommonITILValidation.php:1773
+#: src/CommonITILValidation.php:1776
 msgid "Validate"
 msgstr "Valida"
 
@@ -1976,7 +1976,7 @@ msgstr "Número d'inventari"
 #: src/Computer.php:461 src/ProjectTask_Ticket.php:336 src/Certificate.php:278
 #: src/CronTask.php:1274 src/CronTask.php:1412
 #: src/CommonItilObject_Item.php:506 src/PDU.php:203 src/CommonDBTM.php:3513
-#: src/CommonITILValidation.php:1356 src/Plugin.php:2657
+#: src/CommonITILValidation.php:1359 src/Plugin.php:2657
 msgid "Status"
 msgstr "Estat"
 
@@ -3456,7 +3456,7 @@ msgstr[1] ""
 #: src/CommonITILObject.php:4737 src/CommonITILObject.php:4746
 #: src/CommonITILObject.php:6847 src/CommonITILObject.php:6894
 #: src/CommonITILObject.php:10159 src/NotificationTargetChange.php:308
-#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1498
+#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1501
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "Sol·licitant"
@@ -3466,7 +3466,7 @@ msgstr[1] "Sol·licitants"
 #: src/NotificationTargetTicket.php:676 src/NotificationTargetTicket.php:706
 #: src/NotificationTargetCommonITILObject.php:976
 #: src/ITILValidationTemplate.php:81 src/NotificationTargetChange.php:327
-#: src/CommonITILValidation.php:1391 src/CommonITILValidation.php:1518
+#: src/CommonITILValidation.php:1394 src/CommonITILValidation.php:1521
 msgid "Approver"
 msgstr "Usuari de validació"
 
@@ -4203,7 +4203,7 @@ msgstr "No hi ha històric"
 #: src/OAuthClient.php:94 src/Item_RemoteManagement.php:207
 #: src/Item_RemoteManagement.php:238 src/Certificate.php:125
 #: src/CronTask.php:1391 src/Contact.php:282 src/PDU.php:114
-#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1329
+#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1332
 #: src/Domain.php:233 src/Domain.php:257 src/ConsumableItem.php:167
 msgid "ID"
 msgstr "ID"
@@ -5740,7 +5740,7 @@ msgstr ""
 #: src/Project.php:904 src/ProjectTask.php:963
 #: src/NotificationTargetProjectTask.php:553
 #: src/NotificationTargetProjectTask.php:568 src/Cartridge.php:895
-#: src/CommonITILValidation.php:1252
+#: src/CommonITILValidation.php:1255
 msgctxt "item"
 msgid "State"
 msgstr "Estat"
@@ -17245,7 +17245,7 @@ msgid "Observer group except manager users"
 msgstr ""
 
 #: src/NotificationTargetCommonITILObject.php:973
-#: src/CommonITILValidation.php:1254 src/CommonITILValidation.php:1381
+#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1384
 msgid "Approval requester"
 msgstr "Sol·licitant de la validació"
 
@@ -25395,8 +25395,8 @@ msgstr ""
 msgctxt "form_editor"
 msgid "Dropdown"
 msgid_plural "Dropdowns"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Llista desplegable"
+msgstr[1] "Llistes desplegables"
 
 #: src/Glpi/Form/QuestionType/QuestionTypeUserDevice.php:148
 #: src/Glpi/Form/QuestionType/QuestionTypeUserDevice.php:149
@@ -32848,7 +32848,7 @@ msgstr "No està subjecte a la validació"
 msgid "Granted + Not subject to approval"
 msgstr "Concedida + No subjecte a aprovació"
 
-#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1836
+#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1839
 msgid "Group user(s)"
 msgstr ""
 
@@ -32861,67 +32861,79 @@ msgstr ""
 msgid "Progress: %1$s%% of %2$s%% required"
 msgstr ""
 
-#: src/CommonITILValidation.php:1253 src/CommonITILValidation.php:1365
-#: src/CommonITILValidation.php:1472
+#: src/CommonITILValidation.php:1127
+msgid "Approval step accepted"
+msgstr ""
+
+#: src/CommonITILValidation.php:1128
+msgid "Approval step refused"
+msgstr ""
+
+#: src/CommonITILValidation.php:1129
+msgid "Approval step pending"
+msgstr ""
+
+#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1368
+#: src/CommonITILValidation.php:1475
 msgid "Request date"
 msgstr "Data de la sol·licitud"
 
-#: src/CommonITILValidation.php:1255 src/CommonITILValidation.php:1338
-#: src/CommonITILValidation.php:1430
+#: src/CommonITILValidation.php:1258 src/CommonITILValidation.php:1341
+#: src/CommonITILValidation.php:1433
 msgid "Request comments"
 msgstr "Comentaris de la sol·licitud"
 
-#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1373
-#: src/CommonITILValidation.php:1485
+#: src/CommonITILValidation.php:1259 src/CommonITILValidation.php:1376
+#: src/CommonITILValidation.php:1488
 msgid "Approval date"
 msgstr "Data de la validació"
 
-#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1400
+#: src/CommonITILValidation.php:1260 src/CommonITILValidation.php:1403
 msgid "Requested approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1258
+#: src/CommonITILValidation.php:1261
 msgid "Requested approver"
 msgstr ""
 
-#: src/CommonITILValidation.php:1259
+#: src/CommonITILValidation.php:1262
 msgid "Approval Comment"
 msgstr ""
 
-#: src/CommonITILValidation.php:1260
+#: src/CommonITILValidation.php:1263
 #: src/NotificationTargetKnowbaseItem.php:218
 msgid "Documents"
 msgstr "Documents"
 
-#: src/CommonITILValidation.php:1347 src/CommonITILValidation.php:1444
+#: src/CommonITILValidation.php:1350 src/CommonITILValidation.php:1447
 msgid "Approval comments"
 msgstr "Comentaris de la validació"
 
-#: src/CommonITILValidation.php:1459
+#: src/CommonITILValidation.php:1462
 msgid "Approval status"
 msgstr "Estat de validació"
 
-#: src/CommonITILValidation.php:1541
+#: src/CommonITILValidation.php:1544
 msgid "Approver substitute"
 msgstr ""
 
-#: src/CommonITILValidation.php:1601
+#: src/CommonITILValidation.php:1604
 msgid "Approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1623
+#: src/CommonITILValidation.php:1626
 msgid "Substitute of a member of approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1694
+#: src/CommonITILValidation.php:1697
 msgid "Approval status by users"
 msgstr ""
 
-#: src/CommonITILValidation.php:1849
+#: src/CommonITILValidation.php:1852
 msgid "Approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1954
+#: src/CommonITILValidation.php:1957
 msgid ""
 "This item is waiting for approval, do you really want to resolve or close "
 "it?"
@@ -32929,11 +32941,11 @@ msgstr ""
 "Aquest element està a l'espera de validació, realment el vols resoldre o "
 "tancar?"
 
-#: src/CommonITILValidation.php:1995
+#: src/CommonITILValidation.php:1998
 msgid "This item is waiting for approval."
 msgstr "Aquest element està pendent de validació."
 
-#: src/CommonITILValidation.php:1996
+#: src/CommonITILValidation.php:1999
 msgid "Do you really want to resolve or close it?"
 msgstr "Realment vols resoldre'l o tancar-lo?"
 
@@ -34009,6 +34021,8 @@ msgid ""
 "The regular expression you entered is invalid. Please check it and try "
 "again."
 msgstr ""
+"L'expressió regular que has introduït no és vàlida. Comprova-la i prova-ho "
+"de nou."
 
 #: js/src/vue/Kanban/Kanban.vue:853
 msgid "Invalid regular expression"
@@ -34024,7 +34038,7 @@ msgstr ""
 
 #: js/src/vue/Kanban/Kanban.vue:1339
 msgid "Search or filter results"
-msgstr ""
+msgstr "Cerca o filtre els resultats"
 
 #: js/src/vue/Kanban/Kanban.vue:1342
 msgid "Add column"

--- a/locales/cs_CZ.po
+++ b/locales/cs_CZ.po
@@ -12,17 +12,17 @@
 # Michal Čermák <michal.cermak79@gmail.com>, 2025
 # DOMBRE Julien <moyo@indepnet.net>, 2025
 # Pavel Borecki <pavel.borecki@gmail.com>, 2025
-# alexandre delaunay <delaunay.alexandre@gmail.com>, 2025
 # David Stepan <stepand@tiscali.cz>, 2025
+# alexandre delaunay <delaunay.alexandre@gmail.com>, 2025
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-26 10:20+0000\n"
+"POT-Creation-Date: 2025-08-26 12:21+0000\n"
 "PO-Revision-Date: 2022-09-16 06:53+0000\n"
-"Last-Translator: David Stepan <stepand@tiscali.cz>, 2025\n"
+"Last-Translator: alexandre delaunay <delaunay.alexandre@gmail.com>, 2025\n"
 "Language-Team: Czech (Czech Republic) (https://app.transifex.com/glpi/teams/1637/cs_CZ/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -801,7 +801,7 @@ msgstr ""
 #: templates/components/itilobject/timeline/main_description.html.twig
 #: templates/components/user/info_card.html.twig
 #: templates/pages/tools/kb/comments.html.twig src/KnowbaseItem.php:245
-#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1188
+#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1191
 #: js/src/vue/CustomObject/FieldPreview/Field.vue:30
 msgid "Edit"
 msgstr "Upravit"
@@ -1453,7 +1453,7 @@ msgid "Cancel"
 msgstr "Storno"
 
 #: templates/components/form/basic_inputs_macros.html.twig
-#: src/CommonITILValidation.php:1773
+#: src/CommonITILValidation.php:1776
 msgid "Validate"
 msgstr "Ověřit"
 
@@ -1977,7 +1977,7 @@ msgstr "Inventární číslo"
 #: src/Computer.php:461 src/ProjectTask_Ticket.php:336 src/Certificate.php:278
 #: src/CronTask.php:1274 src/CronTask.php:1412
 #: src/CommonItilObject_Item.php:506 src/PDU.php:203 src/CommonDBTM.php:3513
-#: src/CommonITILValidation.php:1356 src/Plugin.php:2657
+#: src/CommonITILValidation.php:1359 src/Plugin.php:2657
 msgid "Status"
 msgstr "Stav"
 
@@ -3487,7 +3487,7 @@ msgstr[3] ""
 #: src/CommonITILObject.php:4737 src/CommonITILObject.php:4746
 #: src/CommonITILObject.php:6847 src/CommonITILObject.php:6894
 #: src/CommonITILObject.php:10159 src/NotificationTargetChange.php:308
-#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1498
+#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1501
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "Žadatel"
@@ -3499,7 +3499,7 @@ msgstr[3] "Žadatelé"
 #: src/NotificationTargetTicket.php:676 src/NotificationTargetTicket.php:706
 #: src/NotificationTargetCommonITILObject.php:976
 #: src/ITILValidationTemplate.php:81 src/NotificationTargetChange.php:327
-#: src/CommonITILValidation.php:1391 src/CommonITILValidation.php:1518
+#: src/CommonITILValidation.php:1394 src/CommonITILValidation.php:1521
 msgid "Approver"
 msgstr "Schvalovatel"
 
@@ -4245,7 +4245,7 @@ msgstr "Žádná historie"
 #: src/OAuthClient.php:94 src/Item_RemoteManagement.php:207
 #: src/Item_RemoteManagement.php:238 src/Certificate.php:125
 #: src/CronTask.php:1391 src/Contact.php:282 src/PDU.php:114
-#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1329
+#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1332
 #: src/Domain.php:233 src/Domain.php:257 src/ConsumableItem.php:167
 msgid "ID"
 msgstr "ID"
@@ -5810,7 +5810,7 @@ msgstr ""
 #: src/Project.php:904 src/ProjectTask.php:963
 #: src/NotificationTargetProjectTask.php:553
 #: src/NotificationTargetProjectTask.php:568 src/Cartridge.php:895
-#: src/CommonITILValidation.php:1252
+#: src/CommonITILValidation.php:1255
 msgctxt "item"
 msgid "State"
 msgstr "Stav"
@@ -17539,7 +17539,7 @@ msgid "Observer group except manager users"
 msgstr ""
 
 #: src/NotificationTargetCommonITILObject.php:973
-#: src/CommonITILValidation.php:1254 src/CommonITILValidation.php:1381
+#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1384
 msgid "Approval requester"
 msgstr "O schválení žádal"
 
@@ -26112,10 +26112,10 @@ msgstr ""
 msgctxt "form_editor"
 msgid "Dropdown"
 msgid_plural "Dropdowns"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
+msgstr[0] "Rozbalovací seznam"
+msgstr[1] "Rozbalovací seznamy"
+msgstr[2] "Rozbalovacích seznamů"
+msgstr[3] "Rozbalovací seznamy"
 
 #: src/Glpi/Form/QuestionType/QuestionTypeUserDevice.php:148
 #: src/Glpi/Form/QuestionType/QuestionTypeUserDevice.php:149
@@ -33825,7 +33825,7 @@ msgstr "Není předmětem schvalování"
 msgid "Granted + Not subject to approval"
 msgstr "Schváleno + není předmětem schvalování"
 
-#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1836
+#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1839
 msgid "Group user(s)"
 msgstr "Uživatelé skupiny"
 
@@ -33838,78 +33838,90 @@ msgstr ""
 msgid "Progress: %1$s%% of %2$s%% required"
 msgstr ""
 
-#: src/CommonITILValidation.php:1253 src/CommonITILValidation.php:1365
-#: src/CommonITILValidation.php:1472
+#: src/CommonITILValidation.php:1127
+msgid "Approval step accepted"
+msgstr ""
+
+#: src/CommonITILValidation.php:1128
+msgid "Approval step refused"
+msgstr ""
+
+#: src/CommonITILValidation.php:1129
+msgid "Approval step pending"
+msgstr ""
+
+#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1368
+#: src/CommonITILValidation.php:1475
 msgid "Request date"
 msgstr "Datum žádosti"
 
-#: src/CommonITILValidation.php:1255 src/CommonITILValidation.php:1338
-#: src/CommonITILValidation.php:1430
+#: src/CommonITILValidation.php:1258 src/CommonITILValidation.php:1341
+#: src/CommonITILValidation.php:1433
 msgid "Request comments"
 msgstr "Komentáře k žádosti"
 
-#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1373
-#: src/CommonITILValidation.php:1485
+#: src/CommonITILValidation.php:1259 src/CommonITILValidation.php:1376
+#: src/CommonITILValidation.php:1488
 msgid "Approval date"
 msgstr "Datum schválení"
 
-#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1400
+#: src/CommonITILValidation.php:1260 src/CommonITILValidation.php:1403
 msgid "Requested approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1258
+#: src/CommonITILValidation.php:1261
 msgid "Requested approver"
 msgstr ""
 
-#: src/CommonITILValidation.php:1259
+#: src/CommonITILValidation.php:1262
 msgid "Approval Comment"
 msgstr ""
 
-#: src/CommonITILValidation.php:1260
+#: src/CommonITILValidation.php:1263
 #: src/NotificationTargetKnowbaseItem.php:218
 msgid "Documents"
 msgstr "Dokumenty"
 
-#: src/CommonITILValidation.php:1347 src/CommonITILValidation.php:1444
+#: src/CommonITILValidation.php:1350 src/CommonITILValidation.php:1447
 msgid "Approval comments"
 msgstr "Komentáře o schválení"
 
-#: src/CommonITILValidation.php:1459
+#: src/CommonITILValidation.php:1462
 msgid "Approval status"
 msgstr "Stav schválení"
 
-#: src/CommonITILValidation.php:1541
+#: src/CommonITILValidation.php:1544
 msgid "Approver substitute"
 msgstr ""
 
-#: src/CommonITILValidation.php:1601
+#: src/CommonITILValidation.php:1604
 msgid "Approver group"
 msgstr "Skupina schvalovatelů"
 
-#: src/CommonITILValidation.php:1623
+#: src/CommonITILValidation.php:1626
 msgid "Substitute of a member of approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1694
+#: src/CommonITILValidation.php:1697
 msgid "Approval status by users"
 msgstr ""
 
-#: src/CommonITILValidation.php:1849
+#: src/CommonITILValidation.php:1852
 msgid "Approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1954
+#: src/CommonITILValidation.php:1957
 msgid ""
 "This item is waiting for approval, do you really want to resolve or close "
 "it?"
 msgstr ""
 "Tato položka čeká na schválení, opravdu ji chcete vyřešit nebo zavřít?"
 
-#: src/CommonITILValidation.php:1995
+#: src/CommonITILValidation.php:1998
 msgid "This item is waiting for approval."
 msgstr "Tato položka čeká na schválení."
 
-#: src/CommonITILValidation.php:1996
+#: src/CommonITILValidation.php:1999
 msgid "Do you really want to resolve or close it?"
 msgstr "Opravdu ji chcete vyřešit nebo uzavřít?"
 
@@ -35017,7 +35029,7 @@ msgstr "Regex"
 
 #: js/src/vue/Kanban/Kanban.vue:1339
 msgid "Search or filter results"
-msgstr ""
+msgstr "Prohledat nebo filtrovat výsledky"
 
 #: js/src/vue/Kanban/Kanban.vue:1342
 msgid "Add column"

--- a/locales/da_DK.po
+++ b/locales/da_DK.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-26 10:20+0000\n"
+"POT-Creation-Date: 2025-08-26 12:21+0000\n"
 "PO-Revision-Date: 2022-09-16 06:53+0000\n"
 "Last-Translator: alexandre delaunay <delaunay.alexandre@gmail.com>, 2025\n"
 "Language-Team: Danish (Denmark) (https://app.transifex.com/glpi/teams/1637/da_DK/)\n"
@@ -792,7 +792,7 @@ msgstr ""
 #: templates/components/itilobject/timeline/main_description.html.twig
 #: templates/components/user/info_card.html.twig
 #: templates/pages/tools/kb/comments.html.twig src/KnowbaseItem.php:245
-#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1188
+#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1191
 #: js/src/vue/CustomObject/FieldPreview/Field.vue:30
 msgid "Edit"
 msgstr "Rediger"
@@ -1436,7 +1436,7 @@ msgid "Cancel"
 msgstr "Annuller"
 
 #: templates/components/form/basic_inputs_macros.html.twig
-#: src/CommonITILValidation.php:1773
+#: src/CommonITILValidation.php:1776
 msgid "Validate"
 msgstr "Godkend"
 
@@ -1954,7 +1954,7 @@ msgstr "Aktivnummer"
 #: src/Computer.php:461 src/ProjectTask_Ticket.php:336 src/Certificate.php:278
 #: src/CronTask.php:1274 src/CronTask.php:1412
 #: src/CommonItilObject_Item.php:506 src/PDU.php:203 src/CommonDBTM.php:3513
-#: src/CommonITILValidation.php:1356 src/Plugin.php:2657
+#: src/CommonITILValidation.php:1359 src/Plugin.php:2657
 msgid "Status"
 msgstr "Status"
 
@@ -3431,7 +3431,7 @@ msgstr[1] ""
 #: src/CommonITILObject.php:4737 src/CommonITILObject.php:4746
 #: src/CommonITILObject.php:6847 src/CommonITILObject.php:6894
 #: src/CommonITILObject.php:10159 src/NotificationTargetChange.php:308
-#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1498
+#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1501
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] ""
@@ -3441,7 +3441,7 @@ msgstr[1] ""
 #: src/NotificationTargetTicket.php:676 src/NotificationTargetTicket.php:706
 #: src/NotificationTargetCommonITILObject.php:976
 #: src/ITILValidationTemplate.php:81 src/NotificationTargetChange.php:327
-#: src/CommonITILValidation.php:1391 src/CommonITILValidation.php:1518
+#: src/CommonITILValidation.php:1394 src/CommonITILValidation.php:1521
 msgid "Approver"
 msgstr "Validerings-bruger"
 
@@ -4175,7 +4175,7 @@ msgstr "Ingen historik"
 #: src/OAuthClient.php:94 src/Item_RemoteManagement.php:207
 #: src/Item_RemoteManagement.php:238 src/Certificate.php:125
 #: src/CronTask.php:1391 src/Contact.php:282 src/PDU.php:114
-#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1329
+#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1332
 #: src/Domain.php:233 src/Domain.php:257 src/ConsumableItem.php:167
 msgid "ID"
 msgstr "ID"
@@ -5709,7 +5709,7 @@ msgstr ""
 #: src/Project.php:904 src/ProjectTask.php:963
 #: src/NotificationTargetProjectTask.php:553
 #: src/NotificationTargetProjectTask.php:568 src/Cartridge.php:895
-#: src/CommonITILValidation.php:1252
+#: src/CommonITILValidation.php:1255
 msgctxt "item"
 msgid "State"
 msgstr "Tilstand"
@@ -17120,7 +17120,7 @@ msgid "Observer group except manager users"
 msgstr ""
 
 #: src/NotificationTargetCommonITILObject.php:973
-#: src/CommonITILValidation.php:1254 src/CommonITILValidation.php:1381
+#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1384
 msgid "Approval requester"
 msgstr "Validerings forespørger"
 
@@ -32515,7 +32515,7 @@ msgstr "Kræver ikke godkendelse"
 msgid "Granted + Not subject to approval"
 msgstr "Tildelt + godkendelse ikke nødvendig"
 
-#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1836
+#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1839
 msgid "Group user(s)"
 msgstr ""
 
@@ -32528,67 +32528,79 @@ msgstr ""
 msgid "Progress: %1$s%% of %2$s%% required"
 msgstr ""
 
-#: src/CommonITILValidation.php:1253 src/CommonITILValidation.php:1365
-#: src/CommonITILValidation.php:1472
+#: src/CommonITILValidation.php:1127
+msgid "Approval step accepted"
+msgstr ""
+
+#: src/CommonITILValidation.php:1128
+msgid "Approval step refused"
+msgstr ""
+
+#: src/CommonITILValidation.php:1129
+msgid "Approval step pending"
+msgstr ""
+
+#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1368
+#: src/CommonITILValidation.php:1475
 msgid "Request date"
 msgstr "Forespørgselsdato"
 
-#: src/CommonITILValidation.php:1255 src/CommonITILValidation.php:1338
-#: src/CommonITILValidation.php:1430
+#: src/CommonITILValidation.php:1258 src/CommonITILValidation.php:1341
+#: src/CommonITILValidation.php:1433
 msgid "Request comments"
 msgstr "Forespørg efter kommentar"
 
-#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1373
-#: src/CommonITILValidation.php:1485
+#: src/CommonITILValidation.php:1259 src/CommonITILValidation.php:1376
+#: src/CommonITILValidation.php:1488
 msgid "Approval date"
 msgstr "Valideringsdato"
 
-#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1400
+#: src/CommonITILValidation.php:1260 src/CommonITILValidation.php:1403
 msgid "Requested approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1258
+#: src/CommonITILValidation.php:1261
 msgid "Requested approver"
 msgstr ""
 
-#: src/CommonITILValidation.php:1259
+#: src/CommonITILValidation.php:1262
 msgid "Approval Comment"
 msgstr ""
 
-#: src/CommonITILValidation.php:1260
+#: src/CommonITILValidation.php:1263
 #: src/NotificationTargetKnowbaseItem.php:218
 msgid "Documents"
 msgstr "Dokumenter"
 
-#: src/CommonITILValidation.php:1347 src/CommonITILValidation.php:1444
+#: src/CommonITILValidation.php:1350 src/CommonITILValidation.php:1447
 msgid "Approval comments"
 msgstr "Godkendelses kommentar"
 
-#: src/CommonITILValidation.php:1459
+#: src/CommonITILValidation.php:1462
 msgid "Approval status"
 msgstr "Godkendelsesstatus"
 
-#: src/CommonITILValidation.php:1541
+#: src/CommonITILValidation.php:1544
 msgid "Approver substitute"
 msgstr ""
 
-#: src/CommonITILValidation.php:1601
+#: src/CommonITILValidation.php:1604
 msgid "Approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1623
+#: src/CommonITILValidation.php:1626
 msgid "Substitute of a member of approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1694
+#: src/CommonITILValidation.php:1697
 msgid "Approval status by users"
 msgstr ""
 
-#: src/CommonITILValidation.php:1849
+#: src/CommonITILValidation.php:1852
 msgid "Approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1954
+#: src/CommonITILValidation.php:1957
 msgid ""
 "This item is waiting for approval, do you really want to resolve or close "
 "it?"
@@ -32596,11 +32608,11 @@ msgstr ""
 "Dette emne venter på godkendelse, ønsker du virkelig at løse eller lukke "
 "det?"
 
-#: src/CommonITILValidation.php:1995
+#: src/CommonITILValidation.php:1998
 msgid "This item is waiting for approval."
 msgstr ""
 
-#: src/CommonITILValidation.php:1996
+#: src/CommonITILValidation.php:1999
 msgid "Do you really want to resolve or close it?"
 msgstr ""
 

--- a/locales/de_DE.po
+++ b/locales/de_DE.po
@@ -30,20 +30,20 @@
 # Stephan <stephan.rennert@web.de>, 2025
 # Viktor Schopf, 2025
 # Seidler Jean-Louis <jl.seidler@gmx.ch>, 2025
-# alexandre delaunay <delaunay.alexandre@gmail.com>, 2025
 # Florian - <community@subsidoo.net>, 2025
-# Slow Rider, 2025
 # Simon, 2025
 # Ta Bo, 2025
+# Slow Rider, 2025
+# alexandre delaunay <delaunay.alexandre@gmail.com>, 2025
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-26 10:20+0000\n"
+"POT-Creation-Date: 2025-08-26 12:21+0000\n"
 "PO-Revision-Date: 2022-09-16 06:53+0000\n"
-"Last-Translator: Ta Bo, 2025\n"
+"Last-Translator: alexandre delaunay <delaunay.alexandre@gmail.com>, 2025\n"
 "Language-Team: German (Germany) (https://app.transifex.com/glpi/teams/1637/de_DE/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -834,7 +834,7 @@ msgstr "Schreib-Schutz Modus"
 #: templates/components/itilobject/timeline/main_description.html.twig
 #: templates/components/user/info_card.html.twig
 #: templates/pages/tools/kb/comments.html.twig src/KnowbaseItem.php:245
-#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1188
+#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1191
 #: js/src/vue/CustomObject/FieldPreview/Field.vue:30
 msgid "Edit"
 msgstr "Bearbeiten"
@@ -1482,7 +1482,7 @@ msgid "Cancel"
 msgstr "Abbrechen"
 
 #: templates/components/form/basic_inputs_macros.html.twig
-#: src/CommonITILValidation.php:1773
+#: src/CommonITILValidation.php:1776
 msgid "Validate"
 msgstr "Überprüfe"
 
@@ -2005,7 +2005,7 @@ msgstr "Inventarnummer"
 #: src/Computer.php:461 src/ProjectTask_Ticket.php:336 src/Certificate.php:278
 #: src/CronTask.php:1274 src/CronTask.php:1412
 #: src/CommonItilObject_Item.php:506 src/PDU.php:203 src/CommonDBTM.php:3513
-#: src/CommonITILValidation.php:1356 src/Plugin.php:2657
+#: src/CommonITILValidation.php:1359 src/Plugin.php:2657
 msgid "Status"
 msgstr "Status"
 
@@ -3487,7 +3487,7 @@ msgstr[1] ""
 #: src/CommonITILObject.php:4737 src/CommonITILObject.php:4746
 #: src/CommonITILObject.php:6847 src/CommonITILObject.php:6894
 #: src/CommonITILObject.php:10159 src/NotificationTargetChange.php:308
-#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1498
+#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1501
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "Anforderer"
@@ -3497,7 +3497,7 @@ msgstr[1] "Anforderer"
 #: src/NotificationTargetTicket.php:676 src/NotificationTargetTicket.php:706
 #: src/NotificationTargetCommonITILObject.php:976
 #: src/ITILValidationTemplate.php:81 src/NotificationTargetChange.php:327
-#: src/CommonITILValidation.php:1391 src/CommonITILValidation.php:1518
+#: src/CommonITILValidation.php:1394 src/CommonITILValidation.php:1521
 msgid "Approver"
 msgstr "Genehmigende(r)"
 
@@ -4240,7 +4240,7 @@ msgstr "Keine Änderungen"
 #: src/OAuthClient.php:94 src/Item_RemoteManagement.php:207
 #: src/Item_RemoteManagement.php:238 src/Certificate.php:125
 #: src/CronTask.php:1391 src/Contact.php:282 src/PDU.php:114
-#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1329
+#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1332
 #: src/Domain.php:233 src/Domain.php:257 src/ConsumableItem.php:167
 msgid "ID"
 msgstr "ID"
@@ -5793,7 +5793,7 @@ msgstr ""
 #: src/Project.php:904 src/ProjectTask.php:963
 #: src/NotificationTargetProjectTask.php:553
 #: src/NotificationTargetProjectTask.php:568 src/Cartridge.php:895
-#: src/CommonITILValidation.php:1252
+#: src/CommonITILValidation.php:1255
 msgctxt "item"
 msgid "State"
 msgstr "Status"
@@ -17404,7 +17404,7 @@ msgid "Observer group except manager users"
 msgstr "Beobachter-Gruppe ohne Manager"
 
 #: src/NotificationTargetCommonITILObject.php:973
-#: src/CommonITILValidation.php:1254 src/CommonITILValidation.php:1381
+#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1384
 msgid "Approval requester"
 msgstr "Antragsteller für Genehmigung"
 
@@ -33366,7 +33366,7 @@ msgstr "Keine Genehmigung beantragt"
 msgid "Granted + Not subject to approval"
 msgstr "Genehmigt + Genehmigung nicht erforderlich"
 
-#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1836
+#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1839
 msgid "Group user(s)"
 msgstr "Gruppen Benutzer"
 
@@ -33379,67 +33379,79 @@ msgstr ""
 msgid "Progress: %1$s%% of %2$s%% required"
 msgstr ""
 
-#: src/CommonITILValidation.php:1253 src/CommonITILValidation.php:1365
-#: src/CommonITILValidation.php:1472
+#: src/CommonITILValidation.php:1127
+msgid "Approval step accepted"
+msgstr ""
+
+#: src/CommonITILValidation.php:1128
+msgid "Approval step refused"
+msgstr ""
+
+#: src/CommonITILValidation.php:1129
+msgid "Approval step pending"
+msgstr ""
+
+#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1368
+#: src/CommonITILValidation.php:1475
 msgid "Request date"
 msgstr "Datum der Anfrage"
 
-#: src/CommonITILValidation.php:1255 src/CommonITILValidation.php:1338
-#: src/CommonITILValidation.php:1430
+#: src/CommonITILValidation.php:1258 src/CommonITILValidation.php:1341
+#: src/CommonITILValidation.php:1433
 msgid "Request comments"
 msgstr "Kommentar der Genehmigungsanfrage"
 
-#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1373
-#: src/CommonITILValidation.php:1485
+#: src/CommonITILValidation.php:1259 src/CommonITILValidation.php:1376
+#: src/CommonITILValidation.php:1488
 msgid "Approval date"
 msgstr "Datum der Genehmigung"
 
-#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1400
+#: src/CommonITILValidation.php:1260 src/CommonITILValidation.php:1403
 msgid "Requested approver type"
 msgstr "Genehmiger Typ"
 
-#: src/CommonITILValidation.php:1258
+#: src/CommonITILValidation.php:1261
 msgid "Requested approver"
 msgstr "Genehmiger"
 
-#: src/CommonITILValidation.php:1259
+#: src/CommonITILValidation.php:1262
 msgid "Approval Comment"
 msgstr ""
 
-#: src/CommonITILValidation.php:1260
+#: src/CommonITILValidation.php:1263
 #: src/NotificationTargetKnowbaseItem.php:218
 msgid "Documents"
 msgstr "Dokumente"
 
-#: src/CommonITILValidation.php:1347 src/CommonITILValidation.php:1444
+#: src/CommonITILValidation.php:1350 src/CommonITILValidation.php:1447
 msgid "Approval comments"
 msgstr "Kommentar der Genehmigung"
 
-#: src/CommonITILValidation.php:1459
+#: src/CommonITILValidation.php:1462
 msgid "Approval status"
 msgstr "Freigabe der Genehmigung"
 
-#: src/CommonITILValidation.php:1541
+#: src/CommonITILValidation.php:1544
 msgid "Approver substitute"
 msgstr "Vertreter für Genehmigungen"
 
-#: src/CommonITILValidation.php:1601
+#: src/CommonITILValidation.php:1604
 msgid "Approver group"
 msgstr "Genehmiger Gruppe"
 
-#: src/CommonITILValidation.php:1623
+#: src/CommonITILValidation.php:1626
 msgid "Substitute of a member of approver group"
 msgstr "Vertreter einer Person einer Genehmiger Gruppe"
 
-#: src/CommonITILValidation.php:1694
+#: src/CommonITILValidation.php:1697
 msgid "Approval status by users"
 msgstr ""
 
-#: src/CommonITILValidation.php:1849
+#: src/CommonITILValidation.php:1852
 msgid "Approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1954
+#: src/CommonITILValidation.php:1957
 msgid ""
 "This item is waiting for approval, do you really want to resolve or close "
 "it?"
@@ -33447,11 +33459,11 @@ msgstr ""
 "Das Objekt wartet auf eine Genehmigung, wollen Sie es wirklich lösen oder "
 "schließen?"
 
-#: src/CommonITILValidation.php:1995
+#: src/CommonITILValidation.php:1998
 msgid "This item is waiting for approval."
 msgstr "Diese Element wartet auf Genehmigung."
 
-#: src/CommonITILValidation.php:1996
+#: src/CommonITILValidation.php:1999
 msgid "Do you really want to resolve or close it?"
 msgstr "Wollen Sie es wirklich lösen oder schließen?"
 
@@ -34542,6 +34554,8 @@ msgid ""
 "The regular expression you entered is invalid. Please check it and try "
 "again."
 msgstr ""
+"Der von Ihnen eingegebene reguläre Ausdruck ist ungültig. Bitte überprüfen "
+"Sie ihn und versuchen Sie es erneut."
 
 #: js/src/vue/Kanban/Kanban.vue:853
 msgid "Invalid regular expression"
@@ -34557,7 +34571,7 @@ msgstr "Regex"
 
 #: js/src/vue/Kanban/Kanban.vue:1339
 msgid "Search or filter results"
-msgstr ""
+msgstr "In Ergebnissen suchen oder diese filtern"
 
 #: js/src/vue/Kanban/Kanban.vue:1342
 msgid "Add column"

--- a/locales/el_GR.po
+++ b/locales/el_GR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-26 10:20+0000\n"
+"POT-Creation-Date: 2025-08-26 12:21+0000\n"
 "PO-Revision-Date: 2022-09-16 06:53+0000\n"
 "Last-Translator: alexandre delaunay <delaunay.alexandre@gmail.com>, 2025\n"
 "Language-Team: Greek (Greece) (https://app.transifex.com/glpi/teams/1637/el_GR/)\n"
@@ -796,7 +796,7 @@ msgstr ""
 #: templates/components/itilobject/timeline/main_description.html.twig
 #: templates/components/user/info_card.html.twig
 #: templates/pages/tools/kb/comments.html.twig src/KnowbaseItem.php:245
-#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1188
+#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1191
 #: js/src/vue/CustomObject/FieldPreview/Field.vue:30
 msgid "Edit"
 msgstr "Επεξεργασία"
@@ -1440,7 +1440,7 @@ msgid "Cancel"
 msgstr "Ακύρωση"
 
 #: templates/components/form/basic_inputs_macros.html.twig
-#: src/CommonITILValidation.php:1773
+#: src/CommonITILValidation.php:1776
 msgid "Validate"
 msgstr ""
 
@@ -1958,7 +1958,7 @@ msgstr "Αριθμός Απογραφής"
 #: src/Computer.php:461 src/ProjectTask_Ticket.php:336 src/Certificate.php:278
 #: src/CronTask.php:1274 src/CronTask.php:1412
 #: src/CommonItilObject_Item.php:506 src/PDU.php:203 src/CommonDBTM.php:3513
-#: src/CommonITILValidation.php:1356 src/Plugin.php:2657
+#: src/CommonITILValidation.php:1359 src/Plugin.php:2657
 msgid "Status"
 msgstr "Κατάσταση"
 
@@ -3435,7 +3435,7 @@ msgstr[1] ""
 #: src/CommonITILObject.php:4737 src/CommonITILObject.php:4746
 #: src/CommonITILObject.php:6847 src/CommonITILObject.php:6894
 #: src/CommonITILObject.php:10159 src/NotificationTargetChange.php:308
-#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1498
+#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1501
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] ""
@@ -3445,7 +3445,7 @@ msgstr[1] ""
 #: src/NotificationTargetTicket.php:676 src/NotificationTargetTicket.php:706
 #: src/NotificationTargetCommonITILObject.php:976
 #: src/ITILValidationTemplate.php:81 src/NotificationTargetChange.php:327
-#: src/CommonITILValidation.php:1391 src/CommonITILValidation.php:1518
+#: src/CommonITILValidation.php:1394 src/CommonITILValidation.php:1521
 msgid "Approver"
 msgstr "Εγκρίνων"
 
@@ -4180,7 +4180,7 @@ msgstr "Δεν υπάρχει ιστορικό"
 #: src/OAuthClient.php:94 src/Item_RemoteManagement.php:207
 #: src/Item_RemoteManagement.php:238 src/Certificate.php:125
 #: src/CronTask.php:1391 src/Contact.php:282 src/PDU.php:114
-#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1329
+#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1332
 #: src/Domain.php:233 src/Domain.php:257 src/ConsumableItem.php:167
 msgid "ID"
 msgstr "ΑΑ"
@@ -5714,7 +5714,7 @@ msgstr ""
 #: src/Project.php:904 src/ProjectTask.php:963
 #: src/NotificationTargetProjectTask.php:553
 #: src/NotificationTargetProjectTask.php:568 src/Cartridge.php:895
-#: src/CommonITILValidation.php:1252
+#: src/CommonITILValidation.php:1255
 msgctxt "item"
 msgid "State"
 msgstr "Κατάσταση"
@@ -17150,7 +17150,7 @@ msgid "Observer group except manager users"
 msgstr ""
 
 #: src/NotificationTargetCommonITILObject.php:973
-#: src/CommonITILValidation.php:1254 src/CommonITILValidation.php:1381
+#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1384
 msgid "Approval requester"
 msgstr "Αιτών έγκρισης"
 
@@ -32581,7 +32581,7 @@ msgstr "Δεν υπόκειται σε έγκριση"
 msgid "Granted + Not subject to approval"
 msgstr "Παραχωρήθηκε + Δεν υπόκειται σε έγκριση"
 
-#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1836
+#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1839
 msgid "Group user(s)"
 msgstr ""
 
@@ -32594,77 +32594,89 @@ msgstr ""
 msgid "Progress: %1$s%% of %2$s%% required"
 msgstr ""
 
-#: src/CommonITILValidation.php:1253 src/CommonITILValidation.php:1365
-#: src/CommonITILValidation.php:1472
+#: src/CommonITILValidation.php:1127
+msgid "Approval step accepted"
+msgstr ""
+
+#: src/CommonITILValidation.php:1128
+msgid "Approval step refused"
+msgstr ""
+
+#: src/CommonITILValidation.php:1129
+msgid "Approval step pending"
+msgstr ""
+
+#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1368
+#: src/CommonITILValidation.php:1475
 msgid "Request date"
 msgstr "Ημερομηνία αίτησης"
 
-#: src/CommonITILValidation.php:1255 src/CommonITILValidation.php:1338
-#: src/CommonITILValidation.php:1430
+#: src/CommonITILValidation.php:1258 src/CommonITILValidation.php:1341
+#: src/CommonITILValidation.php:1433
 msgid "Request comments"
 msgstr "Σχόλιο αίτησης"
 
-#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1373
-#: src/CommonITILValidation.php:1485
+#: src/CommonITILValidation.php:1259 src/CommonITILValidation.php:1376
+#: src/CommonITILValidation.php:1488
 msgid "Approval date"
 msgstr "Ημερομηνία έγκρισης"
 
-#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1400
+#: src/CommonITILValidation.php:1260 src/CommonITILValidation.php:1403
 msgid "Requested approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1258
+#: src/CommonITILValidation.php:1261
 msgid "Requested approver"
 msgstr ""
 
-#: src/CommonITILValidation.php:1259
+#: src/CommonITILValidation.php:1262
 msgid "Approval Comment"
 msgstr ""
 
-#: src/CommonITILValidation.php:1260
+#: src/CommonITILValidation.php:1263
 #: src/NotificationTargetKnowbaseItem.php:218
 msgid "Documents"
 msgstr "Έγγραφα"
 
-#: src/CommonITILValidation.php:1347 src/CommonITILValidation.php:1444
+#: src/CommonITILValidation.php:1350 src/CommonITILValidation.php:1447
 msgid "Approval comments"
 msgstr "Σχόλιο έγκρισης"
 
-#: src/CommonITILValidation.php:1459
+#: src/CommonITILValidation.php:1462
 msgid "Approval status"
 msgstr ""
 
-#: src/CommonITILValidation.php:1541
+#: src/CommonITILValidation.php:1544
 msgid "Approver substitute"
 msgstr ""
 
-#: src/CommonITILValidation.php:1601
+#: src/CommonITILValidation.php:1604
 msgid "Approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1623
+#: src/CommonITILValidation.php:1626
 msgid "Substitute of a member of approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1694
+#: src/CommonITILValidation.php:1697
 msgid "Approval status by users"
 msgstr ""
 
-#: src/CommonITILValidation.php:1849
+#: src/CommonITILValidation.php:1852
 msgid "Approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1954
+#: src/CommonITILValidation.php:1957
 msgid ""
 "This item is waiting for approval, do you really want to resolve or close "
 "it?"
 msgstr ""
 
-#: src/CommonITILValidation.php:1995
+#: src/CommonITILValidation.php:1998
 msgid "This item is waiting for approval."
 msgstr ""
 
-#: src/CommonITILValidation.php:1996
+#: src/CommonITILValidation.php:1999
 msgid "Do you really want to resolve or close it?"
 msgstr ""
 

--- a/locales/en_GB.po
+++ b/locales/en_GB.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-26 10:20+0000\n"
-"PO-Revision-Date: 2025-08-26 10:20+0000\n"
+"POT-Creation-Date: 2025-08-26 12:21+0000\n"
+"PO-Revision-Date: 2025-08-26 12:21+0000\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
 "Language: en_GB\n"
@@ -786,7 +786,7 @@ msgstr "Read-only mode"
 #: templates/components/itilobject/timeline/main_description.html.twig
 #: templates/components/user/info_card.html.twig
 #: templates/pages/tools/kb/comments.html.twig src/KnowbaseItem.php:245
-#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1188
+#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1191
 #: js/src/vue/CustomObject/FieldPreview/Field.vue:30
 msgid "Edit"
 msgstr "Edit"
@@ -1425,7 +1425,7 @@ msgid "Cancel"
 msgstr "Cancel"
 
 #: templates/components/form/basic_inputs_macros.html.twig
-#: src/CommonITILValidation.php:1773
+#: src/CommonITILValidation.php:1776
 msgid "Validate"
 msgstr "Validate"
 
@@ -1943,7 +1943,7 @@ msgstr "Inventory number"
 #: src/Computer.php:461 src/ProjectTask_Ticket.php:336 src/Certificate.php:278
 #: src/CronTask.php:1274 src/CronTask.php:1412
 #: src/CommonItilObject_Item.php:506 src/PDU.php:203 src/CommonDBTM.php:3513
-#: src/CommonITILValidation.php:1356 src/Plugin.php:2657
+#: src/CommonITILValidation.php:1359 src/Plugin.php:2657
 msgid "Status"
 msgstr "Status"
 
@@ -3418,7 +3418,7 @@ msgstr[1] "Approval step"
 #: src/CommonITILObject.php:4737 src/CommonITILObject.php:4746
 #: src/CommonITILObject.php:6847 src/CommonITILObject.php:6894
 #: src/CommonITILObject.php:10159 src/NotificationTargetChange.php:308
-#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1498
+#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1501
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "Requester"
@@ -3428,7 +3428,7 @@ msgstr[1] "Requesters"
 #: src/NotificationTargetTicket.php:676 src/NotificationTargetTicket.php:706
 #: src/NotificationTargetCommonITILObject.php:976
 #: src/ITILValidationTemplate.php:81 src/NotificationTargetChange.php:327
-#: src/CommonITILValidation.php:1391 src/CommonITILValidation.php:1518
+#: src/CommonITILValidation.php:1394 src/CommonITILValidation.php:1521
 msgid "Approver"
 msgstr "Approver"
 
@@ -4166,7 +4166,7 @@ msgstr "No historical"
 #: src/OAuthClient.php:94 src/Item_RemoteManagement.php:207
 #: src/Item_RemoteManagement.php:238 src/Certificate.php:125
 #: src/CronTask.php:1391 src/Contact.php:282 src/PDU.php:114
-#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1329 src/Domain.php:233
+#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1332 src/Domain.php:233
 #: src/Domain.php:257 src/ConsumableItem.php:167
 msgid "ID"
 msgstr "ID"
@@ -5710,7 +5710,7 @@ msgstr ""
 #: src/Project.php:904 src/ProjectTask.php:963
 #: src/NotificationTargetProjectTask.php:553
 #: src/NotificationTargetProjectTask.php:568 src/Cartridge.php:895
-#: src/CommonITILValidation.php:1252
+#: src/CommonITILValidation.php:1255
 msgctxt "item"
 msgid "State"
 msgstr "State"
@@ -17283,7 +17283,7 @@ msgid "Observer group except manager users"
 msgstr "Observer group except manager users"
 
 #: src/NotificationTargetCommonITILObject.php:973
-#: src/CommonITILValidation.php:1254 src/CommonITILValidation.php:1381
+#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1384
 msgid "Approval requester"
 msgstr "Approval requester"
 
@@ -33053,7 +33053,7 @@ msgstr "Not subject to approval"
 msgid "Granted + Not subject to approval"
 msgstr "Granted + Not subject to approval"
 
-#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1836
+#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1839
 msgid "Group user(s)"
 msgstr "Group user(s)"
 
@@ -33066,76 +33066,88 @@ msgstr "Edit approval step"
 msgid "Progress: %1$s%% of %2$s%% required"
 msgstr "Progress: %1$s%% of %2$s%% required"
 
-#: src/CommonITILValidation.php:1253 src/CommonITILValidation.php:1365
-#: src/CommonITILValidation.php:1472
+#: src/CommonITILValidation.php:1127
+msgid "Approval step accepted"
+msgstr "Approval step accepted"
+
+#: src/CommonITILValidation.php:1128
+msgid "Approval step refused"
+msgstr "Approval step refused"
+
+#: src/CommonITILValidation.php:1129
+msgid "Approval step pending"
+msgstr "Approval step pending"
+
+#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1368
+#: src/CommonITILValidation.php:1475
 msgid "Request date"
 msgstr "Request date"
 
-#: src/CommonITILValidation.php:1255 src/CommonITILValidation.php:1338
-#: src/CommonITILValidation.php:1430
+#: src/CommonITILValidation.php:1258 src/CommonITILValidation.php:1341
+#: src/CommonITILValidation.php:1433
 msgid "Request comments"
 msgstr "Request comments"
 
-#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1373
-#: src/CommonITILValidation.php:1485
+#: src/CommonITILValidation.php:1259 src/CommonITILValidation.php:1376
+#: src/CommonITILValidation.php:1488
 msgid "Approval date"
 msgstr "Approval date"
 
-#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1400
+#: src/CommonITILValidation.php:1260 src/CommonITILValidation.php:1403
 msgid "Requested approver type"
 msgstr "Requested approver type"
 
-#: src/CommonITILValidation.php:1258
+#: src/CommonITILValidation.php:1261
 msgid "Requested approver"
 msgstr "Requested approver"
 
-#: src/CommonITILValidation.php:1259
+#: src/CommonITILValidation.php:1262
 msgid "Approval Comment"
 msgstr "Approval Comment"
 
-#: src/CommonITILValidation.php:1260 src/NotificationTargetKnowbaseItem.php:218
+#: src/CommonITILValidation.php:1263 src/NotificationTargetKnowbaseItem.php:218
 msgid "Documents"
 msgstr "Documents"
 
-#: src/CommonITILValidation.php:1347 src/CommonITILValidation.php:1444
+#: src/CommonITILValidation.php:1350 src/CommonITILValidation.php:1447
 msgid "Approval comments"
 msgstr "Approval comments"
 
-#: src/CommonITILValidation.php:1459
+#: src/CommonITILValidation.php:1462
 msgid "Approval status"
 msgstr "Approval status"
 
-#: src/CommonITILValidation.php:1541
+#: src/CommonITILValidation.php:1544
 msgid "Approver substitute"
 msgstr "Approver substitute"
 
-#: src/CommonITILValidation.php:1601
+#: src/CommonITILValidation.php:1604
 msgid "Approver group"
 msgstr "Approver group"
 
-#: src/CommonITILValidation.php:1623
+#: src/CommonITILValidation.php:1626
 msgid "Substitute of a member of approver group"
 msgstr "Substitute of a member of approver group"
 
-#: src/CommonITILValidation.php:1694
+#: src/CommonITILValidation.php:1697
 msgid "Approval status by users"
 msgstr "Approval status by users"
 
-#: src/CommonITILValidation.php:1849
+#: src/CommonITILValidation.php:1852
 msgid "Approver type"
 msgstr "Approver type"
 
-#: src/CommonITILValidation.php:1954
+#: src/CommonITILValidation.php:1957
 msgid ""
 "This item is waiting for approval, do you really want to resolve or close it?"
 msgstr ""
 "This item is waiting for approval, do you really want to resolve or close it?"
 
-#: src/CommonITILValidation.php:1995
+#: src/CommonITILValidation.php:1998
 msgid "This item is waiting for approval."
 msgstr "This item is waiting for approval."
 
-#: src/CommonITILValidation.php:1996
+#: src/CommonITILValidation.php:1999
 msgid "Do you really want to resolve or close it?"
 msgstr "Do you really want to resolve or close it?"
 

--- a/locales/en_US.po
+++ b/locales/en_US.po
@@ -7,18 +7,18 @@
 # botmaut, 2022
 # Howard Shand <howardshand@gmail.com>, 2024
 # Curtis Conard <cconard96@gmail.com>, 2025
-# alexandre delaunay <delaunay.alexandre@gmail.com>, 2025
-# David Paulus <DiodeDave@gmail.com>, 2025
 # Shawn Long <webaccounts@kkg.org>, 2025
+# David Paulus <DiodeDave@gmail.com>, 2025
+# alexandre delaunay <delaunay.alexandre@gmail.com>, 2025
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-26 10:20+0000\n"
+"POT-Creation-Date: 2025-08-26 12:21+0000\n"
 "PO-Revision-Date: 2022-09-16 06:53+0000\n"
-"Last-Translator: Shawn Long <webaccounts@kkg.org>, 2025\n"
+"Last-Translator: alexandre delaunay <delaunay.alexandre@gmail.com>, 2025\n"
 "Language-Team: English (United States) (https://app.transifex.com/glpi/teams/1637/en_US/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -798,7 +798,7 @@ msgstr "Read-only mode"
 #: templates/components/itilobject/timeline/main_description.html.twig
 #: templates/components/user/info_card.html.twig
 #: templates/pages/tools/kb/comments.html.twig src/KnowbaseItem.php:245
-#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1188
+#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1191
 #: js/src/vue/CustomObject/FieldPreview/Field.vue:30
 msgid "Edit"
 msgstr "Edit"
@@ -1444,7 +1444,7 @@ msgid "Cancel"
 msgstr "Cancel"
 
 #: templates/components/form/basic_inputs_macros.html.twig
-#: src/CommonITILValidation.php:1773
+#: src/CommonITILValidation.php:1776
 msgid "Validate"
 msgstr "Validate"
 
@@ -1962,7 +1962,7 @@ msgstr "Inventory/Asset Number"
 #: src/Computer.php:461 src/ProjectTask_Ticket.php:336 src/Certificate.php:278
 #: src/CronTask.php:1274 src/CronTask.php:1412
 #: src/CommonItilObject_Item.php:506 src/PDU.php:203 src/CommonDBTM.php:3513
-#: src/CommonITILValidation.php:1356 src/Plugin.php:2657
+#: src/CommonITILValidation.php:1359 src/Plugin.php:2657
 msgid "Status"
 msgstr "Status"
 
@@ -3445,7 +3445,7 @@ msgstr[1] "Approval step"
 #: src/CommonITILObject.php:4737 src/CommonITILObject.php:4746
 #: src/CommonITILObject.php:6847 src/CommonITILObject.php:6894
 #: src/CommonITILObject.php:10159 src/NotificationTargetChange.php:308
-#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1498
+#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1501
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "Requester"
@@ -3455,7 +3455,7 @@ msgstr[1] "Requesters"
 #: src/NotificationTargetTicket.php:676 src/NotificationTargetTicket.php:706
 #: src/NotificationTargetCommonITILObject.php:976
 #: src/ITILValidationTemplate.php:81 src/NotificationTargetChange.php:327
-#: src/CommonITILValidation.php:1391 src/CommonITILValidation.php:1518
+#: src/CommonITILValidation.php:1394 src/CommonITILValidation.php:1521
 msgid "Approver"
 msgstr "Approver"
 
@@ -4196,7 +4196,7 @@ msgstr "No historical"
 #: src/OAuthClient.php:94 src/Item_RemoteManagement.php:207
 #: src/Item_RemoteManagement.php:238 src/Certificate.php:125
 #: src/CronTask.php:1391 src/Contact.php:282 src/PDU.php:114
-#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1329
+#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1332
 #: src/Domain.php:233 src/Domain.php:257 src/ConsumableItem.php:167
 msgid "ID"
 msgstr "ID"
@@ -5752,7 +5752,7 @@ msgstr ""
 #: src/Project.php:904 src/ProjectTask.php:963
 #: src/NotificationTargetProjectTask.php:553
 #: src/NotificationTargetProjectTask.php:568 src/Cartridge.php:895
-#: src/CommonITILValidation.php:1252
+#: src/CommonITILValidation.php:1255
 msgctxt "item"
 msgid "State"
 msgstr "State"
@@ -17330,7 +17330,7 @@ msgid "Observer group except manager users"
 msgstr "Observer Group Except Manager Users"
 
 #: src/NotificationTargetCommonITILObject.php:973
-#: src/CommonITILValidation.php:1254 src/CommonITILValidation.php:1381
+#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1384
 msgid "Approval requester"
 msgstr "Approval Requester"
 
@@ -33118,7 +33118,7 @@ msgstr "Not subject to approval"
 msgid "Granted + Not subject to approval"
 msgstr "Granted + Not subject to approval"
 
-#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1836
+#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1839
 msgid "Group user(s)"
 msgstr "Group User(s)"
 
@@ -33131,67 +33131,79 @@ msgstr ""
 msgid "Progress: %1$s%% of %2$s%% required"
 msgstr ""
 
-#: src/CommonITILValidation.php:1253 src/CommonITILValidation.php:1365
-#: src/CommonITILValidation.php:1472
+#: src/CommonITILValidation.php:1127
+msgid "Approval step accepted"
+msgstr ""
+
+#: src/CommonITILValidation.php:1128
+msgid "Approval step refused"
+msgstr ""
+
+#: src/CommonITILValidation.php:1129
+msgid "Approval step pending"
+msgstr ""
+
+#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1368
+#: src/CommonITILValidation.php:1475
 msgid "Request date"
 msgstr "Request Date"
 
-#: src/CommonITILValidation.php:1255 src/CommonITILValidation.php:1338
-#: src/CommonITILValidation.php:1430
+#: src/CommonITILValidation.php:1258 src/CommonITILValidation.php:1341
+#: src/CommonITILValidation.php:1433
 msgid "Request comments"
 msgstr "Request Comments"
 
-#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1373
-#: src/CommonITILValidation.php:1485
+#: src/CommonITILValidation.php:1259 src/CommonITILValidation.php:1376
+#: src/CommonITILValidation.php:1488
 msgid "Approval date"
 msgstr "Approval Date"
 
-#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1400
+#: src/CommonITILValidation.php:1260 src/CommonITILValidation.php:1403
 msgid "Requested approver type"
 msgstr "Requested Approver Type"
 
-#: src/CommonITILValidation.php:1258
+#: src/CommonITILValidation.php:1261
 msgid "Requested approver"
 msgstr "Requested Approver"
 
-#: src/CommonITILValidation.php:1259
+#: src/CommonITILValidation.php:1262
 msgid "Approval Comment"
 msgstr ""
 
-#: src/CommonITILValidation.php:1260
+#: src/CommonITILValidation.php:1263
 #: src/NotificationTargetKnowbaseItem.php:218
 msgid "Documents"
 msgstr "Documents"
 
-#: src/CommonITILValidation.php:1347 src/CommonITILValidation.php:1444
+#: src/CommonITILValidation.php:1350 src/CommonITILValidation.php:1447
 msgid "Approval comments"
 msgstr "Approval comments"
 
-#: src/CommonITILValidation.php:1459
+#: src/CommonITILValidation.php:1462
 msgid "Approval status"
 msgstr "Approval Status"
 
-#: src/CommonITILValidation.php:1541
+#: src/CommonITILValidation.php:1544
 msgid "Approver substitute"
 msgstr "Approver Substitute"
 
-#: src/CommonITILValidation.php:1601
+#: src/CommonITILValidation.php:1604
 msgid "Approver group"
 msgstr "Approver Group"
 
-#: src/CommonITILValidation.php:1623
+#: src/CommonITILValidation.php:1626
 msgid "Substitute of a member of approver group"
 msgstr "Substitute of a Member of Approver Group"
 
-#: src/CommonITILValidation.php:1694
+#: src/CommonITILValidation.php:1697
 msgid "Approval status by users"
 msgstr ""
 
-#: src/CommonITILValidation.php:1849
+#: src/CommonITILValidation.php:1852
 msgid "Approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1954
+#: src/CommonITILValidation.php:1957
 msgid ""
 "This item is waiting for approval, do you really want to resolve or close "
 "it?"
@@ -33199,11 +33211,11 @@ msgstr ""
 "This item is waiting for approval, do you really want to resolve or close "
 "it?"
 
-#: src/CommonITILValidation.php:1995
+#: src/CommonITILValidation.php:1998
 msgid "This item is waiting for approval."
 msgstr "This item is waiting for approval."
 
-#: src/CommonITILValidation.php:1996
+#: src/CommonITILValidation.php:1999
 msgid "Do you really want to resolve or close it?"
 msgstr "Do you really want to resolve or close it?"
 
@@ -34288,6 +34300,8 @@ msgid ""
 "The regular expression you entered is invalid. Please check it and try "
 "again."
 msgstr ""
+"The regular expression you entered is invalid. Please check it and try "
+"again."
 
 #: js/src/vue/Kanban/Kanban.vue:853
 msgid "Invalid regular expression"
@@ -34303,7 +34317,7 @@ msgstr "Regex"
 
 #: js/src/vue/Kanban/Kanban.vue:1339
 msgid "Search or filter results"
-msgstr ""
+msgstr "Search or Filter Results"
 
 #: js/src/vue/Kanban/Kanban.vue:1342
 msgid "Add column"

--- a/locales/eo.po
+++ b/locales/eo.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-26 10:20+0000\n"
+"POT-Creation-Date: 2025-08-26 12:21+0000\n"
 "PO-Revision-Date: 2022-09-16 06:53+0000\n"
 "Last-Translator: alexandre delaunay <delaunay.alexandre@gmail.com>, 2025\n"
 "Language-Team: Esperanto (https://app.transifex.com/glpi/teams/1637/eo/)\n"
@@ -786,7 +786,7 @@ msgstr ""
 #: templates/components/itilobject/timeline/main_description.html.twig
 #: templates/components/user/info_card.html.twig
 #: templates/pages/tools/kb/comments.html.twig src/KnowbaseItem.php:245
-#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1188
+#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1191
 #: js/src/vue/CustomObject/FieldPreview/Field.vue:30
 msgid "Edit"
 msgstr "Редактировать"
@@ -1429,7 +1429,7 @@ msgid "Cancel"
 msgstr "Отмена"
 
 #: templates/components/form/basic_inputs_macros.html.twig
-#: src/CommonITILValidation.php:1773
+#: src/CommonITILValidation.php:1776
 msgid "Validate"
 msgstr "Согласовывать"
 
@@ -1945,7 +1945,7 @@ msgstr "Инвентарный номер"
 #: src/Computer.php:461 src/ProjectTask_Ticket.php:336 src/Certificate.php:278
 #: src/CronTask.php:1274 src/CronTask.php:1412
 #: src/CommonItilObject_Item.php:506 src/PDU.php:203 src/CommonDBTM.php:3513
-#: src/CommonITILValidation.php:1356 src/Plugin.php:2657
+#: src/CommonITILValidation.php:1359 src/Plugin.php:2657
 msgid "Status"
 msgstr ""
 
@@ -3424,7 +3424,7 @@ msgstr[1] ""
 #: src/CommonITILObject.php:4737 src/CommonITILObject.php:4746
 #: src/CommonITILObject.php:6847 src/CommonITILObject.php:6894
 #: src/CommonITILObject.php:10159 src/NotificationTargetChange.php:308
-#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1498
+#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1501
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] ""
@@ -3434,7 +3434,7 @@ msgstr[1] ""
 #: src/NotificationTargetTicket.php:676 src/NotificationTargetTicket.php:706
 #: src/NotificationTargetCommonITILObject.php:976
 #: src/ITILValidationTemplate.php:81 src/NotificationTargetChange.php:327
-#: src/CommonITILValidation.php:1391 src/CommonITILValidation.php:1518
+#: src/CommonITILValidation.php:1394 src/CommonITILValidation.php:1521
 msgid "Approver"
 msgstr "Проверяющий"
 
@@ -4168,7 +4168,7 @@ msgstr "Нет истории"
 #: src/OAuthClient.php:94 src/Item_RemoteManagement.php:207
 #: src/Item_RemoteManagement.php:238 src/Certificate.php:125
 #: src/CronTask.php:1391 src/Contact.php:282 src/PDU.php:114
-#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1329
+#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1332
 #: src/Domain.php:233 src/Domain.php:257 src/ConsumableItem.php:167
 msgid "ID"
 msgstr "ID"
@@ -5703,7 +5703,7 @@ msgstr ""
 #: src/Project.php:904 src/ProjectTask.php:963
 #: src/NotificationTargetProjectTask.php:553
 #: src/NotificationTargetProjectTask.php:568 src/Cartridge.php:895
-#: src/CommonITILValidation.php:1252
+#: src/CommonITILValidation.php:1255
 msgctxt "item"
 msgid "State"
 msgstr "Состояние"
@@ -17167,7 +17167,7 @@ msgid "Observer group except manager users"
 msgstr ""
 
 #: src/NotificationTargetCommonITILObject.php:973
-#: src/CommonITILValidation.php:1254 src/CommonITILValidation.php:1381
+#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1384
 msgid "Approval requester"
 msgstr "Инициатор запроса на согласование"
 
@@ -32647,7 +32647,7 @@ msgstr "Не подлежит согласованию"
 msgid "Granted + Not subject to approval"
 msgstr "Предоставлено + Без согласования"
 
-#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1836
+#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1839
 msgid "Group user(s)"
 msgstr ""
 
@@ -32660,67 +32660,79 @@ msgstr ""
 msgid "Progress: %1$s%% of %2$s%% required"
 msgstr ""
 
-#: src/CommonITILValidation.php:1253 src/CommonITILValidation.php:1365
-#: src/CommonITILValidation.php:1472
+#: src/CommonITILValidation.php:1127
+msgid "Approval step accepted"
+msgstr ""
+
+#: src/CommonITILValidation.php:1128
+msgid "Approval step refused"
+msgstr ""
+
+#: src/CommonITILValidation.php:1129
+msgid "Approval step pending"
+msgstr ""
+
+#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1368
+#: src/CommonITILValidation.php:1475
 msgid "Request date"
 msgstr "Дата запроса"
 
-#: src/CommonITILValidation.php:1255 src/CommonITILValidation.php:1338
-#: src/CommonITILValidation.php:1430
+#: src/CommonITILValidation.php:1258 src/CommonITILValidation.php:1341
+#: src/CommonITILValidation.php:1433
 msgid "Request comments"
 msgstr "Комментарий запроса"
 
-#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1373
-#: src/CommonITILValidation.php:1485
+#: src/CommonITILValidation.php:1259 src/CommonITILValidation.php:1376
+#: src/CommonITILValidation.php:1488
 msgid "Approval date"
 msgstr "Дата согласования"
 
-#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1400
+#: src/CommonITILValidation.php:1260 src/CommonITILValidation.php:1403
 msgid "Requested approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1258
+#: src/CommonITILValidation.php:1261
 msgid "Requested approver"
 msgstr ""
 
-#: src/CommonITILValidation.php:1259
+#: src/CommonITILValidation.php:1262
 msgid "Approval Comment"
 msgstr ""
 
-#: src/CommonITILValidation.php:1260
+#: src/CommonITILValidation.php:1263
 #: src/NotificationTargetKnowbaseItem.php:218
 msgid "Documents"
 msgstr ""
 
-#: src/CommonITILValidation.php:1347 src/CommonITILValidation.php:1444
+#: src/CommonITILValidation.php:1350 src/CommonITILValidation.php:1447
 msgid "Approval comments"
 msgstr "Комментарий согласования"
 
-#: src/CommonITILValidation.php:1459
+#: src/CommonITILValidation.php:1462
 msgid "Approval status"
 msgstr "Статус согласования"
 
-#: src/CommonITILValidation.php:1541
+#: src/CommonITILValidation.php:1544
 msgid "Approver substitute"
 msgstr ""
 
-#: src/CommonITILValidation.php:1601
+#: src/CommonITILValidation.php:1604
 msgid "Approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1623
+#: src/CommonITILValidation.php:1626
 msgid "Substitute of a member of approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1694
+#: src/CommonITILValidation.php:1697
 msgid "Approval status by users"
 msgstr ""
 
-#: src/CommonITILValidation.php:1849
+#: src/CommonITILValidation.php:1852
 msgid "Approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1954
+#: src/CommonITILValidation.php:1957
 msgid ""
 "This item is waiting for approval, do you really want to resolve or close "
 "it?"
@@ -32728,11 +32740,11 @@ msgstr ""
 "Этот объект ждет согласования, вы действительно хотите решить или закрыть "
 "его?"
 
-#: src/CommonITILValidation.php:1995
+#: src/CommonITILValidation.php:1998
 msgid "This item is waiting for approval."
 msgstr ""
 
-#: src/CommonITILValidation.php:1996
+#: src/CommonITILValidation.php:1999
 msgid "Do you really want to resolve or close it?"
 msgstr ""
 

--- a/locales/es_419.po
+++ b/locales/es_419.po
@@ -20,17 +20,17 @@
 # Roberto Flores <robertocarlos.floresh@gmail.com>, 2025
 # Ariel Montoya <ariel.montoya@grouppbs.com>, 2025
 # DOMBRE Julien <moyo@indepnet.net>, 2025
-# Lorenzo Salvador Osorio Orellana, 2025
 # alexandre delaunay <delaunay.alexandre@gmail.com>, 2025
+# Lorenzo Salvador Osorio Orellana, 2025
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-26 10:20+0000\n"
+"POT-Creation-Date: 2025-08-26 12:21+0000\n"
 "PO-Revision-Date: 2022-09-16 06:53+0000\n"
-"Last-Translator: alexandre delaunay <delaunay.alexandre@gmail.com>, 2025\n"
+"Last-Translator: Lorenzo Salvador Osorio Orellana, 2025\n"
 "Language-Team: Spanish (Latin America) (https://app.transifex.com/glpi/teams/1637/es_419/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -812,7 +812,7 @@ msgstr ""
 #: templates/components/itilobject/timeline/main_description.html.twig
 #: templates/components/user/info_card.html.twig
 #: templates/pages/tools/kb/comments.html.twig src/KnowbaseItem.php:245
-#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1188
+#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1191
 #: js/src/vue/CustomObject/FieldPreview/Field.vue:30
 msgid "Edit"
 msgstr "Editar"
@@ -1460,7 +1460,7 @@ msgid "Cancel"
 msgstr "Cancelar"
 
 #: templates/components/form/basic_inputs_macros.html.twig
-#: src/CommonITILValidation.php:1773
+#: src/CommonITILValidation.php:1776
 msgid "Validate"
 msgstr "Validar"
 
@@ -1983,7 +1983,7 @@ msgstr "Número de inventario"
 #: src/Computer.php:461 src/ProjectTask_Ticket.php:336 src/Certificate.php:278
 #: src/CronTask.php:1274 src/CronTask.php:1412
 #: src/CommonItilObject_Item.php:506 src/PDU.php:203 src/CommonDBTM.php:3513
-#: src/CommonITILValidation.php:1356 src/Plugin.php:2657
+#: src/CommonITILValidation.php:1359 src/Plugin.php:2657
 msgid "Status"
 msgstr "Estado"
 
@@ -3477,7 +3477,7 @@ msgstr[2] ""
 #: src/CommonITILObject.php:4737 src/CommonITILObject.php:4746
 #: src/CommonITILObject.php:6847 src/CommonITILObject.php:6894
 #: src/CommonITILObject.php:10159 src/NotificationTargetChange.php:308
-#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1498
+#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1501
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "Solicitante"
@@ -3488,7 +3488,7 @@ msgstr[2] "Solicitantes"
 #: src/NotificationTargetTicket.php:676 src/NotificationTargetTicket.php:706
 #: src/NotificationTargetCommonITILObject.php:976
 #: src/ITILValidationTemplate.php:81 src/NotificationTargetChange.php:327
-#: src/CommonITILValidation.php:1391 src/CommonITILValidation.php:1518
+#: src/CommonITILValidation.php:1394 src/CommonITILValidation.php:1521
 msgid "Approver"
 msgstr "Aprobador"
 
@@ -4229,7 +4229,7 @@ msgstr "No hay histórico"
 #: src/OAuthClient.php:94 src/Item_RemoteManagement.php:207
 #: src/Item_RemoteManagement.php:238 src/Certificate.php:125
 #: src/CronTask.php:1391 src/Contact.php:282 src/PDU.php:114
-#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1329
+#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1332
 #: src/Domain.php:233 src/Domain.php:257 src/ConsumableItem.php:167
 msgid "ID"
 msgstr "ID"
@@ -5779,7 +5779,7 @@ msgstr ""
 #: src/Project.php:904 src/ProjectTask.php:963
 #: src/NotificationTargetProjectTask.php:553
 #: src/NotificationTargetProjectTask.php:568 src/Cartridge.php:895
-#: src/CommonITILValidation.php:1252
+#: src/CommonITILValidation.php:1255
 msgctxt "item"
 msgid "State"
 msgstr "Estado"
@@ -17413,7 +17413,7 @@ msgid "Observer group except manager users"
 msgstr ""
 
 #: src/NotificationTargetCommonITILObject.php:973
-#: src/CommonITILValidation.php:1254 src/CommonITILValidation.php:1381
+#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1384
 msgid "Approval requester"
 msgstr "Solicitante de aprobación"
 
@@ -33429,7 +33429,7 @@ msgstr "No sujeto a aprobación"
 msgid "Granted + Not subject to approval"
 msgstr "Concedida + No sujeto a aprobación"
 
-#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1836
+#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1839
 msgid "Group user(s)"
 msgstr ""
 
@@ -33442,77 +33442,89 @@ msgstr ""
 msgid "Progress: %1$s%% of %2$s%% required"
 msgstr ""
 
-#: src/CommonITILValidation.php:1253 src/CommonITILValidation.php:1365
-#: src/CommonITILValidation.php:1472
+#: src/CommonITILValidation.php:1127
+msgid "Approval step accepted"
+msgstr ""
+
+#: src/CommonITILValidation.php:1128
+msgid "Approval step refused"
+msgstr ""
+
+#: src/CommonITILValidation.php:1129
+msgid "Approval step pending"
+msgstr ""
+
+#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1368
+#: src/CommonITILValidation.php:1475
 msgid "Request date"
 msgstr "Fecha de solicitud"
 
-#: src/CommonITILValidation.php:1255 src/CommonITILValidation.php:1338
-#: src/CommonITILValidation.php:1430
+#: src/CommonITILValidation.php:1258 src/CommonITILValidation.php:1341
+#: src/CommonITILValidation.php:1433
 msgid "Request comments"
 msgstr "Comentario de solicitud"
 
-#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1373
-#: src/CommonITILValidation.php:1485
+#: src/CommonITILValidation.php:1259 src/CommonITILValidation.php:1376
+#: src/CommonITILValidation.php:1488
 msgid "Approval date"
 msgstr "Fecha de aprobación"
 
-#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1400
+#: src/CommonITILValidation.php:1260 src/CommonITILValidation.php:1403
 msgid "Requested approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1258
+#: src/CommonITILValidation.php:1261
 msgid "Requested approver"
 msgstr ""
 
-#: src/CommonITILValidation.php:1259
+#: src/CommonITILValidation.php:1262
 msgid "Approval Comment"
 msgstr ""
 
-#: src/CommonITILValidation.php:1260
+#: src/CommonITILValidation.php:1263
 #: src/NotificationTargetKnowbaseItem.php:218
 msgid "Documents"
 msgstr "Documentos"
 
-#: src/CommonITILValidation.php:1347 src/CommonITILValidation.php:1444
+#: src/CommonITILValidation.php:1350 src/CommonITILValidation.php:1447
 msgid "Approval comments"
 msgstr "Comentario de aprobación"
 
-#: src/CommonITILValidation.php:1459
+#: src/CommonITILValidation.php:1462
 msgid "Approval status"
 msgstr "Estado de aprovación"
 
-#: src/CommonITILValidation.php:1541
+#: src/CommonITILValidation.php:1544
 msgid "Approver substitute"
 msgstr ""
 
-#: src/CommonITILValidation.php:1601
+#: src/CommonITILValidation.php:1604
 msgid "Approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1623
+#: src/CommonITILValidation.php:1626
 msgid "Substitute of a member of approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1694
+#: src/CommonITILValidation.php:1697
 msgid "Approval status by users"
 msgstr ""
 
-#: src/CommonITILValidation.php:1849
+#: src/CommonITILValidation.php:1852
 msgid "Approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1954
+#: src/CommonITILValidation.php:1957
 msgid ""
 "This item is waiting for approval, do you really want to resolve or close "
 "it?"
 msgstr "Pendiente de aprobación. ¿Realmente quiere resolverlo o cerrarlo?"
 
-#: src/CommonITILValidation.php:1995
+#: src/CommonITILValidation.php:1998
 msgid "This item is waiting for approval."
 msgstr "Este elemento está esperando aprobación."
 
-#: src/CommonITILValidation.php:1996
+#: src/CommonITILValidation.php:1999
 msgid "Do you really want to resolve or close it?"
 msgstr "¿Deseas resolverlo o cerrarlo?"
 
@@ -34612,7 +34624,7 @@ msgstr ""
 
 #: js/src/vue/Kanban/Kanban.vue:1339
 msgid "Search or filter results"
-msgstr ""
+msgstr "Buscar o filtrar resultados"
 
 #: js/src/vue/Kanban/Kanban.vue:1342
 msgid "Add column"

--- a/locales/es_AR.po
+++ b/locales/es_AR.po
@@ -34,7 +34,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-26 10:20+0000\n"
+"POT-Creation-Date: 2025-08-26 12:21+0000\n"
 "PO-Revision-Date: 2022-09-16 06:53+0000\n"
 "Last-Translator: Fernando Toledo <ftoledo@docksud.com.ar>, 2025\n"
 "Language-Team: Spanish (Argentina) (https://app.transifex.com/glpi/teams/1637/es_AR/)\n"
@@ -826,7 +826,7 @@ msgstr "Modo de solo lectura"
 #: templates/components/itilobject/timeline/main_description.html.twig
 #: templates/components/user/info_card.html.twig
 #: templates/pages/tools/kb/comments.html.twig src/KnowbaseItem.php:245
-#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1188
+#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1191
 #: js/src/vue/CustomObject/FieldPreview/Field.vue:30
 msgid "Edit"
 msgstr "Editar"
@@ -1477,7 +1477,7 @@ msgid "Cancel"
 msgstr "Anular"
 
 #: templates/components/form/basic_inputs_macros.html.twig
-#: src/CommonITILValidation.php:1773
+#: src/CommonITILValidation.php:1776
 msgid "Validate"
 msgstr "Validar"
 
@@ -2000,7 +2000,7 @@ msgstr "Número de inventario"
 #: src/Computer.php:461 src/ProjectTask_Ticket.php:336 src/Certificate.php:278
 #: src/CronTask.php:1274 src/CronTask.php:1412
 #: src/CommonItilObject_Item.php:506 src/PDU.php:203 src/CommonDBTM.php:3513
-#: src/CommonITILValidation.php:1356 src/Plugin.php:2657
+#: src/CommonITILValidation.php:1359 src/Plugin.php:2657
 msgid "Status"
 msgstr "Estado"
 
@@ -3499,7 +3499,7 @@ msgstr[2] "Paso de aprobación"
 #: src/CommonITILObject.php:4737 src/CommonITILObject.php:4746
 #: src/CommonITILObject.php:6847 src/CommonITILObject.php:6894
 #: src/CommonITILObject.php:10159 src/NotificationTargetChange.php:308
-#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1498
+#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1501
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "Solicitante"
@@ -3510,7 +3510,7 @@ msgstr[2] "Solicitantes"
 #: src/NotificationTargetTicket.php:676 src/NotificationTargetTicket.php:706
 #: src/NotificationTargetCommonITILObject.php:976
 #: src/ITILValidationTemplate.php:81 src/NotificationTargetChange.php:327
-#: src/CommonITILValidation.php:1391 src/CommonITILValidation.php:1518
+#: src/CommonITILValidation.php:1394 src/CommonITILValidation.php:1521
 msgid "Approver"
 msgstr "Autorizante"
 
@@ -4259,7 +4259,7 @@ msgstr "No hay histórico"
 #: src/OAuthClient.php:94 src/Item_RemoteManagement.php:207
 #: src/Item_RemoteManagement.php:238 src/Certificate.php:125
 #: src/CronTask.php:1391 src/Contact.php:282 src/PDU.php:114
-#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1329
+#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1332
 #: src/Domain.php:233 src/Domain.php:257 src/ConsumableItem.php:167
 msgid "ID"
 msgstr "ID"
@@ -5829,7 +5829,7 @@ msgstr ""
 #: src/Project.php:904 src/ProjectTask.php:963
 #: src/NotificationTargetProjectTask.php:553
 #: src/NotificationTargetProjectTask.php:568 src/Cartridge.php:895
-#: src/CommonITILValidation.php:1252
+#: src/CommonITILValidation.php:1255
 msgctxt "item"
 msgid "State"
 msgstr "Estado"
@@ -17613,7 +17613,7 @@ msgid "Observer group except manager users"
 msgstr ""
 
 #: src/NotificationTargetCommonITILObject.php:973
-#: src/CommonITILValidation.php:1254 src/CommonITILValidation.php:1381
+#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1384
 msgid "Approval requester"
 msgstr "Solicitante de la aprobación"
 
@@ -33794,7 +33794,7 @@ msgstr "No sujeto a aprobación"
 msgid "Granted + Not subject to approval"
 msgstr "Otorgado + No sujeto a aprobación"
 
-#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1836
+#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1839
 msgid "Group user(s)"
 msgstr ""
 
@@ -33807,67 +33807,79 @@ msgstr ""
 msgid "Progress: %1$s%% of %2$s%% required"
 msgstr ""
 
-#: src/CommonITILValidation.php:1253 src/CommonITILValidation.php:1365
-#: src/CommonITILValidation.php:1472
+#: src/CommonITILValidation.php:1127
+msgid "Approval step accepted"
+msgstr ""
+
+#: src/CommonITILValidation.php:1128
+msgid "Approval step refused"
+msgstr ""
+
+#: src/CommonITILValidation.php:1129
+msgid "Approval step pending"
+msgstr ""
+
+#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1368
+#: src/CommonITILValidation.php:1475
 msgid "Request date"
 msgstr "Fecha de solicitud"
 
-#: src/CommonITILValidation.php:1255 src/CommonITILValidation.php:1338
-#: src/CommonITILValidation.php:1430
+#: src/CommonITILValidation.php:1258 src/CommonITILValidation.php:1341
+#: src/CommonITILValidation.php:1433
 msgid "Request comments"
 msgstr "Comentarios del solicitante"
 
-#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1373
-#: src/CommonITILValidation.php:1485
+#: src/CommonITILValidation.php:1259 src/CommonITILValidation.php:1376
+#: src/CommonITILValidation.php:1488
 msgid "Approval date"
 msgstr "Fecha de aprobación"
 
-#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1400
+#: src/CommonITILValidation.php:1260 src/CommonITILValidation.php:1403
 msgid "Requested approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1258
+#: src/CommonITILValidation.php:1261
 msgid "Requested approver"
 msgstr ""
 
-#: src/CommonITILValidation.php:1259
+#: src/CommonITILValidation.php:1262
 msgid "Approval Comment"
 msgstr ""
 
-#: src/CommonITILValidation.php:1260
+#: src/CommonITILValidation.php:1263
 #: src/NotificationTargetKnowbaseItem.php:218
 msgid "Documents"
 msgstr "Documentos"
 
-#: src/CommonITILValidation.php:1347 src/CommonITILValidation.php:1444
+#: src/CommonITILValidation.php:1350 src/CommonITILValidation.php:1447
 msgid "Approval comments"
 msgstr "Comentarios de la aprobación"
 
-#: src/CommonITILValidation.php:1459
+#: src/CommonITILValidation.php:1462
 msgid "Approval status"
 msgstr "Estado de aprobación"
 
-#: src/CommonITILValidation.php:1541
+#: src/CommonITILValidation.php:1544
 msgid "Approver substitute"
 msgstr "Aprobador suplente"
 
-#: src/CommonITILValidation.php:1601
+#: src/CommonITILValidation.php:1604
 msgid "Approver group"
 msgstr "Grupo aprobador"
 
-#: src/CommonITILValidation.php:1623
+#: src/CommonITILValidation.php:1626
 msgid "Substitute of a member of approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1694
+#: src/CommonITILValidation.php:1697
 msgid "Approval status by users"
 msgstr ""
 
-#: src/CommonITILValidation.php:1849
+#: src/CommonITILValidation.php:1852
 msgid "Approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1954
+#: src/CommonITILValidation.php:1957
 msgid ""
 "This item is waiting for approval, do you really want to resolve or close "
 "it?"
@@ -33875,11 +33887,11 @@ msgstr ""
 "El elemento está a la espera de validación, ¿realmente quiere resolverlo o "
 "cerrarlo?"
 
-#: src/CommonITILValidation.php:1995
+#: src/CommonITILValidation.php:1998
 msgid "This item is waiting for approval."
 msgstr "Este ítem está esperando aprobación."
 
-#: src/CommonITILValidation.php:1996
+#: src/CommonITILValidation.php:1999
 msgid "Do you really want to resolve or close it?"
 msgstr "¿Realmente desea resolverlo o cerrarlo?"
 
@@ -34992,7 +35004,7 @@ msgstr "Expresión regular"
 
 #: js/src/vue/Kanban/Kanban.vue:1339
 msgid "Search or filter results"
-msgstr ""
+msgstr "Buscar o filtrar resultados"
 
 #: js/src/vue/Kanban/Kanban.vue:1342
 msgid "Add column"

--- a/locales/es_CL.po
+++ b/locales/es_CL.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-26 10:20+0000\n"
+"POT-Creation-Date: 2025-08-26 12:21+0000\n"
 "PO-Revision-Date: 2022-09-16 06:53+0000\n"
 "Last-Translator: alexandre delaunay <delaunay.alexandre@gmail.com>, 2025\n"
 "Language-Team: Spanish (Chile) (https://app.transifex.com/glpi/teams/1637/es_CL/)\n"
@@ -797,7 +797,7 @@ msgstr ""
 #: templates/components/itilobject/timeline/main_description.html.twig
 #: templates/components/user/info_card.html.twig
 #: templates/pages/tools/kb/comments.html.twig src/KnowbaseItem.php:245
-#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1188
+#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1191
 #: js/src/vue/CustomObject/FieldPreview/Field.vue:30
 msgid "Edit"
 msgstr "Editar"
@@ -1443,7 +1443,7 @@ msgid "Cancel"
 msgstr "Cancelar"
 
 #: templates/components/form/basic_inputs_macros.html.twig
-#: src/CommonITILValidation.php:1773
+#: src/CommonITILValidation.php:1776
 msgid "Validate"
 msgstr "Validar"
 
@@ -1965,7 +1965,7 @@ msgstr "Número de inventario"
 #: src/Computer.php:461 src/ProjectTask_Ticket.php:336 src/Certificate.php:278
 #: src/CronTask.php:1274 src/CronTask.php:1412
 #: src/CommonItilObject_Item.php:506 src/PDU.php:203 src/CommonDBTM.php:3513
-#: src/CommonITILValidation.php:1356 src/Plugin.php:2657
+#: src/CommonITILValidation.php:1359 src/Plugin.php:2657
 msgid "Status"
 msgstr "Estado"
 
@@ -3457,7 +3457,7 @@ msgstr[2] ""
 #: src/CommonITILObject.php:4737 src/CommonITILObject.php:4746
 #: src/CommonITILObject.php:6847 src/CommonITILObject.php:6894
 #: src/CommonITILObject.php:10159 src/NotificationTargetChange.php:308
-#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1498
+#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1501
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "Solicitante"
@@ -3468,7 +3468,7 @@ msgstr[2] "Solicitantes"
 #: src/NotificationTargetTicket.php:676 src/NotificationTargetTicket.php:706
 #: src/NotificationTargetCommonITILObject.php:976
 #: src/ITILValidationTemplate.php:81 src/NotificationTargetChange.php:327
-#: src/CommonITILValidation.php:1391 src/CommonITILValidation.php:1518
+#: src/CommonITILValidation.php:1394 src/CommonITILValidation.php:1521
 msgid "Approver"
 msgstr "Aprobador"
 
@@ -4209,7 +4209,7 @@ msgstr "No hay histórico"
 #: src/OAuthClient.php:94 src/Item_RemoteManagement.php:207
 #: src/Item_RemoteManagement.php:238 src/Certificate.php:125
 #: src/CronTask.php:1391 src/Contact.php:282 src/PDU.php:114
-#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1329
+#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1332
 #: src/Domain.php:233 src/Domain.php:257 src/ConsumableItem.php:167
 msgid "ID"
 msgstr "ID"
@@ -5757,7 +5757,7 @@ msgstr ""
 #: src/Project.php:904 src/ProjectTask.php:963
 #: src/NotificationTargetProjectTask.php:553
 #: src/NotificationTargetProjectTask.php:568 src/Cartridge.php:895
-#: src/CommonITILValidation.php:1252
+#: src/CommonITILValidation.php:1255
 msgctxt "item"
 msgid "State"
 msgstr "Estado"
@@ -17323,7 +17323,7 @@ msgid "Observer group except manager users"
 msgstr ""
 
 #: src/NotificationTargetCommonITILObject.php:973
-#: src/CommonITILValidation.php:1254 src/CommonITILValidation.php:1381
+#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1384
 msgid "Approval requester"
 msgstr "Solicitante de aprobación"
 
@@ -33058,7 +33058,7 @@ msgstr "Sin título de aprobación"
 msgid "Granted + Not subject to approval"
 msgstr "Concedida + No sujeto a aprobación"
 
-#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1836
+#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1839
 msgid "Group user(s)"
 msgstr ""
 
@@ -33071,77 +33071,89 @@ msgstr ""
 msgid "Progress: %1$s%% of %2$s%% required"
 msgstr ""
 
-#: src/CommonITILValidation.php:1253 src/CommonITILValidation.php:1365
-#: src/CommonITILValidation.php:1472
+#: src/CommonITILValidation.php:1127
+msgid "Approval step accepted"
+msgstr ""
+
+#: src/CommonITILValidation.php:1128
+msgid "Approval step refused"
+msgstr ""
+
+#: src/CommonITILValidation.php:1129
+msgid "Approval step pending"
+msgstr ""
+
+#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1368
+#: src/CommonITILValidation.php:1475
 msgid "Request date"
 msgstr "Fecha de solicitud"
 
-#: src/CommonITILValidation.php:1255 src/CommonITILValidation.php:1338
-#: src/CommonITILValidation.php:1430
+#: src/CommonITILValidation.php:1258 src/CommonITILValidation.php:1341
+#: src/CommonITILValidation.php:1433
 msgid "Request comments"
 msgstr "Comentario de solicitud"
 
-#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1373
-#: src/CommonITILValidation.php:1485
+#: src/CommonITILValidation.php:1259 src/CommonITILValidation.php:1376
+#: src/CommonITILValidation.php:1488
 msgid "Approval date"
 msgstr "Fecha de aprobación"
 
-#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1400
+#: src/CommonITILValidation.php:1260 src/CommonITILValidation.php:1403
 msgid "Requested approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1258
+#: src/CommonITILValidation.php:1261
 msgid "Requested approver"
 msgstr ""
 
-#: src/CommonITILValidation.php:1259
+#: src/CommonITILValidation.php:1262
 msgid "Approval Comment"
 msgstr ""
 
-#: src/CommonITILValidation.php:1260
+#: src/CommonITILValidation.php:1263
 #: src/NotificationTargetKnowbaseItem.php:218
 msgid "Documents"
 msgstr "Documentos"
 
-#: src/CommonITILValidation.php:1347 src/CommonITILValidation.php:1444
+#: src/CommonITILValidation.php:1350 src/CommonITILValidation.php:1447
 msgid "Approval comments"
 msgstr "Comentario de aprobación"
 
-#: src/CommonITILValidation.php:1459
+#: src/CommonITILValidation.php:1462
 msgid "Approval status"
 msgstr "Estado de aprovación"
 
-#: src/CommonITILValidation.php:1541
+#: src/CommonITILValidation.php:1544
 msgid "Approver substitute"
 msgstr ""
 
-#: src/CommonITILValidation.php:1601
+#: src/CommonITILValidation.php:1604
 msgid "Approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1623
+#: src/CommonITILValidation.php:1626
 msgid "Substitute of a member of approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1694
+#: src/CommonITILValidation.php:1697
 msgid "Approval status by users"
 msgstr ""
 
-#: src/CommonITILValidation.php:1849
+#: src/CommonITILValidation.php:1852
 msgid "Approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1954
+#: src/CommonITILValidation.php:1957
 msgid ""
 "This item is waiting for approval, do you really want to resolve or close "
 "it?"
 msgstr "Pendiente de aprobación. ¿Realmente quiere resolverlo o cerrarlo?"
 
-#: src/CommonITILValidation.php:1995
+#: src/CommonITILValidation.php:1998
 msgid "This item is waiting for approval."
 msgstr ""
 
-#: src/CommonITILValidation.php:1996
+#: src/CommonITILValidation.php:1999
 msgid "Do you really want to resolve or close it?"
 msgstr ""
 

--- a/locales/es_CO.po
+++ b/locales/es_CO.po
@@ -16,17 +16,17 @@
 # Andrey Amado Benavides <andrey66@gmail.com>, 2025
 # Vladimir Támara Patiño <vtamara@pasosdeJesus.org>, 2025
 # DOMBRE Julien <moyo@indepnet.net>, 2025
-# alexandre delaunay <delaunay.alexandre@gmail.com>, 2025
 # Haider López <hlopez@itsoluciones.com.co>, 2025
+# alexandre delaunay <delaunay.alexandre@gmail.com>, 2025
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-26 10:20+0000\n"
+"POT-Creation-Date: 2025-08-26 12:21+0000\n"
 "PO-Revision-Date: 2022-09-16 06:53+0000\n"
-"Last-Translator: Haider López <hlopez@itsoluciones.com.co>, 2025\n"
+"Last-Translator: alexandre delaunay <delaunay.alexandre@gmail.com>, 2025\n"
 "Language-Team: Spanish (Colombia) (https://app.transifex.com/glpi/teams/1637/es_CO/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -812,7 +812,7 @@ msgstr ""
 #: templates/components/itilobject/timeline/main_description.html.twig
 #: templates/components/user/info_card.html.twig
 #: templates/pages/tools/kb/comments.html.twig src/KnowbaseItem.php:245
-#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1188
+#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1191
 #: js/src/vue/CustomObject/FieldPreview/Field.vue:30
 msgid "Edit"
 msgstr "Editar"
@@ -1460,7 +1460,7 @@ msgid "Cancel"
 msgstr "Cancelar"
 
 #: templates/components/form/basic_inputs_macros.html.twig
-#: src/CommonITILValidation.php:1773
+#: src/CommonITILValidation.php:1776
 msgid "Validate"
 msgstr "Validar"
 
@@ -1984,7 +1984,7 @@ msgstr "Número de inventario"
 #: src/Computer.php:461 src/ProjectTask_Ticket.php:336 src/Certificate.php:278
 #: src/CronTask.php:1274 src/CronTask.php:1412
 #: src/CommonItilObject_Item.php:506 src/PDU.php:203 src/CommonDBTM.php:3513
-#: src/CommonITILValidation.php:1356 src/Plugin.php:2657
+#: src/CommonITILValidation.php:1359 src/Plugin.php:2657
 msgid "Status"
 msgstr "Estado"
 
@@ -3476,7 +3476,7 @@ msgstr[2] ""
 #: src/CommonITILObject.php:4737 src/CommonITILObject.php:4746
 #: src/CommonITILObject.php:6847 src/CommonITILObject.php:6894
 #: src/CommonITILObject.php:10159 src/NotificationTargetChange.php:308
-#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1498
+#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1501
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "Solicitante"
@@ -3487,7 +3487,7 @@ msgstr[2] "Solicitantes"
 #: src/NotificationTargetTicket.php:676 src/NotificationTargetTicket.php:706
 #: src/NotificationTargetCommonITILObject.php:976
 #: src/ITILValidationTemplate.php:81 src/NotificationTargetChange.php:327
-#: src/CommonITILValidation.php:1391 src/CommonITILValidation.php:1518
+#: src/CommonITILValidation.php:1394 src/CommonITILValidation.php:1521
 msgid "Approver"
 msgstr "Aprobador"
 
@@ -4228,7 +4228,7 @@ msgstr "No hay históricos"
 #: src/OAuthClient.php:94 src/Item_RemoteManagement.php:207
 #: src/Item_RemoteManagement.php:238 src/Certificate.php:125
 #: src/CronTask.php:1391 src/Contact.php:282 src/PDU.php:114
-#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1329
+#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1332
 #: src/Domain.php:233 src/Domain.php:257 src/ConsumableItem.php:167
 msgid "ID"
 msgstr "ID"
@@ -5778,7 +5778,7 @@ msgstr ""
 #: src/Project.php:904 src/ProjectTask.php:963
 #: src/NotificationTargetProjectTask.php:553
 #: src/NotificationTargetProjectTask.php:568 src/Cartridge.php:895
-#: src/CommonITILValidation.php:1252
+#: src/CommonITILValidation.php:1255
 msgctxt "item"
 msgid "State"
 msgstr "Estado"
@@ -17352,7 +17352,7 @@ msgid "Observer group except manager users"
 msgstr ""
 
 #: src/NotificationTargetCommonITILObject.php:973
-#: src/CommonITILValidation.php:1254 src/CommonITILValidation.php:1381
+#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1384
 msgid "Approval requester"
 msgstr "Solicitante de la aprobación"
 
@@ -33236,7 +33236,7 @@ msgstr "No está sujeto a una aprobación"
 msgid "Granted + Not subject to approval"
 msgstr "Concedido + No esta sujeto a aprobación"
 
-#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1836
+#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1839
 msgid "Group user(s)"
 msgstr ""
 
@@ -33249,67 +33249,79 @@ msgstr ""
 msgid "Progress: %1$s%% of %2$s%% required"
 msgstr ""
 
-#: src/CommonITILValidation.php:1253 src/CommonITILValidation.php:1365
-#: src/CommonITILValidation.php:1472
+#: src/CommonITILValidation.php:1127
+msgid "Approval step accepted"
+msgstr ""
+
+#: src/CommonITILValidation.php:1128
+msgid "Approval step refused"
+msgstr ""
+
+#: src/CommonITILValidation.php:1129
+msgid "Approval step pending"
+msgstr ""
+
+#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1368
+#: src/CommonITILValidation.php:1475
 msgid "Request date"
 msgstr "Fecha de la solicitud"
 
-#: src/CommonITILValidation.php:1255 src/CommonITILValidation.php:1338
-#: src/CommonITILValidation.php:1430
+#: src/CommonITILValidation.php:1258 src/CommonITILValidation.php:1341
+#: src/CommonITILValidation.php:1433
 msgid "Request comments"
 msgstr "Comentario de la solicitud"
 
-#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1373
-#: src/CommonITILValidation.php:1485
+#: src/CommonITILValidation.php:1259 src/CommonITILValidation.php:1376
+#: src/CommonITILValidation.php:1488
 msgid "Approval date"
 msgstr "Fecha de aprobación"
 
-#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1400
+#: src/CommonITILValidation.php:1260 src/CommonITILValidation.php:1403
 msgid "Requested approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1258
+#: src/CommonITILValidation.php:1261
 msgid "Requested approver"
 msgstr ""
 
-#: src/CommonITILValidation.php:1259
+#: src/CommonITILValidation.php:1262
 msgid "Approval Comment"
 msgstr ""
 
-#: src/CommonITILValidation.php:1260
+#: src/CommonITILValidation.php:1263
 #: src/NotificationTargetKnowbaseItem.php:218
 msgid "Documents"
 msgstr "Documentos"
 
-#: src/CommonITILValidation.php:1347 src/CommonITILValidation.php:1444
+#: src/CommonITILValidation.php:1350 src/CommonITILValidation.php:1447
 msgid "Approval comments"
 msgstr "Comentario de la aprobación"
 
-#: src/CommonITILValidation.php:1459
+#: src/CommonITILValidation.php:1462
 msgid "Approval status"
 msgstr "Estado de aprobación"
 
-#: src/CommonITILValidation.php:1541
+#: src/CommonITILValidation.php:1544
 msgid "Approver substitute"
 msgstr ""
 
-#: src/CommonITILValidation.php:1601
+#: src/CommonITILValidation.php:1604
 msgid "Approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1623
+#: src/CommonITILValidation.php:1626
 msgid "Substitute of a member of approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1694
+#: src/CommonITILValidation.php:1697
 msgid "Approval status by users"
 msgstr ""
 
-#: src/CommonITILValidation.php:1849
+#: src/CommonITILValidation.php:1852
 msgid "Approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1954
+#: src/CommonITILValidation.php:1957
 msgid ""
 "This item is waiting for approval, do you really want to resolve or close "
 "it?"
@@ -33317,11 +33329,11 @@ msgstr ""
 "Este asunto está en espera para ser aprobado, realmente quiere resolverlo o "
 "cerrarlo?"
 
-#: src/CommonITILValidation.php:1995
+#: src/CommonITILValidation.php:1998
 msgid "This item is waiting for approval."
 msgstr "Este elemento está esperando aprobación."
 
-#: src/CommonITILValidation.php:1996
+#: src/CommonITILValidation.php:1999
 msgid "Do you really want to resolve or close it?"
 msgstr "¿De verdad quieres resolverlo o cerrarlo?"
 
@@ -34419,7 +34431,7 @@ msgstr "Expresión regular"
 
 #: js/src/vue/Kanban/Kanban.vue:1339
 msgid "Search or filter results"
-msgstr ""
+msgstr "Buscar o filtrar resultados"
 
 #: js/src/vue/Kanban/Kanban.vue:1342
 msgid "Add column"

--- a/locales/es_EC.po
+++ b/locales/es_EC.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-26 10:20+0000\n"
+"POT-Creation-Date: 2025-08-26 12:21+0000\n"
 "PO-Revision-Date: 2022-09-16 06:53+0000\n"
 "Last-Translator: Soporte Infraestructura Standby, 2025\n"
 "Language-Team: Spanish (Ecuador) (https://app.transifex.com/glpi/teams/1637/es_EC/)\n"
@@ -804,7 +804,7 @@ msgstr ""
 #: templates/components/itilobject/timeline/main_description.html.twig
 #: templates/components/user/info_card.html.twig
 #: templates/pages/tools/kb/comments.html.twig src/KnowbaseItem.php:245
-#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1188
+#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1191
 #: js/src/vue/CustomObject/FieldPreview/Field.vue:30
 msgid "Edit"
 msgstr "Editar"
@@ -1452,7 +1452,7 @@ msgid "Cancel"
 msgstr "Cancelar"
 
 #: templates/components/form/basic_inputs_macros.html.twig
-#: src/CommonITILValidation.php:1773
+#: src/CommonITILValidation.php:1776
 msgid "Validate"
 msgstr "Validar"
 
@@ -1976,7 +1976,7 @@ msgstr "Número de inventario"
 #: src/Computer.php:461 src/ProjectTask_Ticket.php:336 src/Certificate.php:278
 #: src/CronTask.php:1274 src/CronTask.php:1412
 #: src/CommonItilObject_Item.php:506 src/PDU.php:203 src/CommonDBTM.php:3513
-#: src/CommonITILValidation.php:1356 src/Plugin.php:2657
+#: src/CommonITILValidation.php:1359 src/Plugin.php:2657
 msgid "Status"
 msgstr "Estado"
 
@@ -3471,7 +3471,7 @@ msgstr[2] ""
 #: src/CommonITILObject.php:4737 src/CommonITILObject.php:4746
 #: src/CommonITILObject.php:6847 src/CommonITILObject.php:6894
 #: src/CommonITILObject.php:10159 src/NotificationTargetChange.php:308
-#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1498
+#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1501
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "Solicitante"
@@ -3482,7 +3482,7 @@ msgstr[2] "Solicitantes"
 #: src/NotificationTargetTicket.php:676 src/NotificationTargetTicket.php:706
 #: src/NotificationTargetCommonITILObject.php:976
 #: src/ITILValidationTemplate.php:81 src/NotificationTargetChange.php:327
-#: src/CommonITILValidation.php:1391 src/CommonITILValidation.php:1518
+#: src/CommonITILValidation.php:1394 src/CommonITILValidation.php:1521
 msgid "Approver"
 msgstr "Aprobador"
 
@@ -4223,7 +4223,7 @@ msgstr "No hay históricos"
 #: src/OAuthClient.php:94 src/Item_RemoteManagement.php:207
 #: src/Item_RemoteManagement.php:238 src/Certificate.php:125
 #: src/CronTask.php:1391 src/Contact.php:282 src/PDU.php:114
-#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1329
+#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1332
 #: src/Domain.php:233 src/Domain.php:257 src/ConsumableItem.php:167
 msgid "ID"
 msgstr "ID"
@@ -5776,7 +5776,7 @@ msgstr ""
 #: src/Project.php:904 src/ProjectTask.php:963
 #: src/NotificationTargetProjectTask.php:553
 #: src/NotificationTargetProjectTask.php:568 src/Cartridge.php:895
-#: src/CommonITILValidation.php:1252
+#: src/CommonITILValidation.php:1255
 msgctxt "item"
 msgid "State"
 msgstr "Estado"
@@ -17437,7 +17437,7 @@ msgid "Observer group except manager users"
 msgstr ""
 
 #: src/NotificationTargetCommonITILObject.php:973
-#: src/CommonITILValidation.php:1254 src/CommonITILValidation.php:1381
+#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1384
 msgid "Approval requester"
 msgstr "Solicitante de la aprobación"
 
@@ -33614,7 +33614,7 @@ msgstr "No está sujeto a una aprobación"
 msgid "Granted + Not subject to approval"
 msgstr "Concedido + No esta sujeto a aprobación"
 
-#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1836
+#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1839
 msgid "Group user(s)"
 msgstr ""
 
@@ -33627,67 +33627,79 @@ msgstr ""
 msgid "Progress: %1$s%% of %2$s%% required"
 msgstr ""
 
-#: src/CommonITILValidation.php:1253 src/CommonITILValidation.php:1365
-#: src/CommonITILValidation.php:1472
+#: src/CommonITILValidation.php:1127
+msgid "Approval step accepted"
+msgstr ""
+
+#: src/CommonITILValidation.php:1128
+msgid "Approval step refused"
+msgstr ""
+
+#: src/CommonITILValidation.php:1129
+msgid "Approval step pending"
+msgstr ""
+
+#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1368
+#: src/CommonITILValidation.php:1475
 msgid "Request date"
 msgstr "Fecha de la solicitud"
 
-#: src/CommonITILValidation.php:1255 src/CommonITILValidation.php:1338
-#: src/CommonITILValidation.php:1430
+#: src/CommonITILValidation.php:1258 src/CommonITILValidation.php:1341
+#: src/CommonITILValidation.php:1433
 msgid "Request comments"
 msgstr "Comentario de la solicitud"
 
-#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1373
-#: src/CommonITILValidation.php:1485
+#: src/CommonITILValidation.php:1259 src/CommonITILValidation.php:1376
+#: src/CommonITILValidation.php:1488
 msgid "Approval date"
 msgstr "Fecha de aprobación"
 
-#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1400
+#: src/CommonITILValidation.php:1260 src/CommonITILValidation.php:1403
 msgid "Requested approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1258
+#: src/CommonITILValidation.php:1261
 msgid "Requested approver"
 msgstr ""
 
-#: src/CommonITILValidation.php:1259
+#: src/CommonITILValidation.php:1262
 msgid "Approval Comment"
 msgstr ""
 
-#: src/CommonITILValidation.php:1260
+#: src/CommonITILValidation.php:1263
 #: src/NotificationTargetKnowbaseItem.php:218
 msgid "Documents"
 msgstr "Documentos"
 
-#: src/CommonITILValidation.php:1347 src/CommonITILValidation.php:1444
+#: src/CommonITILValidation.php:1350 src/CommonITILValidation.php:1447
 msgid "Approval comments"
 msgstr "Comentario de la aprobación"
 
-#: src/CommonITILValidation.php:1459
+#: src/CommonITILValidation.php:1462
 msgid "Approval status"
 msgstr "Estado de aprobación"
 
-#: src/CommonITILValidation.php:1541
+#: src/CommonITILValidation.php:1544
 msgid "Approver substitute"
 msgstr ""
 
-#: src/CommonITILValidation.php:1601
+#: src/CommonITILValidation.php:1604
 msgid "Approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1623
+#: src/CommonITILValidation.php:1626
 msgid "Substitute of a member of approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1694
+#: src/CommonITILValidation.php:1697
 msgid "Approval status by users"
 msgstr ""
 
-#: src/CommonITILValidation.php:1849
+#: src/CommonITILValidation.php:1852
 msgid "Approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1954
+#: src/CommonITILValidation.php:1957
 msgid ""
 "This item is waiting for approval, do you really want to resolve or close "
 "it?"
@@ -33695,11 +33707,11 @@ msgstr ""
 "Este elemento está a la espera de aprobación, ¿realmente desea resolverlo o "
 "cerrarlo?"
 
-#: src/CommonITILValidation.php:1995
+#: src/CommonITILValidation.php:1998
 msgid "This item is waiting for approval."
 msgstr "Este elemento está a la espera de aprobación."
 
-#: src/CommonITILValidation.php:1996
+#: src/CommonITILValidation.php:1999
 msgid "Do you really want to resolve or close it?"
 msgstr "¿Realmente quiere resolverlo o cerrarlo?"
 
@@ -34807,7 +34819,7 @@ msgstr "Regex"
 
 #: js/src/vue/Kanban/Kanban.vue:1339
 msgid "Search or filter results"
-msgstr ""
+msgstr "Buscar o filtrar resultados"
 
 #: js/src/vue/Kanban/Kanban.vue:1342
 msgid "Add column"

--- a/locales/es_ES.po
+++ b/locales/es_ES.po
@@ -33,7 +33,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-26 10:20+0000\n"
+"POT-Creation-Date: 2025-08-26 12:21+0000\n"
 "PO-Revision-Date: 2022-09-16 06:53+0000\n"
 "Last-Translator: alexandre delaunay <delaunay.alexandre@gmail.com>, 2025\n"
 "Language-Team: Spanish (Spain) (https://app.transifex.com/glpi/teams/1637/es_ES/)\n"
@@ -821,7 +821,7 @@ msgstr ""
 #: templates/components/itilobject/timeline/main_description.html.twig
 #: templates/components/user/info_card.html.twig
 #: templates/pages/tools/kb/comments.html.twig src/KnowbaseItem.php:245
-#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1188
+#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1191
 #: js/src/vue/CustomObject/FieldPreview/Field.vue:30
 msgid "Edit"
 msgstr "Editar"
@@ -1469,7 +1469,7 @@ msgid "Cancel"
 msgstr "Cancelar"
 
 #: templates/components/form/basic_inputs_macros.html.twig
-#: src/CommonITILValidation.php:1773
+#: src/CommonITILValidation.php:1776
 msgid "Validate"
 msgstr "Validar"
 
@@ -1990,7 +1990,7 @@ msgstr "Número de inventario"
 #: src/Computer.php:461 src/ProjectTask_Ticket.php:336 src/Certificate.php:278
 #: src/CronTask.php:1274 src/CronTask.php:1412
 #: src/CommonItilObject_Item.php:506 src/PDU.php:203 src/CommonDBTM.php:3513
-#: src/CommonITILValidation.php:1356 src/Plugin.php:2657
+#: src/CommonITILValidation.php:1359 src/Plugin.php:2657
 msgid "Status"
 msgstr "Estado"
 
@@ -3483,7 +3483,7 @@ msgstr[2] ""
 #: src/CommonITILObject.php:4737 src/CommonITILObject.php:4746
 #: src/CommonITILObject.php:6847 src/CommonITILObject.php:6894
 #: src/CommonITILObject.php:10159 src/NotificationTargetChange.php:308
-#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1498
+#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1501
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "Solicitante"
@@ -3494,7 +3494,7 @@ msgstr[2] "Solicitantes"
 #: src/NotificationTargetTicket.php:676 src/NotificationTargetTicket.php:706
 #: src/NotificationTargetCommonITILObject.php:976
 #: src/ITILValidationTemplate.php:81 src/NotificationTargetChange.php:327
-#: src/CommonITILValidation.php:1391 src/CommonITILValidation.php:1518
+#: src/CommonITILValidation.php:1394 src/CommonITILValidation.php:1521
 msgid "Approver"
 msgstr "Responsable de validación"
 
@@ -4235,7 +4235,7 @@ msgstr "No hay histórico"
 #: src/OAuthClient.php:94 src/Item_RemoteManagement.php:207
 #: src/Item_RemoteManagement.php:238 src/Certificate.php:125
 #: src/CronTask.php:1391 src/Contact.php:282 src/PDU.php:114
-#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1329
+#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1332
 #: src/Domain.php:233 src/Domain.php:257 src/ConsumableItem.php:167
 msgid "ID"
 msgstr "ID"
@@ -5787,7 +5787,7 @@ msgstr ""
 #: src/Project.php:904 src/ProjectTask.php:963
 #: src/NotificationTargetProjectTask.php:553
 #: src/NotificationTargetProjectTask.php:568 src/Cartridge.php:895
-#: src/CommonITILValidation.php:1252
+#: src/CommonITILValidation.php:1255
 msgctxt "item"
 msgid "State"
 msgstr "Estado"
@@ -17403,7 +17403,7 @@ msgid "Observer group except manager users"
 msgstr ""
 
 #: src/NotificationTargetCommonITILObject.php:973
-#: src/CommonITILValidation.php:1254 src/CommonITILValidation.php:1381
+#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1384
 msgid "Approval requester"
 msgstr "Solicitante de la validación"
 
@@ -33411,7 +33411,7 @@ msgstr "No está sujeto a validación"
 msgid "Granted + Not subject to approval"
 msgstr "Concedido + No sujeto a validación"
 
-#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1836
+#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1839
 msgid "Group user(s)"
 msgstr ""
 
@@ -33424,67 +33424,79 @@ msgstr ""
 msgid "Progress: %1$s%% of %2$s%% required"
 msgstr ""
 
-#: src/CommonITILValidation.php:1253 src/CommonITILValidation.php:1365
-#: src/CommonITILValidation.php:1472
+#: src/CommonITILValidation.php:1127
+msgid "Approval step accepted"
+msgstr ""
+
+#: src/CommonITILValidation.php:1128
+msgid "Approval step refused"
+msgstr ""
+
+#: src/CommonITILValidation.php:1129
+msgid "Approval step pending"
+msgstr ""
+
+#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1368
+#: src/CommonITILValidation.php:1475
 msgid "Request date"
 msgstr "Fecha de la petición"
 
-#: src/CommonITILValidation.php:1255 src/CommonITILValidation.php:1338
-#: src/CommonITILValidation.php:1430
+#: src/CommonITILValidation.php:1258 src/CommonITILValidation.php:1341
+#: src/CommonITILValidation.php:1433
 msgid "Request comments"
 msgstr "Comentarios de la petición"
 
-#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1373
-#: src/CommonITILValidation.php:1485
+#: src/CommonITILValidation.php:1259 src/CommonITILValidation.php:1376
+#: src/CommonITILValidation.php:1488
 msgid "Approval date"
 msgstr "Fecha de la validación"
 
-#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1400
+#: src/CommonITILValidation.php:1260 src/CommonITILValidation.php:1403
 msgid "Requested approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1258
+#: src/CommonITILValidation.php:1261
 msgid "Requested approver"
 msgstr ""
 
-#: src/CommonITILValidation.php:1259
+#: src/CommonITILValidation.php:1262
 msgid "Approval Comment"
 msgstr ""
 
-#: src/CommonITILValidation.php:1260
+#: src/CommonITILValidation.php:1263
 #: src/NotificationTargetKnowbaseItem.php:218
 msgid "Documents"
 msgstr "Documentos"
 
-#: src/CommonITILValidation.php:1347 src/CommonITILValidation.php:1444
+#: src/CommonITILValidation.php:1350 src/CommonITILValidation.php:1447
 msgid "Approval comments"
 msgstr "Comentarios de la validación"
 
-#: src/CommonITILValidation.php:1459
+#: src/CommonITILValidation.php:1462
 msgid "Approval status"
 msgstr "Estado de aprobación"
 
-#: src/CommonITILValidation.php:1541
+#: src/CommonITILValidation.php:1544
 msgid "Approver substitute"
 msgstr ""
 
-#: src/CommonITILValidation.php:1601
+#: src/CommonITILValidation.php:1604
 msgid "Approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1623
+#: src/CommonITILValidation.php:1626
 msgid "Substitute of a member of approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1694
+#: src/CommonITILValidation.php:1697
 msgid "Approval status by users"
 msgstr ""
 
-#: src/CommonITILValidation.php:1849
+#: src/CommonITILValidation.php:1852
 msgid "Approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1954
+#: src/CommonITILValidation.php:1957
 msgid ""
 "This item is waiting for approval, do you really want to resolve or close "
 "it?"
@@ -33492,11 +33504,11 @@ msgstr ""
 "Este elemento está en espera de aprobación, ¿realmente quiere resolverlo o "
 "cerrarlo?"
 
-#: src/CommonITILValidation.php:1995
+#: src/CommonITILValidation.php:1998
 msgid "This item is waiting for approval."
 msgstr "Este elemento está en espera de aprobación."
 
-#: src/CommonITILValidation.php:1996
+#: src/CommonITILValidation.php:1999
 msgid "Do you really want to resolve or close it?"
 msgstr "¿De verdad quieres resolverlo o cerrarlo?"
 

--- a/locales/es_MX.po
+++ b/locales/es_MX.po
@@ -21,7 +21,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-26 10:20+0000\n"
+"POT-Creation-Date: 2025-08-26 12:21+0000\n"
 "PO-Revision-Date: 2022-09-16 06:53+0000\n"
 "Last-Translator: alberto cruz <alberto.cruz.77@gmail.com>, 2025\n"
 "Language-Team: Spanish (Mexico) (https://app.transifex.com/glpi/teams/1637/es_MX/)\n"
@@ -810,7 +810,7 @@ msgstr ""
 #: templates/components/itilobject/timeline/main_description.html.twig
 #: templates/components/user/info_card.html.twig
 #: templates/pages/tools/kb/comments.html.twig src/KnowbaseItem.php:245
-#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1188
+#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1191
 #: js/src/vue/CustomObject/FieldPreview/Field.vue:30
 msgid "Edit"
 msgstr "Editar"
@@ -1458,7 +1458,7 @@ msgid "Cancel"
 msgstr "Cancelar"
 
 #: templates/components/form/basic_inputs_macros.html.twig
-#: src/CommonITILValidation.php:1773
+#: src/CommonITILValidation.php:1776
 msgid "Validate"
 msgstr "Validar"
 
@@ -1981,7 +1981,7 @@ msgstr "Número de inventario"
 #: src/Computer.php:461 src/ProjectTask_Ticket.php:336 src/Certificate.php:278
 #: src/CronTask.php:1274 src/CronTask.php:1412
 #: src/CommonItilObject_Item.php:506 src/PDU.php:203 src/CommonDBTM.php:3513
-#: src/CommonITILValidation.php:1356 src/Plugin.php:2657
+#: src/CommonITILValidation.php:1359 src/Plugin.php:2657
 msgid "Status"
 msgstr "Estado"
 
@@ -3477,7 +3477,7 @@ msgstr[2] ""
 #: src/CommonITILObject.php:4737 src/CommonITILObject.php:4746
 #: src/CommonITILObject.php:6847 src/CommonITILObject.php:6894
 #: src/CommonITILObject.php:10159 src/NotificationTargetChange.php:308
-#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1498
+#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1501
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "Solicitante"
@@ -3488,7 +3488,7 @@ msgstr[2] "Solicitantes"
 #: src/NotificationTargetTicket.php:676 src/NotificationTargetTicket.php:706
 #: src/NotificationTargetCommonITILObject.php:976
 #: src/ITILValidationTemplate.php:81 src/NotificationTargetChange.php:327
-#: src/CommonITILValidation.php:1391 src/CommonITILValidation.php:1518
+#: src/CommonITILValidation.php:1394 src/CommonITILValidation.php:1521
 msgid "Approver"
 msgstr "Aprobador"
 
@@ -4229,7 +4229,7 @@ msgstr "Sin histórico"
 #: src/OAuthClient.php:94 src/Item_RemoteManagement.php:207
 #: src/Item_RemoteManagement.php:238 src/Certificate.php:125
 #: src/CronTask.php:1391 src/Contact.php:282 src/PDU.php:114
-#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1329
+#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1332
 #: src/Domain.php:233 src/Domain.php:257 src/ConsumableItem.php:167
 msgid "ID"
 msgstr "ID"
@@ -5791,7 +5791,7 @@ msgstr ""
 #: src/Project.php:904 src/ProjectTask.php:963
 #: src/NotificationTargetProjectTask.php:553
 #: src/NotificationTargetProjectTask.php:568 src/Cartridge.php:895
-#: src/CommonITILValidation.php:1252
+#: src/CommonITILValidation.php:1255
 msgctxt "item"
 msgid "State"
 msgstr "Estado"
@@ -17479,7 +17479,7 @@ msgid "Observer group except manager users"
 msgstr "Grupo supervisor excepto administradores"
 
 #: src/NotificationTargetCommonITILObject.php:973
-#: src/CommonITILValidation.php:1254 src/CommonITILValidation.php:1381
+#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1384
 msgid "Approval requester"
 msgstr "Solicitante de aprobación"
 
@@ -33649,7 +33649,7 @@ msgstr "No está sujeto a aprobación"
 msgid "Granted + Not subject to approval"
 msgstr "Concedida + No sujeto a aprobación"
 
-#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1836
+#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1839
 msgid "Group user(s)"
 msgstr "Usuario(s) de grupo"
 
@@ -33662,67 +33662,79 @@ msgstr ""
 msgid "Progress: %1$s%% of %2$s%% required"
 msgstr ""
 
-#: src/CommonITILValidation.php:1253 src/CommonITILValidation.php:1365
-#: src/CommonITILValidation.php:1472
+#: src/CommonITILValidation.php:1127
+msgid "Approval step accepted"
+msgstr ""
+
+#: src/CommonITILValidation.php:1128
+msgid "Approval step refused"
+msgstr ""
+
+#: src/CommonITILValidation.php:1129
+msgid "Approval step pending"
+msgstr ""
+
+#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1368
+#: src/CommonITILValidation.php:1475
 msgid "Request date"
 msgstr "Fecha de solicitud"
 
-#: src/CommonITILValidation.php:1255 src/CommonITILValidation.php:1338
-#: src/CommonITILValidation.php:1430
+#: src/CommonITILValidation.php:1258 src/CommonITILValidation.php:1341
+#: src/CommonITILValidation.php:1433
 msgid "Request comments"
 msgstr "Comentarios"
 
-#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1373
-#: src/CommonITILValidation.php:1485
+#: src/CommonITILValidation.php:1259 src/CommonITILValidation.php:1376
+#: src/CommonITILValidation.php:1488
 msgid "Approval date"
 msgstr "Fecha de aprobación"
 
-#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1400
+#: src/CommonITILValidation.php:1260 src/CommonITILValidation.php:1403
 msgid "Requested approver type"
 msgstr "Tipo de aprobador solicitado"
 
-#: src/CommonITILValidation.php:1258
+#: src/CommonITILValidation.php:1261
 msgid "Requested approver"
 msgstr "Aprobador solicitado"
 
-#: src/CommonITILValidation.php:1259
+#: src/CommonITILValidation.php:1262
 msgid "Approval Comment"
 msgstr ""
 
-#: src/CommonITILValidation.php:1260
+#: src/CommonITILValidation.php:1263
 #: src/NotificationTargetKnowbaseItem.php:218
 msgid "Documents"
 msgstr "Documentos"
 
-#: src/CommonITILValidation.php:1347 src/CommonITILValidation.php:1444
+#: src/CommonITILValidation.php:1350 src/CommonITILValidation.php:1447
 msgid "Approval comments"
 msgstr "Comentario de aprobación"
 
-#: src/CommonITILValidation.php:1459
+#: src/CommonITILValidation.php:1462
 msgid "Approval status"
 msgstr "Estado de la aprobación"
 
-#: src/CommonITILValidation.php:1541
+#: src/CommonITILValidation.php:1544
 msgid "Approver substitute"
 msgstr ""
 
-#: src/CommonITILValidation.php:1601
+#: src/CommonITILValidation.php:1604
 msgid "Approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1623
+#: src/CommonITILValidation.php:1626
 msgid "Substitute of a member of approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1694
+#: src/CommonITILValidation.php:1697
 msgid "Approval status by users"
 msgstr ""
 
-#: src/CommonITILValidation.php:1849
+#: src/CommonITILValidation.php:1852
 msgid "Approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1954
+#: src/CommonITILValidation.php:1957
 msgid ""
 "This item is waiting for approval, do you really want to resolve or close "
 "it?"
@@ -33730,11 +33742,11 @@ msgstr ""
 "El elemento está a la espera de validación, ¿realmente quieres resolverlo o "
 "cerrarlo?"
 
-#: src/CommonITILValidation.php:1995
+#: src/CommonITILValidation.php:1998
 msgid "This item is waiting for approval."
 msgstr "Elemento en espera de aprobación"
 
-#: src/CommonITILValidation.php:1996
+#: src/CommonITILValidation.php:1999
 msgid "Do you really want to resolve or close it?"
 msgstr "¿Deseas resolverlo o cerrarlo?"
 

--- a/locales/es_VE.po
+++ b/locales/es_VE.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-26 10:20+0000\n"
+"POT-Creation-Date: 2025-08-26 12:21+0000\n"
 "PO-Revision-Date: 2022-09-16 06:53+0000\n"
 "Last-Translator: Francisco Bolivar, 2025\n"
 "Language-Team: Spanish (Venezuela) (https://app.transifex.com/glpi/teams/1637/es_VE/)\n"
@@ -806,7 +806,7 @@ msgstr "Modo de solo lectura"
 #: templates/components/itilobject/timeline/main_description.html.twig
 #: templates/components/user/info_card.html.twig
 #: templates/pages/tools/kb/comments.html.twig src/KnowbaseItem.php:245
-#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1188
+#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1191
 #: js/src/vue/CustomObject/FieldPreview/Field.vue:30
 msgid "Edit"
 msgstr "Editar"
@@ -1456,7 +1456,7 @@ msgid "Cancel"
 msgstr "Anular"
 
 #: templates/components/form/basic_inputs_macros.html.twig
-#: src/CommonITILValidation.php:1773
+#: src/CommonITILValidation.php:1776
 msgid "Validate"
 msgstr "Validar"
 
@@ -1978,7 +1978,7 @@ msgstr "Número de inventario"
 #: src/Computer.php:461 src/ProjectTask_Ticket.php:336 src/Certificate.php:278
 #: src/CronTask.php:1274 src/CronTask.php:1412
 #: src/CommonItilObject_Item.php:506 src/PDU.php:203 src/CommonDBTM.php:3513
-#: src/CommonITILValidation.php:1356 src/Plugin.php:2657
+#: src/CommonITILValidation.php:1359 src/Plugin.php:2657
 msgid "Status"
 msgstr "Estado"
 
@@ -3477,7 +3477,7 @@ msgstr[2] "Pasos de aprobación"
 #: src/CommonITILObject.php:4737 src/CommonITILObject.php:4746
 #: src/CommonITILObject.php:6847 src/CommonITILObject.php:6894
 #: src/CommonITILObject.php:10159 src/NotificationTargetChange.php:308
-#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1498
+#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1501
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "Solicitante"
@@ -3488,7 +3488,7 @@ msgstr[2] "Solicitantes"
 #: src/NotificationTargetTicket.php:676 src/NotificationTargetTicket.php:706
 #: src/NotificationTargetCommonITILObject.php:976
 #: src/ITILValidationTemplate.php:81 src/NotificationTargetChange.php:327
-#: src/CommonITILValidation.php:1391 src/CommonITILValidation.php:1518
+#: src/CommonITILValidation.php:1394 src/CommonITILValidation.php:1521
 msgid "Approver"
 msgstr "Autorizante"
 
@@ -4237,7 +4237,7 @@ msgstr "No hay histórico"
 #: src/OAuthClient.php:94 src/Item_RemoteManagement.php:207
 #: src/Item_RemoteManagement.php:238 src/Certificate.php:125
 #: src/CronTask.php:1391 src/Contact.php:282 src/PDU.php:114
-#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1329
+#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1332
 #: src/Domain.php:233 src/Domain.php:257 src/ConsumableItem.php:167
 msgid "ID"
 msgstr "ID"
@@ -5807,7 +5807,7 @@ msgstr ""
 #: src/Project.php:904 src/ProjectTask.php:963
 #: src/NotificationTargetProjectTask.php:553
 #: src/NotificationTargetProjectTask.php:568 src/Cartridge.php:895
-#: src/CommonITILValidation.php:1252
+#: src/CommonITILValidation.php:1255
 msgctxt "item"
 msgid "State"
 msgstr "Estado"
@@ -17602,7 +17602,7 @@ msgid "Observer group except manager users"
 msgstr "Grupo supervisores excepto usuarios administradores"
 
 #: src/NotificationTargetCommonITILObject.php:973
-#: src/CommonITILValidation.php:1254 src/CommonITILValidation.php:1381
+#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1384
 msgid "Approval requester"
 msgstr "Solicitante de la aprobación"
 
@@ -33898,7 +33898,7 @@ msgstr "No sujeto a aprobación"
 msgid "Granted + Not subject to approval"
 msgstr "Otorgado + No sujeto a aprobación"
 
-#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1836
+#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1839
 msgid "Group user(s)"
 msgstr "Grupo de usuario(s)"
 
@@ -33911,67 +33911,79 @@ msgstr "Editar paso de aprobación"
 msgid "Progress: %1$s%% of %2$s%% required"
 msgstr "Progreso: %1$s%% de %2$s%% requerido"
 
-#: src/CommonITILValidation.php:1253 src/CommonITILValidation.php:1365
-#: src/CommonITILValidation.php:1472
+#: src/CommonITILValidation.php:1127
+msgid "Approval step accepted"
+msgstr ""
+
+#: src/CommonITILValidation.php:1128
+msgid "Approval step refused"
+msgstr ""
+
+#: src/CommonITILValidation.php:1129
+msgid "Approval step pending"
+msgstr ""
+
+#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1368
+#: src/CommonITILValidation.php:1475
 msgid "Request date"
 msgstr "Fecha de solicitud"
 
-#: src/CommonITILValidation.php:1255 src/CommonITILValidation.php:1338
-#: src/CommonITILValidation.php:1430
+#: src/CommonITILValidation.php:1258 src/CommonITILValidation.php:1341
+#: src/CommonITILValidation.php:1433
 msgid "Request comments"
 msgstr "Comentarios del solicitante"
 
-#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1373
-#: src/CommonITILValidation.php:1485
+#: src/CommonITILValidation.php:1259 src/CommonITILValidation.php:1376
+#: src/CommonITILValidation.php:1488
 msgid "Approval date"
 msgstr "Fecha de aprobación"
 
-#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1400
+#: src/CommonITILValidation.php:1260 src/CommonITILValidation.php:1403
 msgid "Requested approver type"
 msgstr "Tipo de aprobador solicitado"
 
-#: src/CommonITILValidation.php:1258
+#: src/CommonITILValidation.php:1261
 msgid "Requested approver"
 msgstr "Aprobador solicitado"
 
-#: src/CommonITILValidation.php:1259
+#: src/CommonITILValidation.php:1262
 msgid "Approval Comment"
 msgstr "Comentario de aprobación"
 
-#: src/CommonITILValidation.php:1260
+#: src/CommonITILValidation.php:1263
 #: src/NotificationTargetKnowbaseItem.php:218
 msgid "Documents"
 msgstr "Documentos"
 
-#: src/CommonITILValidation.php:1347 src/CommonITILValidation.php:1444
+#: src/CommonITILValidation.php:1350 src/CommonITILValidation.php:1447
 msgid "Approval comments"
 msgstr "Comentarios de la aprobación"
 
-#: src/CommonITILValidation.php:1459
+#: src/CommonITILValidation.php:1462
 msgid "Approval status"
 msgstr "Estado de aprobación"
 
-#: src/CommonITILValidation.php:1541
+#: src/CommonITILValidation.php:1544
 msgid "Approver substitute"
 msgstr "Aprobador suplente"
 
-#: src/CommonITILValidation.php:1601
+#: src/CommonITILValidation.php:1604
 msgid "Approver group"
 msgstr "Grupo de aprobadores"
 
-#: src/CommonITILValidation.php:1623
+#: src/CommonITILValidation.php:1626
 msgid "Substitute of a member of approver group"
 msgstr "Sustituto de un miembro del grupo aprobador"
 
-#: src/CommonITILValidation.php:1694
+#: src/CommonITILValidation.php:1697
 msgid "Approval status by users"
 msgstr "Estado de aprobación por los usuarios"
 
-#: src/CommonITILValidation.php:1849
+#: src/CommonITILValidation.php:1852
 msgid "Approver type"
 msgstr "Tipo de aprobador"
 
-#: src/CommonITILValidation.php:1954
+#: src/CommonITILValidation.php:1957
 msgid ""
 "This item is waiting for approval, do you really want to resolve or close "
 "it?"
@@ -33979,11 +33991,11 @@ msgstr ""
 "El elemento está a la espera de validación, ¿realmente quiere resolverlo o "
 "cerrarlo?"
 
-#: src/CommonITILValidation.php:1995
+#: src/CommonITILValidation.php:1998
 msgid "This item is waiting for approval."
 msgstr "Este elemento está esperando aprobación."
 
-#: src/CommonITILValidation.php:1996
+#: src/CommonITILValidation.php:1999
 msgid "Do you really want to resolve or close it?"
 msgstr "¿Realmente desea resolverlo o cerrarlo?"
 

--- a/locales/et_EE.po
+++ b/locales/et_EE.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-26 10:20+0000\n"
+"POT-Creation-Date: 2025-08-26 12:21+0000\n"
 "PO-Revision-Date: 2022-09-16 06:53+0000\n"
 "Last-Translator: alexandre delaunay <delaunay.alexandre@gmail.com>, 2025\n"
 "Language-Team: Estonian (Estonia) (https://app.transifex.com/glpi/teams/1637/et_EE/)\n"
@@ -792,7 +792,7 @@ msgstr ""
 #: templates/components/itilobject/timeline/main_description.html.twig
 #: templates/components/user/info_card.html.twig
 #: templates/pages/tools/kb/comments.html.twig src/KnowbaseItem.php:245
-#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1188
+#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1191
 #: js/src/vue/CustomObject/FieldPreview/Field.vue:30
 msgid "Edit"
 msgstr "Redigeeri"
@@ -1435,7 +1435,7 @@ msgid "Cancel"
 msgstr "Tühista"
 
 #: templates/components/form/basic_inputs_macros.html.twig
-#: src/CommonITILValidation.php:1773
+#: src/CommonITILValidation.php:1776
 msgid "Validate"
 msgstr "Valideeri"
 
@@ -1951,7 +1951,7 @@ msgstr "Inventarinumber"
 #: src/Computer.php:461 src/ProjectTask_Ticket.php:336 src/Certificate.php:278
 #: src/CronTask.php:1274 src/CronTask.php:1412
 #: src/CommonItilObject_Item.php:506 src/PDU.php:203 src/CommonDBTM.php:3513
-#: src/CommonITILValidation.php:1356 src/Plugin.php:2657
+#: src/CommonITILValidation.php:1359 src/Plugin.php:2657
 msgid "Status"
 msgstr "Olek"
 
@@ -3428,7 +3428,7 @@ msgstr[1] ""
 #: src/CommonITILObject.php:4737 src/CommonITILObject.php:4746
 #: src/CommonITILObject.php:6847 src/CommonITILObject.php:6894
 #: src/CommonITILObject.php:10159 src/NotificationTargetChange.php:308
-#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1498
+#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1501
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "Taotleja"
@@ -3438,7 +3438,7 @@ msgstr[1] "Taotlejad"
 #: src/NotificationTargetTicket.php:676 src/NotificationTargetTicket.php:706
 #: src/NotificationTargetCommonITILObject.php:976
 #: src/ITILValidationTemplate.php:81 src/NotificationTargetChange.php:327
-#: src/CommonITILValidation.php:1391 src/CommonITILValidation.php:1518
+#: src/CommonITILValidation.php:1394 src/CommonITILValidation.php:1521
 msgid "Approver"
 msgstr "Kinnitaja"
 
@@ -4174,7 +4174,7 @@ msgstr "Ajalugu puudub"
 #: src/OAuthClient.php:94 src/Item_RemoteManagement.php:207
 #: src/Item_RemoteManagement.php:238 src/Certificate.php:125
 #: src/CronTask.php:1391 src/Contact.php:282 src/PDU.php:114
-#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1329
+#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1332
 #: src/Domain.php:233 src/Domain.php:257 src/ConsumableItem.php:167
 msgid "ID"
 msgstr "ID"
@@ -5706,7 +5706,7 @@ msgstr ""
 #: src/Project.php:904 src/ProjectTask.php:963
 #: src/NotificationTargetProjectTask.php:553
 #: src/NotificationTargetProjectTask.php:568 src/Cartridge.php:895
-#: src/CommonITILValidation.php:1252
+#: src/CommonITILValidation.php:1255
 msgctxt "item"
 msgid "State"
 msgstr "Olek"
@@ -17110,7 +17110,7 @@ msgid "Observer group except manager users"
 msgstr ""
 
 #: src/NotificationTargetCommonITILObject.php:973
-#: src/CommonITILValidation.php:1254 src/CommonITILValidation.php:1381
+#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1384
 msgid "Approval requester"
 msgstr "Kinnituse taotleja"
 
@@ -32484,7 +32484,7 @@ msgstr "Ei vaja kinnitust"
 msgid "Granted + Not subject to approval"
 msgstr "Kinnitatud + Ei vaja kinnitust"
 
-#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1836
+#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1839
 msgid "Group user(s)"
 msgstr ""
 
@@ -32497,78 +32497,90 @@ msgstr ""
 msgid "Progress: %1$s%% of %2$s%% required"
 msgstr ""
 
-#: src/CommonITILValidation.php:1253 src/CommonITILValidation.php:1365
-#: src/CommonITILValidation.php:1472
+#: src/CommonITILValidation.php:1127
+msgid "Approval step accepted"
+msgstr ""
+
+#: src/CommonITILValidation.php:1128
+msgid "Approval step refused"
+msgstr ""
+
+#: src/CommonITILValidation.php:1129
+msgid "Approval step pending"
+msgstr ""
+
+#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1368
+#: src/CommonITILValidation.php:1475
 msgid "Request date"
 msgstr "Taotluse kuupäev"
 
-#: src/CommonITILValidation.php:1255 src/CommonITILValidation.php:1338
-#: src/CommonITILValidation.php:1430
+#: src/CommonITILValidation.php:1258 src/CommonITILValidation.php:1341
+#: src/CommonITILValidation.php:1433
 msgid "Request comments"
 msgstr "Taotluse kommentaar"
 
-#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1373
-#: src/CommonITILValidation.php:1485
+#: src/CommonITILValidation.php:1259 src/CommonITILValidation.php:1376
+#: src/CommonITILValidation.php:1488
 msgid "Approval date"
 msgstr "Kinnitamise kuupäev"
 
-#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1400
+#: src/CommonITILValidation.php:1260 src/CommonITILValidation.php:1403
 msgid "Requested approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1258
+#: src/CommonITILValidation.php:1261
 msgid "Requested approver"
 msgstr ""
 
-#: src/CommonITILValidation.php:1259
+#: src/CommonITILValidation.php:1262
 msgid "Approval Comment"
 msgstr ""
 
-#: src/CommonITILValidation.php:1260
+#: src/CommonITILValidation.php:1263
 #: src/NotificationTargetKnowbaseItem.php:218
 msgid "Documents"
 msgstr "Failid"
 
-#: src/CommonITILValidation.php:1347 src/CommonITILValidation.php:1444
+#: src/CommonITILValidation.php:1350 src/CommonITILValidation.php:1447
 msgid "Approval comments"
 msgstr "Vastuse seletus"
 
-#: src/CommonITILValidation.php:1459
+#: src/CommonITILValidation.php:1462
 msgid "Approval status"
 msgstr "Kinnituse olek"
 
-#: src/CommonITILValidation.php:1541
+#: src/CommonITILValidation.php:1544
 msgid "Approver substitute"
 msgstr ""
 
-#: src/CommonITILValidation.php:1601
+#: src/CommonITILValidation.php:1604
 msgid "Approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1623
+#: src/CommonITILValidation.php:1626
 msgid "Substitute of a member of approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1694
+#: src/CommonITILValidation.php:1697
 msgid "Approval status by users"
 msgstr ""
 
-#: src/CommonITILValidation.php:1849
+#: src/CommonITILValidation.php:1852
 msgid "Approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1954
+#: src/CommonITILValidation.php:1957
 msgid ""
 "This item is waiting for approval, do you really want to resolve or close "
 "it?"
 msgstr ""
 "See üksus ootab kinnitamist, kindel et soovid lahendada või sulgeda seda?"
 
-#: src/CommonITILValidation.php:1995
+#: src/CommonITILValidation.php:1998
 msgid "This item is waiting for approval."
 msgstr ""
 
-#: src/CommonITILValidation.php:1996
+#: src/CommonITILValidation.php:1999
 msgid "Do you really want to resolve or close it?"
 msgstr ""
 

--- a/locales/eu_ES.po
+++ b/locales/eu_ES.po
@@ -16,7 +16,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-26 10:20+0000\n"
+"POT-Creation-Date: 2025-08-26 12:21+0000\n"
 "PO-Revision-Date: 2022-09-16 06:53+0000\n"
 "Last-Translator: alexandre delaunay <delaunay.alexandre@gmail.com>, 2025\n"
 "Language-Team: Basque (Spain) (https://app.transifex.com/glpi/teams/1637/eu_ES/)\n"
@@ -791,7 +791,7 @@ msgstr "Soilik irakurtzeko modua"
 #: templates/components/itilobject/timeline/main_description.html.twig
 #: templates/components/user/info_card.html.twig
 #: templates/pages/tools/kb/comments.html.twig src/KnowbaseItem.php:245
-#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1188
+#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1191
 #: js/src/vue/CustomObject/FieldPreview/Field.vue:30
 msgid "Edit"
 msgstr "Editatu"
@@ -1434,7 +1434,7 @@ msgid "Cancel"
 msgstr "Ezeztatu"
 
 #: templates/components/form/basic_inputs_macros.html.twig
-#: src/CommonITILValidation.php:1773
+#: src/CommonITILValidation.php:1776
 msgid "Validate"
 msgstr "Balidatu"
 
@@ -1951,7 +1951,7 @@ msgstr "Inbentario zenbakia"
 #: src/Computer.php:461 src/ProjectTask_Ticket.php:336 src/Certificate.php:278
 #: src/CronTask.php:1274 src/CronTask.php:1412
 #: src/CommonItilObject_Item.php:506 src/PDU.php:203 src/CommonDBTM.php:3513
-#: src/CommonITILValidation.php:1356 src/Plugin.php:2657
+#: src/CommonITILValidation.php:1359 src/Plugin.php:2657
 msgid "Status"
 msgstr "Egoera"
 
@@ -3430,7 +3430,7 @@ msgstr[1] ""
 #: src/CommonITILObject.php:4737 src/CommonITILObject.php:4746
 #: src/CommonITILObject.php:6847 src/CommonITILObject.php:6894
 #: src/CommonITILObject.php:10159 src/NotificationTargetChange.php:308
-#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1498
+#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1501
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "Eskatzailea"
@@ -3440,7 +3440,7 @@ msgstr[1] "Eskatzaileak"
 #: src/NotificationTargetTicket.php:676 src/NotificationTargetTicket.php:706
 #: src/NotificationTargetCommonITILObject.php:976
 #: src/ITILValidationTemplate.php:81 src/NotificationTargetChange.php:327
-#: src/CommonITILValidation.php:1391 src/CommonITILValidation.php:1518
+#: src/CommonITILValidation.php:1394 src/CommonITILValidation.php:1521
 msgid "Approver"
 msgstr "Balidatzailea"
 
@@ -4174,7 +4174,7 @@ msgstr "Ez dago istorikorik"
 #: src/OAuthClient.php:94 src/Item_RemoteManagement.php:207
 #: src/Item_RemoteManagement.php:238 src/Certificate.php:125
 #: src/CronTask.php:1391 src/Contact.php:282 src/PDU.php:114
-#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1329
+#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1332
 #: src/Domain.php:233 src/Domain.php:257 src/ConsumableItem.php:167
 msgid "ID"
 msgstr "ID"
@@ -5709,7 +5709,7 @@ msgstr ""
 #: src/Project.php:904 src/ProjectTask.php:963
 #: src/NotificationTargetProjectTask.php:553
 #: src/NotificationTargetProjectTask.php:568 src/Cartridge.php:895
-#: src/CommonITILValidation.php:1252
+#: src/CommonITILValidation.php:1255
 msgctxt "item"
 msgid "State"
 msgstr "Egoera"
@@ -17146,7 +17146,7 @@ msgid "Observer group except manager users"
 msgstr ""
 
 #: src/NotificationTargetCommonITILObject.php:973
-#: src/CommonITILValidation.php:1254 src/CommonITILValidation.php:1381
+#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1384
 msgid "Approval requester"
 msgstr "Balioztatze eskatzailea"
 
@@ -32546,7 +32546,7 @@ msgstr "Ez du balioztatzerik behar"
 msgid "Granted + Not subject to approval"
 msgstr "Baimendua + onespenarako ez subjektua"
 
-#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1836
+#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1839
 msgid "Group user(s)"
 msgstr ""
 
@@ -32559,67 +32559,79 @@ msgstr ""
 msgid "Progress: %1$s%% of %2$s%% required"
 msgstr ""
 
-#: src/CommonITILValidation.php:1253 src/CommonITILValidation.php:1365
-#: src/CommonITILValidation.php:1472
+#: src/CommonITILValidation.php:1127
+msgid "Approval step accepted"
+msgstr ""
+
+#: src/CommonITILValidation.php:1128
+msgid "Approval step refused"
+msgstr ""
+
+#: src/CommonITILValidation.php:1129
+msgid "Approval step pending"
+msgstr ""
+
+#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1368
+#: src/CommonITILValidation.php:1475
 msgid "Request date"
 msgstr "Eskaera data"
 
-#: src/CommonITILValidation.php:1255 src/CommonITILValidation.php:1338
-#: src/CommonITILValidation.php:1430
+#: src/CommonITILValidation.php:1258 src/CommonITILValidation.php:1341
+#: src/CommonITILValidation.php:1433
 msgid "Request comments"
 msgstr "Eskaeraren iruzkina"
 
-#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1373
-#: src/CommonITILValidation.php:1485
+#: src/CommonITILValidation.php:1259 src/CommonITILValidation.php:1376
+#: src/CommonITILValidation.php:1488
 msgid "Approval date"
 msgstr "Balioztatze-data"
 
-#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1400
+#: src/CommonITILValidation.php:1260 src/CommonITILValidation.php:1403
 msgid "Requested approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1258
+#: src/CommonITILValidation.php:1261
 msgid "Requested approver"
 msgstr ""
 
-#: src/CommonITILValidation.php:1259
+#: src/CommonITILValidation.php:1262
 msgid "Approval Comment"
 msgstr ""
 
-#: src/CommonITILValidation.php:1260
+#: src/CommonITILValidation.php:1263
 #: src/NotificationTargetKnowbaseItem.php:218
 msgid "Documents"
 msgstr "Dokumentuak"
 
-#: src/CommonITILValidation.php:1347 src/CommonITILValidation.php:1444
+#: src/CommonITILValidation.php:1350 src/CommonITILValidation.php:1447
 msgid "Approval comments"
 msgstr "Balioztatzearen iruzkina"
 
-#: src/CommonITILValidation.php:1459
+#: src/CommonITILValidation.php:1462
 msgid "Approval status"
 msgstr "Onespen egoera"
 
-#: src/CommonITILValidation.php:1541
+#: src/CommonITILValidation.php:1544
 msgid "Approver substitute"
 msgstr ""
 
-#: src/CommonITILValidation.php:1601
+#: src/CommonITILValidation.php:1604
 msgid "Approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1623
+#: src/CommonITILValidation.php:1626
 msgid "Substitute of a member of approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1694
+#: src/CommonITILValidation.php:1697
 msgid "Approval status by users"
 msgstr ""
 
-#: src/CommonITILValidation.php:1849
+#: src/CommonITILValidation.php:1852
 msgid "Approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1954
+#: src/CommonITILValidation.php:1957
 msgid ""
 "This item is waiting for approval, do you really want to resolve or close "
 "it?"
@@ -32627,11 +32639,11 @@ msgstr ""
 "Elementu hau onespena itxaroten ari da, ziur zaude konpondu edo itxi nahi "
 "duzula?"
 
-#: src/CommonITILValidation.php:1995
+#: src/CommonITILValidation.php:1998
 msgid "This item is waiting for approval."
 msgstr ""
 
-#: src/CommonITILValidation.php:1996
+#: src/CommonITILValidation.php:1999
 msgid "Do you really want to resolve or close it?"
 msgstr ""
 

--- a/locales/fa_IR.po
+++ b/locales/fa_IR.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-26 10:20+0000\n"
+"POT-Creation-Date: 2025-08-26 12:21+0000\n"
 "PO-Revision-Date: 2022-09-16 06:53+0000\n"
 "Last-Translator: Mohammad Arfa, 2025\n"
 "Language-Team: Persian (Iran) (https://app.transifex.com/glpi/teams/1637/fa_IR/)\n"
@@ -796,7 +796,7 @@ msgstr "Read-only mode"
 #: templates/components/itilobject/timeline/main_description.html.twig
 #: templates/components/user/info_card.html.twig
 #: templates/pages/tools/kb/comments.html.twig src/KnowbaseItem.php:245
-#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1188
+#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1191
 #: js/src/vue/CustomObject/FieldPreview/Field.vue:30
 msgid "Edit"
 msgstr "Edit"
@@ -1443,7 +1443,7 @@ msgid "Cancel"
 msgstr "لغو"
 
 #: templates/components/form/basic_inputs_macros.html.twig
-#: src/CommonITILValidation.php:1773
+#: src/CommonITILValidation.php:1776
 msgid "Validate"
 msgstr "Validate"
 
@@ -1960,7 +1960,7 @@ msgstr "شماره فهرست اموال"
 #: src/Computer.php:461 src/ProjectTask_Ticket.php:336 src/Certificate.php:278
 #: src/CronTask.php:1274 src/CronTask.php:1412
 #: src/CommonItilObject_Item.php:506 src/PDU.php:203 src/CommonDBTM.php:3513
-#: src/CommonITILValidation.php:1356 src/Plugin.php:2657
+#: src/CommonITILValidation.php:1359 src/Plugin.php:2657
 msgid "Status"
 msgstr "وضعیت"
 
@@ -3443,7 +3443,7 @@ msgstr[1] "Approval step"
 #: src/CommonITILObject.php:4737 src/CommonITILObject.php:4746
 #: src/CommonITILObject.php:6847 src/CommonITILObject.php:6894
 #: src/CommonITILObject.php:10159 src/NotificationTargetChange.php:308
-#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1498
+#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1501
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "درخواست کننده"
@@ -3453,7 +3453,7 @@ msgstr[1] "درخواست کننده"
 #: src/NotificationTargetTicket.php:676 src/NotificationTargetTicket.php:706
 #: src/NotificationTargetCommonITILObject.php:976
 #: src/ITILValidationTemplate.php:81 src/NotificationTargetChange.php:327
-#: src/CommonITILValidation.php:1391 src/CommonITILValidation.php:1518
+#: src/CommonITILValidation.php:1394 src/CommonITILValidation.php:1521
 msgid "Approver"
 msgstr "تصویب کننده"
 
@@ -4194,7 +4194,7 @@ msgstr "نگذشته"
 #: src/OAuthClient.php:94 src/Item_RemoteManagement.php:207
 #: src/Item_RemoteManagement.php:238 src/Certificate.php:125
 #: src/CronTask.php:1391 src/Contact.php:282 src/PDU.php:114
-#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1329
+#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1332
 #: src/Domain.php:233 src/Domain.php:257 src/ConsumableItem.php:167
 msgid "ID"
 msgstr "شناسه"
@@ -5749,7 +5749,7 @@ msgstr ""
 #: src/Project.php:904 src/ProjectTask.php:963
 #: src/NotificationTargetProjectTask.php:553
 #: src/NotificationTargetProjectTask.php:568 src/Cartridge.php:895
-#: src/CommonITILValidation.php:1252
+#: src/CommonITILValidation.php:1255
 msgctxt "item"
 msgid "State"
 msgstr "وضعیت"
@@ -17338,7 +17338,7 @@ msgid "Observer group except manager users"
 msgstr "Observer group except manager users"
 
 #: src/NotificationTargetCommonITILObject.php:973
-#: src/CommonITILValidation.php:1254 src/CommonITILValidation.php:1381
+#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1384
 msgid "Approval requester"
 msgstr "درخواست کننده موافقت"
 
@@ -33108,7 +33108,7 @@ msgstr "هیچ موضوعی تایید نشده است"
 msgid "Granted + Not subject to approval"
 msgstr "Granted + Not subject to approval"
 
-#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1836
+#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1839
 msgid "Group user(s)"
 msgstr "Group user(s)"
 
@@ -33121,67 +33121,79 @@ msgstr "Edit approval step"
 msgid "Progress: %1$s%% of %2$s%% required"
 msgstr "Progress: %1$s%% of %2$s%% required"
 
-#: src/CommonITILValidation.php:1253 src/CommonITILValidation.php:1365
-#: src/CommonITILValidation.php:1472
+#: src/CommonITILValidation.php:1127
+msgid "Approval step accepted"
+msgstr ""
+
+#: src/CommonITILValidation.php:1128
+msgid "Approval step refused"
+msgstr ""
+
+#: src/CommonITILValidation.php:1129
+msgid "Approval step pending"
+msgstr ""
+
+#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1368
+#: src/CommonITILValidation.php:1475
 msgid "Request date"
 msgstr "تاریخ درخواست"
 
-#: src/CommonITILValidation.php:1255 src/CommonITILValidation.php:1338
-#: src/CommonITILValidation.php:1430
+#: src/CommonITILValidation.php:1258 src/CommonITILValidation.php:1341
+#: src/CommonITILValidation.php:1433
 msgid "Request comments"
 msgstr "توضیح درخواست"
 
-#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1373
-#: src/CommonITILValidation.php:1485
+#: src/CommonITILValidation.php:1259 src/CommonITILValidation.php:1376
+#: src/CommonITILValidation.php:1488
 msgid "Approval date"
 msgstr "تاریخ موافقت"
 
-#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1400
+#: src/CommonITILValidation.php:1260 src/CommonITILValidation.php:1403
 msgid "Requested approver type"
 msgstr "Requested approver type"
 
-#: src/CommonITILValidation.php:1258
+#: src/CommonITILValidation.php:1261
 msgid "Requested approver"
 msgstr "Requested approver"
 
-#: src/CommonITILValidation.php:1259
+#: src/CommonITILValidation.php:1262
 msgid "Approval Comment"
 msgstr "Approval Comment"
 
-#: src/CommonITILValidation.php:1260
+#: src/CommonITILValidation.php:1263
 #: src/NotificationTargetKnowbaseItem.php:218
 msgid "Documents"
 msgstr "Documents"
 
-#: src/CommonITILValidation.php:1347 src/CommonITILValidation.php:1444
+#: src/CommonITILValidation.php:1350 src/CommonITILValidation.php:1447
 msgid "Approval comments"
 msgstr "توضیح موافقت"
 
-#: src/CommonITILValidation.php:1459
+#: src/CommonITILValidation.php:1462
 msgid "Approval status"
 msgstr "Approval status"
 
-#: src/CommonITILValidation.php:1541
+#: src/CommonITILValidation.php:1544
 msgid "Approver substitute"
 msgstr "Approver substitute"
 
-#: src/CommonITILValidation.php:1601
+#: src/CommonITILValidation.php:1604
 msgid "Approver group"
 msgstr "Approver group"
 
-#: src/CommonITILValidation.php:1623
+#: src/CommonITILValidation.php:1626
 msgid "Substitute of a member of approver group"
 msgstr "Substitute of a member of approver group"
 
-#: src/CommonITILValidation.php:1694
+#: src/CommonITILValidation.php:1697
 msgid "Approval status by users"
 msgstr "Approval status by users"
 
-#: src/CommonITILValidation.php:1849
+#: src/CommonITILValidation.php:1852
 msgid "Approver type"
 msgstr "Approver type"
 
-#: src/CommonITILValidation.php:1954
+#: src/CommonITILValidation.php:1957
 msgid ""
 "This item is waiting for approval, do you really want to resolve or close "
 "it?"
@@ -33189,11 +33201,11 @@ msgstr ""
 "This item is waiting for approval, do you really want to resolve or close "
 "it?"
 
-#: src/CommonITILValidation.php:1995
+#: src/CommonITILValidation.php:1998
 msgid "This item is waiting for approval."
 msgstr "This item is waiting for approval."
 
-#: src/CommonITILValidation.php:1996
+#: src/CommonITILValidation.php:1999
 msgid "Do you really want to resolve or close it?"
 msgstr "Do you really want to resolve or close it?"
 

--- a/locales/fi_FI.po
+++ b/locales/fi_FI.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-26 10:20+0000\n"
+"POT-Creation-Date: 2025-08-26 12:21+0000\n"
 "PO-Revision-Date: 2022-09-16 06:53+0000\n"
 "Last-Translator: alexandre delaunay <delaunay.alexandre@gmail.com>, 2025\n"
 "Language-Team: Finnish (Finland) (https://app.transifex.com/glpi/teams/1637/fi_FI/)\n"
@@ -790,7 +790,7 @@ msgstr ""
 #: templates/components/itilobject/timeline/main_description.html.twig
 #: templates/components/user/info_card.html.twig
 #: templates/pages/tools/kb/comments.html.twig src/KnowbaseItem.php:245
-#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1188
+#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1191
 #: js/src/vue/CustomObject/FieldPreview/Field.vue:30
 msgid "Edit"
 msgstr "Muokkaa"
@@ -1434,7 +1434,7 @@ msgid "Cancel"
 msgstr "Peru"
 
 #: templates/components/form/basic_inputs_macros.html.twig
-#: src/CommonITILValidation.php:1773
+#: src/CommonITILValidation.php:1776
 msgid "Validate"
 msgstr "Hyväksy"
 
@@ -1951,7 +1951,7 @@ msgstr "Inventointinumero"
 #: src/Computer.php:461 src/ProjectTask_Ticket.php:336 src/Certificate.php:278
 #: src/CronTask.php:1274 src/CronTask.php:1412
 #: src/CommonItilObject_Item.php:506 src/PDU.php:203 src/CommonDBTM.php:3513
-#: src/CommonITILValidation.php:1356 src/Plugin.php:2657
+#: src/CommonITILValidation.php:1359 src/Plugin.php:2657
 msgid "Status"
 msgstr "Tila"
 
@@ -3428,7 +3428,7 @@ msgstr[1] ""
 #: src/CommonITILObject.php:4737 src/CommonITILObject.php:4746
 #: src/CommonITILObject.php:6847 src/CommonITILObject.php:6894
 #: src/CommonITILObject.php:10159 src/NotificationTargetChange.php:308
-#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1498
+#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1501
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "Toimeksiantaja"
@@ -3438,7 +3438,7 @@ msgstr[1] "Toimeksiantajat"
 #: src/NotificationTargetTicket.php:676 src/NotificationTargetTicket.php:706
 #: src/NotificationTargetCommonITILObject.php:976
 #: src/ITILValidationTemplate.php:81 src/NotificationTargetChange.php:327
-#: src/CommonITILValidation.php:1391 src/CommonITILValidation.php:1518
+#: src/CommonITILValidation.php:1394 src/CommonITILValidation.php:1521
 msgid "Approver"
 msgstr "Hyväksyjä"
 
@@ -4172,7 +4172,7 @@ msgstr "Ei historiaa"
 #: src/OAuthClient.php:94 src/Item_RemoteManagement.php:207
 #: src/Item_RemoteManagement.php:238 src/Certificate.php:125
 #: src/CronTask.php:1391 src/Contact.php:282 src/PDU.php:114
-#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1329
+#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1332
 #: src/Domain.php:233 src/Domain.php:257 src/ConsumableItem.php:167
 msgid "ID"
 msgstr "Tunnus"
@@ -5706,7 +5706,7 @@ msgstr ""
 #: src/Project.php:904 src/ProjectTask.php:963
 #: src/NotificationTargetProjectTask.php:553
 #: src/NotificationTargetProjectTask.php:568 src/Cartridge.php:895
-#: src/CommonITILValidation.php:1252
+#: src/CommonITILValidation.php:1255
 msgctxt "item"
 msgid "State"
 msgstr "Tila"
@@ -17123,7 +17123,7 @@ msgid "Observer group except manager users"
 msgstr ""
 
 #: src/NotificationTargetCommonITILObject.php:973
-#: src/CommonITILValidation.php:1254 src/CommonITILValidation.php:1381
+#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1384
 msgid "Approval requester"
 msgstr "Hyväksynnän pyytäjä"
 
@@ -32489,7 +32489,7 @@ msgstr "Hyväksyntää ei ole pyydetty"
 msgid "Granted + Not subject to approval"
 msgstr "Hyväksytty + hyväksyntää ei ole pyydetty"
 
-#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1836
+#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1839
 msgid "Group user(s)"
 msgstr ""
 
@@ -32502,78 +32502,90 @@ msgstr ""
 msgid "Progress: %1$s%% of %2$s%% required"
 msgstr ""
 
-#: src/CommonITILValidation.php:1253 src/CommonITILValidation.php:1365
-#: src/CommonITILValidation.php:1472
+#: src/CommonITILValidation.php:1127
+msgid "Approval step accepted"
+msgstr ""
+
+#: src/CommonITILValidation.php:1128
+msgid "Approval step refused"
+msgstr ""
+
+#: src/CommonITILValidation.php:1129
+msgid "Approval step pending"
+msgstr ""
+
+#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1368
+#: src/CommonITILValidation.php:1475
 msgid "Request date"
 msgstr "Palvelupyynnön päiväys"
 
-#: src/CommonITILValidation.php:1255 src/CommonITILValidation.php:1338
-#: src/CommonITILValidation.php:1430
+#: src/CommonITILValidation.php:1258 src/CommonITILValidation.php:1341
+#: src/CommonITILValidation.php:1433
 msgid "Request comments"
 msgstr "Palvelupyynnön kommentit"
 
-#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1373
-#: src/CommonITILValidation.php:1485
+#: src/CommonITILValidation.php:1259 src/CommonITILValidation.php:1376
+#: src/CommonITILValidation.php:1488
 msgid "Approval date"
 msgstr "Hyväksynnän päiväys"
 
-#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1400
+#: src/CommonITILValidation.php:1260 src/CommonITILValidation.php:1403
 msgid "Requested approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1258
+#: src/CommonITILValidation.php:1261
 msgid "Requested approver"
 msgstr ""
 
-#: src/CommonITILValidation.php:1259
+#: src/CommonITILValidation.php:1262
 msgid "Approval Comment"
 msgstr ""
 
-#: src/CommonITILValidation.php:1260
+#: src/CommonITILValidation.php:1263
 #: src/NotificationTargetKnowbaseItem.php:218
 msgid "Documents"
 msgstr "Asiakirjat"
 
-#: src/CommonITILValidation.php:1347 src/CommonITILValidation.php:1444
+#: src/CommonITILValidation.php:1350 src/CommonITILValidation.php:1447
 msgid "Approval comments"
 msgstr "Hyväksynnän kommentit"
 
-#: src/CommonITILValidation.php:1459
+#: src/CommonITILValidation.php:1462
 msgid "Approval status"
 msgstr "Hyväksynnän tila"
 
-#: src/CommonITILValidation.php:1541
+#: src/CommonITILValidation.php:1544
 msgid "Approver substitute"
 msgstr ""
 
-#: src/CommonITILValidation.php:1601
+#: src/CommonITILValidation.php:1604
 msgid "Approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1623
+#: src/CommonITILValidation.php:1626
 msgid "Substitute of a member of approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1694
+#: src/CommonITILValidation.php:1697
 msgid "Approval status by users"
 msgstr ""
 
-#: src/CommonITILValidation.php:1849
+#: src/CommonITILValidation.php:1852
 msgid "Approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1954
+#: src/CommonITILValidation.php:1957
 msgid ""
 "This item is waiting for approval, do you really want to resolve or close "
 "it?"
 msgstr ""
 "Tämä tiketti odotaa hyväksyntää. Vahvista, että ratkaiset tai suljet. sen."
 
-#: src/CommonITILValidation.php:1995
+#: src/CommonITILValidation.php:1998
 msgid "This item is waiting for approval."
 msgstr ""
 
-#: src/CommonITILValidation.php:1996
+#: src/CommonITILValidation.php:1999
 msgid "Do you really want to resolve or close it?"
 msgstr ""
 

--- a/locales/fr_BE.po
+++ b/locales/fr_BE.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-26 10:20+0000\n"
+"POT-Creation-Date: 2025-08-26 12:21+0000\n"
 "PO-Revision-Date: 2022-09-16 06:53+0000\n"
 "Last-Translator: Steven <Nevets82@gmail.com>, 2025\n"
 "Language-Team: French (Belgium) (https://app.transifex.com/glpi/teams/1637/fr_BE/)\n"
@@ -797,7 +797,7 @@ msgstr ""
 #: templates/components/itilobject/timeline/main_description.html.twig
 #: templates/components/user/info_card.html.twig
 #: templates/pages/tools/kb/comments.html.twig src/KnowbaseItem.php:245
-#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1188
+#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1191
 #: js/src/vue/CustomObject/FieldPreview/Field.vue:30
 msgid "Edit"
 msgstr "Éditer"
@@ -1443,7 +1443,7 @@ msgid "Cancel"
 msgstr "Annuler"
 
 #: templates/components/form/basic_inputs_macros.html.twig
-#: src/CommonITILValidation.php:1773
+#: src/CommonITILValidation.php:1776
 msgid "Validate"
 msgstr "Valider"
 
@@ -1965,7 +1965,7 @@ msgstr "Numéro d'inventaire"
 #: src/Computer.php:461 src/ProjectTask_Ticket.php:336 src/Certificate.php:278
 #: src/CronTask.php:1274 src/CronTask.php:1412
 #: src/CommonItilObject_Item.php:506 src/PDU.php:203 src/CommonDBTM.php:3513
-#: src/CommonITILValidation.php:1356 src/Plugin.php:2657
+#: src/CommonITILValidation.php:1359 src/Plugin.php:2657
 msgid "Status"
 msgstr "Statut"
 
@@ -3457,7 +3457,7 @@ msgstr[2] ""
 #: src/CommonITILObject.php:4737 src/CommonITILObject.php:4746
 #: src/CommonITILObject.php:6847 src/CommonITILObject.php:6894
 #: src/CommonITILObject.php:10159 src/NotificationTargetChange.php:308
-#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1498
+#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1501
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "Demandeur"
@@ -3468,7 +3468,7 @@ msgstr[2] "Demandeurs"
 #: src/NotificationTargetTicket.php:676 src/NotificationTargetTicket.php:706
 #: src/NotificationTargetCommonITILObject.php:976
 #: src/ITILValidationTemplate.php:81 src/NotificationTargetChange.php:327
-#: src/CommonITILValidation.php:1391 src/CommonITILValidation.php:1518
+#: src/CommonITILValidation.php:1394 src/CommonITILValidation.php:1521
 msgid "Approver"
 msgstr "Valideur"
 
@@ -4210,7 +4210,7 @@ msgstr "Pas d'historique"
 #: src/OAuthClient.php:94 src/Item_RemoteManagement.php:207
 #: src/Item_RemoteManagement.php:238 src/Certificate.php:125
 #: src/CronTask.php:1391 src/Contact.php:282 src/PDU.php:114
-#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1329
+#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1332
 #: src/Domain.php:233 src/Domain.php:257 src/ConsumableItem.php:167
 msgid "ID"
 msgstr "ID"
@@ -5757,7 +5757,7 @@ msgstr ""
 #: src/Project.php:904 src/ProjectTask.php:963
 #: src/NotificationTargetProjectTask.php:553
 #: src/NotificationTargetProjectTask.php:568 src/Cartridge.php:895
-#: src/CommonITILValidation.php:1252
+#: src/CommonITILValidation.php:1255
 msgctxt "item"
 msgid "State"
 msgstr "État"
@@ -17306,7 +17306,7 @@ msgid "Observer group except manager users"
 msgstr ""
 
 #: src/NotificationTargetCommonITILObject.php:973
-#: src/CommonITILValidation.php:1254 src/CommonITILValidation.php:1381
+#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1384
 msgid "Approval requester"
 msgstr "Demandeur de la validation"
 
@@ -33004,7 +33004,7 @@ msgstr "Non soumis à validation"
 msgid "Granted + Not subject to approval"
 msgstr "Accepté + non soumis à validation"
 
-#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1836
+#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1839
 msgid "Group user(s)"
 msgstr ""
 
@@ -33017,67 +33017,79 @@ msgstr ""
 msgid "Progress: %1$s%% of %2$s%% required"
 msgstr ""
 
-#: src/CommonITILValidation.php:1253 src/CommonITILValidation.php:1365
-#: src/CommonITILValidation.php:1472
+#: src/CommonITILValidation.php:1127
+msgid "Approval step accepted"
+msgstr ""
+
+#: src/CommonITILValidation.php:1128
+msgid "Approval step refused"
+msgstr ""
+
+#: src/CommonITILValidation.php:1129
+msgid "Approval step pending"
+msgstr ""
+
+#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1368
+#: src/CommonITILValidation.php:1475
 msgid "Request date"
 msgstr "Date de la demande"
 
-#: src/CommonITILValidation.php:1255 src/CommonITILValidation.php:1338
-#: src/CommonITILValidation.php:1430
+#: src/CommonITILValidation.php:1258 src/CommonITILValidation.php:1341
+#: src/CommonITILValidation.php:1433
 msgid "Request comments"
 msgstr "Commentaire de la demande"
 
-#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1373
-#: src/CommonITILValidation.php:1485
+#: src/CommonITILValidation.php:1259 src/CommonITILValidation.php:1376
+#: src/CommonITILValidation.php:1488
 msgid "Approval date"
 msgstr "Date de la validation"
 
-#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1400
+#: src/CommonITILValidation.php:1260 src/CommonITILValidation.php:1403
 msgid "Requested approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1258
+#: src/CommonITILValidation.php:1261
 msgid "Requested approver"
 msgstr ""
 
-#: src/CommonITILValidation.php:1259
+#: src/CommonITILValidation.php:1262
 msgid "Approval Comment"
 msgstr ""
 
-#: src/CommonITILValidation.php:1260
+#: src/CommonITILValidation.php:1263
 #: src/NotificationTargetKnowbaseItem.php:218
 msgid "Documents"
 msgstr "Documents"
 
-#: src/CommonITILValidation.php:1347 src/CommonITILValidation.php:1444
+#: src/CommonITILValidation.php:1350 src/CommonITILValidation.php:1447
 msgid "Approval comments"
 msgstr "Commentaire de la validation"
 
-#: src/CommonITILValidation.php:1459
+#: src/CommonITILValidation.php:1462
 msgid "Approval status"
 msgstr "Statut de validation"
 
-#: src/CommonITILValidation.php:1541
+#: src/CommonITILValidation.php:1544
 msgid "Approver substitute"
 msgstr ""
 
-#: src/CommonITILValidation.php:1601
+#: src/CommonITILValidation.php:1604
 msgid "Approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1623
+#: src/CommonITILValidation.php:1626
 msgid "Substitute of a member of approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1694
+#: src/CommonITILValidation.php:1697
 msgid "Approval status by users"
 msgstr ""
 
-#: src/CommonITILValidation.php:1849
+#: src/CommonITILValidation.php:1852
 msgid "Approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1954
+#: src/CommonITILValidation.php:1957
 msgid ""
 "This item is waiting for approval, do you really want to resolve or close "
 "it?"
@@ -33085,11 +33097,11 @@ msgstr ""
 "Cet élément est en attente d'approbation, voulez-vous vraiment le résoudre "
 "ou le fermer?"
 
-#: src/CommonITILValidation.php:1995
+#: src/CommonITILValidation.php:1998
 msgid "This item is waiting for approval."
 msgstr ""
 
-#: src/CommonITILValidation.php:1996
+#: src/CommonITILValidation.php:1999
 msgid "Do you really want to resolve or close it?"
 msgstr ""
 

--- a/locales/fr_CA.po
+++ b/locales/fr_CA.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-26 10:20+0000\n"
+"POT-Creation-Date: 2025-08-26 12:21+0000\n"
 "PO-Revision-Date: 2022-09-16 06:53+0000\n"
 "Last-Translator: Tiago Graça, 2025\n"
 "Language-Team: French (Canada) (https://app.transifex.com/glpi/teams/1637/fr_CA/)\n"
@@ -801,7 +801,7 @@ msgstr ""
 #: templates/components/itilobject/timeline/main_description.html.twig
 #: templates/components/user/info_card.html.twig
 #: templates/pages/tools/kb/comments.html.twig src/KnowbaseItem.php:245
-#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1188
+#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1191
 #: js/src/vue/CustomObject/FieldPreview/Field.vue:30
 msgid "Edit"
 msgstr "Éditer"
@@ -1453,7 +1453,7 @@ msgid "Cancel"
 msgstr "Annuler"
 
 #: templates/components/form/basic_inputs_macros.html.twig
-#: src/CommonITILValidation.php:1773
+#: src/CommonITILValidation.php:1776
 msgid "Validate"
 msgstr "Valider"
 
@@ -1976,7 +1976,7 @@ msgstr "Numéro d'inventaire"
 #: src/Computer.php:461 src/ProjectTask_Ticket.php:336 src/Certificate.php:278
 #: src/CronTask.php:1274 src/CronTask.php:1412
 #: src/CommonItilObject_Item.php:506 src/PDU.php:203 src/CommonDBTM.php:3513
-#: src/CommonITILValidation.php:1356 src/Plugin.php:2657
+#: src/CommonITILValidation.php:1359 src/Plugin.php:2657
 msgid "Status"
 msgstr "État"
 
@@ -3471,7 +3471,7 @@ msgstr[2] ""
 #: src/CommonITILObject.php:4737 src/CommonITILObject.php:4746
 #: src/CommonITILObject.php:6847 src/CommonITILObject.php:6894
 #: src/CommonITILObject.php:10159 src/NotificationTargetChange.php:308
-#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1498
+#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1501
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "Demandeur"
@@ -3482,7 +3482,7 @@ msgstr[2] "Demandeurs"
 #: src/NotificationTargetTicket.php:676 src/NotificationTargetTicket.php:706
 #: src/NotificationTargetCommonITILObject.php:976
 #: src/ITILValidationTemplate.php:81 src/NotificationTargetChange.php:327
-#: src/CommonITILValidation.php:1391 src/CommonITILValidation.php:1518
+#: src/CommonITILValidation.php:1394 src/CommonITILValidation.php:1521
 msgid "Approver"
 msgstr "Approbateur"
 
@@ -4224,7 +4224,7 @@ msgstr "Pas d'historique"
 #: src/OAuthClient.php:94 src/Item_RemoteManagement.php:207
 #: src/Item_RemoteManagement.php:238 src/Certificate.php:125
 #: src/CronTask.php:1391 src/Contact.php:282 src/PDU.php:114
-#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1329
+#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1332
 #: src/Domain.php:233 src/Domain.php:257 src/ConsumableItem.php:167
 msgid "ID"
 msgstr "ID"
@@ -5777,7 +5777,7 @@ msgstr ""
 #: src/Project.php:904 src/ProjectTask.php:963
 #: src/NotificationTargetProjectTask.php:553
 #: src/NotificationTargetProjectTask.php:568 src/Cartridge.php:895
-#: src/CommonITILValidation.php:1252
+#: src/CommonITILValidation.php:1255
 msgctxt "item"
 msgid "State"
 msgstr "État"
@@ -17424,7 +17424,7 @@ msgid "Observer group except manager users"
 msgstr ""
 
 #: src/NotificationTargetCommonITILObject.php:973
-#: src/CommonITILValidation.php:1254 src/CommonITILValidation.php:1381
+#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1384
 msgid "Approval requester"
 msgstr "Demandeur de l'approbation"
 
@@ -33558,7 +33558,7 @@ msgstr "Non soumis à l'approbation"
 msgid "Granted + Not subject to approval"
 msgstr "Autorisé + Non soumis à l'approbation"
 
-#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1836
+#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1839
 msgid "Group user(s)"
 msgstr ""
 
@@ -33571,67 +33571,79 @@ msgstr ""
 msgid "Progress: %1$s%% of %2$s%% required"
 msgstr ""
 
-#: src/CommonITILValidation.php:1253 src/CommonITILValidation.php:1365
-#: src/CommonITILValidation.php:1472
+#: src/CommonITILValidation.php:1127
+msgid "Approval step accepted"
+msgstr ""
+
+#: src/CommonITILValidation.php:1128
+msgid "Approval step refused"
+msgstr ""
+
+#: src/CommonITILValidation.php:1129
+msgid "Approval step pending"
+msgstr ""
+
+#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1368
+#: src/CommonITILValidation.php:1475
 msgid "Request date"
 msgstr "Date de la demande"
 
-#: src/CommonITILValidation.php:1255 src/CommonITILValidation.php:1338
-#: src/CommonITILValidation.php:1430
+#: src/CommonITILValidation.php:1258 src/CommonITILValidation.php:1341
+#: src/CommonITILValidation.php:1433
 msgid "Request comments"
 msgstr "Commentaires de la demande"
 
-#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1373
-#: src/CommonITILValidation.php:1485
+#: src/CommonITILValidation.php:1259 src/CommonITILValidation.php:1376
+#: src/CommonITILValidation.php:1488
 msgid "Approval date"
 msgstr "Date d'approbation"
 
-#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1400
+#: src/CommonITILValidation.php:1260 src/CommonITILValidation.php:1403
 msgid "Requested approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1258
+#: src/CommonITILValidation.php:1261
 msgid "Requested approver"
 msgstr ""
 
-#: src/CommonITILValidation.php:1259
+#: src/CommonITILValidation.php:1262
 msgid "Approval Comment"
 msgstr ""
 
-#: src/CommonITILValidation.php:1260
+#: src/CommonITILValidation.php:1263
 #: src/NotificationTargetKnowbaseItem.php:218
 msgid "Documents"
 msgstr "Documents"
 
-#: src/CommonITILValidation.php:1347 src/CommonITILValidation.php:1444
+#: src/CommonITILValidation.php:1350 src/CommonITILValidation.php:1447
 msgid "Approval comments"
 msgstr "Commentaires de l'approbation"
 
-#: src/CommonITILValidation.php:1459
+#: src/CommonITILValidation.php:1462
 msgid "Approval status"
 msgstr "État d'approbation"
 
-#: src/CommonITILValidation.php:1541
+#: src/CommonITILValidation.php:1544
 msgid "Approver substitute"
 msgstr ""
 
-#: src/CommonITILValidation.php:1601
+#: src/CommonITILValidation.php:1604
 msgid "Approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1623
+#: src/CommonITILValidation.php:1626
 msgid "Substitute of a member of approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1694
+#: src/CommonITILValidation.php:1697
 msgid "Approval status by users"
 msgstr ""
 
-#: src/CommonITILValidation.php:1849
+#: src/CommonITILValidation.php:1852
 msgid "Approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1954
+#: src/CommonITILValidation.php:1957
 msgid ""
 "This item is waiting for approval, do you really want to resolve or close "
 "it?"
@@ -33639,11 +33651,11 @@ msgstr ""
 "Cet élément est en attente d'approbation, voulez-vous vraiment le résoudre "
 "ou le fermer?"
 
-#: src/CommonITILValidation.php:1995
+#: src/CommonITILValidation.php:1998
 msgid "This item is waiting for approval."
 msgstr "Cet élément est en attente d'approbation"
 
-#: src/CommonITILValidation.php:1996
+#: src/CommonITILValidation.php:1999
 msgid "Do you really want to resolve or close it?"
 msgstr "Voulez-vous vraiment le résoudre ou le fermer ?"
 

--- a/locales/fr_FR.po
+++ b/locales/fr_FR.po
@@ -28,7 +28,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-26 10:20+0000\n"
+"POT-Creation-Date: 2025-08-26 12:21+0000\n"
 "PO-Revision-Date: 2022-09-16 06:53+0000\n"
 "Last-Translator: alexandre delaunay <delaunay.alexandre@gmail.com>, 2025\n"
 "Language-Team: French (France) (https://app.transifex.com/glpi/teams/1637/fr_FR/)\n"
@@ -824,7 +824,7 @@ msgstr "Mode lecture seule"
 #: templates/components/itilobject/timeline/main_description.html.twig
 #: templates/components/user/info_card.html.twig
 #: templates/pages/tools/kb/comments.html.twig src/KnowbaseItem.php:245
-#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1188
+#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1191
 #: js/src/vue/CustomObject/FieldPreview/Field.vue:30
 msgid "Edit"
 msgstr "Éditer"
@@ -1478,7 +1478,7 @@ msgid "Cancel"
 msgstr "Annuler"
 
 #: templates/components/form/basic_inputs_macros.html.twig
-#: src/CommonITILValidation.php:1773
+#: src/CommonITILValidation.php:1776
 msgid "Validate"
 msgstr "Valider"
 
@@ -2003,7 +2003,7 @@ msgstr "Numéro d'inventaire"
 #: src/Computer.php:461 src/ProjectTask_Ticket.php:336 src/Certificate.php:278
 #: src/CronTask.php:1274 src/CronTask.php:1412
 #: src/CommonItilObject_Item.php:506 src/PDU.php:203 src/CommonDBTM.php:3513
-#: src/CommonITILValidation.php:1356 src/Plugin.php:2657
+#: src/CommonITILValidation.php:1359 src/Plugin.php:2657
 msgid "Status"
 msgstr "Statut"
 
@@ -3502,7 +3502,7 @@ msgstr[2] "Étapes de validation"
 #: src/CommonITILObject.php:4737 src/CommonITILObject.php:4746
 #: src/CommonITILObject.php:6847 src/CommonITILObject.php:6894
 #: src/CommonITILObject.php:10159 src/NotificationTargetChange.php:308
-#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1498
+#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1501
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "Demandeur"
@@ -3513,7 +3513,7 @@ msgstr[2] "Demandeurs"
 #: src/NotificationTargetTicket.php:676 src/NotificationTargetTicket.php:706
 #: src/NotificationTargetCommonITILObject.php:976
 #: src/ITILValidationTemplate.php:81 src/NotificationTargetChange.php:327
-#: src/CommonITILValidation.php:1391 src/CommonITILValidation.php:1518
+#: src/CommonITILValidation.php:1394 src/CommonITILValidation.php:1521
 msgid "Approver"
 msgstr "Valideur"
 
@@ -4263,7 +4263,7 @@ msgstr "Pas d'historique"
 #: src/OAuthClient.php:94 src/Item_RemoteManagement.php:207
 #: src/Item_RemoteManagement.php:238 src/Certificate.php:125
 #: src/CronTask.php:1391 src/Contact.php:282 src/PDU.php:114
-#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1329
+#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1332
 #: src/Domain.php:233 src/Domain.php:257 src/ConsumableItem.php:167
 msgid "ID"
 msgstr "ID"
@@ -5836,7 +5836,7 @@ msgstr ""
 #: src/Project.php:904 src/ProjectTask.php:963
 #: src/NotificationTargetProjectTask.php:553
 #: src/NotificationTargetProjectTask.php:568 src/Cartridge.php:895
-#: src/CommonITILValidation.php:1252
+#: src/CommonITILValidation.php:1255
 msgctxt "item"
 msgid "State"
 msgstr "État"
@@ -17614,7 +17614,7 @@ msgid "Observer group except manager users"
 msgstr "Groupe observateur sans superviseur"
 
 #: src/NotificationTargetCommonITILObject.php:973
-#: src/CommonITILValidation.php:1254 src/CommonITILValidation.php:1381
+#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1384
 msgid "Approval requester"
 msgstr "Demandeur de la validation"
 
@@ -33963,7 +33963,7 @@ msgstr "Non soumis à validation"
 msgid "Granted + Not subject to approval"
 msgstr "Accepté + non soumis à validation"
 
-#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1836
+#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1839
 msgid "Group user(s)"
 msgstr "Groupe d'utilisateur(s)"
 
@@ -33976,67 +33976,79 @@ msgstr "Modifier les paramètres de l’étape de validation"
 msgid "Progress: %1$s%% of %2$s%% required"
 msgstr "Avancement: %1$s%% de %2$s%% requis"
 
-#: src/CommonITILValidation.php:1253 src/CommonITILValidation.php:1365
-#: src/CommonITILValidation.php:1472
+#: src/CommonITILValidation.php:1127
+msgid "Approval step accepted"
+msgstr ""
+
+#: src/CommonITILValidation.php:1128
+msgid "Approval step refused"
+msgstr ""
+
+#: src/CommonITILValidation.php:1129
+msgid "Approval step pending"
+msgstr ""
+
+#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1368
+#: src/CommonITILValidation.php:1475
 msgid "Request date"
 msgstr "Date de la demande"
 
-#: src/CommonITILValidation.php:1255 src/CommonITILValidation.php:1338
-#: src/CommonITILValidation.php:1430
+#: src/CommonITILValidation.php:1258 src/CommonITILValidation.php:1341
+#: src/CommonITILValidation.php:1433
 msgid "Request comments"
 msgstr "Commentaire de la demande"
 
-#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1373
-#: src/CommonITILValidation.php:1485
+#: src/CommonITILValidation.php:1259 src/CommonITILValidation.php:1376
+#: src/CommonITILValidation.php:1488
 msgid "Approval date"
 msgstr "Date de la validation"
 
-#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1400
+#: src/CommonITILValidation.php:1260 src/CommonITILValidation.php:1403
 msgid "Requested approver type"
 msgstr "Type de validateur demandé"
 
-#: src/CommonITILValidation.php:1258
+#: src/CommonITILValidation.php:1261
 msgid "Requested approver"
 msgstr "Validateur demandé"
 
-#: src/CommonITILValidation.php:1259
+#: src/CommonITILValidation.php:1262
 msgid "Approval Comment"
 msgstr "Commentaire de validation"
 
-#: src/CommonITILValidation.php:1260
+#: src/CommonITILValidation.php:1263
 #: src/NotificationTargetKnowbaseItem.php:218
 msgid "Documents"
 msgstr "Documents"
 
-#: src/CommonITILValidation.php:1347 src/CommonITILValidation.php:1444
+#: src/CommonITILValidation.php:1350 src/CommonITILValidation.php:1447
 msgid "Approval comments"
 msgstr "Commentaire de la validation"
 
-#: src/CommonITILValidation.php:1459
+#: src/CommonITILValidation.php:1462
 msgid "Approval status"
 msgstr "Statut de validation"
 
-#: src/CommonITILValidation.php:1541
+#: src/CommonITILValidation.php:1544
 msgid "Approver substitute"
 msgstr "Suppléant de validation"
 
-#: src/CommonITILValidation.php:1601
+#: src/CommonITILValidation.php:1604
 msgid "Approver group"
 msgstr "Groupe de validation"
 
-#: src/CommonITILValidation.php:1623
+#: src/CommonITILValidation.php:1626
 msgid "Substitute of a member of approver group"
 msgstr "Suppléant d’un membre du groupe de validation"
 
-#: src/CommonITILValidation.php:1694
+#: src/CommonITILValidation.php:1697
 msgid "Approval status by users"
 msgstr "Statut de validation par utilisateur"
 
-#: src/CommonITILValidation.php:1849
+#: src/CommonITILValidation.php:1852
 msgid "Approver type"
 msgstr "Type de validateur"
 
-#: src/CommonITILValidation.php:1954
+#: src/CommonITILValidation.php:1957
 msgid ""
 "This item is waiting for approval, do you really want to resolve or close "
 "it?"
@@ -34044,11 +34056,11 @@ msgstr ""
 "Cet élément est en attente d'approbation, voulez-vous vraiment le résoudre "
 "ou le clôturer ?"
 
-#: src/CommonITILValidation.php:1995
+#: src/CommonITILValidation.php:1998
 msgid "This item is waiting for approval."
 msgstr "Cet élément est en attente d'approbation"
 
-#: src/CommonITILValidation.php:1996
+#: src/CommonITILValidation.php:1999
 msgid "Do you really want to resolve or close it?"
 msgstr "Voulez-vous vraiment le résoudre ou le clôturer ?"
 

--- a/locales/gl_ES.po
+++ b/locales/gl_ES.po
@@ -16,7 +16,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-26 10:20+0000\n"
+"POT-Creation-Date: 2025-08-26 12:21+0000\n"
 "PO-Revision-Date: 2022-09-16 06:53+0000\n"
 "Last-Translator: Raúl Barreiro, 2025\n"
 "Language-Team: Galician (Spain) (https://app.transifex.com/glpi/teams/1637/gl_ES/)\n"
@@ -795,7 +795,7 @@ msgstr ""
 #: templates/components/itilobject/timeline/main_description.html.twig
 #: templates/components/user/info_card.html.twig
 #: templates/pages/tools/kb/comments.html.twig src/KnowbaseItem.php:245
-#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1188
+#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1191
 #: js/src/vue/CustomObject/FieldPreview/Field.vue:30
 msgid "Edit"
 msgstr "Editar"
@@ -1439,7 +1439,7 @@ msgid "Cancel"
 msgstr "Cancelar"
 
 #: templates/components/form/basic_inputs_macros.html.twig
-#: src/CommonITILValidation.php:1773
+#: src/CommonITILValidation.php:1776
 msgid "Validate"
 msgstr "Validación"
 
@@ -1959,7 +1959,7 @@ msgstr "Número de inventario"
 #: src/Computer.php:461 src/ProjectTask_Ticket.php:336 src/Certificate.php:278
 #: src/CronTask.php:1274 src/CronTask.php:1412
 #: src/CommonItilObject_Item.php:506 src/PDU.php:203 src/CommonDBTM.php:3513
-#: src/CommonITILValidation.php:1356 src/Plugin.php:2657
+#: src/CommonITILValidation.php:1359 src/Plugin.php:2657
 msgid "Status"
 msgstr "Estado"
 
@@ -3436,7 +3436,7 @@ msgstr[1] ""
 #: src/CommonITILObject.php:4737 src/CommonITILObject.php:4746
 #: src/CommonITILObject.php:6847 src/CommonITILObject.php:6894
 #: src/CommonITILObject.php:10159 src/NotificationTargetChange.php:308
-#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1498
+#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1501
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "Peticionario"
@@ -3446,7 +3446,7 @@ msgstr[1] "Peticionarios"
 #: src/NotificationTargetTicket.php:676 src/NotificationTargetTicket.php:706
 #: src/NotificationTargetCommonITILObject.php:976
 #: src/ITILValidationTemplate.php:81 src/NotificationTargetChange.php:327
-#: src/CommonITILValidation.php:1391 src/CommonITILValidation.php:1518
+#: src/CommonITILValidation.php:1394 src/CommonITILValidation.php:1521
 msgid "Approver"
 msgstr "Usuario de validación"
 
@@ -4181,7 +4181,7 @@ msgstr "Non hai histórico"
 #: src/OAuthClient.php:94 src/Item_RemoteManagement.php:207
 #: src/Item_RemoteManagement.php:238 src/Certificate.php:125
 #: src/CronTask.php:1391 src/Contact.php:282 src/PDU.php:114
-#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1329
+#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1332
 #: src/Domain.php:233 src/Domain.php:257 src/ConsumableItem.php:167
 msgid "ID"
 msgstr "ID"
@@ -5715,7 +5715,7 @@ msgstr ""
 #: src/Project.php:904 src/ProjectTask.php:963
 #: src/NotificationTargetProjectTask.php:553
 #: src/NotificationTargetProjectTask.php:568 src/Cartridge.php:895
-#: src/CommonITILValidation.php:1252
+#: src/CommonITILValidation.php:1255
 msgctxt "item"
 msgid "State"
 msgstr "Estado"
@@ -17142,7 +17142,7 @@ msgid "Observer group except manager users"
 msgstr ""
 
 #: src/NotificationTargetCommonITILObject.php:973
-#: src/CommonITILValidation.php:1254 src/CommonITILValidation.php:1381
+#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1384
 msgid "Approval requester"
 msgstr "Solicitante da validación"
 
@@ -32519,7 +32519,7 @@ msgstr "Non está suxeito á validación"
 msgid "Granted + Not subject to approval"
 msgstr "Concedida + Non suxeita a aprobación"
 
-#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1836
+#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1839
 msgid "Group user(s)"
 msgstr ""
 
@@ -32532,77 +32532,89 @@ msgstr ""
 msgid "Progress: %1$s%% of %2$s%% required"
 msgstr ""
 
-#: src/CommonITILValidation.php:1253 src/CommonITILValidation.php:1365
-#: src/CommonITILValidation.php:1472
+#: src/CommonITILValidation.php:1127
+msgid "Approval step accepted"
+msgstr ""
+
+#: src/CommonITILValidation.php:1128
+msgid "Approval step refused"
+msgstr ""
+
+#: src/CommonITILValidation.php:1129
+msgid "Approval step pending"
+msgstr ""
+
+#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1368
+#: src/CommonITILValidation.php:1475
 msgid "Request date"
 msgstr "Data da solicitude"
 
-#: src/CommonITILValidation.php:1255 src/CommonITILValidation.php:1338
-#: src/CommonITILValidation.php:1430
+#: src/CommonITILValidation.php:1258 src/CommonITILValidation.php:1341
+#: src/CommonITILValidation.php:1433
 msgid "Request comments"
 msgstr "Comentarios da solicitude"
 
-#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1373
-#: src/CommonITILValidation.php:1485
+#: src/CommonITILValidation.php:1259 src/CommonITILValidation.php:1376
+#: src/CommonITILValidation.php:1488
 msgid "Approval date"
 msgstr "Data da validación"
 
-#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1400
+#: src/CommonITILValidation.php:1260 src/CommonITILValidation.php:1403
 msgid "Requested approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1258
+#: src/CommonITILValidation.php:1261
 msgid "Requested approver"
 msgstr ""
 
-#: src/CommonITILValidation.php:1259
+#: src/CommonITILValidation.php:1262
 msgid "Approval Comment"
 msgstr ""
 
-#: src/CommonITILValidation.php:1260
+#: src/CommonITILValidation.php:1263
 #: src/NotificationTargetKnowbaseItem.php:218
 msgid "Documents"
 msgstr "Documentos"
 
-#: src/CommonITILValidation.php:1347 src/CommonITILValidation.php:1444
+#: src/CommonITILValidation.php:1350 src/CommonITILValidation.php:1447
 msgid "Approval comments"
 msgstr "Comentario da validación"
 
-#: src/CommonITILValidation.php:1459
+#: src/CommonITILValidation.php:1462
 msgid "Approval status"
 msgstr "Estado da aprovación"
 
-#: src/CommonITILValidation.php:1541
+#: src/CommonITILValidation.php:1544
 msgid "Approver substitute"
 msgstr ""
 
-#: src/CommonITILValidation.php:1601
+#: src/CommonITILValidation.php:1604
 msgid "Approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1623
+#: src/CommonITILValidation.php:1626
 msgid "Substitute of a member of approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1694
+#: src/CommonITILValidation.php:1697
 msgid "Approval status by users"
 msgstr ""
 
-#: src/CommonITILValidation.php:1849
+#: src/CommonITILValidation.php:1852
 msgid "Approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1954
+#: src/CommonITILValidation.php:1957
 msgid ""
 "This item is waiting for approval, do you really want to resolve or close "
 "it?"
 msgstr "Este elemento está a agardar aprobación, queres resolver ou fechala?"
 
-#: src/CommonITILValidation.php:1995
+#: src/CommonITILValidation.php:1998
 msgid "This item is waiting for approval."
 msgstr ""
 
-#: src/CommonITILValidation.php:1996
+#: src/CommonITILValidation.php:1999
 msgid "Do you really want to resolve or close it?"
 msgstr ""
 

--- a/locales/glpi.pot
+++ b/locales/glpi.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-26 10:20+0000\n"
+"POT-Creation-Date: 2025-08-26 12:21+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -777,7 +777,7 @@ msgstr ""
 #: templates/components/itilobject/timeline/main_description.html.twig
 #: templates/components/user/info_card.html.twig
 #: templates/pages/tools/kb/comments.html.twig src/KnowbaseItem.php:245
-#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1188
+#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1191
 #: js/src/vue/CustomObject/FieldPreview/Field.vue:30
 msgid "Edit"
 msgstr ""
@@ -1410,7 +1410,7 @@ msgid "Cancel"
 msgstr ""
 
 #: templates/components/form/basic_inputs_macros.html.twig
-#: src/CommonITILValidation.php:1773
+#: src/CommonITILValidation.php:1776
 msgid "Validate"
 msgstr ""
 
@@ -1926,7 +1926,7 @@ msgstr ""
 #: src/Computer.php:461 src/ProjectTask_Ticket.php:336 src/Certificate.php:278
 #: src/CronTask.php:1274 src/CronTask.php:1412
 #: src/CommonItilObject_Item.php:506 src/PDU.php:203 src/CommonDBTM.php:3513
-#: src/CommonITILValidation.php:1356 src/Plugin.php:2657
+#: src/CommonITILValidation.php:1359 src/Plugin.php:2657
 msgid "Status"
 msgstr ""
 
@@ -3398,7 +3398,7 @@ msgstr[1] ""
 #: src/CommonITILObject.php:4737 src/CommonITILObject.php:4746
 #: src/CommonITILObject.php:6847 src/CommonITILObject.php:6894
 #: src/CommonITILObject.php:10159 src/NotificationTargetChange.php:308
-#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1498
+#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1501
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] ""
@@ -3408,7 +3408,7 @@ msgstr[1] ""
 #: src/NotificationTargetTicket.php:676 src/NotificationTargetTicket.php:706
 #: src/NotificationTargetCommonITILObject.php:976
 #: src/ITILValidationTemplate.php:81 src/NotificationTargetChange.php:327
-#: src/CommonITILValidation.php:1391 src/CommonITILValidation.php:1518
+#: src/CommonITILValidation.php:1394 src/CommonITILValidation.php:1521
 msgid "Approver"
 msgstr ""
 
@@ -4138,7 +4138,7 @@ msgstr ""
 #: src/OAuthClient.php:94 src/Item_RemoteManagement.php:207
 #: src/Item_RemoteManagement.php:238 src/Certificate.php:125
 #: src/CronTask.php:1391 src/Contact.php:282 src/PDU.php:114
-#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1329 src/Domain.php:233
+#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1332 src/Domain.php:233
 #: src/Domain.php:257 src/ConsumableItem.php:167
 msgid "ID"
 msgstr ""
@@ -5663,7 +5663,7 @@ msgstr ""
 #: src/Project.php:904 src/ProjectTask.php:963
 #: src/NotificationTargetProjectTask.php:553
 #: src/NotificationTargetProjectTask.php:568 src/Cartridge.php:895
-#: src/CommonITILValidation.php:1252
+#: src/CommonITILValidation.php:1255
 msgctxt "item"
 msgid "State"
 msgstr ""
@@ -17100,7 +17100,7 @@ msgid "Observer group except manager users"
 msgstr ""
 
 #: src/NotificationTargetCommonITILObject.php:973
-#: src/CommonITILValidation.php:1254 src/CommonITILValidation.php:1381
+#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1384
 msgid "Approval requester"
 msgstr ""
 
@@ -32574,7 +32574,7 @@ msgstr ""
 msgid "Granted + Not subject to approval"
 msgstr ""
 
-#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1836
+#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1839
 msgid "Group user(s)"
 msgstr ""
 
@@ -32587,75 +32587,87 @@ msgstr ""
 msgid "Progress: %1$s%% of %2$s%% required"
 msgstr ""
 
-#: src/CommonITILValidation.php:1253 src/CommonITILValidation.php:1365
-#: src/CommonITILValidation.php:1472
+#: src/CommonITILValidation.php:1127
+msgid "Approval step accepted"
+msgstr ""
+
+#: src/CommonITILValidation.php:1128
+msgid "Approval step refused"
+msgstr ""
+
+#: src/CommonITILValidation.php:1129
+msgid "Approval step pending"
+msgstr ""
+
+#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1368
+#: src/CommonITILValidation.php:1475
 msgid "Request date"
 msgstr ""
 
-#: src/CommonITILValidation.php:1255 src/CommonITILValidation.php:1338
-#: src/CommonITILValidation.php:1430
+#: src/CommonITILValidation.php:1258 src/CommonITILValidation.php:1341
+#: src/CommonITILValidation.php:1433
 msgid "Request comments"
 msgstr ""
 
-#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1373
-#: src/CommonITILValidation.php:1485
+#: src/CommonITILValidation.php:1259 src/CommonITILValidation.php:1376
+#: src/CommonITILValidation.php:1488
 msgid "Approval date"
 msgstr ""
 
-#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1400
+#: src/CommonITILValidation.php:1260 src/CommonITILValidation.php:1403
 msgid "Requested approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1258
+#: src/CommonITILValidation.php:1261
 msgid "Requested approver"
 msgstr ""
 
-#: src/CommonITILValidation.php:1259
+#: src/CommonITILValidation.php:1262
 msgid "Approval Comment"
 msgstr ""
 
-#: src/CommonITILValidation.php:1260 src/NotificationTargetKnowbaseItem.php:218
+#: src/CommonITILValidation.php:1263 src/NotificationTargetKnowbaseItem.php:218
 msgid "Documents"
 msgstr ""
 
-#: src/CommonITILValidation.php:1347 src/CommonITILValidation.php:1444
+#: src/CommonITILValidation.php:1350 src/CommonITILValidation.php:1447
 msgid "Approval comments"
 msgstr ""
 
-#: src/CommonITILValidation.php:1459
+#: src/CommonITILValidation.php:1462
 msgid "Approval status"
 msgstr ""
 
-#: src/CommonITILValidation.php:1541
+#: src/CommonITILValidation.php:1544
 msgid "Approver substitute"
 msgstr ""
 
-#: src/CommonITILValidation.php:1601
+#: src/CommonITILValidation.php:1604
 msgid "Approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1623
+#: src/CommonITILValidation.php:1626
 msgid "Substitute of a member of approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1694
+#: src/CommonITILValidation.php:1697
 msgid "Approval status by users"
 msgstr ""
 
-#: src/CommonITILValidation.php:1849
+#: src/CommonITILValidation.php:1852
 msgid "Approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1954
+#: src/CommonITILValidation.php:1957
 msgid ""
 "This item is waiting for approval, do you really want to resolve or close it?"
 msgstr ""
 
-#: src/CommonITILValidation.php:1995
+#: src/CommonITILValidation.php:1998
 msgid "This item is waiting for approval."
 msgstr ""
 
-#: src/CommonITILValidation.php:1996
+#: src/CommonITILValidation.php:1999
 msgid "Do you really want to resolve or close it?"
 msgstr ""
 

--- a/locales/he_IL.po
+++ b/locales/he_IL.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-26 10:20+0000\n"
+"POT-Creation-Date: 2025-08-26 12:21+0000\n"
 "PO-Revision-Date: 2022-09-16 06:53+0000\n"
 "Last-Translator: Rothmann Ehud, 2025\n"
 "Language-Team: Hebrew (Israel) (https://app.transifex.com/glpi/teams/1637/he_IL/)\n"
@@ -797,7 +797,7 @@ msgstr ""
 #: templates/components/itilobject/timeline/main_description.html.twig
 #: templates/components/user/info_card.html.twig
 #: templates/pages/tools/kb/comments.html.twig src/KnowbaseItem.php:245
-#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1188
+#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1191
 #: js/src/vue/CustomObject/FieldPreview/Field.vue:30
 msgid "Edit"
 msgstr "עריכה"
@@ -1439,7 +1439,7 @@ msgid "Cancel"
 msgstr "ביטול"
 
 #: templates/components/form/basic_inputs_macros.html.twig
-#: src/CommonITILValidation.php:1773
+#: src/CommonITILValidation.php:1776
 msgid "Validate"
 msgstr "אשר"
 
@@ -1960,7 +1960,7 @@ msgstr "מספר טבוע"
 #: src/Computer.php:461 src/ProjectTask_Ticket.php:336 src/Certificate.php:278
 #: src/CronTask.php:1274 src/CronTask.php:1412
 #: src/CommonItilObject_Item.php:506 src/PDU.php:203 src/CommonDBTM.php:3513
-#: src/CommonITILValidation.php:1356 src/Plugin.php:2657
+#: src/CommonITILValidation.php:1359 src/Plugin.php:2657
 msgid "Status"
 msgstr "סטטוס"
 
@@ -3455,7 +3455,7 @@ msgstr[2] ""
 #: src/CommonITILObject.php:4737 src/CommonITILObject.php:4746
 #: src/CommonITILObject.php:6847 src/CommonITILObject.php:6894
 #: src/CommonITILObject.php:10159 src/NotificationTargetChange.php:308
-#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1498
+#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1501
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "פונה"
@@ -3466,7 +3466,7 @@ msgstr[2] "פונים"
 #: src/NotificationTargetTicket.php:676 src/NotificationTargetTicket.php:706
 #: src/NotificationTargetCommonITILObject.php:976
 #: src/ITILValidationTemplate.php:81 src/NotificationTargetChange.php:327
-#: src/CommonITILValidation.php:1391 src/CommonITILValidation.php:1518
+#: src/CommonITILValidation.php:1394 src/CommonITILValidation.php:1521
 msgid "Approver"
 msgstr "המאשר"
 
@@ -4207,7 +4207,7 @@ msgstr "אין היסטוריה"
 #: src/OAuthClient.php:94 src/Item_RemoteManagement.php:207
 #: src/Item_RemoteManagement.php:238 src/Certificate.php:125
 #: src/CronTask.php:1391 src/Contact.php:282 src/PDU.php:114
-#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1329
+#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1332
 #: src/Domain.php:233 src/Domain.php:257 src/ConsumableItem.php:167
 msgid "ID"
 msgstr "מזהה"
@@ -5762,7 +5762,7 @@ msgstr ""
 #: src/Project.php:904 src/ProjectTask.php:963
 #: src/NotificationTargetProjectTask.php:553
 #: src/NotificationTargetProjectTask.php:568 src/Cartridge.php:895
-#: src/CommonITILValidation.php:1252
+#: src/CommonITILValidation.php:1255
 msgctxt "item"
 msgid "State"
 msgstr "מצב"
@@ -17339,7 +17339,7 @@ msgid "Observer group except manager users"
 msgstr ""
 
 #: src/NotificationTargetCommonITILObject.php:973
-#: src/CommonITILValidation.php:1254 src/CommonITILValidation.php:1381
+#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1384
 msgid "Approval requester"
 msgstr "מבקש האישור"
 
@@ -33206,7 +33206,7 @@ msgstr "אין צורך באישור"
 msgid "Granted + Not subject to approval"
 msgstr "התקבל + אין צורך באישור"
 
-#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1836
+#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1839
 msgid "Group user(s)"
 msgstr ""
 
@@ -33219,67 +33219,79 @@ msgstr ""
 msgid "Progress: %1$s%% of %2$s%% required"
 msgstr ""
 
-#: src/CommonITILValidation.php:1253 src/CommonITILValidation.php:1365
-#: src/CommonITILValidation.php:1472
+#: src/CommonITILValidation.php:1127
+msgid "Approval step accepted"
+msgstr ""
+
+#: src/CommonITILValidation.php:1128
+msgid "Approval step refused"
+msgstr ""
+
+#: src/CommonITILValidation.php:1129
+msgid "Approval step pending"
+msgstr ""
+
+#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1368
+#: src/CommonITILValidation.php:1475
 msgid "Request date"
 msgstr "תאריך בקשה"
 
-#: src/CommonITILValidation.php:1255 src/CommonITILValidation.php:1338
-#: src/CommonITILValidation.php:1430
+#: src/CommonITILValidation.php:1258 src/CommonITILValidation.php:1341
+#: src/CommonITILValidation.php:1433
 msgid "Request comments"
 msgstr "הערות לגבי הבקשה"
 
-#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1373
-#: src/CommonITILValidation.php:1485
+#: src/CommonITILValidation.php:1259 src/CommonITILValidation.php:1376
+#: src/CommonITILValidation.php:1488
 msgid "Approval date"
 msgstr "תאריך אישור"
 
-#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1400
+#: src/CommonITILValidation.php:1260 src/CommonITILValidation.php:1403
 msgid "Requested approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1258
+#: src/CommonITILValidation.php:1261
 msgid "Requested approver"
 msgstr ""
 
-#: src/CommonITILValidation.php:1259
+#: src/CommonITILValidation.php:1262
 msgid "Approval Comment"
 msgstr "הערת אישור"
 
-#: src/CommonITILValidation.php:1260
+#: src/CommonITILValidation.php:1263
 #: src/NotificationTargetKnowbaseItem.php:218
 msgid "Documents"
 msgstr "מסמכים"
 
-#: src/CommonITILValidation.php:1347 src/CommonITILValidation.php:1444
+#: src/CommonITILValidation.php:1350 src/CommonITILValidation.php:1447
 msgid "Approval comments"
 msgstr "הערת אישור"
 
-#: src/CommonITILValidation.php:1459
+#: src/CommonITILValidation.php:1462
 msgid "Approval status"
 msgstr "סטטוס האישור"
 
-#: src/CommonITILValidation.php:1541
+#: src/CommonITILValidation.php:1544
 msgid "Approver substitute"
 msgstr "מחליף מאשר"
 
-#: src/CommonITILValidation.php:1601
+#: src/CommonITILValidation.php:1604
 msgid "Approver group"
 msgstr "קבוצת מאשרים"
 
-#: src/CommonITILValidation.php:1623
+#: src/CommonITILValidation.php:1626
 msgid "Substitute of a member of approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1694
+#: src/CommonITILValidation.php:1697
 msgid "Approval status by users"
 msgstr "סטטוס האישור עיי משתמש"
 
-#: src/CommonITILValidation.php:1849
+#: src/CommonITILValidation.php:1852
 msgid "Approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1954
+#: src/CommonITILValidation.php:1957
 msgid ""
 "This item is waiting for approval, do you really want to resolve or close "
 "it?"
@@ -33287,11 +33299,11 @@ msgstr ""
 "הפריט ממתין לאישור, אתה באמת\n"
 "רוצה לסגור אותו ?"
 
-#: src/CommonITILValidation.php:1995
+#: src/CommonITILValidation.php:1998
 msgid "This item is waiting for approval."
 msgstr ""
 
-#: src/CommonITILValidation.php:1996
+#: src/CommonITILValidation.php:1999
 msgid "Do you really want to resolve or close it?"
 msgstr "האם אתה באמת רוצה לפתור או לסגור את זה?"
 

--- a/locales/hi_IN.po
+++ b/locales/hi_IN.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-26 10:20+0000\n"
+"POT-Creation-Date: 2025-08-26 12:21+0000\n"
 "PO-Revision-Date: 2022-09-16 06:53+0000\n"
 "Last-Translator: alexandre delaunay <delaunay.alexandre@gmail.com>, 2025\n"
 "Language-Team: Hindi (India) (https://app.transifex.com/glpi/teams/1637/hi_IN/)\n"
@@ -790,7 +790,7 @@ msgstr ""
 #: templates/components/itilobject/timeline/main_description.html.twig
 #: templates/components/user/info_card.html.twig
 #: templates/pages/tools/kb/comments.html.twig src/KnowbaseItem.php:245
-#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1188
+#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1191
 #: js/src/vue/CustomObject/FieldPreview/Field.vue:30
 msgid "Edit"
 msgstr "संपादित करें"
@@ -1434,7 +1434,7 @@ msgid "Cancel"
 msgstr "रद्द करें"
 
 #: templates/components/form/basic_inputs_macros.html.twig
-#: src/CommonITILValidation.php:1773
+#: src/CommonITILValidation.php:1776
 msgid "Validate"
 msgstr "मान्य करें"
 
@@ -1951,7 +1951,7 @@ msgstr "सूची संख्या"
 #: src/Computer.php:461 src/ProjectTask_Ticket.php:336 src/Certificate.php:278
 #: src/CronTask.php:1274 src/CronTask.php:1412
 #: src/CommonItilObject_Item.php:506 src/PDU.php:203 src/CommonDBTM.php:3513
-#: src/CommonITILValidation.php:1356 src/Plugin.php:2657
+#: src/CommonITILValidation.php:1359 src/Plugin.php:2657
 msgid "Status"
 msgstr "वे स्थितियां"
 
@@ -3428,7 +3428,7 @@ msgstr[1] ""
 #: src/CommonITILObject.php:4737 src/CommonITILObject.php:4746
 #: src/CommonITILObject.php:6847 src/CommonITILObject.php:6894
 #: src/CommonITILObject.php:10159 src/NotificationTargetChange.php:308
-#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1498
+#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1501
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "अनुरोधकर्ताओं"
@@ -3438,7 +3438,7 @@ msgstr[1] "अनुरोधकर्ताओं"
 #: src/NotificationTargetTicket.php:676 src/NotificationTargetTicket.php:706
 #: src/NotificationTargetCommonITILObject.php:976
 #: src/ITILValidationTemplate.php:81 src/NotificationTargetChange.php:327
-#: src/CommonITILValidation.php:1391 src/CommonITILValidation.php:1518
+#: src/CommonITILValidation.php:1394 src/CommonITILValidation.php:1521
 msgid "Approver"
 msgstr "स्वीकृति प्रदान करने वाले"
 
@@ -4174,7 +4174,7 @@ msgstr "कोई ऐतिहासिक नहीं"
 #: src/OAuthClient.php:94 src/Item_RemoteManagement.php:207
 #: src/Item_RemoteManagement.php:238 src/Certificate.php:125
 #: src/CronTask.php:1391 src/Contact.php:282 src/PDU.php:114
-#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1329
+#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1332
 #: src/Domain.php:233 src/Domain.php:257 src/ConsumableItem.php:167
 msgid "ID"
 msgstr "ID"
@@ -5709,7 +5709,7 @@ msgstr ""
 #: src/Project.php:904 src/ProjectTask.php:963
 #: src/NotificationTargetProjectTask.php:553
 #: src/NotificationTargetProjectTask.php:568 src/Cartridge.php:895
-#: src/CommonITILValidation.php:1252
+#: src/CommonITILValidation.php:1255
 msgctxt "item"
 msgid "State"
 msgstr "राज्य"
@@ -17119,7 +17119,7 @@ msgid "Observer group except manager users"
 msgstr ""
 
 #: src/NotificationTargetCommonITILObject.php:973
-#: src/CommonITILValidation.php:1254 src/CommonITILValidation.php:1381
+#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1384
 msgid "Approval requester"
 msgstr "स्वीकृति अनुरोधकर्ता"
 
@@ -32483,7 +32483,7 @@ msgstr "अनुमोदन के अधीन नहीं है"
 msgid "Granted + Not subject to approval"
 msgstr "अनुमोदित + अनुमोदन के अधीन नहीं है"
 
-#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1836
+#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1839
 msgid "Group user(s)"
 msgstr ""
 
@@ -32496,67 +32496,79 @@ msgstr ""
 msgid "Progress: %1$s%% of %2$s%% required"
 msgstr ""
 
-#: src/CommonITILValidation.php:1253 src/CommonITILValidation.php:1365
-#: src/CommonITILValidation.php:1472
+#: src/CommonITILValidation.php:1127
+msgid "Approval step accepted"
+msgstr ""
+
+#: src/CommonITILValidation.php:1128
+msgid "Approval step refused"
+msgstr ""
+
+#: src/CommonITILValidation.php:1129
+msgid "Approval step pending"
+msgstr ""
+
+#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1368
+#: src/CommonITILValidation.php:1475
 msgid "Request date"
 msgstr "अनुरोध दिनांक"
 
-#: src/CommonITILValidation.php:1255 src/CommonITILValidation.php:1338
-#: src/CommonITILValidation.php:1430
+#: src/CommonITILValidation.php:1258 src/CommonITILValidation.php:1341
+#: src/CommonITILValidation.php:1433
 msgid "Request comments"
 msgstr "टिप्पणियों का अनुरोध करें"
 
-#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1373
-#: src/CommonITILValidation.php:1485
+#: src/CommonITILValidation.php:1259 src/CommonITILValidation.php:1376
+#: src/CommonITILValidation.php:1488
 msgid "Approval date"
 msgstr "स्वीकृति तिथि"
 
-#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1400
+#: src/CommonITILValidation.php:1260 src/CommonITILValidation.php:1403
 msgid "Requested approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1258
+#: src/CommonITILValidation.php:1261
 msgid "Requested approver"
 msgstr ""
 
-#: src/CommonITILValidation.php:1259
+#: src/CommonITILValidation.php:1262
 msgid "Approval Comment"
 msgstr ""
 
-#: src/CommonITILValidation.php:1260
+#: src/CommonITILValidation.php:1263
 #: src/NotificationTargetKnowbaseItem.php:218
 msgid "Documents"
 msgstr "दस्तावेज़"
 
-#: src/CommonITILValidation.php:1347 src/CommonITILValidation.php:1444
+#: src/CommonITILValidation.php:1350 src/CommonITILValidation.php:1447
 msgid "Approval comments"
 msgstr "स्वीकृति टिप्पणियां"
 
-#: src/CommonITILValidation.php:1459
+#: src/CommonITILValidation.php:1462
 msgid "Approval status"
 msgstr "अनुमोदन स्थिति"
 
-#: src/CommonITILValidation.php:1541
+#: src/CommonITILValidation.php:1544
 msgid "Approver substitute"
 msgstr ""
 
-#: src/CommonITILValidation.php:1601
+#: src/CommonITILValidation.php:1604
 msgid "Approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1623
+#: src/CommonITILValidation.php:1626
 msgid "Substitute of a member of approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1694
+#: src/CommonITILValidation.php:1697
 msgid "Approval status by users"
 msgstr ""
 
-#: src/CommonITILValidation.php:1849
+#: src/CommonITILValidation.php:1852
 msgid "Approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1954
+#: src/CommonITILValidation.php:1957
 msgid ""
 "This item is waiting for approval, do you really want to resolve or close "
 "it?"
@@ -32564,11 +32576,11 @@ msgstr ""
 "यह आइटम अनुमोदन की प्रतीक्षा कर रहा है, क्या आप वास्तव में इसे हल करना या "
 "बंद करना चाहते हैं?"
 
-#: src/CommonITILValidation.php:1995
+#: src/CommonITILValidation.php:1998
 msgid "This item is waiting for approval."
 msgstr ""
 
-#: src/CommonITILValidation.php:1996
+#: src/CommonITILValidation.php:1999
 msgid "Do you really want to resolve or close it?"
 msgstr ""
 

--- a/locales/hr_HR.po
+++ b/locales/hr_HR.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-26 10:20+0000\n"
+"POT-Creation-Date: 2025-08-26 12:21+0000\n"
 "PO-Revision-Date: 2022-09-16 06:53+0000\n"
 "Last-Translator: alexandre delaunay <delaunay.alexandre@gmail.com>, 2025\n"
 "Language-Team: Croatian (Croatia) (https://app.transifex.com/glpi/teams/1637/hr_HR/)\n"
@@ -798,7 +798,7 @@ msgstr ""
 #: templates/components/itilobject/timeline/main_description.html.twig
 #: templates/components/user/info_card.html.twig
 #: templates/pages/tools/kb/comments.html.twig src/KnowbaseItem.php:245
-#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1188
+#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1191
 #: js/src/vue/CustomObject/FieldPreview/Field.vue:30
 msgid "Edit"
 msgstr "Uredi"
@@ -1444,7 +1444,7 @@ msgid "Cancel"
 msgstr "Otkaži"
 
 #: templates/components/form/basic_inputs_macros.html.twig
-#: src/CommonITILValidation.php:1773
+#: src/CommonITILValidation.php:1776
 msgid "Validate"
 msgstr "Provjeri"
 
@@ -1965,7 +1965,7 @@ msgstr "Broj inveture"
 #: src/Computer.php:461 src/ProjectTask_Ticket.php:336 src/Certificate.php:278
 #: src/CronTask.php:1274 src/CronTask.php:1412
 #: src/CommonItilObject_Item.php:506 src/PDU.php:203 src/CommonDBTM.php:3513
-#: src/CommonITILValidation.php:1356 src/Plugin.php:2657
+#: src/CommonITILValidation.php:1359 src/Plugin.php:2657
 msgid "Status"
 msgstr "Stanje"
 
@@ -3460,7 +3460,7 @@ msgstr[2] ""
 #: src/CommonITILObject.php:4737 src/CommonITILObject.php:4746
 #: src/CommonITILObject.php:6847 src/CommonITILObject.php:6894
 #: src/CommonITILObject.php:10159 src/NotificationTargetChange.php:308
-#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1498
+#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1501
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "Podnositelj"
@@ -3471,7 +3471,7 @@ msgstr[2] "Podnositelji"
 #: src/NotificationTargetTicket.php:676 src/NotificationTargetTicket.php:706
 #: src/NotificationTargetCommonITILObject.php:976
 #: src/ITILValidationTemplate.php:81 src/NotificationTargetChange.php:327
-#: src/CommonITILValidation.php:1391 src/CommonITILValidation.php:1518
+#: src/CommonITILValidation.php:1394 src/CommonITILValidation.php:1521
 msgid "Approver"
 msgstr "Odobravatelj"
 
@@ -4212,7 +4212,7 @@ msgstr "Nema povijesti"
 #: src/OAuthClient.php:94 src/Item_RemoteManagement.php:207
 #: src/Item_RemoteManagement.php:238 src/Certificate.php:125
 #: src/CronTask.php:1391 src/Contact.php:282 src/PDU.php:114
-#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1329
+#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1332
 #: src/Domain.php:233 src/Domain.php:257 src/ConsumableItem.php:167
 msgid "ID"
 msgstr "ID"
@@ -5765,7 +5765,7 @@ msgstr ""
 #: src/Project.php:904 src/ProjectTask.php:963
 #: src/NotificationTargetProjectTask.php:553
 #: src/NotificationTargetProjectTask.php:568 src/Cartridge.php:895
-#: src/CommonITILValidation.php:1252
+#: src/CommonITILValidation.php:1255
 msgctxt "item"
 msgid "State"
 msgstr "Stanje"
@@ -17357,7 +17357,7 @@ msgid "Observer group except manager users"
 msgstr ""
 
 #: src/NotificationTargetCommonITILObject.php:973
-#: src/CommonITILValidation.php:1254 src/CommonITILValidation.php:1381
+#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1384
 msgid "Approval requester"
 msgstr "Podnositelj odobrenja"
 
@@ -33246,7 +33246,7 @@ msgstr "Ne zahtijeva odobrenje"
 msgid "Granted + Not subject to approval"
 msgstr "Dodijeljeno + Nije predmet odobrenja"
 
-#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1836
+#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1839
 msgid "Group user(s)"
 msgstr "Korisnik/Korisnici grupe"
 
@@ -33259,78 +33259,90 @@ msgstr ""
 msgid "Progress: %1$s%% of %2$s%% required"
 msgstr ""
 
-#: src/CommonITILValidation.php:1253 src/CommonITILValidation.php:1365
-#: src/CommonITILValidation.php:1472
+#: src/CommonITILValidation.php:1127
+msgid "Approval step accepted"
+msgstr ""
+
+#: src/CommonITILValidation.php:1128
+msgid "Approval step refused"
+msgstr ""
+
+#: src/CommonITILValidation.php:1129
+msgid "Approval step pending"
+msgstr ""
+
+#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1368
+#: src/CommonITILValidation.php:1475
 msgid "Request date"
 msgstr "Datum zahtjeva"
 
-#: src/CommonITILValidation.php:1255 src/CommonITILValidation.php:1338
-#: src/CommonITILValidation.php:1430
+#: src/CommonITILValidation.php:1258 src/CommonITILValidation.php:1341
+#: src/CommonITILValidation.php:1433
 msgid "Request comments"
 msgstr "Komentari zahtjeva"
 
-#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1373
-#: src/CommonITILValidation.php:1485
+#: src/CommonITILValidation.php:1259 src/CommonITILValidation.php:1376
+#: src/CommonITILValidation.php:1488
 msgid "Approval date"
 msgstr "Datum odobrenja"
 
-#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1400
+#: src/CommonITILValidation.php:1260 src/CommonITILValidation.php:1403
 msgid "Requested approver type"
 msgstr "Zatražena vrsta odobravatelja"
 
-#: src/CommonITILValidation.php:1258
+#: src/CommonITILValidation.php:1261
 msgid "Requested approver"
 msgstr "Zatraženi odobravatelj"
 
-#: src/CommonITILValidation.php:1259
+#: src/CommonITILValidation.php:1262
 msgid "Approval Comment"
 msgstr ""
 
-#: src/CommonITILValidation.php:1260
+#: src/CommonITILValidation.php:1263
 #: src/NotificationTargetKnowbaseItem.php:218
 msgid "Documents"
 msgstr "Dokumenti"
 
-#: src/CommonITILValidation.php:1347 src/CommonITILValidation.php:1444
+#: src/CommonITILValidation.php:1350 src/CommonITILValidation.php:1447
 msgid "Approval comments"
 msgstr "Komentari odobrenja"
 
-#: src/CommonITILValidation.php:1459
+#: src/CommonITILValidation.php:1462
 msgid "Approval status"
 msgstr "Stanje odobrenja"
 
-#: src/CommonITILValidation.php:1541
+#: src/CommonITILValidation.php:1544
 msgid "Approver substitute"
 msgstr ""
 
-#: src/CommonITILValidation.php:1601
+#: src/CommonITILValidation.php:1604
 msgid "Approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1623
+#: src/CommonITILValidation.php:1626
 msgid "Substitute of a member of approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1694
+#: src/CommonITILValidation.php:1697
 msgid "Approval status by users"
 msgstr ""
 
-#: src/CommonITILValidation.php:1849
+#: src/CommonITILValidation.php:1852
 msgid "Approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1954
+#: src/CommonITILValidation.php:1957
 msgid ""
 "This item is waiting for approval, do you really want to resolve or close "
 "it?"
 msgstr ""
 "Predmet čeka na odobrenje, želiš li ga stvarno riješiti ili zatvoriti?"
 
-#: src/CommonITILValidation.php:1995
+#: src/CommonITILValidation.php:1998
 msgid "This item is waiting for approval."
 msgstr "Ovaj predmet čeka na odobrenje."
 
-#: src/CommonITILValidation.php:1996
+#: src/CommonITILValidation.php:1999
 msgid "Do you really want to resolve or close it?"
 msgstr ""
 

--- a/locales/hu_HU.po
+++ b/locales/hu_HU.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-26 10:20+0000\n"
+"POT-Creation-Date: 2025-08-26 12:21+0000\n"
 "PO-Revision-Date: 2022-09-16 06:53+0000\n"
 "Last-Translator: Márk Klung, 2025\n"
 "Language-Team: Hungarian (Hungary) (https://app.transifex.com/glpi/teams/1637/hu_HU/)\n"
@@ -795,7 +795,7 @@ msgstr ""
 #: templates/components/itilobject/timeline/main_description.html.twig
 #: templates/components/user/info_card.html.twig
 #: templates/pages/tools/kb/comments.html.twig src/KnowbaseItem.php:245
-#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1188
+#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1191
 #: js/src/vue/CustomObject/FieldPreview/Field.vue:30
 msgid "Edit"
 msgstr "Szerkeszt"
@@ -1439,7 +1439,7 @@ msgid "Cancel"
 msgstr "Mégsem"
 
 #: templates/components/form/basic_inputs_macros.html.twig
-#: src/CommonITILValidation.php:1773
+#: src/CommonITILValidation.php:1776
 msgid "Validate"
 msgstr "Érvényesítés"
 
@@ -1958,7 +1958,7 @@ msgstr "Leltári szám"
 #: src/Computer.php:461 src/ProjectTask_Ticket.php:336 src/Certificate.php:278
 #: src/CronTask.php:1274 src/CronTask.php:1412
 #: src/CommonItilObject_Item.php:506 src/PDU.php:203 src/CommonDBTM.php:3513
-#: src/CommonITILValidation.php:1356 src/Plugin.php:2657
+#: src/CommonITILValidation.php:1359 src/Plugin.php:2657
 msgid "Status"
 msgstr "Státusz"
 
@@ -3438,7 +3438,7 @@ msgstr[1] ""
 #: src/CommonITILObject.php:4737 src/CommonITILObject.php:4746
 #: src/CommonITILObject.php:6847 src/CommonITILObject.php:6894
 #: src/CommonITILObject.php:10159 src/NotificationTargetChange.php:308
-#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1498
+#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1501
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "Kérelmező"
@@ -3448,7 +3448,7 @@ msgstr[1] "Kérelmezők"
 #: src/NotificationTargetTicket.php:676 src/NotificationTargetTicket.php:706
 #: src/NotificationTargetCommonITILObject.php:976
 #: src/ITILValidationTemplate.php:81 src/NotificationTargetChange.php:327
-#: src/CommonITILValidation.php:1391 src/CommonITILValidation.php:1518
+#: src/CommonITILValidation.php:1394 src/CommonITILValidation.php:1521
 msgid "Approver"
 msgstr "Érvényesítő felhasználó"
 
@@ -4184,7 +4184,7 @@ msgstr "Nincs történet"
 #: src/OAuthClient.php:94 src/Item_RemoteManagement.php:207
 #: src/Item_RemoteManagement.php:238 src/Certificate.php:125
 #: src/CronTask.php:1391 src/Contact.php:282 src/PDU.php:114
-#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1329
+#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1332
 #: src/Domain.php:233 src/Domain.php:257 src/ConsumableItem.php:167
 msgid "ID"
 msgstr "ID"
@@ -5722,7 +5722,7 @@ msgstr ""
 #: src/Project.php:904 src/ProjectTask.php:963
 #: src/NotificationTargetProjectTask.php:553
 #: src/NotificationTargetProjectTask.php:568 src/Cartridge.php:895
-#: src/CommonITILValidation.php:1252
+#: src/CommonITILValidation.php:1255
 msgctxt "item"
 msgid "State"
 msgstr "Állapot"
@@ -17199,7 +17199,7 @@ msgid "Observer group except manager users"
 msgstr ""
 
 #: src/NotificationTargetCommonITILObject.php:973
-#: src/CommonITILValidation.php:1254 src/CommonITILValidation.php:1381
+#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1384
 msgid "Approval requester"
 msgstr "Érvényesítés kérelmező"
 
@@ -32708,7 +32708,7 @@ msgstr "Nem kell jóváhagyni"
 msgid "Granted + Not subject to approval"
 msgstr "Engedélyezve + nem kell jóváhagyni"
 
-#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1836
+#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1839
 msgid "Group user(s)"
 msgstr ""
 
@@ -32721,77 +32721,89 @@ msgstr ""
 msgid "Progress: %1$s%% of %2$s%% required"
 msgstr ""
 
-#: src/CommonITILValidation.php:1253 src/CommonITILValidation.php:1365
-#: src/CommonITILValidation.php:1472
+#: src/CommonITILValidation.php:1127
+msgid "Approval step accepted"
+msgstr ""
+
+#: src/CommonITILValidation.php:1128
+msgid "Approval step refused"
+msgstr ""
+
+#: src/CommonITILValidation.php:1129
+msgid "Approval step pending"
+msgstr ""
+
+#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1368
+#: src/CommonITILValidation.php:1475
 msgid "Request date"
 msgstr "Igénylés dátuma"
 
-#: src/CommonITILValidation.php:1255 src/CommonITILValidation.php:1338
-#: src/CommonITILValidation.php:1430
+#: src/CommonITILValidation.php:1258 src/CommonITILValidation.php:1341
+#: src/CommonITILValidation.php:1433
 msgid "Request comments"
 msgstr "Igénylés megjegyzései"
 
-#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1373
-#: src/CommonITILValidation.php:1485
+#: src/CommonITILValidation.php:1259 src/CommonITILValidation.php:1376
+#: src/CommonITILValidation.php:1488
 msgid "Approval date"
 msgstr "Érvényesítés dátuma"
 
-#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1400
+#: src/CommonITILValidation.php:1260 src/CommonITILValidation.php:1403
 msgid "Requested approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1258
+#: src/CommonITILValidation.php:1261
 msgid "Requested approver"
 msgstr ""
 
-#: src/CommonITILValidation.php:1259
+#: src/CommonITILValidation.php:1262
 msgid "Approval Comment"
 msgstr ""
 
-#: src/CommonITILValidation.php:1260
+#: src/CommonITILValidation.php:1263
 #: src/NotificationTargetKnowbaseItem.php:218
 msgid "Documents"
 msgstr "Dokumentumok"
 
-#: src/CommonITILValidation.php:1347 src/CommonITILValidation.php:1444
+#: src/CommonITILValidation.php:1350 src/CommonITILValidation.php:1447
 msgid "Approval comments"
 msgstr "Érvényesség kommentálása"
 
-#: src/CommonITILValidation.php:1459
+#: src/CommonITILValidation.php:1462
 msgid "Approval status"
 msgstr "Érvényesítési státusz"
 
-#: src/CommonITILValidation.php:1541
+#: src/CommonITILValidation.php:1544
 msgid "Approver substitute"
 msgstr ""
 
-#: src/CommonITILValidation.php:1601
+#: src/CommonITILValidation.php:1604
 msgid "Approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1623
+#: src/CommonITILValidation.php:1626
 msgid "Substitute of a member of approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1694
+#: src/CommonITILValidation.php:1697
 msgid "Approval status by users"
 msgstr ""
 
-#: src/CommonITILValidation.php:1849
+#: src/CommonITILValidation.php:1852
 msgid "Approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1954
+#: src/CommonITILValidation.php:1957
 msgid ""
 "This item is waiting for approval, do you really want to resolve or close "
 "it?"
 msgstr "Ez az elem jóváhagyásra vár, biztosan megoldod vagy lezárod ?"
 
-#: src/CommonITILValidation.php:1995
+#: src/CommonITILValidation.php:1998
 msgid "This item is waiting for approval."
 msgstr "Ez az elem jóváhagyásra vár."
 
-#: src/CommonITILValidation.php:1996
+#: src/CommonITILValidation.php:1999
 msgid "Do you really want to resolve or close it?"
 msgstr ""
 

--- a/locales/id_ID.po
+++ b/locales/id_ID.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-26 10:20+0000\n"
+"POT-Creation-Date: 2025-08-26 12:21+0000\n"
 "PO-Revision-Date: 2022-09-16 06:53+0000\n"
 "Last-Translator: Teguh Herwanto <therwanto@gmail.com>, 2025\n"
 "Language-Team: Indonesian (Indonesia) (https://app.transifex.com/glpi/teams/1637/id_ID/)\n"
@@ -790,7 +790,7 @@ msgstr ""
 #: templates/components/itilobject/timeline/main_description.html.twig
 #: templates/components/user/info_card.html.twig
 #: templates/pages/tools/kb/comments.html.twig src/KnowbaseItem.php:245
-#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1188
+#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1191
 #: js/src/vue/CustomObject/FieldPreview/Field.vue:30
 msgid "Edit"
 msgstr "Sunting"
@@ -1428,7 +1428,7 @@ msgid "Cancel"
 msgstr "Batal"
 
 #: templates/components/form/basic_inputs_macros.html.twig
-#: src/CommonITILValidation.php:1773
+#: src/CommonITILValidation.php:1776
 msgid "Validate"
 msgstr "Validasi"
 
@@ -1941,7 +1941,7 @@ msgstr "Nomor inventory"
 #: src/Computer.php:461 src/ProjectTask_Ticket.php:336 src/Certificate.php:278
 #: src/CronTask.php:1274 src/CronTask.php:1412
 #: src/CommonItilObject_Item.php:506 src/PDU.php:203 src/CommonDBTM.php:3513
-#: src/CommonITILValidation.php:1356 src/Plugin.php:2657
+#: src/CommonITILValidation.php:1359 src/Plugin.php:2657
 msgid "Status"
 msgstr ""
 
@@ -3406,7 +3406,7 @@ msgstr[0] ""
 #: src/CommonITILObject.php:4737 src/CommonITILObject.php:4746
 #: src/CommonITILObject.php:6847 src/CommonITILObject.php:6894
 #: src/CommonITILObject.php:10159 src/NotificationTargetChange.php:308
-#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1498
+#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1501
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "Pemohon"
@@ -3415,7 +3415,7 @@ msgstr[0] "Pemohon"
 #: src/NotificationTargetTicket.php:676 src/NotificationTargetTicket.php:706
 #: src/NotificationTargetCommonITILObject.php:976
 #: src/ITILValidationTemplate.php:81 src/NotificationTargetChange.php:327
-#: src/CommonITILValidation.php:1391 src/CommonITILValidation.php:1518
+#: src/CommonITILValidation.php:1394 src/CommonITILValidation.php:1521
 msgid "Approver"
 msgstr "Penyetuju"
 
@@ -4144,7 +4144,7 @@ msgstr "Tak ada histori"
 #: src/OAuthClient.php:94 src/Item_RemoteManagement.php:207
 #: src/Item_RemoteManagement.php:238 src/Certificate.php:125
 #: src/CronTask.php:1391 src/Contact.php:282 src/PDU.php:114
-#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1329
+#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1332
 #: src/Domain.php:233 src/Domain.php:257 src/ConsumableItem.php:167
 msgid "ID"
 msgstr "ID"
@@ -5669,7 +5669,7 @@ msgstr ""
 #: src/Project.php:904 src/ProjectTask.php:963
 #: src/NotificationTargetProjectTask.php:553
 #: src/NotificationTargetProjectTask.php:568 src/Cartridge.php:895
-#: src/CommonITILValidation.php:1252
+#: src/CommonITILValidation.php:1255
 msgctxt "item"
 msgid "State"
 msgstr "State"
@@ -17028,7 +17028,7 @@ msgid "Observer group except manager users"
 msgstr ""
 
 #: src/NotificationTargetCommonITILObject.php:973
-#: src/CommonITILValidation.php:1254 src/CommonITILValidation.php:1381
+#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1384
 msgid "Approval requester"
 msgstr "Pemohon persetujuan"
 
@@ -32233,7 +32233,7 @@ msgstr ""
 msgid "Granted + Not subject to approval"
 msgstr ""
 
-#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1836
+#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1839
 msgid "Group user(s)"
 msgstr ""
 
@@ -32246,77 +32246,89 @@ msgstr ""
 msgid "Progress: %1$s%% of %2$s%% required"
 msgstr ""
 
-#: src/CommonITILValidation.php:1253 src/CommonITILValidation.php:1365
-#: src/CommonITILValidation.php:1472
+#: src/CommonITILValidation.php:1127
+msgid "Approval step accepted"
+msgstr ""
+
+#: src/CommonITILValidation.php:1128
+msgid "Approval step refused"
+msgstr ""
+
+#: src/CommonITILValidation.php:1129
+msgid "Approval step pending"
+msgstr ""
+
+#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1368
+#: src/CommonITILValidation.php:1475
 msgid "Request date"
 msgstr ""
 
-#: src/CommonITILValidation.php:1255 src/CommonITILValidation.php:1338
-#: src/CommonITILValidation.php:1430
+#: src/CommonITILValidation.php:1258 src/CommonITILValidation.php:1341
+#: src/CommonITILValidation.php:1433
 msgid "Request comments"
 msgstr ""
 
-#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1373
-#: src/CommonITILValidation.php:1485
+#: src/CommonITILValidation.php:1259 src/CommonITILValidation.php:1376
+#: src/CommonITILValidation.php:1488
 msgid "Approval date"
 msgstr "Tanggal persetujuan"
 
-#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1400
+#: src/CommonITILValidation.php:1260 src/CommonITILValidation.php:1403
 msgid "Requested approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1258
+#: src/CommonITILValidation.php:1261
 msgid "Requested approver"
 msgstr ""
 
-#: src/CommonITILValidation.php:1259
+#: src/CommonITILValidation.php:1262
 msgid "Approval Comment"
 msgstr ""
 
-#: src/CommonITILValidation.php:1260
+#: src/CommonITILValidation.php:1263
 #: src/NotificationTargetKnowbaseItem.php:218
 msgid "Documents"
 msgstr ""
 
-#: src/CommonITILValidation.php:1347 src/CommonITILValidation.php:1444
+#: src/CommonITILValidation.php:1350 src/CommonITILValidation.php:1447
 msgid "Approval comments"
 msgstr "Komentar persetujuan"
 
-#: src/CommonITILValidation.php:1459
+#: src/CommonITILValidation.php:1462
 msgid "Approval status"
 msgstr ""
 
-#: src/CommonITILValidation.php:1541
+#: src/CommonITILValidation.php:1544
 msgid "Approver substitute"
 msgstr ""
 
-#: src/CommonITILValidation.php:1601
+#: src/CommonITILValidation.php:1604
 msgid "Approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1623
+#: src/CommonITILValidation.php:1626
 msgid "Substitute of a member of approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1694
+#: src/CommonITILValidation.php:1697
 msgid "Approval status by users"
 msgstr ""
 
-#: src/CommonITILValidation.php:1849
+#: src/CommonITILValidation.php:1852
 msgid "Approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1954
+#: src/CommonITILValidation.php:1957
 msgid ""
 "This item is waiting for approval, do you really want to resolve or close "
 "it?"
 msgstr ""
 
-#: src/CommonITILValidation.php:1995
+#: src/CommonITILValidation.php:1998
 msgid "This item is waiting for approval."
 msgstr ""
 
-#: src/CommonITILValidation.php:1996
+#: src/CommonITILValidation.php:1999
 msgid "Do you really want to resolve or close it?"
 msgstr ""
 

--- a/locales/is_IS.po
+++ b/locales/is_IS.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-26 10:20+0000\n"
+"POT-Creation-Date: 2025-08-26 12:21+0000\n"
 "PO-Revision-Date: 2022-09-16 06:53+0000\n"
 "Last-Translator: Guðjón Jónsson <gudjon@247.is>, 2025\n"
 "Language-Team: Icelandic (Iceland) (https://app.transifex.com/glpi/teams/1637/is_IS/)\n"
@@ -786,7 +786,7 @@ msgstr ""
 #: templates/components/itilobject/timeline/main_description.html.twig
 #: templates/components/user/info_card.html.twig
 #: templates/pages/tools/kb/comments.html.twig src/KnowbaseItem.php:245
-#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1188
+#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1191
 #: js/src/vue/CustomObject/FieldPreview/Field.vue:30
 msgid "Edit"
 msgstr ""
@@ -1426,7 +1426,7 @@ msgid "Cancel"
 msgstr ""
 
 #: templates/components/form/basic_inputs_macros.html.twig
-#: src/CommonITILValidation.php:1773
+#: src/CommonITILValidation.php:1776
 msgid "Validate"
 msgstr ""
 
@@ -1942,7 +1942,7 @@ msgstr "Vörunúmer"
 #: src/Computer.php:461 src/ProjectTask_Ticket.php:336 src/Certificate.php:278
 #: src/CronTask.php:1274 src/CronTask.php:1412
 #: src/CommonItilObject_Item.php:506 src/PDU.php:203 src/CommonDBTM.php:3513
-#: src/CommonITILValidation.php:1356 src/Plugin.php:2657
+#: src/CommonITILValidation.php:1359 src/Plugin.php:2657
 msgid "Status"
 msgstr ""
 
@@ -3422,7 +3422,7 @@ msgstr[1] ""
 #: src/CommonITILObject.php:4737 src/CommonITILObject.php:4746
 #: src/CommonITILObject.php:6847 src/CommonITILObject.php:6894
 #: src/CommonITILObject.php:10159 src/NotificationTargetChange.php:308
-#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1498
+#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1501
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] ""
@@ -3432,7 +3432,7 @@ msgstr[1] ""
 #: src/NotificationTargetTicket.php:676 src/NotificationTargetTicket.php:706
 #: src/NotificationTargetCommonITILObject.php:976
 #: src/ITILValidationTemplate.php:81 src/NotificationTargetChange.php:327
-#: src/CommonITILValidation.php:1391 src/CommonITILValidation.php:1518
+#: src/CommonITILValidation.php:1394 src/CommonITILValidation.php:1521
 msgid "Approver"
 msgstr ""
 
@@ -4166,7 +4166,7 @@ msgstr ""
 #: src/OAuthClient.php:94 src/Item_RemoteManagement.php:207
 #: src/Item_RemoteManagement.php:238 src/Certificate.php:125
 #: src/CronTask.php:1391 src/Contact.php:282 src/PDU.php:114
-#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1329
+#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1332
 #: src/Domain.php:233 src/Domain.php:257 src/ConsumableItem.php:167
 msgid "ID"
 msgstr "KENNI"
@@ -5702,7 +5702,7 @@ msgstr ""
 #: src/Project.php:904 src/ProjectTask.php:963
 #: src/NotificationTargetProjectTask.php:553
 #: src/NotificationTargetProjectTask.php:568 src/Cartridge.php:895
-#: src/CommonITILValidation.php:1252
+#: src/CommonITILValidation.php:1255
 msgctxt "item"
 msgid "State"
 msgstr ""
@@ -17136,7 +17136,7 @@ msgid "Observer group except manager users"
 msgstr ""
 
 #: src/NotificationTargetCommonITILObject.php:973
-#: src/CommonITILValidation.php:1254 src/CommonITILValidation.php:1381
+#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1384
 msgid "Approval requester"
 msgstr ""
 
@@ -32592,7 +32592,7 @@ msgstr ""
 msgid "Granted + Not subject to approval"
 msgstr ""
 
-#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1836
+#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1839
 msgid "Group user(s)"
 msgstr ""
 
@@ -32605,77 +32605,89 @@ msgstr ""
 msgid "Progress: %1$s%% of %2$s%% required"
 msgstr ""
 
-#: src/CommonITILValidation.php:1253 src/CommonITILValidation.php:1365
-#: src/CommonITILValidation.php:1472
+#: src/CommonITILValidation.php:1127
+msgid "Approval step accepted"
+msgstr ""
+
+#: src/CommonITILValidation.php:1128
+msgid "Approval step refused"
+msgstr ""
+
+#: src/CommonITILValidation.php:1129
+msgid "Approval step pending"
+msgstr ""
+
+#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1368
+#: src/CommonITILValidation.php:1475
 msgid "Request date"
 msgstr ""
 
-#: src/CommonITILValidation.php:1255 src/CommonITILValidation.php:1338
-#: src/CommonITILValidation.php:1430
+#: src/CommonITILValidation.php:1258 src/CommonITILValidation.php:1341
+#: src/CommonITILValidation.php:1433
 msgid "Request comments"
 msgstr ""
 
-#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1373
-#: src/CommonITILValidation.php:1485
+#: src/CommonITILValidation.php:1259 src/CommonITILValidation.php:1376
+#: src/CommonITILValidation.php:1488
 msgid "Approval date"
 msgstr ""
 
-#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1400
+#: src/CommonITILValidation.php:1260 src/CommonITILValidation.php:1403
 msgid "Requested approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1258
+#: src/CommonITILValidation.php:1261
 msgid "Requested approver"
 msgstr ""
 
-#: src/CommonITILValidation.php:1259
+#: src/CommonITILValidation.php:1262
 msgid "Approval Comment"
 msgstr ""
 
-#: src/CommonITILValidation.php:1260
+#: src/CommonITILValidation.php:1263
 #: src/NotificationTargetKnowbaseItem.php:218
 msgid "Documents"
 msgstr ""
 
-#: src/CommonITILValidation.php:1347 src/CommonITILValidation.php:1444
+#: src/CommonITILValidation.php:1350 src/CommonITILValidation.php:1447
 msgid "Approval comments"
 msgstr ""
 
-#: src/CommonITILValidation.php:1459
+#: src/CommonITILValidation.php:1462
 msgid "Approval status"
 msgstr ""
 
-#: src/CommonITILValidation.php:1541
+#: src/CommonITILValidation.php:1544
 msgid "Approver substitute"
 msgstr ""
 
-#: src/CommonITILValidation.php:1601
+#: src/CommonITILValidation.php:1604
 msgid "Approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1623
+#: src/CommonITILValidation.php:1626
 msgid "Substitute of a member of approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1694
+#: src/CommonITILValidation.php:1697
 msgid "Approval status by users"
 msgstr ""
 
-#: src/CommonITILValidation.php:1849
+#: src/CommonITILValidation.php:1852
 msgid "Approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1954
+#: src/CommonITILValidation.php:1957
 msgid ""
 "This item is waiting for approval, do you really want to resolve or close "
 "it?"
 msgstr ""
 
-#: src/CommonITILValidation.php:1995
+#: src/CommonITILValidation.php:1998
 msgid "This item is waiting for approval."
 msgstr ""
 
-#: src/CommonITILValidation.php:1996
+#: src/CommonITILValidation.php:1999
 msgid "Do you really want to resolve or close it?"
 msgstr ""
 

--- a/locales/it_IT.po
+++ b/locales/it_IT.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-26 10:20+0000\n"
+"POT-Creation-Date: 2025-08-26 12:21+0000\n"
 "PO-Revision-Date: 2022-09-16 06:53+0000\n"
 "Last-Translator: Cédric Anne, 2025\n"
 "Language-Team: Italian (Italy) (https://app.transifex.com/glpi/teams/1637/it_IT/)\n"
@@ -812,7 +812,7 @@ msgstr "Modalità di sola lettura"
 #: templates/components/itilobject/timeline/main_description.html.twig
 #: templates/components/user/info_card.html.twig
 #: templates/pages/tools/kb/comments.html.twig src/KnowbaseItem.php:245
-#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1188
+#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1191
 #: js/src/vue/CustomObject/FieldPreview/Field.vue:30
 msgid "Edit"
 msgstr "Modifica"
@@ -1462,7 +1462,7 @@ msgid "Cancel"
 msgstr "Annulla"
 
 #: templates/components/form/basic_inputs_macros.html.twig
-#: src/CommonITILValidation.php:1773
+#: src/CommonITILValidation.php:1776
 msgid "Validate"
 msgstr "Conferma"
 
@@ -1985,7 +1985,7 @@ msgstr "Numero di inventario"
 #: src/Computer.php:461 src/ProjectTask_Ticket.php:336 src/Certificate.php:278
 #: src/CronTask.php:1274 src/CronTask.php:1412
 #: src/CommonItilObject_Item.php:506 src/PDU.php:203 src/CommonDBTM.php:3513
-#: src/CommonITILValidation.php:1356 src/Plugin.php:2657
+#: src/CommonITILValidation.php:1359 src/Plugin.php:2657
 msgid "Status"
 msgstr "Stato"
 
@@ -3484,7 +3484,7 @@ msgstr[2] "Passaggi di approvazione"
 #: src/CommonITILObject.php:4737 src/CommonITILObject.php:4746
 #: src/CommonITILObject.php:6847 src/CommonITILObject.php:6894
 #: src/CommonITILObject.php:10159 src/NotificationTargetChange.php:308
-#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1498
+#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1501
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "Richiedente"
@@ -3495,7 +3495,7 @@ msgstr[2] "Richiedenti"
 #: src/NotificationTargetTicket.php:676 src/NotificationTargetTicket.php:706
 #: src/NotificationTargetCommonITILObject.php:976
 #: src/ITILValidationTemplate.php:81 src/NotificationTargetChange.php:327
-#: src/CommonITILValidation.php:1391 src/CommonITILValidation.php:1518
+#: src/CommonITILValidation.php:1394 src/CommonITILValidation.php:1521
 msgid "Approver"
 msgstr "Validatore"
 
@@ -4244,7 +4244,7 @@ msgstr "Nessuna operazione recente"
 #: src/OAuthClient.php:94 src/Item_RemoteManagement.php:207
 #: src/Item_RemoteManagement.php:238 src/Certificate.php:125
 #: src/CronTask.php:1391 src/Contact.php:282 src/PDU.php:114
-#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1329
+#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1332
 #: src/Domain.php:233 src/Domain.php:257 src/ConsumableItem.php:167
 msgid "ID"
 msgstr "ID"
@@ -5816,7 +5816,7 @@ msgstr ""
 #: src/Project.php:904 src/ProjectTask.php:963
 #: src/NotificationTargetProjectTask.php:553
 #: src/NotificationTargetProjectTask.php:568 src/Cartridge.php:895
-#: src/CommonITILValidation.php:1252
+#: src/CommonITILValidation.php:1255
 msgctxt "item"
 msgid "State"
 msgstr "Stato"
@@ -17603,7 +17603,7 @@ msgid "Observer group except manager users"
 msgstr "Gruppo osservatore tranne il responsabile"
 
 #: src/NotificationTargetCommonITILObject.php:973
-#: src/CommonITILValidation.php:1254 src/CommonITILValidation.php:1381
+#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1384
 msgid "Approval requester"
 msgstr "Richiede convalida"
 
@@ -33876,7 +33876,7 @@ msgstr "Non soggetto a convalida"
 msgid "Granted + Not subject to approval"
 msgstr "Concesso o non soggetto a convalida"
 
-#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1836
+#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1839
 msgid "Group user(s)"
 msgstr "Gruppo dell'utente(i)"
 
@@ -33889,67 +33889,79 @@ msgstr "Modifica passaggio di approvazione"
 msgid "Progress: %1$s%% of %2$s%% required"
 msgstr "Progresso: %1$s%% di %2$s%% necessario"
 
-#: src/CommonITILValidation.php:1253 src/CommonITILValidation.php:1365
-#: src/CommonITILValidation.php:1472
+#: src/CommonITILValidation.php:1127
+msgid "Approval step accepted"
+msgstr ""
+
+#: src/CommonITILValidation.php:1128
+msgid "Approval step refused"
+msgstr ""
+
+#: src/CommonITILValidation.php:1129
+msgid "Approval step pending"
+msgstr ""
+
+#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1368
+#: src/CommonITILValidation.php:1475
 msgid "Request date"
 msgstr "Data di richiesta"
 
-#: src/CommonITILValidation.php:1255 src/CommonITILValidation.php:1338
-#: src/CommonITILValidation.php:1430
+#: src/CommonITILValidation.php:1258 src/CommonITILValidation.php:1341
+#: src/CommonITILValidation.php:1433
 msgid "Request comments"
 msgstr "Richiesta di commento"
 
-#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1373
-#: src/CommonITILValidation.php:1485
+#: src/CommonITILValidation.php:1259 src/CommonITILValidation.php:1376
+#: src/CommonITILValidation.php:1488
 msgid "Approval date"
 msgstr "Data di convalida"
 
-#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1400
+#: src/CommonITILValidation.php:1260 src/CommonITILValidation.php:1403
 msgid "Requested approver type"
 msgstr "Tipo di approvatore necessario"
 
-#: src/CommonITILValidation.php:1258
+#: src/CommonITILValidation.php:1261
 msgid "Requested approver"
 msgstr "Approvatore necessario"
 
-#: src/CommonITILValidation.php:1259
+#: src/CommonITILValidation.php:1262
 msgid "Approval Comment"
 msgstr "Commento di approvazione"
 
-#: src/CommonITILValidation.php:1260
+#: src/CommonITILValidation.php:1263
 #: src/NotificationTargetKnowbaseItem.php:218
 msgid "Documents"
 msgstr "Documenti"
 
-#: src/CommonITILValidation.php:1347 src/CommonITILValidation.php:1444
+#: src/CommonITILValidation.php:1350 src/CommonITILValidation.php:1447
 msgid "Approval comments"
 msgstr "Commento alla convalida"
 
-#: src/CommonITILValidation.php:1459
+#: src/CommonITILValidation.php:1462
 msgid "Approval status"
 msgstr "Stato convalida"
 
-#: src/CommonITILValidation.php:1541
+#: src/CommonITILValidation.php:1544
 msgid "Approver substitute"
 msgstr "Sostituto approvatore"
 
-#: src/CommonITILValidation.php:1601
+#: src/CommonITILValidation.php:1604
 msgid "Approver group"
 msgstr "Gruppo approvatore"
 
-#: src/CommonITILValidation.php:1623
+#: src/CommonITILValidation.php:1626
 msgid "Substitute of a member of approver group"
 msgstr "Sostituzione di un membro del gruppo degli approvatori"
 
-#: src/CommonITILValidation.php:1694
+#: src/CommonITILValidation.php:1697
 msgid "Approval status by users"
 msgstr "Stato di approvazione per utente"
 
-#: src/CommonITILValidation.php:1849
+#: src/CommonITILValidation.php:1852
 msgid "Approver type"
 msgstr "Tipo di approvatore"
 
-#: src/CommonITILValidation.php:1954
+#: src/CommonITILValidation.php:1957
 msgid ""
 "This item is waiting for approval, do you really want to resolve or close "
 "it?"
@@ -33957,11 +33969,11 @@ msgstr ""
 "L'elemento è in attesa di approvazione, vuoi veramente contrassegnarlo come "
 "risolto o chiuderlo?"
 
-#: src/CommonITILValidation.php:1995
+#: src/CommonITILValidation.php:1998
 msgid "This item is waiting for approval."
 msgstr "Questo articolo è in attesa di approvazione."
 
-#: src/CommonITILValidation.php:1996
+#: src/CommonITILValidation.php:1999
 msgid "Do you really want to resolve or close it?"
 msgstr "Vuoi davvero risolverlo o chiuderlo?"
 

--- a/locales/ja_JP.po
+++ b/locales/ja_JP.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-26 10:20+0000\n"
+"POT-Creation-Date: 2025-08-26 12:21+0000\n"
 "PO-Revision-Date: 2022-09-16 06:53+0000\n"
 "Last-Translator: alexandre delaunay <delaunay.alexandre@gmail.com>, 2025\n"
 "Language-Team: Japanese (Japan) (https://app.transifex.com/glpi/teams/1637/ja_JP/)\n"
@@ -790,7 +790,7 @@ msgstr "表示のみモード"
 #: templates/components/itilobject/timeline/main_description.html.twig
 #: templates/components/user/info_card.html.twig
 #: templates/pages/tools/kb/comments.html.twig src/KnowbaseItem.php:245
-#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1188
+#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1191
 #: js/src/vue/CustomObject/FieldPreview/Field.vue:30
 msgid "Edit"
 msgstr "編集"
@@ -1428,7 +1428,7 @@ msgid "Cancel"
 msgstr "取消"
 
 #: templates/components/form/basic_inputs_macros.html.twig
-#: src/CommonITILValidation.php:1773
+#: src/CommonITILValidation.php:1776
 msgid "Validate"
 msgstr "検証"
 
@@ -1941,7 +1941,7 @@ msgstr "資産番号"
 #: src/Computer.php:461 src/ProjectTask_Ticket.php:336 src/Certificate.php:278
 #: src/CronTask.php:1274 src/CronTask.php:1412
 #: src/CommonItilObject_Item.php:506 src/PDU.php:203 src/CommonDBTM.php:3513
-#: src/CommonITILValidation.php:1356 src/Plugin.php:2657
+#: src/CommonITILValidation.php:1359 src/Plugin.php:2657
 msgid "Status"
 msgstr "状態"
 
@@ -3406,7 +3406,7 @@ msgstr[0] "承認ステップ"
 #: src/CommonITILObject.php:4737 src/CommonITILObject.php:4746
 #: src/CommonITILObject.php:6847 src/CommonITILObject.php:6894
 #: src/CommonITILObject.php:10159 src/NotificationTargetChange.php:308
-#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1498
+#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1501
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "依頼者"
@@ -3415,7 +3415,7 @@ msgstr[0] "依頼者"
 #: src/NotificationTargetTicket.php:676 src/NotificationTargetTicket.php:706
 #: src/NotificationTargetCommonITILObject.php:976
 #: src/ITILValidationTemplate.php:81 src/NotificationTargetChange.php:327
-#: src/CommonITILValidation.php:1391 src/CommonITILValidation.php:1518
+#: src/CommonITILValidation.php:1394 src/CommonITILValidation.php:1521
 msgid "Approver"
 msgstr "承認者"
 
@@ -4144,7 +4144,7 @@ msgstr "履歴はありません"
 #: src/OAuthClient.php:94 src/Item_RemoteManagement.php:207
 #: src/Item_RemoteManagement.php:238 src/Certificate.php:125
 #: src/CronTask.php:1391 src/Contact.php:282 src/PDU.php:114
-#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1329
+#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1332
 #: src/Domain.php:233 src/Domain.php:257 src/ConsumableItem.php:167
 msgid "ID"
 msgstr "ID"
@@ -5673,7 +5673,7 @@ msgstr "自動計算が有効の場合、状態をこのタスク完了率を元
 #: src/Project.php:904 src/ProjectTask.php:963
 #: src/NotificationTargetProjectTask.php:553
 #: src/NotificationTargetProjectTask.php:568 src/Cartridge.php:895
-#: src/CommonITILValidation.php:1252
+#: src/CommonITILValidation.php:1255
 msgctxt "item"
 msgid "State"
 msgstr "状態"
@@ -17035,7 +17035,7 @@ msgid "Observer group except manager users"
 msgstr "管理者ユーザーを除く関係者グループ"
 
 #: src/NotificationTargetCommonITILObject.php:973
-#: src/CommonITILValidation.php:1254 src/CommonITILValidation.php:1381
+#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1384
 msgid "Approval requester"
 msgstr "承認依頼者"
 
@@ -32260,7 +32260,7 @@ msgstr "承認不要"
 msgid "Granted + Not subject to approval"
 msgstr "承認済み + 承認の対象外"
 
-#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1836
+#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1839
 msgid "Group user(s)"
 msgstr "グループ ユーザー"
 
@@ -32273,77 +32273,89 @@ msgstr "承認ステップの編集"
 msgid "Progress: %1$s%% of %2$s%% required"
 msgstr "進捗 ( %1$s%% / %2$s%% 必要 )"
 
-#: src/CommonITILValidation.php:1253 src/CommonITILValidation.php:1365
-#: src/CommonITILValidation.php:1472
+#: src/CommonITILValidation.php:1127
+msgid "Approval step accepted"
+msgstr ""
+
+#: src/CommonITILValidation.php:1128
+msgid "Approval step refused"
+msgstr ""
+
+#: src/CommonITILValidation.php:1129
+msgid "Approval step pending"
+msgstr ""
+
+#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1368
+#: src/CommonITILValidation.php:1475
 msgid "Request date"
 msgstr "要求日"
 
-#: src/CommonITILValidation.php:1255 src/CommonITILValidation.php:1338
-#: src/CommonITILValidation.php:1430
+#: src/CommonITILValidation.php:1258 src/CommonITILValidation.php:1341
+#: src/CommonITILValidation.php:1433
 msgid "Request comments"
 msgstr "要求についてのコメント"
 
-#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1373
-#: src/CommonITILValidation.php:1485
+#: src/CommonITILValidation.php:1259 src/CommonITILValidation.php:1376
+#: src/CommonITILValidation.php:1488
 msgid "Approval date"
 msgstr "承認日"
 
-#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1400
+#: src/CommonITILValidation.php:1260 src/CommonITILValidation.php:1403
 msgid "Requested approver type"
 msgstr "要求を受けた承認者の型"
 
-#: src/CommonITILValidation.php:1258
+#: src/CommonITILValidation.php:1261
 msgid "Requested approver"
 msgstr "要求を受けた承認者"
 
-#: src/CommonITILValidation.php:1259
+#: src/CommonITILValidation.php:1262
 msgid "Approval Comment"
 msgstr "承認コメント"
 
-#: src/CommonITILValidation.php:1260
+#: src/CommonITILValidation.php:1263
 #: src/NotificationTargetKnowbaseItem.php:218
 msgid "Documents"
 msgstr "ドキュメント"
 
-#: src/CommonITILValidation.php:1347 src/CommonITILValidation.php:1444
+#: src/CommonITILValidation.php:1350 src/CommonITILValidation.php:1447
 msgid "Approval comments"
 msgstr "承認のコメント"
 
-#: src/CommonITILValidation.php:1459
+#: src/CommonITILValidation.php:1462
 msgid "Approval status"
 msgstr "承認状況"
 
-#: src/CommonITILValidation.php:1541
+#: src/CommonITILValidation.php:1544
 msgid "Approver substitute"
 msgstr "承認者の代理人"
 
-#: src/CommonITILValidation.php:1601
+#: src/CommonITILValidation.php:1604
 msgid "Approver group"
 msgstr "承認者グループ"
 
-#: src/CommonITILValidation.php:1623
+#: src/CommonITILValidation.php:1626
 msgid "Substitute of a member of approver group"
 msgstr "承認グループメンバーの代理人"
 
-#: src/CommonITILValidation.php:1694
+#: src/CommonITILValidation.php:1697
 msgid "Approval status by users"
 msgstr "ユーザーによる承認状態"
 
-#: src/CommonITILValidation.php:1849
+#: src/CommonITILValidation.php:1852
 msgid "Approver type"
 msgstr "承認者の型"
 
-#: src/CommonITILValidation.php:1954
+#: src/CommonITILValidation.php:1957
 msgid ""
 "This item is waiting for approval, do you really want to resolve or close "
 "it?"
 msgstr "このアイテムは承認を待っています。解決または終了にして、よろしいですか?"
 
-#: src/CommonITILValidation.php:1995
+#: src/CommonITILValidation.php:1998
 msgid "This item is waiting for approval."
 msgstr "このアイテムは承認待ちです。"
 
-#: src/CommonITILValidation.php:1996
+#: src/CommonITILValidation.php:1999
 msgid "Do you really want to resolve or close it?"
 msgstr "解決または終了に変更します。よろしいですか？"
 

--- a/locales/kn.po
+++ b/locales/kn.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-26 10:20+0000\n"
+"POT-Creation-Date: 2025-08-26 12:21+0000\n"
 "PO-Revision-Date: 2022-09-16 06:53+0000\n"
 "Last-Translator: Roshan Roche <roshan6@gmail.com>, 2025\n"
 "Language-Team: Kannada (https://app.transifex.com/glpi/teams/1637/kn/)\n"
@@ -786,7 +786,7 @@ msgstr ""
 #: templates/components/itilobject/timeline/main_description.html.twig
 #: templates/components/user/info_card.html.twig
 #: templates/pages/tools/kb/comments.html.twig src/KnowbaseItem.php:245
-#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1188
+#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1191
 #: js/src/vue/CustomObject/FieldPreview/Field.vue:30
 msgid "Edit"
 msgstr ""
@@ -1430,7 +1430,7 @@ msgid "Cancel"
 msgstr "ರದ್ದುಮಾಡಿ"
 
 #: templates/components/form/basic_inputs_macros.html.twig
-#: src/CommonITILValidation.php:1773
+#: src/CommonITILValidation.php:1776
 msgid "Validate"
 msgstr ""
 
@@ -1945,7 +1945,7 @@ msgstr "ಇನ್ವೆಂಟರಿ ಸಂಖ್ಯೆ"
 #: src/Computer.php:461 src/ProjectTask_Ticket.php:336 src/Certificate.php:278
 #: src/CronTask.php:1274 src/CronTask.php:1412
 #: src/CommonItilObject_Item.php:506 src/PDU.php:203 src/CommonDBTM.php:3513
-#: src/CommonITILValidation.php:1356 src/Plugin.php:2657
+#: src/CommonITILValidation.php:1359 src/Plugin.php:2657
 msgid "Status"
 msgstr "ಅ೦ತಸ್ಥು"
 
@@ -3423,7 +3423,7 @@ msgstr[1] ""
 #: src/CommonITILObject.php:4737 src/CommonITILObject.php:4746
 #: src/CommonITILObject.php:6847 src/CommonITILObject.php:6894
 #: src/CommonITILObject.php:10159 src/NotificationTargetChange.php:308
-#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1498
+#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1501
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "ವಿನಂತಿದಾರರು"
@@ -3433,7 +3433,7 @@ msgstr[1] "ವಿನಂತಿದಾರರು"
 #: src/NotificationTargetTicket.php:676 src/NotificationTargetTicket.php:706
 #: src/NotificationTargetCommonITILObject.php:976
 #: src/ITILValidationTemplate.php:81 src/NotificationTargetChange.php:327
-#: src/CommonITILValidation.php:1391 src/CommonITILValidation.php:1518
+#: src/CommonITILValidation.php:1394 src/CommonITILValidation.php:1521
 msgid "Approver"
 msgstr ""
 
@@ -4167,7 +4167,7 @@ msgstr ""
 #: src/OAuthClient.php:94 src/Item_RemoteManagement.php:207
 #: src/Item_RemoteManagement.php:238 src/Certificate.php:125
 #: src/CronTask.php:1391 src/Contact.php:282 src/PDU.php:114
-#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1329
+#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1332
 #: src/Domain.php:233 src/Domain.php:257 src/ConsumableItem.php:167
 msgid "ID"
 msgstr "ID"
@@ -5704,7 +5704,7 @@ msgstr ""
 #: src/Project.php:904 src/ProjectTask.php:963
 #: src/NotificationTargetProjectTask.php:553
 #: src/NotificationTargetProjectTask.php:568 src/Cartridge.php:895
-#: src/CommonITILValidation.php:1252
+#: src/CommonITILValidation.php:1255
 msgctxt "item"
 msgid "State"
 msgstr "ಸ್ಥಿತಿ"
@@ -17150,7 +17150,7 @@ msgid "Observer group except manager users"
 msgstr ""
 
 #: src/NotificationTargetCommonITILObject.php:973
-#: src/CommonITILValidation.php:1254 src/CommonITILValidation.php:1381
+#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1384
 msgid "Approval requester"
 msgstr ""
 
@@ -32594,7 +32594,7 @@ msgstr ""
 msgid "Granted + Not subject to approval"
 msgstr ""
 
-#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1836
+#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1839
 msgid "Group user(s)"
 msgstr ""
 
@@ -32607,77 +32607,89 @@ msgstr ""
 msgid "Progress: %1$s%% of %2$s%% required"
 msgstr ""
 
-#: src/CommonITILValidation.php:1253 src/CommonITILValidation.php:1365
-#: src/CommonITILValidation.php:1472
+#: src/CommonITILValidation.php:1127
+msgid "Approval step accepted"
+msgstr ""
+
+#: src/CommonITILValidation.php:1128
+msgid "Approval step refused"
+msgstr ""
+
+#: src/CommonITILValidation.php:1129
+msgid "Approval step pending"
+msgstr ""
+
+#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1368
+#: src/CommonITILValidation.php:1475
 msgid "Request date"
 msgstr ""
 
-#: src/CommonITILValidation.php:1255 src/CommonITILValidation.php:1338
-#: src/CommonITILValidation.php:1430
+#: src/CommonITILValidation.php:1258 src/CommonITILValidation.php:1341
+#: src/CommonITILValidation.php:1433
 msgid "Request comments"
 msgstr ""
 
-#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1373
-#: src/CommonITILValidation.php:1485
+#: src/CommonITILValidation.php:1259 src/CommonITILValidation.php:1376
+#: src/CommonITILValidation.php:1488
 msgid "Approval date"
 msgstr ""
 
-#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1400
+#: src/CommonITILValidation.php:1260 src/CommonITILValidation.php:1403
 msgid "Requested approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1258
+#: src/CommonITILValidation.php:1261
 msgid "Requested approver"
 msgstr ""
 
-#: src/CommonITILValidation.php:1259
+#: src/CommonITILValidation.php:1262
 msgid "Approval Comment"
 msgstr ""
 
-#: src/CommonITILValidation.php:1260
+#: src/CommonITILValidation.php:1263
 #: src/NotificationTargetKnowbaseItem.php:218
 msgid "Documents"
 msgstr "ದಾಖಲೆಗಳು"
 
-#: src/CommonITILValidation.php:1347 src/CommonITILValidation.php:1444
+#: src/CommonITILValidation.php:1350 src/CommonITILValidation.php:1447
 msgid "Approval comments"
 msgstr ""
 
-#: src/CommonITILValidation.php:1459
+#: src/CommonITILValidation.php:1462
 msgid "Approval status"
 msgstr ""
 
-#: src/CommonITILValidation.php:1541
+#: src/CommonITILValidation.php:1544
 msgid "Approver substitute"
 msgstr ""
 
-#: src/CommonITILValidation.php:1601
+#: src/CommonITILValidation.php:1604
 msgid "Approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1623
+#: src/CommonITILValidation.php:1626
 msgid "Substitute of a member of approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1694
+#: src/CommonITILValidation.php:1697
 msgid "Approval status by users"
 msgstr ""
 
-#: src/CommonITILValidation.php:1849
+#: src/CommonITILValidation.php:1852
 msgid "Approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1954
+#: src/CommonITILValidation.php:1957
 msgid ""
 "This item is waiting for approval, do you really want to resolve or close "
 "it?"
 msgstr ""
 
-#: src/CommonITILValidation.php:1995
+#: src/CommonITILValidation.php:1998
 msgid "This item is waiting for approval."
 msgstr ""
 
-#: src/CommonITILValidation.php:1996
+#: src/CommonITILValidation.php:1999
 msgid "Do you really want to resolve or close it?"
 msgstr ""
 

--- a/locales/ko_KR.po
+++ b/locales/ko_KR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-26 10:20+0000\n"
+"POT-Creation-Date: 2025-08-26 12:21+0000\n"
 "PO-Revision-Date: 2022-09-16 06:53+0000\n"
 "Last-Translator: alexandre delaunay <delaunay.alexandre@gmail.com>, 2025\n"
 "Language-Team: Korean (Korea) (https://app.transifex.com/glpi/teams/1637/ko_KR/)\n"
@@ -786,7 +786,7 @@ msgstr ""
 #: templates/components/itilobject/timeline/main_description.html.twig
 #: templates/components/user/info_card.html.twig
 #: templates/pages/tools/kb/comments.html.twig src/KnowbaseItem.php:245
-#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1188
+#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1191
 #: js/src/vue/CustomObject/FieldPreview/Field.vue:30
 msgid "Edit"
 msgstr "편집"
@@ -1424,7 +1424,7 @@ msgid "Cancel"
 msgstr "취소"
 
 #: templates/components/form/basic_inputs_macros.html.twig
-#: src/CommonITILValidation.php:1773
+#: src/CommonITILValidation.php:1776
 msgid "Validate"
 msgstr "인증하다"
 
@@ -1937,7 +1937,7 @@ msgstr "재고 번호"
 #: src/Computer.php:461 src/ProjectTask_Ticket.php:336 src/Certificate.php:278
 #: src/CronTask.php:1274 src/CronTask.php:1412
 #: src/CommonItilObject_Item.php:506 src/PDU.php:203 src/CommonDBTM.php:3513
-#: src/CommonITILValidation.php:1356 src/Plugin.php:2657
+#: src/CommonITILValidation.php:1359 src/Plugin.php:2657
 msgid "Status"
 msgstr "상태"
 
@@ -3402,7 +3402,7 @@ msgstr[0] ""
 #: src/CommonITILObject.php:4737 src/CommonITILObject.php:4746
 #: src/CommonITILObject.php:6847 src/CommonITILObject.php:6894
 #: src/CommonITILObject.php:10159 src/NotificationTargetChange.php:308
-#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1498
+#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1501
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "요청자"
@@ -3411,7 +3411,7 @@ msgstr[0] "요청자"
 #: src/NotificationTargetTicket.php:676 src/NotificationTargetTicket.php:706
 #: src/NotificationTargetCommonITILObject.php:976
 #: src/ITILValidationTemplate.php:81 src/NotificationTargetChange.php:327
-#: src/CommonITILValidation.php:1391 src/CommonITILValidation.php:1518
+#: src/CommonITILValidation.php:1394 src/CommonITILValidation.php:1521
 msgid "Approver"
 msgstr "승인자"
 
@@ -4140,7 +4140,7 @@ msgstr "이력 없음"
 #: src/OAuthClient.php:94 src/Item_RemoteManagement.php:207
 #: src/Item_RemoteManagement.php:238 src/Certificate.php:125
 #: src/CronTask.php:1391 src/Contact.php:282 src/PDU.php:114
-#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1329
+#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1332
 #: src/Domain.php:233 src/Domain.php:257 src/ConsumableItem.php:167
 msgid "ID"
 msgstr "ID"
@@ -5665,7 +5665,7 @@ msgstr ""
 #: src/Project.php:904 src/ProjectTask.php:963
 #: src/NotificationTargetProjectTask.php:553
 #: src/NotificationTargetProjectTask.php:568 src/Cartridge.php:895
-#: src/CommonITILValidation.php:1252
+#: src/CommonITILValidation.php:1255
 msgctxt "item"
 msgid "State"
 msgstr "상태"
@@ -17010,7 +17010,7 @@ msgid "Observer group except manager users"
 msgstr ""
 
 #: src/NotificationTargetCommonITILObject.php:973
-#: src/CommonITILValidation.php:1254 src/CommonITILValidation.php:1381
+#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1384
 msgid "Approval requester"
 msgstr "승인요청자"
 
@@ -32209,7 +32209,7 @@ msgstr "승인 대상 제외"
 msgid "Granted + Not subject to approval"
 msgstr "승인됨 + 승인 제외"
 
-#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1836
+#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1839
 msgid "Group user(s)"
 msgstr ""
 
@@ -32222,77 +32222,89 @@ msgstr ""
 msgid "Progress: %1$s%% of %2$s%% required"
 msgstr ""
 
-#: src/CommonITILValidation.php:1253 src/CommonITILValidation.php:1365
-#: src/CommonITILValidation.php:1472
+#: src/CommonITILValidation.php:1127
+msgid "Approval step accepted"
+msgstr ""
+
+#: src/CommonITILValidation.php:1128
+msgid "Approval step refused"
+msgstr ""
+
+#: src/CommonITILValidation.php:1129
+msgid "Approval step pending"
+msgstr ""
+
+#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1368
+#: src/CommonITILValidation.php:1475
 msgid "Request date"
 msgstr "요청일"
 
-#: src/CommonITILValidation.php:1255 src/CommonITILValidation.php:1338
-#: src/CommonITILValidation.php:1430
+#: src/CommonITILValidation.php:1258 src/CommonITILValidation.php:1341
+#: src/CommonITILValidation.php:1433
 msgid "Request comments"
 msgstr "요청 주석"
 
-#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1373
-#: src/CommonITILValidation.php:1485
+#: src/CommonITILValidation.php:1259 src/CommonITILValidation.php:1376
+#: src/CommonITILValidation.php:1488
 msgid "Approval date"
 msgstr "승인일"
 
-#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1400
+#: src/CommonITILValidation.php:1260 src/CommonITILValidation.php:1403
 msgid "Requested approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1258
+#: src/CommonITILValidation.php:1261
 msgid "Requested approver"
 msgstr ""
 
-#: src/CommonITILValidation.php:1259
+#: src/CommonITILValidation.php:1262
 msgid "Approval Comment"
 msgstr ""
 
-#: src/CommonITILValidation.php:1260
+#: src/CommonITILValidation.php:1263
 #: src/NotificationTargetKnowbaseItem.php:218
 msgid "Documents"
 msgstr "문서"
 
-#: src/CommonITILValidation.php:1347 src/CommonITILValidation.php:1444
+#: src/CommonITILValidation.php:1350 src/CommonITILValidation.php:1447
 msgid "Approval comments"
 msgstr "승인 주석"
 
-#: src/CommonITILValidation.php:1459
+#: src/CommonITILValidation.php:1462
 msgid "Approval status"
 msgstr "승인 상태"
 
-#: src/CommonITILValidation.php:1541
+#: src/CommonITILValidation.php:1544
 msgid "Approver substitute"
 msgstr ""
 
-#: src/CommonITILValidation.php:1601
+#: src/CommonITILValidation.php:1604
 msgid "Approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1623
+#: src/CommonITILValidation.php:1626
 msgid "Substitute of a member of approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1694
+#: src/CommonITILValidation.php:1697
 msgid "Approval status by users"
 msgstr ""
 
-#: src/CommonITILValidation.php:1849
+#: src/CommonITILValidation.php:1852
 msgid "Approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1954
+#: src/CommonITILValidation.php:1957
 msgid ""
 "This item is waiting for approval, do you really want to resolve or close "
 "it?"
 msgstr "이 품목은 승인 대기 중입니다, 정말로 완결 또는 종료 처리 하시겠습니까?"
 
-#: src/CommonITILValidation.php:1995
+#: src/CommonITILValidation.php:1998
 msgid "This item is waiting for approval."
 msgstr ""
 
-#: src/CommonITILValidation.php:1996
+#: src/CommonITILValidation.php:1999
 msgid "Do you really want to resolve or close it?"
 msgstr ""
 

--- a/locales/lt_LT.po
+++ b/locales/lt_LT.po
@@ -20,7 +20,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-26 10:20+0000\n"
+"POT-Creation-Date: 2025-08-26 12:21+0000\n"
 "PO-Revision-Date: 2022-09-16 06:53+0000\n"
 "Last-Translator: Džiugas Jan., 2025\n"
 "Language-Team: Lithuanian (Lithuania) (https://app.transifex.com/glpi/teams/1637/lt_LT/)\n"
@@ -807,7 +807,7 @@ msgstr ""
 #: templates/components/itilobject/timeline/main_description.html.twig
 #: templates/components/user/info_card.html.twig
 #: templates/pages/tools/kb/comments.html.twig src/KnowbaseItem.php:245
-#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1188
+#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1191
 #: js/src/vue/CustomObject/FieldPreview/Field.vue:30
 msgid "Edit"
 msgstr "Redaguoti"
@@ -1454,7 +1454,7 @@ msgid "Cancel"
 msgstr "Atšaukti"
 
 #: templates/components/form/basic_inputs_macros.html.twig
-#: src/CommonITILValidation.php:1773
+#: src/CommonITILValidation.php:1776
 msgid "Validate"
 msgstr "Tvirtinti"
 
@@ -1975,7 +1975,7 @@ msgstr "Inventorinis Nr"
 #: src/Computer.php:461 src/ProjectTask_Ticket.php:336 src/Certificate.php:278
 #: src/CronTask.php:1274 src/CronTask.php:1412
 #: src/CommonItilObject_Item.php:506 src/PDU.php:203 src/CommonDBTM.php:3513
-#: src/CommonITILValidation.php:1356 src/Plugin.php:2657
+#: src/CommonITILValidation.php:1359 src/Plugin.php:2657
 msgid "Status"
 msgstr "Būsena/Būklė"
 
@@ -3482,7 +3482,7 @@ msgstr[3] ""
 #: src/CommonITILObject.php:4737 src/CommonITILObject.php:4746
 #: src/CommonITILObject.php:6847 src/CommonITILObject.php:6894
 #: src/CommonITILObject.php:10159 src/NotificationTargetChange.php:308
-#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1498
+#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1501
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "Užsakovas"
@@ -3494,7 +3494,7 @@ msgstr[3] "Užsakovas"
 #: src/NotificationTargetTicket.php:676 src/NotificationTargetTicket.php:706
 #: src/NotificationTargetCommonITILObject.php:976
 #: src/ITILValidationTemplate.php:81 src/NotificationTargetChange.php:327
-#: src/CommonITILValidation.php:1391 src/CommonITILValidation.php:1518
+#: src/CommonITILValidation.php:1394 src/CommonITILValidation.php:1521
 msgid "Approver"
 msgstr "Tvirtintojas"
 
@@ -4238,7 +4238,7 @@ msgstr "Nėra istorijos"
 #: src/OAuthClient.php:94 src/Item_RemoteManagement.php:207
 #: src/Item_RemoteManagement.php:238 src/Certificate.php:125
 #: src/CronTask.php:1391 src/Contact.php:282 src/PDU.php:114
-#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1329
+#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1332
 #: src/Domain.php:233 src/Domain.php:257 src/ConsumableItem.php:167
 msgid "ID"
 msgstr "ID"
@@ -5796,7 +5796,7 @@ msgstr ""
 #: src/Project.php:904 src/ProjectTask.php:963
 #: src/NotificationTargetProjectTask.php:553
 #: src/NotificationTargetProjectTask.php:568 src/Cartridge.php:895
-#: src/CommonITILValidation.php:1252
+#: src/CommonITILValidation.php:1255
 msgctxt "item"
 msgid "State"
 msgstr "Valstybė"
@@ -17403,7 +17403,7 @@ msgid "Observer group except manager users"
 msgstr ""
 
 #: src/NotificationTargetCommonITILObject.php:973
-#: src/CommonITILValidation.php:1254 src/CommonITILValidation.php:1381
+#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1384
 msgid "Approval requester"
 msgstr "Patvirtinimo užklausėjas"
 
@@ -33308,7 +33308,7 @@ msgstr "Nėra subjektų, kuriuos reikėtų patvirtinti"
 msgid "Granted + Not subject to approval"
 msgstr ""
 
-#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1836
+#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1839
 msgid "Group user(s)"
 msgstr ""
 
@@ -33321,77 +33321,89 @@ msgstr ""
 msgid "Progress: %1$s%% of %2$s%% required"
 msgstr ""
 
-#: src/CommonITILValidation.php:1253 src/CommonITILValidation.php:1365
-#: src/CommonITILValidation.php:1472
+#: src/CommonITILValidation.php:1127
+msgid "Approval step accepted"
+msgstr ""
+
+#: src/CommonITILValidation.php:1128
+msgid "Approval step refused"
+msgstr ""
+
+#: src/CommonITILValidation.php:1129
+msgid "Approval step pending"
+msgstr ""
+
+#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1368
+#: src/CommonITILValidation.php:1475
 msgid "Request date"
 msgstr "Prašymo data"
 
-#: src/CommonITILValidation.php:1255 src/CommonITILValidation.php:1338
-#: src/CommonITILValidation.php:1430
+#: src/CommonITILValidation.php:1258 src/CommonITILValidation.php:1341
+#: src/CommonITILValidation.php:1433
 msgid "Request comments"
 msgstr "Prašymo komentaras"
 
-#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1373
-#: src/CommonITILValidation.php:1485
+#: src/CommonITILValidation.php:1259 src/CommonITILValidation.php:1376
+#: src/CommonITILValidation.php:1488
 msgid "Approval date"
 msgstr "Patvirtinimo data"
 
-#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1400
+#: src/CommonITILValidation.php:1260 src/CommonITILValidation.php:1403
 msgid "Requested approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1258
+#: src/CommonITILValidation.php:1261
 msgid "Requested approver"
 msgstr ""
 
-#: src/CommonITILValidation.php:1259
+#: src/CommonITILValidation.php:1262
 msgid "Approval Comment"
 msgstr ""
 
-#: src/CommonITILValidation.php:1260
+#: src/CommonITILValidation.php:1263
 #: src/NotificationTargetKnowbaseItem.php:218
 msgid "Documents"
 msgstr "Dokumentus"
 
-#: src/CommonITILValidation.php:1347 src/CommonITILValidation.php:1444
+#: src/CommonITILValidation.php:1350 src/CommonITILValidation.php:1447
 msgid "Approval comments"
 msgstr "Patvirtinimo komentarai"
 
-#: src/CommonITILValidation.php:1459
+#: src/CommonITILValidation.php:1462
 msgid "Approval status"
 msgstr "Patvirtinimo statusas"
 
-#: src/CommonITILValidation.php:1541
+#: src/CommonITILValidation.php:1544
 msgid "Approver substitute"
 msgstr ""
 
-#: src/CommonITILValidation.php:1601
+#: src/CommonITILValidation.php:1604
 msgid "Approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1623
+#: src/CommonITILValidation.php:1626
 msgid "Substitute of a member of approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1694
+#: src/CommonITILValidation.php:1697
 msgid "Approval status by users"
 msgstr ""
 
-#: src/CommonITILValidation.php:1849
+#: src/CommonITILValidation.php:1852
 msgid "Approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1954
+#: src/CommonITILValidation.php:1957
 msgid ""
 "This item is waiting for approval, do you really want to resolve or close "
 "it?"
 msgstr ""
 
-#: src/CommonITILValidation.php:1995
+#: src/CommonITILValidation.php:1998
 msgid "This item is waiting for approval."
 msgstr ""
 
-#: src/CommonITILValidation.php:1996
+#: src/CommonITILValidation.php:1999
 msgid "Do you really want to resolve or close it?"
 msgstr ""
 

--- a/locales/lv_LV.po
+++ b/locales/lv_LV.po
@@ -18,7 +18,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-26 10:20+0000\n"
+"POT-Creation-Date: 2025-08-26 12:21+0000\n"
 "PO-Revision-Date: 2022-09-16 06:53+0000\n"
 "Last-Translator: alexandre delaunay <delaunay.alexandre@gmail.com>, 2025\n"
 "Language-Team: Latvian (Latvia) (https://app.transifex.com/glpi/teams/1637/lv_LV/)\n"
@@ -801,7 +801,7 @@ msgstr ""
 #: templates/components/itilobject/timeline/main_description.html.twig
 #: templates/components/user/info_card.html.twig
 #: templates/pages/tools/kb/comments.html.twig src/KnowbaseItem.php:245
-#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1188
+#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1191
 #: js/src/vue/CustomObject/FieldPreview/Field.vue:30
 msgid "Edit"
 msgstr "Rediģēt"
@@ -1448,7 +1448,7 @@ msgid "Cancel"
 msgstr "Atcelt"
 
 #: templates/components/form/basic_inputs_macros.html.twig
-#: src/CommonITILValidation.php:1773
+#: src/CommonITILValidation.php:1776
 msgid "Validate"
 msgstr "Apstiprināt"
 
@@ -1967,7 +1967,7 @@ msgstr "Inventāra Nr."
 #: src/Computer.php:461 src/ProjectTask_Ticket.php:336 src/Certificate.php:278
 #: src/CronTask.php:1274 src/CronTask.php:1412
 #: src/CommonItilObject_Item.php:506 src/PDU.php:203 src/CommonDBTM.php:3513
-#: src/CommonITILValidation.php:1356 src/Plugin.php:2657
+#: src/CommonITILValidation.php:1359 src/Plugin.php:2657
 msgid "Status"
 msgstr "Statuss"
 
@@ -3456,7 +3456,7 @@ msgstr[2] ""
 #: src/CommonITILObject.php:4737 src/CommonITILObject.php:4746
 #: src/CommonITILObject.php:6847 src/CommonITILObject.php:6894
 #: src/CommonITILObject.php:10159 src/NotificationTargetChange.php:308
-#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1498
+#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1501
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "Pieprasītāji"
@@ -3467,7 +3467,7 @@ msgstr[2] "Pieprasītāji"
 #: src/NotificationTargetTicket.php:676 src/NotificationTargetTicket.php:706
 #: src/NotificationTargetCommonITILObject.php:976
 #: src/ITILValidationTemplate.php:81 src/NotificationTargetChange.php:327
-#: src/CommonITILValidation.php:1391 src/CommonITILValidation.php:1518
+#: src/CommonITILValidation.php:1394 src/CommonITILValidation.php:1521
 msgid "Approver"
 msgstr "Apstiprinātājs"
 
@@ -4208,7 +4208,7 @@ msgstr "Nav vēsturisku"
 #: src/OAuthClient.php:94 src/Item_RemoteManagement.php:207
 #: src/Item_RemoteManagement.php:238 src/Certificate.php:125
 #: src/CronTask.php:1391 src/Contact.php:282 src/PDU.php:114
-#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1329
+#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1332
 #: src/Domain.php:233 src/Domain.php:257 src/ConsumableItem.php:167
 msgid "ID"
 msgstr "ID"
@@ -5749,7 +5749,7 @@ msgstr ""
 #: src/Project.php:904 src/ProjectTask.php:963
 #: src/NotificationTargetProjectTask.php:553
 #: src/NotificationTargetProjectTask.php:568 src/Cartridge.php:895
-#: src/CommonITILValidation.php:1252
+#: src/CommonITILValidation.php:1255
 msgctxt "item"
 msgid "State"
 msgstr "Novads"
@@ -17197,7 +17197,7 @@ msgid "Observer group except manager users"
 msgstr ""
 
 #: src/NotificationTargetCommonITILObject.php:973
-#: src/CommonITILValidation.php:1254 src/CommonITILValidation.php:1381
+#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1384
 msgid "Approval requester"
 msgstr "Apstiprinājuma pieprasītājs"
 
@@ -32688,7 +32688,7 @@ msgstr "Apstiprināšana nav paredzēta"
 msgid "Granted + Not subject to approval"
 msgstr "Piešķirt + Apstiprināšana nav paredzēta"
 
-#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1836
+#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1839
 msgid "Group user(s)"
 msgstr ""
 
@@ -32701,67 +32701,79 @@ msgstr ""
 msgid "Progress: %1$s%% of %2$s%% required"
 msgstr ""
 
-#: src/CommonITILValidation.php:1253 src/CommonITILValidation.php:1365
-#: src/CommonITILValidation.php:1472
+#: src/CommonITILValidation.php:1127
+msgid "Approval step accepted"
+msgstr ""
+
+#: src/CommonITILValidation.php:1128
+msgid "Approval step refused"
+msgstr ""
+
+#: src/CommonITILValidation.php:1129
+msgid "Approval step pending"
+msgstr ""
+
+#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1368
+#: src/CommonITILValidation.php:1475
 msgid "Request date"
 msgstr "Pieprasījuma datums"
 
-#: src/CommonITILValidation.php:1255 src/CommonITILValidation.php:1338
-#: src/CommonITILValidation.php:1430
+#: src/CommonITILValidation.php:1258 src/CommonITILValidation.php:1341
+#: src/CommonITILValidation.php:1433
 msgid "Request comments"
 msgstr "Iesniedzēja komentārs"
 
-#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1373
-#: src/CommonITILValidation.php:1485
+#: src/CommonITILValidation.php:1259 src/CommonITILValidation.php:1376
+#: src/CommonITILValidation.php:1488
 msgid "Approval date"
 msgstr "Apstiprinājuma datums"
 
-#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1400
+#: src/CommonITILValidation.php:1260 src/CommonITILValidation.php:1403
 msgid "Requested approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1258
+#: src/CommonITILValidation.php:1261
 msgid "Requested approver"
 msgstr ""
 
-#: src/CommonITILValidation.php:1259
+#: src/CommonITILValidation.php:1262
 msgid "Approval Comment"
 msgstr ""
 
-#: src/CommonITILValidation.php:1260
+#: src/CommonITILValidation.php:1263
 #: src/NotificationTargetKnowbaseItem.php:218
 msgid "Documents"
 msgstr "Dokumenti"
 
-#: src/CommonITILValidation.php:1347 src/CommonITILValidation.php:1444
+#: src/CommonITILValidation.php:1350 src/CommonITILValidation.php:1447
 msgid "Approval comments"
 msgstr "Apstiprinājuma piezīmes"
 
-#: src/CommonITILValidation.php:1459
+#: src/CommonITILValidation.php:1462
 msgid "Approval status"
 msgstr "Apstiprinājuma statuss"
 
-#: src/CommonITILValidation.php:1541
+#: src/CommonITILValidation.php:1544
 msgid "Approver substitute"
 msgstr ""
 
-#: src/CommonITILValidation.php:1601
+#: src/CommonITILValidation.php:1604
 msgid "Approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1623
+#: src/CommonITILValidation.php:1626
 msgid "Substitute of a member of approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1694
+#: src/CommonITILValidation.php:1697
 msgid "Approval status by users"
 msgstr ""
 
-#: src/CommonITILValidation.php:1849
+#: src/CommonITILValidation.php:1852
 msgid "Approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1954
+#: src/CommonITILValidation.php:1957
 msgid ""
 "This item is waiting for approval, do you really want to resolve or close "
 "it?"
@@ -32769,11 +32781,11 @@ msgstr ""
 "Šī vienība gaida apstiprinājumu, vai jūs patiešam gribat to atrisināt vai "
 "aizvērt?"
 
-#: src/CommonITILValidation.php:1995
+#: src/CommonITILValidation.php:1998
 msgid "This item is waiting for approval."
 msgstr ""
 
-#: src/CommonITILValidation.php:1996
+#: src/CommonITILValidation.php:1999
 msgid "Do you really want to resolve or close it?"
 msgstr ""
 

--- a/locales/mn_MN.po
+++ b/locales/mn_MN.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-26 10:20+0000\n"
+"POT-Creation-Date: 2025-08-26 12:21+0000\n"
 "PO-Revision-Date: 2022-09-16 06:53+0000\n"
 "Last-Translator: alexandre delaunay <delaunay.alexandre@gmail.com>, 2025\n"
 "Language-Team: Mongolian (Mongolia) (https://app.transifex.com/glpi/teams/1637/mn_MN/)\n"
@@ -798,7 +798,7 @@ msgstr ""
 #: templates/components/itilobject/timeline/main_description.html.twig
 #: templates/components/user/info_card.html.twig
 #: templates/pages/tools/kb/comments.html.twig src/KnowbaseItem.php:245
-#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1188
+#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1191
 #: js/src/vue/CustomObject/FieldPreview/Field.vue:30
 msgid "Edit"
 msgstr "Өөрчлөх"
@@ -1446,7 +1446,7 @@ msgid "Cancel"
 msgstr "Цуцлах"
 
 #: templates/components/form/basic_inputs_macros.html.twig
-#: src/CommonITILValidation.php:1773
+#: src/CommonITILValidation.php:1776
 msgid "Validate"
 msgstr "Баталгаажуулах"
 
@@ -1965,7 +1965,7 @@ msgstr "Хөрөнгийн код"
 #: src/Computer.php:461 src/ProjectTask_Ticket.php:336 src/Certificate.php:278
 #: src/CronTask.php:1274 src/CronTask.php:1412
 #: src/CommonItilObject_Item.php:506 src/PDU.php:203 src/CommonDBTM.php:3513
-#: src/CommonITILValidation.php:1356 src/Plugin.php:2657
+#: src/CommonITILValidation.php:1359 src/Plugin.php:2657
 msgid "Status"
 msgstr "Төлөв"
 
@@ -3445,7 +3445,7 @@ msgstr[1] ""
 #: src/CommonITILObject.php:4737 src/CommonITILObject.php:4746
 #: src/CommonITILObject.php:6847 src/CommonITILObject.php:6894
 #: src/CommonITILObject.php:10159 src/NotificationTargetChange.php:308
-#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1498
+#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1501
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "Хүсэлт гаргагч"
@@ -3455,7 +3455,7 @@ msgstr[1] "Хүсэлт гаргагч"
 #: src/NotificationTargetTicket.php:676 src/NotificationTargetTicket.php:706
 #: src/NotificationTargetCommonITILObject.php:976
 #: src/ITILValidationTemplate.php:81 src/NotificationTargetChange.php:327
-#: src/CommonITILValidation.php:1391 src/CommonITILValidation.php:1518
+#: src/CommonITILValidation.php:1394 src/CommonITILValidation.php:1521
 msgid "Approver"
 msgstr "Зөвшөөрөл олгогч"
 
@@ -4191,7 +4191,7 @@ msgstr "Түүх байхгүй байна"
 #: src/OAuthClient.php:94 src/Item_RemoteManagement.php:207
 #: src/Item_RemoteManagement.php:238 src/Certificate.php:125
 #: src/CronTask.php:1391 src/Contact.php:282 src/PDU.php:114
-#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1329
+#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1332
 #: src/Domain.php:233 src/Domain.php:257 src/ConsumableItem.php:167
 msgid "ID"
 msgstr "ID"
@@ -5729,7 +5729,7 @@ msgstr ""
 #: src/Project.php:904 src/ProjectTask.php:963
 #: src/NotificationTargetProjectTask.php:553
 #: src/NotificationTargetProjectTask.php:568 src/Cartridge.php:895
-#: src/CommonITILValidation.php:1252
+#: src/CommonITILValidation.php:1255
 msgctxt "item"
 msgid "State"
 msgstr "Бүтэц"
@@ -17226,7 +17226,7 @@ msgid "Observer group except manager users"
 msgstr ""
 
 #: src/NotificationTargetCommonITILObject.php:973
-#: src/CommonITILValidation.php:1254 src/CommonITILValidation.php:1381
+#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1384
 msgid "Approval requester"
 msgstr "Зөвшөөрөл хүсэгч"
 
@@ -32942,7 +32942,7 @@ msgstr "Зөвшөөрөгдөөгүй сэдэв"
 msgid "Granted + Not subject to approval"
 msgstr "Хүлээн авсан + Зөвшөөрөгдөөгүй сэдэв"
 
-#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1836
+#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1839
 msgid "Group user(s)"
 msgstr ""
 
@@ -32955,77 +32955,89 @@ msgstr ""
 msgid "Progress: %1$s%% of %2$s%% required"
 msgstr ""
 
-#: src/CommonITILValidation.php:1253 src/CommonITILValidation.php:1365
-#: src/CommonITILValidation.php:1472
+#: src/CommonITILValidation.php:1127
+msgid "Approval step accepted"
+msgstr ""
+
+#: src/CommonITILValidation.php:1128
+msgid "Approval step refused"
+msgstr ""
+
+#: src/CommonITILValidation.php:1129
+msgid "Approval step pending"
+msgstr ""
+
+#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1368
+#: src/CommonITILValidation.php:1475
 msgid "Request date"
 msgstr "Хүсэлтийн огноо"
 
-#: src/CommonITILValidation.php:1255 src/CommonITILValidation.php:1338
-#: src/CommonITILValidation.php:1430
+#: src/CommonITILValidation.php:1258 src/CommonITILValidation.php:1341
+#: src/CommonITILValidation.php:1433
 msgid "Request comments"
 msgstr "Хүсэлтийн тайлбар"
 
-#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1373
-#: src/CommonITILValidation.php:1485
+#: src/CommonITILValidation.php:1259 src/CommonITILValidation.php:1376
+#: src/CommonITILValidation.php:1488
 msgid "Approval date"
 msgstr "Зөвшөөрөх огноо"
 
-#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1400
+#: src/CommonITILValidation.php:1260 src/CommonITILValidation.php:1403
 msgid "Requested approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1258
+#: src/CommonITILValidation.php:1261
 msgid "Requested approver"
 msgstr ""
 
-#: src/CommonITILValidation.php:1259
+#: src/CommonITILValidation.php:1262
 msgid "Approval Comment"
 msgstr ""
 
-#: src/CommonITILValidation.php:1260
+#: src/CommonITILValidation.php:1263
 #: src/NotificationTargetKnowbaseItem.php:218
 msgid "Documents"
 msgstr "Бичиг баримтууд"
 
-#: src/CommonITILValidation.php:1347 src/CommonITILValidation.php:1444
+#: src/CommonITILValidation.php:1350 src/CommonITILValidation.php:1447
 msgid "Approval comments"
 msgstr "Зөвшөөрөх тайлбар"
 
-#: src/CommonITILValidation.php:1459
+#: src/CommonITILValidation.php:1462
 msgid "Approval status"
 msgstr "Батлагдсан төлөв"
 
-#: src/CommonITILValidation.php:1541
+#: src/CommonITILValidation.php:1544
 msgid "Approver substitute"
 msgstr ""
 
-#: src/CommonITILValidation.php:1601
+#: src/CommonITILValidation.php:1604
 msgid "Approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1623
+#: src/CommonITILValidation.php:1626
 msgid "Substitute of a member of approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1694
+#: src/CommonITILValidation.php:1697
 msgid "Approval status by users"
 msgstr ""
 
-#: src/CommonITILValidation.php:1849
+#: src/CommonITILValidation.php:1852
 msgid "Approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1954
+#: src/CommonITILValidation.php:1957
 msgid ""
 "This item is waiting for approval, do you really want to resolve or close "
 "it?"
 msgstr "Батлахыг хүлээж байна, та дуудлагыг шийдвэрлэх үү эсвэл хаах уу?"
 
-#: src/CommonITILValidation.php:1995
+#: src/CommonITILValidation.php:1998
 msgid "This item is waiting for approval."
 msgstr "Үүнийг батлагдахыг хүлээж байна."
 
-#: src/CommonITILValidation.php:1996
+#: src/CommonITILValidation.php:1999
 msgid "Do you really want to resolve or close it?"
 msgstr "Та үнэхээр шийдвэрлэхийг хүсч байна уу эсвэл хаах уу?"
 

--- a/locales/ms_MY.po
+++ b/locales/ms_MY.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-26 10:20+0000\n"
+"POT-Creation-Date: 2025-08-26 12:21+0000\n"
 "PO-Revision-Date: 2022-09-16 06:53+0000\n"
 "Last-Translator: Cédric Anne, 2025\n"
 "Language-Team: Malay (Malaysia) (https://app.transifex.com/glpi/teams/1637/ms_MY/)\n"
@@ -785,7 +785,7 @@ msgstr ""
 #: templates/components/itilobject/timeline/main_description.html.twig
 #: templates/components/user/info_card.html.twig
 #: templates/pages/tools/kb/comments.html.twig src/KnowbaseItem.php:245
-#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1188
+#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1191
 #: js/src/vue/CustomObject/FieldPreview/Field.vue:30
 msgid "Edit"
 msgstr ""
@@ -1423,7 +1423,7 @@ msgid "Cancel"
 msgstr ""
 
 #: templates/components/form/basic_inputs_macros.html.twig
-#: src/CommonITILValidation.php:1773
+#: src/CommonITILValidation.php:1776
 msgid "Validate"
 msgstr ""
 
@@ -1936,7 +1936,7 @@ msgstr "Nombor inventori"
 #: src/Computer.php:461 src/ProjectTask_Ticket.php:336 src/Certificate.php:278
 #: src/CronTask.php:1274 src/CronTask.php:1412
 #: src/CommonItilObject_Item.php:506 src/PDU.php:203 src/CommonDBTM.php:3513
-#: src/CommonITILValidation.php:1356 src/Plugin.php:2657
+#: src/CommonITILValidation.php:1359 src/Plugin.php:2657
 msgid "Status"
 msgstr ""
 
@@ -3401,7 +3401,7 @@ msgstr[0] ""
 #: src/CommonITILObject.php:4737 src/CommonITILObject.php:4746
 #: src/CommonITILObject.php:6847 src/CommonITILObject.php:6894
 #: src/CommonITILObject.php:10159 src/NotificationTargetChange.php:308
-#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1498
+#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1501
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "Peminta"
@@ -3410,7 +3410,7 @@ msgstr[0] "Peminta"
 #: src/NotificationTargetTicket.php:676 src/NotificationTargetTicket.php:706
 #: src/NotificationTargetCommonITILObject.php:976
 #: src/ITILValidationTemplate.php:81 src/NotificationTargetChange.php:327
-#: src/CommonITILValidation.php:1391 src/CommonITILValidation.php:1518
+#: src/CommonITILValidation.php:1394 src/CommonITILValidation.php:1521
 msgid "Approver"
 msgstr ""
 
@@ -4139,7 +4139,7 @@ msgstr ""
 #: src/OAuthClient.php:94 src/Item_RemoteManagement.php:207
 #: src/Item_RemoteManagement.php:238 src/Certificate.php:125
 #: src/CronTask.php:1391 src/Contact.php:282 src/PDU.php:114
-#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1329
+#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1332
 #: src/Domain.php:233 src/Domain.php:257 src/ConsumableItem.php:167
 msgid "ID"
 msgstr "ID"
@@ -5664,7 +5664,7 @@ msgstr ""
 #: src/Project.php:904 src/ProjectTask.php:963
 #: src/NotificationTargetProjectTask.php:553
 #: src/NotificationTargetProjectTask.php:568 src/Cartridge.php:895
-#: src/CommonITILValidation.php:1252
+#: src/CommonITILValidation.php:1255
 msgctxt "item"
 msgid "State"
 msgstr "Keadaan"
@@ -17013,7 +17013,7 @@ msgid "Observer group except manager users"
 msgstr ""
 
 #: src/NotificationTargetCommonITILObject.php:973
-#: src/CommonITILValidation.php:1254 src/CommonITILValidation.php:1381
+#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1384
 msgid "Approval requester"
 msgstr ""
 
@@ -32207,7 +32207,7 @@ msgstr ""
 msgid "Granted + Not subject to approval"
 msgstr ""
 
-#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1836
+#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1839
 msgid "Group user(s)"
 msgstr ""
 
@@ -32220,77 +32220,89 @@ msgstr ""
 msgid "Progress: %1$s%% of %2$s%% required"
 msgstr ""
 
-#: src/CommonITILValidation.php:1253 src/CommonITILValidation.php:1365
-#: src/CommonITILValidation.php:1472
+#: src/CommonITILValidation.php:1127
+msgid "Approval step accepted"
+msgstr ""
+
+#: src/CommonITILValidation.php:1128
+msgid "Approval step refused"
+msgstr ""
+
+#: src/CommonITILValidation.php:1129
+msgid "Approval step pending"
+msgstr ""
+
+#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1368
+#: src/CommonITILValidation.php:1475
 msgid "Request date"
 msgstr ""
 
-#: src/CommonITILValidation.php:1255 src/CommonITILValidation.php:1338
-#: src/CommonITILValidation.php:1430
+#: src/CommonITILValidation.php:1258 src/CommonITILValidation.php:1341
+#: src/CommonITILValidation.php:1433
 msgid "Request comments"
 msgstr ""
 
-#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1373
-#: src/CommonITILValidation.php:1485
+#: src/CommonITILValidation.php:1259 src/CommonITILValidation.php:1376
+#: src/CommonITILValidation.php:1488
 msgid "Approval date"
 msgstr ""
 
-#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1400
+#: src/CommonITILValidation.php:1260 src/CommonITILValidation.php:1403
 msgid "Requested approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1258
+#: src/CommonITILValidation.php:1261
 msgid "Requested approver"
 msgstr ""
 
-#: src/CommonITILValidation.php:1259
+#: src/CommonITILValidation.php:1262
 msgid "Approval Comment"
 msgstr ""
 
-#: src/CommonITILValidation.php:1260
+#: src/CommonITILValidation.php:1263
 #: src/NotificationTargetKnowbaseItem.php:218
 msgid "Documents"
 msgstr ""
 
-#: src/CommonITILValidation.php:1347 src/CommonITILValidation.php:1444
+#: src/CommonITILValidation.php:1350 src/CommonITILValidation.php:1447
 msgid "Approval comments"
 msgstr ""
 
-#: src/CommonITILValidation.php:1459
+#: src/CommonITILValidation.php:1462
 msgid "Approval status"
 msgstr ""
 
-#: src/CommonITILValidation.php:1541
+#: src/CommonITILValidation.php:1544
 msgid "Approver substitute"
 msgstr ""
 
-#: src/CommonITILValidation.php:1601
+#: src/CommonITILValidation.php:1604
 msgid "Approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1623
+#: src/CommonITILValidation.php:1626
 msgid "Substitute of a member of approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1694
+#: src/CommonITILValidation.php:1697
 msgid "Approval status by users"
 msgstr ""
 
-#: src/CommonITILValidation.php:1849
+#: src/CommonITILValidation.php:1852
 msgid "Approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1954
+#: src/CommonITILValidation.php:1957
 msgid ""
 "This item is waiting for approval, do you really want to resolve or close "
 "it?"
 msgstr ""
 
-#: src/CommonITILValidation.php:1995
+#: src/CommonITILValidation.php:1998
 msgid "This item is waiting for approval."
 msgstr ""
 
-#: src/CommonITILValidation.php:1996
+#: src/CommonITILValidation.php:1999
 msgid "Do you really want to resolve or close it?"
 msgstr ""
 

--- a/locales/nb_NO.po
+++ b/locales/nb_NO.po
@@ -18,7 +18,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-26 10:20+0000\n"
+"POT-Creation-Date: 2025-08-26 12:21+0000\n"
 "PO-Revision-Date: 2022-09-16 06:53+0000\n"
 "Last-Translator: Evert Meulie <evert@arkivo.no>, 2025\n"
 "Language-Team: Norwegian Bokmål (Norway) (https://app.transifex.com/glpi/teams/1637/nb_NO/)\n"
@@ -795,7 +795,7 @@ msgstr ""
 #: templates/components/itilobject/timeline/main_description.html.twig
 #: templates/components/user/info_card.html.twig
 #: templates/pages/tools/kb/comments.html.twig src/KnowbaseItem.php:245
-#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1188
+#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1191
 #: js/src/vue/CustomObject/FieldPreview/Field.vue:30
 msgid "Edit"
 msgstr "Rediger"
@@ -1439,7 +1439,7 @@ msgid "Cancel"
 msgstr "Avbryt"
 
 #: templates/components/form/basic_inputs_macros.html.twig
-#: src/CommonITILValidation.php:1773
+#: src/CommonITILValidation.php:1776
 msgid "Validate"
 msgstr "Valider"
 
@@ -1955,7 +1955,7 @@ msgstr "Inventarnummer"
 #: src/Computer.php:461 src/ProjectTask_Ticket.php:336 src/Certificate.php:278
 #: src/CronTask.php:1274 src/CronTask.php:1412
 #: src/CommonItilObject_Item.php:506 src/PDU.php:203 src/CommonDBTM.php:3513
-#: src/CommonITILValidation.php:1356 src/Plugin.php:2657
+#: src/CommonITILValidation.php:1359 src/Plugin.php:2657
 msgid "Status"
 msgstr "Status"
 
@@ -3435,7 +3435,7 @@ msgstr[1] ""
 #: src/CommonITILObject.php:4737 src/CommonITILObject.php:4746
 #: src/CommonITILObject.php:6847 src/CommonITILObject.php:6894
 #: src/CommonITILObject.php:10159 src/NotificationTargetChange.php:308
-#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1498
+#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1501
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "Innmelder"
@@ -3445,7 +3445,7 @@ msgstr[1] "Innmeldere"
 #: src/NotificationTargetTicket.php:676 src/NotificationTargetTicket.php:706
 #: src/NotificationTargetCommonITILObject.php:976
 #: src/ITILValidationTemplate.php:81 src/NotificationTargetChange.php:327
-#: src/CommonITILValidation.php:1391 src/CommonITILValidation.php:1518
+#: src/CommonITILValidation.php:1394 src/CommonITILValidation.php:1521
 msgid "Approver"
 msgstr "Godkjenner"
 
@@ -4181,7 +4181,7 @@ msgstr "Ingen historik"
 #: src/OAuthClient.php:94 src/Item_RemoteManagement.php:207
 #: src/Item_RemoteManagement.php:238 src/Certificate.php:125
 #: src/CronTask.php:1391 src/Contact.php:282 src/PDU.php:114
-#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1329
+#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1332
 #: src/Domain.php:233 src/Domain.php:257 src/ConsumableItem.php:167
 msgid "ID"
 msgstr "ID"
@@ -5718,7 +5718,7 @@ msgstr ""
 #: src/Project.php:904 src/ProjectTask.php:963
 #: src/NotificationTargetProjectTask.php:553
 #: src/NotificationTargetProjectTask.php:568 src/Cartridge.php:895
-#: src/CommonITILValidation.php:1252
+#: src/CommonITILValidation.php:1255
 msgctxt "item"
 msgid "State"
 msgstr "Status"
@@ -17203,7 +17203,7 @@ msgid "Observer group except manager users"
 msgstr ""
 
 #: src/NotificationTargetCommonITILObject.php:973
-#: src/CommonITILValidation.php:1254 src/CommonITILValidation.php:1381
+#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1384
 msgid "Approval requester"
 msgstr "Anmoder om godkjenning"
 
@@ -32732,7 +32732,7 @@ msgstr "Godkjenning ikke nødvendig"
 msgid "Granted + Not subject to approval"
 msgstr "Akseptert + Ikke nødvendig med godkjenning"
 
-#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1836
+#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1839
 msgid "Group user(s)"
 msgstr ""
 
@@ -32745,77 +32745,89 @@ msgstr ""
 msgid "Progress: %1$s%% of %2$s%% required"
 msgstr ""
 
-#: src/CommonITILValidation.php:1253 src/CommonITILValidation.php:1365
-#: src/CommonITILValidation.php:1472
+#: src/CommonITILValidation.php:1127
+msgid "Approval step accepted"
+msgstr ""
+
+#: src/CommonITILValidation.php:1128
+msgid "Approval step refused"
+msgstr ""
+
+#: src/CommonITILValidation.php:1129
+msgid "Approval step pending"
+msgstr ""
+
+#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1368
+#: src/CommonITILValidation.php:1475
 msgid "Request date"
 msgstr "Dato for forespørsel"
 
-#: src/CommonITILValidation.php:1255 src/CommonITILValidation.php:1338
-#: src/CommonITILValidation.php:1430
+#: src/CommonITILValidation.php:1258 src/CommonITILValidation.php:1341
+#: src/CommonITILValidation.php:1433
 msgid "Request comments"
 msgstr "Be om kommentarer"
 
-#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1373
-#: src/CommonITILValidation.php:1485
+#: src/CommonITILValidation.php:1259 src/CommonITILValidation.php:1376
+#: src/CommonITILValidation.php:1488
 msgid "Approval date"
 msgstr "Godkjent dato"
 
-#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1400
+#: src/CommonITILValidation.php:1260 src/CommonITILValidation.php:1403
 msgid "Requested approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1258
+#: src/CommonITILValidation.php:1261
 msgid "Requested approver"
 msgstr ""
 
-#: src/CommonITILValidation.php:1259
+#: src/CommonITILValidation.php:1262
 msgid "Approval Comment"
 msgstr ""
 
-#: src/CommonITILValidation.php:1260
+#: src/CommonITILValidation.php:1263
 #: src/NotificationTargetKnowbaseItem.php:218
 msgid "Documents"
 msgstr "Dokumenter"
 
-#: src/CommonITILValidation.php:1347 src/CommonITILValidation.php:1444
+#: src/CommonITILValidation.php:1350 src/CommonITILValidation.php:1447
 msgid "Approval comments"
 msgstr "Kommentar til godkjenning"
 
-#: src/CommonITILValidation.php:1459
+#: src/CommonITILValidation.php:1462
 msgid "Approval status"
 msgstr "Status for godkjenning"
 
-#: src/CommonITILValidation.php:1541
+#: src/CommonITILValidation.php:1544
 msgid "Approver substitute"
 msgstr ""
 
-#: src/CommonITILValidation.php:1601
+#: src/CommonITILValidation.php:1604
 msgid "Approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1623
+#: src/CommonITILValidation.php:1626
 msgid "Substitute of a member of approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1694
+#: src/CommonITILValidation.php:1697
 msgid "Approval status by users"
 msgstr ""
 
-#: src/CommonITILValidation.php:1849
+#: src/CommonITILValidation.php:1852
 msgid "Approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1954
+#: src/CommonITILValidation.php:1957
 msgid ""
 "This item is waiting for approval, do you really want to resolve or close "
 "it?"
 msgstr "Dette elementet venter på godkjenning. Vil du virkelig lukke det?"
 
-#: src/CommonITILValidation.php:1995
+#: src/CommonITILValidation.php:1998
 msgid "This item is waiting for approval."
 msgstr ""
 
-#: src/CommonITILValidation.php:1996
+#: src/CommonITILValidation.php:1999
 msgid "Do you really want to resolve or close it?"
 msgstr ""
 

--- a/locales/nl_BE.po
+++ b/locales/nl_BE.po
@@ -16,7 +16,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-26 10:20+0000\n"
+"POT-Creation-Date: 2025-08-26 12:21+0000\n"
 "PO-Revision-Date: 2022-09-16 06:53+0000\n"
 "Last-Translator: alexandre delaunay <delaunay.alexandre@gmail.com>, 2025\n"
 "Language-Team: Dutch (Belgium) (https://app.transifex.com/glpi/teams/1637/nl_BE/)\n"
@@ -797,7 +797,7 @@ msgstr ""
 #: templates/components/itilobject/timeline/main_description.html.twig
 #: templates/components/user/info_card.html.twig
 #: templates/pages/tools/kb/comments.html.twig src/KnowbaseItem.php:245
-#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1188
+#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1191
 #: js/src/vue/CustomObject/FieldPreview/Field.vue:30
 msgid "Edit"
 msgstr "Wijzig"
@@ -1443,7 +1443,7 @@ msgid "Cancel"
 msgstr "Annuleren"
 
 #: templates/components/form/basic_inputs_macros.html.twig
-#: src/CommonITILValidation.php:1773
+#: src/CommonITILValidation.php:1776
 msgid "Validate"
 msgstr "Bevestig"
 
@@ -1964,7 +1964,7 @@ msgstr "Inventarisnummer"
 #: src/Computer.php:461 src/ProjectTask_Ticket.php:336 src/Certificate.php:278
 #: src/CronTask.php:1274 src/CronTask.php:1412
 #: src/CommonItilObject_Item.php:506 src/PDU.php:203 src/CommonDBTM.php:3513
-#: src/CommonITILValidation.php:1356 src/Plugin.php:2657
+#: src/CommonITILValidation.php:1359 src/Plugin.php:2657
 msgid "Status"
 msgstr "Status"
 
@@ -3442,7 +3442,7 @@ msgstr[1] ""
 #: src/CommonITILObject.php:4737 src/CommonITILObject.php:4746
 #: src/CommonITILObject.php:6847 src/CommonITILObject.php:6894
 #: src/CommonITILObject.php:10159 src/NotificationTargetChange.php:308
-#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1498
+#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1501
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "Aanvrager"
@@ -3452,7 +3452,7 @@ msgstr[1] "Aanvragers"
 #: src/NotificationTargetTicket.php:676 src/NotificationTargetTicket.php:706
 #: src/NotificationTargetCommonITILObject.php:976
 #: src/ITILValidationTemplate.php:81 src/NotificationTargetChange.php:327
-#: src/CommonITILValidation.php:1391 src/CommonITILValidation.php:1518
+#: src/CommonITILValidation.php:1394 src/CommonITILValidation.php:1521
 msgid "Approver"
 msgstr "Gevalideerd door"
 
@@ -4188,7 +4188,7 @@ msgstr "Geen geschiedenis"
 #: src/OAuthClient.php:94 src/Item_RemoteManagement.php:207
 #: src/Item_RemoteManagement.php:238 src/Certificate.php:125
 #: src/CronTask.php:1391 src/Contact.php:282 src/PDU.php:114
-#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1329
+#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1332
 #: src/Domain.php:233 src/Domain.php:257 src/ConsumableItem.php:167
 msgid "ID"
 msgstr "ID"
@@ -5723,7 +5723,7 @@ msgstr ""
 #: src/Project.php:904 src/ProjectTask.php:963
 #: src/NotificationTargetProjectTask.php:553
 #: src/NotificationTargetProjectTask.php:568 src/Cartridge.php:895
-#: src/CommonITILValidation.php:1252
+#: src/CommonITILValidation.php:1255
 msgctxt "item"
 msgid "State"
 msgstr "Status"
@@ -17174,7 +17174,7 @@ msgid "Observer group except manager users"
 msgstr ""
 
 #: src/NotificationTargetCommonITILObject.php:973
-#: src/CommonITILValidation.php:1254 src/CommonITILValidation.php:1381
+#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1384
 msgid "Approval requester"
 msgstr "Aanvrager van de goedkeuring"
 
@@ -32583,7 +32583,7 @@ msgstr "Niet gevalideerd"
 msgid "Granted + Not subject to approval"
 msgstr "Toegewezen + Geen goedkeuring nodig"
 
-#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1836
+#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1839
 msgid "Group user(s)"
 msgstr "Groep gebruiker(s)"
 
@@ -32596,67 +32596,79 @@ msgstr ""
 msgid "Progress: %1$s%% of %2$s%% required"
 msgstr ""
 
-#: src/CommonITILValidation.php:1253 src/CommonITILValidation.php:1365
-#: src/CommonITILValidation.php:1472
+#: src/CommonITILValidation.php:1127
+msgid "Approval step accepted"
+msgstr ""
+
+#: src/CommonITILValidation.php:1128
+msgid "Approval step refused"
+msgstr ""
+
+#: src/CommonITILValidation.php:1129
+msgid "Approval step pending"
+msgstr ""
+
+#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1368
+#: src/CommonITILValidation.php:1475
 msgid "Request date"
 msgstr "Datum aanvraag"
 
-#: src/CommonITILValidation.php:1255 src/CommonITILValidation.php:1338
-#: src/CommonITILValidation.php:1430
+#: src/CommonITILValidation.php:1258 src/CommonITILValidation.php:1341
+#: src/CommonITILValidation.php:1433
 msgid "Request comments"
 msgstr "Opmerkingen bij de aanvraag"
 
-#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1373
-#: src/CommonITILValidation.php:1485
+#: src/CommonITILValidation.php:1259 src/CommonITILValidation.php:1376
+#: src/CommonITILValidation.php:1488
 msgid "Approval date"
 msgstr "Datum validatie"
 
-#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1400
+#: src/CommonITILValidation.php:1260 src/CommonITILValidation.php:1403
 msgid "Requested approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1258
+#: src/CommonITILValidation.php:1261
 msgid "Requested approver"
 msgstr ""
 
-#: src/CommonITILValidation.php:1259
+#: src/CommonITILValidation.php:1262
 msgid "Approval Comment"
 msgstr ""
 
-#: src/CommonITILValidation.php:1260
+#: src/CommonITILValidation.php:1263
 #: src/NotificationTargetKnowbaseItem.php:218
 msgid "Documents"
 msgstr "Documenten"
 
-#: src/CommonITILValidation.php:1347 src/CommonITILValidation.php:1444
+#: src/CommonITILValidation.php:1350 src/CommonITILValidation.php:1447
 msgid "Approval comments"
 msgstr "Opmerkingen bij de goedkeuring"
 
-#: src/CommonITILValidation.php:1459
+#: src/CommonITILValidation.php:1462
 msgid "Approval status"
 msgstr "Goedkeuring status"
 
-#: src/CommonITILValidation.php:1541
+#: src/CommonITILValidation.php:1544
 msgid "Approver substitute"
 msgstr ""
 
-#: src/CommonITILValidation.php:1601
+#: src/CommonITILValidation.php:1604
 msgid "Approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1623
+#: src/CommonITILValidation.php:1626
 msgid "Substitute of a member of approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1694
+#: src/CommonITILValidation.php:1697
 msgid "Approval status by users"
 msgstr ""
 
-#: src/CommonITILValidation.php:1849
+#: src/CommonITILValidation.php:1852
 msgid "Approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1954
+#: src/CommonITILValidation.php:1957
 msgid ""
 "This item is waiting for approval, do you really want to resolve or close "
 "it?"
@@ -32664,11 +32676,11 @@ msgstr ""
 "Ddit item wacht op goedkeuring, weet u zeker dat u het als opgelost of "
 "gesloten wilt markeren?"
 
-#: src/CommonITILValidation.php:1995
+#: src/CommonITILValidation.php:1998
 msgid "This item is waiting for approval."
 msgstr ""
 
-#: src/CommonITILValidation.php:1996
+#: src/CommonITILValidation.php:1999
 msgid "Do you really want to resolve or close it?"
 msgstr ""
 

--- a/locales/nl_NL.po
+++ b/locales/nl_NL.po
@@ -27,7 +27,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-26 10:20+0000\n"
+"POT-Creation-Date: 2025-08-26 12:21+0000\n"
 "PO-Revision-Date: 2022-09-16 06:53+0000\n"
 "Last-Translator: Roy Hoenen, 2025\n"
 "Language-Team: Dutch (Netherlands) (https://app.transifex.com/glpi/teams/1637/nl_NL/)\n"
@@ -808,7 +808,7 @@ msgstr ""
 #: templates/components/itilobject/timeline/main_description.html.twig
 #: templates/components/user/info_card.html.twig
 #: templates/pages/tools/kb/comments.html.twig src/KnowbaseItem.php:245
-#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1188
+#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1191
 #: js/src/vue/CustomObject/FieldPreview/Field.vue:30
 msgid "Edit"
 msgstr "Wijzig"
@@ -1454,7 +1454,7 @@ msgid "Cancel"
 msgstr "Annuleren"
 
 #: templates/components/form/basic_inputs_macros.html.twig
-#: src/CommonITILValidation.php:1773
+#: src/CommonITILValidation.php:1776
 msgid "Validate"
 msgstr "Bevestig"
 
@@ -1976,7 +1976,7 @@ msgstr "Inventarisnummer"
 #: src/Computer.php:461 src/ProjectTask_Ticket.php:336 src/Certificate.php:278
 #: src/CronTask.php:1274 src/CronTask.php:1412
 #: src/CommonItilObject_Item.php:506 src/PDU.php:203 src/CommonDBTM.php:3513
-#: src/CommonITILValidation.php:1356 src/Plugin.php:2657
+#: src/CommonITILValidation.php:1359 src/Plugin.php:2657
 msgid "Status"
 msgstr "Status"
 
@@ -3455,7 +3455,7 @@ msgstr[1] ""
 #: src/CommonITILObject.php:4737 src/CommonITILObject.php:4746
 #: src/CommonITILObject.php:6847 src/CommonITILObject.php:6894
 #: src/CommonITILObject.php:10159 src/NotificationTargetChange.php:308
-#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1498
+#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1501
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "Aanvrager"
@@ -3465,7 +3465,7 @@ msgstr[1] "Aanvragers"
 #: src/NotificationTargetTicket.php:676 src/NotificationTargetTicket.php:706
 #: src/NotificationTargetCommonITILObject.php:976
 #: src/ITILValidationTemplate.php:81 src/NotificationTargetChange.php:327
-#: src/CommonITILValidation.php:1391 src/CommonITILValidation.php:1518
+#: src/CommonITILValidation.php:1394 src/CommonITILValidation.php:1521
 msgid "Approver"
 msgstr "Gevalideerd door"
 
@@ -4201,7 +4201,7 @@ msgstr "Geen geschiedenis"
 #: src/OAuthClient.php:94 src/Item_RemoteManagement.php:207
 #: src/Item_RemoteManagement.php:238 src/Certificate.php:125
 #: src/CronTask.php:1391 src/Contact.php:282 src/PDU.php:114
-#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1329
+#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1332
 #: src/Domain.php:233 src/Domain.php:257 src/ConsumableItem.php:167
 msgid "ID"
 msgstr "ID"
@@ -5737,7 +5737,7 @@ msgstr ""
 #: src/Project.php:904 src/ProjectTask.php:963
 #: src/NotificationTargetProjectTask.php:553
 #: src/NotificationTargetProjectTask.php:568 src/Cartridge.php:895
-#: src/CommonITILValidation.php:1252
+#: src/CommonITILValidation.php:1255
 msgctxt "item"
 msgid "State"
 msgstr "Status"
@@ -17199,7 +17199,7 @@ msgid "Observer group except manager users"
 msgstr "Volger groep behalve Manager gebruikers"
 
 #: src/NotificationTargetCommonITILObject.php:973
-#: src/CommonITILValidation.php:1254 src/CommonITILValidation.php:1381
+#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1384
 msgid "Approval requester"
 msgstr "Aanvrager van de goedkeuring"
 
@@ -32615,7 +32615,7 @@ msgstr "Niet gevalideerd"
 msgid "Granted + Not subject to approval"
 msgstr "Toegewezen + Geen goedkeuring nodig"
 
-#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1836
+#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1839
 msgid "Group user(s)"
 msgstr ""
 
@@ -32628,67 +32628,79 @@ msgstr ""
 msgid "Progress: %1$s%% of %2$s%% required"
 msgstr ""
 
-#: src/CommonITILValidation.php:1253 src/CommonITILValidation.php:1365
-#: src/CommonITILValidation.php:1472
+#: src/CommonITILValidation.php:1127
+msgid "Approval step accepted"
+msgstr ""
+
+#: src/CommonITILValidation.php:1128
+msgid "Approval step refused"
+msgstr ""
+
+#: src/CommonITILValidation.php:1129
+msgid "Approval step pending"
+msgstr ""
+
+#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1368
+#: src/CommonITILValidation.php:1475
 msgid "Request date"
 msgstr "Datum aanvraag"
 
-#: src/CommonITILValidation.php:1255 src/CommonITILValidation.php:1338
-#: src/CommonITILValidation.php:1430
+#: src/CommonITILValidation.php:1258 src/CommonITILValidation.php:1341
+#: src/CommonITILValidation.php:1433
 msgid "Request comments"
 msgstr "Opmerkingen bij de aanvraag"
 
-#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1373
-#: src/CommonITILValidation.php:1485
+#: src/CommonITILValidation.php:1259 src/CommonITILValidation.php:1376
+#: src/CommonITILValidation.php:1488
 msgid "Approval date"
 msgstr "Datum validatie"
 
-#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1400
+#: src/CommonITILValidation.php:1260 src/CommonITILValidation.php:1403
 msgid "Requested approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1258
+#: src/CommonITILValidation.php:1261
 msgid "Requested approver"
 msgstr ""
 
-#: src/CommonITILValidation.php:1259
+#: src/CommonITILValidation.php:1262
 msgid "Approval Comment"
 msgstr ""
 
-#: src/CommonITILValidation.php:1260
+#: src/CommonITILValidation.php:1263
 #: src/NotificationTargetKnowbaseItem.php:218
 msgid "Documents"
 msgstr "Documenten"
 
-#: src/CommonITILValidation.php:1347 src/CommonITILValidation.php:1444
+#: src/CommonITILValidation.php:1350 src/CommonITILValidation.php:1447
 msgid "Approval comments"
 msgstr "Opmerkingen bij de goedkeuring"
 
-#: src/CommonITILValidation.php:1459
+#: src/CommonITILValidation.php:1462
 msgid "Approval status"
 msgstr "Goedkeuring status"
 
-#: src/CommonITILValidation.php:1541
+#: src/CommonITILValidation.php:1544
 msgid "Approver substitute"
 msgstr ""
 
-#: src/CommonITILValidation.php:1601
+#: src/CommonITILValidation.php:1604
 msgid "Approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1623
+#: src/CommonITILValidation.php:1626
 msgid "Substitute of a member of approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1694
+#: src/CommonITILValidation.php:1697
 msgid "Approval status by users"
 msgstr ""
 
-#: src/CommonITILValidation.php:1849
+#: src/CommonITILValidation.php:1852
 msgid "Approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1954
+#: src/CommonITILValidation.php:1957
 msgid ""
 "This item is waiting for approval, do you really want to resolve or close "
 "it?"
@@ -32696,11 +32708,11 @@ msgstr ""
 "Ddit item wacht op goedkeuring, weet u zeker dat u het als opgelost of "
 "gesloten wilt markeren?"
 
-#: src/CommonITILValidation.php:1995
+#: src/CommonITILValidation.php:1998
 msgid "This item is waiting for approval."
 msgstr ""
 
-#: src/CommonITILValidation.php:1996
+#: src/CommonITILValidation.php:1999
 msgid "Do you really want to resolve or close it?"
 msgstr ""
 

--- a/locales/nn_NO.po
+++ b/locales/nn_NO.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-26 10:20+0000\n"
+"POT-Creation-Date: 2025-08-26 12:21+0000\n"
 "PO-Revision-Date: 2022-09-16 06:53+0000\n"
 "Last-Translator: alexandre delaunay <delaunay.alexandre@gmail.com>, 2025\n"
 "Language-Team: Norwegian Nynorsk (Norway) (https://app.transifex.com/glpi/teams/1637/nn_NO/)\n"
@@ -784,7 +784,7 @@ msgstr ""
 #: templates/components/itilobject/timeline/main_description.html.twig
 #: templates/components/user/info_card.html.twig
 #: templates/pages/tools/kb/comments.html.twig src/KnowbaseItem.php:245
-#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1188
+#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1191
 #: js/src/vue/CustomObject/FieldPreview/Field.vue:30
 msgid "Edit"
 msgstr ""
@@ -1424,7 +1424,7 @@ msgid "Cancel"
 msgstr "Avbryt"
 
 #: templates/components/form/basic_inputs_macros.html.twig
-#: src/CommonITILValidation.php:1773
+#: src/CommonITILValidation.php:1776
 msgid "Validate"
 msgstr ""
 
@@ -1939,7 +1939,7 @@ msgstr "Inventar nummer"
 #: src/Computer.php:461 src/ProjectTask_Ticket.php:336 src/Certificate.php:278
 #: src/CronTask.php:1274 src/CronTask.php:1412
 #: src/CommonItilObject_Item.php:506 src/PDU.php:203 src/CommonDBTM.php:3513
-#: src/CommonITILValidation.php:1356 src/Plugin.php:2657
+#: src/CommonITILValidation.php:1359 src/Plugin.php:2657
 msgid "Status"
 msgstr "Status"
 
@@ -3418,7 +3418,7 @@ msgstr[1] ""
 #: src/CommonITILObject.php:4737 src/CommonITILObject.php:4746
 #: src/CommonITILObject.php:6847 src/CommonITILObject.php:6894
 #: src/CommonITILObject.php:10159 src/NotificationTargetChange.php:308
-#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1498
+#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1501
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] ""
@@ -3428,7 +3428,7 @@ msgstr[1] ""
 #: src/NotificationTargetTicket.php:676 src/NotificationTargetTicket.php:706
 #: src/NotificationTargetCommonITILObject.php:976
 #: src/ITILValidationTemplate.php:81 src/NotificationTargetChange.php:327
-#: src/CommonITILValidation.php:1391 src/CommonITILValidation.php:1518
+#: src/CommonITILValidation.php:1394 src/CommonITILValidation.php:1521
 msgid "Approver"
 msgstr ""
 
@@ -4162,7 +4162,7 @@ msgstr "Ingen historik"
 #: src/OAuthClient.php:94 src/Item_RemoteManagement.php:207
 #: src/Item_RemoteManagement.php:238 src/Certificate.php:125
 #: src/CronTask.php:1391 src/Contact.php:282 src/PDU.php:114
-#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1329
+#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1332
 #: src/Domain.php:233 src/Domain.php:257 src/ConsumableItem.php:167
 msgid "ID"
 msgstr "ID"
@@ -5699,7 +5699,7 @@ msgstr ""
 #: src/Project.php:904 src/ProjectTask.php:963
 #: src/NotificationTargetProjectTask.php:553
 #: src/NotificationTargetProjectTask.php:568 src/Cartridge.php:895
-#: src/CommonITILValidation.php:1252
+#: src/CommonITILValidation.php:1255
 msgctxt "item"
 msgid "State"
 msgstr "Status"
@@ -17142,7 +17142,7 @@ msgid "Observer group except manager users"
 msgstr ""
 
 #: src/NotificationTargetCommonITILObject.php:973
-#: src/CommonITILValidation.php:1254 src/CommonITILValidation.php:1381
+#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1384
 msgid "Approval requester"
 msgstr ""
 
@@ -32602,7 +32602,7 @@ msgstr ""
 msgid "Granted + Not subject to approval"
 msgstr ""
 
-#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1836
+#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1839
 msgid "Group user(s)"
 msgstr ""
 
@@ -32615,77 +32615,89 @@ msgstr ""
 msgid "Progress: %1$s%% of %2$s%% required"
 msgstr ""
 
-#: src/CommonITILValidation.php:1253 src/CommonITILValidation.php:1365
-#: src/CommonITILValidation.php:1472
+#: src/CommonITILValidation.php:1127
+msgid "Approval step accepted"
+msgstr ""
+
+#: src/CommonITILValidation.php:1128
+msgid "Approval step refused"
+msgstr ""
+
+#: src/CommonITILValidation.php:1129
+msgid "Approval step pending"
+msgstr ""
+
+#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1368
+#: src/CommonITILValidation.php:1475
 msgid "Request date"
 msgstr ""
 
-#: src/CommonITILValidation.php:1255 src/CommonITILValidation.php:1338
-#: src/CommonITILValidation.php:1430
+#: src/CommonITILValidation.php:1258 src/CommonITILValidation.php:1341
+#: src/CommonITILValidation.php:1433
 msgid "Request comments"
 msgstr ""
 
-#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1373
-#: src/CommonITILValidation.php:1485
+#: src/CommonITILValidation.php:1259 src/CommonITILValidation.php:1376
+#: src/CommonITILValidation.php:1488
 msgid "Approval date"
 msgstr ""
 
-#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1400
+#: src/CommonITILValidation.php:1260 src/CommonITILValidation.php:1403
 msgid "Requested approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1258
+#: src/CommonITILValidation.php:1261
 msgid "Requested approver"
 msgstr ""
 
-#: src/CommonITILValidation.php:1259
+#: src/CommonITILValidation.php:1262
 msgid "Approval Comment"
 msgstr ""
 
-#: src/CommonITILValidation.php:1260
+#: src/CommonITILValidation.php:1263
 #: src/NotificationTargetKnowbaseItem.php:218
 msgid "Documents"
 msgstr "Dokumenter"
 
-#: src/CommonITILValidation.php:1347 src/CommonITILValidation.php:1444
+#: src/CommonITILValidation.php:1350 src/CommonITILValidation.php:1447
 msgid "Approval comments"
 msgstr ""
 
-#: src/CommonITILValidation.php:1459
+#: src/CommonITILValidation.php:1462
 msgid "Approval status"
 msgstr ""
 
-#: src/CommonITILValidation.php:1541
+#: src/CommonITILValidation.php:1544
 msgid "Approver substitute"
 msgstr ""
 
-#: src/CommonITILValidation.php:1601
+#: src/CommonITILValidation.php:1604
 msgid "Approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1623
+#: src/CommonITILValidation.php:1626
 msgid "Substitute of a member of approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1694
+#: src/CommonITILValidation.php:1697
 msgid "Approval status by users"
 msgstr ""
 
-#: src/CommonITILValidation.php:1849
+#: src/CommonITILValidation.php:1852
 msgid "Approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1954
+#: src/CommonITILValidation.php:1957
 msgid ""
 "This item is waiting for approval, do you really want to resolve or close "
 "it?"
 msgstr ""
 
-#: src/CommonITILValidation.php:1995
+#: src/CommonITILValidation.php:1998
 msgid "This item is waiting for approval."
 msgstr ""
 
-#: src/CommonITILValidation.php:1996
+#: src/CommonITILValidation.php:1999
 msgid "Do you really want to resolve or close it?"
 msgstr ""
 

--- a/locales/pl_PL.po
+++ b/locales/pl_PL.po
@@ -41,7 +41,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-26 10:20+0000\n"
+"POT-Creation-Date: 2025-08-26 12:21+0000\n"
 "PO-Revision-Date: 2022-09-16 06:53+0000\n"
 "Last-Translator: alexandre delaunay <delaunay.alexandre@gmail.com>, 2025\n"
 "Language-Team: Polish (Poland) (https://app.transifex.com/glpi/teams/1637/pl_PL/)\n"
@@ -824,7 +824,7 @@ msgstr ""
 #: templates/components/itilobject/timeline/main_description.html.twig
 #: templates/components/user/info_card.html.twig
 #: templates/pages/tools/kb/comments.html.twig src/KnowbaseItem.php:245
-#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1188
+#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1191
 #: js/src/vue/CustomObject/FieldPreview/Field.vue:30
 msgid "Edit"
 msgstr "Edytuj"
@@ -1473,7 +1473,7 @@ msgid "Cancel"
 msgstr "Anuluj"
 
 #: templates/components/form/basic_inputs_macros.html.twig
-#: src/CommonITILValidation.php:1773
+#: src/CommonITILValidation.php:1776
 msgid "Validate"
 msgstr "Weryfikuj"
 
@@ -1998,7 +1998,7 @@ msgstr "Numer inwentarzowy"
 #: src/Computer.php:461 src/ProjectTask_Ticket.php:336 src/Certificate.php:278
 #: src/CronTask.php:1274 src/CronTask.php:1412
 #: src/CommonItilObject_Item.php:506 src/PDU.php:203 src/CommonDBTM.php:3513
-#: src/CommonITILValidation.php:1356 src/Plugin.php:2657
+#: src/CommonITILValidation.php:1359 src/Plugin.php:2657
 msgid "Status"
 msgstr "Status"
 
@@ -3510,7 +3510,7 @@ msgstr[3] ""
 #: src/CommonITILObject.php:4737 src/CommonITILObject.php:4746
 #: src/CommonITILObject.php:6847 src/CommonITILObject.php:6894
 #: src/CommonITILObject.php:10159 src/NotificationTargetChange.php:308
-#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1498
+#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1501
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "Zgłaszający"
@@ -3522,7 +3522,7 @@ msgstr[3] "Zgłaszających"
 #: src/NotificationTargetTicket.php:676 src/NotificationTargetTicket.php:706
 #: src/NotificationTargetCommonITILObject.php:976
 #: src/ITILValidationTemplate.php:81 src/NotificationTargetChange.php:327
-#: src/CommonITILValidation.php:1391 src/CommonITILValidation.php:1518
+#: src/CommonITILValidation.php:1394 src/CommonITILValidation.php:1521
 msgid "Approver"
 msgstr "Zatwierdzający"
 
@@ -4268,7 +4268,7 @@ msgstr "Brak historii"
 #: src/OAuthClient.php:94 src/Item_RemoteManagement.php:207
 #: src/Item_RemoteManagement.php:238 src/Certificate.php:125
 #: src/CronTask.php:1391 src/Contact.php:282 src/PDU.php:114
-#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1329
+#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1332
 #: src/Domain.php:233 src/Domain.php:257 src/ConsumableItem.php:167
 msgid "ID"
 msgstr "ID"
@@ -5843,7 +5843,7 @@ msgstr ""
 #: src/Project.php:904 src/ProjectTask.php:963
 #: src/NotificationTargetProjectTask.php:553
 #: src/NotificationTargetProjectTask.php:568 src/Cartridge.php:895
-#: src/CommonITILValidation.php:1252
+#: src/CommonITILValidation.php:1255
 msgctxt "item"
 msgid "State"
 msgstr "Stan"
@@ -17600,7 +17600,7 @@ msgid "Observer group except manager users"
 msgstr ""
 
 #: src/NotificationTargetCommonITILObject.php:973
-#: src/CommonITILValidation.php:1254 src/CommonITILValidation.php:1381
+#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1384
 msgid "Approval requester"
 msgstr "Wnioskujący"
 
@@ -33999,7 +33999,7 @@ msgstr "Nie podlegają weryfikacji"
 msgid "Granted + Not subject to approval"
 msgstr "Zaakceptowane + Nie podlegają weryfikacji"
 
-#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1836
+#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1839
 msgid "Group user(s)"
 msgstr "Użytkownik(cy) grupy"
 
@@ -34012,67 +34012,79 @@ msgstr ""
 msgid "Progress: %1$s%% of %2$s%% required"
 msgstr ""
 
-#: src/CommonITILValidation.php:1253 src/CommonITILValidation.php:1365
-#: src/CommonITILValidation.php:1472
+#: src/CommonITILValidation.php:1127
+msgid "Approval step accepted"
+msgstr ""
+
+#: src/CommonITILValidation.php:1128
+msgid "Approval step refused"
+msgstr ""
+
+#: src/CommonITILValidation.php:1129
+msgid "Approval step pending"
+msgstr ""
+
+#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1368
+#: src/CommonITILValidation.php:1475
 msgid "Request date"
 msgstr "Data wniosku"
 
-#: src/CommonITILValidation.php:1255 src/CommonITILValidation.php:1338
-#: src/CommonITILValidation.php:1430
+#: src/CommonITILValidation.php:1258 src/CommonITILValidation.php:1341
+#: src/CommonITILValidation.php:1433
 msgid "Request comments"
 msgstr "Wymagaj komentarza"
 
-#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1373
-#: src/CommonITILValidation.php:1485
+#: src/CommonITILValidation.php:1259 src/CommonITILValidation.php:1376
+#: src/CommonITILValidation.php:1488
 msgid "Approval date"
 msgstr "Data zatwierdzenia"
 
-#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1400
+#: src/CommonITILValidation.php:1260 src/CommonITILValidation.php:1403
 msgid "Requested approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1258
+#: src/CommonITILValidation.php:1261
 msgid "Requested approver"
 msgstr ""
 
-#: src/CommonITILValidation.php:1259
+#: src/CommonITILValidation.php:1262
 msgid "Approval Comment"
 msgstr ""
 
-#: src/CommonITILValidation.php:1260
+#: src/CommonITILValidation.php:1263
 #: src/NotificationTargetKnowbaseItem.php:218
 msgid "Documents"
 msgstr "Dokumenty"
 
-#: src/CommonITILValidation.php:1347 src/CommonITILValidation.php:1444
+#: src/CommonITILValidation.php:1350 src/CommonITILValidation.php:1447
 msgid "Approval comments"
 msgstr "Komentarze zatwierdzenia"
 
-#: src/CommonITILValidation.php:1459
+#: src/CommonITILValidation.php:1462
 msgid "Approval status"
 msgstr "Status zatwierdzenia"
 
-#: src/CommonITILValidation.php:1541
+#: src/CommonITILValidation.php:1544
 msgid "Approver substitute"
 msgstr "Zastępca osoby zatwierdzającej"
 
-#: src/CommonITILValidation.php:1601
+#: src/CommonITILValidation.php:1604
 msgid "Approver group"
 msgstr "Grupa osoby zatwierdzającej"
 
-#: src/CommonITILValidation.php:1623
+#: src/CommonITILValidation.php:1626
 msgid "Substitute of a member of approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1694
+#: src/CommonITILValidation.php:1697
 msgid "Approval status by users"
 msgstr ""
 
-#: src/CommonITILValidation.php:1849
+#: src/CommonITILValidation.php:1852
 msgid "Approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1954
+#: src/CommonITILValidation.php:1957
 msgid ""
 "This item is waiting for approval, do you really want to resolve or close "
 "it?"
@@ -34080,11 +34092,11 @@ msgstr ""
 "Ten element oczekuje na zatwierdzenie, naprawdę chcesz go rozwiązać lub "
 "zamknąć?"
 
-#: src/CommonITILValidation.php:1995
+#: src/CommonITILValidation.php:1998
 msgid "This item is waiting for approval."
 msgstr "Ten element czeka na zatwierdzenie."
 
-#: src/CommonITILValidation.php:1996
+#: src/CommonITILValidation.php:1999
 msgid "Do you really want to resolve or close it?"
 msgstr "Czy na pewno chcesz rozwiązać lub zamknąć?"
 

--- a/locales/pt_BR.po
+++ b/locales/pt_BR.po
@@ -42,7 +42,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-26 10:20+0000\n"
+"POT-Creation-Date: 2025-08-26 12:21+0000\n"
 "PO-Revision-Date: 2022-09-16 06:53+0000\n"
 "Last-Translator: alexandre delaunay <delaunay.alexandre@gmail.com>, 2025\n"
 "Language-Team: Portuguese (Brazil) (https://app.transifex.com/glpi/teams/1637/pt_BR/)\n"
@@ -832,7 +832,7 @@ msgstr "Modo somente leitura"
 #: templates/components/itilobject/timeline/main_description.html.twig
 #: templates/components/user/info_card.html.twig
 #: templates/pages/tools/kb/comments.html.twig src/KnowbaseItem.php:245
-#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1188
+#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1191
 #: js/src/vue/CustomObject/FieldPreview/Field.vue:30
 msgid "Edit"
 msgstr "Editar"
@@ -1482,7 +1482,7 @@ msgid "Cancel"
 msgstr "Cancelar"
 
 #: templates/components/form/basic_inputs_macros.html.twig
-#: src/CommonITILValidation.php:1773
+#: src/CommonITILValidation.php:1776
 msgid "Validate"
 msgstr "Validar"
 
@@ -2004,7 +2004,7 @@ msgstr "Número de inventário"
 #: src/Computer.php:461 src/ProjectTask_Ticket.php:336 src/Certificate.php:278
 #: src/CronTask.php:1274 src/CronTask.php:1412
 #: src/CommonItilObject_Item.php:506 src/PDU.php:203 src/CommonDBTM.php:3513
-#: src/CommonITILValidation.php:1356 src/Plugin.php:2657
+#: src/CommonITILValidation.php:1359 src/Plugin.php:2657
 msgid "Status"
 msgstr "Status"
 
@@ -3503,7 +3503,7 @@ msgstr[2] "Etapa de Aprovação"
 #: src/CommonITILObject.php:4737 src/CommonITILObject.php:4746
 #: src/CommonITILObject.php:6847 src/CommonITILObject.php:6894
 #: src/CommonITILObject.php:10159 src/NotificationTargetChange.php:308
-#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1498
+#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1501
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "Requerente"
@@ -3514,7 +3514,7 @@ msgstr[2] "Requerentes"
 #: src/NotificationTargetTicket.php:676 src/NotificationTargetTicket.php:706
 #: src/NotificationTargetCommonITILObject.php:976
 #: src/ITILValidationTemplate.php:81 src/NotificationTargetChange.php:327
-#: src/CommonITILValidation.php:1391 src/CommonITILValidation.php:1518
+#: src/CommonITILValidation.php:1394 src/CommonITILValidation.php:1521
 msgid "Approver"
 msgstr "Aprovador"
 
@@ -4262,7 +4262,7 @@ msgstr "Sem histórico"
 #: src/OAuthClient.php:94 src/Item_RemoteManagement.php:207
 #: src/Item_RemoteManagement.php:238 src/Certificate.php:125
 #: src/CronTask.php:1391 src/Contact.php:282 src/PDU.php:114
-#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1329
+#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1332
 #: src/Domain.php:233 src/Domain.php:257 src/ConsumableItem.php:167
 msgid "ID"
 msgstr "ID"
@@ -5830,7 +5830,7 @@ msgstr ""
 #: src/Project.php:904 src/ProjectTask.php:963
 #: src/NotificationTargetProjectTask.php:553
 #: src/NotificationTargetProjectTask.php:568 src/Cartridge.php:895
-#: src/CommonITILValidation.php:1252
+#: src/CommonITILValidation.php:1255
 msgctxt "item"
 msgid "State"
 msgstr "Estado"
@@ -17578,7 +17578,7 @@ msgid "Observer group except manager users"
 msgstr "Grupo de observador, exceto usuários gerentes"
 
 #: src/NotificationTargetCommonITILObject.php:973
-#: src/CommonITILValidation.php:1254 src/CommonITILValidation.php:1381
+#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1384
 msgid "Approval requester"
 msgstr "Requerente do pedido de aprovação"
 
@@ -33816,7 +33816,7 @@ msgstr "Não está sujeita a aprovação"
 msgid "Granted + Not subject to approval"
 msgstr "Concedida + Não está sujeita a aprovação"
 
-#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1836
+#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1839
 msgid "Group user(s)"
 msgstr "Grupo de usuário(s)"
 
@@ -33829,67 +33829,79 @@ msgstr "Editar etapa de aprovação"
 msgid "Progress: %1$s%% of %2$s%% required"
 msgstr "Progresso: %1$s%% de %2$s%% necessário"
 
-#: src/CommonITILValidation.php:1253 src/CommonITILValidation.php:1365
-#: src/CommonITILValidation.php:1472
+#: src/CommonITILValidation.php:1127
+msgid "Approval step accepted"
+msgstr ""
+
+#: src/CommonITILValidation.php:1128
+msgid "Approval step refused"
+msgstr ""
+
+#: src/CommonITILValidation.php:1129
+msgid "Approval step pending"
+msgstr ""
+
+#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1368
+#: src/CommonITILValidation.php:1475
 msgid "Request date"
 msgstr "Data da requisição"
 
-#: src/CommonITILValidation.php:1255 src/CommonITILValidation.php:1338
-#: src/CommonITILValidation.php:1430
+#: src/CommonITILValidation.php:1258 src/CommonITILValidation.php:1341
+#: src/CommonITILValidation.php:1433
 msgid "Request comments"
 msgstr "Comentários da requisição"
 
-#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1373
-#: src/CommonITILValidation.php:1485
+#: src/CommonITILValidation.php:1259 src/CommonITILValidation.php:1376
+#: src/CommonITILValidation.php:1488
 msgid "Approval date"
 msgstr "Data da validação"
 
-#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1400
+#: src/CommonITILValidation.php:1260 src/CommonITILValidation.php:1403
 msgid "Requested approver type"
 msgstr "Tipo de aprovação requerida"
 
-#: src/CommonITILValidation.php:1258
+#: src/CommonITILValidation.php:1261
 msgid "Requested approver"
 msgstr "Aprovador requerido"
 
-#: src/CommonITILValidation.php:1259
+#: src/CommonITILValidation.php:1262
 msgid "Approval Comment"
 msgstr "Comentários da Validação"
 
-#: src/CommonITILValidation.php:1260
+#: src/CommonITILValidation.php:1263
 #: src/NotificationTargetKnowbaseItem.php:218
 msgid "Documents"
 msgstr "Documentos"
 
-#: src/CommonITILValidation.php:1347 src/CommonITILValidation.php:1444
+#: src/CommonITILValidation.php:1350 src/CommonITILValidation.php:1447
 msgid "Approval comments"
 msgstr "Comentários da validação"
 
-#: src/CommonITILValidation.php:1459
+#: src/CommonITILValidation.php:1462
 msgid "Approval status"
 msgstr "Status de aprovação"
 
-#: src/CommonITILValidation.php:1541
+#: src/CommonITILValidation.php:1544
 msgid "Approver substitute"
 msgstr "Substituto do aprovador"
 
-#: src/CommonITILValidation.php:1601
+#: src/CommonITILValidation.php:1604
 msgid "Approver group"
 msgstr "Grupo aprovador"
 
-#: src/CommonITILValidation.php:1623
+#: src/CommonITILValidation.php:1626
 msgid "Substitute of a member of approver group"
 msgstr "Substituto de um membro do grupo de aprovadores"
 
-#: src/CommonITILValidation.php:1694
+#: src/CommonITILValidation.php:1697
 msgid "Approval status by users"
 msgstr "Status de aprovação por usuários"
 
-#: src/CommonITILValidation.php:1849
+#: src/CommonITILValidation.php:1852
 msgid "Approver type"
 msgstr "Tipo de aprovador"
 
-#: src/CommonITILValidation.php:1954
+#: src/CommonITILValidation.php:1957
 msgid ""
 "This item is waiting for approval, do you really want to resolve or close "
 "it?"
@@ -33897,11 +33909,11 @@ msgstr ""
 "Este item está esperando uma aprovação; você realmente deseja resolver ou "
 "fechá-lo?"
 
-#: src/CommonITILValidation.php:1995
+#: src/CommonITILValidation.php:1998
 msgid "This item is waiting for approval."
 msgstr "Este item está aguardando aprovação."
 
-#: src/CommonITILValidation.php:1996
+#: src/CommonITILValidation.php:1999
 msgid "Do you really want to resolve or close it?"
 msgstr "Deseja realmente resolvê-lo ou fechá-lo?"
 

--- a/locales/pt_PT.po
+++ b/locales/pt_PT.po
@@ -37,7 +37,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-26 10:20+0000\n"
+"POT-Creation-Date: 2025-08-26 12:21+0000\n"
 "PO-Revision-Date: 2022-09-16 06:53+0000\n"
 "Last-Translator: alexandre delaunay <delaunay.alexandre@gmail.com>, 2025\n"
 "Language-Team: Portuguese (Portugal) (https://app.transifex.com/glpi/teams/1637/pt_PT/)\n"
@@ -826,7 +826,7 @@ msgstr ""
 #: templates/components/itilobject/timeline/main_description.html.twig
 #: templates/components/user/info_card.html.twig
 #: templates/pages/tools/kb/comments.html.twig src/KnowbaseItem.php:245
-#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1188
+#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1191
 #: js/src/vue/CustomObject/FieldPreview/Field.vue:30
 msgid "Edit"
 msgstr "Editar"
@@ -1476,7 +1476,7 @@ msgid "Cancel"
 msgstr "Cancelar"
 
 #: templates/components/form/basic_inputs_macros.html.twig
-#: src/CommonITILValidation.php:1773
+#: src/CommonITILValidation.php:1776
 msgid "Validate"
 msgstr "Validar"
 
@@ -2000,7 +2000,7 @@ msgstr "Número de inventário"
 #: src/Computer.php:461 src/ProjectTask_Ticket.php:336 src/Certificate.php:278
 #: src/CronTask.php:1274 src/CronTask.php:1412
 #: src/CommonItilObject_Item.php:506 src/PDU.php:203 src/CommonDBTM.php:3513
-#: src/CommonITILValidation.php:1356 src/Plugin.php:2657
+#: src/CommonITILValidation.php:1359 src/Plugin.php:2657
 msgid "Status"
 msgstr "Estado"
 
@@ -3497,7 +3497,7 @@ msgstr[2] ""
 #: src/CommonITILObject.php:4737 src/CommonITILObject.php:4746
 #: src/CommonITILObject.php:6847 src/CommonITILObject.php:6894
 #: src/CommonITILObject.php:10159 src/NotificationTargetChange.php:308
-#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1498
+#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1501
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "Requerente"
@@ -3508,7 +3508,7 @@ msgstr[2] "Requerentes"
 #: src/NotificationTargetTicket.php:676 src/NotificationTargetTicket.php:706
 #: src/NotificationTargetCommonITILObject.php:976
 #: src/ITILValidationTemplate.php:81 src/NotificationTargetChange.php:327
-#: src/CommonITILValidation.php:1391 src/CommonITILValidation.php:1518
+#: src/CommonITILValidation.php:1394 src/CommonITILValidation.php:1521
 msgid "Approver"
 msgstr "Aprovador"
 
@@ -4249,7 +4249,7 @@ msgstr "Sem histórico"
 #: src/OAuthClient.php:94 src/Item_RemoteManagement.php:207
 #: src/Item_RemoteManagement.php:238 src/Certificate.php:125
 #: src/CronTask.php:1391 src/Contact.php:282 src/PDU.php:114
-#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1329
+#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1332
 #: src/Domain.php:233 src/Domain.php:257 src/ConsumableItem.php:167
 msgid "ID"
 msgstr "ID"
@@ -5815,7 +5815,7 @@ msgstr ""
 #: src/Project.php:904 src/ProjectTask.php:963
 #: src/NotificationTargetProjectTask.php:553
 #: src/NotificationTargetProjectTask.php:568 src/Cartridge.php:895
-#: src/CommonITILValidation.php:1252
+#: src/CommonITILValidation.php:1255
 msgctxt "item"
 msgid "State"
 msgstr "Estado"
@@ -17470,7 +17470,7 @@ msgid "Observer group except manager users"
 msgstr "Grupo observador exceto utilizadores gestores"
 
 #: src/NotificationTargetCommonITILObject.php:973
-#: src/CommonITILValidation.php:1254 src/CommonITILValidation.php:1381
+#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1384
 msgid "Approval requester"
 msgstr "Requerente da aprovação"
 
@@ -33593,7 +33593,7 @@ msgstr "Não tem matéria para aprovação"
 msgid "Granted + Not subject to approval"
 msgstr "Concedido + Não tem matéria para aprovação"
 
-#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1836
+#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1839
 msgid "Group user(s)"
 msgstr "Utilizador(es) do grupo"
 
@@ -33606,67 +33606,79 @@ msgstr ""
 msgid "Progress: %1$s%% of %2$s%% required"
 msgstr ""
 
-#: src/CommonITILValidation.php:1253 src/CommonITILValidation.php:1365
-#: src/CommonITILValidation.php:1472
+#: src/CommonITILValidation.php:1127
+msgid "Approval step accepted"
+msgstr ""
+
+#: src/CommonITILValidation.php:1128
+msgid "Approval step refused"
+msgstr ""
+
+#: src/CommonITILValidation.php:1129
+msgid "Approval step pending"
+msgstr ""
+
+#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1368
+#: src/CommonITILValidation.php:1475
 msgid "Request date"
 msgstr "Data do pedido"
 
-#: src/CommonITILValidation.php:1255 src/CommonITILValidation.php:1338
-#: src/CommonITILValidation.php:1430
+#: src/CommonITILValidation.php:1258 src/CommonITILValidation.php:1341
+#: src/CommonITILValidation.php:1433
 msgid "Request comments"
 msgstr "Comentário do pedido"
 
-#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1373
-#: src/CommonITILValidation.php:1485
+#: src/CommonITILValidation.php:1259 src/CommonITILValidation.php:1376
+#: src/CommonITILValidation.php:1488
 msgid "Approval date"
 msgstr "Data da aprovação"
 
-#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1400
+#: src/CommonITILValidation.php:1260 src/CommonITILValidation.php:1403
 msgid "Requested approver type"
 msgstr "Tipo de aprovador solicitado"
 
-#: src/CommonITILValidation.php:1258
+#: src/CommonITILValidation.php:1261
 msgid "Requested approver"
 msgstr "Aprovador solicitado"
 
-#: src/CommonITILValidation.php:1259
+#: src/CommonITILValidation.php:1262
 msgid "Approval Comment"
 msgstr ""
 
-#: src/CommonITILValidation.php:1260
+#: src/CommonITILValidation.php:1263
 #: src/NotificationTargetKnowbaseItem.php:218
 msgid "Documents"
 msgstr "Documentos"
 
-#: src/CommonITILValidation.php:1347 src/CommonITILValidation.php:1444
+#: src/CommonITILValidation.php:1350 src/CommonITILValidation.php:1447
 msgid "Approval comments"
 msgstr "Comentário da aprovação"
 
-#: src/CommonITILValidation.php:1459
+#: src/CommonITILValidation.php:1462
 msgid "Approval status"
 msgstr "Estado aprovação"
 
-#: src/CommonITILValidation.php:1541
+#: src/CommonITILValidation.php:1544
 msgid "Approver substitute"
 msgstr "Substituto do responsável pela aprovação"
 
-#: src/CommonITILValidation.php:1601
+#: src/CommonITILValidation.php:1604
 msgid "Approver group"
 msgstr "Grupo responsável pela aprovação"
 
-#: src/CommonITILValidation.php:1623
+#: src/CommonITILValidation.php:1626
 msgid "Substitute of a member of approver group"
 msgstr "Substituto de um membro do grupo de aprovadores"
 
-#: src/CommonITILValidation.php:1694
+#: src/CommonITILValidation.php:1697
 msgid "Approval status by users"
 msgstr ""
 
-#: src/CommonITILValidation.php:1849
+#: src/CommonITILValidation.php:1852
 msgid "Approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1954
+#: src/CommonITILValidation.php:1957
 msgid ""
 "This item is waiting for approval, do you really want to resolve or close "
 "it?"
@@ -33674,11 +33686,11 @@ msgstr ""
 "Este item está a aguardar aprovação. Deseja atribuir resolução ou encerrá-"
 "lo?"
 
-#: src/CommonITILValidation.php:1995
+#: src/CommonITILValidation.php:1998
 msgid "This item is waiting for approval."
 msgstr "Este item aguarda aprovação."
 
-#: src/CommonITILValidation.php:1996
+#: src/CommonITILValidation.php:1999
 msgid "Do you really want to resolve or close it?"
 msgstr "Deseja realmente resolvê-lo ou fechá-lo?"
 

--- a/locales/ro_RO.po
+++ b/locales/ro_RO.po
@@ -16,7 +16,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-26 10:20+0000\n"
+"POT-Creation-Date: 2025-08-26 12:21+0000\n"
 "PO-Revision-Date: 2022-09-16 06:53+0000\n"
 "Last-Translator: alexandre delaunay <delaunay.alexandre@gmail.com>, 2025\n"
 "Language-Team: Romanian (Romania) (https://app.transifex.com/glpi/teams/1637/ro_RO/)\n"
@@ -796,7 +796,7 @@ msgstr ""
 #: templates/components/itilobject/timeline/main_description.html.twig
 #: templates/components/user/info_card.html.twig
 #: templates/pages/tools/kb/comments.html.twig src/KnowbaseItem.php:245
-#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1188
+#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1191
 #: js/src/vue/CustomObject/FieldPreview/Field.vue:30
 msgid "Edit"
 msgstr "Editează"
@@ -1442,7 +1442,7 @@ msgid "Cancel"
 msgstr "Anulează"
 
 #: templates/components/form/basic_inputs_macros.html.twig
-#: src/CommonITILValidation.php:1773
+#: src/CommonITILValidation.php:1776
 msgid "Validate"
 msgstr "Valideaza"
 
@@ -1963,7 +1963,7 @@ msgstr "Numar de inventar"
 #: src/Computer.php:461 src/ProjectTask_Ticket.php:336 src/Certificate.php:278
 #: src/CronTask.php:1274 src/CronTask.php:1412
 #: src/CommonItilObject_Item.php:506 src/PDU.php:203 src/CommonDBTM.php:3513
-#: src/CommonITILValidation.php:1356 src/Plugin.php:2657
+#: src/CommonITILValidation.php:1359 src/Plugin.php:2657
 msgid "Status"
 msgstr "Status"
 
@@ -3452,7 +3452,7 @@ msgstr[2] ""
 #: src/CommonITILObject.php:4737 src/CommonITILObject.php:4746
 #: src/CommonITILObject.php:6847 src/CommonITILObject.php:6894
 #: src/CommonITILObject.php:10159 src/NotificationTargetChange.php:308
-#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1498
+#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1501
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "Solicitant"
@@ -3463,7 +3463,7 @@ msgstr[2] "Solicitanţi"
 #: src/NotificationTargetTicket.php:676 src/NotificationTargetTicket.php:706
 #: src/NotificationTargetCommonITILObject.php:976
 #: src/ITILValidationTemplate.php:81 src/NotificationTargetChange.php:327
-#: src/CommonITILValidation.php:1391 src/CommonITILValidation.php:1518
+#: src/CommonITILValidation.php:1394 src/CommonITILValidation.php:1521
 msgid "Approver"
 msgstr "Validator"
 
@@ -4202,7 +4202,7 @@ msgstr "Fără istorie"
 #: src/OAuthClient.php:94 src/Item_RemoteManagement.php:207
 #: src/Item_RemoteManagement.php:238 src/Certificate.php:125
 #: src/CronTask.php:1391 src/Contact.php:282 src/PDU.php:114
-#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1329
+#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1332
 #: src/Domain.php:233 src/Domain.php:257 src/ConsumableItem.php:167
 msgid "ID"
 msgstr "ID"
@@ -5743,7 +5743,7 @@ msgstr ""
 #: src/Project.php:904 src/ProjectTask.php:963
 #: src/NotificationTargetProjectTask.php:553
 #: src/NotificationTargetProjectTask.php:568 src/Cartridge.php:895
-#: src/CommonITILValidation.php:1252
+#: src/CommonITILValidation.php:1255
 msgctxt "item"
 msgid "State"
 msgstr "Stare"
@@ -17210,7 +17210,7 @@ msgid "Observer group except manager users"
 msgstr ""
 
 #: src/NotificationTargetCommonITILObject.php:973
-#: src/CommonITILValidation.php:1254 src/CommonITILValidation.php:1381
+#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1384
 msgid "Approval requester"
 msgstr "Iniţiatorul cererii de validare"
 
@@ -32733,7 +32733,7 @@ msgstr "Ne supuse validării"
 msgid "Granted + Not subject to approval"
 msgstr "Acceptat sau nesupus validării"
 
-#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1836
+#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1839
 msgid "Group user(s)"
 msgstr ""
 
@@ -32746,67 +32746,79 @@ msgstr ""
 msgid "Progress: %1$s%% of %2$s%% required"
 msgstr ""
 
-#: src/CommonITILValidation.php:1253 src/CommonITILValidation.php:1365
-#: src/CommonITILValidation.php:1472
+#: src/CommonITILValidation.php:1127
+msgid "Approval step accepted"
+msgstr ""
+
+#: src/CommonITILValidation.php:1128
+msgid "Approval step refused"
+msgstr ""
+
+#: src/CommonITILValidation.php:1129
+msgid "Approval step pending"
+msgstr ""
+
+#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1368
+#: src/CommonITILValidation.php:1475
 msgid "Request date"
 msgstr "Data cererii"
 
-#: src/CommonITILValidation.php:1255 src/CommonITILValidation.php:1338
-#: src/CommonITILValidation.php:1430
+#: src/CommonITILValidation.php:1258 src/CommonITILValidation.php:1341
+#: src/CommonITILValidation.php:1433
 msgid "Request comments"
 msgstr "Comentariu solicitant"
 
-#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1373
-#: src/CommonITILValidation.php:1485
+#: src/CommonITILValidation.php:1259 src/CommonITILValidation.php:1376
+#: src/CommonITILValidation.php:1488
 msgid "Approval date"
 msgstr "Data validării"
 
-#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1400
+#: src/CommonITILValidation.php:1260 src/CommonITILValidation.php:1403
 msgid "Requested approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1258
+#: src/CommonITILValidation.php:1261
 msgid "Requested approver"
 msgstr ""
 
-#: src/CommonITILValidation.php:1259
+#: src/CommonITILValidation.php:1262
 msgid "Approval Comment"
 msgstr ""
 
-#: src/CommonITILValidation.php:1260
+#: src/CommonITILValidation.php:1263
 #: src/NotificationTargetKnowbaseItem.php:218
 msgid "Documents"
 msgstr "Documente"
 
-#: src/CommonITILValidation.php:1347 src/CommonITILValidation.php:1444
+#: src/CommonITILValidation.php:1350 src/CommonITILValidation.php:1447
 msgid "Approval comments"
 msgstr "Comentarii validare"
 
-#: src/CommonITILValidation.php:1459
+#: src/CommonITILValidation.php:1462
 msgid "Approval status"
 msgstr "Statusul aprobării"
 
-#: src/CommonITILValidation.php:1541
+#: src/CommonITILValidation.php:1544
 msgid "Approver substitute"
 msgstr ""
 
-#: src/CommonITILValidation.php:1601
+#: src/CommonITILValidation.php:1604
 msgid "Approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1623
+#: src/CommonITILValidation.php:1626
 msgid "Substitute of a member of approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1694
+#: src/CommonITILValidation.php:1697
 msgid "Approval status by users"
 msgstr ""
 
-#: src/CommonITILValidation.php:1849
+#: src/CommonITILValidation.php:1852
 msgid "Approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1954
+#: src/CommonITILValidation.php:1957
 msgid ""
 "This item is waiting for approval, do you really want to resolve or close "
 "it?"
@@ -32814,11 +32826,11 @@ msgstr ""
 "Acest element este în aşteptarea aprobării, doriţi rezolvarea sau închiderea"
 " acestuia ?"
 
-#: src/CommonITILValidation.php:1995
+#: src/CommonITILValidation.php:1998
 msgid "This item is waiting for approval."
 msgstr ""
 
-#: src/CommonITILValidation.php:1996
+#: src/CommonITILValidation.php:1999
 msgid "Do you really want to resolve or close it?"
 msgstr ""
 

--- a/locales/ru_RU.po
+++ b/locales/ru_RU.po
@@ -55,7 +55,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-26 10:20+0000\n"
+"POT-Creation-Date: 2025-08-26 12:21+0000\n"
 "PO-Revision-Date: 2022-09-16 06:53+0000\n"
 "Last-Translator: alexandre delaunay <delaunay.alexandre@gmail.com>, 2025\n"
 "Language-Team: Russian (Russia) (https://app.transifex.com/glpi/teams/1637/ru_RU/)\n"
@@ -840,7 +840,7 @@ msgstr "Режим только чтение"
 #: templates/components/itilobject/timeline/main_description.html.twig
 #: templates/components/user/info_card.html.twig
 #: templates/pages/tools/kb/comments.html.twig src/KnowbaseItem.php:245
-#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1188
+#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1191
 #: js/src/vue/CustomObject/FieldPreview/Field.vue:30
 msgid "Edit"
 msgstr "Редактировать"
@@ -1491,7 +1491,7 @@ msgid "Cancel"
 msgstr "Отмена"
 
 #: templates/components/form/basic_inputs_macros.html.twig
-#: src/CommonITILValidation.php:1773
+#: src/CommonITILValidation.php:1776
 msgid "Validate"
 msgstr "Согласовывать"
 
@@ -2014,7 +2014,7 @@ msgstr "Инвентарный номер"
 #: src/Computer.php:461 src/ProjectTask_Ticket.php:336 src/Certificate.php:278
 #: src/CronTask.php:1274 src/CronTask.php:1412
 #: src/CommonItilObject_Item.php:506 src/PDU.php:203 src/CommonDBTM.php:3513
-#: src/CommonITILValidation.php:1356 src/Plugin.php:2657
+#: src/CommonITILValidation.php:1359 src/Plugin.php:2657
 msgid "Status"
 msgstr "Статус"
 
@@ -3528,7 +3528,7 @@ msgstr[3] "Этапов согласования"
 #: src/CommonITILObject.php:4737 src/CommonITILObject.php:4746
 #: src/CommonITILObject.php:6847 src/CommonITILObject.php:6894
 #: src/CommonITILObject.php:10159 src/NotificationTargetChange.php:308
-#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1498
+#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1501
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "Инициатор запроса"
@@ -3540,7 +3540,7 @@ msgstr[3] "Инициаторы запроса"
 #: src/NotificationTargetTicket.php:676 src/NotificationTargetTicket.php:706
 #: src/NotificationTargetCommonITILObject.php:976
 #: src/ITILValidationTemplate.php:81 src/NotificationTargetChange.php:327
-#: src/CommonITILValidation.php:1391 src/CommonITILValidation.php:1518
+#: src/CommonITILValidation.php:1394 src/CommonITILValidation.php:1521
 msgid "Approver"
 msgstr "Проверяющий"
 
@@ -4293,7 +4293,7 @@ msgstr "Нет истории"
 #: src/OAuthClient.php:94 src/Item_RemoteManagement.php:207
 #: src/Item_RemoteManagement.php:238 src/Certificate.php:125
 #: src/CronTask.php:1391 src/Contact.php:282 src/PDU.php:114
-#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1329
+#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1332
 #: src/Domain.php:233 src/Domain.php:257 src/ConsumableItem.php:167
 msgid "ID"
 msgstr "ID"
@@ -5877,7 +5877,7 @@ msgstr ""
 #: src/Project.php:904 src/ProjectTask.php:963
 #: src/NotificationTargetProjectTask.php:553
 #: src/NotificationTargetProjectTask.php:568 src/Cartridge.php:895
-#: src/CommonITILValidation.php:1252
+#: src/CommonITILValidation.php:1255
 msgctxt "item"
 msgid "State"
 msgstr "Состояние"
@@ -17719,7 +17719,7 @@ msgid "Observer group except manager users"
 msgstr "Группа наблюдателей, за исключением пользователей-менеджеров"
 
 #: src/NotificationTargetCommonITILObject.php:973
-#: src/CommonITILValidation.php:1254 src/CommonITILValidation.php:1381
+#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1384
 msgid "Approval requester"
 msgstr "Инициатор запроса на согласование"
 
@@ -34189,7 +34189,7 @@ msgstr "Не подлежит согласованию"
 msgid "Granted + Not subject to approval"
 msgstr "Предоставлено + Без согласования"
 
-#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1836
+#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1839
 msgid "Group user(s)"
 msgstr "Группа пользователя(-ей)"
 
@@ -34202,67 +34202,79 @@ msgstr ""
 msgid "Progress: %1$s%% of %2$s%% required"
 msgstr ""
 
-#: src/CommonITILValidation.php:1253 src/CommonITILValidation.php:1365
-#: src/CommonITILValidation.php:1472
+#: src/CommonITILValidation.php:1127
+msgid "Approval step accepted"
+msgstr ""
+
+#: src/CommonITILValidation.php:1128
+msgid "Approval step refused"
+msgstr ""
+
+#: src/CommonITILValidation.php:1129
+msgid "Approval step pending"
+msgstr ""
+
+#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1368
+#: src/CommonITILValidation.php:1475
 msgid "Request date"
 msgstr "Дата запроса"
 
-#: src/CommonITILValidation.php:1255 src/CommonITILValidation.php:1338
-#: src/CommonITILValidation.php:1430
+#: src/CommonITILValidation.php:1258 src/CommonITILValidation.php:1341
+#: src/CommonITILValidation.php:1433
 msgid "Request comments"
 msgstr "Комментарий запроса"
 
-#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1373
-#: src/CommonITILValidation.php:1485
+#: src/CommonITILValidation.php:1259 src/CommonITILValidation.php:1376
+#: src/CommonITILValidation.php:1488
 msgid "Approval date"
 msgstr "Дата согласования"
 
-#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1400
+#: src/CommonITILValidation.php:1260 src/CommonITILValidation.php:1403
 msgid "Requested approver type"
 msgstr "Тип запрошенного утверждающего"
 
-#: src/CommonITILValidation.php:1258
+#: src/CommonITILValidation.php:1261
 msgid "Requested approver"
 msgstr "Запрошенный утверждающий"
 
-#: src/CommonITILValidation.php:1259
+#: src/CommonITILValidation.php:1262
 msgid "Approval Comment"
 msgstr "Утвержденный комментарий"
 
-#: src/CommonITILValidation.php:1260
+#: src/CommonITILValidation.php:1263
 #: src/NotificationTargetKnowbaseItem.php:218
 msgid "Documents"
 msgstr "Документов"
 
-#: src/CommonITILValidation.php:1347 src/CommonITILValidation.php:1444
+#: src/CommonITILValidation.php:1350 src/CommonITILValidation.php:1447
 msgid "Approval comments"
 msgstr "Комментарий согласования"
 
-#: src/CommonITILValidation.php:1459
+#: src/CommonITILValidation.php:1462
 msgid "Approval status"
 msgstr "Статус согласования"
 
-#: src/CommonITILValidation.php:1541
+#: src/CommonITILValidation.php:1544
 msgid "Approver substitute"
 msgstr "Заместитель утверждающего"
 
-#: src/CommonITILValidation.php:1601
+#: src/CommonITILValidation.php:1604
 msgid "Approver group"
 msgstr "Группа утверждающих"
 
-#: src/CommonITILValidation.php:1623
+#: src/CommonITILValidation.php:1626
 msgid "Substitute of a member of approver group"
 msgstr "Замена члена группы утверждения"
 
-#: src/CommonITILValidation.php:1694
+#: src/CommonITILValidation.php:1697
 msgid "Approval status by users"
 msgstr "Статус утверждения пользователями"
 
-#: src/CommonITILValidation.php:1849
+#: src/CommonITILValidation.php:1852
 msgid "Approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1954
+#: src/CommonITILValidation.php:1957
 msgid ""
 "This item is waiting for approval, do you really want to resolve or close "
 "it?"
@@ -34270,11 +34282,11 @@ msgstr ""
 "Этот объект ждет согласования, вы действительно хотите решить или закрыть "
 "его?"
 
-#: src/CommonITILValidation.php:1995
+#: src/CommonITILValidation.php:1998
 msgid "This item is waiting for approval."
 msgstr "Этот элемент в ожидании подтверждения"
 
-#: src/CommonITILValidation.php:1996
+#: src/CommonITILValidation.php:1999
 msgid "Do you really want to resolve or close it?"
 msgstr "Вы действительно хотите решить или закрыть его?"
 

--- a/locales/sk_SK.po
+++ b/locales/sk_SK.po
@@ -16,7 +16,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-26 10:20+0000\n"
+"POT-Creation-Date: 2025-08-26 12:21+0000\n"
 "PO-Revision-Date: 2022-09-16 06:53+0000\n"
 "Last-Translator: alexandre delaunay <delaunay.alexandre@gmail.com>, 2025\n"
 "Language-Team: Slovak (Slovakia) (https://app.transifex.com/glpi/teams/1637/sk_SK/)\n"
@@ -800,7 +800,7 @@ msgstr ""
 #: templates/components/itilobject/timeline/main_description.html.twig
 #: templates/components/user/info_card.html.twig
 #: templates/pages/tools/kb/comments.html.twig src/KnowbaseItem.php:245
-#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1188
+#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1191
 #: js/src/vue/CustomObject/FieldPreview/Field.vue:30
 msgid "Edit"
 msgstr "Upraviť"
@@ -1452,7 +1452,7 @@ msgid "Cancel"
 msgstr "Zrušiť"
 
 #: templates/components/form/basic_inputs_macros.html.twig
-#: src/CommonITILValidation.php:1773
+#: src/CommonITILValidation.php:1776
 msgid "Validate"
 msgstr "Schváliť"
 
@@ -1976,7 +1976,7 @@ msgstr "Inventárne číslo"
 #: src/Computer.php:461 src/ProjectTask_Ticket.php:336 src/Certificate.php:278
 #: src/CronTask.php:1274 src/CronTask.php:1412
 #: src/CommonItilObject_Item.php:506 src/PDU.php:203 src/CommonDBTM.php:3513
-#: src/CommonITILValidation.php:1356 src/Plugin.php:2657
+#: src/CommonITILValidation.php:1359 src/Plugin.php:2657
 msgid "Status"
 msgstr "Stav"
 
@@ -3488,7 +3488,7 @@ msgstr[3] ""
 #: src/CommonITILObject.php:4737 src/CommonITILObject.php:4746
 #: src/CommonITILObject.php:6847 src/CommonITILObject.php:6894
 #: src/CommonITILObject.php:10159 src/NotificationTargetChange.php:308
-#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1498
+#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1501
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "Žiadateľ"
@@ -3500,7 +3500,7 @@ msgstr[3] "Žiadatelia"
 #: src/NotificationTargetTicket.php:676 src/NotificationTargetTicket.php:706
 #: src/NotificationTargetCommonITILObject.php:976
 #: src/ITILValidationTemplate.php:81 src/NotificationTargetChange.php:327
-#: src/CommonITILValidation.php:1391 src/CommonITILValidation.php:1518
+#: src/CommonITILValidation.php:1394 src/CommonITILValidation.php:1521
 msgid "Approver"
 msgstr "Schvaľovateľ"
 
@@ -4249,7 +4249,7 @@ msgstr "Žiadna história"
 #: src/OAuthClient.php:94 src/Item_RemoteManagement.php:207
 #: src/Item_RemoteManagement.php:238 src/Certificate.php:125
 #: src/CronTask.php:1391 src/Contact.php:282 src/PDU.php:114
-#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1329
+#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1332
 #: src/Domain.php:233 src/Domain.php:257 src/ConsumableItem.php:167
 msgid "ID"
 msgstr "ID"
@@ -5825,7 +5825,7 @@ msgstr ""
 #: src/Project.php:904 src/ProjectTask.php:963
 #: src/NotificationTargetProjectTask.php:553
 #: src/NotificationTargetProjectTask.php:568 src/Cartridge.php:895
-#: src/CommonITILValidation.php:1252
+#: src/CommonITILValidation.php:1255
 msgctxt "item"
 msgid "State"
 msgstr "Stav"
@@ -17616,7 +17616,7 @@ msgid "Observer group except manager users"
 msgstr "Skupina pozorovateľov okrem manažérov"
 
 #: src/NotificationTargetCommonITILObject.php:973
-#: src/CommonITILValidation.php:1254 src/CommonITILValidation.php:1381
+#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1384
 msgid "Approval requester"
 msgstr "Žiadateľ schválenia"
 
@@ -34012,7 +34012,7 @@ msgstr "Nepodlieha schvaľovaniu"
 msgid "Granted + Not subject to approval"
 msgstr "Schválené + Nepodlieha schvaľovaniu"
 
-#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1836
+#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1839
 msgid "Group user(s)"
 msgstr "Skupinoví používatelia"
 
@@ -34025,78 +34025,90 @@ msgstr ""
 msgid "Progress: %1$s%% of %2$s%% required"
 msgstr ""
 
-#: src/CommonITILValidation.php:1253 src/CommonITILValidation.php:1365
-#: src/CommonITILValidation.php:1472
+#: src/CommonITILValidation.php:1127
+msgid "Approval step accepted"
+msgstr ""
+
+#: src/CommonITILValidation.php:1128
+msgid "Approval step refused"
+msgstr ""
+
+#: src/CommonITILValidation.php:1129
+msgid "Approval step pending"
+msgstr ""
+
+#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1368
+#: src/CommonITILValidation.php:1475
 msgid "Request date"
 msgstr "Dátum žiadosti"
 
-#: src/CommonITILValidation.php:1255 src/CommonITILValidation.php:1338
-#: src/CommonITILValidation.php:1430
+#: src/CommonITILValidation.php:1258 src/CommonITILValidation.php:1341
+#: src/CommonITILValidation.php:1433
 msgid "Request comments"
 msgstr "Komentáre k žiadosti"
 
-#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1373
-#: src/CommonITILValidation.php:1485
+#: src/CommonITILValidation.php:1259 src/CommonITILValidation.php:1376
+#: src/CommonITILValidation.php:1488
 msgid "Approval date"
 msgstr "Dátum schválenia"
 
-#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1400
+#: src/CommonITILValidation.php:1260 src/CommonITILValidation.php:1403
 msgid "Requested approver type"
 msgstr "Typ požadovaného schvaľovateľa"
 
-#: src/CommonITILValidation.php:1258
+#: src/CommonITILValidation.php:1261
 msgid "Requested approver"
 msgstr "Požadovaný schvaľovateľ"
 
-#: src/CommonITILValidation.php:1259
+#: src/CommonITILValidation.php:1262
 msgid "Approval Comment"
 msgstr "Komentár k schváleniu"
 
-#: src/CommonITILValidation.php:1260
+#: src/CommonITILValidation.php:1263
 #: src/NotificationTargetKnowbaseItem.php:218
 msgid "Documents"
 msgstr "Súbory"
 
-#: src/CommonITILValidation.php:1347 src/CommonITILValidation.php:1444
+#: src/CommonITILValidation.php:1350 src/CommonITILValidation.php:1447
 msgid "Approval comments"
 msgstr "Komentáre k schváleniu"
 
-#: src/CommonITILValidation.php:1459
+#: src/CommonITILValidation.php:1462
 msgid "Approval status"
 msgstr "Stav schválenia"
 
-#: src/CommonITILValidation.php:1541
+#: src/CommonITILValidation.php:1544
 msgid "Approver substitute"
 msgstr "Zástupca schvaľovateľa"
 
-#: src/CommonITILValidation.php:1601
+#: src/CommonITILValidation.php:1604
 msgid "Approver group"
 msgstr "Skupina schvaľovateľov"
 
-#: src/CommonITILValidation.php:1623
+#: src/CommonITILValidation.php:1626
 msgid "Substitute of a member of approver group"
 msgstr "Zástupca člena skupiny schvaľovateľov"
 
-#: src/CommonITILValidation.php:1694
+#: src/CommonITILValidation.php:1697
 msgid "Approval status by users"
 msgstr "Stav schválenia podľa používateľov"
 
-#: src/CommonITILValidation.php:1849
+#: src/CommonITILValidation.php:1852
 msgid "Approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1954
+#: src/CommonITILValidation.php:1957
 msgid ""
 "This item is waiting for approval, do you really want to resolve or close "
 "it?"
 msgstr ""
 "Táto položka čaká na schválenie, naozaj ju chcete vyriešiť alebo uzavrieť?"
 
-#: src/CommonITILValidation.php:1995
+#: src/CommonITILValidation.php:1998
 msgid "This item is waiting for approval."
 msgstr "Táto položka čaká na potvrdenie."
 
-#: src/CommonITILValidation.php:1996
+#: src/CommonITILValidation.php:1999
 msgid "Do you really want to resolve or close it?"
 msgstr "Chcete to naozaj vyriešiť alebo uzavrieť?"
 

--- a/locales/sl_SI.po
+++ b/locales/sl_SI.po
@@ -16,7 +16,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-26 10:20+0000\n"
+"POT-Creation-Date: 2025-08-26 12:21+0000\n"
 "PO-Revision-Date: 2022-09-16 06:53+0000\n"
 "Last-Translator: Aktivni Uporabnik, 2025\n"
 "Language-Team: Slovenian (Slovenia) (https://app.transifex.com/glpi/teams/1637/sl_SI/)\n"
@@ -804,7 +804,7 @@ msgstr ""
 #: templates/components/itilobject/timeline/main_description.html.twig
 #: templates/components/user/info_card.html.twig
 #: templates/pages/tools/kb/comments.html.twig src/KnowbaseItem.php:245
-#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1188
+#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1191
 #: js/src/vue/CustomObject/FieldPreview/Field.vue:30
 msgid "Edit"
 msgstr "Uredi"
@@ -1454,7 +1454,7 @@ msgid "Cancel"
 msgstr "Prekliči"
 
 #: templates/components/form/basic_inputs_macros.html.twig
-#: src/CommonITILValidation.php:1773
+#: src/CommonITILValidation.php:1776
 msgid "Validate"
 msgstr "Potrditi"
 
@@ -1978,7 +1978,7 @@ msgstr "Inventarna številka"
 #: src/Computer.php:461 src/ProjectTask_Ticket.php:336 src/Certificate.php:278
 #: src/CronTask.php:1274 src/CronTask.php:1412
 #: src/CommonItilObject_Item.php:506 src/PDU.php:203 src/CommonDBTM.php:3513
-#: src/CommonITILValidation.php:1356 src/Plugin.php:2657
+#: src/CommonITILValidation.php:1359 src/Plugin.php:2657
 msgid "Status"
 msgstr "Status"
 
@@ -3488,7 +3488,7 @@ msgstr[3] ""
 #: src/CommonITILObject.php:4737 src/CommonITILObject.php:4746
 #: src/CommonITILObject.php:6847 src/CommonITILObject.php:6894
 #: src/CommonITILObject.php:10159 src/NotificationTargetChange.php:308
-#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1498
+#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1501
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "Naročnik"
@@ -3500,7 +3500,7 @@ msgstr[3] "Naročnikov"
 #: src/NotificationTargetTicket.php:676 src/NotificationTargetTicket.php:706
 #: src/NotificationTargetCommonITILObject.php:976
 #: src/ITILValidationTemplate.php:81 src/NotificationTargetChange.php:327
-#: src/CommonITILValidation.php:1391 src/CommonITILValidation.php:1518
+#: src/CommonITILValidation.php:1394 src/CommonITILValidation.php:1521
 msgid "Approver"
 msgstr "Odobritelj"
 
@@ -4246,7 +4246,7 @@ msgstr "Ne zgodovinsko"
 #: src/OAuthClient.php:94 src/Item_RemoteManagement.php:207
 #: src/Item_RemoteManagement.php:238 src/Certificate.php:125
 #: src/CronTask.php:1391 src/Contact.php:282 src/PDU.php:114
-#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1329
+#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1332
 #: src/Domain.php:233 src/Domain.php:257 src/ConsumableItem.php:167
 msgid "ID"
 msgstr "ID"
@@ -5811,7 +5811,7 @@ msgstr ""
 #: src/Project.php:904 src/ProjectTask.php:963
 #: src/NotificationTargetProjectTask.php:553
 #: src/NotificationTargetProjectTask.php:568 src/Cartridge.php:895
-#: src/CommonITILValidation.php:1252
+#: src/CommonITILValidation.php:1255
 msgctxt "item"
 msgid "State"
 msgstr "Stanje"
@@ -17544,7 +17544,7 @@ msgid "Observer group except manager users"
 msgstr ""
 
 #: src/NotificationTargetCommonITILObject.php:973
-#: src/CommonITILValidation.php:1254 src/CommonITILValidation.php:1381
+#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1384
 msgid "Approval requester"
 msgstr "Prosilec za odobritev"
 
@@ -33889,7 +33889,7 @@ msgstr "Ni predmet odobritve"
 msgid "Granted + Not subject to approval"
 msgstr "Odobreno + Ni predmet odobritve"
 
-#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1836
+#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1839
 msgid "Group user(s)"
 msgstr ""
 
@@ -33902,77 +33902,89 @@ msgstr ""
 msgid "Progress: %1$s%% of %2$s%% required"
 msgstr ""
 
-#: src/CommonITILValidation.php:1253 src/CommonITILValidation.php:1365
-#: src/CommonITILValidation.php:1472
+#: src/CommonITILValidation.php:1127
+msgid "Approval step accepted"
+msgstr ""
+
+#: src/CommonITILValidation.php:1128
+msgid "Approval step refused"
+msgstr ""
+
+#: src/CommonITILValidation.php:1129
+msgid "Approval step pending"
+msgstr ""
+
+#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1368
+#: src/CommonITILValidation.php:1475
 msgid "Request date"
 msgstr "Datum zahteve"
 
-#: src/CommonITILValidation.php:1255 src/CommonITILValidation.php:1338
-#: src/CommonITILValidation.php:1430
+#: src/CommonITILValidation.php:1258 src/CommonITILValidation.php:1341
+#: src/CommonITILValidation.php:1433
 msgid "Request comments"
 msgstr "Zahteva komentarja"
 
-#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1373
-#: src/CommonITILValidation.php:1485
+#: src/CommonITILValidation.php:1259 src/CommonITILValidation.php:1376
+#: src/CommonITILValidation.php:1488
 msgid "Approval date"
 msgstr "Datum odobritve"
 
-#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1400
+#: src/CommonITILValidation.php:1260 src/CommonITILValidation.php:1403
 msgid "Requested approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1258
+#: src/CommonITILValidation.php:1261
 msgid "Requested approver"
 msgstr ""
 
-#: src/CommonITILValidation.php:1259
+#: src/CommonITILValidation.php:1262
 msgid "Approval Comment"
 msgstr ""
 
-#: src/CommonITILValidation.php:1260
+#: src/CommonITILValidation.php:1263
 #: src/NotificationTargetKnowbaseItem.php:218
 msgid "Documents"
 msgstr "Dokumenti"
 
-#: src/CommonITILValidation.php:1347 src/CommonITILValidation.php:1444
+#: src/CommonITILValidation.php:1350 src/CommonITILValidation.php:1447
 msgid "Approval comments"
 msgstr "Opomba odobritelja"
 
-#: src/CommonITILValidation.php:1459
+#: src/CommonITILValidation.php:1462
 msgid "Approval status"
 msgstr "Status odobritve"
 
-#: src/CommonITILValidation.php:1541
+#: src/CommonITILValidation.php:1544
 msgid "Approver substitute"
 msgstr ""
 
-#: src/CommonITILValidation.php:1601
+#: src/CommonITILValidation.php:1604
 msgid "Approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1623
+#: src/CommonITILValidation.php:1626
 msgid "Substitute of a member of approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1694
+#: src/CommonITILValidation.php:1697
 msgid "Approval status by users"
 msgstr ""
 
-#: src/CommonITILValidation.php:1849
+#: src/CommonITILValidation.php:1852
 msgid "Approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1954
+#: src/CommonITILValidation.php:1957
 msgid ""
 "This item is waiting for approval, do you really want to resolve or close "
 "it?"
 msgstr "Ta element čaka na odobritev. Ali ga res želite rešiti ali zapreti?"
 
-#: src/CommonITILValidation.php:1995
+#: src/CommonITILValidation.php:1998
 msgid "This item is waiting for approval."
 msgstr "Ta predmet čaka na odobritev."
 
-#: src/CommonITILValidation.php:1996
+#: src/CommonITILValidation.php:1999
 msgid "Do you really want to resolve or close it?"
 msgstr "Ali ga res želite rešiti ali zapreti?"
 

--- a/locales/sq_AL.po
+++ b/locales/sq_AL.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-26 10:20+0000\n"
+"POT-Creation-Date: 2025-08-26 12:21+0000\n"
 "PO-Revision-Date: 2022-09-16 06:53+0000\n"
 "Last-Translator: Albion Paliqi, 2025\n"
 "Language-Team: Albanian (Albania) (https://app.transifex.com/glpi/teams/1637/sq_AL/)\n"
@@ -799,7 +799,7 @@ msgstr "Mënyra e vetëm për lexim"
 #: templates/components/itilobject/timeline/main_description.html.twig
 #: templates/components/user/info_card.html.twig
 #: templates/pages/tools/kb/comments.html.twig src/KnowbaseItem.php:245
-#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1188
+#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1191
 #: js/src/vue/CustomObject/FieldPreview/Field.vue:30
 msgid "Edit"
 msgstr "Redakto"
@@ -1448,7 +1448,7 @@ msgid "Cancel"
 msgstr "Anulo"
 
 #: templates/components/form/basic_inputs_macros.html.twig
-#: src/CommonITILValidation.php:1773
+#: src/CommonITILValidation.php:1776
 msgid "Validate"
 msgstr "Valido"
 
@@ -1966,7 +1966,7 @@ msgstr "Numri i inventarit"
 #: src/Computer.php:461 src/ProjectTask_Ticket.php:336 src/Certificate.php:278
 #: src/CronTask.php:1274 src/CronTask.php:1412
 #: src/CommonItilObject_Item.php:506 src/PDU.php:203 src/CommonDBTM.php:3513
-#: src/CommonITILValidation.php:1356 src/Plugin.php:2657
+#: src/CommonITILValidation.php:1359 src/Plugin.php:2657
 msgid "Status"
 msgstr "Statusi"
 
@@ -3450,7 +3450,7 @@ msgstr[1] "Hapi i miratimit"
 #: src/CommonITILObject.php:4737 src/CommonITILObject.php:4746
 #: src/CommonITILObject.php:6847 src/CommonITILObject.php:6894
 #: src/CommonITILObject.php:10159 src/NotificationTargetChange.php:308
-#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1498
+#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1501
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "Requester"
@@ -3460,7 +3460,7 @@ msgstr[1] "Kërkuesit"
 #: src/NotificationTargetTicket.php:676 src/NotificationTargetTicket.php:706
 #: src/NotificationTargetCommonITILObject.php:976
 #: src/ITILValidationTemplate.php:81 src/NotificationTargetChange.php:327
-#: src/CommonITILValidation.php:1391 src/CommonITILValidation.php:1518
+#: src/CommonITILValidation.php:1394 src/CommonITILValidation.php:1521
 msgid "Approver"
 msgstr "Aftësoj"
 
@@ -4204,7 +4204,7 @@ msgstr "Jo historike"
 #: src/OAuthClient.php:94 src/Item_RemoteManagement.php:207
 #: src/Item_RemoteManagement.php:238 src/Certificate.php:125
 #: src/CronTask.php:1391 src/Contact.php:282 src/PDU.php:114
-#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1329
+#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1332
 #: src/Domain.php:233 src/Domain.php:257 src/ConsumableItem.php:167
 msgid "ID"
 msgstr "Edhull"
@@ -5762,7 +5762,7 @@ msgstr ""
 #: src/Project.php:904 src/ProjectTask.php:963
 #: src/NotificationTargetProjectTask.php:553
 #: src/NotificationTargetProjectTask.php:568 src/Cartridge.php:895
-#: src/CommonITILValidation.php:1252
+#: src/CommonITILValidation.php:1255
 msgctxt "item"
 msgid "State"
 msgstr "Gjendje"
@@ -17408,7 +17408,7 @@ msgid "Observer group except manager users"
 msgstr "Grupi vëzhgues përveç përdoruesve menaxherë"
 
 #: src/NotificationTargetCommonITILObject.php:973
-#: src/CommonITILValidation.php:1254 src/CommonITILValidation.php:1381
+#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1384
 msgid "Approval requester"
 msgstr "Kërkuesi i miratimit"
 
@@ -33391,7 +33391,7 @@ msgstr "Nuk i nënshtrohet miratimit"
 msgid "Granted + Not subject to approval"
 msgstr "Dhënë + nuk i nënshtrohet miratimit"
 
-#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1836
+#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1839
 msgid "Group user(s)"
 msgstr "Përdorues(ë) të grupit"
 
@@ -33404,67 +33404,79 @@ msgstr "Modifiko hapin e miratimit"
 msgid "Progress: %1$s%% of %2$s%% required"
 msgstr "Progresi: Kërkohet %1$s%% nga %2$s%%"
 
-#: src/CommonITILValidation.php:1253 src/CommonITILValidation.php:1365
-#: src/CommonITILValidation.php:1472
+#: src/CommonITILValidation.php:1127
+msgid "Approval step accepted"
+msgstr ""
+
+#: src/CommonITILValidation.php:1128
+msgid "Approval step refused"
+msgstr ""
+
+#: src/CommonITILValidation.php:1129
+msgid "Approval step pending"
+msgstr ""
+
+#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1368
+#: src/CommonITILValidation.php:1475
 msgid "Request date"
 msgstr "Data e kërkesës"
 
-#: src/CommonITILValidation.php:1255 src/CommonITILValidation.php:1338
-#: src/CommonITILValidation.php:1430
+#: src/CommonITILValidation.php:1258 src/CommonITILValidation.php:1341
+#: src/CommonITILValidation.php:1433
 msgid "Request comments"
 msgstr "Kërko komente"
 
-#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1373
-#: src/CommonITILValidation.php:1485
+#: src/CommonITILValidation.php:1259 src/CommonITILValidation.php:1376
+#: src/CommonITILValidation.php:1488
 msgid "Approval date"
 msgstr "Data e Miratimit"
 
-#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1400
+#: src/CommonITILValidation.php:1260 src/CommonITILValidation.php:1403
 msgid "Requested approver type"
 msgstr "Lloji i miratimit të kërkuar"
 
-#: src/CommonITILValidation.php:1258
+#: src/CommonITILValidation.php:1261
 msgid "Requested approver"
 msgstr "Miratuesi i kërkuar"
 
-#: src/CommonITILValidation.php:1259
+#: src/CommonITILValidation.php:1262
 msgid "Approval Comment"
 msgstr "Koment për miratimin"
 
-#: src/CommonITILValidation.php:1260
+#: src/CommonITILValidation.php:1263
 #: src/NotificationTargetKnowbaseItem.php:218
 msgid "Documents"
 msgstr "Dokumente"
 
-#: src/CommonITILValidation.php:1347 src/CommonITILValidation.php:1444
+#: src/CommonITILValidation.php:1350 src/CommonITILValidation.php:1447
 msgid "Approval comments"
 msgstr "Komentet e miratimit"
 
-#: src/CommonITILValidation.php:1459
+#: src/CommonITILValidation.php:1462
 msgid "Approval status"
 msgstr "Statusi i miratimit"
 
-#: src/CommonITILValidation.php:1541
+#: src/CommonITILValidation.php:1544
 msgid "Approver substitute"
 msgstr "Zëvendësuesi i miratuesit"
 
-#: src/CommonITILValidation.php:1601
+#: src/CommonITILValidation.php:1604
 msgid "Approver group"
 msgstr "Grupi i miratuesve"
 
-#: src/CommonITILValidation.php:1623
+#: src/CommonITILValidation.php:1626
 msgid "Substitute of a member of approver group"
 msgstr "Zëvendësuesi i një Anëtari të Grupit Miratues"
 
-#: src/CommonITILValidation.php:1694
+#: src/CommonITILValidation.php:1697
 msgid "Approval status by users"
 msgstr "Statusi i miratimit nga përdoruesit"
 
-#: src/CommonITILValidation.php:1849
+#: src/CommonITILValidation.php:1852
 msgid "Approver type"
 msgstr "Lloji i miratuesit"
 
-#: src/CommonITILValidation.php:1954
+#: src/CommonITILValidation.php:1957
 msgid ""
 "This item is waiting for approval, do you really want to resolve or close "
 "it?"
@@ -33472,11 +33484,11 @@ msgstr ""
 "Ky artikull është duke pritur për miratim, vërtet doni ta zgjidhni apo "
 "mbyllni atë?"
 
-#: src/CommonITILValidation.php:1995
+#: src/CommonITILValidation.php:1998
 msgid "This item is waiting for approval."
 msgstr "Ky artikull po pret miratimin."
 
-#: src/CommonITILValidation.php:1996
+#: src/CommonITILValidation.php:1999
 msgid "Do you really want to resolve or close it?"
 msgstr "A doni vërtet ta zgjidhni ose ta mbyllni atë?"
 

--- a/locales/sr_RS.po
+++ b/locales/sr_RS.po
@@ -16,7 +16,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-26 10:20+0000\n"
+"POT-Creation-Date: 2025-08-26 12:21+0000\n"
 "PO-Revision-Date: 2022-09-16 06:53+0000\n"
 "Last-Translator: alexandre delaunay <delaunay.alexandre@gmail.com>, 2025\n"
 "Language-Team: Serbian (Serbia) (https://app.transifex.com/glpi/teams/1637/sr_RS/)\n"
@@ -795,7 +795,7 @@ msgstr ""
 #: templates/components/itilobject/timeline/main_description.html.twig
 #: templates/components/user/info_card.html.twig
 #: templates/pages/tools/kb/comments.html.twig src/KnowbaseItem.php:245
-#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1188
+#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1191
 #: js/src/vue/CustomObject/FieldPreview/Field.vue:30
 msgid "Edit"
 msgstr "Izmeni"
@@ -1441,7 +1441,7 @@ msgid "Cancel"
 msgstr "Otkaži"
 
 #: templates/components/form/basic_inputs_macros.html.twig
-#: src/CommonITILValidation.php:1773
+#: src/CommonITILValidation.php:1776
 msgid "Validate"
 msgstr "Potvrda"
 
@@ -1961,7 +1961,7 @@ msgstr "Inventarski broj"
 #: src/Computer.php:461 src/ProjectTask_Ticket.php:336 src/Certificate.php:278
 #: src/CronTask.php:1274 src/CronTask.php:1412
 #: src/CommonItilObject_Item.php:506 src/PDU.php:203 src/CommonDBTM.php:3513
-#: src/CommonITILValidation.php:1356 src/Plugin.php:2657
+#: src/CommonITILValidation.php:1359 src/Plugin.php:2657
 msgid "Status"
 msgstr ""
 
@@ -3450,7 +3450,7 @@ msgstr[2] ""
 #: src/CommonITILObject.php:4737 src/CommonITILObject.php:4746
 #: src/CommonITILObject.php:6847 src/CommonITILObject.php:6894
 #: src/CommonITILObject.php:10159 src/NotificationTargetChange.php:308
-#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1498
+#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1501
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] ""
@@ -3461,7 +3461,7 @@ msgstr[2] ""
 #: src/NotificationTargetTicket.php:676 src/NotificationTargetTicket.php:706
 #: src/NotificationTargetCommonITILObject.php:976
 #: src/ITILValidationTemplate.php:81 src/NotificationTargetChange.php:327
-#: src/CommonITILValidation.php:1391 src/CommonITILValidation.php:1518
+#: src/CommonITILValidation.php:1394 src/CommonITILValidation.php:1521
 msgid "Approver"
 msgstr "Odobravatelj"
 
@@ -4200,7 +4200,7 @@ msgstr "Neistorijski"
 #: src/OAuthClient.php:94 src/Item_RemoteManagement.php:207
 #: src/Item_RemoteManagement.php:238 src/Certificate.php:125
 #: src/CronTask.php:1391 src/Contact.php:282 src/PDU.php:114
-#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1329
+#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1332
 #: src/Domain.php:233 src/Domain.php:257 src/ConsumableItem.php:167
 msgid "ID"
 msgstr "ID"
@@ -5743,7 +5743,7 @@ msgstr ""
 #: src/Project.php:904 src/ProjectTask.php:963
 #: src/NotificationTargetProjectTask.php:553
 #: src/NotificationTargetProjectTask.php:568 src/Cartridge.php:895
-#: src/CommonITILValidation.php:1252
+#: src/CommonITILValidation.php:1255
 msgctxt "item"
 msgid "State"
 msgstr "Stanje"
@@ -17216,7 +17216,7 @@ msgid "Observer group except manager users"
 msgstr ""
 
 #: src/NotificationTargetCommonITILObject.php:973
-#: src/CommonITILValidation.php:1254 src/CommonITILValidation.php:1381
+#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1384
 msgid "Approval requester"
 msgstr "Potraživač odobrenja"
 
@@ -32773,7 +32773,7 @@ msgstr "Nije predmet za odobrenje"
 msgid "Granted + Not subject to approval"
 msgstr "Odobreno + Nije predmet za odobrenje"
 
-#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1836
+#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1839
 msgid "Group user(s)"
 msgstr ""
 
@@ -32786,67 +32786,79 @@ msgstr ""
 msgid "Progress: %1$s%% of %2$s%% required"
 msgstr ""
 
-#: src/CommonITILValidation.php:1253 src/CommonITILValidation.php:1365
-#: src/CommonITILValidation.php:1472
+#: src/CommonITILValidation.php:1127
+msgid "Approval step accepted"
+msgstr ""
+
+#: src/CommonITILValidation.php:1128
+msgid "Approval step refused"
+msgstr ""
+
+#: src/CommonITILValidation.php:1129
+msgid "Approval step pending"
+msgstr ""
+
+#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1368
+#: src/CommonITILValidation.php:1475
 msgid "Request date"
 msgstr "Datum zahteva"
 
-#: src/CommonITILValidation.php:1255 src/CommonITILValidation.php:1338
-#: src/CommonITILValidation.php:1430
+#: src/CommonITILValidation.php:1258 src/CommonITILValidation.php:1341
+#: src/CommonITILValidation.php:1433
 msgid "Request comments"
 msgstr "Komentar zahteva"
 
-#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1373
-#: src/CommonITILValidation.php:1485
+#: src/CommonITILValidation.php:1259 src/CommonITILValidation.php:1376
+#: src/CommonITILValidation.php:1488
 msgid "Approval date"
 msgstr "Datum odobrenja"
 
-#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1400
+#: src/CommonITILValidation.php:1260 src/CommonITILValidation.php:1403
 msgid "Requested approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1258
+#: src/CommonITILValidation.php:1261
 msgid "Requested approver"
 msgstr ""
 
-#: src/CommonITILValidation.php:1259
+#: src/CommonITILValidation.php:1262
 msgid "Approval Comment"
 msgstr ""
 
-#: src/CommonITILValidation.php:1260
+#: src/CommonITILValidation.php:1263
 #: src/NotificationTargetKnowbaseItem.php:218
 msgid "Documents"
 msgstr "Dokumenti"
 
-#: src/CommonITILValidation.php:1347 src/CommonITILValidation.php:1444
+#: src/CommonITILValidation.php:1350 src/CommonITILValidation.php:1447
 msgid "Approval comments"
 msgstr "Komentar odobrenja"
 
-#: src/CommonITILValidation.php:1459
+#: src/CommonITILValidation.php:1462
 msgid "Approval status"
 msgstr "Status odobrenja"
 
-#: src/CommonITILValidation.php:1541
+#: src/CommonITILValidation.php:1544
 msgid "Approver substitute"
 msgstr ""
 
-#: src/CommonITILValidation.php:1601
+#: src/CommonITILValidation.php:1604
 msgid "Approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1623
+#: src/CommonITILValidation.php:1626
 msgid "Substitute of a member of approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1694
+#: src/CommonITILValidation.php:1697
 msgid "Approval status by users"
 msgstr ""
 
-#: src/CommonITILValidation.php:1849
+#: src/CommonITILValidation.php:1852
 msgid "Approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1954
+#: src/CommonITILValidation.php:1957
 msgid ""
 "This item is waiting for approval, do you really want to resolve or close "
 "it?"
@@ -32854,11 +32866,11 @@ msgstr ""
 "Ova stavka čeka na odobrenje, da li stvarno želite da je rešite ili "
 "zatvorite?"
 
-#: src/CommonITILValidation.php:1995
+#: src/CommonITILValidation.php:1998
 msgid "This item is waiting for approval."
 msgstr ""
 
-#: src/CommonITILValidation.php:1996
+#: src/CommonITILValidation.php:1999
 msgid "Do you really want to resolve or close it?"
 msgstr ""
 

--- a/locales/sv_SE.po
+++ b/locales/sv_SE.po
@@ -7,17 +7,17 @@
 # Jan Friberg, 2023
 # DOMBRE Julien <moyo@indepnet.net>, 2025
 # alexandre delaunay <delaunay.alexandre@gmail.com>, 2025
-# Peter Rundqvist, 2025
 # Daniel M, 2025
+# Peter Rundqvist, 2025
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-26 10:20+0000\n"
+"POT-Creation-Date: 2025-08-26 12:21+0000\n"
 "PO-Revision-Date: 2022-09-16 06:53+0000\n"
-"Last-Translator: Daniel M, 2025\n"
+"Last-Translator: Peter Rundqvist, 2025\n"
 "Language-Team: Swedish (Sweden) (https://app.transifex.com/glpi/teams/1637/sv_SE/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -798,7 +798,7 @@ msgstr "Endast läsrättighet"
 #: templates/components/itilobject/timeline/main_description.html.twig
 #: templates/components/user/info_card.html.twig
 #: templates/pages/tools/kb/comments.html.twig src/KnowbaseItem.php:245
-#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1188
+#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1191
 #: js/src/vue/CustomObject/FieldPreview/Field.vue:30
 msgid "Edit"
 msgstr "Redigera"
@@ -1446,7 +1446,7 @@ msgid "Cancel"
 msgstr "Avbryt"
 
 #: templates/components/form/basic_inputs_macros.html.twig
-#: src/CommonITILValidation.php:1773
+#: src/CommonITILValidation.php:1776
 msgid "Validate"
 msgstr "Validera"
 
@@ -1965,7 +1965,7 @@ msgstr "Inventarienummer"
 #: src/Computer.php:461 src/ProjectTask_Ticket.php:336 src/Certificate.php:278
 #: src/CronTask.php:1274 src/CronTask.php:1412
 #: src/CommonItilObject_Item.php:506 src/PDU.php:203 src/CommonDBTM.php:3513
-#: src/CommonITILValidation.php:1356 src/Plugin.php:2657
+#: src/CommonITILValidation.php:1359 src/Plugin.php:2657
 msgid "Status"
 msgstr "Status"
 
@@ -3447,7 +3447,7 @@ msgstr[1] "Godkännandesteg"
 #: src/CommonITILObject.php:4737 src/CommonITILObject.php:4746
 #: src/CommonITILObject.php:6847 src/CommonITILObject.php:6894
 #: src/CommonITILObject.php:10159 src/NotificationTargetChange.php:308
-#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1498
+#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1501
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "Rapportör"
@@ -3457,7 +3457,7 @@ msgstr[1] "Rapportörer"
 #: src/NotificationTargetTicket.php:676 src/NotificationTargetTicket.php:706
 #: src/NotificationTargetCommonITILObject.php:976
 #: src/ITILValidationTemplate.php:81 src/NotificationTargetChange.php:327
-#: src/CommonITILValidation.php:1391 src/CommonITILValidation.php:1518
+#: src/CommonITILValidation.php:1394 src/CommonITILValidation.php:1521
 msgid "Approver"
 msgstr "Godkännare"
 
@@ -4198,7 +4198,7 @@ msgstr "Ingen historik funnen"
 #: src/OAuthClient.php:94 src/Item_RemoteManagement.php:207
 #: src/Item_RemoteManagement.php:238 src/Certificate.php:125
 #: src/CronTask.php:1391 src/Contact.php:282 src/PDU.php:114
-#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1329
+#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1332
 #: src/Domain.php:233 src/Domain.php:257 src/ConsumableItem.php:167
 msgid "ID"
 msgstr "ID"
@@ -5755,7 +5755,7 @@ msgstr ""
 #: src/Project.php:904 src/ProjectTask.php:963
 #: src/NotificationTargetProjectTask.php:553
 #: src/NotificationTargetProjectTask.php:568 src/Cartridge.php:895
-#: src/CommonITILValidation.php:1252
+#: src/CommonITILValidation.php:1255
 msgctxt "item"
 msgid "State"
 msgstr "Status"
@@ -7134,11 +7134,12 @@ msgstr "Förhindra återanvändning av lösenord"
 
 #: templates/pages/setup/general/security_setup.html.twig
 msgid "2FA Suffix"
-msgstr ""
+msgstr "2FA-suffix"
 
 #: templates/pages/setup/general/security_setup.html.twig
 msgid "This will be added in the issuer name for authenticator app."
 msgstr ""
+"Detta kommer att läggas till i utfärdarens namn för autentiseringsappen."
 
 #: templates/pages/setup/general/security_setup.html.twig
 msgid "2FA grace period (in days)"
@@ -17388,7 +17389,7 @@ msgid "Observer group except manager users"
 msgstr "Observatörsgrupp förutom chefer"
 
 #: src/NotificationTargetCommonITILObject.php:973
-#: src/CommonITILValidation.php:1254 src/CommonITILValidation.php:1381
+#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1384
 msgid "Approval requester"
 msgstr "Person som begär godkännande"
 
@@ -20751,7 +20752,9 @@ msgstr[1] "Tidsintervall"
 
 #: src/CalendarSegment.php:87
 msgid "Can not add a range riding an existing period"
-msgstr "Det går inte att lägga till en räckvidd som kör en befintlig period"
+msgstr ""
+"Det går inte att lägga till ett intervall som överlappar ett befintligt "
+"intervall"
 
 #: src/PendingReasonCron.php:50
 msgid ""
@@ -25202,7 +25205,7 @@ msgstr "Specifik rapporterad prioritet"
 
 #: src/Glpi/Form/Destination/CommonITILField/UrgencyFieldStrategy.php:54
 msgid "Answer to last \"Urgency\" question"
-msgstr "Svar på senaste \"Angelägenhetsnivå\"-fråga"
+msgstr "Svar på senaste \"Rapporterad prioritet\"-fråga"
 
 #: src/Glpi/Form/Destination/CommonITILField/EntityFieldStrategy.php:54
 msgid "Active entity of the form filler"
@@ -25222,7 +25225,7 @@ msgstr "Svara på den senaste frågan för objektet 'Enhet'"
 
 #: src/Glpi/Form/Destination/CommonITILField/UrgencyField.php:96
 msgid "Select an urgency level..."
-msgstr "Välj en brådskandehetsnivå..."
+msgstr "Välj en rapporterad prioritet..."
 
 #: src/Glpi/Form/Destination/CommonITILField/UrgencyField.php:104
 #: src/Glpi/Form/Destination/CommonITILField/LocationField.php:99
@@ -33274,7 +33277,7 @@ msgstr "Godkännande krävs inte"
 msgid "Granted + Not subject to approval"
 msgstr "Godkänd - Behöver ej godkännas"
 
-#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1836
+#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1839
 msgid "Group user(s)"
 msgstr "Gruppanvändare"
 
@@ -33287,67 +33290,79 @@ msgstr "Redigera steg"
 msgid "Progress: %1$s%% of %2$s%% required"
 msgstr "Förlopp: %1$s%% av %2$s%% krävs"
 
-#: src/CommonITILValidation.php:1253 src/CommonITILValidation.php:1365
-#: src/CommonITILValidation.php:1472
+#: src/CommonITILValidation.php:1127
+msgid "Approval step accepted"
+msgstr ""
+
+#: src/CommonITILValidation.php:1128
+msgid "Approval step refused"
+msgstr ""
+
+#: src/CommonITILValidation.php:1129
+msgid "Approval step pending"
+msgstr ""
+
+#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1368
+#: src/CommonITILValidation.php:1475
 msgid "Request date"
 msgstr "Datum för begäran"
 
-#: src/CommonITILValidation.php:1255 src/CommonITILValidation.php:1338
-#: src/CommonITILValidation.php:1430
+#: src/CommonITILValidation.php:1258 src/CommonITILValidation.php:1341
+#: src/CommonITILValidation.php:1433
 msgid "Request comments"
 msgstr "Kommentarer"
 
-#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1373
-#: src/CommonITILValidation.php:1485
+#: src/CommonITILValidation.php:1259 src/CommonITILValidation.php:1376
+#: src/CommonITILValidation.php:1488
 msgid "Approval date"
 msgstr "Datum för godkännande"
 
-#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1400
+#: src/CommonITILValidation.php:1260 src/CommonITILValidation.php:1403
 msgid "Requested approver type"
 msgstr "Typ av godkännare"
 
-#: src/CommonITILValidation.php:1258
+#: src/CommonITILValidation.php:1261
 msgid "Requested approver"
 msgstr "Godkännare"
 
-#: src/CommonITILValidation.php:1259
+#: src/CommonITILValidation.php:1262
 msgid "Approval Comment"
 msgstr "Godkännandekommentar"
 
-#: src/CommonITILValidation.php:1260
+#: src/CommonITILValidation.php:1263
 #: src/NotificationTargetKnowbaseItem.php:218
 msgid "Documents"
 msgstr "Dokument"
 
-#: src/CommonITILValidation.php:1347 src/CommonITILValidation.php:1444
+#: src/CommonITILValidation.php:1350 src/CommonITILValidation.php:1447
 msgid "Approval comments"
 msgstr "Kommentar vid godkännande"
 
-#: src/CommonITILValidation.php:1459
+#: src/CommonITILValidation.php:1462
 msgid "Approval status"
 msgstr "Status för godkännande"
 
-#: src/CommonITILValidation.php:1541
+#: src/CommonITILValidation.php:1544
 msgid "Approver substitute"
 msgstr "Ersättare för godkännare"
 
-#: src/CommonITILValidation.php:1601
+#: src/CommonITILValidation.php:1604
 msgid "Approver group"
 msgstr "Godkännargrupp"
 
-#: src/CommonITILValidation.php:1623
+#: src/CommonITILValidation.php:1626
 msgid "Substitute of a member of approver group"
 msgstr "Ersättande av en medlem i en godkännargrupp"
 
-#: src/CommonITILValidation.php:1694
+#: src/CommonITILValidation.php:1697
 msgid "Approval status by users"
 msgstr "Godkännandestatus efter användare"
 
-#: src/CommonITILValidation.php:1849
+#: src/CommonITILValidation.php:1852
 msgid "Approver type"
 msgstr "Typ av godkännare"
 
-#: src/CommonITILValidation.php:1954
+#: src/CommonITILValidation.php:1957
 msgid ""
 "This item is waiting for approval, do you really want to resolve or close "
 "it?"
@@ -33355,11 +33370,11 @@ msgstr ""
 "Det här ärendet väntar på godkännande. Vill du verkligen lösa eller stänga "
 "det?"
 
-#: src/CommonITILValidation.php:1995
+#: src/CommonITILValidation.php:1998
 msgid "This item is waiting for approval."
 msgstr "Ärendet väntar på godkännande."
 
-#: src/CommonITILValidation.php:1996
+#: src/CommonITILValidation.php:1999
 msgid "Do you really want to resolve or close it?"
 msgstr "Vill du verkligen lösa eller stänga det?"
 
@@ -34367,23 +34382,23 @@ msgstr "Uppladdningen lyckades"
 #: js/src/vue/CustomObject/FieldPreview/Field.vue:33
 #: js/src/vue/CustomObject/FieldPreview/FieldDisplay.vue:282
 msgid "Hide"
-msgstr ""
+msgstr "Dölj"
 
 #: js/src/vue/CustomObject/FieldPreview/FieldDisplay.vue:282
 msgid "Cannot remove the last field"
-msgstr ""
+msgstr "Kan inte ta bort sista fältet"
 
 #: js/src/vue/CustomObject/FieldPreview/FieldDisplay.vue:302
 msgid "Readonly"
-msgstr ""
+msgstr "Endast läs"
 
 #: js/src/vue/CustomObject/FieldPreview/Sidebar.vue:42
 msgid "Add more fields"
-msgstr ""
+msgstr "Lägg till fler fält"
 
 #: js/src/vue/CustomObject/FieldPreview/Sidebar.vue:44
 msgid "Native fields"
-msgstr ""
+msgstr "Inbyggda fält"
 
 #: js/src/vue/CustomObject/FieldPreview/Sidebar.vue:49
 msgid "Custom fields"
@@ -34406,10 +34421,12 @@ msgid ""
 "This column cannot support showing cards due to how many cards would be "
 "shown. You can still drag cards into this column."
 msgstr ""
+"Den här kolumnen kan inte visa alla kort eftersom det finns för många. Du "
+"kan dock fortfarande dra och släppa kort till kolumnen."
 
 #: js/src/vue/Kanban/Column.vue:180
 msgid "Toggle collapse"
-msgstr ""
+msgstr "Fäll ihop"
 
 #: js/src/vue/Kanban/Column.vue:206
 msgid "More"
@@ -34421,17 +34438,19 @@ msgstr "Masstillägg"
 
 #: js/src/vue/Kanban/Kanban.vue:405
 msgid "Failed to reset Kanban view"
-msgstr ""
+msgstr "Det gick inte att återställa Kanban-tavlan"
 
 #: js/src/vue/Kanban/Kanban.vue:410 js/src/vue/Kanban/Kanban.vue:1394
 msgid "Reset view"
-msgstr ""
+msgstr "Återställ"
 
 #: js/src/vue/Kanban/Kanban.vue:411
 msgid ""
 "Resetting the view will reset the shown columns and remove custom card "
 "ordering"
 msgstr ""
+"Återställning av tavlan kommer att återställa de visade kolumnerna och ta "
+"bort den anpassade kortordningen."
 
 #: js/src/vue/Kanban/Kanban.vue:830
 msgid "Failed to add team member"
@@ -34442,6 +34461,7 @@ msgid ""
 "The regular expression you entered is invalid. Please check it and try "
 "again."
 msgstr ""
+"Det reguljära uttryck du angav är ogiltigt. Kontrollera det och försök igen."
 
 #: js/src/vue/Kanban/Kanban.vue:853
 msgid "Invalid regular expression"
@@ -34469,7 +34489,7 @@ msgstr "Lägg till en kolumn från befintlig status"
 
 #: js/src/vue/Kanban/Kanban.vue:1363
 msgid "Or add a new status"
-msgstr ""
+msgstr "...eller lägg till ny status"
 
 #: js/src/vue/Kanban/Kanban.vue:1365 js/src/vue/Kanban/Kanban.vue:1369
 #: js/src/vue/Kanban/Kanban.vue:1380
@@ -34478,4 +34498,4 @@ msgstr "Skapa status"
 
 #: js/src/vue/Kanban/Kanban.vue:1419
 msgid "There are no columns added to this Kanban yet"
-msgstr ""
+msgstr "Kanban-tavlan innehåller inga kolumner ännu"

--- a/locales/th_TH.po
+++ b/locales/th_TH.po
@@ -18,7 +18,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-26 10:20+0000\n"
+"POT-Creation-Date: 2025-08-26 12:21+0000\n"
 "PO-Revision-Date: 2022-09-16 06:53+0000\n"
 "Last-Translator: Cédric Anne, 2025\n"
 "Language-Team: Thai (Thailand) (https://app.transifex.com/glpi/teams/1637/th_TH/)\n"
@@ -789,7 +789,7 @@ msgstr ""
 #: templates/components/itilobject/timeline/main_description.html.twig
 #: templates/components/user/info_card.html.twig
 #: templates/pages/tools/kb/comments.html.twig src/KnowbaseItem.php:245
-#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1188
+#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1191
 #: js/src/vue/CustomObject/FieldPreview/Field.vue:30
 msgid "Edit"
 msgstr "แก้ไข"
@@ -1430,7 +1430,7 @@ msgid "Cancel"
 msgstr "ยกเลิก"
 
 #: templates/components/form/basic_inputs_macros.html.twig
-#: src/CommonITILValidation.php:1773
+#: src/CommonITILValidation.php:1776
 msgid "Validate"
 msgstr "การตรวจสอบ"
 
@@ -1945,7 +1945,7 @@ msgstr "รหัสทรัพย์สิน"
 #: src/Computer.php:461 src/ProjectTask_Ticket.php:336 src/Certificate.php:278
 #: src/CronTask.php:1274 src/CronTask.php:1412
 #: src/CommonItilObject_Item.php:506 src/PDU.php:203 src/CommonDBTM.php:3513
-#: src/CommonITILValidation.php:1356 src/Plugin.php:2657
+#: src/CommonITILValidation.php:1359 src/Plugin.php:2657
 msgid "Status"
 msgstr ""
 
@@ -3410,7 +3410,7 @@ msgstr[0] ""
 #: src/CommonITILObject.php:4737 src/CommonITILObject.php:4746
 #: src/CommonITILObject.php:6847 src/CommonITILObject.php:6894
 #: src/CommonITILObject.php:10159 src/NotificationTargetChange.php:308
-#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1498
+#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1501
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "ผู้แจ้ง"
@@ -3419,7 +3419,7 @@ msgstr[0] "ผู้แจ้ง"
 #: src/NotificationTargetTicket.php:676 src/NotificationTargetTicket.php:706
 #: src/NotificationTargetCommonITILObject.php:976
 #: src/ITILValidationTemplate.php:81 src/NotificationTargetChange.php:327
-#: src/CommonITILValidation.php:1391 src/CommonITILValidation.php:1518
+#: src/CommonITILValidation.php:1394 src/CommonITILValidation.php:1521
 msgid "Approver"
 msgstr "ผู้อนุมัติ"
 
@@ -4148,7 +4148,7 @@ msgstr "ไม่มีประวัติ"
 #: src/OAuthClient.php:94 src/Item_RemoteManagement.php:207
 #: src/Item_RemoteManagement.php:238 src/Certificate.php:125
 #: src/CronTask.php:1391 src/Contact.php:282 src/PDU.php:114
-#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1329
+#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1332
 #: src/Domain.php:233 src/Domain.php:257 src/ConsumableItem.php:167
 msgid "ID"
 msgstr "ID"
@@ -5673,7 +5673,7 @@ msgstr ""
 #: src/Project.php:904 src/ProjectTask.php:963
 #: src/NotificationTargetProjectTask.php:553
 #: src/NotificationTargetProjectTask.php:568 src/Cartridge.php:895
-#: src/CommonITILValidation.php:1252
+#: src/CommonITILValidation.php:1255
 msgctxt "item"
 msgid "State"
 msgstr "สถานะ"
@@ -17027,7 +17027,7 @@ msgid "Observer group except manager users"
 msgstr ""
 
 #: src/NotificationTargetCommonITILObject.php:973
-#: src/CommonITILValidation.php:1254 src/CommonITILValidation.php:1381
+#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1384
 msgid "Approval requester"
 msgstr "ร้องขออนุมัติ"
 
@@ -32227,7 +32227,7 @@ msgstr "ไม่มีเรื่องได้รับการอนุม
 msgid "Granted + Not subject to approval"
 msgstr "ที่ได้รับ + ไม่มีเรื่องได้รับการอนุมัติ"
 
-#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1836
+#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1839
 msgid "Group user(s)"
 msgstr ""
 
@@ -32240,77 +32240,89 @@ msgstr ""
 msgid "Progress: %1$s%% of %2$s%% required"
 msgstr ""
 
-#: src/CommonITILValidation.php:1253 src/CommonITILValidation.php:1365
-#: src/CommonITILValidation.php:1472
+#: src/CommonITILValidation.php:1127
+msgid "Approval step accepted"
+msgstr ""
+
+#: src/CommonITILValidation.php:1128
+msgid "Approval step refused"
+msgstr ""
+
+#: src/CommonITILValidation.php:1129
+msgid "Approval step pending"
+msgstr ""
+
+#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1368
+#: src/CommonITILValidation.php:1475
 msgid "Request date"
 msgstr "วันที่แจ้ง"
 
-#: src/CommonITILValidation.php:1255 src/CommonITILValidation.php:1338
-#: src/CommonITILValidation.php:1430
+#: src/CommonITILValidation.php:1258 src/CommonITILValidation.php:1341
+#: src/CommonITILValidation.php:1433
 msgid "Request comments"
 msgstr "Request comments"
 
-#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1373
-#: src/CommonITILValidation.php:1485
+#: src/CommonITILValidation.php:1259 src/CommonITILValidation.php:1376
+#: src/CommonITILValidation.php:1488
 msgid "Approval date"
 msgstr "วันที่อนุมัติ"
 
-#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1400
+#: src/CommonITILValidation.php:1260 src/CommonITILValidation.php:1403
 msgid "Requested approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1258
+#: src/CommonITILValidation.php:1261
 msgid "Requested approver"
 msgstr ""
 
-#: src/CommonITILValidation.php:1259
+#: src/CommonITILValidation.php:1262
 msgid "Approval Comment"
 msgstr ""
 
-#: src/CommonITILValidation.php:1260
+#: src/CommonITILValidation.php:1263
 #: src/NotificationTargetKnowbaseItem.php:218
 msgid "Documents"
 msgstr "เอกสาร"
 
-#: src/CommonITILValidation.php:1347 src/CommonITILValidation.php:1444
+#: src/CommonITILValidation.php:1350 src/CommonITILValidation.php:1447
 msgid "Approval comments"
 msgstr "ความเห็นอนุมัติ"
 
-#: src/CommonITILValidation.php:1459
+#: src/CommonITILValidation.php:1462
 msgid "Approval status"
 msgstr "สถานะการอนุมัติ"
 
-#: src/CommonITILValidation.php:1541
+#: src/CommonITILValidation.php:1544
 msgid "Approver substitute"
 msgstr ""
 
-#: src/CommonITILValidation.php:1601
+#: src/CommonITILValidation.php:1604
 msgid "Approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1623
+#: src/CommonITILValidation.php:1626
 msgid "Substitute of a member of approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1694
+#: src/CommonITILValidation.php:1697
 msgid "Approval status by users"
 msgstr ""
 
-#: src/CommonITILValidation.php:1849
+#: src/CommonITILValidation.php:1852
 msgid "Approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1954
+#: src/CommonITILValidation.php:1957
 msgid ""
 "This item is waiting for approval, do you really want to resolve or close "
 "it?"
 msgstr "รายการนี้กำลังรอการอนุมัติคุณต้องการที่จะแก้ไขหรือปิดมันได้หรือไม่ ?"
 
-#: src/CommonITILValidation.php:1995
+#: src/CommonITILValidation.php:1998
 msgid "This item is waiting for approval."
 msgstr ""
 
-#: src/CommonITILValidation.php:1996
+#: src/CommonITILValidation.php:1999
 msgid "Do you really want to resolve or close it?"
 msgstr ""
 

--- a/locales/tr_TR.po
+++ b/locales/tr_TR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-26 10:20+0000\n"
+"POT-Creation-Date: 2025-08-26 12:21+0000\n"
 "PO-Revision-Date: 2022-09-16 06:53+0000\n"
 "Last-Translator: alexandre delaunay <delaunay.alexandre@gmail.com>, 2025\n"
 "Language-Team: Turkish (Turkey) (https://app.transifex.com/glpi/teams/1637/tr_TR/)\n"
@@ -793,7 +793,7 @@ msgstr "Salt okunur kip"
 #: templates/components/itilobject/timeline/main_description.html.twig
 #: templates/components/user/info_card.html.twig
 #: templates/pages/tools/kb/comments.html.twig src/KnowbaseItem.php:245
-#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1188
+#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1191
 #: js/src/vue/CustomObject/FieldPreview/Field.vue:30
 msgid "Edit"
 msgstr "Düzenle"
@@ -1443,7 +1443,7 @@ msgid "Cancel"
 msgstr "İptal"
 
 #: templates/components/form/basic_inputs_macros.html.twig
-#: src/CommonITILValidation.php:1773
+#: src/CommonITILValidation.php:1776
 msgid "Validate"
 msgstr "Doğrula"
 
@@ -1961,7 +1961,7 @@ msgstr "Stok numarası"
 #: src/Computer.php:461 src/ProjectTask_Ticket.php:336 src/Certificate.php:278
 #: src/CronTask.php:1274 src/CronTask.php:1412
 #: src/CommonItilObject_Item.php:506 src/PDU.php:203 src/CommonDBTM.php:3513
-#: src/CommonITILValidation.php:1356 src/Plugin.php:2657
+#: src/CommonITILValidation.php:1359 src/Plugin.php:2657
 msgid "Status"
 msgstr "Durum"
 
@@ -3443,7 +3443,7 @@ msgstr[1] "Onay adımı"
 #: src/CommonITILObject.php:4737 src/CommonITILObject.php:4746
 #: src/CommonITILObject.php:6847 src/CommonITILObject.php:6894
 #: src/CommonITILObject.php:10159 src/NotificationTargetChange.php:308
-#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1498
+#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1501
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "İstekte bulunan"
@@ -3453,7 +3453,7 @@ msgstr[1] "İstekte bulunanlar"
 #: src/NotificationTargetTicket.php:676 src/NotificationTargetTicket.php:706
 #: src/NotificationTargetCommonITILObject.php:976
 #: src/ITILValidationTemplate.php:81 src/NotificationTargetChange.php:327
-#: src/CommonITILValidation.php:1391 src/CommonITILValidation.php:1518
+#: src/CommonITILValidation.php:1394 src/CommonITILValidation.php:1521
 msgid "Approver"
 msgstr "Onaylayan"
 
@@ -4195,7 +4195,7 @@ msgstr "Geçmiş kaydı yok"
 #: src/OAuthClient.php:94 src/Item_RemoteManagement.php:207
 #: src/Item_RemoteManagement.php:238 src/Certificate.php:125
 #: src/CronTask.php:1391 src/Contact.php:282 src/PDU.php:114
-#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1329
+#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1332
 #: src/Domain.php:233 src/Domain.php:257 src/ConsumableItem.php:167
 msgid "ID"
 msgstr "Kimlik"
@@ -5751,7 +5751,7 @@ msgstr ""
 #: src/Project.php:904 src/ProjectTask.php:963
 #: src/NotificationTargetProjectTask.php:553
 #: src/NotificationTargetProjectTask.php:568 src/Cartridge.php:895
-#: src/CommonITILValidation.php:1252
+#: src/CommonITILValidation.php:1255
 msgctxt "item"
 msgid "State"
 msgstr "Durum"
@@ -17370,7 +17370,7 @@ msgid "Observer group except manager users"
 msgstr "Yönetici kullanıcılar dışında kalan gözlemci grubu"
 
 #: src/NotificationTargetCommonITILObject.php:973
-#: src/CommonITILValidation.php:1254 src/CommonITILValidation.php:1381
+#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1384
 msgid "Approval requester"
 msgstr "Onay isteyen"
 
@@ -33213,7 +33213,7 @@ msgstr "Onay gerekmiyor"
 msgid "Granted + Not subject to approval"
 msgstr "İzin verilmiş + Onay gerekmiyor"
 
-#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1836
+#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1839
 msgid "Group user(s)"
 msgstr "Kullanıcıları grupla"
 
@@ -33226,67 +33226,79 @@ msgstr ""
 msgid "Progress: %1$s%% of %2$s%% required"
 msgstr ""
 
-#: src/CommonITILValidation.php:1253 src/CommonITILValidation.php:1365
-#: src/CommonITILValidation.php:1472
+#: src/CommonITILValidation.php:1127
+msgid "Approval step accepted"
+msgstr ""
+
+#: src/CommonITILValidation.php:1128
+msgid "Approval step refused"
+msgstr ""
+
+#: src/CommonITILValidation.php:1129
+msgid "Approval step pending"
+msgstr ""
+
+#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1368
+#: src/CommonITILValidation.php:1475
 msgid "Request date"
 msgstr "İstek tarihi"
 
-#: src/CommonITILValidation.php:1255 src/CommonITILValidation.php:1338
-#: src/CommonITILValidation.php:1430
+#: src/CommonITILValidation.php:1258 src/CommonITILValidation.php:1341
+#: src/CommonITILValidation.php:1433
 msgid "Request comments"
 msgstr "Açıklama iste"
 
-#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1373
-#: src/CommonITILValidation.php:1485
+#: src/CommonITILValidation.php:1259 src/CommonITILValidation.php:1376
+#: src/CommonITILValidation.php:1488
 msgid "Approval date"
 msgstr "Onay tarihi"
 
-#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1400
+#: src/CommonITILValidation.php:1260 src/CommonITILValidation.php:1403
 msgid "Requested approver type"
 msgstr "İstenen onaylayıcı türü"
 
-#: src/CommonITILValidation.php:1258
+#: src/CommonITILValidation.php:1261
 msgid "Requested approver"
 msgstr "İstenen onaylayıcı"
 
-#: src/CommonITILValidation.php:1259
+#: src/CommonITILValidation.php:1262
 msgid "Approval Comment"
 msgstr "Onay yorumu"
 
-#: src/CommonITILValidation.php:1260
+#: src/CommonITILValidation.php:1263
 #: src/NotificationTargetKnowbaseItem.php:218
 msgid "Documents"
 msgstr "Belgeler"
 
-#: src/CommonITILValidation.php:1347 src/CommonITILValidation.php:1444
+#: src/CommonITILValidation.php:1350 src/CommonITILValidation.php:1447
 msgid "Approval comments"
 msgstr "Onay notları"
 
-#: src/CommonITILValidation.php:1459
+#: src/CommonITILValidation.php:1462
 msgid "Approval status"
 msgstr "Onay durumu"
 
-#: src/CommonITILValidation.php:1541
+#: src/CommonITILValidation.php:1544
 msgid "Approver substitute"
 msgstr "Onaylayıcı yerine geçme"
 
-#: src/CommonITILValidation.php:1601
+#: src/CommonITILValidation.php:1604
 msgid "Approver group"
 msgstr "Onaylayıcı grubu"
 
-#: src/CommonITILValidation.php:1623
+#: src/CommonITILValidation.php:1626
 msgid "Substitute of a member of approver group"
 msgstr "Onaylayıcı grubunun bir üyesinin yerine geçen kişi"
 
-#: src/CommonITILValidation.php:1694
+#: src/CommonITILValidation.php:1697
 msgid "Approval status by users"
 msgstr "Kullanıcılara göre onay durumu"
 
-#: src/CommonITILValidation.php:1849
+#: src/CommonITILValidation.php:1852
 msgid "Approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1954
+#: src/CommonITILValidation.php:1957
 msgid ""
 "This item is waiting for approval, do you really want to resolve or close "
 "it?"
@@ -33294,11 +33306,11 @@ msgstr ""
 "Ögenin onaylanması bekleniyor, gerçekten çözümlemek ya da kapatmak istiyor "
 "musunuz?"
 
-#: src/CommonITILValidation.php:1995
+#: src/CommonITILValidation.php:1998
 msgid "This item is waiting for approval."
 msgstr "Öge onay bekliyor."
 
-#: src/CommonITILValidation.php:1996
+#: src/CommonITILValidation.php:1999
 msgid "Do you really want to resolve or close it?"
 msgstr "Çözümlemek ya da kapatmak istediğinize emin misiniz?"
 

--- a/locales/uk_UA.po
+++ b/locales/uk_UA.po
@@ -22,7 +22,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-26 10:20+0000\n"
+"POT-Creation-Date: 2025-08-26 12:21+0000\n"
 "PO-Revision-Date: 2022-09-16 06:53+0000\n"
 "Last-Translator: alexandre delaunay <delaunay.alexandre@gmail.com>, 2025\n"
 "Language-Team: Ukrainian (Ukraine) (https://app.transifex.com/glpi/teams/1637/uk_UA/)\n"
@@ -804,7 +804,7 @@ msgstr ""
 #: templates/components/itilobject/timeline/main_description.html.twig
 #: templates/components/user/info_card.html.twig
 #: templates/pages/tools/kb/comments.html.twig src/KnowbaseItem.php:245
-#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1188
+#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1191
 #: js/src/vue/CustomObject/FieldPreview/Field.vue:30
 msgid "Edit"
 msgstr "Змінити"
@@ -1455,7 +1455,7 @@ msgid "Cancel"
 msgstr "Відміна"
 
 #: templates/components/form/basic_inputs_macros.html.twig
-#: src/CommonITILValidation.php:1773
+#: src/CommonITILValidation.php:1776
 msgid "Validate"
 msgstr "Перевірити"
 
@@ -1978,7 +1978,7 @@ msgstr "Інвентарний номер"
 #: src/Computer.php:461 src/ProjectTask_Ticket.php:336 src/Certificate.php:278
 #: src/CronTask.php:1274 src/CronTask.php:1412
 #: src/CommonItilObject_Item.php:506 src/PDU.php:203 src/CommonDBTM.php:3513
-#: src/CommonITILValidation.php:1356 src/Plugin.php:2657
+#: src/CommonITILValidation.php:1359 src/Plugin.php:2657
 msgid "Status"
 msgstr "Статус"
 
@@ -3487,7 +3487,7 @@ msgstr[3] ""
 #: src/CommonITILObject.php:4737 src/CommonITILObject.php:4746
 #: src/CommonITILObject.php:6847 src/CommonITILObject.php:6894
 #: src/CommonITILObject.php:10159 src/NotificationTargetChange.php:308
-#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1498
+#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1501
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "Заявник"
@@ -3499,7 +3499,7 @@ msgstr[3] "Заявники"
 #: src/NotificationTargetTicket.php:676 src/NotificationTargetTicket.php:706
 #: src/NotificationTargetCommonITILObject.php:976
 #: src/ITILValidationTemplate.php:81 src/NotificationTargetChange.php:327
-#: src/CommonITILValidation.php:1391 src/CommonITILValidation.php:1518
+#: src/CommonITILValidation.php:1394 src/CommonITILValidation.php:1521
 msgid "Approver"
 msgstr "Схвалив"
 
@@ -4245,7 +4245,7 @@ msgstr "Історія відсутня"
 #: src/OAuthClient.php:94 src/Item_RemoteManagement.php:207
 #: src/Item_RemoteManagement.php:238 src/Certificate.php:125
 #: src/CronTask.php:1391 src/Contact.php:282 src/PDU.php:114
-#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1329
+#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1332
 #: src/Domain.php:233 src/Domain.php:257 src/ConsumableItem.php:167
 msgid "ID"
 msgstr "ID"
@@ -5810,7 +5810,7 @@ msgstr ""
 #: src/Project.php:904 src/ProjectTask.php:963
 #: src/NotificationTargetProjectTask.php:553
 #: src/NotificationTargetProjectTask.php:568 src/Cartridge.php:895
-#: src/CommonITILValidation.php:1252
+#: src/CommonITILValidation.php:1255
 msgctxt "item"
 msgid "State"
 msgstr "Стан"
@@ -17526,7 +17526,7 @@ msgid "Observer group except manager users"
 msgstr ""
 
 #: src/NotificationTargetCommonITILObject.php:973
-#: src/CommonITILValidation.php:1254 src/CommonITILValidation.php:1381
+#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1384
 msgid "Approval requester"
 msgstr "Заявник схвалення"
 
@@ -33770,7 +33770,7 @@ msgstr "Не підлягає схваленню"
 msgid "Granted + Not subject to approval"
 msgstr "Прийнято + Не підлягає схваленню"
 
-#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1836
+#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1839
 msgid "Group user(s)"
 msgstr "Користувач(и) групи"
 
@@ -33783,77 +33783,89 @@ msgstr ""
 msgid "Progress: %1$s%% of %2$s%% required"
 msgstr ""
 
-#: src/CommonITILValidation.php:1253 src/CommonITILValidation.php:1365
-#: src/CommonITILValidation.php:1472
+#: src/CommonITILValidation.php:1127
+msgid "Approval step accepted"
+msgstr ""
+
+#: src/CommonITILValidation.php:1128
+msgid "Approval step refused"
+msgstr ""
+
+#: src/CommonITILValidation.php:1129
+msgid "Approval step pending"
+msgstr ""
+
+#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1368
+#: src/CommonITILValidation.php:1475
 msgid "Request date"
 msgstr "Дата запиту"
 
-#: src/CommonITILValidation.php:1255 src/CommonITILValidation.php:1338
-#: src/CommonITILValidation.php:1430
+#: src/CommonITILValidation.php:1258 src/CommonITILValidation.php:1341
+#: src/CommonITILValidation.php:1433
 msgid "Request comments"
 msgstr "Коментар запиту"
 
-#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1373
-#: src/CommonITILValidation.php:1485
+#: src/CommonITILValidation.php:1259 src/CommonITILValidation.php:1376
+#: src/CommonITILValidation.php:1488
 msgid "Approval date"
 msgstr "Дата схвалення"
 
-#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1400
+#: src/CommonITILValidation.php:1260 src/CommonITILValidation.php:1403
 msgid "Requested approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1258
+#: src/CommonITILValidation.php:1261
 msgid "Requested approver"
 msgstr ""
 
-#: src/CommonITILValidation.php:1259
+#: src/CommonITILValidation.php:1262
 msgid "Approval Comment"
 msgstr ""
 
-#: src/CommonITILValidation.php:1260
+#: src/CommonITILValidation.php:1263
 #: src/NotificationTargetKnowbaseItem.php:218
 msgid "Documents"
 msgstr "Документів"
 
-#: src/CommonITILValidation.php:1347 src/CommonITILValidation.php:1444
+#: src/CommonITILValidation.php:1350 src/CommonITILValidation.php:1447
 msgid "Approval comments"
 msgstr "Коментар схвалення"
 
-#: src/CommonITILValidation.php:1459
+#: src/CommonITILValidation.php:1462
 msgid "Approval status"
 msgstr "Статус схвалення"
 
-#: src/CommonITILValidation.php:1541
+#: src/CommonITILValidation.php:1544
 msgid "Approver substitute"
 msgstr ""
 
-#: src/CommonITILValidation.php:1601
+#: src/CommonITILValidation.php:1604
 msgid "Approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1623
+#: src/CommonITILValidation.php:1626
 msgid "Substitute of a member of approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1694
+#: src/CommonITILValidation.php:1697
 msgid "Approval status by users"
 msgstr ""
 
-#: src/CommonITILValidation.php:1849
+#: src/CommonITILValidation.php:1852
 msgid "Approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1954
+#: src/CommonITILValidation.php:1957
 msgid ""
 "This item is waiting for approval, do you really want to resolve or close "
 "it?"
 msgstr "Цей елемент очікує схвалення, справді вирішити чи закрити його?"
 
-#: src/CommonITILValidation.php:1995
+#: src/CommonITILValidation.php:1998
 msgid "This item is waiting for approval."
 msgstr "Цей елемент очікує схвалення."
 
-#: src/CommonITILValidation.php:1996
+#: src/CommonITILValidation.php:1999
 msgid "Do you really want to resolve or close it?"
 msgstr "Ви дійсно хочете вирішити чи закрити це?"
 

--- a/locales/vi_VN.po
+++ b/locales/vi_VN.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-26 10:20+0000\n"
+"POT-Creation-Date: 2025-08-26 12:21+0000\n"
 "PO-Revision-Date: 2022-09-16 06:53+0000\n"
 "Last-Translator: Cédric Anne, 2025\n"
 "Language-Team: Vietnamese (Viet Nam) (https://app.transifex.com/glpi/teams/1637/vi_VN/)\n"
@@ -790,7 +790,7 @@ msgstr ""
 #: templates/components/itilobject/timeline/main_description.html.twig
 #: templates/components/user/info_card.html.twig
 #: templates/pages/tools/kb/comments.html.twig src/KnowbaseItem.php:245
-#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1188
+#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1191
 #: js/src/vue/CustomObject/FieldPreview/Field.vue:30
 msgid "Edit"
 msgstr "Sửa"
@@ -1432,7 +1432,7 @@ msgid "Cancel"
 msgstr "Hủy"
 
 #: templates/components/form/basic_inputs_macros.html.twig
-#: src/CommonITILValidation.php:1773
+#: src/CommonITILValidation.php:1776
 msgid "Validate"
 msgstr "Đánh giá"
 
@@ -1947,7 +1947,7 @@ msgstr "Số hàng tồn kho"
 #: src/Computer.php:461 src/ProjectTask_Ticket.php:336 src/Certificate.php:278
 #: src/CronTask.php:1274 src/CronTask.php:1412
 #: src/CommonItilObject_Item.php:506 src/PDU.php:203 src/CommonDBTM.php:3513
-#: src/CommonITILValidation.php:1356 src/Plugin.php:2657
+#: src/CommonITILValidation.php:1359 src/Plugin.php:2657
 msgid "Status"
 msgstr ""
 
@@ -3412,7 +3412,7 @@ msgstr[0] ""
 #: src/CommonITILObject.php:4737 src/CommonITILObject.php:4746
 #: src/CommonITILObject.php:6847 src/CommonITILObject.php:6894
 #: src/CommonITILObject.php:10159 src/NotificationTargetChange.php:308
-#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1498
+#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1501
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "Những người yêu cầu"
@@ -3421,7 +3421,7 @@ msgstr[0] "Những người yêu cầu"
 #: src/NotificationTargetTicket.php:676 src/NotificationTargetTicket.php:706
 #: src/NotificationTargetCommonITILObject.php:976
 #: src/ITILValidationTemplate.php:81 src/NotificationTargetChange.php:327
-#: src/CommonITILValidation.php:1391 src/CommonITILValidation.php:1518
+#: src/CommonITILValidation.php:1394 src/CommonITILValidation.php:1521
 msgid "Approver"
 msgstr "Người xác nhận"
 
@@ -4150,7 +4150,7 @@ msgstr "Không có lịch sử"
 #: src/OAuthClient.php:94 src/Item_RemoteManagement.php:207
 #: src/Item_RemoteManagement.php:238 src/Certificate.php:125
 #: src/CronTask.php:1391 src/Contact.php:282 src/PDU.php:114
-#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1329
+#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1332
 #: src/Domain.php:233 src/Domain.php:257 src/ConsumableItem.php:167
 msgid "ID"
 msgstr "ID"
@@ -5675,7 +5675,7 @@ msgstr ""
 #: src/Project.php:904 src/ProjectTask.php:963
 #: src/NotificationTargetProjectTask.php:553
 #: src/NotificationTargetProjectTask.php:568 src/Cartridge.php:895
-#: src/CommonITILValidation.php:1252
+#: src/CommonITILValidation.php:1255
 msgctxt "item"
 msgid "State"
 msgstr "Tình trạng"
@@ -17048,7 +17048,7 @@ msgid "Observer group except manager users"
 msgstr ""
 
 #: src/NotificationTargetCommonITILObject.php:973
-#: src/CommonITILValidation.php:1254 src/CommonITILValidation.php:1381
+#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1384
 msgid "Approval requester"
 msgstr "Người gởi yêu cầu xác nhận"
 
@@ -32276,7 +32276,7 @@ msgstr "Không có chủ đề để phê chuẩn"
 msgid "Granted + Not subject to approval"
 msgstr "Đã cấp + Không có chủ đề được phê chuẩn"
 
-#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1836
+#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1839
 msgid "Group user(s)"
 msgstr ""
 
@@ -32289,78 +32289,90 @@ msgstr ""
 msgid "Progress: %1$s%% of %2$s%% required"
 msgstr ""
 
-#: src/CommonITILValidation.php:1253 src/CommonITILValidation.php:1365
-#: src/CommonITILValidation.php:1472
+#: src/CommonITILValidation.php:1127
+msgid "Approval step accepted"
+msgstr ""
+
+#: src/CommonITILValidation.php:1128
+msgid "Approval step refused"
+msgstr ""
+
+#: src/CommonITILValidation.php:1129
+msgid "Approval step pending"
+msgstr ""
+
+#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1368
+#: src/CommonITILValidation.php:1475
 msgid "Request date"
 msgstr "Ngày yêu cầu"
 
-#: src/CommonITILValidation.php:1255 src/CommonITILValidation.php:1338
-#: src/CommonITILValidation.php:1430
+#: src/CommonITILValidation.php:1258 src/CommonITILValidation.php:1341
+#: src/CommonITILValidation.php:1433
 msgid "Request comments"
 msgstr "Yêu cầu bình luận"
 
-#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1373
-#: src/CommonITILValidation.php:1485
+#: src/CommonITILValidation.php:1259 src/CommonITILValidation.php:1376
+#: src/CommonITILValidation.php:1488
 msgid "Approval date"
 msgstr "Ngày xác nhận"
 
-#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1400
+#: src/CommonITILValidation.php:1260 src/CommonITILValidation.php:1403
 msgid "Requested approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1258
+#: src/CommonITILValidation.php:1261
 msgid "Requested approver"
 msgstr ""
 
-#: src/CommonITILValidation.php:1259
+#: src/CommonITILValidation.php:1262
 msgid "Approval Comment"
 msgstr ""
 
-#: src/CommonITILValidation.php:1260
+#: src/CommonITILValidation.php:1263
 #: src/NotificationTargetKnowbaseItem.php:218
 msgid "Documents"
 msgstr "Các tài liệu"
 
-#: src/CommonITILValidation.php:1347 src/CommonITILValidation.php:1444
+#: src/CommonITILValidation.php:1350 src/CommonITILValidation.php:1447
 msgid "Approval comments"
 msgstr "Xác nhận bình luận"
 
-#: src/CommonITILValidation.php:1459
+#: src/CommonITILValidation.php:1462
 msgid "Approval status"
 msgstr "Trạng thái xác nhận"
 
-#: src/CommonITILValidation.php:1541
+#: src/CommonITILValidation.php:1544
 msgid "Approver substitute"
 msgstr ""
 
-#: src/CommonITILValidation.php:1601
+#: src/CommonITILValidation.php:1604
 msgid "Approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1623
+#: src/CommonITILValidation.php:1626
 msgid "Substitute of a member of approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1694
+#: src/CommonITILValidation.php:1697
 msgid "Approval status by users"
 msgstr ""
 
-#: src/CommonITILValidation.php:1849
+#: src/CommonITILValidation.php:1852
 msgid "Approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1954
+#: src/CommonITILValidation.php:1957
 msgid ""
 "This item is waiting for approval, do you really want to resolve or close "
 "it?"
 msgstr ""
 "Mục này đang chờ phê duyệt, bạn có thực sự muốn giải quyết hoặc đóng nó?"
 
-#: src/CommonITILValidation.php:1995
+#: src/CommonITILValidation.php:1998
 msgid "This item is waiting for approval."
 msgstr ""
 
-#: src/CommonITILValidation.php:1996
+#: src/CommonITILValidation.php:1999
 msgid "Do you really want to resolve or close it?"
 msgstr ""
 

--- a/locales/zh_CN.po
+++ b/locales/zh_CN.po
@@ -20,7 +20,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-26 10:20+0000\n"
+"POT-Creation-Date: 2025-08-26 12:21+0000\n"
 "PO-Revision-Date: 2022-09-16 06:53+0000\n"
 "Last-Translator: Cédric Anne, 2025\n"
 "Language-Team: Chinese (China) (https://app.transifex.com/glpi/teams/1637/zh_CN/)\n"
@@ -792,7 +792,7 @@ msgstr "只读模式"
 #: templates/components/itilobject/timeline/main_description.html.twig
 #: templates/components/user/info_card.html.twig
 #: templates/pages/tools/kb/comments.html.twig src/KnowbaseItem.php:245
-#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1188
+#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1191
 #: js/src/vue/CustomObject/FieldPreview/Field.vue:30
 msgid "Edit"
 msgstr "编辑"
@@ -1430,7 +1430,7 @@ msgid "Cancel"
 msgstr "取消"
 
 #: templates/components/form/basic_inputs_macros.html.twig
-#: src/CommonITILValidation.php:1773
+#: src/CommonITILValidation.php:1776
 msgid "Validate"
 msgstr "验证"
 
@@ -1943,7 +1943,7 @@ msgstr "资产编号"
 #: src/Computer.php:461 src/ProjectTask_Ticket.php:336 src/Certificate.php:278
 #: src/CronTask.php:1274 src/CronTask.php:1412
 #: src/CommonItilObject_Item.php:506 src/PDU.php:203 src/CommonDBTM.php:3513
-#: src/CommonITILValidation.php:1356 src/Plugin.php:2657
+#: src/CommonITILValidation.php:1359 src/Plugin.php:2657
 msgid "Status"
 msgstr "状态: "
 
@@ -3408,7 +3408,7 @@ msgstr[0] "审批阶段"
 #: src/CommonITILObject.php:4737 src/CommonITILObject.php:4746
 #: src/CommonITILObject.php:6847 src/CommonITILObject.php:6894
 #: src/CommonITILObject.php:10159 src/NotificationTargetChange.php:308
-#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1498
+#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1501
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "请求者"
@@ -3417,7 +3417,7 @@ msgstr[0] "请求者"
 #: src/NotificationTargetTicket.php:676 src/NotificationTargetTicket.php:706
 #: src/NotificationTargetCommonITILObject.php:976
 #: src/ITILValidationTemplate.php:81 src/NotificationTargetChange.php:327
-#: src/CommonITILValidation.php:1391 src/CommonITILValidation.php:1518
+#: src/CommonITILValidation.php:1394 src/CommonITILValidation.php:1521
 msgid "Approver"
 msgstr "审批人"
 
@@ -4146,7 +4146,7 @@ msgstr "没有历史"
 #: src/OAuthClient.php:94 src/Item_RemoteManagement.php:207
 #: src/Item_RemoteManagement.php:238 src/Certificate.php:125
 #: src/CronTask.php:1391 src/Contact.php:282 src/PDU.php:114
-#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1329
+#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1332
 #: src/Domain.php:233 src/Domain.php:257 src/ConsumableItem.php:167
 msgid "ID"
 msgstr "ID"
@@ -5671,7 +5671,7 @@ msgstr "当启用自动计算，状态会基于任务的完成比例计算。不
 #: src/Project.php:904 src/ProjectTask.php:963
 #: src/NotificationTargetProjectTask.php:553
 #: src/NotificationTargetProjectTask.php:568 src/Cartridge.php:895
-#: src/CommonITILValidation.php:1252
+#: src/CommonITILValidation.php:1255
 msgctxt "item"
 msgid "State"
 msgstr "状态"
@@ -17019,7 +17019,7 @@ msgid "Observer group except manager users"
 msgstr "除了经理的观察者组"
 
 #: src/NotificationTargetCommonITILObject.php:973
-#: src/CommonITILValidation.php:1254 src/CommonITILValidation.php:1381
+#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1384
 msgid "Approval requester"
 msgstr "审批请求人"
 
@@ -32228,7 +32228,7 @@ msgstr "无需审批"
 msgid "Granted + Not subject to approval"
 msgstr "同意 + 无需审批"
 
-#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1836
+#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1839
 msgid "Group user(s)"
 msgstr "群组用户"
 
@@ -32241,77 +32241,89 @@ msgstr "编辑审批步骤"
 msgid "Progress: %1$s%% of %2$s%% required"
 msgstr "进程: %1$s%% 之 %2$s%% 必须"
 
-#: src/CommonITILValidation.php:1253 src/CommonITILValidation.php:1365
-#: src/CommonITILValidation.php:1472
+#: src/CommonITILValidation.php:1127
+msgid "Approval step accepted"
+msgstr ""
+
+#: src/CommonITILValidation.php:1128
+msgid "Approval step refused"
+msgstr ""
+
+#: src/CommonITILValidation.php:1129
+msgid "Approval step pending"
+msgstr ""
+
+#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1368
+#: src/CommonITILValidation.php:1475
 msgid "Request date"
 msgstr "申请日期"
 
-#: src/CommonITILValidation.php:1255 src/CommonITILValidation.php:1338
-#: src/CommonITILValidation.php:1430
+#: src/CommonITILValidation.php:1258 src/CommonITILValidation.php:1341
+#: src/CommonITILValidation.php:1433
 msgid "Request comments"
 msgstr "申请说明"
 
-#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1373
-#: src/CommonITILValidation.php:1485
+#: src/CommonITILValidation.php:1259 src/CommonITILValidation.php:1376
+#: src/CommonITILValidation.php:1488
 msgid "Approval date"
 msgstr "审批日期"
 
-#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1400
+#: src/CommonITILValidation.php:1260 src/CommonITILValidation.php:1403
 msgid "Requested approver type"
 msgstr "申请的批准类型"
 
-#: src/CommonITILValidation.php:1258
+#: src/CommonITILValidation.php:1261
 msgid "Requested approver"
 msgstr "申请的批准人"
 
-#: src/CommonITILValidation.php:1259
+#: src/CommonITILValidation.php:1262
 msgid "Approval Comment"
 msgstr "审批评论"
 
-#: src/CommonITILValidation.php:1260
+#: src/CommonITILValidation.php:1263
 #: src/NotificationTargetKnowbaseItem.php:218
 msgid "Documents"
 msgstr "文档"
 
-#: src/CommonITILValidation.php:1347 src/CommonITILValidation.php:1444
+#: src/CommonITILValidation.php:1350 src/CommonITILValidation.php:1447
 msgid "Approval comments"
 msgstr "审批评论"
 
-#: src/CommonITILValidation.php:1459
+#: src/CommonITILValidation.php:1462
 msgid "Approval status"
 msgstr "审批状态"
 
-#: src/CommonITILValidation.php:1541
+#: src/CommonITILValidation.php:1544
 msgid "Approver substitute"
 msgstr "替代的审批者"
 
-#: src/CommonITILValidation.php:1601
+#: src/CommonITILValidation.php:1604
 msgid "Approver group"
 msgstr "审批组"
 
-#: src/CommonITILValidation.php:1623
+#: src/CommonITILValidation.php:1626
 msgid "Substitute of a member of approver group"
 msgstr "审批组成员的替代者"
 
-#: src/CommonITILValidation.php:1694
+#: src/CommonITILValidation.php:1697
 msgid "Approval status by users"
 msgstr "依照用户的审批状态"
 
-#: src/CommonITILValidation.php:1849
+#: src/CommonITILValidation.php:1852
 msgid "Approver type"
 msgstr "审批人类型"
 
-#: src/CommonITILValidation.php:1954
+#: src/CommonITILValidation.php:1957
 msgid ""
 "This item is waiting for approval, do you really want to resolve or close "
 "it?"
 msgstr "此项目正在等待批准，您确定要解决或关闭它吗？"
 
-#: src/CommonITILValidation.php:1995
+#: src/CommonITILValidation.php:1998
 msgid "This item is waiting for approval."
 msgstr "正在等待审批。"
 
-#: src/CommonITILValidation.php:1996
+#: src/CommonITILValidation.php:1999
 msgid "Do you really want to resolve or close it?"
 msgstr "确定要解决或关闭？"
 

--- a/locales/zh_HK.po
+++ b/locales/zh_HK.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-26 10:20+0000\n"
+"POT-Creation-Date: 2025-08-26 12:21+0000\n"
 "PO-Revision-Date: 2022-09-16 06:53+0000\n"
 "Last-Translator: Cédric Anne, 2022\n"
 "Language-Team: Chinese (Hong Kong) (https://app.transifex.com/glpi/teams/1637/zh_HK/)\n"
@@ -780,7 +780,7 @@ msgstr ""
 #: templates/components/itilobject/timeline/main_description.html.twig
 #: templates/components/user/info_card.html.twig
 #: templates/pages/tools/kb/comments.html.twig src/KnowbaseItem.php:245
-#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1188
+#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1191
 #: js/src/vue/CustomObject/FieldPreview/Field.vue:30
 msgid "Edit"
 msgstr ""
@@ -1418,7 +1418,7 @@ msgid "Cancel"
 msgstr ""
 
 #: templates/components/form/basic_inputs_macros.html.twig
-#: src/CommonITILValidation.php:1773
+#: src/CommonITILValidation.php:1776
 msgid "Validate"
 msgstr ""
 
@@ -1931,7 +1931,7 @@ msgstr ""
 #: src/Computer.php:461 src/ProjectTask_Ticket.php:336 src/Certificate.php:278
 #: src/CronTask.php:1274 src/CronTask.php:1412
 #: src/CommonItilObject_Item.php:506 src/PDU.php:203 src/CommonDBTM.php:3513
-#: src/CommonITILValidation.php:1356 src/Plugin.php:2657
+#: src/CommonITILValidation.php:1359 src/Plugin.php:2657
 msgid "Status"
 msgstr ""
 
@@ -3396,7 +3396,7 @@ msgstr[0] ""
 #: src/CommonITILObject.php:4737 src/CommonITILObject.php:4746
 #: src/CommonITILObject.php:6847 src/CommonITILObject.php:6894
 #: src/CommonITILObject.php:10159 src/NotificationTargetChange.php:308
-#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1498
+#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1501
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] ""
@@ -3405,7 +3405,7 @@ msgstr[0] ""
 #: src/NotificationTargetTicket.php:676 src/NotificationTargetTicket.php:706
 #: src/NotificationTargetCommonITILObject.php:976
 #: src/ITILValidationTemplate.php:81 src/NotificationTargetChange.php:327
-#: src/CommonITILValidation.php:1391 src/CommonITILValidation.php:1518
+#: src/CommonITILValidation.php:1394 src/CommonITILValidation.php:1521
 msgid "Approver"
 msgstr ""
 
@@ -4134,7 +4134,7 @@ msgstr ""
 #: src/OAuthClient.php:94 src/Item_RemoteManagement.php:207
 #: src/Item_RemoteManagement.php:238 src/Certificate.php:125
 #: src/CronTask.php:1391 src/Contact.php:282 src/PDU.php:114
-#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1329
+#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1332
 #: src/Domain.php:233 src/Domain.php:257 src/ConsumableItem.php:167
 msgid "ID"
 msgstr ""
@@ -5659,7 +5659,7 @@ msgstr ""
 #: src/Project.php:904 src/ProjectTask.php:963
 #: src/NotificationTargetProjectTask.php:553
 #: src/NotificationTargetProjectTask.php:568 src/Cartridge.php:895
-#: src/CommonITILValidation.php:1252
+#: src/CommonITILValidation.php:1255
 msgctxt "item"
 msgid "State"
 msgstr ""
@@ -17004,7 +17004,7 @@ msgid "Observer group except manager users"
 msgstr ""
 
 #: src/NotificationTargetCommonITILObject.php:973
-#: src/CommonITILValidation.php:1254 src/CommonITILValidation.php:1381
+#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1384
 msgid "Approval requester"
 msgstr ""
 
@@ -32193,7 +32193,7 @@ msgstr ""
 msgid "Granted + Not subject to approval"
 msgstr ""
 
-#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1836
+#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1839
 msgid "Group user(s)"
 msgstr ""
 
@@ -32206,77 +32206,89 @@ msgstr ""
 msgid "Progress: %1$s%% of %2$s%% required"
 msgstr ""
 
-#: src/CommonITILValidation.php:1253 src/CommonITILValidation.php:1365
-#: src/CommonITILValidation.php:1472
+#: src/CommonITILValidation.php:1127
+msgid "Approval step accepted"
+msgstr ""
+
+#: src/CommonITILValidation.php:1128
+msgid "Approval step refused"
+msgstr ""
+
+#: src/CommonITILValidation.php:1129
+msgid "Approval step pending"
+msgstr ""
+
+#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1368
+#: src/CommonITILValidation.php:1475
 msgid "Request date"
 msgstr ""
 
-#: src/CommonITILValidation.php:1255 src/CommonITILValidation.php:1338
-#: src/CommonITILValidation.php:1430
+#: src/CommonITILValidation.php:1258 src/CommonITILValidation.php:1341
+#: src/CommonITILValidation.php:1433
 msgid "Request comments"
 msgstr ""
 
-#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1373
-#: src/CommonITILValidation.php:1485
+#: src/CommonITILValidation.php:1259 src/CommonITILValidation.php:1376
+#: src/CommonITILValidation.php:1488
 msgid "Approval date"
 msgstr ""
 
-#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1400
+#: src/CommonITILValidation.php:1260 src/CommonITILValidation.php:1403
 msgid "Requested approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1258
+#: src/CommonITILValidation.php:1261
 msgid "Requested approver"
 msgstr ""
 
-#: src/CommonITILValidation.php:1259
+#: src/CommonITILValidation.php:1262
 msgid "Approval Comment"
 msgstr ""
 
-#: src/CommonITILValidation.php:1260
+#: src/CommonITILValidation.php:1263
 #: src/NotificationTargetKnowbaseItem.php:218
 msgid "Documents"
 msgstr ""
 
-#: src/CommonITILValidation.php:1347 src/CommonITILValidation.php:1444
+#: src/CommonITILValidation.php:1350 src/CommonITILValidation.php:1447
 msgid "Approval comments"
 msgstr ""
 
-#: src/CommonITILValidation.php:1459
+#: src/CommonITILValidation.php:1462
 msgid "Approval status"
 msgstr ""
 
-#: src/CommonITILValidation.php:1541
+#: src/CommonITILValidation.php:1544
 msgid "Approver substitute"
 msgstr ""
 
-#: src/CommonITILValidation.php:1601
+#: src/CommonITILValidation.php:1604
 msgid "Approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1623
+#: src/CommonITILValidation.php:1626
 msgid "Substitute of a member of approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1694
+#: src/CommonITILValidation.php:1697
 msgid "Approval status by users"
 msgstr ""
 
-#: src/CommonITILValidation.php:1849
+#: src/CommonITILValidation.php:1852
 msgid "Approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1954
+#: src/CommonITILValidation.php:1957
 msgid ""
 "This item is waiting for approval, do you really want to resolve or close "
 "it?"
 msgstr ""
 
-#: src/CommonITILValidation.php:1995
+#: src/CommonITILValidation.php:1998
 msgid "This item is waiting for approval."
 msgstr ""
 
-#: src/CommonITILValidation.php:1996
+#: src/CommonITILValidation.php:1999
 msgid "Do you really want to resolve or close it?"
 msgstr ""
 

--- a/locales/zh_TW.po
+++ b/locales/zh_TW.po
@@ -18,7 +18,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-26 10:20+0000\n"
+"POT-Creation-Date: 2025-08-26 12:21+0000\n"
 "PO-Revision-Date: 2022-09-16 06:53+0000\n"
 "Last-Translator: Cédric Anne, 2025\n"
 "Language-Team: Chinese (Taiwan) (https://app.transifex.com/glpi/teams/1637/zh_TW/)\n"
@@ -787,7 +787,7 @@ msgstr ""
 #: templates/components/itilobject/timeline/main_description.html.twig
 #: templates/components/user/info_card.html.twig
 #: templates/pages/tools/kb/comments.html.twig src/KnowbaseItem.php:245
-#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1188
+#: src/KnowbaseItemTranslation.php:90 src/CommonITILValidation.php:1191
 #: js/src/vue/CustomObject/FieldPreview/Field.vue:30
 msgid "Edit"
 msgstr "編輯"
@@ -1425,7 +1425,7 @@ msgid "Cancel"
 msgstr "取消"
 
 #: templates/components/form/basic_inputs_macros.html.twig
-#: src/CommonITILValidation.php:1773
+#: src/CommonITILValidation.php:1776
 msgid "Validate"
 msgstr "驗證"
 
@@ -1938,7 +1938,7 @@ msgstr "財產編號"
 #: src/Computer.php:461 src/ProjectTask_Ticket.php:336 src/Certificate.php:278
 #: src/CronTask.php:1274 src/CronTask.php:1412
 #: src/CommonItilObject_Item.php:506 src/PDU.php:203 src/CommonDBTM.php:3513
-#: src/CommonITILValidation.php:1356 src/Plugin.php:2657
+#: src/CommonITILValidation.php:1359 src/Plugin.php:2657
 msgid "Status"
 msgstr "狀態"
 
@@ -3403,7 +3403,7 @@ msgstr[0] ""
 #: src/CommonITILObject.php:4737 src/CommonITILObject.php:4746
 #: src/CommonITILObject.php:6847 src/CommonITILObject.php:6894
 #: src/CommonITILObject.php:10159 src/NotificationTargetChange.php:308
-#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1498
+#: src/NotImportedEmail.php:179 src/CommonITILValidation.php:1501
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "請求者"
@@ -3412,7 +3412,7 @@ msgstr[0] "請求者"
 #: src/NotificationTargetTicket.php:676 src/NotificationTargetTicket.php:706
 #: src/NotificationTargetCommonITILObject.php:976
 #: src/ITILValidationTemplate.php:81 src/NotificationTargetChange.php:327
-#: src/CommonITILValidation.php:1391 src/CommonITILValidation.php:1518
+#: src/CommonITILValidation.php:1394 src/CommonITILValidation.php:1521
 msgid "Approver"
 msgstr "核准者"
 
@@ -4141,7 +4141,7 @@ msgstr "沒有歷史"
 #: src/OAuthClient.php:94 src/Item_RemoteManagement.php:207
 #: src/Item_RemoteManagement.php:238 src/Certificate.php:125
 #: src/CronTask.php:1391 src/Contact.php:282 src/PDU.php:114
-#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1329
+#: src/CommonDBTM.php:4385 src/CommonITILValidation.php:1332
 #: src/Domain.php:233 src/Domain.php:257 src/ConsumableItem.php:167
 msgid "ID"
 msgstr "ID"
@@ -5666,7 +5666,7 @@ msgstr ""
 #: src/Project.php:904 src/ProjectTask.php:963
 #: src/NotificationTargetProjectTask.php:553
 #: src/NotificationTargetProjectTask.php:568 src/Cartridge.php:895
-#: src/CommonITILValidation.php:1252
+#: src/CommonITILValidation.php:1255
 msgctxt "item"
 msgid "State"
 msgstr "狀態"
@@ -17011,7 +17011,7 @@ msgid "Observer group except manager users"
 msgstr ""
 
 #: src/NotificationTargetCommonITILObject.php:973
-#: src/CommonITILValidation.php:1254 src/CommonITILValidation.php:1381
+#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1384
 msgid "Approval requester"
 msgstr "核准請求者"
 
@@ -32200,7 +32200,7 @@ msgstr "不須經批准"
 msgid "Granted + Not subject to approval"
 msgstr "准予 + 不須核准"
 
-#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1836
+#: src/CommonITILValidation.php:891 src/CommonITILValidation.php:1839
 msgid "Group user(s)"
 msgstr ""
 
@@ -32213,77 +32213,89 @@ msgstr ""
 msgid "Progress: %1$s%% of %2$s%% required"
 msgstr ""
 
-#: src/CommonITILValidation.php:1253 src/CommonITILValidation.php:1365
-#: src/CommonITILValidation.php:1472
+#: src/CommonITILValidation.php:1127
+msgid "Approval step accepted"
+msgstr ""
+
+#: src/CommonITILValidation.php:1128
+msgid "Approval step refused"
+msgstr ""
+
+#: src/CommonITILValidation.php:1129
+msgid "Approval step pending"
+msgstr ""
+
+#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1368
+#: src/CommonITILValidation.php:1475
 msgid "Request date"
 msgstr "申請日期"
 
-#: src/CommonITILValidation.php:1255 src/CommonITILValidation.php:1338
-#: src/CommonITILValidation.php:1430
+#: src/CommonITILValidation.php:1258 src/CommonITILValidation.php:1341
+#: src/CommonITILValidation.php:1433
 msgid "Request comments"
 msgstr "申請說明"
 
-#: src/CommonITILValidation.php:1256 src/CommonITILValidation.php:1373
-#: src/CommonITILValidation.php:1485
+#: src/CommonITILValidation.php:1259 src/CommonITILValidation.php:1376
+#: src/CommonITILValidation.php:1488
 msgid "Approval date"
 msgstr "核准日期"
 
-#: src/CommonITILValidation.php:1257 src/CommonITILValidation.php:1400
+#: src/CommonITILValidation.php:1260 src/CommonITILValidation.php:1403
 msgid "Requested approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1258
+#: src/CommonITILValidation.php:1261
 msgid "Requested approver"
 msgstr ""
 
-#: src/CommonITILValidation.php:1259
+#: src/CommonITILValidation.php:1262
 msgid "Approval Comment"
 msgstr ""
 
-#: src/CommonITILValidation.php:1260
+#: src/CommonITILValidation.php:1263
 #: src/NotificationTargetKnowbaseItem.php:218
 msgid "Documents"
 msgstr "文件"
 
-#: src/CommonITILValidation.php:1347 src/CommonITILValidation.php:1444
+#: src/CommonITILValidation.php:1350 src/CommonITILValidation.php:1447
 msgid "Approval comments"
 msgstr "核准說明"
 
-#: src/CommonITILValidation.php:1459
+#: src/CommonITILValidation.php:1462
 msgid "Approval status"
 msgstr "簽核狀態"
 
-#: src/CommonITILValidation.php:1541
+#: src/CommonITILValidation.php:1544
 msgid "Approver substitute"
 msgstr ""
 
-#: src/CommonITILValidation.php:1601
+#: src/CommonITILValidation.php:1604
 msgid "Approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1623
+#: src/CommonITILValidation.php:1626
 msgid "Substitute of a member of approver group"
 msgstr ""
 
-#: src/CommonITILValidation.php:1694
+#: src/CommonITILValidation.php:1697
 msgid "Approval status by users"
 msgstr ""
 
-#: src/CommonITILValidation.php:1849
+#: src/CommonITILValidation.php:1852
 msgid "Approver type"
 msgstr ""
 
-#: src/CommonITILValidation.php:1954
+#: src/CommonITILValidation.php:1957
 msgid ""
 "This item is waiting for approval, do you really want to resolve or close "
 "it?"
 msgstr ""
 
-#: src/CommonITILValidation.php:1995
+#: src/CommonITILValidation.php:1998
 msgid "This item is waiting for approval."
 msgstr ""
 
-#: src/CommonITILValidation.php:1996
+#: src/CommonITILValidation.php:1999
 msgid "Do you really want to resolve or close it?"
 msgstr ""
 

--- a/src/CommonITILValidation.php
+++ b/src/CommonITILValidation.php
@@ -1072,15 +1072,15 @@ abstract class CommonITILValidation extends CommonDBChild
                         <div class="flex-shrink-0"><strong>{{ step_name }}</strong></div>
                         <div class="flex-shrink-0">
                             {% if step_status == constant('CommonITILValidation::ACCEPTED') %}
-                                <span class="text-green" data-bs-toogle="tooltip" title="{{ __("Approval step accepted") }}">
+                                <span class="text-green" data-bs-toogle="tooltip" title="{{ accepted_label }}">
                                     <i class="ti ti-check"></i>
                                 </span>
                             {% elseif step_status == constant('CommonITILValidation::REFUSED') %}
-                                <span class="text-red" data-bs-toggle="tooltip" title="{{ __("Approval step refused") }}">
+                                <span class="text-red" data-bs-toggle="tooltip" title="{{ refused_label }}">
                                     <i class="ti ti-ban"></i>
                                 </span>
                             {% elseif step_status == constant('CommonITILValidation::WAITING') %}
-                                <span class="text-yellow" data-bs-toggle="tooltip" title="{{ __("Approval step pending") }}">
+                                <span class="text-yellow" data-bs-toggle="tooltip" title="{{ pending_label }}">
                                     <i class="ti ti-clock"></i>
                                 </span>
                             {% endif %}
@@ -1124,6 +1124,9 @@ abstract class CommonITILValidation extends CommonDBChild
                     'edit_dialog_params' => $edit_dialog_params,
                     'edit_button_label'  => __('Edit approval step'),
                     'progress_label'     => __('Progress: %1$s%% of %2$s%% required'),
+                    'accepted_label'     => __('Approval step accepted'),
+                    'refused_label'      => __('Approval step refused'),
+                    'pending_label'      => __('Approval step pending'),
                 ]
             );
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

The following translations were not extracted because they were located in an inlined Twig template.

```
#: src/CommonITILValidation.php:1127
msgid "Approval step accepted"
msgstr ""

#: src/CommonITILValidation.php:1128
msgid "Approval step refused"
msgstr ""

#: src/CommonITILValidation.php:1129
msgid "Approval step pending"
msgstr ""
```