### PR TITLE
feat(forms): Implement "Is empty/Is not empty" value operator

### DIFF
--- a/phpunit/functional/Glpi/Form/Condition/ConditionHandler/EmptyConditionHandlerTest.php
+++ b/phpunit/functional/Glpi/Form/Condition/ConditionHandler/EmptyConditionHandlerTest.php
@@ -1,0 +1,309 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Form\Condition\ConditionHandler;
+
+use Glpi\Form\Condition\ValueOperator;
+use Glpi\Form\QuestionType\QuestionTypeActorsExtraDataConfig;
+use Glpi\Form\QuestionType\QuestionTypeAssignee;
+use Glpi\Form\QuestionType\QuestionTypeCheckbox;
+use Glpi\Form\QuestionType\QuestionTypeDateTime;
+use Glpi\Form\QuestionType\QuestionTypeDateTimeExtraDataConfig;
+use Glpi\Form\QuestionType\QuestionTypeDropdown;
+use Glpi\Form\QuestionType\QuestionTypeDropdownExtraDataConfig;
+use Glpi\Form\QuestionType\QuestionTypeEmail;
+use Glpi\Form\QuestionType\QuestionTypeFile;
+use Glpi\Form\QuestionType\QuestionTypeItem;
+use Glpi\Form\QuestionType\QuestionTypeItemDefaultValueConfig;
+use Glpi\Form\QuestionType\QuestionTypeItemDropdown;
+use Glpi\Form\QuestionType\QuestionTypeItemDropdownExtraDataConfig;
+use Glpi\Form\QuestionType\QuestionTypeItemExtraDataConfig;
+use Glpi\Form\QuestionType\QuestionTypeLongText;
+use Glpi\Form\QuestionType\QuestionTypeNumber;
+use Glpi\Form\QuestionType\QuestionTypeObserver;
+use Glpi\Form\QuestionType\QuestionTypeRadio;
+use Glpi\Form\QuestionType\QuestionTypeRequester;
+use Glpi\Form\QuestionType\QuestionTypeRequestType;
+use Glpi\Form\QuestionType\QuestionTypeSelectableExtraDataConfig;
+use Glpi\Form\QuestionType\QuestionTypeShortText;
+use Glpi\Form\QuestionType\QuestionTypesManager;
+use Glpi\Form\QuestionType\QuestionTypeUrgency;
+use Glpi\Form\QuestionType\QuestionTypeUserDevice;
+use Glpi\Form\QuestionType\QuestionTypeUserDevicesConfig;
+use Location;
+use Override;
+use Software;
+use tests\units\Glpi\Form\Condition\AbstractConditionHandler;
+
+final class EmptyConditionHandlerTest extends AbstractConditionHandler
+{
+    public static function getConditionHandler(): ConditionHandlerInterface
+    {
+        return new EmptyConditionHandler(new QuestionTypeShortText(), null);
+    }
+
+    #[Override]
+    public static function conditionHandlerProvider(): iterable
+    {
+        $types = [
+            // List each types and their configs
+            "QuestionTypeItem" => [
+                'type'             => QuestionTypeItem::class,
+                'extra_data'       => new QuestionTypeItemExtraDataConfig(
+                    itemtype: Software::class,
+                ),
+                'empty_answer'     => (new QuestionTypeItemDefaultValueConfig())->jsonSerialize(),
+                'not_empty_answer' => (new QuestionTypeItemDefaultValueConfig(1))->jsonSerialize(),
+            ],
+            "QuestionTypeLongText" => [
+                'type'             => QuestionTypeLongText::class,
+                'empty_answer'     => '',
+                'not_empty_answer' => '<p>Not empty long text</p>',
+            ],
+            "QuestionTypeShortText" => [
+                'type'             => QuestionTypeShortText::class,
+                'empty_answer'     => '',
+                'not_empty_answer' => 'Not empty short text',
+            ],
+            "QuestionTypeEmail" => [
+                'type'             => QuestionTypeEmail::class,
+                'empty_answer'     => '',
+                'not_empty_answer' => 'test@test.test',
+            ],
+            "QuestionTypeNumber" => [
+                'type'             => QuestionTypeNumber::class,
+                'empty_answer'     => "",
+                'not_empty_answer' => 1,
+            ],
+            "QuestionTypeRequester (simple)" => [
+                'type'             => QuestionTypeRequester::class,
+                'extra_data'       => new QuestionTypeActorsExtraDataConfig(
+                    is_multiple_actors: false,
+                ),
+                'empty_answer'     => [],
+                'not_empty_answer' => ['users_id-2'],
+            ],
+            "QuestionTypeRequester (multiple)" => [
+                'type'             => QuestionTypeRequester::class,
+                'extra_data'       => new QuestionTypeActorsExtraDataConfig(
+                    is_multiple_actors: true,
+                ),
+                'empty_answer'     => [],
+                'not_empty_answer' => ['users_id-3', 'users_id-2'],
+            ],
+            "QuestionTypeObserver (simple)" => [
+                'type'             => QuestionTypeObserver::class,
+                'extra_data'       => new QuestionTypeActorsExtraDataConfig(
+                    is_multiple_actors: false,
+                ),
+                'empty_answer'     => [],
+                'not_empty_answer' => ['users_id-2'],
+            ],
+            "QuestionTypeObserver (multiple)" => [
+                'type'             => QuestionTypeObserver::class,
+                'extra_data'       => new QuestionTypeActorsExtraDataConfig(
+                    is_multiple_actors: true,
+                ),
+                'empty_answer'     => [],
+                'not_empty_answer' => ['users_id-3', 'users_id-2'],
+            ],
+            "QuestionTypeAssignee (simple)" => [
+                'type'             => QuestionTypeAssignee::class,
+                'extra_data'       => new QuestionTypeActorsExtraDataConfig(
+                    is_multiple_actors: false,
+                ),
+                'empty_answer'     => [],
+                'not_empty_answer' => ['users_id-2'],
+            ],
+            "QuestionTypeAssignee (multiple)" => [
+                'type'             => QuestionTypeAssignee::class,
+                'extra_data'       => new QuestionTypeActorsExtraDataConfig(
+                    is_multiple_actors: true,
+                ),
+                'empty_answer'     => [],
+                'not_empty_answer' => ['users_id-3', 'users_id-2'],
+            ],
+            "QuestionTypeDropdown (simple)" => [
+                'type'             => QuestionTypeDropdown::class,
+                'extra_data'       => new QuestionTypeDropdownExtraDataConfig(
+                    is_multiple_dropdown: false,
+                    options: [1 => 'a', 2 => 'b'],
+                ),
+                'empty_answer'     => [0],
+                'not_empty_answer' => [1],
+            ],
+            "QuestionTypeDropdown (multiple)" => [
+                'type'             => QuestionTypeDropdown::class,
+                'extra_data'       => new QuestionTypeDropdownExtraDataConfig(
+                    is_multiple_dropdown: true,
+                    options: [1 => 'a', 2 => 'b'],
+                ),
+                'empty_answer'     => [0],
+                'not_empty_answer' => [1, 2],
+            ],
+            "QuestionTypeCheckbox" => [
+                'type'             => QuestionTypeCheckbox::class,
+                'extra_data'       => new QuestionTypeSelectableExtraDataConfig(
+                    options: [1 => 'a', 2 => 'b'],
+                ),
+                'empty_answer'     => [0],
+                'not_empty_answer' => [1, 2],
+            ],
+            "QuestionTypeRadio" => [
+                'type'             => QuestionTypeRadio::class,
+                'extra_data'       => new QuestionTypeSelectableExtraDataConfig(
+                    options: [1 => 'a', 2 => 'b'],
+                ),
+                'empty_answer'     => [0],
+                'not_empty_answer' => [1],
+            ],
+            "QuestionTypeUserDevice (simple)" => [
+                'type'             => QuestionTypeUserDevice::class,
+                'extra_data'       => new QuestionTypeUserDevicesConfig(
+                    is_multiple_devices: false,
+                ),
+                'empty_answer'     => "",
+                'not_empty_answer' => ["Computer_1"],
+            ],
+            "QuestionTypeUserDevice (multiple)" => [
+                'type'             => QuestionTypeUserDevice::class,
+                'extra_data'       => new QuestionTypeUserDevicesConfig(
+                    is_multiple_devices: true,
+                ),
+                'empty_answer'     => "",
+                'not_empty_answer' => ["Computer_1", "Computer_2"],
+            ],
+            "QuestionTypeDateTime (date and time)" => [
+                'type'             => QuestionTypeDateTime::class,
+                'extra_data'       => new QuestionTypeDateTimeExtraDataConfig(
+                    is_date_enabled: true,
+                    is_time_enabled: true,
+                ),
+                'empty_answer'     => "",
+                'not_empty_answer' => "2025-08-12T12:24",
+            ],
+            "QuestionTypeDateTime (date)" => [
+                'type'             => QuestionTypeDateTime::class,
+                'extra_data'       => new QuestionTypeDateTimeExtraDataConfig(
+                    is_date_enabled: true,
+                    is_time_enabled: false,
+                ),
+                'empty_answer'     => "",
+                'not_empty_answer' => "2025-08-12",
+            ],
+            "QuestionTypeDateTime (time)" => [
+                'type'             => QuestionTypeDateTime::class,
+                'extra_data'       => new QuestionTypeDateTimeExtraDataConfig(
+                    is_date_enabled: false,
+                    is_time_enabled: true,
+                ),
+                'empty_answer'     => "",
+                'not_empty_answer' => "12:24",
+            ],
+            "QuestionTypeFile" => [
+                'type'             => QuestionTypeFile::class,
+                'empty_answer'     => "",
+                'not_empty_answer' => "file.txt",
+            ],
+            "QuestionTypeUrgency" => [
+                'type'             => QuestionTypeUrgency::class,
+                'empty_answer'     => "0",
+                'not_empty_answer' => "1",
+            ],
+            "QuestionTypeRequestType" => [
+                'type'             => QuestionTypeRequestType::class,
+                'empty_answer'     => "0",
+                'not_empty_answer' => "1",
+            ],
+            "QuestionTypeItemDropdown" => [
+                'type' => QuestionTypeItemDropdown::class,
+                'extra_data' => new QuestionTypeItemDropdownExtraDataConfig(
+                    itemtype: Location::class,
+                ),
+                'empty_answer'     => (new QuestionTypeItemDefaultValueConfig())->jsonSerialize(),
+                'not_empty_answer' => (new QuestionTypeItemDefaultValueConfig(1))->jsonSerialize(),
+            ],
+        ];
+
+        foreach ($types as $label => $data) {
+            $type             = $data['type'];
+            $empty_answer     = $data['empty_answer'];
+            $not_empty_answer = $data['not_empty_answer'];
+            $extra_data       = $data['extra_data'] ?? null;
+
+            /**
+             * Test default empty behavior with questions
+             * Empty conditions are more tested in other test methods
+             */
+            yield "Is empty check for $label" => [
+                'question_type'       => $type,
+                'condition_operator'  => ValueOperator::EMPTY,
+                'condition_value'     => null,
+                'submitted_answer'    => $empty_answer,
+                'expected_result'     => true,
+                'question_extra_data' => $extra_data,
+            ];
+
+            yield "Is not empty check for $label" => [
+                'question_type'       => $type,
+                'condition_operator'  => ValueOperator::NOT_EMPTY,
+                'condition_value'     => null,
+                'submitted_answer'    => $not_empty_answer,
+                'expected_result'     => true,
+                'question_extra_data' => $extra_data,
+            ];
+        }
+    }
+
+    public function testAllQuestionTypesAreTested(): void
+    {
+        // Get a map of all used types in the provider
+        $types = iterator_to_array(self::conditionHandlerProvider());
+        $types_found = array_map(fn($case) => $case['question_type'], $types);
+        $types_map = array_flip($types_found);
+
+        // Get all types defined by the manager
+        $possible_types = QuestionTypesManager::getInstance()->getQuestionTypes();
+        $possible_types_classes = array_map(fn($type) => $type::class, $possible_types);
+
+        foreach ($possible_types_classes as $type) {
+            // Ignore tester plugin types
+            if (str_starts_with($type, "GlpiPlugin\Tester")) {
+                continue;
+            }
+
+            $this->assertArrayHasKey($type, $types_map);
+        }
+    }
+}

