### PR TITLE
Put description above form sections

### DIFF
--- a/css/includes/components/form/_form-renderer.scss
+++ b/css/includes/components/form/_form-renderer.scss
@@ -150,6 +150,7 @@
             color: var(--tblr-form-invalid-color);
             padding: unset;
             margin-top: .25rem;
+            top: unset;
         }
     }
 }

--- a/css/includes/components/form/_form-renderer.scss
+++ b/css/includes/components/form/_form-renderer.scss
@@ -42,6 +42,13 @@
         }
     }
 
+    .block-description {
+        // Reduce default rich text paragraph margins
+        p {
+            margin-bottom: 0.3rem;
+        }
+    }
+
     .fileupload {
         margin: 0;
     }

--- a/templates/pages/admin/form/form_question.html.twig
+++ b/templates/pages/admin/form/form_question.html.twig
@@ -189,14 +189,6 @@
                 </div>
             </div>
 
-            {# Render the specific question type #}
-            <div
-                class="mt-3 ms-1"
-                data-glpi-form-editor-question-type-specific
-            >
-                {{ question_type.renderAdministrationTemplate(question)|raw }}
-            </div>
-
             {# Display common fields #}
             <div
                 class="content-editable-tinymce mt-2"
@@ -224,6 +216,14 @@
                         }
                     })
                 ) }}
