### PR TITLE
Fix locales extraction

### DIFF
--- a/src/Glpi/UI/IllustrationManager.php
+++ b/src/Glpi/UI/IllustrationManager.php
@@ -36,6 +36,7 @@ namespace Glpi\UI;
 
 use Glpi\Application\View\TemplateRenderer;
 use RuntimeException;
+use Throwable;
 
 use function Safe\file_get_contents;
 use function Safe\json_decode;
@@ -255,16 +256,27 @@ final class IllustrationManager
 
     private function renderNativeIcon(string $icon_id, ?int $size = null): string
     {
+        global $TRANSLATE;
+
         $size = $this->computeSize($size);
 
         $icons = $this->getIconsDefinitions();
+
+        try {
+            // Cannot call `_x()` here as it results in an illegal empty translation `id` when strings are extracted.
+            // see #21049
+            $title = $TRANSLATE->translate("Icon\004" . ($icons[$icon_id]['title'] ?? ""), 'glpi');
+        } catch (Throwable $e) {
+            $title = '';
+        }
+
         $twig = TemplateRenderer::getInstance();
         return $twig->render('components/illustration/icon.svg.twig', [
             'file_path' => $this->icons_sprites_path,
             'icon_id'   => $icon_id,
             'width'     => $size,
             'height'    => $size,
-            'title'     => _x("Icon", $icons[$icon_id]['title'] ?? ""),
+            'title'     => $title,
         ]);
     }
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Using the `_x("Icon", $icons[$icon_id]['title'] ?? "")` syntax resulted in the generation of an empty message id:
```
#: src/Glpi/UI/IllustrationManager.php:267
msgid ""
msgstr ""
```

Pushing the `glpi.pot` file to the transifex service was refused:
`GLPI.glpi-11-0 - failed to upload of resource 'o:glpi:p:GLPI:r:glpi-11-0' - parse_error: Found empty msgid.`