--- a/phpunit/functional/Glpi/Form/Condition/EditorManagerTest.php
+++ b/phpunit/functional/Glpi/Form/Condition/EditorManagerTest.php
@@ -351,7 +351,8 @@ final class EditorManagerTest extends GLPITestCase
                 'length_greater_than_or_equals' => __('Length is greater than or equals to'),
                 'length_less_than'              => __('Length is less than'),
                 'length_less_than_or_equals'    => __('Length is less than or equals to'),
-
+                'empty'                         => __('Is empty'),
+                'not_empty'                     => __('Is not empty'),
             ],
         ];
 
@@ -431,6 +432,8 @@ final class EditorManagerTest extends GLPITestCase
             'not_visible'     => __("Is not visible"),
             'match_regex'     => __("Match regular expression"),
             'not_match_regex' => __("Do not match regular expression"),
+            'empty'           => __("Is empty"),
+            'not_empty'       => __("Is not empty"),
         ], $dropdown_values);
     }
 

--- a/phpunit/functional/Glpi/Form/Migration/FormMigrationTest.php
+++ b/phpunit/functional/Glpi/Form/Migration/FormMigrationTest.php
@@ -1550,6 +1550,26 @@ final class FormMigrationTest extends DbTestCase
             'expected_visibility_strategy' => VisibilityStrategy::ALWAYS_VISIBLE,
             'expected_conditions'          => [],
         ];
