### PR TITLE
Allow plugins to hook into the form question types migration process

### DIFF
--- a/src/Glpi/Form/Migration/FormMigration.php
+++ b/src/Glpi/Form/Migration/FormMigration.php
@@ -543,7 +543,10 @@ class FormMigration extends AbstractPluginMigration
             $fieldtype = $raw_question['fieldtype'];
             $converter = $this->getTypesConvertMap()[$fieldtype] ?? null;
 
-            if ($converter === null) {
+            if (
+                $converter === null
+                || !$converter instanceof FormQuestionDataConverterInterface
+            ) {
                 // Retrieve the form to provide context in the error message
                 $section = Section::getById($section_id);
                 $form = $section->getForm();
@@ -562,13 +565,11 @@ class FormMigration extends AbstractPluginMigration
 
             $default_value = null;
             $extra_data = null;
-            if ($converter instanceof FormQuestionDataConverterInterface) {
-                $converter->beforeConversion($raw_question);
 
-                $default_value = $converter->convertDefaultValue($raw_question);
-                $extra_data    = $converter->convertExtraData($raw_question);
-                $type_class    = $converter->getTargetQuestionType($raw_question);
-            }
+            $converter->beforeConversion($raw_question);
+            $default_value = $converter->convertDefaultValue($raw_question);
+            $extra_data    = $converter->convertExtraData($raw_question);
+            $type_class    = $converter->getTargetQuestionType($raw_question);
 
             $question = new Question();
             $data = array_filter([

--- a/src/Glpi/Form/Migration/TypesConversionMapper.php
+++ b/src/Glpi/Form/Migration/TypesConversionMapper.php
@@ -1,0 +1,129 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Form\Migration;
+
+use Glpi\Form\QuestionType\QuestionTypeCheckbox;
+use Glpi\Form\QuestionType\QuestionTypeDateTime;
+use Glpi\Form\QuestionType\QuestionTypeDropdown;
+use Glpi\Form\QuestionType\QuestionTypeEmail;
+use Glpi\Form\QuestionType\QuestionTypeFile;
+use Glpi\Form\QuestionType\QuestionTypeItem;
+use Glpi\Form\QuestionType\QuestionTypeItemDropdown;
+use Glpi\Form\QuestionType\QuestionTypeLongText;
+use Glpi\Form\QuestionType\QuestionTypeNumber;
+use Glpi\Form\QuestionType\QuestionTypeRadio;
+use Glpi\Form\QuestionType\QuestionTypeRequester;
+use Glpi\Form\QuestionType\QuestionTypeRequestType;
+use Glpi\Form\QuestionType\QuestionTypeShortText;
+use Glpi\Form\QuestionType\QuestionTypeUrgency;
+use Glpi\Toolbox\SingletonTrait;
+use InvalidArgumentException;
+
+final class TypesConversionMapper
+{
+    use SingletonTrait;
+
+    /** @var array<string, ?FormQuestionDataConverterInterface> */
+    private array $questions_types_conversion_map;
+
+    private function __construct()
+    {
+        $this->questions_types_conversion_map = $this->getDefaultQuestionTypesConverter();
+    }
+
+    /**
+     * Retrieve the map of types to convert
+     *
+     * @return array
+     */
+    public function getQuestionTypesConversionMap(): array
+    {
+        return $this->questions_types_conversion_map;
+    }
+
+    public function registerPluginQuestionTypeConverter(
+        string $formcreator_type,
+        ?FormQuestionDataConverterInterface $converter
+    ): void {
+        if (!array_key_exists($formcreator_type, $this->questions_types_conversion_map)) {
+            throw new InvalidArgumentException("Unknown type: `$formcreator_type`");
+        }
+
+        $this->questions_types_conversion_map[$formcreator_type] = $converter;
+    }
+
+    /** @return array<string, ?FormQuestionDataConverterInterface> */
+    private function getDefaultQuestionTypesConverter(): array
+    {
+        return [
+            'checkboxes'  => new QuestionTypeCheckbox(),
+            'date'        => new QuestionTypeDateTime(),
+            'datetime'    => new QuestionTypeDateTime(),
+            'dropdown'    => new QuestionTypeItemDropdown(),
+            'email'       => new QuestionTypeEmail(),
+            'file'        => new QuestionTypeFile(),
+            'float'       => new QuestionTypeNumber(),
+            'glpiselect'  => new QuestionTypeItem(),
+            'integer'     => new QuestionTypeNumber(),
+            'multiselect' => new QuestionTypeDropdown(),
+            'radios'      => new QuestionTypeRadio(),
+            'requesttype' => new QuestionTypeRequestType(),
+            'select'      => new QuestionTypeDropdown(),
+            'textarea'    => new QuestionTypeLongText(),
+            'text'        => new QuestionTypeShortText(),
+            'time'        => new QuestionTypeDateTime(),
+            'urgency'     => new QuestionTypeUrgency(),
+
+            // We do not have a question of type "Actor", we have more specific
+            // types: "Assignee", "Requester" and "Observer".
+            // Fallback to "Requester" as we can't guess the expected type.
+            'actor'       => new QuestionTypeRequester(),
+
+            // Description is replaced by a new block : Comment
+            'description' => null,
+
+            // Unsupported types, some of them might be implemented by plugins.
+            'fields'      => null,
+            'tag'         => null,
+            'hidden'      => null,
+            'hostname'    => null,
+            'ip'          => null,
+            'ldapselect'  => null,
+
+            // Invalid type
+            'undefined'   => null,
+        ];
+    }
+}

--- a/src/Glpi/Form/QuestionType/AbstractQuestionTypeActors.php
+++ b/src/Glpi/Form/QuestionType/AbstractQuestionTypeActors.php
@@ -622,4 +622,14 @@ TWIG;
 
         return $default_value_data;
     }
+
+    #[Override]
+    public function getTargetQuestionType(array $rawData): string
+    {
+        return static::class;
+    }
+
+
+    #[Override]
+    public function beforeConversion(array $rawData): void {}
 }

--- a/src/Glpi/Form/QuestionType/AbstractQuestionTypeSelectable.php
+++ b/src/Glpi/Form/QuestionType/AbstractQuestionTypeSelectable.php
@@ -54,7 +54,6 @@ abstract class AbstractQuestionTypeSelectable extends AbstractQuestionType imple
 {
     public const TRANSLATION_KEY_OPTION = 'option';
 
-    #[Override]
     public function __construct() {}
 
     #[Override]
@@ -494,4 +493,14 @@ TWIG;
 
         return array_filter(array_map(fn($item) => $question_config->getOptions()[$item] ?? null, $value));
     }
+
+    #[Override]
+    public function getTargetQuestionType(array $rawData): string
+    {
+        return static::class;
+    }
+
+
+    #[Override]
+    public function beforeConversion(array $rawData): void {}
 }

--- a/src/Glpi/Form/QuestionType/AbstractQuestionTypeShortAnswer.php
+++ b/src/Glpi/Form/QuestionType/AbstractQuestionTypeShortAnswer.php
@@ -197,4 +197,14 @@ TWIG;
     {
         return null;
     }
+
+    #[Override]
+    public function getTargetQuestionType(array $rawData): string
+    {
+        return static::class;
+    }
+
+
+    #[Override]
+    public function beforeConversion(array $rawData): void {}
 }

