### PR TITLE
Fix SMTP Oauth2 callback compat with `samesite=strict` cookies

### DIFF
--- a/src/Glpi/Http/SessionManager.php
+++ b/src/Glpi/Http/SessionManager.php
@@ -144,6 +144,12 @@ class SessionManager
             return true;
         }
 
+        if (\str_starts_with($path, '/front/smtp_oauth2_callback.php') && !$request->query->has('cookie_refresh')) {
+            // The SMTP Oauth2 callback endpoint should try to reload/init the session before the `cookie_refresh` hack
+            // has been used.
+            return true;
+        }
+
         if (\str_starts_with($path, '/front/planning.php') && $request->query->has('genical')) {
             // The `genical` endpoint must not use cookies, as the authentication is expected to be passed in the query parameters.
             return true;


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

When `samesite=strict` is used for session cookies, the browser will send the cookies to GLPI only if the referer page is a GLPI page too. It means that when the Oauth provider redirects the user to the GLPI Oauth callback URL, the GLPI session cookie is not sent to the server.

To bypass this limitation, the `/front/smtp_oauth2_callback.php` endpoint will redirect to itself when its URL does not contain a specific flag. The browser will so reload the URL and pass the GLPI session cookie in the request headers. This require the `/front/smtp_oauth2_callback.php` endpoint to be loaded in stateless mode unless the `cookie_refresh` URL param is set, to be sure that it will not create a new session when the GLPI session cookie is not passed in the first request.

If fixes #20980.