### PR TITLE
fix(service-catalog): Fixed search across categories in service catalog

### DIFF
--- a/phpunit/functional/Glpi/Form/ServiceCatalog/Provider/CategoryProviderTest.php
+++ b/phpunit/functional/Glpi/Form/ServiceCatalog/Provider/CategoryProviderTest.php
@@ -1,0 +1,397 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Form\ServiceCatalog\Provider;
+
+use DbTestCase;
+use Glpi\Form\AccessControl\FormAccessParameters;
+use Glpi\Form\Category;
+use Glpi\Form\ServiceCatalog\ItemRequest;
+use Glpi\Form\ServiceCatalog\Provider\CategoryProvider;
+use Session;
+
+class CategoryProviderTest extends DbTestCase
+{
+    private CategoryProvider $provider;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->provider = new CategoryProvider();
+    }
+
+    /**
+     * Test that all categories are returned when no category filter is applied
+     */
+    public function testGetItemsWithoutCategoryFilter()
+    {
+        $this->login();
+
+        // Create categories
+        $category1 = $this->createItem(Category::class, [
+            'name' => 'IT Support',
+            'description' => 'Information Technology support requests',
+        ]);
+
+        $category2 = $this->createItem(Category::class, [
+            'name' => 'HR Services',
+            'description' => 'Human Resources related services',
+        ]);
+
+        $category3 = $this->createItem(Category::class, [
+            'name' => 'Facilities',
+            'description' => 'Building and office facilities',
+        ]);
+
+        // Create request without category filter
+        $request = new ItemRequest(
+            access_parameters: new FormAccessParameters(
+                session_info: Session::getCurrentSessionInfo()
+            ),
+            filter: ''
+        );
+
+        $categories = $this->provider->getItems($request);
+
+        // All categories should be returned
+        $category_names = array_column(array_map(fn($category) => $category->fields, $categories), 'name');
+        $this->assertContains('IT Support', $category_names);
+        $this->assertContains('HR Services', $category_names);
+        $this->assertContains('Facilities', $category_names);
+    }
+
+    /**
+     * Test that only the specified category is returned when category filter is applied
+     */
+    public function testGetItemsWithCategoryFilter()
+    {
+        $this->login();
+
+        // Create parent and child categories
+        $parent_category = $this->createItem(Category::class, [
+            'name' => 'IT Services',
+            'description' => 'All IT related services',
+        ]);
+
+        $child_category = $this->createItem(Category::class, [
+            'name' => 'Software Support',
+            'description' => 'Software-specific support',
+            'forms_categories_id' => $parent_category->getID(),
+        ]);
+
+        $unrelated_category = $this->createItem(Category::class, [
+            'name' => 'HR Services',
+            'description' => 'Human Resources services',
+        ]);
+
+        // Create request with category filter for the child category
+        $request = new ItemRequest(
+            access_parameters: new FormAccessParameters(
+                session_info: Session::getCurrentSessionInfo()
+            ),
+            filter: '',
+            category_id: $parent_category->getID()
+        );
+
+        $categories = $this->provider->getItems($request);
+
+        // Only the child category should be returned
+        $category_names = array_column(array_map(fn($category) => $category->fields, $categories), 'name');
+        $this->assertContains('Software Support', $category_names);
+        $this->assertNotContains('IT Services', $category_names);
+        $this->assertNotContains('HR Services', $category_names);
+    }
+
+    /**
+     * Test that categories are filtered by name using fuzzy matching
+     */
+    public function testCategoriesFilteredByName()
+    {
+        $this->login();
+
+        // Create categories with different names
+        $category1 = $this->createItem(Category::class, [
+            'name' => 'Technical Support',
+            'description' => 'General technical assistance',
+        ]);
+
+        $category2 = $this->createItem(Category::class, [
+            'name' => 'Hardware Requests',
+            'description' => 'Equipment and hardware needs',
+        ]);
+
+        $category3 = $this->createItem(Category::class, [
+            'name' => 'Software Installation',
+            'description' => 'Software deployment and setup',
+        ]);
+
+        $category4 = $this->createItem(Category::class, [
+            'name' => 'Access Management',
+            'description' => 'User access and permissions',
+        ]);
+
+        // Test filter by partial name match
+        $request = new ItemRequest(
+            access_parameters: new FormAccessParameters(
+                session_info: Session::getCurrentSessionInfo()
+            ),
+            filter: 'tech'
+        );
+
+        $categories = $this->provider->getItems($request);
+        $category_names = array_column(array_map(fn($category) => $category->fields, $categories), 'name');
+
+        // Should match "Technical Support" (name contains "tech")
+        $this->assertContains('Technical Support', $category_names);
+        $this->assertNotContains('Hardware Requests', $category_names);
+        $this->assertNotContains('Software Installation', $category_names);
+        $this->assertNotContains('Access Management', $category_names);
+    }
+
+    /**
+     * Test that categories are filtered by description using fuzzy matching
+     */
+    public function testCategoriesFilteredByDescription()
+    {
+        $this->login();
+
+        // Create categories with different descriptions
+        $category1 = $this->createItem(Category::class, [
+            'name' => 'IT Support',
+            'description' => 'Technical assistance for hardware and software',
+        ]);
+
+        $category2 = $this->createItem(Category::class, [
+            'name' => 'Equipment',
+            'description' => 'Request new technical equipment and devices',
+        ]);
+
+        $category3 = $this->createItem(Category::class, [
+            'name' => 'Training',
+            'description' => 'Educational courses and workshops',
+        ]);
+
+        // Test filter by description content
+        $request = new ItemRequest(
+            access_parameters: new FormAccessParameters(
+                session_info: Session::getCurrentSessionInfo()
+            ),
+            filter: 'technical'
+        );
+
+        $categories = $this->provider->getItems($request);
+        $category_names = array_column(array_map(fn($category) => $category->fields, $categories), 'name');
+
+        // Should match both categories that contain "technical" in description
+        $this->assertContains('IT Support', $category_names);
+        $this->assertContains('Equipment', $category_names);
+        $this->assertNotContains('Training', $category_names);
+    }
+
+    /**
+     * Test that categories are filtered by both name and description
+     */
+    public function testCategoriesFilteredByNameAndDescription()
+    {
+        $this->login();
+
+        // Create categories
+        $category1 = $this->createItem(Category::class, [
+            'name' => 'Software Issues',
+            'description' => 'Report bugs and software problems',
+        ]);
+
+        $category2 = $this->createItem(Category::class, [
+            'name' => 'Hardware Support',
+            'description' => 'Physical equipment and software installation',
+        ]);
+
+        $category3 = $this->createItem(Category::class, [
+            'name' => 'Training',
+            'description' => 'Educational programs',
+        ]);
+
+        // Test filter that matches both name and description
+        $request = new ItemRequest(
+            access_parameters: new FormAccessParameters(
+                session_info: Session::getCurrentSessionInfo()
+            ),
+            filter: 'software'
+        );
+
+        $categories = $this->provider->getItems($request);
+        $category_names = array_column(array_map(fn($category) => $category->fields, $categories), 'name');
+
+        // Should match "Software Issues" (name) and "Hardware Support" (description)
+        $this->assertContains('Software Issues', $category_names);
+        $this->assertContains('Hardware Support', $category_names);
+        $this->assertNotContains('Training', $category_names);
+    }
+
+    /**
+     * Test that no categories are returned when filter doesn't match anything
+     */
+    public function testNoMatchingCategories()
+    {
+        $this->login();
+
+        // Create a category
+        $category = $this->createItem(Category::class, [
+            'name' => 'IT Support',
+            'description' => 'Technical assistance',
+        ]);
+
+        // Test filter that doesn't match
+        $request = new ItemRequest(
+            access_parameters: new FormAccessParameters(
+                session_info: Session::getCurrentSessionInfo()
+            ),
+            filter: 'nonexistent'
+        );
+
+        $categories = $this->provider->getItems($request);
+
+        // No categories should be returned
+        $this->assertEmpty($categories);
+    }
+
+    /**
+     * Test that categories are sorted by name
+     */
+    public function testCategoriesSortedByName()
+    {
+        $this->login();
+
+        // Create categories in non-alphabetical order
+        $category_z = $this->createItem(Category::class, [
+            'name' => 'Zebra Category',
+            'description' => 'Last in alphabet',
+        ]);
+
+        $category_a = $this->createItem(Category::class, [
+            'name' => 'Alpha Category',
+            'description' => 'First in alphabet',
+        ]);
+
+        $category_m = $this->createItem(Category::class, [
+            'name' => 'Middle Category',
+            'description' => 'Middle of alphabet',
+        ]);
+
+        // Create request without filter
+        $request = new ItemRequest(
+            access_parameters: new FormAccessParameters(
+                session_info: Session::getCurrentSessionInfo()
+            ),
+            filter: ''
+        );
+
+        $categories = $this->provider->getItems($request);
+        $category_names = array_map(fn($category) => $category->fields['name'], $categories);
+
+        // Categories should be sorted alphabetically by name
+        $expected_order = ['Alpha Category', 'Middle Category', 'Zebra Category'];
+        $this->assertEquals($expected_order, $category_names);
+    }
+
+    /**
+     * Test that empty filter returns all categories
+     */
+    public function testEmptyFilterReturnsAllCategories()
+    {
+        $this->login();
+
+        // Create categories
+        $category1 = $this->createItem(Category::class, [
+            'name' => 'Category One',
+            'description' => 'First category',
+        ]);
+
+        $category2 = $this->createItem(Category::class, [
+            'name' => 'Category Two',
+            'description' => 'Second category',
+        ]);
+
+        // Test with empty filter
+        $request = new ItemRequest(
+            access_parameters: new FormAccessParameters(
+                session_info: Session::getCurrentSessionInfo()
+            ),
+            filter: ''
+        );
+
+        $categories = $this->provider->getItems($request);
+
+        // All categories should be returned
+        $this->assertCount(2, $categories);
+        $category_names = array_column(array_map(fn($category) => $category->fields, $categories), 'name');
+        $this->assertContains('Category One', $category_names);
+        $this->assertContains('Category Two', $category_names);
+    }
+
+    /**
+     * Test that categories with null/empty name or description are handled properly
+     */
+    public function testCategoriesWithEmptyFields()
+    {
+        $this->login();
+
+        // Create category with empty description
+        $category1 = $this->createItem(Category::class, [
+            'name' => 'Category with empty description',
+            'description' => '',
+        ]);
+
+        // Create category with only description
+        $category2 = $this->createItem(Category::class, [
+            'name' => '',
+            'description' => 'Only description here',
+        ]);
+
+        // Test filter that should match the description
+        $request = new ItemRequest(
+            access_parameters: new FormAccessParameters(
+                session_info: Session::getCurrentSessionInfo()
+            ),
+            filter: 'description'
+        );
+
+        $categories = $this->provider->getItems($request);
+        $category_ids = array_map(fn($category) => $category->fields['id'], $categories);
+
+        // Should match the category with "description" in name and description
+        $this->assertContains($category1->getID(), $category_ids);
+        $this->assertContains($category2->getID(), $category_ids);
+    }
+}

