### PR TITLE
Fix (PlanningEvent) - Handle guests removal when field is not submitted

### DIFF
--- a/phpunit/functional/PlanningExternalEventTest.php
+++ b/phpunit/functional/PlanningExternalEventTest.php
@@ -79,4 +79,51 @@ class PlanningExternalEventTest extends \AbstractPlanningEvent
         $this->assertCount(3, $rrule['exceptions']);
         $this->assertContains($start_day, $rrule['exceptions']);
     }
+
+    public function testGuestsRemoval()
+    {
+        $this->login();
+
+        $user1 = $this->createItem('User', [
+            'name' => 'test_guest_1',
+            'realname' => 'Test Guest 1',
+            'firstname' => 'Test',
+        ]);
+
+        $user2 = $this->createItem('User', [
+            'name' => 'test_guest_2',
+            'realname' => 'Test Guest 2',
+            'firstname' => 'Test',
+        ]);
+
+        // Create an event with guests
+        $event = new $this->myclass();
+        $input_with_guests = $this->input;
+        $input_with_guests['users_id_guests'] = [$user1->getID(), $user2->getID()];
+
+        $id = $event->add($input_with_guests);
+        $this->assertGreaterThan(0, (int) $id);
+        $this->assertTrue($event->getFromDB($id));
+
+        // Verify guests are set
+        $guests = $event->fields['users_id_guests'];
+        $this->assertCount(2, $guests);
+        $this->assertContains($user1->getID(), $guests);
+        $this->assertContains($user2->getID(), $guests);
+
+        // Update event without users_id_guests field (simulating form submission with no guests)
+        $this->updateItem(
+            $this->myclass,
+            $id,
+            [
+                'name' => 'Updated event name',
+                // Note: users_id_guests is not present, simulating clearing the guests field
+            ]
+        );
+        $this->assertTrue($event->getFromDB($id));
+
+        // Verify guests are removed
+        $guests_after_update = $event->fields['users_id_guests'];
+        $this->assertEmpty($guests_after_update, 'Guests should be removed when users_id_guests field is not present in update input');
+    }
 }

--- a/src/Features/PlanningEvent.php
+++ b/src/Features/PlanningEvent.php
@@ -237,6 +237,9 @@ trait PlanningEvent
             $input['users_id_guests'] = exportArrayToDB(
                 ArrayNormalizer::normalizeValues($input['users_id_guests'], 'intval')
             );
+        } elseif (!isset($input['users_id_guests']) && !$this->isNewItem()) {
+            // If users_id_guests is not in input, it means all guests were removed
+            $input['users_id_guests'] = exportArrayToDB([]);
         }
 
         return $input;


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !39339
- Here is a brief description of what this PR does

### Fix

Fixed an issue where removing all guests from a planning event would not persist the change.

When clearing the guests field in the form, the `users_id_guests` field is not submitted (normal HTML behavior), causing the existing guests to remain unchanged.

### Changes

- Modified `prepareGuestsInput()` method to detect when `users_id_guests` is missing during update operations
- Added test case to verify guests are properly removed when field is not present in form submission


## Screenshots (if appropriate):

<img width="1867" height="734" alt="image" src="https://github.com/user-attachments/assets/7f20072f-c6d7-4585-ae82-50602acc4a20" />
