### PR TITLE
fix(forms-migration): Limit the import of form categories when the import is restricted to certain forms

### DIFF
--- a/src/Glpi/Form/Migration/FormMigration.php
+++ b/src/Glpi/Form/Migration/FormMigration.php
@@ -373,10 +373,22 @@ class FormMigration extends AbstractPluginMigration
     {
         $this->updateProgressWithMessage(__('Importing form categories...'));
 
+        $additional_criteria = [];
+        if ($this->specificFormsIds !== []) {
+            $additional_criteria[] = [
+                'glpi_plugin_formcreator_categories.id' => new QuerySubQuery([
+                    'SELECT' => 'glpi_plugin_formcreator_forms.plugin_formcreator_categories_id',
+                    'FROM'   => 'glpi_plugin_formcreator_forms',
+                    'WHERE'  => ['glpi_plugin_formcreator_forms.id' => $this->specificFormsIds],
+                ]),
+            ];
+        }
+
         // Retrieve data from glpi_plugin_formcreator_categories table
         $raw_form_categories = $this->db->request([
             'SELECT' => ['id', 'name', 'plugin_formcreator_categories_id'],
             'FROM'   => 'glpi_plugin_formcreator_categories',
+            'WHERE'   => $additional_criteria,
             'ORDER'  => ['level ASC'],
         ]);
 
@@ -1171,9 +1183,18 @@ class FormMigration extends AbstractPluginMigration
         $raw_languages = $this->db->request([
             'SELECT' => [
                 'plugin_formcreator_forms_id',
-                'name',
+                'glpi_plugin_formcreator_forms_languages.name',
             ],
             'FROM'   => 'glpi_plugin_formcreator_forms_languages',
+            'LEFT JOIN'   => [
+                'glpi_plugin_formcreator_forms' => [
+                    'ON' => [
+                        'glpi_plugin_formcreator_forms_languages' => 'plugin_formcreator_forms_id',
+                        'glpi_plugin_formcreator_forms'           => 'id',
+                    ],
+                ],
+            ],
+            'WHERE'  => $this->getFormWhereCriteria(),
         ]);
 
         foreach ($raw_languages as $raw_language) {


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Limits the categories migrated when migration has been restricted to certain forms.