### PR TITLE
fix border-radius for single action btn on bottom-right of ticket

### DIFF
--- a/css/includes/components/_buttons-group.scss
+++ b/css/includes/components/_buttons-group.scss
@@ -74,28 +74,23 @@ which broke styles of btn-group > .btn-check
 
 // Reverse border radius for flex-row-reverse
 .btn-group.flex-row-reverse {
-    // btn-group in bottom right of single ticket page contains a button contained in an intermediate btn-group
-    // & part is here for other buttons (not in the intermediate group)
-    //
     // !important are set for buttons in the middle (not first, not last) to have both radius neutralized
     // (and avoid the inheritance)
-    .btn-group, & {
-        .btn:not(:last-child, .dropdown-toggle),
-        .btn.dropdown-toggle-split:first-child,
-        .btn-group:not(:last-child) > .btn {
-            border-top-right-radius: inherit;
-            border-bottom-right-radius: inherit;
-            border-top-left-radius: 0 !important;
-            border-bottom-left-radius: 0 !important;
-        }
+    .btn:not(:last-child, .dropdown-toggle),
+    .btn.dropdown-toggle-split:first-child,
+    .btn-group:not(:last-child) > .btn {
+        border-top-right-radius: inherit;
+        border-bottom-right-radius: inherit;
+        border-top-left-radius: 0 !important;
+        border-bottom-left-radius: 0 !important;
+    }
 
-        .btn:nth-child(n+3),
-        :not(.btn-check) + .btn,
-        .btn-group:not(:first-child) > .btn {
-            border-top-left-radius: inherit;
-            border-bottom-left-radius: inherit;
-            border-top-right-radius: 0 !important;
-            border-bottom-right-radius: 0 !important;
-        }
+    .btn:nth-child(n+3),
+    :not(.btn-check) + .btn,
+    .btn-group:not(:first-child) > .btn {
+        border-top-left-radius: inherit;
+        border-bottom-left-radius: inherit;
+        border-top-right-radius: 0 !important;
+        border-bottom-right-radius: 0 !important;
     }
 }

--- a/css/includes/components/_buttons-group.scss
+++ b/css/includes/components/_buttons-group.scss
@@ -73,20 +73,29 @@ which broke styles of btn-group > .btn-check
 }
 
 // Reverse border radius for flex-row-reverse
-.btn-group.flex-row-reverse > .btn:not(:last-child, .dropdown-toggle),
-.btn-group.flex-row-reverse > .btn.dropdown-toggle-split:first-child,
-.btn-group.flex-row-reverse > .btn-group:not(:last-child) > .btn {
-    border-top-right-radius: inherit;
-    border-bottom-right-radius: inherit;
-    border-top-left-radius: 0;
-    border-bottom-left-radius: 0;
-}
+.btn-group.flex-row-reverse {
+    // btn-group in bottom right of single ticket page contains a button contained in an intermediate btn-group
+    // & part is here for other buttons (not in the intermediate group)
+    //
+    // !important are set for buttons in the middle (not first, not last) to have both radius neutralized
+    // (and avoid the inheritance)
+    .btn-group, & {
+        .btn:not(:last-child, .dropdown-toggle),
+        .btn.dropdown-toggle-split:first-child,
+        .btn-group:not(:last-child) > .btn {
+            border-top-right-radius: inherit;
+            border-bottom-right-radius: inherit;
+            border-top-left-radius: 0 !important;
+            border-bottom-left-radius: 0 !important;
+        }
 
-.btn-group.flex-row-reverse > .btn:nth-child(n+3),
-.btn-group.flex-row-reverse > :not(.btn-check) + .btn,
-.btn-group.flex-row-reverse > .btn-group:not(:first-child) > .btn {
-    border-top-left-radius: inherit;
-    border-bottom-left-radius: inherit;
-    border-top-right-radius: 0;
-    border-bottom-right-radius: 0;
+        .btn:nth-child(n+3),
+        :not(.btn-check) + .btn,
+        .btn-group:not(:first-child) > .btn {
+            border-top-left-radius: inherit;
+            border-bottom-left-radius: inherit;
+            border-top-right-radius: 0 !important;
+            border-bottom-right-radius: 0 !important;
+        }
+    }
 }


### PR DESCRIPTION
Initial mess comes from #15765 which aimed to make the [Enter] key save the ticket.
Followed by #19443 adding a `.flex-row-reverse` to keep the order of button in the same way of 10.0/bf.
Then #19516, fixed border radius, but I missed at that time the radius on middle `.btn`.

To note, I simplified the scss to avoid repetitions and I removed the `>` because there is the `#single-action.btn-group` included in the parent `.btn-group`, so final `.btn` may be not placed directly under the parent. It works this way in tabler `.btn-group` without the `.flex-row-reverse`

**Before:**
<img width="243" height="65" alt="image" src="https://github.com/user-attachments/assets/bf8abc78-bb9b-449d-8a49-2a28602b59ec" />

**After:**
<img width="252" height="66" alt="image" src="https://github.com/user-attachments/assets/8cde1775-904a-4de2-97be-6eb70b057cc8" />
