### PR TITLE
Rename new form comment placeholder

### DIFF
--- a/templates/pages/admin/form/form_comment.html.twig
+++ b/templates/pages/admin/form/form_comment.html.twig
@@ -78,7 +78,7 @@
                     type="text"
                     name="name"
                     value="{{ comment is not null ? comment.fields.name : '' }}"
-                    placeholder="{{ __("Add a title...") }}"
+                    placeholder="{{ __("New comment") }}"
                     aria-label="{{ __("Comment title") }}"
                     data-glpi-form-editor-dynamic-input
                     data-glpi-form-editor-on-input="compute-dynamic-input"


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.

## Description

We use "New question" and "New section" for questions and section but "Add a title..." for form comment:

<img width="1121" height="382" alt="image" src="https://github.com/user-attachments/assets/b3407e00-6900-44ec-9f86-7fc404b90296" />

I've renamed it to "New comment" to be consistent with questions and sections.
