### PR TITLE
Fix disabled checkboxes and radio being almost invisible

### DIFF
--- a/css/includes/_base.scss
+++ b/css/includes/_base.scss
@@ -573,3 +573,10 @@ html {
         margin-left: 0 !important;
     }
 }
+
+// Disabled checkboxes and radio are almost invisible in tabler.
+// We increase their opacity here to make them more accessible.
+input.form-check-input[type="radio"]:disabled,
+input.form-check-input[type="checkbox"]:disabled {
+    opacity: 0.9;
+}


### PR DESCRIPTION
## Description

Tabler default styling for disabled checkboxes and radios is very hard to see.
I've made a bit better.

Before:
<img width="1062" height="318" alt="image" src="https://github.com/user-attachments/assets/99082f83-214e-4925-97e9-c6943811b693" />

After:
<img width="1059" height="321" alt="image" src="https://github.com/user-attachments/assets/adafca5a-96a4-4758-ba26-72dade5f4f61" />

