### PR TITLE
Add config to disable service catalog categories "expansion"

### DIFF
--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -2535,6 +2535,7 @@ $empty_data_builder = new class {
                 'custom_helpdesk_home_title' => '',
                 'enable_helpdesk_home_search_bar' => 1,
                 'enable_helpdesk_service_catalog' => 1,
+                'expand_service_catalog' => 1,
             ],
         ];
 

--- a/install/migrations/update_10.0.x_to_11.0.0/form.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/form.php
@@ -333,7 +333,7 @@ foreach ($fields as $field) {
     }
 }
 
-$fields = ['enable_helpdesk_home_search_bar', 'enable_helpdesk_service_catalog'];
+$fields = ['enable_helpdesk_home_search_bar', 'enable_helpdesk_service_catalog', 'expand_service_catalog'];
 foreach ($fields as $field) {
     if (!$DB->fieldExists("glpi_entities", $field)) {
         $migration->addField(

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -2851,6 +2851,7 @@ CREATE TABLE `glpi_entities` (
   `custom_helpdesk_home_title` varchar(255) NOT NULL DEFAULT '-2',
   `enable_helpdesk_home_search_bar` tinyint NOT NULL DEFAULT '-2',
   `enable_helpdesk_service_catalog` tinyint NOT NULL DEFAULT '-2',
+  `expand_service_catalog` tinyint NOT NULL DEFAULT '-2',
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`entities_id`,`name`),
   KEY `name` (`name`),

--- a/phpunit/functional/EntityTest.php
+++ b/phpunit/functional/EntityTest.php
@@ -39,7 +39,10 @@ use Contract;
 use DbTestCase;
 use Entity;
 use Glpi\Application\View\TemplateRenderer;
+use Glpi\Controller\ServiceCatalog\IndexController;
 use Glpi\DBAL\QueryExpression;
+use Glpi\Form\Category;
+use Glpi\Form\Form;
 use Glpi\Helpdesk\HomePageTabs;
 use ITILFollowup;
 use ITILSolution;
@@ -49,6 +52,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use Profile_User;
 use Symfony\Component\DomCrawler\Crawler;
+use Symfony\Component\HttpFoundation\Request;
 use Ticket;
 use Ticket_Contract;
 use Ticket_User;
@@ -1888,6 +1892,108 @@ class EntityTest extends DbTestCase
         $this->assertCount(
             $should_be_enabled ? 1 : 0,
             $search_bar
+        );
+    }
+
+    public static function helpdeskExpandCategoriesConfigIsAppliedProvider(): iterable
+    {
+        yield 'One entity without config' => [
+            'entities' => [
+                ['name' => 'entity_a', 'config' => -2],
+            ],
+            'entity' => 'entity_a',
+            'should_be_expanded' => true, // Inherit from root
+        ];
+
+        yield 'Inherit enabled from parent' => [
+            'entities' => [
+                ['name' => 'entity_a', 'config' => 1],
+                ['name' => 'entity_aa', 'parent' => 'entity_a', 'config' => -2],
+            ],
+            'entity' => 'entity_aa',
+            'should_be_expanded' => true,
+        ];
+
+        yield 'Inherit disabled from parent' => [
+            'entities' => [
+                ['name' => 'entity_a', 'config' => 0],
+                ['name' => 'entity_aa', 'parent' => 'entity_a', 'config' => -2],
+            ],
+            'entity' => 'entity_aa',
+            'should_be_expanded' => false,
+        ];
+
+        yield 'Enabled from child' => [
+            'entities' => [
+                ['name' => 'entity_a', 'config' => 0],
+                ['name' => 'entity_aa', 'parent' => 'entity_a', 'config' => 1],
+            ],
+            'entity' => 'entity_aa',
+            'should_be_expanded' => true,
+        ];
+
+        yield 'Disabled from child' => [
+            'entities' => [
+                ['name' => 'entity_a', 'config' => 1],
+                ['name' => 'entity_aa', 'parent' => 'entity_a', 'config' => 0],
+            ],
+            'entity' => 'entity_aa',
+            'should_be_expanded' => false,
+        ];
+    }
+
+    #[DataProvider('helpdeskExpandCategoriesConfigIsAppliedProvider')]
+    public function testHelpdeskExpandCategoriesConfigIsApplied(
+        array $entities,
+        string $entity,
+        bool $should_be_expanded,
+    ): void {
+        // Arrange: create requested entities
+        $this->login();
+        $root = $this->getTestRootEntity(only_id: true);
+        foreach ($entities as $to_create) {
+            if (isset($to_create['parent'])) {
+                $parent = getItemByTypeName(
+                    Entity::class,
+                    $to_create['parent'],
+                    onlyid: true,
+                );
+            } else {
+                $parent = $root;
+            }
+
+            $this->createItem(Entity::class, [
+                'name'                   => $to_create['name'],
+                'entities_id'            => $parent,
+                'expand_service_catalog' => $to_create['config'],
+            ]);
+        }
+
+        // Create a category and move the request form into it
+        $category = $this->createItem(Category::class, [
+            'name' => 'My category',
+        ]);
+        $request_form = getItemByTypeName(Form::class, "Request a service");
+        $this->updateItem(Form::class, $request_form->getID(), [
+            Category::getForeignKeyField() => $category->getID(),
+        ]);
+
+        // Act: render service catalog page
+        $entity = getItemByTypeName(Entity::class, $entity);
+        $this->login('post-only');
+        $this->setEntity($entity->getId(), true);
+        $controller = new IndexController();
+        $response = $controller->__invoke(Request::create(""));
+        $html = $response->getContent();
+
+        // Assert: try to find the request form, it should only be displayed
+        // if categories are expanded
+        $request_form = (new Crawler($html))
+            ->filter("a[href=\"/Form/Render/{$request_form->getID()}\"]")
+        ;
+        $this->assertCount(
+            $should_be_expanded ? 1 : 0,
+            $request_form
         );
     }
 }

--- a/src/Entity.php
+++ b/src/Entity.php
@@ -180,6 +180,7 @@ class Entity extends CommonTreeDropdown implements LinkableToTilesInterface, Pro
             'contracts_strategy_default', 'contracts_id_default', 'show_tickets_properties_on_helpdesk',
             'custom_helpdesk_home_scene_left', 'custom_helpdesk_home_scene_right',
             'custom_helpdesk_home_title', 'enable_helpdesk_home_search_bar', 'enable_helpdesk_service_catalog',
+            'expand_service_catalog',
         ],
         // Configuration
         'config' => ['enable_custom_css', 'custom_css_code'],
