### PR TITLE
Add openldap service to dev compose file

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -56,6 +56,27 @@ services:
       PORT_glpi: 3306
       ENGINE_glpi: "mysql@dbgate-plugin-mysql"
 
+  # To use as a LDAP connection inside GLPI, you'll need to set the following values:
+  # server: openldap
+  # port: 1389
+  # connection filter: (objectClass=inetOrgPerson)
+  # base dn: dc=example,dc=org
+  # Use bind: yes
+  # Root DN: cn=admin,dc=example,dc=org
+  # Password: adminpassword
+  # Login field: uid
+  # Synchronization field: entryuuid
+  # TODO: create a bin/console dev command that create a LDAP server object with
+  # the information above to make things even easier ;)
+  openldap:
+    image: bitnami/openldap:latest
+    environment:
+      - LDAP_ADMIN_USERNAME=admin
+      - LDAP_ADMIN_PASSWORD=adminpassword
+      - LDAP_USERS=user01,user02
+      - LDAP_PASSWORDS=password1,password2
+      - LDAP_ROOT=dc=example,dc=org
+
 volumes:
   db:
   custom_php_ini:


### PR DESCRIPTION
## Description

Add an `openldap` service to the docker compose dev file, with instructions on how to set it up from inside GLPI.
This should help developers that need to work on LDAP related features/bugs to get started much faster.

<img width="1935" height="813" alt="image" src="https://github.com/user-attachments/assets/f63f5359-d3ff-445c-b0f7-59c2cb6d2edd" />

<img width="771" height="496" alt="image" src="https://github.com/user-attachments/assets/48891459-ea00-458c-93df-fe9ed299690e" />

I didn't add a volume, this is a minimal configuration. Users are free to use an override file to add one if needed.