### PR TITLE
Hide duplicated rich text tags UI thing

### DIFF
--- a/css/includes/components/_tinymce.scss
+++ b/css/includes/components/_tinymce.scss
@@ -51,3 +51,9 @@ html[data-glpi-theme-dark="1"] {
     content: attr(data-mce-placeholder);
     position: absolute;
 }
+
+/* Tinymce duplicate some tags on selection, unsure why but it does not fit our
+expectations for forms tags and user mentions  */
+.mce-offscreen-selection {
+    display: none;
+}


### PR DESCRIPTION
## Description

I don't know how to call it, but tinyce add some UI thing when the user click on readonly nodes:

<img width="295" height="137" alt="image" src="https://github.com/user-attachments/assets/fee4f58a-e308-4d85-96bf-b1d53114ff8d" />

I don't understand what is the purpose here but I doesn't look great and it is confusing (making it looks like the tag is duplicated) so I've removed it.


