### PR TITLE
fix(forms): Add validation logic to ConditionData to filter invalid conditions

### DIFF
--- a/phpunit/functional/Glpi/Form/Condition/ConditionDataTest.php
+++ b/phpunit/functional/Glpi/Form/Condition/ConditionDataTest.php
@@ -1,0 +1,282 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Form\Condition;
+
+use Glpi\Form\Condition\ConditionData;
+use Glpi\Form\Condition\LogicOperator;
+use Glpi\Form\Condition\Type;
+use Glpi\Form\Condition\ValueOperator;
+use GLPITestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+final class ConditionDataTest extends GLPITestCase
+{
+    public static function provideValidConditions(): iterable
+    {
+        yield 'Valid condition with EQUALS operator' => [
+            'item_uuid' => '123',
+            'item_type' => Type::QUESTION->value,
+            'value_operator' => ValueOperator::EQUALS->value,
+            'value' => 'test_value',
+            'logic_operator' => LogicOperator::AND->value,
+            'expected' => true,
+        ];
+
+        yield 'Valid condition with VISIBLE operator' => [
+            'item_uuid' => '456',
+            'item_type' => Type::SECTION->value,
+            'value_operator' => ValueOperator::VISIBLE->value,
+            'value' => null,
+            'logic_operator' => LogicOperator::OR->value,
+            'expected' => true,
+        ];
+
+        yield 'Valid condition with empty value' => [
+            'item_uuid' => '789',
+            'item_type' => Type::COMMENT->value,
+            'value_operator' => ValueOperator::CONTAINS->value,
+            'value' => '',
+            'logic_operator' => null,
+            'expected' => true,
+        ];
+
+        yield 'Valid condition with null value' => [
+            'item_uuid' => 'abc',
+            'item_type' => Type::QUESTION->value,
+            'value_operator' => ValueOperator::GREATER_THAN->value,
+            'value' => null,
+            'logic_operator' => LogicOperator::AND->value,
+            'expected' => true,
+        ];
+    }
+
+    public static function provideInvalidConditions(): iterable
+    {
+        yield 'Empty item UUID' => [
+            'item_uuid' => '',
+            'item_type' => Type::QUESTION->value,
+            'value_operator' => ValueOperator::EQUALS->value,
+            'value' => 'test_value',
+            'logic_operator' => LogicOperator::AND->value,
+            'expected' => false,
+        ];
+
+        yield 'Null item UUID' => [
+            'item_uuid' => null,
+            'item_type' => Type::QUESTION->value,
+            'value_operator' => ValueOperator::EQUALS->value,
+            'value' => 'test_value',
+            'logic_operator' => LogicOperator::AND->value,
+            'expected' => false,
+        ];
+
+        yield 'Invalid item type' => [
+            'item_uuid' => '123',
+            'item_type' => 'invalid_type',
+            'value_operator' => ValueOperator::EQUALS->value,
+            'value' => 'test_value',
+            'logic_operator' => LogicOperator::AND->value,
+            'expected' => false,
+        ];
+
+        yield 'Null value operator' => [
+            'item_uuid' => '123',
+            'item_type' => Type::QUESTION->value,
+            'value_operator' => null,
+            'value' => 'test_value',
+            'logic_operator' => LogicOperator::AND->value,
+            'expected' => false,
+        ];
+
+        yield 'Empty value operator' => [
+            'item_uuid' => '123',
+            'item_type' => Type::QUESTION->value,
+            'value_operator' => '',
+            'value' => 'test_value',
+            'logic_operator' => LogicOperator::AND->value,
+            'expected' => false,
+        ];
+
+        yield 'Invalid value operator' => [
+            'item_uuid' => '123',
+            'item_type' => Type::QUESTION->value,
+            'value_operator' => 'invalid_operator',
+            'value' => 'test_value',
+            'logic_operator' => LogicOperator::AND->value,
+            'expected' => false,
+        ];
+    }
+
+    #[DataProvider('provideValidConditions')]
+    public function testIsValidReturnsTrueForValidConditions(
+        ?string $item_uuid,
+        string $item_type,
+        ?string $value_operator,
+        mixed $value,
+        ?string $logic_operator,
+        bool $expected
+    ): void {
+        $condition = new ConditionData(
+            item_uuid: $item_uuid ?? '',
+            item_type: $item_type,
+            value_operator: $value_operator,
+            value: $value,
+            logic_operator: $logic_operator
+        );
+
+        $this->assertEquals($expected, $condition->isValid());
+    }
+
+    #[DataProvider('provideInvalidConditions')]
+    public function testIsValidReturnsFalseForInvalidConditions(
+        ?string $item_uuid,
+        string $item_type,
+        ?string $value_operator,
+        mixed $value,
+        ?string $logic_operator,
+        bool $expected
+    ): void {
+        $condition = new ConditionData(
+            item_uuid: $item_uuid ?? '',
+            item_type: $item_type,
+            value_operator: $value_operator,
+            value: $value,
+            logic_operator: $logic_operator
+        );
+
+        $this->assertEquals($expected, $condition->isValid());
+    }
+
+    public function testIsValidWithAllValueOperators(): void
+    {
+        $validOperators = [
+            ValueOperator::EQUALS,
+            ValueOperator::NOT_EQUALS,
+            ValueOperator::CONTAINS,
+            ValueOperator::NOT_CONTAINS,
+            ValueOperator::GREATER_THAN,
+            ValueOperator::GREATER_THAN_OR_EQUALS,
+            ValueOperator::LESS_THAN,
+            ValueOperator::LESS_THAN_OR_EQUALS,
+            ValueOperator::VISIBLE,
+            ValueOperator::NOT_VISIBLE,
+            ValueOperator::EMPTY,
+            ValueOperator::NOT_EMPTY,
+            ValueOperator::MATCH_REGEX,
+            ValueOperator::NOT_MATCH_REGEX,
+        ];
+
+        foreach ($validOperators as $operator) {
+            $condition = new ConditionData(
+                item_uuid: 'test-uuid',
+                item_type: Type::QUESTION->value,
+                value_operator: $operator->value,
+                value: 'test_value',
+                logic_operator: LogicOperator::AND->value
+            );
+
+            $this->assertTrue(
+                $condition->isValid(),
+                "Condition should be valid with operator: {$operator->value}"
+            );
+        }
+    }
+
+    public function testIsValidWithAllItemTypes(): void
+    {
+        $validTypes = [
+            Type::QUESTION,
+            Type::SECTION,
+            Type::COMMENT,
+        ];
+
+        foreach ($validTypes as $type) {
+            $condition = new ConditionData(
+                item_uuid: 'test-uuid',
+                item_type: $type->value,
+                value_operator: ValueOperator::EQUALS->value,
+                value: 'test_value',
+                logic_operator: LogicOperator::AND->value
+            );
+
+            $this->assertTrue(
+                $condition->isValid(),
+                "Condition should be valid with item type: {$type->value}"
+            );
+        }
+    }
+
+    public function testGettersWorkCorrectlyWithValidCondition(): void
+    {
+        $condition = new ConditionData(
+            item_uuid: 'test-uuid-123',
+            item_type: Type::QUESTION->value,
+            value_operator: ValueOperator::CONTAINS->value,
+            value: 'test_value',
+            logic_operator: LogicOperator::OR->value
+        );
+
+        $this->assertTrue($condition->isValid());
+        $this->assertEquals('test-uuid-123', $condition->getItemUuid());
+        $this->assertEquals(Type::QUESTION, $condition->getItemType());
+        $this->assertEquals(ValueOperator::CONTAINS, $condition->getValueOperator());
+        $this->assertEquals('test_value', $condition->getValue());
+        $this->assertEquals(LogicOperator::OR, $condition->getLogicOperator());
+        $this->assertEquals('question-test-uuid-123', $condition->getItemDropdownKey());
+    }
+
+    public function testJsonSerializationIncludesValidation(): void
+    {
+        $condition = new ConditionData(
+            item_uuid: 'json-test-uuid',
+            item_type: Type::SECTION->value,
+            value_operator: ValueOperator::EQUALS->value,
+            value: 'json_value',
+            logic_operator: LogicOperator::AND->value
+        );
+
+        $this->assertTrue($condition->isValid());
+
+        $serialized = json_encode($condition);
+        $decoded = json_decode($serialized, true);
+
+        $this->assertEquals('section-json-test-uuid', $decoded['item']);
+        $this->assertEquals('json-test-uuid', $decoded['item_uuid']);
+        $this->assertEquals('section', $decoded['item_type']);
+        $this->assertEquals('equals', $decoded['value_operator']);
+        $this->assertEquals('json_value', $decoded['value']);
+        $this->assertEquals('and', $decoded['logic_operator']);
+    }
+}

