### PR TITLE
Prevent illustrations from shrinking in flex containers

### DIFF
--- a/templates/components/illustration/icon.svg.twig
+++ b/templates/components/illustration/icon.svg.twig
@@ -30,7 +30,7 @@
  # ---------------------------------------------------------------------
  #}
 
-<svg role="img" width="{{ width }}" height="{{ height }}">
+<svg role="img" width="{{ width }}" height="{{ height }}" class="flex-shrink-0">
     <title>{{ title ?? '' }}</title>
     <use xlink:href="{{ path(file_path) }}#{{ icon_id }}"/>
 </svg>


### PR DESCRIPTION
## Description

Before:

<img width="1323" height="449" alt="image" src="https://github.com/user-attachments/assets/48de97ba-2a8f-4a58-a3c5-2e2131c3e57f" />

After:

<img width="1298" height="603" alt="image" src="https://github.com/user-attachments/assets/dc69d7fa-cb96-4cab-b206-030071f67ac4" />

