### PR TITLE
Fix "Tickets status by month" fake series order

### DIFF
--- a/src/Glpi/Dashboard/FakeProvider.php
+++ b/src/Glpi/Dashboard/FakeProvider.php
@@ -456,6 +456,11 @@ final class FakeProvider extends Provider
             }
         }
 
+        $date_labels = array_reverse($date_labels);
+        foreach ($series as $status => $serie) {
+            $series[$status]['data'] = array_reverse($serie['data']);
+        }
+
         $data = [
             'labels' => $date_labels,
             'series' => $series,


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

The "Tickets status by month" graph was displayed with an invcerted chronological order. Similar `array_reverse` operations are present in the other dashboard graphs.

## Screenshots (if appropriate):

Before:
<img width="737" height="422" alt="image" src="https://github.com/user-attachments/assets/e63e88b9-d3fb-47a3-a833-4036afa0bace" />

After:
<img width="737" height="422" alt="image" src="https://github.com/user-attachments/assets/c1750c94-2a2e-4365-ba09-36ae58cb617b" />

