### PR TITLE
fix: remove PluginsMakefile from official build

### DIFF
--- a/tools/build_glpi.sh
+++ b/tools/build_glpi.sh
@@ -101,6 +101,7 @@ dev_nodes=(
     "tools"
     "vendor/glpi-project/inventory_format/examples"
     "vendor/glpi-project/inventory_format/source_files"
+    "PluginsMakefile.mk"
 )
 for node in "${dev_nodes[@]}"
 do


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] My feature works.

## Description

I don't think this file is needed in a production environment?


