### PR TITLE
Fix associated items from form not being set for non english users

### DIFF
--- a/src/Glpi/Form/Destination/CommonITILField/AssociatedItemsFieldStrategy.php
+++ b/src/Glpi/Form/Destination/CommonITILField/AssociatedItemsFieldStrategy.php
@@ -84,7 +84,8 @@ enum AssociatedItemsFieldStrategy: string
             return false;
         }
 
-        if (!in_array($value['itemtype'], CommonITILObject::getAllTypesForHelpdesk())) {
+        $valid_itemtypes = CommonITILObject::getAllTypesForHelpdesk();
+        if (!isset($valid_itemtypes[$value['itemtype']])) {
             return false;
         }
 


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Forms with assets questions were only added correctly to the destination ticket for english users.

This is because `CommonITILObject::getAllTypesForHelpdesk` return locales dependent values, we must check its keys instead to validate a given itemtype.

<img width="448" height="271" alt="image" src="https://github.com/user-attachments/assets/522a3038-548f-4953-8aef-17e97052681c" />

