### PR TITLE
better adaptive colors icons for dark palettes

### DIFF
--- a/css/includes/_palette_dark.scss
+++ b/css/includes/_palette_dark.scss
@@ -71,6 +71,11 @@
     --glpi-timeline-badge-fg: rgb(236, 236, 236, 80%);
     --glpi-badge-bg: color-mix(in srgb, var(--tblr-link-color), var(--tblr-dark) 85%);
 
+    --glpi-illustrations-background: rgb(204, 204, 204);
+    --glpi-illustrations-primary: hsl(from var(--tblr-primary) h s 65);
+    --glpi-illustrations-header-dark: hsl(from var(--glpi-illustrations-background) h s 30);
+    --glpi-illustrations-header-light: hsl(from var(--glpi-illustrations-background) h s 50);
+
     .navbar-nav.user-menu .bg-red-lt {
         background-color: rgb(214, 57, 57, 20%) !important
     }

--- a/css/includes/_palette_dark.scss
+++ b/css/includes/_palette_dark.scss
@@ -70,7 +70,6 @@
     --glpi-timeline-badge-bg: rgb(104, 104, 104, 15%);
     --glpi-timeline-badge-fg: rgb(236, 236, 236, 80%);
     --glpi-badge-bg: color-mix(in srgb, var(--tblr-link-color), var(--tblr-dark) 85%);
-
     --glpi-illustrations-background: rgb(204, 204, 204);
     --glpi-illustrations-primary: hsl(from var(--tblr-primary) h s 65);
     --glpi-illustrations-header-dark: hsl(from var(--glpi-illustrations-background) h s 30);


### PR DESCRIPTION
It fixes #20725
Current PR make a global style for **all** dark palettes when displaying home and “service catalog” icons.

**darker**
<img width="2008" height="829" alt="image" src="https://github.com/user-attachments/assets/74043f76-769c-4728-ad33-121ac40024cd" />

**midnight**
<img width="1971" height="801" alt="image" src="https://github.com/user-attachments/assets/baab710a-5626-4055-a54f-9d1d82bc8376" />

**dark auror**
<img width="1964" height="768" alt="image" src="https://github.com/user-attachments/assets/6c64538d-3152-4322-b528-6461f70e8b63" />

