### PR TITLE
dashboards demo mode may break plugins widgets

### DIFF
--- a/src/Glpi/Dashboard/Grid.php
+++ b/src/Glpi/Dashboard/Grid.php
@@ -993,8 +993,7 @@ HTML;
                 global $CFG_GLPI;
                 Profiler::getInstance()->start($card['provider'] . ' (Provider function)');
                 $provider_func = explode('::', $card['provider']);
-                /** @phpstan-ignore booleanAnd.leftAlwaysFalse */
-                if ($CFG_GLPI['is_demo_dashboards'] ?? 0 && $provider_func[0] === Provider::class) {
+                if (($CFG_GLPI['is_demo_dashboards'] ?? 0) && $provider_func[0] === Provider::class) {
                     $fake_provider_func = FakeProvider::class . '::' . $provider_func[1];
                     $widget_args = call_user_func_array($fake_provider_func, array_values($provider_args));
                 } else {


### PR DESCRIPTION
Override provider class only if if is the core provider

Without this fix, a provider in a plugin is overridden and the widget breaks.

<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does

## Screenshots (if appropriate):


