### PR TITLE
Missed format on some values

### DIFF
--- a/templates/components/infocom.html.twig
+++ b/templates/components/infocom.html.twig
@@ -169,7 +169,7 @@
 
                      {{ fields.numberField(
                         'value',
-                        infocom.fields['value'],
+                        infocom.fields['value']|formatted_number,
                         _x('price', 'Value'),
                         {
                             'disabled': disabled,
@@ -179,7 +179,7 @@
 
                      {{ fields.numberField(
                         'warranty_value',
-                        infocom.fields['warranty_value'],
+                        infocom.fields['warranty_value']|formatted_number,
                         __('Warranty extension value'),
                         {
                             'disabled': disabled,


### PR DESCRIPTION
closes #20918

Seems the format has been lost during Twig conversion, in 9.5 those fields were displayed using `Html::formatNumber()` method