### PR TITLE
fix(service-catalog): Fixed opacity issue with service catalog tab

### DIFF
--- a/templates/pages/admin/form/service_catalog_tab.html.twig
+++ b/templates/pages/admin/form/service_catalog_tab.html.twig
@@ -35,7 +35,7 @@
 <form method="POST" action="{{ item.getFormURL() }}" data-submit-once>
     <div class="py-2 px-3 container-narrow ms-0">
         <section data-service-catalog-config
-            style="{{ item.isField('show_in_service_catalog') and item.fields.show_in_service_catalog ? "" : "opacity: 0.5" }}"
+            style="{{ item.fields.show_in_service_catalog|default(true) ? "" : "opacity: 0.5" }}"
         >
             <h2 class="d-flex align-items-center">
                 <i class="{{ icon }} me-2"></i>


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

PR #20804 was merged a little too quickly and introduced a bug with the opacity of the service catalog configuration tab.
The tab was inevitably semi-visible when the parent object did not have a `show_in_service_catalog` property.