--- a/src/Glpi/Form/Condition/ConditionData.php
+++ b/src/Glpi/Form/Condition/ConditionData.php
@@ -84,6 +84,32 @@ final class ConditionData implements JsonSerializable
         return ValueOperator::tryFrom($this->value_operator ?? "");
     }
 
+    /**
+     * Check if the condition is valid and fully specified
+     *
+     * @return bool True if the condition is valid, false otherwise
+     */
+    public function isValid(): bool
+    {
+        // Check if item UUID is not empty
+        if (empty($this->item_uuid)) {
+            return false;
+        }
+
+        // Check if item type is valid
+        if (Type::tryFrom($this->item_type) === null) {
+            return false;
+        }
+
+        // Check if value operator is valid
+        $value_operator = $this->getValueOperator();
+        if ($value_operator === null) {
+            return false;
+        }
+
+        return true;
+    }
+
     #[Override]
     public function jsonSerialize(): array
     {

--- a/src/Glpi/Form/Condition/ConditionableTrait.php
+++ b/src/Glpi/Form/Condition/ConditionableTrait.php
@@ -74,6 +74,12 @@ trait ConditionableTrait
             'conditions' => $raw_data,
         ]);
 
-        return $form_data->getConditionsData();
+        // Filter out invalid conditions
+        $conditions = array_filter(
+            $form_data->getConditionsData(),
+            fn(ConditionData $condition) => $condition->isValid()
+        );
+
+        return $conditions;
     }
 }


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description
It is possible to end up with "empty" conditions; if a visibility strategy is defined but no source item is defined, the default value (`0`) is sent.
This does not cause any problems for processing or displaying conditions, but it is problematic when exporting forms.