### PR TITLE
Fix KB export

### DIFF
--- a/front/report.dynamic.php
+++ b/front/report.dynamic.php
@@ -59,10 +59,6 @@ if (isset($_GET["display_type"])) {
     }
 
     switch ($itemtype) {
-        case 'KnowbaseItem':
-            KnowbaseItem::showList($_GET, $_GET["type"]);
-            break;
-
         case 'Stat':
             if (isset($_GET["item_type_param"])) {
                 $params = Toolbox::decodeArrayFromInput($_GET["item_type_param"]);


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Since #11323, the KB list uses the generic implementation of the search engine. Therefore, the export feature should also use the generic implementation.

It fixes #20890.