### PR TITLE
Do not force usage of TLS when sending emails over a secured port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -254,7 +254,7 @@ The present file will list all changes made to the project; according to the
 - Usage of the `/marketplace` path for plugins URLs. All plugins URLs should now start with `/plugins`.
 - Usage of `GLPI_PLUGINS_PATH` javascript variable.
 - Usage of the `GLPI_FORCE_MAIL` constant.
-- Usage of `MAIL_SMTPSSL` and `MAIL_SMTPTLS` constants.
+- Usage of `MAIL_SMTPSSL` constants.
 - Usage of `name` and `users_id_validate` parameter in `ajax/dropdownValidator.php`.
 - Usage of `users_id_validate` parameter in `front/commonitilvalidation.form.php`.
 - `front/ticket_ticket.form.php` script usage.

--- a/install/migrations/update_10.0.x_to_11.0.0/mailer.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/mailer.php
@@ -39,12 +39,12 @@ $migration->addPostQuery(
     $DB->buildUpdate(
         Config::getTable(),
         [
-            'value' => 2, // MAIL_SMTPS
+            'value' => 1, // MAIL_SMTP
         ],
         [
             'context' => 'core',
             'name' => 'smtp_mode',
-            'value' => 3, // old MAIL_SMTP+SSLTLS
+            'value' => 2, // deprecated MAIL_SMTPSSL
         ]
     )
 );

--- a/src/Config.php
+++ b/src/Config.php
@@ -383,9 +383,9 @@ class Config extends CommonDBTM
     {
         global $CFG_GLPI;
 
-        if (array_key_exists('smtp_mode', $input) && $input['smtp_mode'] === MAIL_SMTPTLS) {
-            $input['smtp_mode'] = MAIL_SMTPS;
-            Toolbox::deprecated('Usage of "MAIL_SMTPTLS" SMTP mode is deprecated. Switch to "MAIL_SMTPS" mode.');
+        if (array_key_exists('smtp_mode', $input) && $input['smtp_mode'] === MAIL_SMTPSSL) {
+            $input['smtp_mode'] = MAIL_SMTP;
+            Toolbox::deprecated('Usage of "MAIL_SMTPSSL" SMTP mode is deprecated. Switch to "MAIL_SMTP" mode.');
         }
 
         if (array_key_exists('smtp_mode', $input) && (int) $input['smtp_mode'] === MAIL_SMTPOAUTH) {

--- a/src/GLPIMailer.php
+++ b/src/GLPIMailer.php
@@ -150,7 +150,7 @@ class GLPIMailer
             }
             $dsn = sprintf(
                 '%s://%s%s:%s',
-                (in_array($CFG_GLPI['smtp_mode'], [MAIL_SMTPS, MAIL_SMTPSSL, MAIL_SMTPTLS]) ? 'smtps' : 'smtp'),
+                (((int) $CFG_GLPI['smtp_mode']) === MAIL_SMTPTLS ? 'smtps' : 'smtp'),
                 ($CFG_GLPI['smtp_username'] != '' ? sprintf(
                     '%s:%s@',
                     urlencode($CFG_GLPI['smtp_username']),

--- a/src/MailCollector.php
+++ b/src/MailCollector.php
@@ -1888,13 +1888,12 @@ class MailCollector extends CommonDBTM
                 break;
 
             case MAIL_SMTP:
+            case MAIL_SMTPSSL:
                 $content .= 'SMTP';
                 break;
 
-            case MAIL_SMTPS:
-            case MAIL_SMTPSSL:
             case MAIL_SMTPTLS:
-                $content .= 'SMTPS';
+                $content .= 'SMTP+TLS';
                 break;
 
             case MAIL_SMTPOAUTH:

--- a/src/NotificationMailingSetting.php
+++ b/src/NotificationMailingSetting.php
@@ -135,7 +135,7 @@ class NotificationMailingSetting extends NotificationSetting
         $mail_methods = [
             MAIL_MAIL       => __('PHP'),
             MAIL_SMTP       => __('SMTP'),
-            MAIL_SMTPS      => __('SMTPS'),
+            MAIL_SMTPTLS    => __('SMTP+TLS'),
             MAIL_SMTPOAUTH  => __('SMTP+OAUTH'),
         ];
         $is_mail_function_available = true;

--- a/src/autoload/constants.php
+++ b/src/autoload/constants.php
@@ -98,7 +98,6 @@ define("MANAGEMENT_GLOBAL", 1);
 //Mail send methods
 define("MAIL_MAIL", 0);
 define("MAIL_SMTP", 1);
-define("MAIL_SMTPS", 2);
 define("MAIL_SMTPSSL", 2);
 define("MAIL_SMTPTLS", 3);
 define("MAIL_SMTPOAUTH", 4);


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

When we switched to `symfony/mailer` in #11423, we considered both secured connection (SMTP+SSSL and SMTP+TLS) have to use the `smtps://` scheme in the DNS provided to `symfony/mailer`, but this was not correct. Indeed, the `smtps://` will force the usage of TLS, but when it is done using the port 587 (the SSL secured port for SMTP), it result in the following errors:
```
Connection could not be established with host "ssl://smtp-hve.office365.com:587": stream_socket_client(): SSL operation failed with code 1. OpenSSL Error messages:
error:0A00010B:SSL routines::wrong version number
```

I put back the `SMTP+TLS` case that was existing in GLPI 10.0 and removed the `SMTPS` case that has been introduced in #11423 and was not clear to anyone.

It fixes !39324.

