### PR TITLE
Remove grant requirement on `mysql.time_zone_name` table

### DIFF
--- a/.docker/initdb.sql
+++ b/.docker/initdb.sql
@@ -4,4 +4,3 @@
 # This may be executed before automatic `glpi` user creation, so we have to create it manually.
 CREATE USER IF NOT EXISTS 'glpi'@'%' IDENTIFIED BY 'glpi';
 SET PASSWORD FOR 'glpi'@'%' = PASSWORD('glpi');
-GRANT SELECT ON `mysql`.`time_zone_name` TO 'glpi'@'%';

--- a/phpunit/functional/Glpi/System/Requirement/DbTimezonesTest.php
+++ b/phpunit/functional/Glpi/System/Requirement/DbTimezonesTest.php
@@ -36,89 +36,13 @@ namespace tests\units\Glpi\System\Requirement;
 
 class DbTimezonesTest extends \GLPITestCase
 {
-    public function testCheckWithUnavailableMysqlDb()
+    public function testCheckWithTimezonenameEmptyList()
     {
         $db = $this->getMockBuilder(\DB::class)
             ->disableOriginalConstructor()
-            ->onlyMethods(['request'])
+            ->onlyMethods(['getTimezones'])
             ->getMock();
-        $that = $this;
-
-        $db->method('request')->willReturnCallback(
-            function ($query) use ($that) {
-                $result = $this->getMockBuilder(\DBmysqlIterator::class)
-                    ->setConstructorArgs([null])
-                    ->onlyMethods(['count'])
-                    ->getMock();
-                if ($query === "SHOW DATABASES LIKE 'mysql'") {
-                    $result->method('count')->willReturn(0);
-                }
-                return $result;
-            }
-        );
-
-        $instance = new \Glpi\System\Requirement\DbTimezones($db);
-        $this->assertFalse($instance->isValidated());
-        $this->assertEquals(
-            ['Access to timezone database (mysql) is not allowed.'],
-            $instance->getValidationMessages()
-        );
-    }
-
-    public function testCheckWithUnavailableTimezonenameTable()
-    {
-        $db = $this->getMockBuilder(\DB::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['request'])
-            ->getMock();
-        $that = $this;
-
-        $db->method('request')->willReturnCallback(
-            function ($query) {
-                $result = $this->getMockBuilder(\DBmysqlIterator::class)
-                    ->setConstructorArgs([null])
-                    ->onlyMethods(['count'])
-                    ->getMock();
-                if ($query === "SHOW DATABASES LIKE 'mysql'") {
-                    $result->method('count')->willReturn(1);
-                } elseif ($query === "SHOW TABLES FROM `mysql` LIKE 'time_zone_name'") {
-                    $result->method('count')->willReturn(0);
-                }
-                return $result;
-            }
-        );
-
-        $instance = new \Glpi\System\Requirement\DbTimezones($db);
-        $this->assertFalse($instance->isValidated());
-        $this->assertEquals(
-            ['Access to timezone table (mysql.time_zone_name) is not allowed.'],
-            $instance->getValidationMessages()
-        );
-    }
-
-    public function testCheckWithTimezonenameEmptyTable()
-    {
-        $db = $this->getMockBuilder(\DB::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['request'])
-            ->getMock();
-
-        $db->method('request')->willReturnCallback(
-            function ($query) {
-                $result = $this->getMockBuilder(\DBmysqlIterator::class)
-                    ->setConstructorArgs([null])
-                    ->onlyMethods(['count', 'current'])
-                    ->getMock();
-                if ($query === "SHOW DATABASES LIKE 'mysql'") {
-                    $result->method('count')->willReturn(1);
-                } elseif ($query === "SHOW TABLES FROM `mysql` LIKE 'time_zone_name'") {
-                    $result->method('count')->willReturn(1);
-                } else {
-                    $result->method('current')->willReturn(['cpt' => 0]);
-                }
-                return $result;
-            }
-        );
+        $db->method('getTimezones')->willReturn([]);
 
         $instance = new \Glpi\System\Requirement\DbTimezones($db);
         $this->assertFalse($instance->isValidated());
@@ -132,25 +56,18 @@ class DbTimezonesTest extends \GLPITestCase
     {
         $db = $this->getMockBuilder(\DB::class)
             ->disableOriginalConstructor()
-            ->onlyMethods(['request'])
+            ->onlyMethods(['getTimezones'])
             ->getMock();
-
-        $db->method('request')->willReturnCallback(
-            function ($query) {
-                $result = $this->getMockBuilder(\DBmysqlIterator::class)
-                    ->setConstructorArgs([null])
-                    ->onlyMethods(['count', 'current'])
-                    ->getMock();
-                if ($query === "SHOW DATABASES LIKE 'mysql'") {
-                    $result->method('count')->willReturn(1);
-                } elseif ($query === "SHOW TABLES FROM `mysql` LIKE 'time_zone_name'") {
-                    $result->method('count')->willReturn(1);
-                } else {
-                    $result->method('current')->willReturn(['cpt' => 30]);
-                }
-                return $result;
-            }
-        );
+        $db->method('getTimezones')->willReturn([
+            'Africa/Abidjan',
+            'America/Cancun',
+            'Asia/Beirut',
+            'Atlantic/Faeroe',
+            'Australia/Canberra',
+            'Europe/Paris',
+            'Pacific/Noumea',
+            'UTC',
+        ]);
 
         $instance = new \Glpi\System\Requirement\DbTimezones($db);
         $this->assertTrue($instance->isValidated());

--- a/src/DBmysql.php
+++ b/src/DBmysql.php
@@ -1878,7 +1878,7 @@ class DBmysql
     }
 
     /**
-     * Returns list of timezones.
+     * Returns list of available timezones.
      *
      * @return string[]
      *
@@ -1886,24 +1886,36 @@ class DBmysql
      */
     public function getTimezones()
     {
-        if (!$this->use_timezones) {
-            return [];
+        $list = [];
+
+        $timezones = DateTimeZone::listIdentifiers();
+        $results_queries = [];
+        foreach ($timezones as $index => $timezone) {
+            $results_queries[] =  new QuerySubQuery([
+                'SELECT' => ['name', 'value'],
+                'FROM' => new QueryExpression(
+                    sprintf(
+                        '(SELECT %1$s as %2$s, CONVERT_TZ(%3$s, %4$s, %5$s) as %6$s) as %7$s',
+                        self::quoteValue($timezone),
+                        self::quoteName('name'),
+                        self::quoteValue('2000-01-01 00:00:00'),
+                        self::quoteValue('GMT'),
+                        self::quoteValue($timezone),
+                        self::quoteName('value'),
+                        self::quoteName(sprintf('timezone_%d', $index)),
+                    )
+                ),
+                'WHERE' => [
+                    ['NOT' => ['value' => null]],
+                ],
+            ]);
         }
 
-        $list = []; //default $tz is empty
-
-        $from_php = \DateTimeZone::listIdentifiers();
-        $now = new \DateTime();
-
-        $iterator = $this->request([
-            'SELECT' => 'Name',
-            'FROM'   => 'mysql.time_zone_name',
-            'WHERE'  => ['Name' => $from_php],
-        ]);
-
-        foreach ($iterator as $from_mysql) {
-            $now->setTimezone(new \DateTimeZone($from_mysql['Name']));
-            $list[$from_mysql['Name']] = $from_mysql['Name'] . $now->format(" (T P)");
+        $iterator = $this->request(['FROM' => new QueryUnion($results_queries)]);
+        foreach ($iterator as $row) {
+            $now = new DateTime();
+            $now->setTimezone(new DateTimeZone($row['name']));
+            $list[$row['name']] = $row['name'] . $now->format(" (T P)");
         }
 
         return $list;

--- a/src/System/Requirement/DbTimezones.php
+++ b/src/System/Requirement/DbTimezones.php
@@ -60,33 +60,9 @@ class DbTimezones extends AbstractRequirement
 
     protected function check()
     {
-        $mysql_db_res = $this->db->request('SHOW DATABASES LIKE ' . $this->db->quoteValue('mysql'));
-        if ($mysql_db_res->count() === 0) {
-            $this->validated = false;
-            $this->validation_messages[] = __('Access to timezone database (mysql) is not allowed.');
-            return;
-        }
+        $available_timezones = $this->db->getTimezones();
 
-        $tz_table_res = $this->db->request(
-            'SHOW TABLES FROM '
-            . $this->db->quoteName('mysql')
-            . ' LIKE '
-            . $this->db->quoteValue('time_zone_name')
-        );
-        if ($tz_table_res->count() === 0) {
-            $this->validated = false;
-            $this->validation_messages[] = __('Access to timezone table (mysql.time_zone_name) is not allowed.');
-            return;
-        }
-
-        $iterator = $this->db->request(
-            [
-                'COUNT'  => 'cpt',
-                'FROM'   => 'mysql.time_zone_name',
-            ]
-        );
-        $result = $iterator->current();
-        if ($result['cpt'] === 0) {
+        if (count($available_timezones) === 0) {
             $this->validated = false;
             $this->validation_messages[] = __('Timezones seems not loaded, see https://glpi-install.readthedocs.io/en/latest/timezones.html.');
             return;


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] This change requires a documentation update.

## Description

To know if a timezone is available on MySQL side, it is possible to check the result of a `SELECT CONVERT_TZ();` query. Indeed, if the target timezone is not known on MySQL side, then the result will be `null`, otherwise it will correspond to a valid timestamp string.
Therefore, we can check timezones availability without having to access the `mysql.time_zone_name` table and remove the corresponding grant requirement.

This change is pretty simple, maybe we could backport it on GLPI 10.0, to simplify the handling of timezones support on our docker image, see https://github.com/glpi-project/docker-images/issues/190.