### PR TITLE
neutralize a few annoying shadow (notably in healpdesk fields)

### DIFF
--- a/css/includes/_base.scss
+++ b/css/includes/_base.scss
@@ -289,6 +289,14 @@ body.in_modal {
     }
 }
 
+.btn-group {
+    box-shadow: none;
+
+    .btn, input.form-control {
+        box-shadow: none;
+    }
+}
+
 .status {
     --tblr-status-color: var(--tblr-secondary);
 

--- a/css/includes/components/_select2.scss
+++ b/css/includes/components/_select2.scss
@@ -239,6 +239,7 @@
             .select2-selection {
                 border-top-right-radius: 0;
                 border-bottom-right-radius: 0;
+                border-right: 0;
             }
         }
     }


### PR DESCRIPTION
I saw this since months but didn't took the time to fix it.
It's subtle but a bit annoying

**Before**
<img width="635" height="402" alt="image" src="https://github.com/user-attachments/assets/c138cfba-229a-43c0-8cf2-921c133103b4" />


**After**
<img width="643" height="400" alt="image" src="https://github.com/user-attachments/assets/5ec75184-3de8-4da4-9e79-845ff6d47e55" />

There is also a double border between the select and the add button, but cannot tackle it for the moment
