### PR TITLE
Form editor: handle invalid question types

### DIFF
--- a/src/Glpi/Form/Question.php
+++ b/src/Glpi/Form/Question.php
@@ -189,11 +189,7 @@ final class Question extends CommonDBChild implements BlockInterface, Conditiona
     public function getQuestionType(): ?QuestionTypeInterface
     {
         $type = $this->fields['type'] ?? "";
-
-        if (
-            !is_a($type, QuestionTypeInterface::class, true)
-            || (new ReflectionClass($type))->isAbstract()
-        ) {
+        if (!QuestionTypesManager::getInstance()->isValidQuestionType($type)) {
             return null;
         }
 

--- a/templates/pages/admin/form/form_editor.html.twig
+++ b/templates/pages/admin/form/form_editor.html.twig
@@ -85,6 +85,24 @@
                                 data-glpi-form-editor-on-click="set-active"
                                 aria-label="{{ __("Form details") }}"
                             >
+                                {% if invalid_questions|length %}
+                                    <div class="alert alert-danger" role="alert">
+                                        <div class="alert-icon">
+                                            <i class="ti ti-exclamation-circle"></i>
+                                        </div>
+                                        <div>
+                                            <h4 class="alert-heading">{{ __("These questions have an unknown type and will be deleted the next time this form is saved:") }}</h4>
+                                            <div class="alert-description">
+                                                <ul class="alert-list">
+                                                    {% for invalid_question in invalid_questions %}
+                                                        <li>{{ invalid_question.fields['name'] }}</li>
+                                                    {% endfor %}
+                                                </ul>
+                                            </div>
+                                        </div>
+                                    </div>
+                                {% endif %}
+
                                 {# Card containing the main form data: title, header and status #}
                                 <div class="card form-details">
                                     <div


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works. -> Not really testable as we can't properly disable plugins in our tests suites.

## Description

I'm doing some testing to see how GLPI's handle invalid questions type (for example, a type from a plugin that was then disabled).

I've fixed a case where a missing question type was not detected correctly (we need to check the official types from the types manager class) and added an error message to let the user know that the invalid question will be discarded:

<img width="1360" height="485" alt="image" src="https://github.com/user-attachments/assets/b9dad58c-b5f9-4602-857f-a64b9f3d4c10" />


