### PR TITLE
fix(stats): correct technicien_followup actiontime calculation

### DIFF
--- a/src/Stat.php
+++ b/src/Stat.php
@@ -1334,6 +1334,10 @@ class Stat extends CommonGLPI
                 break;
 
             case "inter_solved_with_actiontime":
+                if ($param == "technicien_followup") {
+                    $WHERE["$tasktable.users_id_tech"] = $value;
+                    unset( $WHERE["$tasktable.users_id"] );
+                }
                 $WHERE["$table.status"] = $solved_status;
                 $WHERE["$table.actiontime"] = ['>', 0];
                 $WHERE[] = ['NOT' => ["$table.solvedate" => null]];
@@ -1400,6 +1404,8 @@ class Stat extends CommonGLPI
             case "inter_avgactiontime":
                 if ($param == "technicien_followup") {
                     $actiontime_table = $tasktable;
+                    unset( $WHERE["$tasktable.users_id"] );
+                    $WHERE["$tasktable.users_id_tech"] = $value;
                 } else {
                     $actiontime_table = $table;
                 }


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !39338
- This patch resolves inconsistencies in the calculation of task duration statistics for technicians in the GLPI statistics module. The statistics that averaged the duration of tasks per resolved or closed ticket used the author (users_id) of the task and not the technician assigned to the task (users_id_tech).

## Screenshots (if appropriate):
First Ticket - 1h30 task assigned to tech user
<img width="1911" height="706" alt="image" src="https://github.com/user-attachments/assets/17f1cf04-8016-4ac5-9d30-966315bdf288" />

Second Ticket - 30min task assigned to tech user
<img width="1266" height="328" alt="image" src="https://github.com/user-attachments/assets/1847feee-4b9d-449d-8484-eefa2ec02d09" />

The user glpi created 3 30 minutes tasks and assigned them to the user tech, but in the statistics, they are not assigned to tech but to the user glpi.
Before fix
<img width="1920" height="502" alt="annotely_image(7)" src="https://github.com/user-attachments/assets/99c389a3-3f74-49ef-a7dc-c2873576531c" />

After fix
<img width="1920" height="487" alt="annotely_image(8)" src="https://github.com/user-attachments/assets/eef2ec32-8403-460e-afd7-8b4c13caffd1" />


