### PR TITLE
Fix already applied composer patch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -203,7 +203,7 @@
             "patch -f -p1 -d vendor/laminas/laminas-mail/ < tools/patches/laminas-laminas-mail-address-no-length-check.patch || true",
             "patch -f -p1 -d vendor/laminas/laminas-mail/ < tools/patches/laminas-laminas-mail-invalid-header-ignore.patch || true",
             "patch -f -p1 -d vendor/atoum/atoum/ < tools/patches/atoum-atoum-php-8.5-compat.patch || true",
-            "patch -f -p1 -d vendor/scssphp/scssphp/ < tools/patches/scssphp-scssphp-php-8.5-compat.patch",
+            "patch -f -p1 -d vendor/scssphp/scssphp/ < tools/patches/scssphp-scssphp-php-8.5-compat.patch || true",
             "patch -f -p1 -d vendor/wapmorgan/unified-archive/ < tools/patches/wapmorgan-unified-archive-php-8.5-compat.patch || true"
         ]
     }


### PR DESCRIPTION
## Description

The new composer patch block the composer install command if it is already applied:

<img width="1220" height="88" alt="image" src="https://github.com/user-attachments/assets/e0f2267f-9b5a-403f-8f0e-6269e867e19f" />
