### PR TITLE
fix(entity-selector): Make the entity selection dropdown menu scrollable when necessary

### DIFF
--- a/templates/layout/parts/profile_selector.html.twig
+++ b/templates/layout/parts/profile_selector.html.twig
@@ -79,7 +79,7 @@
             <i class="ti ti-stack"></i>
             {{ current_entity_short|u.truncate(35, '...') }}
         </a>
-        <div class="dropdown-menu p-3">
+        <div class="dropdown-menu p-3 overflow-y-auto" style="max-height: calc(100vh - 8rem)">
             <h3>{{ __('Select the desired entity') }}</h3>
 
             <div class="alert alert-info" role="alert">


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes #20504

When a screen has a width greater than or equal to 992 pixels (≥ large viewport) with a low height, the dropdown menu for selecting entities may not be fully visible on the screen.
In this case, it is not possible to scroll to display the hidden information.
Since the dropdown menu is initialized in the navbar, it inherits the fixed position on the screen.
This problem does not occur on smaller screens, as the navbar is managed differently.

## Screenshots

### Before
![Capture vidéo du 27-08-2025 16:26:02](https://github.com/user-attachments/assets/45dab7b2-bff0-4f47-9d20-3c884fd081d7)

### After
![Capture vidéo du 27-08-2025 16:22:21](https://github.com/user-attachments/assets/518bfca4-6e98-4ca4-a4dc-27e61c828670)
