### PR TITLE
Run cypress with docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,7 +190,6 @@ rector-apply: ## Run rector
 
 cypress: ## Run cypress tests
 	@$(eval c ?=)
-	@$(CONSOLE) cache:clear --env=testing
 	@$(CONSOLE) config:set url_base http://localhost:8080 --env=testing
 	@$(PHP) bash -c 'node_modules/.bin/cypress verify || node_modules/.bin/cypress install'
 	@$(PHP) node_modules/.bin/cypress run --project tests $(c)

--- a/Makefile
+++ b/Makefile
@@ -188,6 +188,14 @@ rector-apply: ## Run rector
 	@$(PHP) php vendor/bin/rector $(c)
 .PHONY: rector-apply
 
+cypress: ## Run cypress tests
+	@$(eval c ?=)
+	@$(CONSOLE) cache:clear --env=testing
+	@$(CONSOLE) config:set url_base http://localhost:8080 --env=testing
+	@$(PHP) bash -c 'node_modules/.bin/cypress verify || node_modules/.bin/cypress install'
+	@$(PHP) node_modules/.bin/cypress run --project tests $(c)
+.PHONY: cypress
+
 ## —— Coding standards —————————————————————————————————————————————————————————
 phpcsfixer-check: ## Check for php coding standards issues
 	@$(PHP) vendor/bin/php-cs-fixer check --diff -vvv

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,6 +14,9 @@ services:
       - "9637:9637"
     depends_on:
       - db
+    environment:
+      # By default the testing env is exposed under the 8080 internal port
+      CYPRESS_BASE_URL: http://localhost:8080
     extra_hosts:
       - "host.docker.internal:host-gateway"
 

--- a/tests/cypress/README.md
+++ b/tests/cypress/README.md
@@ -1,0 +1,21 @@
+# Running Cypress tests 
+
+First, make sure the test database is freshly installed:
+
+```sh
+make test-db-install
+```
+
+You might need to reinstall it from time to time to restore the original data.
+
+Then, you can run the whole tests suite with the following command:
+
+```sh
+make cypress
+```
+
+To run a specific tests, use the `c` parameter:
+
+```sh
+make cypress c="--spec tests/cypress/e2e/ajax_controller.cy.js"
+```


### PR DESCRIPTION
## Description

Allow cypress tests to run inside docker without any configuration, which will make it easier for newcomers to run them easily on their machine.