@@ -3335,6 +3336,21 @@ class Entity extends CommonTreeDropdown implements LinkableToTilesInterface, Pro
         if ($value == self::CONFIG_PARENT) {
             $value = self::getUsedConfig(
                 'enable_helpdesk_service_catalog',
+                $this->fields['entities_id']
+            );
+        }
+
+        return $value === 1;
+    }
+
+    public function shouldExpandCategoriesInServiceCatalog(): bool
+    {
+        $value = $this->fields['expand_service_catalog'] ?? '';
+
+        // Load from parent if needed
+        if ($value == self::CONFIG_PARENT) {
+            $value = self::getUsedConfig(
+                'expand_service_catalog',
                 $this->fields['entities_id']
             );
         }

--- a/src/Glpi/Controller/ServiceCatalog/IndexController.php
+++ b/src/Glpi/Controller/ServiceCatalog/IndexController.php
@@ -103,6 +103,7 @@ final class IndexController extends AbstractController
             'items' => $items,
             'sort_strategies' => SortStrategyEnum::getAvailableStrategies(),
             'default_sort_strategy' => SortStrategyEnum::getDefault()->value,
+            'expand_categories' => $entity->shouldExpandCategoriesInServiceCatalog(),
         ]);
     }
 }

--- a/templates/components/helpdesk_forms/service_catalog_item.html.twig
+++ b/templates/components/helpdesk_forms/service_catalog_item.html.twig
@@ -31,13 +31,17 @@
  #}
 
 {% set unique_dom_id = 'service-catalog-tree-' ~ random() %}
-{% set is_pinned = item.fields['is_pinned'] %}
+{% set is_pinned = item.fields['is_pinned']|default(false) %}
 
 <div class="col-12 col-sm-6 col-md-4 d-flex">
     <a
         class="card mx-1 my-2 flex-grow-1 {{ is_pinned ? "border-menu" : "" }}"
         {% if item is instanceof("Glpi\\Form\\ServiceCatalog\\ServiceCatalogLeafInterface") %}
             href="{{ path(item.getServiceCatalogLink()) }}"
+        {% elseif item is instanceof("Glpi\\Form\\ServiceCatalog\\ServiceCatalogCompositeInterface") %}
+            href="?{{ item.getChildrenUrlParameters() }}"
+            data-children-url-parameters="{{ item.getChildrenUrlParameters() }}"
+            data-composite-item
         {% endif %}
     >
         <section

--- a/templates/components/helpdesk_forms/service_catalog_items.html.twig
+++ b/templates/components/helpdesk_forms/service_catalog_items.html.twig
@@ -39,35 +39,43 @@
         ) }}
     {% endif %}
     {% if item is instanceof("Glpi\\Form\\ServiceCatalog\\ServiceCatalogCompositeInterface") %}
