### PR TITLE
fix(forms-serializer): Handle invalid items_id for Item question type

### DIFF
--- a/src/Glpi/Form/QuestionType/QuestionTypeItem.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeItem.php
@@ -402,6 +402,10 @@ class QuestionTypeItem extends AbstractQuestionType implements
         $item = $itemtype::getById(
             $default_value_config->getItemsId()
         );
+        if (!$item) {
+            // Invalid item, return empty data with no requirements
+            return new DynamicExportDataField(null, []);
+        }
 
         // Replace id and register requirement
         $key = QuestionTypeItemDefaultValueConfig::KEY_ITEMS_ID;


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Fixed an issue that occurs when exporting a form that has a `QuestionTypeItem` question with an invalid default value (invalid items_id).
This case is not supposed to occur with our current logic, but may occur on forms that have been migrated from Formcreator.
Formcreator uses several formats to handle default/empty/invalid values. :exploding_head: 