### PR TITLE
Hidden fields have no label

### DIFF
--- a/templates/components/form/fields_macros.html.twig
+++ b/templates/components/form/fields_macros.html.twig
@@ -425,6 +425,15 @@
 {% endmacro %}
 
 {% macro hiddenField(name, value, options = {}) %}
+    {% if options is not iterable %}
+        {#
+            If `options` is not iterable, it means that this macro was used
+            with its previous signature (name, value, label, options = {}).
+            We get the `options` value from the extra positional arguments (available in `varargs`).
+            @TODO Add a deprecation in GLPI 11.1.
+         #}
+        {% set options = varargs[0]|default({}) %}
+    {% endif %}
     {% import 'components/form/basic_inputs_macros.html.twig' as _inputs %}
     {{ _inputs.hidden(name, value, options) }}
 {% endmacro %}

--- a/templates/components/form/fields_macros.html.twig
+++ b/templates/components/form/fields_macros.html.twig
@@ -424,7 +424,7 @@
    })) }}
 {% endmacro %}
 
-{% macro hiddenField(name, value, label = '', options = {}) %}
+{% macro hiddenField(name, value, options = {}) %}
     {% import 'components/form/basic_inputs_macros.html.twig' as _inputs %}
     {{ _inputs.hidden(name, value, options) }}
 {% endmacro %}

--- a/templates/components/form/link_existing_or_new.html.twig
+++ b/templates/components/form/link_existing_or_new.html.twig
@@ -36,9 +36,7 @@
 <div class="firstbloc">
    <form id="{{ link_itemtype|lower ~ "_form" ~ rand }}" name="{{ link_itemtype|lower ~ "_form" ~ rand }}" method="post" action="{{ link_itemtype|itemtype_form_path }}">
       {{ form_label }}
-      {{ fields.hiddenField(source_itemtype|itemtype_foreign_key, source_items_id, '', {
-         no_label: true,
-      }) }}
+      {{ fields.hiddenField(source_itemtype|itemtype_foreign_key, source_items_id) }}
       {% set primary_dropdown_itemtype = dropdown_options['itemtype']|default(target_itemtype) %}
       <div class="d-flex">
          {% if link_types is defined and link_types is not empty %}

--- a/templates/components/form/reservation.html.twig
+++ b/templates/components/form/reservation.html.twig
@@ -48,11 +48,7 @@
             ) }}
             {{ fields.hiddenField(
                 'items[' ~ item.id ~ ']',
-                item.id,
-                '',
-                {
-                    add_field_class: 'd-none'
-                }
+                item.id
             ) }}
         {% endfor %}
     {% else %}

--- a/templates/generic_show_form.html.twig
+++ b/templates/generic_show_form.html.twig
@@ -73,9 +73,7 @@
                           {% elseif field is same as 'template_name' and withtemplate == 1 and no_header %}
                               {{ fields.autoNameField('template_name', item, __('Template name'), 0, specific_field_options) }}
                           {% elseif item.isField('is_active') and field is same as '_template_is_active' and withtemplate >= 1 %}
-                              {{ fields.hiddenField('is_active', item.fields['is_active'], __('Is active'), {
-                                  'add_field_html': __('No')
-                              }) }}
+                              {{ fields.hiddenField('is_active', item.fields['is_active']) }}
                           {% elseif field is same as 'states_id' and item is usingtrait('Glpi\\Features\\State') %}
                               {{ fields.dropdownField(
                                   'State',

--- a/templates/pages/admin/form/question_type/item_dropdown/end_user_template.html.twig
+++ b/templates/pages/admin/form/question_type/item_dropdown/end_user_template.html.twig
@@ -34,12 +34,7 @@
 
 {{ fields.hiddenField(
     question.getEndUserInputName() ~ '[itemtype]',
-    itemtype,
-    '',
-    {
-        'no_label': true,
-        'mb': ''
-    }
+    itemtype
 ) }}
 {{ fields.dropdownField(
     itemtype,


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Follows #20849.

The `label` parameter will never be used. I kept the ability to define options, for instance to define a specific `id`, or some data attributes values.