### PR TITLE
Drop useless comments related to `phpcs`

### DIFF
--- a/front/rule.backup.php
+++ b/front/rule.backup.php
@@ -86,13 +86,11 @@ switch ($action) {
         echo "<a href='" . htmlescape($itemtype::getSearchURL()) . "'>" . __s('Back') . "</a>";
         echo "</div>";
         Html::redirect("rule.backup.php?action=export&itemtype=" . urlencode($_REQUEST['itemtype']));
-        // phpcs doesn't understand that the script stops in Html::redirect() so we need a comment to avoid the fallthrough warning
         // no break
     case "process_import":
         $rulecollection->checkGlobal(UPDATE);
         RuleCollection::processImportRules();
         Html::back();
-        // phpcs doesn't understand that the script stops in Html::redirect() so we need a comment to avoid the fallthrough warning
 }
 if ($action !== "export") {
     Html::footer();

--- a/phpunit/functional/SearchTest.php
+++ b/phpunit/functional/SearchTest.php
@@ -6131,8 +6131,6 @@ class DupSearchOpt extends CommonDBTM
     }
 }
 
-// phpcs:ignore SlevomatCodingStandard.Namespaces
-
 namespace SearchTest;
 
 // @codingStandardsIgnoreStart

--- a/src/GLPIPDF.php
+++ b/src/GLPIPDF.php
@@ -115,7 +115,7 @@ class GLPIPDF extends TCPDF
      *
      * @see TCPDF::Header()
     **/
-    public function Header() // phpcs:ignore PSR1.Methods.CamelCapsMethodName
+    public function Header()
     {
         // Title
         $this->Cell(0, $this->config['margin_bottom'], $this->title, 0, 0, 'C', false, '', 0, false, 'M', 'M');
@@ -127,7 +127,7 @@ class GLPIPDF extends TCPDF
      *
      * @see TCPDF::Footer()
     **/
-    public function Footer() // phpcs:ignore PSR1.Methods.CamelCapsMethodName
+    public function Footer()
     {
         // Position at 15 mm from bottom
         $this->SetY(-$this->config['margin_bottom']);

--- a/stubs/db_config_classes.php
+++ b/stubs/db_config_classes.php
@@ -35,8 +35,6 @@
 // This file contains class stubs for the DB config classes.
 // It permits to indicates to PHPStan and IDEs that the `DB` and the `DBSlave` classes are extending the `DBmysql` class.
 
-// phpcs:disable PSR1.Classes.ClassDeclaration
-
 if (!class_exists('DB', false)) {
     class DB extends DBmysql {}
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Since we do not use anymore `PHP_CodeSniffer`, these comments are useless.