### PR TITLE
fix(migration): Use completename as a priority to retrieve dropdown item

### DIFF
--- a/src/Glpi/Form/Condition/ConditionHandler/ItemConditionHandler.php
+++ b/src/Glpi/Form/Condition/ConditionHandler/ItemConditionHandler.php
@@ -35,6 +35,7 @@
 namespace Glpi\Form\Condition\ConditionHandler;
 
 use CommonDBTM;
+use CommonTreeDropdown;
 use Glpi\Form\Condition\ConditionData;
 use Glpi\Form\Condition\ValueOperator;
 use Glpi\Form\Migration\ConditionHandlerDataConverterInterface;
@@ -94,11 +95,11 @@ final class ItemConditionHandler implements ConditionHandlerInterface, Condition
     public function convertConditionValue(string $value): int
     {
         $nameFields = [];
-        $item = getItemForItemtype($this->itemtype);
-        if ($item->isField($item->getCompleteNameField())) {
-            $nameFields[] = $item->getCompleteNameField();
+        $item = new $this->itemtype();
+        if ($item instanceof CommonTreeDropdown) {
+            $nameFields[] = $this->itemtype::getCompleteNameField();
         }
-        $nameFields[] = $item->getNameField();
+        $nameFields[] = $this->itemtype::getNameField();
 
         foreach ($nameFields as $nameField) {
             // Retrieve item by name

--- a/src/Glpi/Form/Condition/ConditionHandler/ItemConditionHandler.php
+++ b/src/Glpi/Form/Condition/ConditionHandler/ItemConditionHandler.php
@@ -95,11 +95,11 @@ final class ItemConditionHandler implements ConditionHandlerInterface, Condition
     public function convertConditionValue(string $value): int
     {
         $nameFields = [];
-        $item = new $this->itemtype();
+        $item = getItemForItemtype($this->itemtype);
         if ($item instanceof CommonTreeDropdown) {
-            $nameFields[] = $this->itemtype::getCompleteNameField();
+            $nameFields[] = $item::getCompleteNameField();
         }
-        $nameFields[] = $this->itemtype::getNameField();
+        $nameFields[] = $item::getNameField();
 
         foreach ($nameFields as $nameField) {
             // Retrieve item by name

--- a/src/Glpi/Form/Condition/ConditionHandler/ItemConditionHandler.php
+++ b/src/Glpi/Form/Condition/ConditionHandler/ItemConditionHandler.php
@@ -93,11 +93,12 @@ final class ItemConditionHandler implements ConditionHandlerInterface, Condition
     #[Override]
     public function convertConditionValue(string $value): int
     {
+        $nameFields = [];
         $item = getItemForItemtype($this->itemtype);
-        $nameFields = [$item->getNameField()];
         if ($item->isField($item->getCompleteNameField())) {
             $nameFields[] = $item->getCompleteNameField();
         }
+        $nameFields[] = $item->getNameField();
 
         foreach ($nameFields as $nameField) {
             // Retrieve item by name


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Prioritize using `completename` to retrieve a dropdown item rather than the name, avoiding results with multiple items; this causes the migration of formcreator forms to the new form system to crash.