-        <div class="col-12 d-flex">
-            {% set unique_dom_id = 'service-catalog-tree-' ~ random() %}
-            <section
-                class="card mx-1 my-2 flex-grow-1"
-                aria-labelledby="{{ unique_dom_id }}"
-            >
-                <div class="card-body">
-                    <div class="card-title mb-0 d-flex align-items-center w-100">
-                        <h2 id="{{ unique_dom_id }}" class="mb-0 fs-2">
-                            {{ item.getServiceCatalogItemTitle() }}
-                        </h2>
-                        <div class="card-subtitle ms-2 remove-last-tinymce-margin">
-                            {{ item.getServiceCatalogItemDescription()|safe_html }}
+        {% if expand_categories %}
+            <div class="col-12 d-flex">
+                {% set unique_dom_id = 'service-catalog-tree-' ~ random() %}
+                <section
+                    class="card mx-1 my-2 flex-grow-1"
+                    aria-labelledby="{{ unique_dom_id }}"
+                >
+                    <div class="card-body">
+                        <div class="card-title mb-0 d-flex align-items-center w-100">
+                            <h2 id="{{ unique_dom_id }}" class="mb-0 fs-2">
+                                {{ item.getServiceCatalogItemTitle() }}
+                            </h2>
+                            <div class="card-subtitle ms-2 remove-last-tinymce-margin">
+                                {{ item.getServiceCatalogItemDescription()|safe_html }}
+                            </div>
                         </div>
                     </div>
-                </div>
-                <div class="card-body p-0">
-                    <div class="row g-0">
-                        {% for child in item.getChildren() %}
-                            {{ include(
-                                'components/helpdesk_forms/service_catalog_nested_item.html.twig',
-                                {child: child},
-                                with_context = false
-                            ) }}
-                        {% endfor %}
+                    <div class="card-body p-0">
+                        <div class="row g-0">
+                            {% for child in item.getChildren() %}
+                                {{ include(
+                                    'components/helpdesk_forms/service_catalog_nested_item.html.twig',
+                                    {child: child},
+                                    with_context = false
+                                ) }}
+                            {% endfor %}
+                        </div>
                     </div>
-                </div>
-            </section>
-        </div>
+                </section>
+            </div>
+        {% else %}
+            {{ include(
+                'components/helpdesk_forms/service_catalog_item.html.twig',
+                {item: item},
+                with_context = false
+            ) }}
+        {% endif %}
     {% endif %}
 {% else %}
     {% if is_default_search %}

--- a/templates/pages/admin/helpdesk_home_config_for_entity.html.twig
+++ b/templates/pages/admin/helpdesk_home_config_for_entity.html.twig
@@ -314,6 +314,35 @@
                     ]) %}
                 </div>
             </div>
+
+            <div class="col-6">
+                {% if is_root_entity %}
+                    {% set expand_categories_options = {
+                        1: __("Enabled"),
+                        0: __("Disabled"),
+                    } %}
+                {% else %}
+                    {% set expand_categories_config = entity.shouldExpandCategoriesInServiceCatalog() %}
+                    {% set expand_categories_options = {
+                        1: __("Enabled"),
+                        0: __("Disabled"),
+                        (constant("Entity::CONFIG_PARENT")): __("Inherited from parent entity (%1$s)")|format(expand_categories_config ? __("Enabled") : __("Disabled")),
+                    } %}
+                {% endif %}
+
+                <h3 class="mb-2 mt-1">{{ __("Expand categories in the service catalog") }}</h3>
+                <div class="mb-2">
+                    {% do call('Dropdown::showFromArray', [
+                        'expand_service_catalog',
+                        expand_categories_options,
+                        {
+                            value: entity.fields.expand_service_catalog,
+                            width: "100%",
+                            aria_label: __('Expand categories in the service catalog'),
+                        }
+                    ]) %}
+                </div>
+            </div>
         </div>
 
         {# Form actions #}

--- a/templates/pages/self-service/service_catalog.html.twig
+++ b/templates/pages/self-service/service_catalog.html.twig
@@ -103,6 +103,7 @@
                 'current_page': 1,
                 'items_per_page': constant('Glpi\\Form\\ServiceCatalog\\ServiceCatalogManager::ITEMS_PER_PAGE'),
                 'is_default_search': true,
+                'expand_categories': expand_categories,
             },
             with_context = false
         ) }}


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

As explain in our daily meeting, this is a feature requested by our internal support team.

This add a small entity option to configure whether service catalog categories should be expanded or not.

Enabled:
<img width="1348" height="471" alt="image" src="https://github.com/user-attachments/assets/0e99afd3-7746-46a8-9844-7a198700d812" />

Disabled:
<img width="874" height="223" alt="image" src="https://github.com/user-attachments/assets/9ecd4300-39bf-4c36-bfc4-e396c1655190" />

The default behavior was not modified.
