### PR TITLE
Prevent session init error on kernel reboot

### DIFF
--- a/src/Glpi/Kernel/Kernel.php
+++ b/src/Glpi/Kernel/Kernel.php
@@ -60,6 +60,8 @@ final class Kernel extends BaseKernel
 
     private LoggerInterface $logger;
 
+    private bool $in_reboot = false;
+
     public function __construct(?string $env = null)
     {
         // Initialize system configuration.
@@ -136,16 +138,26 @@ final class Kernel extends BaseKernel
     #[Override()]
     public function boot(): void
     {
-        $dispatch_postboot = !$this->booted;
+        $already_booted = $this->booted;
 
         parent::boot();
 
-        // Define synthetic logger service
-        $this->container->set('logger', $this->logger);
+        if (!$already_booted) {
+            // Define synthetic logger service
+            $this->container->set('logger', $this->logger);
 
-        if ($dispatch_postboot) {
-            $this->container->get('event_dispatcher')->dispatch(new PostBootEvent());
+            $this->container->get('event_dispatcher')->dispatch(new PostBootEvent($this->in_reboot));
         }
+    }
+
+    #[Override()]
+    public function reboot(?string $warmupDir)
+    {
+        $this->in_reboot = true;
+
+        parent::reboot($warmupDir);
+
+        $this->in_reboot = false;
     }
 
     #[Override()]

--- a/src/Glpi/Kernel/Listener/PostBootListener/BootPlugins.php
+++ b/src/Glpi/Kernel/Listener/PostBootListener/BootPlugins.php
@@ -52,9 +52,16 @@ final readonly class BootPlugins implements EventSubscriberInterface
         ];
     }
 
-    public function onPostBoot(): void
+    public function onPostBoot(PostBootEvent $event): void
     {
         global $DB;
+
+        if ($event->isReboot()) {
+            // Since plugins are handled outside the services managed by the kernel container,
+            // a kernel reboot does not unload plugins related stuffs, and (re)booting them again may have
+            // unexpected side effects.
+            return;
+        }
 
         if (
             !$this->isDatabaseUsable()

--- a/src/Glpi/Kernel/Listener/PostBootListener/CheckPluginsStates.php
+++ b/src/Glpi/Kernel/Listener/PostBootListener/CheckPluginsStates.php
@@ -51,9 +51,15 @@ final readonly class CheckPluginsStates implements EventSubscriberInterface
         ];
     }
 
-    public function onPostBoot(): void
+    public function onPostBoot(PostBootEvent $event): void
     {
         global $DB;
+
+        if ($event->isReboot()) {
+            // The kernel reboot has no impact on plugins states, no need to check them again.
+            return;
+        }
+
         if (
             !DBConnection::isDbAvailable()
             || !Config::isLegacyConfigurationLoaded()

--- a/src/Glpi/Kernel/Listener/PostBootListener/CustomObjectsAutoloaderRegistration.php
+++ b/src/Glpi/Kernel/Listener/PostBootListener/CustomObjectsAutoloaderRegistration.php
@@ -53,8 +53,14 @@ final readonly class CustomObjectsAutoloaderRegistration implements EventSubscri
         ];
     }
 
-    public function onPostBoot(): void
+    public function onPostBoot(PostBootEvent $event): void
     {
+        if ($event->isReboot()) {
+            // Custom objects autoloader are not unloaded on kernel reboot,
+            // they do not have to be registered again.
+            return;
+        }
+
         if (!$this->isDatabaseUsable()) {
             // Requires the database to be available.
             return;

--- a/src/Glpi/Kernel/Listener/PostBootListener/CustomObjectsBoot.php
+++ b/src/Glpi/Kernel/Listener/PostBootListener/CustomObjectsBoot.php
@@ -53,8 +53,15 @@ final readonly class CustomObjectsBoot implements EventSubscriberInterface
         ];
     }
 
-    public function onPostBoot(): void
+    public function onPostBoot(PostBootEvent $event): void
     {
+        if ($event->isReboot()) {
+            // Since custom objects are handled outside the services managed by the kernel container,
+            // a kernel reboot does not custom objects from configs and static properties,
+            // and (re)booting definitins again may have unexpected side effects.
+            return;
+        }
+
         if (!$this->isDatabaseUsable()) {
             // Requires the database to be available.
             return;

--- a/src/Glpi/Kernel/Listener/PostBootListener/FlushBootErrors.php
+++ b/src/Glpi/Kernel/Listener/PostBootListener/FlushBootErrors.php
@@ -49,8 +49,13 @@ final readonly class FlushBootErrors implements EventSubscriberInterface
         ];
     }
 
