### PR TITLE
fix(migration): Handle specific forms parameter in orphan warning message

### DIFF
--- a/src/Glpi/Form/Migration/FormMigration.php
+++ b/src/Glpi/Form/Migration/FormMigration.php
@@ -1475,18 +1475,26 @@ class FormMigration extends AbstractPluginMigration
 
     private function displayWarningForNonMigratedItems(): void
     {
+        $criteria = [
+            'is_deleted' => 0,
+            'NOT' => [
+                'entities_id' => new QuerySubQuery([
+                    'SELECT' => 'id',
+                    'FROM'   => Entity::getTable(),
+                ]),
+            ],
+        ];
+
+
+        // Add specific form IDs to the additional criteria
+        if ($this->specificFormsIds !== []) {
+            $criteria['glpi_plugin_formcreator_forms.id'] = $this->specificFormsIds;
+        }
+
         // Retrieve orphan forms
         $orphan_forms = $this->db->request([
             'FROM'   => 'glpi_plugin_formcreator_forms',
-            'WHERE'  => [
-                'is_deleted' => 0,
-                'NOT' => [
-                    'entities_id' => new QuerySubQuery([
-                        'SELECT' => 'id',
-                        'FROM'   => Entity::getTable(),
-                    ]),
-                ],
-            ],
+            'WHERE'  => $criteria,
         ]);
 
         if (count($orphan_forms) > 0) {


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.

## Description

This pull request updates the way orphan forms are retrieved in the `displayWarningForNonMigratedItems` method to allow for more targeted queries. The change introduces additional criteria based on specific form IDs.