--- a/phpunit/functional/Glpi/Form/ServiceCatalog/Provider/KnowbaseItemProviderTest.php
+++ b/phpunit/functional/Glpi/Form/ServiceCatalog/Provider/KnowbaseItemProviderTest.php
@@ -1,0 +1,538 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Form\ServiceCatalog\Provider;
+
+use DbTestCase;
+use Glpi\Form\AccessControl\FormAccessParameters;
+use Glpi\Form\Category;
+use Glpi\Form\ServiceCatalog\ItemRequest;
+use Glpi\Form\ServiceCatalog\Provider\KnowbaseItemProvider;
+use KnowbaseItem;
+use Session;
+
+class KnowbaseItemProviderTest extends DbTestCase
+{
+    private KnowbaseItemProvider $provider;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->provider = new KnowbaseItemProvider();
+    }
+
+    /**
+     * Test that knowbase items without category are included when no category filter is applied
+     */
+    public function testGetItemsWithoutCategoryFilter()
+    {
+        $this->login();
+
+        // Create knowbase items without category
+        $kb_item1 = $this->createKnowbaseItem([
+            'name' => 'How to reset password',
+            'description' => 'Password reset procedure',
+            'answer' => 'Step by step guide to reset your password',
+            'show_in_service_catalog' => 1,
+            'forms_categories_id' => 0,
+        ]);
+
+        // Create knowbase item with category
+        $category = $this->createItem(Category::class, [
+            'name' => 'IT Support',
+        ]);
+        $kb_item2 = $this->createKnowbaseItem([
+            'name' => 'VPN Setup Guide',
+            'description' => 'How to configure VPN',
+            'answer' => 'Detailed VPN configuration steps',
+            'show_in_service_catalog' => 1,
+            'forms_categories_id' => $category->getID(),
+        ]);
+
+        // Create request without category filter
+        $request = new ItemRequest(
+            access_parameters: new FormAccessParameters(
+                session_info: Session::getCurrentSessionInfo()
+            ),
+            filter: ''
+        );
+
+        $knowbase_items = $this->provider->getItems($request);
+
+        // Both items should be returned
+        $kb_names = array_column(array_map(fn($kb) => $kb->fields, $knowbase_items), 'name');
+        $this->assertContains('How to reset password', $kb_names);
+        $this->assertContains('VPN Setup Guide', $kb_names);
+    }
+
+    /**
+     * Test that only knowbase items from specified category are returned when category filter is applied
+     */
+    public function testGetItemsWithCategoryFilter()
+    {
+        $this->login();
+
+        // Create categories
+        $category1 = $this->createItem(Category::class, [
+            'name' => 'IT Support',
+        ]);
+        $category2 = $this->createItem(Category::class, [
+            'name' => 'HR Services',
+        ]);
+
+        // Create knowbase items
+        $kb_without_category = $this->createKnowbaseItem([
+            'name' => 'General FAQ',
+            'description' => 'Frequently asked questions',
+            'answer' => 'Common questions and answers',
+            'show_in_service_catalog' => 1,
+            'forms_categories_id' => 0,
+        ]);
+
+        $kb_category1 = $this->createKnowbaseItem([
+            'name' => 'IT Troubleshooting',
+            'description' => 'Technical problem solutions',
+            'answer' => 'How to solve common IT issues',
+            'show_in_service_catalog' => 1,
+            'forms_categories_id' => $category1->getID(),
+        ]);
+
+        $kb_category2 = $this->createKnowbaseItem([
+            'name' => 'HR Policies',
+            'description' => 'Company HR policies',
+            'answer' => 'Employee handbook and policies',
+            'show_in_service_catalog' => 1,
+            'forms_categories_id' => $category2->getID(),
+        ]);
+
+        // Create request with category 1 filter
+        $request = new ItemRequest(
+            access_parameters: new FormAccessParameters(
+                session_info: Session::getCurrentSessionInfo()
+            ),
+            filter: '',
+            category_id: $category1->getID()
+        );
+
+        $knowbase_items = $this->provider->getItems($request);
+
+        // Only item from category 1 should be returned
+        $kb_names = array_column(array_map(fn($kb) => $kb->fields, $knowbase_items), 'name');
+        $this->assertContains('IT Troubleshooting', $kb_names);
+        $this->assertNotContains('General FAQ', $kb_names);
+        $this->assertNotContains('HR Policies', $kb_names);
+    }
+
+    /**
+     * Test that only items marked for service catalog are returned
+     */
+    public function testOnlyServiceCatalogItemsReturned()
+    {
+        $this->login();
+
+        // Create knowbase items
+        $kb_in_catalog = $this->createKnowbaseItem([
+            'name' => 'Service Catalog Item',
+            'description' => 'Item visible in service catalog',
+            'answer' => 'This item should appear in service catalog',
+            'show_in_service_catalog' => 1,
+        ]);
+
+        $kb_not_in_catalog = $this->createKnowbaseItem([
+            'name' => 'Internal Documentation',
+            'description' => 'Internal use only',
+            'answer' => 'This item should not appear in service catalog',
+            'show_in_service_catalog' => 0,
+        ]);
+
+        // Create request
+        $request = new ItemRequest(
+            access_parameters: new FormAccessParameters(
+                session_info: Session::getCurrentSessionInfo()
+            ),
+            filter: ''
+        );
+
+        $knowbase_items = $this->provider->getItems($request);
+        $kb_names = array_column(array_map(fn($kb) => $kb->fields, $knowbase_items), 'name');
+
+        // Only item marked for service catalog should be returned
+        $this->assertContains('Service Catalog Item', $kb_names);
+        $this->assertNotContains('Internal Documentation', $kb_names);
+    }
+
+    /**
+     * Test that knowbase items are filtered by name using fuzzy matching
+     */
+    public function testKnowbaseItemsFilteredByName()
+    {
+        $this->login();
+
+        // Create knowbase items with different names
+        $kb1 = $this->createKnowbaseItem([
+            'name' => 'Password Reset Guide',
+            'description' => 'How to reset passwords',
+            'answer' => 'Step by step password reset',
+            'show_in_service_catalog' => 1,
+        ]);
+
+        $kb2 = $this->createKnowbaseItem([
+            'name' => 'Email Configuration',
+            'description' => 'Setting up email clients',
+            'answer' => 'Configure your email application',
+            'show_in_service_catalog' => 1,
+        ]);
+
+        $kb3 = $this->createKnowbaseItem([
+            'name' => 'VPN Access Guide',
+            'description' => 'Remote access setup',
+            'answer' => 'Connect to company VPN',
+            'show_in_service_catalog' => 1,
+        ]);
+
+        // Test filter by name
+        $request = new ItemRequest(
+            access_parameters: new FormAccessParameters(
+                session_info: Session::getCurrentSessionInfo()
+            ),
+            filter: 'password'
+        );
+
+        $knowbase_items = $this->provider->getItems($request);
+        $kb_names = array_column(array_map(fn($kb) => $kb->fields, $knowbase_items), 'name');
+
+        // Should match "Password Reset Guide" (name contains "password")
+        $this->assertContains('Password Reset Guide', $kb_names);
+        $this->assertNotContains('Email Configuration', $kb_names);
+        $this->assertNotContains('VPN Access Guide', $kb_names);
+    }
+
+    /**
+     * Test that knowbase items are filtered by description using fuzzy matching
+     */
+    public function testKnowbaseItemsFilteredByDescription()
+    {
+        $this->login();
+
+        // Create knowbase items with different descriptions
+        $kb1 = $this->createKnowbaseItem([
+            'name' => 'Account Management',
+            'description' => 'User account troubleshooting and support',
+            'answer' => 'Manage user accounts effectively',
+            'show_in_service_catalog' => 1,
+        ]);
+
+        $kb2 = $this->createKnowbaseItem([
+            'name' => 'Software Installation',
+            'description' => 'How to install business applications',
+            'answer' => 'Step by step software setup',
+            'show_in_service_catalog' => 1,
+        ]);
+
+        $kb3 = $this->createKnowbaseItem([
+            'name' => 'Network Issues',
+            'description' => 'Connectivity problems and solutions',
+            'answer' => 'Resolve network connectivity issues',
+            'show_in_service_catalog' => 1,
+        ]);
+
+        // Test filter by description content
+        $request = new ItemRequest(
+            access_parameters: new FormAccessParameters(
+                session_info: Session::getCurrentSessionInfo()
+            ),
+            filter: 'troubleshooting'
+        );
+
+        $knowbase_items = $this->provider->getItems($request);
+        $kb_names = array_column(array_map(fn($kb) => $kb->fields, $knowbase_items), 'name');
+
+        // Should match "Account Management" (description contains "troubleshooting")
+        $this->assertContains('Account Management', $kb_names);
+        $this->assertNotContains('Software Installation', $kb_names);
+        $this->assertNotContains('Network Issues', $kb_names);
+    }
+
+    /**
+     * Test that knowbase items are filtered by answer using fuzzy matching
+     */
+    public function testKnowbaseItemsFilteredByAnswer()
+    {
+        $this->login();
+
+        // Create knowbase items with different answer content
+        $kb1 = $this->createKnowbaseItem([
+            'name' => 'System Access',
+            'description' => 'Getting system access',
+            'answer' => 'Contact administrator for authentication setup',
+            'show_in_service_catalog' => 1,
+        ]);
+
+        $kb2 = $this->createKnowbaseItem([
+            'name' => 'File Sharing',
+            'description' => 'Share files securely',
+            'answer' => 'Use the company file sharing platform',
+            'show_in_service_catalog' => 1,
+        ]);
+
+        $kb3 = $this->createKnowbaseItem([
+            'name' => 'Backup Procedures',
+            'description' => 'Data backup guidelines',
+            'answer' => 'Regular backup ensures data safety',
+            'show_in_service_catalog' => 1,
+        ]);
+
+        // Test filter by answer content
+        $request = new ItemRequest(
+            access_parameters: new FormAccessParameters(
+                session_info: Session::getCurrentSessionInfo()
+            ),
+            filter: 'administrator'
+        );
+
+        $knowbase_items = $this->provider->getItems($request);
+        $kb_names = array_column(array_map(fn($kb) => $kb->fields, $knowbase_items), 'name');
+
+        // Should match "System Access" (answer contains "administrator")
+        $this->assertContains('System Access', $kb_names);
+        $this->assertNotContains('File Sharing', $kb_names);
+        $this->assertNotContains('Backup Procedures', $kb_names);
+    }
+
+    /**
+     * Test that knowbase items are filtered by name, description, and answer
+     */
+    public function testKnowbaseItemsFilteredByAllFields()
+    {
+        $this->login();
+
+        // Create knowbase items
+        $kb1 = $this->createKnowbaseItem([
+            'name' => 'Security Guidelines',
+            'description' => 'Information security best practices',
+            'answer' => 'Follow these guidelines for data protection',
+            'show_in_service_catalog' => 1,
+        ]);
+
+        $kb2 = $this->createKnowbaseItem([
+            'name' => 'Password Policy',
+            'description' => 'Company password requirements',
+            'answer' => 'Create strong passwords for security',
+            'show_in_service_catalog' => 1,
+        ]);
+
+        $kb3 = $this->createKnowbaseItem([
+            'name' => 'Email Usage',
+            'description' => 'Best practices for email',
+            'answer' => 'Best practices for business email',
+            'show_in_service_catalog' => 1,
+        ]);
+
+        // Test filter that matches different fields
+        $request = new ItemRequest(
+            access_parameters: new FormAccessParameters(
+                session_info: Session::getCurrentSessionInfo()
+            ),
+            filter: 'security'
+        );
+
+        $knowbase_items = $this->provider->getItems($request);
+        $kb_names = array_column(array_map(fn($kb) => $kb->fields, $knowbase_items), 'name');
+
+        // Should match "Security Guidelines" (name) and "Password Policy" (answer)
+        $this->assertContains('Security Guidelines', $kb_names);
+        $this->assertContains('Password Policy', $kb_names);
+        $this->assertNotContains('Email Usage', $kb_names);
+    }
+
+    /**
+     * Test that knowbase items are sorted by name
+     */
+    public function testKnowbaseItemsSortedByName()
+    {
+        $this->login();
+
+        // Create knowbase items in non-alphabetical order
+        $kb_z = $this->createKnowbaseItem([
+            'name' => 'Zoom Usage Guide',
+            'description' => 'How to use Zoom',
+            'answer' => 'Video conferencing with Zoom',
+            'show_in_service_catalog' => 1,
+        ]);
+
+        $kb_a = $this->createKnowbaseItem([
+            'name' => 'Account Setup',
+            'description' => 'New user account setup',
+            'answer' => 'Setting up new accounts',
+            'show_in_service_catalog' => 1,
+        ]);
+
+        $kb_m = $this->createKnowbaseItem([
+            'name' => 'Mobile Device Policy',
+            'description' => 'Company mobile device guidelines',
+            'answer' => 'Using mobile devices at work',
+            'show_in_service_catalog' => 1,
+        ]);
+
+        // Create request without filter
+        $request = new ItemRequest(
+            access_parameters: new FormAccessParameters(
+                session_info: Session::getCurrentSessionInfo()
+            ),
+            filter: ''
+        );
+
+        $knowbase_items = $this->provider->getItems($request);
+        $kb_names = array_map(fn($kb) => $kb->fields['name'], $knowbase_items);
+
+        // Items should be sorted alphabetically by name
+        $expected_order = ['Account Setup', 'Mobile Device Policy', 'Zoom Usage Guide'];
+        $this->assertEquals($expected_order, $kb_names);
+    }
+
+    /**
+     * Test that no knowbase items are returned when filter doesn't match anything
+     */
+    public function testNoMatchingKnowbaseItems()
+    {
+        $this->login();
+
+        // Create a knowbase item
+        $kb = $this->createKnowbaseItem([
+            'name' => 'IT Support Guide',
+            'description' => 'Technical assistance',
+            'answer' => 'Get help with technical issues',
+            'show_in_service_catalog' => 1,
+        ]);
+
+        // Test filter that doesn't match
+        $request = new ItemRequest(
+            access_parameters: new FormAccessParameters(
+                session_info: Session::getCurrentSessionInfo()
+            ),
+            filter: 'nonexistent'
+        );
+
+        $knowbase_items = $this->provider->getItems($request);
+
+        // No items should be returned
+        $this->assertEmpty($knowbase_items);
+    }
+
+    /**
+     * Test that empty filter returns all service catalog knowbase items
+     */
+    public function testEmptyFilterReturnsAllServiceCatalogItems()
+    {
+        $this->login();
+
+        // Create knowbase items
+        $kb1 = $this->createKnowbaseItem([
+            'name' => 'Item One',
+            'description' => 'First item',
+            'answer' => 'First item content',
+            'show_in_service_catalog' => 1,
+        ]);
+
+        $kb2 = $this->createKnowbaseItem([
+            'name' => 'Item Two',
+            'description' => 'Second item',
+            'answer' => 'Second item content',
+            'show_in_service_catalog' => 1,
+        ]);
+
+        // Test with empty filter
+        $request = new ItemRequest(
+            access_parameters: new FormAccessParameters(
+                session_info: Session::getCurrentSessionInfo()
+            ),
+            filter: ''
+        );
+
+        $knowbase_items = $this->provider->getItems($request);
+
+        // All service catalog items should be returned
+        $this->assertCount(2, $knowbase_items);
+        $kb_names = array_column(array_map(fn($kb) => $kb->fields, $knowbase_items), 'name');
+        $this->assertContains('Item One', $kb_names);
+        $this->assertContains('Item Two', $kb_names);
+    }
+
+    /**
+     * Test that knowbase items with empty fields are handled properly
+     */
+    public function testKnowbaseItemsWithEmptyFields()
+    {
+        $this->login();
+
+        // Create knowbase item with empty description
+        $kb1 = $this->createKnowbaseItem([
+            'name' => 'Item with empty description',
+            'description' => '',
+            'answer' => 'Only answer here',
+            'show_in_service_catalog' => 1,
+        ]);
+
+        // Create knowbase item with empty content
+        $kb2 = $this->createKnowbaseItem([
+            'name' => 'Item with empty name',
+            'description' => 'Only description here',
+            'answer' => '',
+            'show_in_service_catalog' => 1,
+        ]);
+
+        // Test filter that should match the content/description
+        $request = new ItemRequest(
+            access_parameters: new FormAccessParameters(
+                session_info: Session::getCurrentSessionInfo()
+            ),
+            filter: 'description'
+        );
+
+        $knowbase_items = $this->provider->getItems($request);
+        $kb_ids = array_map(fn($kb) => $kb->fields['id'], $knowbase_items);
+
+        // Should match both items
+        $this->assertContains($kb1->getID(), $kb_ids);
+        $this->assertContains($kb2->getID(), $kb_ids);
+    }
+
+    /**
+     * Helper method to create a knowbase item
+     */
+    private function createKnowbaseItem(array $input): KnowbaseItem
+    {
+        return $this->createItem(KnowbaseItem::class, $input);
+    }
+}