-    public function onPostBoot(): void
+    public function onPostBoot(PostBootEvent $event): void
     {
+        if ($event->isReboot()) {
+            // The boot error buffer is only used during the initial boot sequence.
+            return;
+        }
+
         Profiler::getInstance()->start('FlushBootErrors::execute', Profiler::CATEGORY_BOOT);
 
         ErrorHandler::disableBufferAndFlushMessages();

--- a/src/Glpi/Kernel/Listener/PostBootListener/InitializeCache.php
+++ b/src/Glpi/Kernel/Listener/PostBootListener/InitializeCache.php
@@ -50,8 +50,15 @@ final readonly class InitializeCache implements EventSubscriberInterface
         ];
     }
 
-    public function onPostBoot(): void
+    public function onPostBoot(PostBootEvent $event): void
     {
+        if ($event->isReboot()) {
+            // Since the GLPI core cache service is not managed by the kernel container,
+            // a kernel reboot has no effect on it,
+            // therefore reinstantiating it is not required.
+            return;
+        }
+
         /** @var CacheInterface|null $GLPI_CACHE */
         global $GLPI_CACHE;
 

--- a/src/Glpi/Kernel/Listener/PostBootListener/InitializeDbConnection.php
+++ b/src/Glpi/Kernel/Listener/PostBootListener/InitializeDbConnection.php
@@ -49,8 +49,15 @@ final readonly class InitializeDbConnection implements EventSubscriberInterface
         ];
     }
 
-    public function onPostBoot(): void
+    public function onPostBoot(PostBootEvent $event): void
     {
+        if ($event->isReboot()) {
+            // Since the database service is not managed by the kernel container,
+            // a kernel reboot has no effect on it,
+            // therefore reinstantiating it is not required.
+            return;
+        }
+
         Profiler::getInstance()->start('InitializeDbConnection::execute', Profiler::CATEGORY_BOOT);
 
         if (file_exists(GLPI_CONFIG_DIR . '/config_db.php')) {

--- a/src/Glpi/Kernel/Listener/PostBootListener/InitializePlugins.php
+++ b/src/Glpi/Kernel/Listener/PostBootListener/InitializePlugins.php
@@ -56,8 +56,15 @@ final readonly class InitializePlugins implements EventSubscriberInterface
         ];
     }
 
-    public function onPostBoot(): void
+    public function onPostBoot(PostBootEvent $event): void
     {
+        if ($event->isReboot()) {
+            // Since plugins are handled outside the services managed by the kernel container,
+            // a kernel reboot does not unload plugins related stuffs,
+            // and (re)initializing them again may have unexpected side effects.
+            return;
+        }
+
         if (!$this->isDatabaseUsable()) {
             // Requires the database to be available.
             return;

--- a/src/Glpi/Kernel/Listener/PostBootListener/LoadLanguage.php
+++ b/src/Glpi/Kernel/Listener/PostBootListener/LoadLanguage.php
@@ -49,8 +49,15 @@ final readonly class LoadLanguage implements EventSubscriberInterface
         ];
     }
 
-    public function onPostBoot(): void
+    public function onPostBoot(PostBootEvent $event): void
     {
+        if ($event->isReboot()) {
+            // Since the translation service is not managed by the kernel container,
+            // a kernel reboot has no effect on it,
+            // therefore reinstantiating it is not required.
+            return;
+        }
+
         Profiler::getInstance()->start('LoadLanguage::execute', Profiler::CATEGORY_BOOT);
 
         Session::loadLanguage();

--- a/src/Glpi/Kernel/Listener/PostBootListener/LoadLegacyConfiguration.php
+++ b/src/Glpi/Kernel/Listener/PostBootListener/LoadLegacyConfiguration.php
@@ -49,9 +49,14 @@ final readonly class LoadLegacyConfiguration implements EventSubscriberInterface
         ];
     }
 
-    public function onPostBoot(): void
+    public function onPostBoot(PostBootEvent $event): void
     {
-        global $CFG_GLPI;
+        if ($event->isReboot()) {
+            // Since the configuration service is not managed by the kernel container,
+            // a kernel reboot has no effect on it,
+            // therefore reinstantiating it is not required.
+            return;
+        }
 
         Profiler::getInstance()->start('LoadLegacyConfiguration::execute', Profiler::CATEGORY_BOOT);
 

--- a/src/Glpi/Kernel/Listener/PostBootListener/ProfilerStart.php
+++ b/src/Glpi/Kernel/Listener/PostBootListener/ProfilerStart.php
@@ -49,8 +49,13 @@ final readonly class ProfilerStart implements EventSubscriberInterface
         ];
     }
 
-    public function onPostBoot(): void
+    public function onPostBoot(PostBootEvent $event): void
     {
+        if ($event->isReboot()) {
+            // The profiler profile has already been started by the initial request.
+            return;
+        }
+
         if (isCommandLine()) {
             Profiler::getInstance()->disable();
         } else {

--- a/src/Glpi/Kernel/Listener/PostBootListener/SessionStart.php
+++ b/src/Glpi/Kernel/Listener/PostBootListener/SessionStart.php
@@ -73,8 +73,14 @@ class SessionStart implements EventSubscriberInterface
         ];
     }
 
