### PR TITLE
Replace `escapeMarkupText()` by `_.escape()`

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -822,22 +822,22 @@ function markMatch (text, term) {
 
     // If there is no match, move on
     if (match < 0) {
-        _result.append(escapeMarkupText(text));
+        _result.append(_.escape(text));
         return _result.html();
     }
 
     // Put in whatever text is before the match
-    _result.html(escapeMarkupText(text.substring(0, match)));
+    _result.html(_.escape(text.substring(0, match)));
 
     // Mark the match
     var _match = $('<span class=\'select2-rendered__match\'></span>');
-    _match.html(escapeMarkupText(text.substring(match, match + term.length)));
+    _match.html(_.escape(text.substring(match, match + term.length)));
 
     // Append the matching text
     _result.append(_match);
 
     // Put in whatever is after the match
-    _result.append(escapeMarkupText(text.substring(match + term.length)));
+    _result.append(_.escape(text.substring(match + term.length)));
 
     return _result.html();
 }
@@ -859,7 +859,7 @@ var templateResult = function(result) {
         var text = result.text;
         if (!result.id) {
             // If result has no id, then it is used as an optgroup and is not used for matches
-            _elt.html(escapeMarkupText(text));
+            _elt.html(_.escape(text));
             return _elt;
         }
 
@@ -909,7 +909,7 @@ var templateSelection = function (selection) {
         text = selection.text;
     }
     var _elt = $('<span></span>');
-    _elt.html(escapeMarkupText(text));
+    _elt.html(_.escape(text));
     return _elt;
 };
 
@@ -1035,14 +1035,13 @@ var getTextWithoutDiacriticalMarks = function (text) {
  * @return {string}
  */
 var escapeMarkupText = function (text) {
+    // TODO in GLPI 11.1: console.warn('`escapeMarkupText()` is deprecated, use `_.escape()` instead.');
+
     if (typeof(text) !== 'string') {
         return text;
     }
-    if (text.indexOf('>') !== -1 || text.indexOf('<') !== -1) {
-        // escape text, if it contains chevrons (can already be escaped prior to this point :/)
-        text = jQuery.fn.select2.defaults.defaults.escapeMarkup(text);
-    }
-    return text;
+
+    return _.escape(text);
 };
 
 /**

--- a/js/modules/ObjectLock.js
+++ b/js/modules/ObjectLock.js
@@ -31,7 +31,8 @@
  * ---------------------------------------------------------------------
  */
 
-/* global glpi_confirm, glpi_alert, escapeMarkupText, getAjaxCsrfToken */
+/* global glpi_confirm, glpi_alert, getAjaxCsrfToken */
+/* global _ */
 
 /**
  * @todo Candidate for a websocket-based feature (or a mix of Ajax + Server-Sent Events)
@@ -96,7 +97,7 @@ class ObjectLock {
                     }).then(() => {
                         glpi_alert({
                             title: __('Unlock request sent!'),
-                            message: escapeMarkupText(__('Request sent to %s').replace('%s', this.user_data['name'])),
+                            message: __('Request sent to %s').replace('%s', _.escape(this.user_data['name'])),
                         });
                     }, () => {
                         glpi_alert({

--- a/js/src/vue/Debug/Widget/ProfilerTable.vue
+++ b/js/src/vue/Debug/Widget/ProfilerTable.vue
@@ -1,5 +1,6 @@
 <script setup>
     /* global tinycolor */
+    /* global _ */
     import {computed} from "vue";
 
     const props = defineProps({
@@ -77,8 +78,8 @@
 
             const data = {
                 id: section.id,
-                name: escapeMarkupText(section.name),
-                category: escapeMarkupText(section.category),
+                name: _.escape(section.name),
+                category: _.escape(section.category),
                 bg_color: cat_colors.bg_color,
                 start: section.start,
                 end: section.end,

--- a/js/src/vue/Debug/Widget/SQLRequests.vue
+++ b/js/src/vue/Debug/Widget/SQLRequests.vue
@@ -1,5 +1,6 @@
 <script setup>
     /* global copyTextToClipboard */
+    /* global _ */
     import {computed, reactive, ref, watch} from "vue";
 
     const props = defineProps({
@@ -62,8 +63,8 @@
                     time: query['time'],
                     query: query['query'],
                     rows: query['rows'],
-                    warnings: escapeMarkupText(query['warnings']),
-                    errors: escapeMarkupText(query['errors']),
+                    warnings: _.escape(query['warnings']),
+                    errors: _.escape(query['errors']),
                 });
             });
         });