+            </div>
+
+            {# Render the specific question type #}
+            <div
+                class="mt-2 ms-1"
+                data-glpi-form-editor-question-type-specific
+            >
+                {{ question_type.renderAdministrationTemplate(question)|raw }}
             </div>
 
             <div

--- a/templates/pages/form_renderer.html.twig
+++ b/templates/pages/form_renderer.html.twig
@@ -142,7 +142,7 @@
                                         {% if not skip_question %}
                                             <section
                                                 aria-label="{{ form_block.fields.name }}"
-                                                class="{{ (is_single_page_layout or is_first_section) ? "" : "d-none" }}"
+                                                class="{{ (is_single_page_layout or is_first_section) ? "" : "d-none" }} mb-3"
                                                 style="flex: 1;"
                                                 data-glpi-form-renderer-parent-section="{{ section_index }}"
                                                 data-glpi-form-renderer-id="{{ form_block.fields.id }}"
@@ -175,15 +175,13 @@
                                                     {% endif %}
                                                 </h3>
 
-                                                {% if form_block is instanceof('Glpi\\Form\\Question') %}
-                                                    <div class="mb-2">
-                                                        {{ question_type.renderEndUserTemplate(form_block)|raw }}
-                                                    </div>
-                                                {% endif %}
-
-                                                <div class="text-muted block-description" role="note" aria-label="{{ __('%s description')|format(form_block.getTypeName(1)) }}">
+                                                <div class="text-muted block-description mb-2" role="note" aria-label="{{ __('%s description')|format(form_block.getTypeName(1)) }}">
                                                     {{ translate_form_item_key(form_block, constant('TRANSLATION_KEY_DESCRIPTION', form_block))|safe_html }}
                                                 </div>
+
+                                                {% if form_block is instanceof('Glpi\\Form\\Question') %}
+                                                    {{ question_type.renderEndUserTemplate(form_block)|raw }}
+                                                {% endif %}
                                             </section>
                                         {% endif %}
                                     {% endfor %}

--- a/tests/cypress/e2e/form/editor/conditions.cy.js
+++ b/tests/cypress/e2e/form/editor/conditions.cy.js
@@ -765,6 +765,7 @@ describe ('Conditions', () => {
         getAndFocusQuestion('My question that is always visible').within(() => {
             initVisibilityConfiguration();
             setConditionStrategy('Always visible');
+            closeValidationConditionEditor();
         });
         getAndFocusQuestion('My question that is visible if some criteria are met').within(() => {
             initVisibilityConfiguration();
@@ -776,6 +777,7 @@ describe ('Conditions', () => {
                 'Is equal to',
                 'Expected answer 1'
             );
+            closeValidationConditionEditor();
         });
         getAndFocusQuestion('My question that is hidden if some criteria are met').within(() => {
             initVisibilityConfiguration();
@@ -787,6 +789,7 @@ describe ('Conditions', () => {
                 'Is equal to',
                 'Expected answer 2'
             );
+            closeValidationConditionEditor();
         });
         save();
         preview();
@@ -913,6 +916,7 @@ describe ('Conditions', () => {
                     test_case.is_array ? ['Option 3'] : 'Option 3',
                     test_case.is_array ? 'dropdown_multiple' : 'dropdown',
                 );
+                closeValidationConditionEditor();
             });
             save();
             preview();

--- a/tests/cypress/e2e/form/editor/conditions.cy.js
+++ b/tests/cypress/e2e/form/editor/conditions.cy.js
@@ -765,7 +765,7 @@ describe ('Conditions', () => {
         getAndFocusQuestion('My question that is always visible').within(() => {
             initVisibilityConfiguration();
             setConditionStrategy('Always visible');
-            closeValidationConditionEditor();
+            closeConditionEditor();
         });
         getAndFocusQuestion('My question that is visible if some criteria are met').within(() => {
             initVisibilityConfiguration();
@@ -777,7 +777,7 @@ describe ('Conditions', () => {
                 'Is equal to',
                 'Expected answer 1'
             );
-            closeValidationConditionEditor();
+            closeConditionEditor();
         });
         getAndFocusQuestion('My question that is hidden if some criteria are met').within(() => {
             initVisibilityConfiguration();
@@ -789,7 +789,7 @@ describe ('Conditions', () => {
                 'Is equal to',
                 'Expected answer 2'
             );
-            closeValidationConditionEditor();
+            closeConditionEditor();
         });
         save();
         preview();
@@ -916,7 +916,7 @@ describe ('Conditions', () => {
                     test_case.is_array ? ['Option 3'] : 'Option 3',
                     test_case.is_array ? 'dropdown_multiple' : 'dropdown',
                 );
-                closeValidationConditionEditor();
+                closeConditionEditor();
             });
             save();
             preview();

--- a/tests/cypress/e2e/form/editor/conditions.cy.js
+++ b/tests/cypress/e2e/form/editor/conditions.cy.js
@@ -897,7 +897,7 @@ describe ('Conditions', () => {
             addQuestion('My question used as a criteria');
             setQuestionTypeCategory(test_case.question_type);
             getAndFocusQuestion('My question used as a criteria').within(() => {
-                cy.findByPlaceholderText('Enter an option').type('Option 1{enter}');
+                cy.findByPlaceholderText('Enter an option').type('Option 1{enter}', {force: true}); // Force because getAndFocusQuestion will click in the middle of the question, thus trigerring the default value dropdown that will be displayed over this field. There are no good solutions here.
             });
             cy.focused().type('Option 2{enter}');
             cy.focused().type('Option 3{enter}');

--- a/tests/cypress/e2e/form/editor/validations.cy.js
+++ b/tests/cypress/e2e/form/editor/validations.cy.js
@@ -410,6 +410,7 @@ describe ('Validations', () => {
         getAndFocusQuestion('My question that has no validation').within(() => {
             initValidationConfiguration();
             setConditionStrategy('No validation');
+            closeValidationConditionEditor();
         });
         getAndFocusQuestion('My question that is valid if some criteria are met').within(() => {
             initValidationConfiguration();
@@ -420,6 +421,7 @@ describe ('Validations', () => {
                 'Match regular expression',
                 '/^I love GLPI$/'
             );
+            closeValidationConditionEditor();
         });
         getAndFocusQuestion('My question that is invalid if some criteria are met').within(() => {
             initValidationConfiguration();
@@ -430,6 +432,7 @@ describe ('Validations', () => {
                 'Match regular expression',
                 '/^I love GLPI$/'
             );
+            closeValidationConditionEditor();
         });
         save();
         preview();


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.

## Description

I originally decided to put the description below the questions because this is a UI standard for small hints under a form field,
However a lot of formcreator users were using very long descriptions so it break the "small hint" effect that I was looking for.

With this in mind, it seems better to move the description above the question, like it was done on formcreator.

Before:

<img width="1089" height="326" alt="image" src="https://github.com/user-attachments/assets/88788831-b953-4af0-84b7-98c66e3b9992" />

<img width="982" height="380" alt="image" src="https://github.com/user-attachments/assets/40af605d-05ca-4a21-9753-6bf147ff4c3f" />


After:

<img width="1078" height="337" alt="image" src="https://github.com/user-attachments/assets/8ed09674-4342-4c96-89dc-ea1cb4b4a028" />

<img width="995" height="377" alt="image" src="https://github.com/user-attachments/assets/5333af3b-91ed-413a-87b6-3cb5c0a59ad3" />


## References

Fix #20960 (and some internal complaints too).