### PR TITLE
Display translated titles for illustrations

### DIFF
--- a/src/Glpi/UI/IllustrationManager.php
+++ b/src/Glpi/UI/IllustrationManager.php
@@ -264,7 +264,7 @@ final class IllustrationManager
             'icon_id'   => $icon_id,
             'width'     => $size,
             'height'    => $size,
-            'title'     => $icons[$icon_id]['title'] ?? "",
+            'title'     => _x("Icon", $icons[$icon_id]['title'] ?? ""),
         ]);
     }
 


### PR DESCRIPTION
## Description

Before:
<img width="742" height="298" alt="image" src="https://github.com/user-attachments/assets/b2da693b-d4df-47a6-93eb-b26dc912d92f" />


After:
<img width="753" height="303" alt="image" src="https://github.com/user-attachments/assets/31f752ab-f335-4392-ae7b-cab19a84e312" />



