### PR TITLE
Fix(Ticket): check delegate when approrpiate

### DIFF
--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -1834,8 +1834,9 @@ class Ticket extends CommonITILObject
         // This to avoid plugins having their process broken.
         if (
             isset($input['check_delegatee'], $input['_users_id_requester'])
-            && $input['check_delegatee']
+            && $input['check_delegatee'] && !($input['nodelegate'] ?? false)
         ) {
+
             $requesters_ids = is_array($input['_users_id_requester'])
                 ? $input['_users_id_requester']
                 : [$input['_users_id_requester']];


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !39369 and #20973

When a user is tagged as a delegate in a group, they have the ability to create a ticket on behalf of a member of that group.

However, in cases where the request concerns the delegate themselves, the verification checks a list of requesters, which is currently empty. As a result, the delegation check returns false.

I propose adding the recipient to the list of requesters during this verification to ensure the delegation is correctly recognized.

## Screenshots (if appropriate):


