### PR TITLE
Fix `genericobject` migration compat with specific singular/plural rules

### DIFF
--- a/phpunit/functional/Glpi/Migration/GenericobjectPluginMigrationTest.php
+++ b/phpunit/functional/Glpi/Migration/GenericobjectPluginMigrationTest.php
@@ -228,8 +228,9 @@ class GenericobjectPluginMigrationTest extends DbTestCase
                     ['key' => 'custom_assets_assets_id_tablet', 'order' => 23, 'field_options' => []],
                     ['key' => 'custom_dropdowns_dropdowns_id_bar', 'order' => 24, 'field_options' => []],
                     ['key' => 'custom_dropdowns_dropdowns_id_foo', 'order' => 25, 'field_options' => []],
-                    ['key' => 'custom_dropdowns_dropdowns_id_item_state', 'order' => 26, 'field_options' => []],
-                    ['key' => 'custom_dropdowns_dropdowns_id_test_abc', 'order' => 27, 'field_options' => []],
+                    ['key' => 'custom_dropdowns_dropdowns_id_uaus', 'order' => 26, 'field_options' => []],
+                    ['key' => 'custom_dropdowns_dropdowns_id_item_state', 'order' => 27, 'field_options' => []],
+                    ['key' => 'custom_dropdowns_dropdowns_id_test_abc', 'order' => 28, 'field_options' => []],
                 ],
                 'date_creation'  => '2025-03-05 16:28:56',
                 // 'date_mod'       => '2025-03-06 14:19:23',
@@ -316,6 +317,16 @@ class GenericobjectPluginMigrationTest extends DbTestCase
             ],
             [
                 'label'         => 'Foo',
+                'icon'          => null,
+                'comment'       => null,
+                'is_active'     => true,
+                'profiles'      => \array_fill_keys([1, 2, 3, 4, 5, 6, 7, 8], 23),
+                'translations'  => [],
+                'date_creation' => $_SESSION['glpi_currenttime'],
+                'date_mod'      => $_SESSION['glpi_currenttime'],
+            ],
+            [
+                'label'         => 'Uaus',
                 'icon'          => null,
                 'comment'       => null,
                 'is_active'     => true,
@@ -536,6 +547,7 @@ class GenericobjectPluginMigrationTest extends DbTestCase
         // Validate created dropdowns
         $bar_definition = \getItemByTypeName(DropdownDefinition::class, 'Bar');
         $foo_definition = \getItemByTypeName(DropdownDefinition::class, 'Foo');
+        $uau_definition = \getItemByTypeName(DropdownDefinition::class, 'Uaus');
         $item_state_definition = \getItemByTypeName(DropdownDefinition::class, 'Item_State');
         $cat_definition = \getItemByTypeName(DropdownDefinition::class, 'SmartphoneCategory');
         $test_abc_definition = \getItemByTypeName(DropdownDefinition::class, 'Test_Abc');
@@ -623,6 +635,18 @@ class GenericobjectPluginMigrationTest extends DbTestCase
                 ],
                 [
                     'name'          => 'Foo 10',
+                ],
+            ]
+        );
+
+        $this->checkItems(
+            $uau_definition->getDropdownClassName(),
+            [
+                [
+                    'name'          => 'Uau 1',
+                ],
+                [
+                    'name'          => 'Uau 2',
                 ],
             ]
         );

