### PR TITLE
Pass missing required attribute

### DIFF
--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -301,6 +301,7 @@ class Dropdown
             'multiple'             => $params['multiple'] ?? false,
             'init'                 => $params['init'] ?? true,
             'aria_label'           => $params['aria_label'],
+            'required'             => $params['required'],
         ];
 
         if ($params['multiple']) {


### PR DESCRIPTION
Required attribute was never passed from `Dropdown::show()` to `Html::jsAjaxDropdown()` - while this one has support for it.