### PR TITLE
fix(forms): Detect changes made to the `File` question type when rendering the form

### DIFF
--- a/js/fileupload.js
+++ b/js/fileupload.js
@@ -153,6 +153,13 @@ var displayUploadedFile = function(file, tag, editor, input_name, filecontainer)
     var elementsIdToRemove = {0:file.id, 1:`${file.id}2`};
     $('<span class="ti ti-circle-x pointer remove_file_upload"></span>').on('click', () => {
         deleteImagePasted(elementsIdToRemove, tag.tag, editor);
+
+        // Trigger an event to notify that an image has been removed
+        $(document).trigger('glpi_fileupload_remove', {
+            elementsIdToRemove: elementsIdToRemove,
+            tagToRemove: tag.tag,
+            editor: editor
+        });
     }).appendTo(p);
 };
 

--- a/js/modules/Forms/Condition/Engine.js
+++ b/js/modules/Forms/Condition/Engine.js
@@ -78,13 +78,13 @@ export class GlpiFormConditionEngine
             const value = entry[1];
 
             // Skip data unrelated to form answers
-            if (key.indexOf('answers_') !== 0) {
+            if (key.indexOf('answers_') !== 0 && key.indexOf('_answers_') !== 0) {
                 continue;
             }
 
             if (key.includes('[')) {
                 // Handle array values: answers_questionId[] or answers_questionId[key]
-                const array_key_regex = /^answers_([^[]+)(\[(\d*|[^\]]*)\])$/;
+                const array_key_regex = /^_?answers_([^[]+)(\[(\d*|[^\]]*)\])$/;
                 const match = array_key_regex.exec(key);
 
                 if (match && match[1]) {

--- a/js/modules/Forms/RendererController.js
+++ b/js/modules/Forms/RendererController.js
@@ -124,7 +124,7 @@ export class GlpiFormRendererController
             () => this.#computeItemsVisibilities(),
             400,
         );
-        $(document).on('input tinyMCEInput', this.#target, () => {
+        $(document).on('input tinyMCEInput glpi_fileupload_remove', this.#target, () => {
             // Disable actions immediately to avoid someone clicking on the actions
             // while the conditions have not been computed yet.
             this.#disableActions();

--- a/tests/cypress/e2e/form/editor/conditions.cy.js
+++ b/tests/cypress/e2e/form/editor/conditions.cy.js
@@ -2888,4 +2888,48 @@ describe ('Conditions', () => {
         closeConditionEditor();
         checkConditionsCount('0');
     });
+
+    it('check whether uploading a file in a “File” question updates the visibility of a target question', () => {
+        createForm();
+
+        // Add a target question
+        addQuestion('My target question');
+
+        // Add a file upload question
+        addQuestion('My file question');
+        setQuestionTypeCategory('File');
+
+        // Add a condition to show the target question if the file question is not empty
+        getAndFocusQuestion('My target question').within(() => {
+            initVisibilityConfiguration();
+            setConditionStrategy('Visible if...');
+            fillCondition(0, null, 'My file question', 'Is not empty', null, null);
+            closeVisibilityConfiguration();
+        });
+
+        // Save and reload to ensure conditions are applied
+        saveAndReload();
+
+        // Preview the form
+        preview();
+
+        // Check that the target question is not visible initially
+        validateThatQuestionIsNotVisible('My target question');
+
+        // Upload a file to the file question
+        cy.findByRole('region', {'name': 'My file question'}).within(() => {
+            cy.get('input[type="file"]').selectFile('fixtures/uploads/bar.png');
+        });
+
+        // Check that the target question is now visible
+        validateThatQuestionIsVisible('My target question');
+
+        // Remove the uploaded file
+        cy.findByRole('region', {'name': 'My file question'}).within(() => {
+            cy.get('.fileupload .remove_file_upload').click();
+        });
+
+        // Check that the target question is not visible anymore
+        validateThatQuestionIsNotVisible('My target question');
+    });
 });


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

- #20823 must be merged before

Correction of the upload detection and upload deletion behavior of the condition engine and the JS rendering controller.
Currently, when you add a file to a `File` type question,  the addition is not detected to initiate a new calculation of visibility conditions, and when the form is submitted to the condition rendering engine, it does not detect the file.