### PR TITLE
Harmonize links UI

### DIFF
--- a/src/Contract_Item.php
+++ b/src/Contract_Item.php
@@ -286,21 +286,25 @@ class Contract_Item extends CommonDBRelation
             // language=Twig
             echo TemplateRenderer::getInstance()->renderFromStringTemplate(<<<TWIG
                 {% import 'components/form/fields_macros.html.twig' as fields %}
+                {% import 'components/form/basic_inputs_macros.html.twig' as inputs %}
                 <div class="mb-3">
                     <form method="post" action="{{ 'Contract_Item'|itemtype_form_path }}">
                         <input type="hidden" name="itemtype" value="{{ get_class(item) }}">
                         <input type="hidden" name="items_id" value="{{ item.getID() }}">
                         <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}">
                         <div class="d-flex">
+                            <div class="col-auto">
                             {{ fields.dropdownField('Contract', 'contracts_id', 0, null, {
+                                add_field_class: 'd-inline',
+                                no_label: true,
                                 entity: item.fields['entities_id'],
                                 used: used,
-                                expired: false,
+                                expired: false
                             }) }}
-                            {% set btn %}
-                                <button type="submit" name="add" class="btn btn-primary">{{ btn_label }}</button>
-                            {% endset %}
-                            {{ fields.htmlField('', btn, null) }}
+                            </div>
+                            <div class="col-auto">
+                            {{ inputs.submit('add', _x('button', 'Add'), 1, {'class': 'btn btn-primary ms-1', 'icon': 'ti ti-link'}) }}
+                           </div>
                         </div>
                     </form>
                 </div>

--- a/src/Itil_Project.php
+++ b/src/Itil_Project.php
@@ -306,19 +306,24 @@ TWIG, $twig_params);
                     {% import 'components/form/fields_macros.html.twig' as fields %}
                     <div class="mb-3">
                         <form method="post" action="{{ 'Itil_Project'|itemtype_form_path }}">
-                            <input type="hidden" name="itemtype" value="{{ itemtype }}"/>
-                            <input type="hidden" name="items_id" value="{{ items_id }}"/>
-                            <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}"/>
                             <div class="d-flex">
-                                {{ fields.dropdownField('Project', 'projects_id', '', null, {
-                                    add_field_class: 'd-inline',
-                                    no_label: true,
-                                    used: used,
-                                    entity: entities_id,
-                                }) }}
-                            </div>
-                            <div>
-                                <button class="btn btn-primary ms-3" type="submit" name="add" value="">{{ btn_msg }}</button>
+                                <input type="hidden" name="itemtype" value="{{ itemtype }}"/>
+                                <input type="hidden" name="items_id" value="{{ items_id }}"/>
+                                <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}"/>
+                                <div class="col-auto">
+                                    {{ fields.dropdownField('Project', 'projects_id', '', null, {
+                                        add_field_class: 'd-inline',
+                                        no_label: true,
+                                        used: used,
+                                        entity: entities_id
+                                    }) }}
+                                </div>
+                                <div class="col-auto">
+                                    <button class="btn btn-primary ms-1" type="submit" name="add" value="">
+                                        <i class="ti ti-link"></i>
+                                        {{ btn_msg }}
+                                    </button>
+                                </div>
                             </div>
                         </form>
                     </div>

--- a/templates/pages/tools/kb/knowbaseitem_item.html.twig
+++ b/templates/pages/tools/kb/knowbaseitem_item.html.twig
@@ -42,6 +42,7 @@
         {{ inputs.hidden('itemtype', get_class(item)) }}
     {% endif %}
     <div class="d-flex">
+        <div class="col-auto">
         {% if get_class(item) == 'KnowbaseItem' %}
             {# TODO pass used array to restrict visible items in list #}
             {% set dropdown %}
@@ -55,8 +56,9 @@
                 'condition': visibility_condition
             }) }}
         {% endif %}
-    </div>
-    <div class="d-flex flex-row-reverse pe-2">
-        {{ inputs.submit('add', _x('button', 'Add'), 1) }}
+        </div>
+        <div class="col-auto">
+            {{ inputs.submit('add', _x('button', 'Add'), 1, {'class': 'btn btn-primary ms-1', 'icon': 'ti ti-link'}) }}
+        </div>
     </div>
 </form>


### PR DESCRIPTION
There are probably other pages where such a change can be done; but I'll wait to know if change is OK before working on it.

Before:
<img width="1280" height="595" alt="image" src="https://github.com/user-attachments/assets/a0f33a11-0095-4ec9-9809-2cbff71fce34" />
<img width="1280" height="595" alt="image" src="https://github.com/user-attachments/assets/ddfb3769-ac67-41e6-b40f-35b8b00f16f8" />

After:
<img width="1280" height="595" alt="image" src="https://github.com/user-attachments/assets/96eeff8d-737e-45d1-b2b5-ad827d5b5b5c" />
<img width="1280" height="595" alt="image" src="https://github.com/user-attachments/assets/0858522c-d31c-4d09-8d4c-c21483efdba2" />