--- a/src/Glpi/Migration/GenericobjectPluginMigration.php
+++ b/src/Glpi/Migration/GenericobjectPluginMigration.php
@@ -1028,16 +1028,21 @@ class GenericobjectPluginMigration extends AbstractPluginMigration
         $expected_table = \getTableForItemType($classname);
 
         if (!$this->db->tableExists($expected_table)) {
-            // Try to match with an existing table.
-            //
+            // Try to match with an existing table if the expected table does not exists.
+
             // Sometimes, the plugin table name has only its last chunk pluralized
             // (e.g. `glpi_plugin_genericobject_item_states` instead of `glpi_plugin_genericobject_items_states`).
             // It means that `\getTableForItemType(\getItemTypeForTable($table)))` result differs
             // from the original `$table` value.
-            //
-            // If the expected table does not exists, but a table exists with only its last chunk pluralized,
-            // then we fallback to this last one.
             $fallback_table = 'glpi_plugin_genericobject_' . \strtolower(\getPlural($classname_matches['itemtype_chunk']));
+
+            if ($this->db->tableExists($fallback_table)) {
+                return $fallback_table;
+            }
+
+            // Sometimes, multiple tranformations from singular to plural or from plural to singular produces unexpected
+            // results, e.g. `getPlural('uau')` -> `uaus`, then `getSingular('uaus')` -> `uaus`.
+            $fallback_table = 'glpi_plugin_genericobject_' . \strtolower(\getSingular($classname_matches['itemtype_chunk']));
 
             if ($this->db->tableExists($fallback_table)) {
                 return $fallback_table;

--- a/tests/fixtures/genericobject-migration/genericobject-db.sql
+++ b/tests/fixtures/genericobject-migration/genericobject-db.sql
@@ -131,6 +131,21 @@ INSERT INTO `glpi_plugin_genericobject_foos` (`id`, `name`, `comment`, `date_mod
 (9, 'Foo 9', '', '2025-03-06 10:27:05', '2025-03-06 10:27:05'),
 (10, 'Foo 10', '', '2025-03-06 10:27:08', '2025-03-06 10:27:08');
 
+CREATE TABLE `glpi_plugin_genericobject_uaus` (
+  `id` INT UNSIGNED AUTO_INCREMENT NOT NULL,
+  `name` VARCHAR(255) NULL,
+  `comment` TEXT NULL,
+  `date_mod` TIMESTAMP NULL,
+  `date_creation` TIMESTAMP NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `date_mod` (`date_mod`),
+  KEY `date_creation` (`date_creation`),
+  KEY `name` (`name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+INSERT INTO `glpi_plugin_genericobject_uaus` (`id`, `name`, `comment`, `date_mod`, `date_creation`) VALUES
+(1, 'Uau 1', '', '2025-01-13 08:47:23', '2025-01-13 08:47:23'),
+(2, 'Uau 2', '', '2025-02-24 17:43:01', '2025-02-26 14:12:17');
+
 CREATE TABLE `glpi_plugin_genericobject_items_states` (
   `id` INT UNSIGNED AUTO_INCREMENT NOT NULL,
   `name` VARCHAR(255) NULL,
@@ -215,16 +230,17 @@ CREATE TABLE `glpi_plugin_genericobject_smartphones` (
   `plugin_genericobject_tablets_id` INT UNSIGNED NOT NULL DEFAULT 0 ,
   `plugin_genericobject_bars_id` INT UNSIGNED NOT NULL DEFAULT 0 ,
   `plugin_genericobject_foos_id` INT UNSIGNED NOT NULL DEFAULT 0 ,
+  `plugin_genericobject_uaus_id` INT UNSIGNED NOT NULL DEFAULT 0 ,
   `plugin_genericobject_items_states_id` INT UNSIGNED NOT NULL DEFAULT 0 ,
   `plugin_genericobject_test_abcs_id` INT UNSIGNED NOT NULL DEFAULT 0 ,
    PRIMARY KEY (`id`),
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
-INSERT INTO `glpi_plugin_genericobject_smartphones` (`id`, `is_template`, `template_name`, `is_deleted`, `entities_id`, `is_recursive`, `name`, `serial`, `otherserial`, `locations_id`, `states_id`, `users_id`, `groups_id`, `manufacturers_id`, `users_id_tech`, `comment`, `is_helpdesk_visible`, `notepad`, `date_mod`, `date_creation`, `computers_id_host`, `config_str`, `contact`, `contact_num`, `creationdate`, `count`, `domains_id`, `expirationdate`, `groups_id_tech`, `is_global`, `other`, `plugin_genericobject_smartphonecategories_id`, `plugin_genericobject_smartphonemodels_id`, `plugin_genericobject_smartphonetypes_id`, `url`, `plugin_genericobject_tablets_id`, `plugin_genericobject_bars_id`, `plugin_genericobject_foos_id`, `plugin_genericobject_items_states_id`, `plugin_genericobject_test_abcs_id`) VALUES
-(1, 0, '', 0, 0, 0, 'Smartphone 1', 'SER0123', '', 1, 1, 3, 2, 3, 4, '', 1, NULL, '2025-03-06 10:08:51', '2025-03-06 10:08:51', 1, '# is_foo=0\nis_foo=1\nbar="adbizq"', '', '', '2025-02-01', 19, 4, '2025-12-31', 0, 0, 'some random value', 5, 2, 5, 'https://example.org/?id=9783', 1, 3, 2, 0, 1),
-(2, 0, '', 0, 0, 1, 'Smartphone 2', 'SER0198', '', 2, 2, 5, 1, 2, 0, '', 1, NULL, '2025-03-06 10:11:46', '2025-03-06 10:11:46', 2, '# no config', '', '', NULL, 0, 0, NULL, 4, 0, '', 4, 2, 0, '', 0, 4, 0, 3, 0),
-(3, 0, '', 0, 0, 0, 'Smartphone 3', '', 'INV123456', 0, 0, 0, 0, 0, 4, 'Some comments...', 1, NULL, '2025-03-06 10:12:59', '2025-03-06 10:12:59', 0, '', '', '', NULL, 0, 3, NULL, 0, 1, '', 0, 0, 4, '', 3, 0, 0, 1, 2);
+INSERT INTO `glpi_plugin_genericobject_smartphones` (`id`, `is_template`, `template_name`, `is_deleted`, `entities_id`, `is_recursive`, `name`, `serial`, `otherserial`, `locations_id`, `states_id`, `users_id`, `groups_id`, `manufacturers_id`, `users_id_tech`, `comment`, `is_helpdesk_visible`, `notepad`, `date_mod`, `date_creation`, `computers_id_host`, `config_str`, `contact`, `contact_num`, `creationdate`, `count`, `domains_id`, `expirationdate`, `groups_id_tech`, `is_global`, `other`, `plugin_genericobject_smartphonecategories_id`, `plugin_genericobject_smartphonemodels_id`, `plugin_genericobject_smartphonetypes_id`, `url`, `plugin_genericobject_tablets_id`, `plugin_genericobject_bars_id`, `plugin_genericobject_foos_id`, `plugin_genericobject_uaus_id`, `plugin_genericobject_items_states_id`, `plugin_genericobject_test_abcs_id`) VALUES
+(1, 0, '', 0, 0, 0, 'Smartphone 1', 'SER0123', '', 1, 1, 3, 2, 3, 4, '', 1, NULL, '2025-03-06 10:08:51', '2025-03-06 10:08:51', 1, '# is_foo=0\nis_foo=1\nbar="adbizq"', '', '', '2025-02-01', 19, 4, '2025-12-31', 0, 0, 'some random value', 5, 2, 5, 'https://example.org/?id=9783', 1, 3, 2, 0, 0, 1),
+(2, 0, '', 0, 0, 1, 'Smartphone 2', 'SER0198', '', 2, 2, 5, 1, 2, 0, '', 1, NULL, '2025-03-06 10:11:46', '2025-03-06 10:11:46', 2, '# no config', '', '', NULL, 0, 0, NULL, 4, 0, '', 4, 2, 0, '', 0, 4, 0, 1, 3, 0),
+(3, 0, '', 0, 0, 0, 'Smartphone 3', '', 'INV123456', 0, 0, 0, 0, 0, 4, 'Some comments...', 1, NULL, '2025-03-06 10:12:59', '2025-03-06 10:12:59', 0, '', '', '', NULL, 0, 3, NULL, 0, 1, '', 0, 0, 4, '', 3, 0, 0, 2, 1, 2);
 
 CREATE TABLE `glpi_plugin_genericobject_smartphonecategories` (
   `id` INT UNSIGNED AUTO_INCREMENT NOT NULL,


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

The singular/plural transformations are not always reversible. It can result in unexpected results, e.g. `getPlural('uau')` -> `uaus`, but `getSingular('uaus')` -> `uaus`. These transformations are used in functions like `getItemTypeForTable()` and `getTableForItemType()` that are indirectly used in many places of the initial `genericobject` tables/class creation and in the migration of them into GLPI.

It fixes #21080.