### PR TITLE
Restore AJAX dropdowns boolean casting removed in #20826

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -4569,6 +4569,15 @@ JS;
         $output = '';
 
         // Escape variables for JS
+        foreach ($params as $key => $val) {
+            // Specific boolean case: cast them to integer to prevent issues when passing `"false"` strings through
+            // URL / form body.
+            // see #21025
+            if (is_bool($val)) {
+                $params[$key] = $val ? 1 : 0;
+            }
+        }
+
         $field_id            = jsescape($field_id);
         $width               = jsescape($width);
         $multiple            = jsescape($multiple);


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

A specific boolean casting has been removed in #20826:
<img width="1480" height="434" alt="image" src="https://github.com/user-attachments/assets/89aabb2c-73b0-4947-b5d3-7fe5fd3dc2a3" />

It is the source of issues with dropdowns boolean params.

The fix made in #21025 is probably useless now, but I keeping it could not hurt.