### PR TITLE
Forms: fix allow list groups checks

### DIFF
--- a/phpunit/functional/Glpi/Form/AccessControl/ControlType/AllowListDropdownTest.php
+++ b/phpunit/functional/Glpi/Form/AccessControl/ControlType/AllowListDropdownTest.php
@@ -86,6 +86,17 @@ class AllowListDropdownTest extends DbTestCase
         );
     }
 
+    public function testAllowListWithUserInChildGroup(): void
+    {
+        $this->addToTestGroup2("_test_user");
+        $this->checkCountUserForCriteria(
+            criteria: [
+                'groups' => [getItemByTypeName(Group::class, '_test_group_1', true)],
+            ],
+            expected_users_count: 1,
+        );
+    }
+
     public function testAllowListWithSpecificProfiles(): void
     {
         $this->checkCountUserForCriteria(
@@ -128,6 +139,15 @@ class AllowListDropdownTest extends DbTestCase
         $this->createItem(Group_User::class, [
             'users_id'  => getItemByTypeName(User::class, $name, true),
             'groups_id' => getItemByTypeName(Group::class, '_test_group_1', true),
+        ]);
+    }
+
+    private function addToTestGroup2(string $name): void
+    {
+        // Link post-only to a group.
+        $this->createItem(Group_User::class, [
+            'users_id'  => getItemByTypeName(User::class, $name, true),
+            'groups_id' => getItemByTypeName(Group::class, '_test_group_2', true),
         ]);
     }
 

--- a/src/Glpi/Form/AccessControl/ControlType/AllowList.php
+++ b/src/Glpi/Form/AccessControl/ControlType/AllowList.php
@@ -172,7 +172,19 @@ final class AllowList implements ControlTypeInterface
         SessionInfo $session_info
     ): bool {
         foreach ($session_info->getGroupIds() as $group_id) {
+            // Check if the user is directly part of the allowed group
             if (in_array($group_id, $config->getGroupIds())) {
+                return true;
+            }
+
+            // If at least one parent group of the user is part of the allowlist
+            // then he should be able to see the form
+            $children_groups = getAncestorsOf(Group::getTable(), $group_id);
+            $membership = array_intersect(
+                $config->getGroupIds(),
+                $children_groups
+            );
+            if (count($membership) > 0) {
                 return true;
             }
         }

--- a/src/Glpi/Form/AccessControl/ControlType/AllowListDropdown.php
+++ b/src/Glpi/Form/AccessControl/ControlType/AllowListDropdown.php
@@ -112,11 +112,19 @@ final class AllowListDropdown extends AbstractRightsDropdown
 
             // Filter by group
             if ($groups !== []) {
+                $groups_with_parents = [];
+                foreach ($groups as $group) {
+                    $groups_with_parents[] = $group;
+                    $parents = getSonsOf(Group::getTable(), $group);
+                    array_push($groups_with_parents, ...$parents);
+                }
+
+                $groups_with_parents = array_unique($groups_with_parents);
                 $condition['OR'][] = [
                     'id' => new QuerySubQuery([
                         'SELECT' => 'users_id',
                         'FROM'   => Group_User::getTable(),
-                        'WHERE'  => ['groups_id' => array_values($groups)],
+                        'WHERE'  => ['groups_id' => array_values($groups_with_parents)],
                     ]),
                 ];
             }
@@ -166,7 +174,7 @@ final class AllowListDropdown extends AbstractRightsDropdown
             foreach ($groups as $group_id) {
                 $user_filters[] = [
                     'link'       => 'OR',
-                    'searchtype' => 'equals',
+                    'searchtype' => 'under',
                     'field'      => 13, // Linked group,
                     'value'      => $group_id,
                 ];


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

If a user is part of group `A > A1`,  he should be allowed to see forms that are accessible to the `A` group.

## References

Fix #21094.