+
+        yield 'QuestionTypeShortText - Visible if value is not empty' => [
+            'field_type' => 'text',
+            'show_rule'  => 2,
+            'conditions' => [
+                [
+                    'show_condition' => 2,
+                    'show_value'     => '',
+                    'show_logic'     => 1,
+                ],
+            ],
+            'expected_visibility_strategy' => VisibilityStrategy::VISIBLE_IF,
+            'expected_conditions'          => [
+                [
+                    'value_operator' => ValueOperator::NOT_EMPTY,
+                    'value'          => '',
+                    'logic_operator' => LogicOperator::AND,
+                ],
+            ],
+        ];
     }
 
     #[DataProvider('provideFormMigrationVisibilityConditionsForQuestions')]

--- a/src/Glpi/Form/AnswersHandler/AnswersHandler.php
+++ b/src/Glpi/Form/AnswersHandler/AnswersHandler.php
@@ -110,6 +110,7 @@ final class AnswersHandler
             // Check if the question is not answered (empty or not set)
             if (
                 empty($answers[$question->getID()])
+                || (is_string($answers[$question->getID()]) && empty(strip_tags($answers[$question->getID()])))
                 || (isset($answers[$question->getID()]['items_id']) && empty($answers[$question->getID()]['items_id']))
             ) {
                 $result->addError($question, __('This field is mandatory'));

--- a/src/Glpi/Form/Condition/ConditionHandler/EmptyConditionHandler.php
+++ b/src/Glpi/Form/Condition/ConditionHandler/EmptyConditionHandler.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Form\Condition\ConditionHandler;
+
+use Glpi\DBAL\JsonFieldInterface;
+use Glpi\Form\Condition\ConditionData;
+use Glpi\Form\Condition\ConditionValueTransformerInterface;
+use Glpi\Form\Condition\ValueOperator;
+use Glpi\Form\QuestionType\QuestionTypeInterface;
+use Override;
+
+/**
+ * Handler for conditions that check if another form element is empty or not
+ */
+class EmptyConditionHandler implements ConditionHandlerInterface
+{
+    public function __construct(
+        private QuestionTypeInterface $question_type,
+        private ?JsonFieldInterface $question_config
+    ) {}
+
+    #[Override]
+    public function getSupportedValueOperators(): array
+    {
+        return [
+            ValueOperator::EMPTY,
+            ValueOperator::NOT_EMPTY,
+        ];
+    }
+
+    #[Override]
+    public function getTemplate(): null
+    {
+        // No input field needed for empty conditions
+        return null;
+    }
+
+    #[Override]
+    public function getTemplateParameters(ConditionData $condition): array
+    {
+        return [];
+    }
+
+    #[Override]
+    public function applyValueOperator(
+        mixed $a,
+        ValueOperator $operator,
+        mixed $b,
+    ): bool {
+        if ($this->question_type instanceof ConditionValueTransformerInterface) {
+            $a = $this->question_type->transformConditionValueForComparisons($a, $this->question_config);
+        }
+
+        return match ($operator) {
+            ValueOperator::EMPTY     => empty($a),
+            ValueOperator::NOT_EMPTY => !empty($a),
+
+            // Unsupported operators
+            default => false,
+        };
+    }
+}

--- a/src/Glpi/Form/Condition/ValueOperator.php
+++ b/src/Glpi/Form/Condition/ValueOperator.php
@@ -59,6 +59,9 @@ enum ValueOperator: string
     case VISIBLE = 'visible';
     case NOT_VISIBLE = 'not_visible';
 
+    case EMPTY = 'empty';
+    case NOT_EMPTY = 'not_empty';
+
     public function getLabel(): string
     {
         return match ($this) {
@@ -84,6 +87,9 @@ enum ValueOperator: string
 
             self::VISIBLE                => __("Is visible"),
             self::NOT_VISIBLE            => __("Is not visible"),
+
+            self::EMPTY                 => __("Is empty"),
+            self::NOT_EMPTY             => __("Is not empty"),
         };
     }
 

--- a/src/Glpi/Form/Migration/FormMigration.php
+++ b/src/Glpi/Form/Migration/FormMigration.php
@@ -223,13 +223,14 @@ class FormMigration extends AbstractPluginMigration
      * Get the value operator from the legacy value
      *
      * @param int $value_operator The legacy value operator
+     * @param mixed $value The value to compare against
      * @return ValueOperator|null The corresponding value operator or null if not found
      */
-    private function getValueOperatorFromLegacy(int $value_operator): ?ValueOperator
+    private function getValueOperatorFromLegacy(int $value_operator, mixed $value): ?ValueOperator
     {
         return match ($value_operator) {
-            1 => ValueOperator::EQUALS,
-            2 => ValueOperator::NOT_EQUALS,
+            1 => $value === "" ? ValueOperator::EMPTY : ValueOperator::EQUALS,
+            2 => $value === "" ? ValueOperator::NOT_EMPTY : ValueOperator::NOT_EQUALS,
             3 => ValueOperator::LESS_THAN,
             4 => ValueOperator::GREATER_THAN,
             5 => ValueOperator::LESS_THAN_OR_EQUALS,
@@ -1382,7 +1383,7 @@ class FormMigration extends AbstractPluginMigration
                 $condition_handlers = $question_type->getConditionHandlers($config);
 
                 // Get the value operator before trying to find a compatible handler
-                $value_operator = $this->getValueOperatorFromLegacy($raw_condition['show_condition']);
+                $value_operator = $this->getValueOperatorFromLegacy($raw_condition['show_condition'], $value);
 
                 // If the value operator is null, we skip this condition
                 if ($value_operator === null) {
@@ -1436,7 +1437,7 @@ class FormMigration extends AbstractPluginMigration
                         'value'          => $value,
                         'item_type'      => 'question',
                         'item_uuid'      => $question->getUUID(),
-                        'value_operator' => $this->getValueOperatorFromLegacy($raw_condition['show_condition']),
+                        'value_operator' => $this->getValueOperatorFromLegacy($raw_condition['show_condition'], $value),
                         'logic_operator' => $this->getLogicOperatorFromLegacy($raw_condition['show_logic']),
                     ];
                 }
@@ -1449,7 +1450,7 @@ class FormMigration extends AbstractPluginMigration
                         'value'          => $value,
                         'item_type'      => 'question',
                         'item_uuid'      => $question->getUUID(),
-                        'value_operator' => $this->getValueOperatorFromLegacy($raw_condition['show_condition']),
+                        'value_operator' => $this->getValueOperatorFromLegacy($raw_condition['show_condition'], $value),
                         'logic_operator' => $this->getLogicOperatorFromLegacy($raw_condition['show_logic']),
                     ];
                 }

