### PR TITLE
Fix collasped sections width

### DIFF
--- a/templates/pages/admin/form/form_section.html.twig
+++ b/templates/pages/admin/form/form_section.html.twig
@@ -94,7 +94,7 @@
                     <div class="d-flex">
                         {# Section's description #}
                         <div
-                            class="content-editable-tinymce me-auto"
+                            class="content-editable-tinymce me-auto flex-grow-1"
                             data-glpi-form-editor-section-description
                         >
                             {{ fields.textareaField(
@@ -114,7 +114,7 @@
                                 })
                             ) }}
                         </div>
-                        <div class="d-flex align-items-start w-100">
+                        <div class="d-flex align-items-start flex-grow-1">
                             {# Question count #}
                             <span
                                 class="badge bg-secondary-lt"


### PR DESCRIPTION
## Description

Before:
<img width="1041" height="126" alt="image" src="https://github.com/user-attachments/assets/0bcc2c33-cbe4-47d4-ba0b-c1c15b5b05b6" />

After:
<img width="1048" height="132" alt="image" src="https://github.com/user-attachments/assets/13954fe0-76b0-4c38-a232-21396cc6ca66" />

