### PR TITLE
Form editor readonly UI

### DIFF
--- a/css/includes/components/form/_form-editor.scss
+++ b/css/includes/components/form/_form-editor.scss
@@ -572,3 +572,14 @@ html {
 div:has(> [data-glpi-form-editor-section-details].d-none) {
     display: none !important;
 }
+
+// Hide some actions if the form is readonly
+.form-editor-readonly {
+    [data-glpi-form-editor-state-action] {
+        display: none;
+    }
+
+    input, div.tox-tinymce, span.select2, label.form-check, [data-glpi-form-editor-visibility-dropdown] {
+        pointer-events: none;
+    }
+}

--- a/templates/pages/admin/form/form_comment.html.twig
+++ b/templates/pages/admin/form/form_comment.html.twig
@@ -68,6 +68,7 @@
                     class="glpi-form-editor-question-handle ti ti-grip-horizontal cursor-grab ms-auto me-auto mt-n3 mb-n2"
                     data-glpi-form-editor-question-handle
                     draggable="true"
+                    data-glpi-form-editor-state-action
                 ></i>
             </div>
             {# Display comment's title #}
@@ -101,6 +102,7 @@
                     title="{{ __("Duplicate comment") }}"
                     data-glpi-form-editor-on-click="duplicate-comment"
                     data-glpi-form-editor-comment-extra-details
+                    data-glpi-form-editor-state-action
                 ></i>
 
                 {# Delete comment #}
@@ -113,6 +115,7 @@
                     aria-label="{{ __("Delete") }}"
                     data-glpi-form-editor-on-click="delete-comment"
                     data-glpi-form-editor-comment-extra-details
+                    data-glpi-form-editor-state-action
                 ></i>
 
                 {# Extra actions #}
@@ -123,6 +126,7 @@
                         aria-expanded="false"
                         role="button"
                         title="{{ __('More actions') }}"
+                        data-glpi-form-editor-state-action
                     ></i>
                     <ul class="dropdown-menu" data-bs-popper="none">
                         <li>

--- a/templates/pages/admin/form/form_editor.html.twig
+++ b/templates/pages/admin/form/form_editor.html.twig
@@ -54,6 +54,9 @@
         different background color than the parent item #}
         mt-n2
         mb-n2
+        {% if not can_update %}
+            form-editor-readonly
+        {% endif %}
     "
     method="POST"
     action="{{ item.getFormURL() }}"
@@ -483,7 +486,8 @@
             'id': destination.fields.id,
             'name': destination.fields.name,
             'conditions': destination.getConfiguredConditionsData(),
-        })|json_encode|raw }}
+        })|json_encode|raw }},
+        {{ can_update ? 'false' : 'true' }}, // is_readonly
     );
 
     // Temporary solution, would be better to import it directly where it is needed but the current

--- a/templates/pages/admin/form/form_question.html.twig
+++ b/templates/pages/admin/form/form_question.html.twig
@@ -72,6 +72,7 @@
                     class="glpi-form-editor-question-handle ti ti-grip-horizontal cursor-grab ms-auto me-auto mt-n3 mb-n2"
                     data-glpi-form-editor-question-handle
                     draggable="true"
+                    data-glpi-form-editor-state-action
                 ></i>
             </div>
             {# Display question's title #}
@@ -127,6 +128,7 @@
                     title="{{ __("Duplicate question") }}"
                     data-glpi-form-editor-on-click="duplicate-question"
                     data-glpi-form-editor-question-extra-details
+                    data-glpi-form-editor-state-action
                 ></i>
 
                 {# Delete question #}
@@ -139,6 +141,7 @@
                     aria-label="{{ __("Delete") }}"
                     data-glpi-form-editor-on-click="delete-question"
                     data-glpi-form-editor-question-extra-details
+                    data-glpi-form-editor-state-action
                 ></i>
 
                 {# Extra actions #}
@@ -149,6 +152,7 @@
                         aria-expanded="false"
                         role="button"
                         title="{{ __('More actions') }}"
+                        data-glpi-form-editor-state-action
                     ></i>
                     <ul class="dropdown-menu" data-bs-popper="none">
                         <li>

--- a/templates/pages/admin/form/form_section.html.twig
+++ b/templates/pages/admin/form/form_section.html.twig
@@ -150,6 +150,7 @@
                                     aria-expanded="false"
                                     role="button"
                                     title="{{ __('More actions') }}"
+                                    data-glpi-form-editor-state-action
                                 ></i>
                                 <ul class="dropdown-menu" data-bs-popper="none">
                                     <li>


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.

## Description

Add readonly mode to the form editor when the current user doens't have the right to edit forms.
This prevent some JS errors and make sure the user can't change any settings (note that the update button was already correctly removed in this case, this is just to prevent the user from doing meaningless changes that he wont be able to save). 