--- a/src/Glpi/Form/QuestionType/QuestionTypeDateTime.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeDateTime.php
@@ -378,4 +378,14 @@ TWIG;
             throw new RuntimeException();
         }
     }
+
+    #[Override]
+    public function getTargetQuestionType(array $rawData): string
+    {
+        return static::class;
+    }
+
+
+    #[Override]
+    public function beforeConversion(array $rawData): void {}
 }

--- a/src/Glpi/Form/QuestionType/QuestionTypeFile.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeFile.php
@@ -38,10 +38,11 @@ namespace Glpi\Form\QuestionType;
 use Config;
 use Document;
 use Glpi\Application\View\TemplateRenderer;
+use Glpi\Form\Migration\FormQuestionDataConverterInterface;
 use Glpi\Form\Question;
 use Override;
 
-final class QuestionTypeFile extends AbstractQuestionType
+final class QuestionTypeFile extends AbstractQuestionType implements FormQuestionDataConverterInterface
 {
     #[Override]
     public function prepareEndUserAnswer(Question $question, mixed $answer): mixed
@@ -137,5 +138,27 @@ TWIG;
     public function isAllowedForUnauthenticatedAccess(): bool
     {
         return Config::allowUnauthenticatedUploads();
+    }
+
+    #[Override]
+    public function getTargetQuestionType(array $rawData): string
+    {
+        return static::class;
+    }
+
+
+    #[Override]
+    public function beforeConversion(array $rawData): void {}
+
+    #[Override]
+    public function convertDefaultValue(array $rawData): null
+    {
+        return null;
+    }
+
+    #[Override]
+    public function convertExtraData(array $rawData): null
+    {
+        return null;
     }
 }

--- a/src/Glpi/Form/QuestionType/QuestionTypeFile.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeFile.php
@@ -143,7 +143,7 @@ TWIG;
     #[Override]
     public function getTargetQuestionType(array $rawData): string
     {
-        return static::class;
+        return self::class;
     }
 
 

