### PR TITLE
Update RegexConditionHandler.php

### DIFF
--- a/src/Glpi/Form/Condition/ConditionHandler/RegexConditionHandler.php
+++ b/src/Glpi/Form/Condition/ConditionHandler/RegexConditionHandler.php
@@ -80,7 +80,7 @@ class RegexConditionHandler implements ConditionHandlerInterface
         }
 
         $a = is_array($a) ? $a : [$a];
-        $b = strtolower(strval($b));
+        $b = strval($b);
 
         // Handle empty array input: empty values don't match any regex,
         // so MATCH_REGEX returns false and NOT_MATCH_REGEX returns true
@@ -90,7 +90,7 @@ class RegexConditionHandler implements ConditionHandlerInterface
 
         $matches_count = 0;
         foreach ($a as $value) {
-            $value = strtolower(strval($value));
+            $value = strval($value);
 
             // Note: we do not want to throw warnings here if an invalid regex
             // is configured by the user.


### PR DESCRIPTION
Description
This PR fixes an issue in RegexConditionHandler where both the regex pattern and the input values were being forced to lowercase before evaluation.

Problem
Lowercasing changed the semantics of regex patterns.

Example: /[A-Z]/ was transformed into /[a-z]/, breaking expected behavior.

Case-insensitive matching was implicitly applied, making /abc/ match "ABC" even without the i flag.

Change
Removed forced lowercase normalization (strtolower) for both regex patterns and input values.

Regex semantics are now respected as written by the user.

Impact
Breaking change (major version): regex is now case-sensitive by default.

Before: /abc/ matched "abc", "ABC", "AbC".
After: /abc/ matches only "abc".

To preserve case-insensitive matching, users must explicitly add the i flag (e.g., /abc/i).

Benefits
Correct and predictable regex behavior.
Proper use of standard regex flags (i, u, etc.).