--- a/src/Glpi/Form/QuestionType/AbstractQuestionType.php
+++ b/src/Glpi/Form/QuestionType/AbstractQuestionType.php
@@ -37,6 +37,7 @@ namespace Glpi\Form\QuestionType;
 
 use Glpi\DBAL\JsonFieldInterface;
 use Glpi\Form\Condition\ConditionHandler\ConditionHandlerInterface;
+use Glpi\Form\Condition\ConditionHandler\EmptyConditionHandler;
 use Glpi\Form\Condition\ConditionHandler\RegexConditionHandler;
 use Glpi\Form\Condition\ConditionHandler\VisibilityConditionHandler;
 use Glpi\Form\Export\Context\DatabaseMapper;
@@ -247,8 +248,10 @@ abstract class AbstractQuestionType implements QuestionTypeInterface
         ?JsonFieldInterface $question_config
     ): array {
         return [
+
             new VisibilityConditionHandler(),
             new RegexConditionHandler($this, $question_config),
+            new EmptyConditionHandler($this, $question_config),
         ];
     }
 }

--- a/tests/cypress/e2e/form/editor/conditions.cy.js
+++ b/tests/cypress/e2e/form/editor/conditions.cy.js
@@ -1078,18 +1078,6 @@ describe ('Conditions', () => {
                 type: 'Glpi\\Form\\QuestionType\\QuestionTypeShortText',
                 conditions: [
                     {
-                        logic: null,
-                        operator: 'Is visible',
-                        value: null,
-                        valueType: null
-                    },
-                    {
-                        logic: 'Or',
-                        operator: 'Is not visible',
-                        value: null,
-                        valueType: null
-                    },
-                    {
                         logic: 'Or',
                         operator: 'Is equal to',
                         value: 'Exact match',
@@ -1158,18 +1146,6 @@ describe ('Conditions', () => {
                 type: 'Glpi\\Form\\QuestionType\\QuestionTypeNumber',
                 subType: 'Number',
                 conditions: [
-                    {
-                        logic: null,
-                        operator: 'Is visible',
-                        value: null,
-                        valueType: null
-                    },
-                    {
-                        logic: 'Or',
-                        operator: 'Is not visible',
-                        value: null,
-                        valueType: null
-                    },
                     {
                         logic: 'Or',
                         operator: 'Is equal to',
@@ -1307,18 +1283,6 @@ describe ('Conditions', () => {
                 type: 'Glpi\\Form\\QuestionType\\QuestionTypeLongText',
                 conditions: [
                     {
-                        logic: null,
-                        operator: 'Is visible',
-                        value: null,
-                        valueType: null
-                    },
-                    {
-                        logic: 'Or',
-                        operator: 'Is not visible',
-                        value: null,
-                        valueType: null
-                    },
-                    {
                         logic: 'Or',
                         operator: 'Is equal to',
                         value: 'Exact match',
@@ -1388,18 +1352,6 @@ describe ('Conditions', () => {
                 extra_data: '{"is_default_value_current_time":"0","is_date_enabled":"1","is_time_enabled":"0"}',
                 conditions: [
                     {
-                        logic: null,
-                        operator: 'Is visible',
-                        value: null,
-                        valueType: null
-                    },
-                    {
-                        logic: 'Or',
-                        operator: 'Is not visible',
-                        value: null,
-                        valueType: null
-                    },
-                    {
                         logic: 'Or',
                         operator: 'Is equal to',
                         value: '2021-01-01',
@@ -1456,18 +1408,6 @@ describe ('Conditions', () => {
                 type: 'Glpi\\Form\\QuestionType\\QuestionTypeDateTime',
                 extra_data: '{"is_default_value_current_time":"0","is_date_enabled":"0","is_time_enabled":"1"}',
                 conditions: [
-                    {
-                        logic: null,
-                        operator: 'Is visible',
-                        value: null,
-                        valueType: null
-                    },
-                    {
-                        logic: 'Or',
-                        operator: 'Is not visible',
-                        value: null,
-                        valueType: null
-                    },
                     {
                         logic: 'Or',
                         operator: 'Is equal to',
@@ -1526,18 +1466,6 @@ describe ('Conditions', () => {
                 extra_data: '{"is_default_value_current_time":"0","is_date_enabled":"1","is_time_enabled":"1"}',
                 conditions: [
                     {
-                        logic: null,
-                        operator: 'Is visible',
-                        value: null,
-                        valueType: null
-                    },
-                    {
-                        logic: 'Or',
-                        operator: 'Is not visible',
-                        value: null,
-                        valueType: null
-                    },
-                    {
                         logic: 'Or',
                         operator: 'Is equal to',
                         value: '2021-01-01T12:00',
@@ -1594,18 +1522,6 @@ describe ('Conditions', () => {
                 type: 'Glpi\\Form\\QuestionType\\QuestionTypeRequester',
                 conditions: [
                     {
-                        logic: null,
-                        operator: 'Is visible',
-                        value: null,
-                        valueType: null
-                    },
-                    {
-                        logic: 'Or',
-                        operator: 'Is not visible',
-                        value: null,
-                        valueType: null
-                    },
-                    {
                         logic: 'Or',
                         operator: 'Is equal to',
                         value: 'glpi',
@@ -1649,18 +1565,6 @@ describe ('Conditions', () => {
                 name: 'My observer question',
                 type: 'Glpi\\Form\\QuestionType\\QuestionTypeObserver',
                 conditions: [
-                    {
-                        logic: null,
-                        operator: 'Is visible',
-                        value: null,
-                        valueType: null
-                    },
-                    {
-                        logic: 'Or',
-                        operator: 'Is not visible',
-                        value: null,
-                        valueType: null
-                    },
                     {
                         logic: 'Or',
                         operator: 'Is equal to',
@@ -1706,18 +1610,6 @@ describe ('Conditions', () => {
                 type: 'Glpi\\Form\\QuestionType\\QuestionTypeAssignee',
                 conditions: [
                     {
-                        logic: null,
-                        operator: 'Is visible',
-                        value: null,
-                        valueType: null
-                    },
-                    {
-                        logic: 'Or',
-                        operator: 'Is not visible',
-                        value: null,
-                        valueType: null
-                    },
-                    {
                         logic: 'Or',
                         operator: 'Is equal to',
                         value: 'glpi',
@@ -1761,18 +1653,6 @@ describe ('Conditions', () => {
                 name: 'My urgency question',
                 type: 'Glpi\\Form\\QuestionType\\QuestionTypeUrgency',
                 conditions: [
-                    {
-                        logic: null,
-                        operator: 'Is visible',
-                        value: null,
-                        valueType: null
-                    },
-                    {
-                        logic: 'Or',
-                        operator: 'Is not visible',
-                        value: null,
-                        valueType: null
-                    },
                     {
                         logic: 'Or',
                         operator: 'Is equal to',
@@ -1830,18 +1710,6 @@ describe ('Conditions', () => {
                 type: 'Glpi\\Form\\QuestionType\\QuestionTypeRequestType',
                 conditions: [
                     {
-                        logic: null,
-                        operator: 'Is visible',
-                        value: null,
-                        valueType: null
-                    },
-                    {
-                        logic: 'Or',
-                        operator: 'Is not visible',
-                        value: null,
-                        valueType: null
-                    },
-                    {
                         logic: 'Or',
                         operator: 'Is equal to',
                         value: 'Request',
@@ -1874,18 +1742,6 @@ describe ('Conditions', () => {
                 type: 'Glpi\\Form\\QuestionType\\QuestionTypeFile',
                 conditions: [
                     {
-                        logic: null,
-                        operator: 'Is visible',
-                        value: null,
-                        valueType: null
-                    },
-                    {
-                        logic: 'Or',
-                        operator: 'Is not visible',
-                        value: null,
-                        valueType: null
-                    },
-                    {
                         logic: 'Or',
                         operator: 'Match regular expression',
                         value: '/^file_[0-9]+\\.txt$/',
@@ -1896,7 +1752,7 @@ describe ('Conditions', () => {
                         operator: 'Do not match regular expression',
                         value: '/^file_[0-9]+\\.txt$/',
                         valueType: 'string'
-                    }
+                    },
                 ],
             },
         ],
@@ -1906,18 +1762,6 @@ describe ('Conditions', () => {
                 type: 'Glpi\\Form\\QuestionType\\QuestionTypeRadio',
                 extra_data: '{"options":{"1":"Option 1","2":"Option 2","3":"Option 3","4":"Option 4"}}',
                 conditions: [
-                    {
-                        logic: null,
-                        operator: 'Is visible',
-                        value: null,
-                        valueType: null
-                    },
-                    {
-                        logic: 'Or',
-                        operator: 'Is not visible',
-                        value: null,
-                        valueType: null
-                    },
                     {
                         logic: 'Or',
                         operator: 'Is equal to',
@@ -1951,18 +1795,6 @@ describe ('Conditions', () => {
                 type: 'Glpi\\Form\\QuestionType\\QuestionTypeCheckbox',
                 extra_data: '{"options":{"1":"Option 1","2":"Option 2","3":"Option 3","4":"Option 4"}}',
                 conditions: [
-                    {
-                        logic: null,
-                        operator: 'Is visible',
-                        value: null,
-                        valueType: null
-                    },
-                    {
-                        logic: 'Or',
-                        operator: 'Is not visible',
-                        value: null,
-                        valueType: null
-                    },
                     {
                         logic: 'Or',
                         operator: 'Is equal to',
@@ -2009,18 +1841,6 @@ describe ('Conditions', () => {
                 extra_data: '{"is_multiple_dropdown":false,"options":{"1":"Option 1","2":"Option 2","3":"Option 3","4":"Option 4"}}',
                 conditions: [
                     {
-                        logic: null,
-                        operator: 'Is visible',
-                        value: null,
-                        valueType: null
-                    },
-                    {
-                        logic: 'Or',
-                        operator: 'Is not visible',
-                        value: null,
-                        valueType: null
-                    },
-                    {
                         logic: 'Or',
                         operator: 'Is equal to',
                         value: 'Option 3',
@@ -2053,18 +1873,6 @@ describe ('Conditions', () => {
                 type: 'Glpi\\Form\\QuestionType\\QuestionTypeDropdown',
                 extra_data: '{"is_multiple_dropdown":true,"options":{"1":"Option 1","2":"Option 2","3":"Option 3","4":"Option 4"}}',
                 conditions: [
-                    {
-                        logic: null,
-                        operator: 'Is visible',
-                        value: null,
-                        valueType: null
-                    },
-                    {
-                        logic: 'Or',
-                        operator: 'Is not visible',
-                        value: null,
-                        valueType: null
-                    },
                     {
                         logic: 'Or',
                         operator: 'Is equal to',
@@ -2111,18 +1919,6 @@ describe ('Conditions', () => {
                 extra_data: '{"itemtype":"Computer"}',
                 conditions: [
                     {
-                        logic: null,
-                        operator: 'Is visible',
-                        value: null,
-                        valueType: null
-                    },
-                    {
-                        logic: 'Or',
-                        operator: 'Is not visible',
-                        value: null,
-                        valueType: null
-                    },
-                    {
                         logic: 'Or',
                         operator: 'Is equal to',
                         value: 'Computer - {uuid}',
@@ -2167,18 +1963,6 @@ describe ('Conditions', () => {
                 type: 'Glpi\\Form\\QuestionType\\QuestionTypeItemDropdown',
                 extra_data: '{"itemtype":"Location","categories_filter":[],"root_items_id":0,"subtree_depth":0}',
                 conditions: [
-                    {
-                        logic: null,
-                        operator: 'Is visible',
-                        value: null,
-                        valueType: null
-                    },
-                    {
-                        logic: 'Or',
-                        operator: 'Is not visible',
-                        value: null,
-                        valueType: null
-                    },
                     {
                         logic: 'Or',
                         operator: 'Is equal to',
@@ -2225,18 +2009,6 @@ describe ('Conditions', () => {
                 extra_data: '{"is_multiple_devices":false}',
                 conditions: [
                     {
-                        logic: null,
-                        operator: 'Is visible',
-                        value: null,
-                        valueType: null
-                    },
-                    {
-                        logic: 'Or',
-                        operator: 'Is not visible',
-                        value: null,
-                        valueType: null
-                    },
-                    {
                         logic: 'Or',
                         operator: 'Is of itemtype',
                         value: 'Computer',
@@ -2282,18 +2054,6 @@ describe ('Conditions', () => {
                 extra_data: '{"is_multiple_devices":true}',
                 conditions: [
                     {
-                        logic: null,
-                        operator: 'Is visible',
-                        value: null,
-                        valueType: null
-                    },
-                    {
-                        logic: 'Or',
-                        operator: 'Is not visible',
-                        value: null,
-                        valueType: null
-                    },
-                    {
                         logic: 'Or',
                         operator: 'At least one item of itemtype',
                         value: ['Computer'],
@@ -2331,8 +2091,40 @@ describe ('Conditions', () => {
                     },
                 ]
             }
-        ]
+        ],
     };
+
+    // All questions implement "Is visible", "Is not visible", "Is empty" and "Is not empty" conditions
+    Object.values(questionsToAdd).forEach((questions) => {
+        questions.forEach((question) => {
+            question.conditions.push(
+                {
+                    logic: null,
+                    operator: 'Is visible',
+                    value: null,
+                    valueType: null
+                },
+                {
+                    logic: 'Or',
+                    operator: 'Is not visible',
+                    value: null,
+                    valueType: null
+                },
+                {
+                    logic: 'Or',
+                    operator: 'Is empty',
+                    value: null,
+                    valueType: null
+                },
+                {
+                    logic: 'Or',
+                    operator: 'Is not empty',
+                    value: null,
+                    valueType: null
+                }
+            );
+        });
+    });
 
     it('can all questions type are tested for conditions', () => {
         const expected_types = Object.values(questionsToAdd).reduce((acc, questions) => {


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Addition of two new value operators for visibility conditions.
These operators replace conditions using comparison operators with an empty value during migration.
These workarounds seem to be widely used by Formcreator users but will no longer be possible in the new form integration.
