### PR TITLE
improve profiler info in debug bar

### DIFF
--- a/js/src/vue/Debug/Widget/ProfilerTable.vue
+++ b/js/src/vue/Debug/Widget/ProfilerTable.vue
@@ -59,7 +59,7 @@
         };
     }
 
-    const col_count = 6 + props.nest_level;
+    const col_count = 5 + props.nest_level;
 
     function getProfilerData(parent_id) {
         const sections = props.profiler_sections.filter((section) => section.parent_id === parent_id);
@@ -85,6 +85,7 @@
                 duration: duration,
                 percent_of_parent: percent_of_parent,
                 has_children: props.profiler_sections.filter((child) => child.parent_id === section.id).length > 0,
+                auto_ended: section.auto_ended || false,
             };
             sections_data.push(data);
         }
@@ -117,10 +118,9 @@
                 <th class="nesting-spacer" v-for="i in nest_level" :key="i" aria-hidden="true"></th>
                 <th>Category</th>
                 <th>Name</th>
-                <th>Start</th>
-                <th>End</th>
                 <th>Duration</th>
                 <th>Percent of parent</th>
+                <th>Auto-ended</th>
             </tr>
         </thead>
         <tbody>
@@ -133,10 +133,9 @@
                         </span>
                     </td>
                     <td data-prop="name">{{ section.name }}</td>
-                    <td data-prop="start">{{ section.start }}</td>
-                    <td data-prop="end">{{ section.end }}</td>
                     <td data-prop="duration">{{ section.duration.toFixed(0) }} ms</td>
                     <td data-prop="percent_of_parent">{{ section.percent_of_parent }}%</td>
+                    <td data-prop="auto_ended">{{ section.auto_ended ? 'Yes' : 'No' }}</td>
                 </tr>
                 <tr v-if="section.has_children" v-show="!props.hide_instant_sections || (section.duration > instant_threshold)">
                     <td :colspan="col_count">

--- a/src/Glpi/Debug/Profiler.php
+++ b/src/Glpi/Debug/Profiler.php
@@ -127,9 +127,10 @@ final class Profiler
     /**
      * Stops a section started with Profiler::start()
      * @param string $name The name of the section to stop. This name must be the same as the one used in Profiler::start()
+     * @param bool $auto_ended Whether the section was automatically ended (e.g. at the end of the request)
      * @return int The duration of the section in milliseconds
      */
-    public function stop(string $name): int
+    public function stop(string $name, bool $auto_ended = false): int
     {
         // get the last section with the given name and stop it
         $section = array_filter($this->current_sections, static fn(ProfilerSection $section) => $section->getName() === $name);
@@ -139,7 +140,7 @@ final class Profiler
             $section->end(microtime(true) * 1000);
             $duration = $section->getDuration();
             unset($this->current_sections[$k]);
-            Profile::getCurrent()->setData('profiler', $section->toArray());
+            Profile::getCurrent()->setData('profiler', $section->toArray() + ['auto_ended' => $auto_ended]);
         }
         return $duration ?? 0;
     }
@@ -166,7 +167,7 @@ final class Profiler
     public function stopAll(): void
     {
         foreach ($this->current_sections as $section) {
-            $this->stop($section->getName());
+            $this->stop($section->getName(), true);
         }
     }
 

--- a/tests/cypress/e2e/DebugMode/debug_bar.cy.js
+++ b/tests/cypress/e2e/DebugMode/debug_bar.cy.js
@@ -144,17 +144,14 @@ describe("Debug Bar", () => {
                     cy.get('tr[data-profiler-section-id] > td[data-prop="category"]').each(($el) => {
                         cy.wrap($el).find('.category-badge').should('exist');
                     });
-                    cy.get('tr[data-profiler-section-id] > td[data-prop="start"]').each(($el) => {
-                        expect($el.text()).to.match(/\d+/);
-                    });
-                    cy.get('tr[data-profiler-section-id] > td[data-prop="end"]').each(($el) => {
-                        expect($el.text()).to.match(/\d+/);
-                    });
                     cy.get('tr[data-profiler-section-id] > td[data-prop="duration"]').each(($el) => {
                         expect($el.text()).to.match(/\d+\sms/);
                     });
                     cy.get('tr[data-profiler-section-id] > td[data-prop="percent_of_parent"]').each(($el) => {
                         expect($el.text()).to.match(/[\d.]%/);
+                    });
+                    cy.get('tr[data-profiler-section-id] > td[data-prop="auto_ended"]').each(($el) => {
+                        expect($el.text()).to.match(/(Yes|No)/);
                     });
                 });
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Some profiler cleanup work while I was chasing an unusual performance issue with the cache initialization.

- Remove start and end timestamps as they do not have much use but were taking up a lot of horizontal space.
- Add auto-ended information which can be used to indicate a profiler section was not manually ended and therefore the timings for it may not be accurate as it was only ended at the end of the request. Under normal circumstances, only the "php_request" section can be expected to be auto-ended.

## Screenshots (if appropriate):