--- a/src/Glpi/Form/QuestionType/QuestionTypeItem.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeItem.php
@@ -456,4 +456,14 @@ class QuestionTypeItem extends AbstractQuestionType implements
     {
         return [];
     }
+
+    #[Override]
+    public function getTargetQuestionType(array $rawData): string
+    {
+        return static::class;
+    }
+
+
+    #[Override]
+    public function beforeConversion(array $rawData): void {}
 }

--- a/src/Glpi/Form/QuestionType/QuestionTypeLongText.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeLongText.php
@@ -238,4 +238,14 @@ TWIG;
 
         return $handlers;
     }
+
+    #[Override]
+    public function getTargetQuestionType(array $rawData): string
+    {
+        return static::class;
+    }
+
+
+    #[Override]
+    public function beforeConversion(array $rawData): void {}
 }

--- a/src/Glpi/Form/QuestionType/QuestionTypeLongText.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeLongText.php
@@ -242,7 +242,7 @@ TWIG;
     #[Override]
     public function getTargetQuestionType(array $rawData): string
     {
-        return static::class;
+        return self::class;
     }
 
 

--- a/src/Glpi/Form/QuestionType/QuestionTypeRequestType.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeRequestType.php
@@ -177,7 +177,7 @@ TWIG;
     #[Override]
     public function getTargetQuestionType(array $rawData): string
     {
-        return static::class;
+        return self::class;
     }
 
 

--- a/src/Glpi/Form/QuestionType/QuestionTypeRequestType.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeRequestType.php
@@ -173,4 +173,14 @@ TWIG;
     {
         return null;
     }
+
+    #[Override]
+    public function getTargetQuestionType(array $rawData): string
+    {
+        return static::class;
+    }
+
+
+    #[Override]
+    public function beforeConversion(array $rawData): void {}
 }

--- a/src/Glpi/Form/QuestionType/QuestionTypeUrgency.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeUrgency.php
@@ -212,4 +212,14 @@ TWIG;
     {
         return null;
     }
+
+    #[Override]
+    public function getTargetQuestionType(array $rawData): string
+    {
+        return static::class;
+    }
+
+
+    #[Override]
+    public function beforeConversion(array $rawData): void {}
 }

--- a/src/Glpi/Form/QuestionType/QuestionTypeUrgency.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeUrgency.php
@@ -216,7 +216,7 @@ TWIG;
     #[Override]
     public function getTargetQuestionType(array $rawData): string
     {
-        return static::class;
+        return self::class;
     }
 
 

--- a/tests/fixtures/plugins/tester/src/Form/QuestionTypeIpConverter.php
+++ b/tests/fixtures/plugins/tester/src/Form/QuestionTypeIpConverter.php
@@ -32,38 +32,36 @@
  * ---------------------------------------------------------------------
  */
 
-namespace Glpi\Form\Migration;
+namespace GlpiPlugin\Tester\Form;
 
-use Glpi\Form\QuestionType\QuestionTypeInterface;
+use Glpi\Form\Migration\FormQuestionDataConverterInterface;
+use Glpi\Form\QuestionType\QuestionTypeShortText;
+use Override;
 
-interface FormQuestionDataConverterInterface
+/**
+ * Convert IP questions into normal text questions
+ */
+final class QuestionTypeIpConverter implements FormQuestionDataConverterInterface
 {
-    /**
-     * Convert default value
-     *
-     * @param array $rawData
-     * @return mixed
-     */
-    public function convertDefaultValue(array $rawData): mixed;
+    #[Override]
+    public function convertDefaultValue(array $rawData): null
+    {
+        return null;
+    }
 
-    /**
-     * Convert extra data
-     *
-     * @param array $rawData
-     * @return mixed
-     */
-    public function convertExtraData(array $rawData): mixed;
+    #[Override]
+    public function convertExtraData(array $rawData): null
+    {
+        return null;
+    }
 
-    /**
-     * @return class-string<QuestionTypeInterface>
-     */
-    public function getTargetQuestionType(array $rawData): string;
+    #[Override]
+    public function getTargetQuestionType(array $rawData): string
+    {
+        return QuestionTypeShortText::class;
+    }
 
-    /**
-     * Allow the converter to run some arbitrary code before we begin converting
-     * values.
-     *
-     * For example, it might be used to create some required database items.
-     */
-    public function beforeConversion(array $rawData): void;
+    #[Override]
+    public function beforeConversion(array $rawData): void {}
+
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Since plugins are allowed to add new question types, it make sense to also allow them to integrate them into the form migration.

For example, a plugin that add the "Ip address" question type (a type from formcreator that we did not reuse in native forms) might want to make sure his new type is taken into account during the formcreator -> core migration.

