### PR TITLE
Take form tags into account when cloning

### DIFF
--- a/src/Glpi/Form/Destination/CommonITILField/ContentField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ContentField.php
@@ -39,6 +39,7 @@ use Glpi\DBAL\JsonFieldInterface;
 use Glpi\Form\AnswersSet;
 use Glpi\Form\Destination\AbstractConfigField;
 use Glpi\Form\Destination\FormDestination;
+use Glpi\Form\Destination\HasFormTags;
 use Glpi\Form\Form;
 use Glpi\Form\Migration\DestinationFieldConverterInterface;
 use Glpi\Form\Migration\FormMigration;
@@ -50,6 +51,7 @@ use Glpi\Form\Tag\SectionTagProvider;
 use InvalidArgumentException;
 use Override;
 
+#[HasFormTags]
 final class ContentField extends AbstractConfigField implements DestinationFieldConverterInterface
 {
     use TagConversionTrait;

--- a/src/Glpi/Form/Destination/CommonITILField/TitleField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/TitleField.php
@@ -39,6 +39,7 @@ use Glpi\DBAL\JsonFieldInterface;
 use Glpi\Form\AnswersSet;
 use Glpi\Form\Destination\AbstractConfigField;
 use Glpi\Form\Destination\FormDestination;
+use Glpi\Form\Destination\HasFormTags;
 use Glpi\Form\Form;
 use Glpi\Form\Migration\DestinationFieldConverterInterface;
 use Glpi\Form\Migration\FormMigration;
@@ -48,6 +49,7 @@ use Glpi\Form\Tag\FormTagsManager;
 use InvalidArgumentException;
 use Override;
 
+#[HasFormTags]
 final class TitleField extends AbstractConfigField implements DestinationFieldConverterInterface
 {
     use TagConversionTrait;

--- a/src/Glpi/Form/Destination/HasFormTags.php
+++ b/src/Glpi/Form/Destination/HasFormTags.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2025 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -33,52 +32,12 @@
  * ---------------------------------------------------------------------
  */
 
-namespace Glpi\Form\Tag;
+namespace Glpi\Form\Destination;
 
-use Glpi\Form\AnswersSet;
-use Glpi\Form\Form;
-use Override;
+use Attribute;
 
-final class FormTagProvider implements TagProviderInterface, TagWithIdValueInterface
+#[Attribute(Attribute::TARGET_CLASS)]
+final class HasFormTags
 {
-    #[Override]
-    public function getTagColor(): string
-    {
-        return "yellow";
-    }
-
-    #[Override]
-    public function getTags(Form $form): array
-    {
-        return [$this->getTagForForm($form)];
-    }
-
-    #[Override]
-    public function getTagContentForValue(
-        string $value,
-        AnswersSet $answers_set
-    ): string {
-        $id = (int) $value;
-
-        $form = Form::getById($id);
-        if ($form === false) {
-            return '';
-        }
-        return $form->fields['name'];
-    }
-
-    #[Override]
-    public function getItemtype(): string
-    {
-        return Form::class;
-    }
-
-    public function getTagForForm(Form $form): Tag
-    {
-        return new Tag(
-            label: sprintf(__('Form name: %s'), $form->fields['name']),
-            value: $form->getId(),
-            provider: $this,
-        );
-    }
+    public function __construct() {}
 }

--- a/src/Glpi/Form/Tag/AnswerTagProvider.php
+++ b/src/Glpi/Form/Tag/AnswerTagProvider.php
@@ -41,7 +41,7 @@ use Glpi\Form\Form;
 use Glpi\Form\Question;
 use Override;
 
-final class AnswerTagProvider implements TagProviderInterface
+final class AnswerTagProvider implements TagProviderInterface, TagWithIdValueInterface
 {
     #[Override]
     public function getTagColor(): string
@@ -78,6 +78,12 @@ final class AnswerTagProvider implements TagProviderInterface
 
         $answer = array_pop($answers);
         return $answer->getFormattedAnswer();
+    }
+
+    #[Override]
+    public function getItemtype(): string
+    {
+        return Question::class;
     }
 
     public function getTagForQuestion(Question $question): Tag

--- a/src/Glpi/Form/Tag/CommentDescriptionTagProvider.php
+++ b/src/Glpi/Form/Tag/CommentDescriptionTagProvider.php
@@ -40,7 +40,7 @@ use Glpi\Form\Comment;
 use Glpi\Form\Form;
 use Override;
 
-final class CommentDescriptionTagProvider implements TagProviderInterface
+final class CommentDescriptionTagProvider implements TagProviderInterface, TagWithIdValueInterface
 {
     #[Override]
     public function getTagColor(): string
@@ -71,6 +71,12 @@ final class CommentDescriptionTagProvider implements TagProviderInterface
             return '';
         }
         return $comment->fields['description'];
+    }
+
+    #[Override]
+    public function getItemtype(): string
+    {
+        return Comment::class;
     }
 
     public function getDescriptionTagForComment(Comment $comment): Tag

--- a/src/Glpi/Form/Tag/CommentTitleTagProvider.php
+++ b/src/Glpi/Form/Tag/CommentTitleTagProvider.php
@@ -40,7 +40,7 @@ use Glpi\Form\Comment;
 use Glpi\Form\Form;
 use Override;
 
-final class CommentTitleTagProvider implements TagProviderInterface
+final class CommentTitleTagProvider implements TagProviderInterface, TagWithIdValueInterface
 {
     #[Override]
     public function getTagColor(): string
@@ -71,6 +71,12 @@ final class CommentTitleTagProvider implements TagProviderInterface
             return '';
         }
         return $comment->fields['name'];
+    }
+
+    #[Override]
+    public function getItemtype(): string
+    {
+        return Comment::class;
     }
 
     public function getTitleTagForComment(Comment $comment): Tag

