### PR TITLE
fix(migration): Fixed form selectable question types to use 1-based indexing for options

### DIFF
--- a/src/Glpi/Form/QuestionType/AbstractQuestionTypeSelectable.php
+++ b/src/Glpi/Form/QuestionType/AbstractQuestionTypeSelectable.php
@@ -210,14 +210,22 @@ TWIG;
         }
 
         // Return the indexes of the default values
-        return array_map(fn($value) => array_search($value, $options), $default_values);
+        return array_map(fn($value) => array_search($value, $options) + 1, $default_values);
     }
 
     #[Override]
     public function convertExtraData(array $rawData): array
     {
+        $values = json_decode($rawData['values'], true) ?? [];
+
+        // Convert array values to use index + 1 as keys
+        $options = [];
+        foreach ($values as $index => $value) {
+            $options[$index + 1] = $value;
+        }
+
         $config = new QuestionTypeSelectableExtraDataConfig(
-            options: json_decode($rawData['values'], true) ?? []
+            options: $options
         );
         return $config->jsonSerialize();
     }

--- a/src/Glpi/Form/QuestionType/QuestionTypeDropdown.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeDropdown.php
@@ -66,8 +66,16 @@ final class QuestionTypeDropdown extends AbstractQuestionTypeSelectable implemen
     #[Override]
     public function convertExtraData(array $rawData): array
     {
+        $values = json_decode($rawData['values'], true) ?? [];
+
+        // Convert array values to use index + 1 as keys
+        $options = [];
+        foreach ($values as $index => $value) {
+            $options[$index + 1] = $value;
+        }
+
         $config = new QuestionTypeDropdownExtraDataConfig(
-            options: json_decode($rawData['values'] ?? '[]', true) ?? [],
+            options: $options,
             is_multiple_dropdown: $rawData['fieldtype'] === 'multiselect'
         );
         return $config->jsonSerialize();


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.

## Description

When migrating Formcreator forms to core forms, radio button, checkbox, and dropdown question options do not have defined keys. The new system needs keys to link the option to the default value or conditions. Until now, we used the option index in the array as the key, but this causes problems with select2, which considers id 0 to be the default option and replaces the label with the empty choice.