### PR TITLE
restore completname as default column for CommonTreeDropdown's

### DIFF
--- a/phpunit/functional/Glpi/Search/SearchOptionTest.php
+++ b/phpunit/functional/Glpi/Search/SearchOptionTest.php
@@ -45,6 +45,7 @@ class SearchOptionTest extends DbTestCase
     {
         return [
             [\Computer::class, [1, 80]], // Name, Entity
+            [\ITILCategory::class, [1, 80]], // Completename, Entity
             [\Item_DeviceSimcard::class, [10, 80]], // Serial (marked as the name field), Entity
             [\Ticket::class, [2, 1, 80]], // ID (Always shown for ITIL Objects), Name, Entity
             [\KnowbaseItem::class, [1, 80]], // Name, Entity Target

--- a/src/Glpi/Search/SearchOption.php
+++ b/src/Glpi/Search/SearchOption.php
@@ -717,14 +717,19 @@ final class SearchOption implements ArrayAccess
         if ($itemtype !== AllAssets::getType()) {
             $item = getItemForItemtype($itemtype);
             $entity_check = $item->isEntityAssign();
-        }
 
-        if ($itemtype !== AllAssets::getType()) {
             // Add the related search option for the 'name' OR 'id' field. If none is found, add the search option 1 (how it was handled before).
             // Since not all itemtypes have ID set to 1, it used to add other, heavier search options like content in the case of Followups.
+
+            // force completename for CommonTreeDropdown itemtypes to improve readability
+            $namefield_key = $itemtype::getNameField();
+            if ($item instanceof CommonTreeDropdown) {
+                $namefield_key = $itemtype::getCompleteNameField();
+            }
+
             $options = array_filter(self::getOptionsForItemtype($itemtype, false), static fn($o) => is_numeric($o), ARRAY_FILTER_USE_KEY);
             $id_field = array_filter($options, static fn($option) => $option['field'] === $itemtype::getIndexName() && $option['table'] === $itemtype::getTable());
-            $name_field = array_filter($options, static fn($option) => $option['field'] === $itemtype::getNameField() && $option['table'] === $itemtype::getTable());
+            $name_field = array_filter($options, static fn($option) => $option['field'] === $namefield_key && $option['table'] === $itemtype::getTable());
         } else {
             $id_field = [];
             $name_field = [];


### PR DESCRIPTION
May fixes also #20707 (I suspect the last screenshot was a Location one which is a CommonTreeDropdown)

in 11 
<img width="1066" height="379" alt="image" src="https://github.com/user-attachments/assets/58d7783c-96c7-437f-9b36-0bb9e4fc9fda" />

in 10
<img width="1246" height="660" alt="image" src="https://github.com/user-attachments/assets/0ae25180-f753-4293-bec8-84e956d3b2ad" />