--- a/src/Glpi/Form/Tag/QuestionTagProvider.php
+++ b/src/Glpi/Form/Tag/QuestionTagProvider.php
@@ -40,7 +40,7 @@ use Glpi\Form\Form;
 use Glpi\Form\Question;
 use Override;
 
-final class QuestionTagProvider implements TagProviderInterface
+final class QuestionTagProvider implements TagProviderInterface, TagWithIdValueInterface
 {
     #[Override]
     public function getTagColor(): string
@@ -71,6 +71,12 @@ final class QuestionTagProvider implements TagProviderInterface
             return '';
         }
         return $question->fields['name'];
+    }
+
+    #[Override]
+    public function getItemtype(): string
+    {
+        return Question::class;
     }
 
     public function getTagForQuestion(Question $question): Tag

--- a/src/Glpi/Form/Tag/SectionTagProvider.php
+++ b/src/Glpi/Form/Tag/SectionTagProvider.php
@@ -40,7 +40,7 @@ use Glpi\Form\Form;
 use Glpi\Form\Section;
 use Override;
 
-final class SectionTagProvider implements TagProviderInterface
+final class SectionTagProvider implements TagProviderInterface, TagWithIdValueInterface
 {
     #[Override]
     public function getTagColor(): string
@@ -71,6 +71,12 @@ final class SectionTagProvider implements TagProviderInterface
             return '';
         }
         return $section->fields['name'];
+    }
+
+    #[Override]
+    public function getItemtype(): string
+    {
+        return Section::class;
     }
 
     public function getTagForSection(Section $section): Tag

--- a/src/Glpi/Form/Tag/TagWithIdValueInterface.php
+++ b/src/Glpi/Form/Tag/TagWithIdValueInterface.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2025 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -35,50 +34,15 @@
 
 namespace Glpi\Form\Tag;
 
-use Glpi\Form\AnswersSet;
-use Glpi\Form\Form;
-use Override;
-
-final class FormTagProvider implements TagProviderInterface, TagWithIdValueInterface
+/**
+ * If a tag reference an ID as its value, it must also implement this interface
+ * to indicate the target class that must be instanciate the value.
+ */
+interface TagWithIdValueInterface
 {
-    #[Override]
-    public function getTagColor(): string
-    {
-        return "yellow";
-    }
-
-    #[Override]
-    public function getTags(Form $form): array
-    {
-        return [$this->getTagForForm($form)];
-    }
-
-    #[Override]
-    public function getTagContentForValue(
-        string $value,
-        AnswersSet $answers_set
-    ): string {
-        $id = (int) $value;
-
-        $form = Form::getById($id);
-        if ($form === false) {
-            return '';
-        }
-        return $form->fields['name'];
-    }
-
-    #[Override]
-    public function getItemtype(): string
-    {
-        return Form::class;
-    }
-
-    public function getTagForForm(Form $form): Tag
-    {
-        return new Tag(
-            label: sprintf(__('Form name: %s'), $form->fields['name']),
-            value: $form->getId(),
-            provider: $this,
-        );
-    }
+    /**
+     * Indicate the itemtype referenced by the tag "value" property.
+     * @return class-string<\CommonDBTM>
+     */
+    public function getItemtype(): string;
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Form tags can contains IDs references to its questions:
<img width="1328" height="1006" alt="image" src="https://github.com/user-attachments/assets/0de0fcf0-c55a-4df1-8f4a-6a7444d850e5" />

This need to be taken into account when cloning a form as we want the ID to match the newly cloned form parts, not the original form parts.

It will also need to be handled for the export/import feature, I'll do it in another PR once this one is merged.