--- a/phpunit/functional/Glpi/Form/ServiceCatalog/ServiceCatalogManagerTest.php
+++ b/phpunit/functional/Glpi/Form/ServiceCatalog/ServiceCatalogManagerTest.php
@@ -687,7 +687,8 @@ final class ServiceCatalogManagerTest extends \DbTestCase
         // Get the root items
         $this->login();
         $item_request = new ItemRequest(
-            new FormAccessParameters(Session::getCurrentSessionInfo()),
+            access_parameters: new FormAccessParameters(Session::getCurrentSessionInfo()),
+            category_id: 0,
         );
         $items = self::$manager->getItems($item_request)['items'];
         $items_names = array_map(

--- a/src/Glpi/Controller/ServiceCatalog/ItemsController.php
+++ b/src/Glpi/Controller/ServiceCatalog/ItemsController.php
@@ -94,6 +94,11 @@ final class ItemsController extends AbstractController
             url_parameters: $request->query->all()
         );
 
+        // If we have a filter, we search in all categories
+        if (!empty($filter)) {
+            $category_id = null;
+        }
+
         // Get items from the service catalog
         $item_request = new ItemRequest(
             access_parameters: $parameters,

--- a/src/Glpi/Form/ServiceCatalog/Provider/CategoryProvider.php
+++ b/src/Glpi/Form/ServiceCatalog/Provider/CategoryProvider.php
@@ -57,14 +57,19 @@ final class CategoryProvider implements CompositeProviderInterface
         $category_id = $item_request->getCategoryID();
         $filter = $item_request->getFilter();
 
-        $categories = [];
-        $raw_categories = (new Category())->find([
-            'forms_categories_id' => $category_id ?? 0,
-        ], ['name']);
+        $category_restriction = [];
+        if ($category_id !== null) {
+            $category_restriction = [
+                'forms_categories_id' => $category_id,
+            ];
+        }
 
-        foreach ($raw_categories as $raw_categoriy) {
+        $categories = [];
+        $raw_categories = (new Category())->find($category_restriction, ['name']);
+
+        foreach ($raw_categories as $raw_category) {
             $category = new Category();
-            $category->getFromResultSet($raw_categoriy);
+            $category->getFromResultSet($raw_category);
             $category->post_getFromDB();
 
             // Fuzzy matching

--- a/src/Glpi/Form/ServiceCatalog/Provider/KnowbaseItemProvider.php
+++ b/src/Glpi/Form/ServiceCatalog/Provider/KnowbaseItemProvider.php
@@ -56,11 +56,17 @@ final class KnowbaseItemProvider implements LeafProviderInterface
         $category_id = $item_request->getCategoryID();
         $filter = $item_request->getFilter();
 
+        $category_restriction = [];
+        if ($category_id !== null) {
+            $category_restriction = [
+                'forms_categories_id' => $category_id,
+            ];
+        }
+
         $knowbase_items = [];
         $raw_knowbase_items = (new KnowbaseItem())->find([
-            'forms_categories_id'     => $category_id ?? 0,
             'show_in_service_catalog' => true,
-        ], ['name']);
+        ] + $category_restriction, ['name']);
 
         foreach ($raw_knowbase_items as $raw_knowbase_item) {
             $knowbase_item = new KnowbaseItem();
@@ -69,11 +75,11 @@ final class KnowbaseItemProvider implements LeafProviderInterface
 
             // Fuzzy matching
             $name        = $knowbase_item->fields['name'] ?? "";
-            $content     = $knowbase_item->fields['content'] ?? "";
+            $answer     = $knowbase_item->fields['answer'] ?? "";
             $description = $knowbase_item->fields['description'] ?? "";
             if (
                 !$this->matcher->match($name, $filter)
-                && !$this->matcher->match($content, $filter)
+                && !$this->matcher->match($answer, $filter)
                 && !$this->matcher->match($description, $filter)
             ) {
                 continue;

--- a/tests/cypress/e2e/form/service_catalog/service_catalog_page.cy.js
+++ b/tests/cypress/e2e/form/service_catalog/service_catalog_page.cy.js
@@ -252,7 +252,7 @@ describe('Service catalog page', () => {
         cy.get('@filter_input').type('application');
         cy.waitForNetworkIdle(1000);
         findItemInServiceCatalog(kb_name_1).should('not.exist');
-        findItemInServiceCatalog(kb_name_2).should('not.exist');
+        findItemInServiceCatalog(kb_name_2).should('exist');
     });
 
     it('can pick a category in the service catalog', () => {

--- a/tests/cypress/e2e/form/service_catalog/service_catalog_page.cy.js
+++ b/tests/cypress/e2e/form/service_catalog/service_catalog_page.cy.js
@@ -690,4 +690,36 @@ describe('Service catalog page', () => {
         cy.findByRole('region', { 'name': form_name }).should('not.exist');
         cy.findByRole('region', { 'name': 'Forms' }).contains('No forms found').should('exist');
     });
+
+    it('can filter forms, kb items and categories nested in category', () => {
+        const uuid = Cypress._.uniqueId(Date.now().toString());
+
+        // Arrange: Create categories, form and KB item
+        cy.createWithAPI('Glpi\\Form\\Category', {
+            'name': `Root Category ${uuid}`,
+        }).then(category_id => {
+            cy.createWithAPI('Glpi\\Form\\Category', {
+                'name': `Nested category ${uuid}`,
+                'forms_categories_id': category_id
+            }).then(sub_category_id => {
+                createActiveForm(`Nested form for ${sub_category_id}`, sub_category_id);
+            });
+
+            createActiveForm(`Nested form ${uuid}`, category_id);
+            createKnowledgeBaseItem(`Nested KB item ${uuid}`, {'forms_categories_id': category_id});
+        });
+
+        // Act: Visit the service catalog and apply filters
+        cy.visit('/ServiceCatalog');
+        cy.findByPlaceholderText('Search for forms...').as('filter_input');
+        cy.get('@filter_input').type(`Nested ${uuid}`);
+
+        // Wait input debounce
+        cy.waitForNetworkIdle(1000);
+
+        // Assert: Check that the correct category, form and KB item are displayed
+        findItemInServiceCatalog(`Nested category ${uuid}`).should('exist');
+        findItemInServiceCatalog(`Nested form ${uuid}`).should('exist');
+        findItemInServiceCatalog(`Nested KB item ${uuid}`).should('exist');
+    });
 });


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes #20660

Fixed search input in the service catalog: the search was only performed in the current category (or at the root if there was no category).
This PR fixes this issue by ignoring the category filter in the case of a search filter.