### PR TITLE
Fix multidomains SSO

### DIFF
--- a/src/Auth.php
+++ b/src/Auth.php
@@ -813,6 +813,25 @@ class Auth extends CommonGLPI
                 && !empty($this->user->fields['name'])
             ) {
                 // Used for log when login process failed
+
+                // If we use $ssovariable, we have to make sure to only select the realm described in
+                // the variable. In case of multiple LDAPs, this will avoid username collisions and
+                // hostile profile takeovers.
+                // Note that multiple AuthLDAP could use the same realm (although the user should only
+                // be in one of them), so we use an array of LDAP IDs here.
+                $ssovariable = Dropdown::getDropdownName('glpi_ssovariables', $CFG_GLPI["ssovariables_id"]);
+                $sso_realm = "";
+                $sso_ldap_servers = [];
+                if (isset($_SERVER[$ssovariable])) {
+                    $sso_realm = explode("@", $_SERVER[$ssovariable])[1];
+                    $authldap = new AuthLdap();
+                    foreach (AuthLDAP::getLdapServers() as $ldap_config) {
+                        $authldap->getFromDB($ldap_config["id"]);
+                        if ($authldap->isActive() and $sso_realm == $authldap->getKerberosRealm()) {
+                            $sso_ldap_servers[] = $authldap->fields["id"];
+                        }
+                    }
+                }
                 $login_name                        = $this->user->fields['name'];
                 $this->auth_succeded               = true;
                 $this->user_present                = $this->user->getFromDBbyName(addslashes($login_name));
@@ -827,6 +846,36 @@ class Auth extends CommonGLPI
                 $ldapservers_status = false;
                 //if LDAP enabled too, get user's infos from LDAP
                 if ((!isset($this->user->fields['authtype']) || $this->user->fields['authtype'] === self::LDAP) && Toolbox::canUseLdap()) {
+
+                    // Wrong user: user's directory is different from SSO's realm.
+                    // This is a case of either username collision or hostile action.
+                    // We need to correct the info.
+                    if ($sso_ldap_servers
+                        && isset($this->user->fields["auths_id"])
+                        && !in_array($this->user->fields["auths_id"], $sso_ldap_servers)) {
+                        $this->user_present = false;
+                        $this->user->fields["auths_id"] = 0;
+                        foreach ($sso_ldap_servers as $ldap_id) {
+                            // There shouldn't be more than one login_name per realm, so
+                            // we can exit when we find it, even if several servers point to
+                            // the same LDAP.
+                            // (If the GLPI instance is configured to allow the same AD user
+                            // to have two profiles via two AuthLDAP pointing to the same LDAP
+                            // this will most probably break. But I'm not sorry, because whoever
+                            // set it up that way did a Very Wrong Thing.)
+                            $this->user_present = $this->user->getFromDBByCrit(['name' => $login_name, 'authtype' => self::LDAP, 'auths_id' => $ldap_id]);
+                            if ($this->user_present) {
+                                break;
+                            }
+                        }
+                        // There can be a case where multiple LDAPs know the same login_name, but
+                        // only some of them are known by GLPI yet (user is not yet sync'ed, or is deleted).
+                        // So the user may try their login in good faith but we must refuse it.
+                        if (!$this->user_present) {
+                            $this->auth_succeded = false;
+                        }
+                    }
+
                     //User has already authenticated, at least once: it's ldap server if filled
                     if (
                         isset($this->user->fields["auths_id"])

--- a/src/Auth.php
+++ b/src/Auth.php
@@ -824,7 +824,7 @@ class Auth extends CommonGLPI
                 $sso_ldap_servers = [];
                 if (isset($_SERVER[$ssovariable])) {
                     $sso_realm = explode("@", $_SERVER[$ssovariable])[1];
-                    $authldap = new AuthLdap();
+                    $authldap = new AuthLDAP();
                     foreach (AuthLDAP::getLdapServers() as $ldap_config) {
                         $authldap->getFromDB($ldap_config["id"]);
                         if ($authldap->isActive() and $sso_realm == $authldap->getKerberosRealm()) {

--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -4845,4 +4845,41 @@ class AuthLDAP extends CommonDBTM
         );
         return $message;
     }
+
+    /**
+     * Extracts the Kerberos realm from the basedn's DC components.
+     *
+     * This makes the assuption that the Kerberos realm's name is the LDAP's fully qualified domain name, in uppercase.
+     * While this is true for a large majority of configurations (and notably Active Directories), this is _not_ a
+     * Kerberos requirement. Therefore, some realms may not be aligned on the domain's FDQN and this method will not
+     * return a correct answer.
+     *
+     * A manual override would require a new field in glpi_authldaps, though.
+     *
+     * @return string The LDAP server's Kerberos realm
+     */
+    public function getKerberosRealm()
+    {
+       return strtoupper(
+          implode(
+             ".",
+             array_map(
+                function ($c) {
+                   return $c[1];
+                },
+                array_filter(
+                   array_map(
+                      function ($c) {
+                         return explode("=", $c, 2);
+                      },
+                      explode(",", $this->fields['basedn'])),
+                   function ($c) {
+                      return $c[0] == "DC";
+                   }
+                )
+             )
+          )
+       );
+   }
+
 }


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

When using Kerberos/Negotiate-style SSO (auth_gssapi / auth_kerb), GLPI strips the realm part of the Kerberos principal before looking for the user.

This means that when GLPI is set up with multiple LDAP sources _and_ SSO:

- if the login name "user1" exists in GLPI for two or more domains, those users will all be logged as the first user created in the base.
- even if "user1" exists in GLPI for one domain only, any "user1" from any domain will be allowed to log in, as long as the domain is present in the webserver's keytab.

This PR adds a Kerberos realm check when the user is authenticating and $ssovariable is set ("Field storage of the login in the HTTP request").

Caveat: This PR constructs the LDAP's realm name by extracting the DC parts of the baseDN. This is generally true but in some edge cases, it may be necessary to adjust the Kerberos client's configuration. On Linux, this is the [domain_realm] section of /etc/krb5.conf.

I have never encountered a domain that didn't follow this convention, though, so I cannot estimate how often such a config mismatch occurs in the wild.
