### PR TITLE
Fix handling of `QuerySubQuery` in foreign keys

### DIFF
--- a/src/DBmysqlIterator.php
+++ b/src/DBmysqlIterator.php
@@ -733,7 +733,7 @@ class DBmysqlIterator implements SeekableIterator, Countable
                 if ($f2 instanceof QuerySubQuery || $f2 instanceof QueryExpression) {
                     return (is_numeric($t1) ? DBmysql::quoteName($f1) : DBmysql::quoteName($t1) . '.' . DBmysql::quoteName($f1))
                         . ' = '
-                        . $f2->getValue();
+                        . ((string) $f2);
                 } else {
                     return (is_numeric($t1) ? DBmysql::quoteName($f1) : DBmysql::quoteName($t1) . '.' . DBmysql::quoteName($f1))
                         . ' = '


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

It fixes this kind of issues:
```
glpi.CRITICAL:   *** Uncaught PHP Exception Symfony\Component\ErrorHandler\Error\UndefinedMethodError: "Attempted to call an undefined method named "getValue" of class "Glpi\DBAL\QuerySubQuery"." at DBmysqlIterator.php line 736
  Backtrace :
  ./src/DBmysqlIterator.php:736
  ./src/DBmysqlIterator.php:570                      DBmysqlIterator->analyseFkey()
  ./src/DBmysqlIterator.php:711                      DBmysqlIterator->analyseCrit()
  ./src/DBmysqlIterator.php:294                      DBmysqlIterator->analyseJoins()
  ./src/DBmysqlIterator.php:122                      DBmysqlIterator->buildQuery()
  ./src/DBmysql.php:1050                             DBmysqlIterator->execute()
  ./src/Ticket.php:4074                              DBmysql->request()
  ./ajax/central.php:75                              Ticket::showCentralList()
  ...Glpi/Controller/LegacyFileLoadController.php:63 require()
  ./vendor/symfony/http-kernel/HttpKernel.php:181    Glpi\Controller\LegacyFileLoadController->__invoke()
  ./vendor/symfony/http-kernel/HttpKernel.php:76     Symfony\Component\HttpKernel\HttpKernel->handleRaw()
  ./vendor/symfony/http-kernel/Kernel.php:197        Symfony\Component\HttpKernel\HttpKernel->handle()
  ./public/index.php:70                              Symfony\Component\HttpKernel\Kernel->handle()
```