### PR TITLE
fix(forms): prevent duplicate condition entries for questions within sections

### DIFF
--- a/js/modules/Forms/EditorController.js
+++ b/js/modules/Forms/EditorController.js
@@ -1190,17 +1190,17 @@ export class GlpiFormEditorController
                     type: 'question',
                     element: parentItem
                 });
-            }
-
-            // Check if condition is in a section
-            const parentSection = $(element).closest('[data-glpi-form-editor-section]');
-            if (parentSection.length > 0) {
-                elementsWithConditions.push({
-                    name: this.#getItemInput(parentSection, "name"),
-                    uuid: this.#getItemInput(parentSection, "uuid"),
-                    type: 'section',
-                    element: parentSection
-                });
+            } else {
+                // Check if condition is in a section
+                const parentSection = $(element).closest('[data-glpi-form-editor-section]');
+                if (parentSection.length > 0) {
+                    elementsWithConditions.push({
+                        name: this.#getItemInput(parentSection, "name"),
+                        uuid: this.#getItemInput(parentSection, "uuid"),
+                        type: 'section',
+                        element: parentSection
+                    });
+                }
             }
         });
 

--- a/tests/cypress/e2e/form/editor/conditions.cy.js
+++ b/tests/cypress/e2e/form/editor/conditions.cy.js
@@ -2523,6 +2523,7 @@ describe ('Conditions', () => {
             .should('have.attr', 'data-cy-shown', 'true')
             .within(() => {
                 cy.findByRole('link', {'name': 'My second question'}).should('be.visible');
+                cy.findByRole('link', {'name': 'First section'}).should('not.exist');
                 cy.findByRole('button', {'name': 'Close'}).click();
             });
         saveAndReload();
@@ -2546,6 +2547,7 @@ describe ('Conditions', () => {
             .should('have.attr', 'data-cy-shown', 'true')
             .within(() => {
                 cy.findByRole('link', {'name': 'My second question'}).should('be.visible');
+                cy.findByRole('link', {'name': 'First section'}).should('not.exist');
                 cy.findByRole('button', {'name': 'Close'}).click();
             });
 
@@ -2582,6 +2584,7 @@ describe ('Conditions', () => {
             .should('have.attr', 'data-cy-shown', 'true')
             .within(() => {
                 cy.findByRole('link', {'name': 'My question'}).should('be.visible');
+                cy.findByRole('link', {'name': 'First section'}).should('not.exist');
                 cy.findByRole('button', {'name': 'Close'}).click();
             });
         saveAndReload();
@@ -2606,6 +2609,7 @@ describe ('Conditions', () => {
             .should('have.attr', 'data-cy-shown', 'true')
             .within(() => {
                 cy.findByRole('link', {'name': 'My question'}).should('be.visible');
+                cy.findByRole('link', {'name': 'First section'}).should('not.exist');
                 cy.findByRole('button', {'name': 'Close'}).click();
             });
 


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

When attempting to delete a question that was the source of a condition for another question, the question was displayed as expected in the modal, but its section was also displayed regardless of whether it used the question as a source.