### PR TITLE
fix(ticket): task changes parent status during creation with rule or template

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -8202,6 +8202,7 @@ abstract class CommonITILObject extends CommonDBTM
                 '_tasktemplates_id'           => $tasktemplates_id,
                 $this->getForeignKeyField()   => $this->fields['id'],
                 'date'                        => $this->fields['date'],
+                '_do_not_compute_status'      => $this->input['_do_not_compute_status'] ?? 0,
                 '_disablenotif'               => true,
             ]);
         }


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !39169
- If a ticket is closed during its creation with rules and a task is added to it via a ticket template or rules, the ticket status changes from “Closed” to “Assigned.”

## Screenshots (if appropriate):

Ticket Template:
<img width="1144" height="517" alt="image" src="https://github.com/user-attachments/assets/89a0d59a-bae5-495e-a6ae-87fb6bf6763f" />

Rule:
<img width="1455" height="302" alt="image" src="https://github.com/user-attachments/assets/30112ecb-bb80-4556-bcee-aa19f2a972c5" />


