### PR TITLE
Fix `chr(): Providing a value not in-between 0 and 255 is deprecated`

### DIFF
--- a/src/GLPIKey.php
+++ b/src/GLPIKey.php
@@ -468,8 +468,14 @@ class GLPIKey
         for ($i = 0; $i < strlen($string); $i++) {
             $char    = substr($string, $i, 1);
             $keychar = substr($key, ($i % strlen($key)) - 1, 1);
-            $char    = chr(ord($char) - ord($keychar));
-            $result .= $char;
+
+            $bytevalue = ord($char) - ord($keychar);
+            while ($bytevalue < 0) {
+                $bytevalue += 256;
+            }
+            $bytevalue %= 256;
+
+            $result .= chr($bytevalue);
         }
 
         return Sanitizer::unsanitize($result);


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Using `chr` with a value outside the 0-255 range is deprecated. I reproduced the logic automatically made by PHP, see https://www.php.net/manual/en/function.chr.php

> Values outside the valid range (0..255) will be bitwise and'ed with 255, which is equivalent to the following algorithm:
> ```php
> while ($bytevalue < 0) {
>     $bytevalue += 256;
> }
> $bytevalue %= 256;
> ```

This fixes the following issue:
```
Deprecated: chr(): Providing a value not in-between 0 and 255 is deprecated, this is because a byte value must be in the [0, 255] interval. The value used will be constrained using % 256 at GLPIKey.php line 485
#0 /var/www/glpi/src/GLPIKey.php(304): GLPIKey->decryptUsingLegacyKey('\x85X\xA3T\x8F\x9E\x90s\xA2\x0Fz\xE4\xCF\x8A\x88...')
#1 /var/www/glpi/src/GLPIKey.php(212): GLPIKey->migrateFieldsInDb(NULL)
#2 /var/www/glpi/phpunit/functional/GLPIKeyTest.php(212): GLPIKey->generate()
#3 /var/www/glpi/vendor/phpunit/phpunit/src/Framework/TestCase.php(1656): tests\units\GLPIKeyTest->testGenerateWithoutPreviousKey()
#4 /var/www/glpi/vendor/phpunit/phpunit/src/Framework/TestCase.php(514): PHPUnit\Framework\TestCase->runTest()
#5 /var/www/glpi/vendor/phpunit/phpunit/src/Framework/TestRunner/TestRunner.php(87): PHPUnit\Framework\TestCase->runBare()
#6 /var/www/glpi/vendor/phpunit/phpunit/src/Framework/TestCase.php(361): PHPUnit\Framework\TestRunner->run(Object(tests\units\GLPIKeyTest))
#7 /var/www/glpi/vendor/phpunit/phpunit/src/Framework/TestSuite.php(369): PHPUnit\Framework\TestCase->run()
#8 /var/www/glpi/vendor/phpunit/phpunit/src/Framework/TestSuite.php(369): PHPUnit\Framework\TestSuite->run()
#9 /var/www/glpi/vendor/phpunit/phpunit/src/Framework/TestSuite.php(369): PHPUnit\Framework\TestSuite->run()
#10 /var/www/glpi/vendor/phpunit/phpunit/src/TextUI/TestRunner.php(64): PHPUnit\Framework\TestSuite->run()
#11 /var/www/glpi/vendor/phpunit/phpunit/src/TextUI/Application.php(210): PHPUnit\TextUI\TestRunner->run(Object(PHPUnit\TextUI\Configuration\Configuration), Object(PHPUnit\Runner\ResultCache\DefaultResultCache), Object(PHPUnit\Framework\TestSuite))
#12 /var/www/glpi/vendor/phpunit/phpunit/phpunit(104): PHPUnit\TextUI\Application->run(Array)
#13 /var/www/glpi/vendor/bin/phpunit(122): include('/var/www/glpi/v...')
#14 {main}
```