### PR TITLE
fix(forms-renderer): Fix section index parsing to ensure it's an integer

### DIFF
--- a/js/modules/Forms/RendererController.js
+++ b/js/modules/Forms/RendererController.js
@@ -513,13 +513,13 @@ export class GlpiFormRendererController
         const sections = $(this.#target).find('[data-glpi-form-renderer-section]');
         sections.each((_i, section) => {
             // Ignore previous and current section
-            if (section.dataset.glpiFormRendererSection <= this.#section_index) {
+            if (parseInt(section.dataset.glpiFormRendererSection) <= this.#section_index) {
                 return;
             }
 
             // A visible section won't have the following data property
             if (section.dataset.glpiFormRendererHiddenByCondition === undefined) {
-                index = section.dataset.glpiFormRendererSection;
+                index = parseInt(section.dataset.glpiFormRendererSection);
                 return false; // Break
             }
         });


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.

## Description

- It fixes #21125 

Fixed an issue with the type of the current section index.
Currently, starting from the second section, the index type is stored as a string when it should be an integer.
This issue causes a problem when there are more than 10 sections in a form, since for JS `9 > "10"`.