### PR TITLE
Number of licence cannot be 0

### DIFF
--- a/phpunit/functional/SoftwareLicenseTest.php
+++ b/phpunit/functional/SoftwareLicenseTest.php
@@ -65,6 +65,7 @@ class SoftwareLicenseTest extends DbTestCase
             'softwarelicenses_id' => 0,
             'level' => 1,
             'completename' => 'not_inserted_software_license',
+            'number' => 1,
         ];
         $this->assertSame($expected, $license->prepareInputForAdd($input));
 
@@ -77,6 +78,7 @@ class SoftwareLicenseTest extends DbTestCase
             'softwarelicenses_id' => 0,
             'level' => 1,
             'completename' => 'inserted_sofwarelicense',
+            'number' => 1,
         ];
         $this->assertSame($expected, $license->prepareInputForAdd($input));
 
@@ -96,6 +98,7 @@ class SoftwareLicenseTest extends DbTestCase
             'level' => 1,
             'completename' => 'other_inserted_sofwarelicense',
             '_oldID' => 1,
+            'number' => 1,
         ];
         $this->assertSame($expected, $license->prepareInputForAdd($input));
     }

--- a/src/SoftwareLicense.php
+++ b/src/SoftwareLicense.php
@@ -118,6 +118,11 @@ class SoftwareLicense extends CommonTreeDropdown implements AssignableItemInterf
             unset($input['expire']);
         }
 
+        if (!isset($input['number'])) {
+            //number is not defined when creating a child licence; and it cannot be 0
+            $input['number'] = 1;
+        }
+
         $input = $this->managePictures($input);
         return $input;
     }
@@ -266,6 +271,9 @@ class SoftwareLicense extends CommonTreeDropdown implements AssignableItemInterf
             ) {
                 $options['entities_id'] = $soft->getEntityID();
             }
+        } elseif ($this->fields['number'] == 0) {
+            //fix licenses stored with number = 0
+            $this->fields['number'] = 1;
         }
 
         $this->initForm($ID, $options);

--- a/templates/pages/management/license_progressbar.html.twig
+++ b/templates/pages/management/license_progressbar.html.twig
@@ -31,7 +31,7 @@
  #}
 
 <div class="position-relative w-100 d-flex">
-
+    {% set total = total|number_format %}
     {% set remaining = total - licences_assigned %}
     {% set is_unlimited = total == -1 %}
     {% set license_contexts = {

--- a/templates/pages/management/license_progressbar.html.twig
+++ b/templates/pages/management/license_progressbar.html.twig
@@ -31,7 +31,6 @@
  #}
 
 <div class="position-relative w-100 d-flex">
-    {% set total = total|number_format %}
     {% set remaining = total - licences_assigned %}
     {% set is_unlimited = total == -1 %}
     {% set license_contexts = {

--- a/templates/pages/management/softwarelicense.html.twig
+++ b/templates/pages/management/softwarelicense.html.twig
@@ -109,11 +109,11 @@
    {{ fields.field('softwareversions_id_buy', field, __('Purchase version')) }}
 
    {% set validity_msg = null %}
-   {% if item_type == 'SoftwareLicense' %}
+   {% if item_type == 'SoftwareLicense' and not item.isNewItem() %}
       {% set validity_msg %}
          <div class="d-flex justify-content-around pt-2">
             {{ include('pages/management/license_progressbar.html.twig', {
-               total: item.fields['number'],
+               total: item.fields['number']|number_format,
                licences_assigned: licences_assigned,
             }, with_context: false) }}
          </div>

--- a/templates/pages/management/softwarelicense.html.twig
+++ b/templates/pages/management/softwarelicense.html.twig
@@ -113,7 +113,7 @@
       {% set validity_msg %}
          <div class="d-flex justify-content-around pt-2">
             {{ include('pages/management/license_progressbar.html.twig', {
-               total: item.fields['number']|number_format,
+               total: item.fields['number'],
                licences_assigned: licences_assigned,
             }, with_context: false) }}
          </div>


### PR DESCRIPTION
closes #20976

I did not find how to "use" a child licence; so maybe existing ones with a `number` field set to `0` can cause issues.