### PR TITLE
Fix predefined hidden fields not added to _hidden_fields

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -751,13 +751,13 @@ abstract class CommonITILObject extends CommonDBTM
         if ($this->isNewItem()) {
             if (isset($tt->predefined) && count($tt->predefined)) {
                 foreach ($tt->predefined as $predeffield => $predefvalue) {
-                    
+
                     // Force predefined hidden fields to be added to _hidden_fields and continue
                     if ($tt->isFieldHidden($predeffield)) {
 						$options['_hidden_fields'][$predeffield] = $predefvalue;
 						continue;
 					}
-                    
+
                     if (isset($options[$predeffield]) && isset($default_values[$predeffield])) {
                         // Is always default value : not set
                         // Set if already predefined field

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -751,6 +751,13 @@ abstract class CommonITILObject extends CommonDBTM
         if ($this->isNewItem()) {
             if (isset($tt->predefined) && count($tt->predefined)) {
                 foreach ($tt->predefined as $predeffield => $predefvalue) {
+                    
+                    // Force predefined hidden fields to be added to _hidden_fields and continue
+                    if ($tt->isFieldHidden($predeffield)) {
+						$options['_hidden_fields'][$predeffield] = $predefvalue;
+						continue;
+					}
+                    
                     if (isset($options[$predeffield]) && isset($default_values[$predeffield])) {
                         // Is always default value : not set
                         // Set if already predefined field

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -751,13 +751,11 @@ abstract class CommonITILObject extends CommonDBTM
         if ($this->isNewItem()) {
             if (isset($tt->predefined) && count($tt->predefined)) {
                 foreach ($tt->predefined as $predeffield => $predefvalue) {
-
                     // Force predefined hidden fields to be added to _hidden_fields and continue
                     if ($tt->isFieldHidden($predeffield)) {
-						$options['_hidden_fields'][$predeffield] = $predefvalue;
-						continue;
-					}
-
+                        $options['_hidden_fields'][$predeffield] = $predefvalue;
+                        continue;
+                    }
                     if (isset($options[$predeffield]) && isset($default_values[$predeffield])) {
                         // Is always default value : not set
                         // Set if already predefined field


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x ] I have read the CONTRIBUTING document.
- [x ] I have performed a self-review of my code.
- [x ] I have added tests that prove my fix is effective or that my feature works.

## Description

- It fixes #21128 
- This commit forces predefined hidden fields to be added to _hidden_fields even if a default value exists, restoring the expected behavior for ticket templates with hidden fields
- This fix applies to GLPI >= 10.0.19. The same issue may also exist in GLPI 11.x.