--- a/js/src/vue/Kanban/Kanban.vue
+++ b/js/src/vue/Kanban/Kanban.vue
@@ -1,7 +1,7 @@
 <script setup>
-    /* global escapeMarkupText */
     /* global sortable */
     /* global glpi_toast_error, glpi_confirm */
+    /* global _ */
 
     import { Rights } from "./Rights.js";
     import Column from "./Column.vue";
@@ -690,7 +690,7 @@
                 l.append(`
                     <div class="member-details">
                         ${member_item}
-                        ${escapeMarkupText(l.attr('data-name')) || `${member_itemtype} (${member_items_id})`}
+                        ${_.escape(l.attr('data-name')) || `${member_itemtype} (${member_items_id})`}
                     </div>
                     <button type="button" name="delete" class="btn btn-ghost-danger">
                         <i class="ti ti-x" title="${__('Delete')}"></i>

--- a/js/src/vue/Kanban/SearchInput.js
+++ b/js/src/vue/Kanban/SearchInput.js
@@ -31,7 +31,7 @@
  * ---------------------------------------------------------------------
  */
 
-/* global escapeMarkupText */
+/* global _ */
 
 import SearchTokenizer from "./SearchTokenizer.js";
 
@@ -412,7 +412,7 @@ export default class SearchInput {
             style_overrides = tag_color_override ? `style="background-color: ${tag_color_override} !important"` : '';
         }
         return `<span class="search-input-tag badge bg-secondary text-secondary-fg me-1" contenteditable="false" data-tag="${token.tag}" ${style_overrides}>
-                  <span class="search-input-tag-value" contenteditable="false">${tag_display}${escapeMarkupText(token.term) || ''}</span>
+                  <span class="search-input-tag-value" contenteditable="false">${tag_display}${_.escape(token.term) || ''}</span>
                   <i class="ti ti-x cursor-pointer ms-1" title="${__('Delete')}" contenteditable="false"></i>
                </span>`;
     }

--- a/templates/components/itilobject/actors/field.html.twig
+++ b/templates/components/itilobject/actors/field.html.twig
@@ -91,8 +91,8 @@
             const element   = $(option.element);
             const itemtype  = element.data('itemtype') ?? option.itemtype;
             const items_id  = element.data('items-id') ?? option.items_id;
-            let text        = escapeMarkupText(element.data('text') ?? option.text ?? '');
-            const title     = escapeMarkupText(element.data('title') ?? option.title ?? '');
+            let text        = _.escape(element.data('text') ?? option.text ?? '');
+            const title     = _.escape(element.data('title') ?? option.title ?? '');
             const use_notif = element.data('use-notification') ?? option.use_notification ?? 1;
             const alt_email = element.data('alternative-email') ?? option.alternative_email ?? '';
 

--- a/tests/js/modules/ObjectLock.test.js
+++ b/tests/js/modules/ObjectLock.test.js
@@ -98,10 +98,6 @@ describe('Object Lock', () => {
             return 0; // Unlocked
         }));
 
-        window.escapeMarkupText = jest.fn((text) => {
-            return text;
-        });
-
         initObjectLock({
             id: 3450,
             itemtype: 'Ticket',


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

While working on HTML escaping in the JS code context, I figured out that we still had a specific `escapeMarkupText()` function that escapes the text only if it contains `<` or `>`. This was doing the job in GLPI 10., when we had an autoescaping of almost everything, but it is not safe anymore in GLPI 11.0.
Also, we could directly use the `_.escape()` method from the `lodash` component, as we do in other pieces of our code.