### PR TITLE
fix: search button location and hover color

### DIFF
--- a/templates/components/search/query_builder/main.html.twig
+++ b/templates/components/search/query_builder/main.html.twig
@@ -117,7 +117,7 @@
          </button>
          {% if mainform %}
             {% set action_count = showaction + p['showbookmark'] + p['showreset'] %}
-            <span class="ms-auto {{ action_count > 1 ? 'btn-group' : '' }}">
+            <span class="ms-3 {{ action_count > 1 ? 'btn-group' : '' }}">
                 {% if (showaction) %}
                 {# Display submit button #}
                 <button class="btn {{ p['is_criteria_filter'] ? 'btn-ghost-secondary' : 'btn-sm btn-primary' }}" type="button" name="{{ p['actionname'] }}">
@@ -133,7 +133,7 @@
                 }) }}
                 {% endif %}
                 {% if p['showreset'] %}
-                <a class="btn btn-sm btn-icon px-2 search-reset"
+                <a class="btn btn-sm btn-outline-secondary btn-icon px-2 search-reset"
                    data-bs-toggle="tooltip" data-bs-placement="bottom"
                    href="{{ p['target'] ~ ('?' in p['target'] ? '&' : '?') ~ "reset=reset" }}" title="{{ __('Blank') }}">
                     <i class="ti ti-square-x"></i>

--- a/templates/pages/tools/savedsearch/save_button.html.twig
+++ b/templates/pages/tools/savedsearch/save_button.html.twig
@@ -41,7 +41,7 @@
    }) %}
 {% endif %}
 
-<button type="button" name="save_bookmark_record" class="btn btn-sm px-2 btn-icon"
+<button type="button" name="save_bookmark_record" class="btn btn-sm px-2 btn-outline-secondary btn-icon"
         title="{{ __('Save current search') }}" data-bs-toggle="tooltip" data-bs-placement="bottom">
    <i class="ti ti-bookmark-plus {{ active ? 'active text-yellow' : '' }}"></i>
 </button>


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] My feature works.

## Description

This PR focuses on the three buttons when re-enabling the "Show search form above results" option. Their placement on the far right of the page is not intuitive (in GLPI 10, they were correctly positioned on the left), so I moved them back to the left.

I also tried to fix the "hover" effect, but there might still be a small border issue that should be handled by an expert :)

Before:

<img width="1998" height="753" alt="image" src="https://github.com/user-attachments/assets/0bbedaf6-3df9-4f74-874d-0f2dc67cbede" />

After:

<img width="649" height="399" alt="image" src="https://github.com/user-attachments/assets/dcd811a6-7264-4d1d-adb6-b42fb91c7e96" />


