### PR TITLE
Fix monaco editor layout race condition

### DIFF
--- a/templates/pages/setup/webhook/payload_editor.html.twig
+++ b/templates/pages/setup/webhook/payload_editor.html.twig
@@ -57,54 +57,51 @@
       }) }}
    </div>
 </div>
-<script>
-    $(() => {
-        {% set payload = item.fields['payload']|default(default_payload) %}
-        window.GLPI.Monaco.createEditor('payload', 'twig', {{ payload|json_encode|raw }}, {{ response_schema|json_encode|raw }}).then((monaco) => {
-            $("#webhook-payload-editor-container button[name='editor_find']").on('click', function() {
-                monaco.editor.getAction('actions.find').run();
-            });
-            $("#webhook-payload-editor-container button[name='editor_save']").on('click', function() {
-                let payload_template = '';
-                let reload_page = false;
-                if (!$('#payload').hasClass('d-none')) {
-                    payload_template = monaco.editor.getValue();
+<script type="module">
+    {% set payload = item.fields['payload']|default(default_payload) %}
+    window.GLPI.Monaco.createEditor('payload', 'twig', {{ payload|json_encode|raw }}, {{ response_schema|json_encode|raw }}).then((monaco) => {
+        $("#webhook-payload-editor-container button[name='editor_find']").on('click', function() {
+            monaco.editor.getAction('actions.find').run();
+        });
+        $("#webhook-payload-editor-container button[name='editor_save']").on('click', function() {
+            let payload_template = '';
+            let reload_page = false;
+            if (!$('#payload').hasClass('d-none')) {
+                payload_template = monaco.editor.getValue();
+            }
+            $.ajax({
+                url: CFG_GLPI['root_doc'] + '/ajax/webhook.php',
+                type: 'POST',
+                data: {
+                    action: 'update_payload_template',
+                    webhook_id: $("#webhook-payload-editor-container").data('webhook-id'),
+                    payload_template: payload_template,
+                    use_default_payload: $('input[name="use_default_payload"]').is(':checked'),
                 }
-                $.ajax({
-                    url: CFG_GLPI['root_doc'] + '/ajax/webhook.php',
-                    type: 'POST',
-                    data: {
-                        action: 'update_payload_template',
-                        webhook_id: $("#webhook-payload-editor-container").data('webhook-id'),
-                        payload_template: payload_template,
-                        use_default_payload: $('input[name="use_default_payload"]').is(':checked'),
-                    }
-                }).done(function() {
-                    if (reload_page) {
-                        window.location.reload();
-                    } else {
-                        glpi_toast_info(__('Saved'));
-                    }
-                });
+            }).done(function() {
+                if (reload_page) {
+                    window.location.reload();
+                } else {
+                    glpi_toast_info(__('Saved'));
+                }
             });
         });
-
         $('input[name="use_default_payload"]').on('change', () => {
-           const is_default_payload = $('input[name="use_default_payload"]').is(':checked');
-           if (is_default_payload) {
-               $('#webhook-payload-editor-toolbar button').addClass('d-none');
-               $('#payload').addClass('d-none');
-               $('#default_payload').removeClass('d-none');
-           } else {
-               $('#webhook-payload-editor-toolbar button').removeClass('d-none');
-               $('#payload').removeClass('d-none');
-               $('#default_payload').addClass('d-none');
-           }
-           // Force save button to be visible
-           $('#webhook-payload-editor-toolbar button:first').removeClass('d-none');
+            const is_default_payload = $('input[name="use_default_payload"]').is(':checked');
+            if (is_default_payload) {
+                $('#webhook-payload-editor-toolbar button').addClass('d-none');
+                $('#payload').addClass('d-none');
+                $('#default_payload').removeClass('d-none');
+            } else {
+                $('#webhook-payload-editor-toolbar button').removeClass('d-none');
+                $('#payload').removeClass('d-none');
+                $('#default_payload').addClass('d-none');
+                // Force Monaco layout
+                monaco.editor.layout();
+            }
+            // Force save button to be visible
+            $('#webhook-payload-editor-toolbar button:first').removeClass('d-none');
         });
-        $(() => {
-           $('input[name="use_default_payload"]').trigger('change');
-        });
+        $('input[name="use_default_payload"]').trigger('change');
     });
 </script>

--- a/templates/pages/setup/webhook/payload_editor.html.twig
+++ b/templates/pages/setup/webhook/payload_editor.html.twig
@@ -41,10 +41,10 @@
 <div id="webhook-payload-editor-container" data-webhook-id="{{ item.fields['id'] }}">
    <div id="webhook-payload-editor-toolbar" class="mx-1" style="font-size: 1.25em">
       <button name="editor_save" class="btn btn-icon btn-ghost-secondary">
-         <i class="ti ti-device-floppy" title="{{ _x('button', 'Save') }}"></i>
+         <i class="ti ti-device-floppy" title="{{ _x('button', 'Save') }}" aria-label="{{ _x('button', 'Save') }}"></i>
       </button>
       <button name="editor_find" class="btn btn-icon btn-ghost-secondary">
-         <i class="ti ti-search" title="{{ __('Search') }}"></i>
+         <i class="ti ti-search" title="{{ __('Search') }}" aria-label="{{ __('Search') }}"></i>
       </button>
    </div>
    <div id="payload" class="webhook-payload-editor" style="height: 600px"></div>

--- a/tests/cypress/e2e/Setup/webhooks.cy.js
+++ b/tests/cypress/e2e/Setup/webhooks.cy.js
@@ -1,0 +1,68 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+describe('Webhooks', () => {
+    let webhook_id;
+
+    before(() => {
+        cy.initApi().createWithAPI('Webhook', {
+            name: 'New computer',
+            entities_id: 1,
+            itemtype: 'Computer',
+            event: 'new',
+        }).then(id => webhook_id = id);
+    });
+    beforeEach(() => {
+        cy.login();
+    });
+
+    it('Payload editor switches', {retries: 0}, () => {
+        // Test with no retries as this test was added in response to a race condition. It should always pass.
+        cy.visit(`/front/webhook.form.php?id=${webhook_id}`);
+        cy.findByRole('tab', { name: 'Payload editor' }).click();
+        cy.findByRole('tabpanel').within(() => {
+            cy.findByRole('button', { name: 'Save' }).should('be.visible');
+            cy.findByRole('button', { name: 'Search' }).should('not.exist');
+            cy.get('textarea[name="default_payload"]').should('be.visible').and('have.attr', 'readonly');
+            cy.get('#payload').should('not.be.visible');
+
+            cy.findByLabelText('Use default payload').click();
+            cy.findByRole('button', { name: 'Save' }).should('be.visible');
+            cy.findByRole('button', { name: 'Search' }).should('be.visible');
+            cy.get('textarea[name="default_payload"]').should('not.be.visible');
+            cy.get('#payload').should('be.visible');
+            // Ensure the monaco editor has a usable size. If initialized with a hidden parent, it can have a size less then 10px by 10px.
+            cy.get('#payload .monaco-editor').invoke('outerWidth').should('be.gte', 100);
+            cy.get('#payload .monaco-editor').invoke('outerHeight').should('be.gte', 100);
+        });
+    });
+});


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

Fix what appears to be a race condition affecting the payload editor for webhooks. The Monaco editor initialization is started, but the container element is hidden before it can finish which causes the editor to have a 5px size instead of properly resizing to the parent.

This PR moves some logic after the editor creation promise resolves and also forces another editor layout when switching to the editor from the default payload.
