### PR TITLE
Preserve showmassiveactions on search refresh

### DIFF
--- a/templates/components/search/display_data.html.twig
+++ b/templates/components/search/display_data.html.twig
@@ -96,7 +96,7 @@
    {% if not as_map %}
       <script>
           window.initFluidSearch{{ rand }}  = () => {
-             const allowed_forced_params = ['hide_controls', 'usesession', 'forcetoview', 'criteria'];
+             const allowed_forced_params = ['hide_controls', 'usesession', 'forcetoview', 'criteria', 'showmassiveactions'];
              let forced_params = {};
              let all_params = {{ data['search']|default({})|json_encode|raw }};
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Seen on the Queries Log tab for webhooks. On initial load, the massive action checkboxes are hidden, but if the search results are refreshed the checkboxes appear. This was because the fluid search code was not preserving this parameter.
