### PR TITLE
Make sure helpdesk scenes stick to the bottom

### DIFF
--- a/css/helpdesk_home.scss
+++ b/css/helpdesk_home.scss
@@ -122,6 +122,14 @@ header {
         bottom: 0;
         width: 555px;
         height:90%;
+        display: flex;
+        flex-direction: row;
+        align-items: flex-end;
+        z-index: 0;
+
+        svg {
+            height: 393px;
+        }
 
         // Hide for screens smaller than 1600px
         @media (max-width: 1600px) {
@@ -135,6 +143,13 @@ header {
 
     .scene-right {
         right: 0;
+    }
+
+    h1 {
+        // Make sure the title is always diplayed above the illustrations in case
+        // of overlap.
+        z-index: 1;
+        position: relative;
     }
 }
 


### PR DESCRIPTION
## Description

Small UI tweak to make sure the helpdesk scenes stays to the bottom of their container even if the title is longer than expected.

Before:
<img width="2191" height="643" alt="image" src="https://github.com/user-attachments/assets/dadf2f62-4ee5-4445-95fa-b9b0e9d21e3c" />

After:
<img width="2191" height="624" alt="image" src="https://github.com/user-attachments/assets/503a6d83-1d81-4d4e-b9ff-d8807734fe86" />