-    public function onPostBoot(): void
+    public function onPostBoot(PostBootEvent $event): void
     {
+        if ($event->isReboot()) {
+            // Restarting the session during a kernel reboot may have unexpected side effects
+            // and it is preferable to not do it.
+            return;
+        }
+
         global $CFG_GLPI;
 
         Profiler::getInstance()->start('SessionStart::execute', Profiler::CATEGORY_BOOT);

--- a/src/Glpi/Kernel/PostBootEvent.php
+++ b/src/Glpi/Kernel/PostBootEvent.php
@@ -34,4 +34,12 @@
 
 namespace Glpi\Kernel;
 
-class PostBootEvent {}
+class PostBootEvent
+{
+    public function __construct(private bool $is_reboot) {}
+
+    public function isReboot(): bool
+    {
+        return $this->is_reboot;
+    }
+}


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

When the GLPI cache is cleared, the Kernel is rebooted, triggering the `PostBootEvent`. Since most of the logic done in the corresponding listeners act on services that are not yet handled by the kernel services container, rebooting the kernel has no impact on them and it is not necessary to reexecute the listeners logic.

I added a `PostBootEvent::isReboot()` method as, in the future, when we will start to migrate our services to the kernel services container, some listeners may have to be reexecuted on reboot.

It fixes the following error:
```
glpi.WARNING:   *** Warning: session_save_path(): Session save path cannot be changed after headers have already been sent at session.php line 444
  Backtrace :
  ...odingmachine/safe/generated/8.4/session.php:444 
  ./src/Session.php:255                              Safe\session_save_path()
  ...l/Listener/PostBootListener/SessionStart.php:85 Session::setPath()
  .../event-dispatcher/Debug/WrappedListener.php:116 Glpi\Kernel\Listener\PostBootListener\SessionStart->onPostBoot()
  ...ymfony/event-dispatcher/EventDispatcher.php:220 Symfony\Component\EventDispatcher\Debug\WrappedListener->__invoke()
  ...symfony/event-dispatcher/EventDispatcher.php:56 Symfony\Component\EventDispatcher\EventDispatcher->callListeners()
  ...spatcher/Debug/TraceableEventDispatcher.php:139 Symfony\Component\EventDispatcher\EventDispatcher->dispatch()
  ./src/Glpi/Kernel/Kernel.php:147                   Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcher->dispatch()
  ./vendor/symfony/http-kernel/Kernel.php:144        Glpi\Kernel\Kernel->boot()
  ...mework-bundle/Command/CacheClearCommand.php:239 Symfony\Component\HttpKernel\Kernel->reboot()
  ...mework-bundle/Command/CacheClearCommand.php:141 Symfony\Bundle\FrameworkBundle\Command\CacheClearCommand->warmup()
  ./vendor/symfony/console/Command/Command.php:326   Symfony\Bundle\FrameworkBundle\Command\CacheClearCommand->execute()
  ./vendor/symfony/console/Application.php:1096      Symfony\Component\Console\Command\Command->run()
  ...ny/framework-bundle/Console/Application.php:126 Symfony\Component\Console\Application->doRunCommand()
  ./vendor/symfony/console/Application.php:324       Symfony\Bundle\FrameworkBundle\Console\Application->doRunCommand()
  ...ony/framework-bundle/Console/Application.php:80 Symfony\Component\Console\Application->doRun()
  ./vendor/symfony/console/Application.php:175       Symfony\Bundle\FrameworkBundle\Console\Application->doRun()
  ./src/Glpi/Cache/CacheManager.php:590              Symfony\Component\Console\Application->run()
  ./src/Glpi/Cache/CacheManager.php:327              Glpi\Cache\CacheManager->clearSymfonyCache()
  ./src/Glpi/Controller/InstallController.php:133    Glpi\Cache\CacheManager->resetAllCaches()
  ...ts/AsyncOperationProgressControllerTrait.php:83 Glpi\Controller\InstallController->{closure:Glpi\Controller\InstallController::updateDatabase():114}()
  ./vendor/symfony/http-kernel/HttpKernel.php:101    Glpi\Controller\InstallController->{closure:Glpi\Controller\Traits\AsyncOperationProgressControllerTrait::getProgressInitResponse():66}()
  ...ymfony/http-foundation/StreamedResponse.php:106 Symfony\Component\HttpKernel\HttpKernel::{closure:Symfony\Component\HttpKernel\HttpKernel::handle():98}()
  ./vendor/symfony/http-foundation/Response.php:423  Symfony\Component\HttpFoundation\StreamedResponse->sendContent()
  ./src/Glpi/Kernel/Kernel.php:283                   Symfony\Component\HttpFoundation\Response->send()
  ./public/index.php:72                              Glpi\Kernel\Kernel->sendResponse()
```