### PR TITLE
fix(forms): Support for destination mapping during serialization to handle destination_ids in fields

### DIFF
--- a/src/Glpi/Form/Destination/CommonITILField/LinkedITILObjectsField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/LinkedITILObjectsField.php
@@ -452,6 +452,16 @@ final class LinkedITILObjectsField extends AbstractConfigField implements Destin
                     }
                     $strategy_config[LinkedITILObjectsFieldStrategyConfig::SPECIFIC_QUESTION_IDS] = $questions;
                 }
+
+                // Handle specific destinations
+                if (isset($strategy_config[LinkedITILObjectsFieldStrategyConfig::SPECIFIC_DESTINATION_IDS])) {
+                    $destinations = $strategy_config[LinkedITILObjectsFieldStrategyConfig::SPECIFIC_DESTINATION_IDS];
+                    foreach ($destinations as $i => $destination) {
+                        $id = $mapper->getItemId(FormDestination::class, $destination);
+                        $destinations[$i] = $id;
+                    }
+                    $strategy_config[LinkedITILObjectsFieldStrategyConfig::SPECIFIC_DESTINATION_IDS] = $destinations;
+                }
             }
             $config[LinkedITILObjectsFieldConfig::STRATEGY_CONFIGS] = $strategy_configs;
         }


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

This pull request enhances the test coverage and import/export logic for form destination fields, specifically focusing on the `LinkedITILObjectsField` and its handling of configurations that reference other destinations, questions, or items. The changes ensure that destination configurations are correctly imported after all destinations are created, allowing references between them to be resolved reliably.