### PR TITLE
Fix missing default option for `dropdownIcons` option

### DIFF
--- a/templates/components/form/fields_macros.html.twig
+++ b/templates/components/form/fields_macros.html.twig
@@ -596,6 +596,7 @@
     {% set options = {
         'rand': random(),
         'width': '100%',
+        'disabled': false,
     }|merge(options) %}
    {% if options.fields_template.isMandatoryField(name)|default(false) %}
       {% set options = {'required': true}|merge(options) %}


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

It fixes the following issue:
```
Key "disabled" for sequence/mapping with keys "rand, width" does not exist in "components/form/fields_macros.html.twig" at line 608.
In ./templates/components/form/fields_macros.html.twig(608)
#0 ./files/_cache/11.0.0-rc4-00000000-development/templates/3c/3c6f7de2563457a570255cf8d3ee7982.php(1848): Twig\Extension\CoreExtension::getAttribute(Object(Twig\Environment), Object(Twig\Source), Array, 'disabled', Array, 'any', false, false, false, 608)
#1 ./vendor/twig/twig/src/Extension/CoreExtension.php(2106): __TwigTemplate_2bc7f74aff378e9f98b2c08c6e0977cf->{closure:__TwigTemplate_2bc7f74aff378e9f98b2c08c6e0977cf::macro_dropdownIcons():1819}()
#2 ./files/_cache/11.0.0-rc4-00000000-development/templates/3c/3c6f7de2563457a570255cf8d3ee7982.php(1819): Twig\Extension\CoreExtension::captureOutput(Object(Generator))
#3 ./files/_cache/11.0.0-rc4-00000000-development/templates/b4/b4f1ad9adcf90ad0625fe77c045b1a57.php(349): __TwigTemplate_2bc7f74aff378e9f98b2c08c6e0977cf->macro_dropdownIcons('icon', 'jpg-dist.png', 'Icon', Array)
#4 ./vendor/twig/twig/src/Template.php(446): __TwigTemplate_b9e2fd7efd45e9d6b5eeceb21e6befd6->block_form_fields(Array, Array)
#5 ./files/_cache/11.0.0-rc4-00000000-development/templates/b4/b4f1ad9adcf90ad0625fe77c045b1a57.php(75): Twig\Template->yieldBlock('form_fields', Array, Array)
#6 ./vendor/twig/twig/src/Template.php(402): __TwigTemplate_b9e2fd7efd45e9d6b5eeceb21e6befd6->doDisplay(Array, Array)
#7 ./vendor/twig/twig/src/Template.php(358): Twig\Template->yield(Array, Array)
#8 ./vendor/twig/twig/src/Template.php(373): Twig\Template->display(Array)
#9 ./vendor/twig/twig/src/TemplateWrapper.php(51): Twig\Template->render(Array)
#10 ./src/Glpi/Application/View/TemplateRenderer.php(170): Twig\TemplateWrapper->render(Array)
#11 ./src/CommonDropdown.php(353): Glpi\Application\View\TemplateRenderer->render('dropdown_form.h...', Array)
#12 ./src/CommonGLPI.php(683): CommonDropdown->showForm(1, Array)
#13 ./ajax/common.tabs.php(108): CommonGLPI::displayStandardTab(Object(DocumentType), 'DocumentType$ma...', 0, Array)
#14 ./src/Glpi/Controller/LegacyFileLoadController.php(63): require('./a...')
#15 ./vendor/symfony/http-kernel/HttpKernel.php(181): Glpi\Controller\LegacyFileLoadController->__invoke(Object(Symfony\Component\HttpFoundation\Request))
#16 ./vendor/symfony/http-kernel/HttpKernel.php(76): Symfony\Component\HttpKernel\HttpKernel->handleRaw(Object(Symfony\Component\HttpFoundation\Request), 1)
#17 ./vendor/symfony/http-kernel/Kernel.php(197): Symfony\Component\HttpKernel\HttpKernel->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#18 ./public/index.php(70): Symfony\Component\HttpKernel\Kernel->handle(Object(Symfony\Component\HttpFoundation\Request))
#19 {main}
```