### PR TITLE
 Add loading indicator when submitting helpdesk form #20835 

### DIFF
--- a/js/modules/Forms/RendererController.js
+++ b/js/modules/Forms/RendererController.js
@@ -247,11 +247,14 @@ export class GlpiFormRendererController
      * Submit the target form using an AJAX request.
      */
     async #submitForm() {
+        const submit = $(this.#target).find('button[data-glpi-form-renderer-action=submit]');
+
         // Form will be sumitted using an AJAX request instead
         try {
             // Disable actions immediately to avoid someone clicking on the actions
             // while the form is being submitted.
             this.#disableActions();
+            submit.addClass('btn-loading');
 
             // Update tinymce values
             this.#saveTinymceEditors();
@@ -309,6 +312,7 @@ export class GlpiFormRendererController
             );
         } finally {
             this.#enableActions();
+            submit.removeClass('btn-loading');
         }
     }
 


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.

## Description

Small UX improvement.
Currently there is no indicator which may be confusing for the user if the server is slow to respond.

![loading](https://github.com/user-attachments/assets/0e5eb842-b037-4144-82db-9902c1ae6c08)


