### PR TITLE
Simplify hidden fields macro

### DIFF
--- a/templates/components/form/fields_macros.html.twig
+++ b/templates/components/form/fields_macros.html.twig
@@ -425,16 +425,8 @@
 {% endmacro %}
 
 {% macro hiddenField(name, value, label = '', options = {}) %}
-   {% if options.no_label ?? false %}
-      {% set options = {
-         mb: 'mb-0'
-      }|merge(options) %}
-   {% endif %}
-   {% set field %}
-        {% import 'components/form/basic_inputs_macros.html.twig' as _inputs %}
-        {{ _inputs.hidden(name, value, options) }}
-   {% endset %}
-   {{ _self.field(name, field, label, options) }}
+    {% import 'components/form/basic_inputs_macros.html.twig' as _inputs %}
+    {{ _inputs.hidden(name, value, options) }}
 {% endmacro %}
 
 {% macro dropdownNumberField(name, value, label = '', options = {}) %}


### PR DESCRIPTION
It seems quite useless to have the possibility to add a label or style hidden fields.

Before:
<img width="1911" height="697" alt="image" src="https://github.com/user-attachments/assets/eba5f2f8-067a-4b02-bff8-498f9b2209d2" />

After:
<img width="1911" height="697" alt="image" src="https://github.com/user-attachments/assets/ccfbadfc-2520-4764-916c-398f62752d67" />
