### PR TITLE
[HLAPI] use readOnly and writeOnly

### DIFF
--- a/phpunit/HLAPITestCase.php
+++ b/phpunit/HLAPITestCase.php
@@ -358,7 +358,7 @@ final class HLAPIHelper
         }
         // remove writeonly properties from $create_params so checks below don't fail
         foreach ($flattened_props as $key => $value) {
-            if (isset($value['x-writeonly']) && $value['x-writeonly'] === true) {
+            if (isset($value['writeOnly']) && $value['writeOnly'] === true) {
                 unset($create_params[$key]);
             }
         }

--- a/src/Glpi/Api/HL/Controller/AbstractController.php
+++ b/src/Glpi/Api/HL/Controller/AbstractController.php
@@ -154,7 +154,7 @@ abstract class AbstractController
                 'id' => [
                     'type' => Doc\Schema::TYPE_INTEGER,
                     'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                    'x-readonly' => $class !== Entity::class,
+                    'readOnly' => $class !== Entity::class,
                 ],
                 $name_field => ['type' => Doc\Schema::TYPE_STRING],
             ],

--- a/src/Glpi/Api/HL/Controller/AdministrationController.php
+++ b/src/Glpi/Api/HL/Controller/AdministrationController.php
@@ -92,7 +92,7 @@ final class AdministrationController extends AbstractController
                         'type' => Doc\Schema::TYPE_INTEGER,
                         'format' => Doc\Schema::FORMAT_INTEGER_INT64,
                         'description' => 'ID',
-                        'x-readonly' => true,
+                        'readOnly' => true,
                     ],
                     'username' => [
                         'x-field' => 'name',
@@ -168,13 +168,13 @@ final class AdministrationController extends AbstractController
                         'type' => Doc\Schema::TYPE_STRING,
                         'format' => Doc\Schema::FORMAT_STRING_PASSWORD,
                         'description' => 'Password',
-                        'x-writeonly' => true,
+                        'writeOnly' => true,
                     ],
                     'password2' => [
                         'type' => Doc\Schema::TYPE_STRING,
                         'format' => Doc\Schema::FORMAT_STRING_PASSWORD,
                         'description' => 'Password confirmation',
-                        'x-writeonly' => true,
+                        'writeOnly' => true,
                     ],
                     'picture' => [
                         'type' => Doc\Schema::TYPE_STRING,
@@ -199,7 +199,7 @@ final class AdministrationController extends AbstractController
                         'type' => Doc\Schema::TYPE_INTEGER,
                         'format' => Doc\Schema::FORMAT_INTEGER_INT64,
                         'description' => 'ID',
-                        'x-readonly' => true,
+                        'readOnly' => true,
                     ],
                     'name' => [
                         'type' => Doc\Schema::TYPE_STRING,
@@ -251,7 +251,7 @@ final class AdministrationController extends AbstractController
                         'type' => Doc\Schema::TYPE_INTEGER,
                         'format' => Doc\Schema::FORMAT_INTEGER_INT64,
                         'description' => 'ID',
-                        'x-readonly' => true,
+                        'readOnly' => true,
                     ],
                     'name' => [
                         'type' => Doc\Schema::TYPE_STRING,
@@ -302,7 +302,7 @@ final class AdministrationController extends AbstractController
                         'type' => Doc\Schema::TYPE_INTEGER,
                         'format' => Doc\Schema::FORMAT_INTEGER_INT64,
                         'description' => 'ID',
-                        'x-readonly' => true,
+                        'readOnly' => true,
                     ],
                     'name' => [
                         'type' => Doc\Schema::TYPE_STRING,

--- a/src/Glpi/Api/HL/Controller/AssetController.php
+++ b/src/Glpi/Api/HL/Controller/AssetController.php
@@ -135,7 +135,7 @@ final class AssetController extends AbstractController
                 'id' => [
                     'type' => Doc\Schema::TYPE_INTEGER,
                     'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
                 'name' => ['type' => Doc\Schema::TYPE_STRING],
                 'comment' => ['type' => Doc\Schema::TYPE_STRING],
@@ -152,7 +152,7 @@ final class AssetController extends AbstractController
                 'id' => [
                     'type' => Doc\Schema::TYPE_INTEGER,
                     'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
                 'name' => ['type' => Doc\Schema::TYPE_STRING],
                 'comment' => ['type' => Doc\Schema::TYPE_STRING],
@@ -170,7 +170,7 @@ final class AssetController extends AbstractController
                 'id' => [
                     'type' => Doc\Schema::TYPE_INTEGER,
                     'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
                 'name' => ['type' => Doc\Schema::TYPE_STRING],
                 'completename' => ['type' => Doc\Schema::TYPE_STRING],
@@ -188,7 +188,7 @@ final class AssetController extends AbstractController
                 'id' => [
                     'type' => Doc\Schema::TYPE_INTEGER,
                     'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
                 'name' => ['type' => Doc\Schema::TYPE_STRING],
                 'comment' => ['type' => Doc\Schema::TYPE_STRING],
@@ -205,7 +205,7 @@ final class AssetController extends AbstractController
                 'id' => [
                     'type' => Doc\Schema::TYPE_INTEGER,
                     'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
                 'name' => ['type' => Doc\Schema::TYPE_STRING],
                 'comment' => ['type' => Doc\Schema::TYPE_STRING],
@@ -223,7 +223,7 @@ final class AssetController extends AbstractController
                 'id' => [
                     'type' => Doc\Schema::TYPE_INTEGER,
                     'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
                 'name' => ['type' => Doc\Schema::TYPE_STRING],
                 'comment' => ['type' => Doc\Schema::TYPE_STRING],
@@ -242,7 +242,7 @@ final class AssetController extends AbstractController
                 'id' => [
                     'type' => Doc\Schema::TYPE_INTEGER,
                     'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
                 'name' => ['type' => Doc\Schema::TYPE_STRING],
                 'comment' => ['type' => Doc\Schema::TYPE_STRING],
@@ -267,7 +267,7 @@ final class AssetController extends AbstractController
                 'id' => [
                     'type' => Doc\Schema::TYPE_INTEGER,
                     'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
                 'name' => ['type' => Doc\Schema::TYPE_STRING],
                 'comment' => ['type' => Doc\Schema::TYPE_STRING],
@@ -286,7 +286,7 @@ final class AssetController extends AbstractController
                 'id' => [
                     'type' => Doc\Schema::TYPE_INTEGER,
                     'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
                 'name' => ['type' => Doc\Schema::TYPE_STRING],
                 'comment' => ['type' => Doc\Schema::TYPE_STRING],
@@ -311,7 +311,7 @@ final class AssetController extends AbstractController
                 'id' => [
                     'type' => Doc\Schema::TYPE_INTEGER,
                     'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
                 'name' => ['type' => Doc\Schema::TYPE_STRING],
                 'comment' => ['type' => Doc\Schema::TYPE_STRING],
@@ -328,7 +328,7 @@ final class AssetController extends AbstractController
                 'id' => [
                     'type' => Doc\Schema::TYPE_INTEGER,
                     'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
                 'name' => ['type' => Doc\Schema::TYPE_STRING],
                 'comment' => ['type' => Doc\Schema::TYPE_STRING],
@@ -345,7 +345,7 @@ final class AssetController extends AbstractController
                 'id' => [
                     'type' => Doc\Schema::TYPE_INTEGER,
                     'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
                 'name' => ['type' => Doc\Schema::TYPE_STRING],
                 'comment' => ['type' => Doc\Schema::TYPE_STRING],
@@ -382,7 +382,7 @@ final class AssetController extends AbstractController
                 'id' => [
                     'type' => Doc\Schema::TYPE_INTEGER,
                     'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
                 'name' => ['type' => Doc\Schema::TYPE_STRING],
                 'entity' => self::getDropdownTypeSchema(class: Entity::class, full_schema: 'Entity'),
@@ -549,7 +549,7 @@ final class AssetController extends AbstractController
                 'id' => [
                     'type' => Doc\Schema::TYPE_INTEGER,
                     'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
                 'entities_id' => self::getDropdownTypeSchema(class: Entity::class, full_schema: 'Entity'),
                 'cartridgeitems_id' => self::getDropdownTypeSchema(class: CartridgeItem::class, full_schema: 'CartridgeItem'),
@@ -557,27 +557,27 @@ final class AssetController extends AbstractController
                 'date_in' => [
                     'type' => Doc\Schema::TYPE_STRING,
                     'format' => Doc\Schema::FORMAT_STRING_DATE_TIME,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
                 'date_use' => [
                     'type' => Doc\Schema::TYPE_STRING,
                     'format' => Doc\Schema::FORMAT_STRING_DATE_TIME,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
                 'date_out' => [
                     'type' => Doc\Schema::TYPE_STRING,
                     'format' => Doc\Schema::FORMAT_STRING_DATE_TIME,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
                 'date_creation' => [
                     'type' => Doc\Schema::TYPE_STRING,
                     'format' => Doc\Schema::FORMAT_STRING_DATE_TIME,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
                 'date_mod' => [
                     'type' => Doc\Schema::TYPE_STRING,
                     'format' => Doc\Schema::FORMAT_STRING_DATE_TIME,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
             ],
         ];
@@ -591,7 +591,7 @@ final class AssetController extends AbstractController
                 'id' => [
                     'type' => Doc\Schema::TYPE_INTEGER,
                     'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
                 'name' => ['type' => Doc\Schema::TYPE_STRING],
                 'comment' => ['type' => Doc\Schema::TYPE_STRING],
@@ -619,7 +619,7 @@ final class AssetController extends AbstractController
                             'id' => [
                                 'type' => Doc\Schema::TYPE_INTEGER,
                                 'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                                'x-readonly' => true,
+                                'readOnly' => true,
                             ],
                             'name' => ['type' => Doc\Schema::TYPE_STRING],
                             'comment' => ['type' => Doc\Schema::TYPE_STRING],
@@ -641,7 +641,7 @@ final class AssetController extends AbstractController
                             'id' => [
                                 'type' => Doc\Schema::TYPE_INTEGER,
                                 'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                                'x-readonly' => true,
+                                'readOnly' => true,
                             ],
                             'pages' => ['type' => Doc\Schema::TYPE_INTEGER, 'format' => Doc\Schema::FORMAT_INTEGER_INT32],
                             'date_in' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
@@ -663,29 +663,29 @@ final class AssetController extends AbstractController
                 'id' => [
                     'type' => Doc\Schema::TYPE_INTEGER,
                     'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
                 'entities_id' => self::getDropdownTypeSchema(class: Entity::class, full_schema: 'Entity'),
                 'consumableitems_id' => self::getDropdownTypeSchema(class: ConsumableItem::class, full_schema: 'ConsumableItem'),
                 'date_in' => [
                     'type' => Doc\Schema::TYPE_STRING,
                     'format' => Doc\Schema::FORMAT_STRING_DATE_TIME,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
                 'date_out' => [
                     'type' => Doc\Schema::TYPE_STRING,
                     'format' => Doc\Schema::FORMAT_STRING_DATE_TIME,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
                 'date_creation' => [
                     'type' => Doc\Schema::TYPE_STRING,
                     'format' => Doc\Schema::FORMAT_STRING_DATE_TIME,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
                 'date_mod' => [
                     'type' => Doc\Schema::TYPE_STRING,
                     'format' => Doc\Schema::FORMAT_STRING_DATE_TIME,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
                 'itemtype' => ['type' => Doc\Schema::TYPE_STRING],
                 'items_id' => ['type' => Doc\Schema::TYPE_INTEGER, 'format' => Doc\Schema::FORMAT_INTEGER_INT64],
@@ -701,7 +701,7 @@ final class AssetController extends AbstractController
                 'id' => [
                     'type' => Doc\Schema::TYPE_INTEGER,
                     'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
                 'name' => ['type' => Doc\Schema::TYPE_STRING],
                 'comment' => ['type' => Doc\Schema::TYPE_STRING],
@@ -724,7 +724,7 @@ final class AssetController extends AbstractController
                             'id' => [
                                 'type' => Doc\Schema::TYPE_INTEGER,
                                 'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                                'x-readonly' => true,
+                                'readOnly' => true,
                             ],
                             'date_in' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
                             'date_out' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
@@ -747,7 +747,7 @@ final class AssetController extends AbstractController
                 'id' => [
                     'type' => Doc\Schema::TYPE_INTEGER,
                     'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
                 'name' => ['type' => Doc\Schema::TYPE_STRING],
                 'comment' => ['type' => Doc\Schema::TYPE_STRING],
@@ -834,7 +834,7 @@ final class AssetController extends AbstractController
                 'id' => [
                     'type' => Doc\Schema::TYPE_INTEGER,
                     'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
                 'name' => ['type' => Doc\Schema::TYPE_STRING],
                 'arch' => ['type' => Doc\Schema::TYPE_STRING],
@@ -858,7 +858,7 @@ final class AssetController extends AbstractController
                 'id' => [
                     'type' => Doc\Schema::TYPE_INTEGER,
                     'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
                 'name' => ['type' => Doc\Schema::TYPE_STRING],
                 'comment' => ['type' => Doc\Schema::TYPE_STRING],
@@ -963,7 +963,7 @@ final class AssetController extends AbstractController
                             'id' => [
                                 'type' => Doc\Schema::TYPE_INTEGER,
                                 'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                                'x-readonly' => true,
+                                'readOnly' => true,
                             ],
                             'itemtype' => ['type' => Doc\Schema::TYPE_STRING],
                             'items_id' => ['type' => Doc\Schema::TYPE_INTEGER, 'format' => Doc\Schema::FORMAT_INTEGER_INT64],
@@ -983,7 +983,7 @@ final class AssetController extends AbstractController
                 'id' => [
                     'type' => Doc\Schema::TYPE_INTEGER,
                     'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
                 'rack' => self::getDropdownTypeSchema(class: Rack::class, full_schema: 'Rack'),
                 'itemtype' => ['type' => Doc\Schema::TYPE_STRING],
@@ -1018,7 +1018,7 @@ final class AssetController extends AbstractController
                 'id' => [
                     'type' => Doc\Schema::TYPE_INTEGER,
                     'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
                 'name' => ['type' => Doc\Schema::TYPE_STRING],
                 'comment' => ['type' => Doc\Schema::TYPE_STRING],
@@ -1107,7 +1107,7 @@ final class AssetController extends AbstractController
                 'id' => [
                     'type' => Doc\Schema::TYPE_INTEGER,
                     'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
                 'name' => ['type' => Doc\Schema::TYPE_STRING],
                 'comment' => ['type' => Doc\Schema::TYPE_STRING],
@@ -1195,7 +1195,7 @@ final class AssetController extends AbstractController
                 'id' => [
                     'type' => Doc\Schema::TYPE_INTEGER,
                     'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
                 'name' => ['type' => Doc\Schema::TYPE_STRING],
                 'comment' => ['type' => Doc\Schema::TYPE_STRING],
@@ -1283,7 +1283,7 @@ final class AssetController extends AbstractController
                 'id' => [
                     'type' => Doc\Schema::TYPE_INTEGER,
                     'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
                 'name' => ['type' => Doc\Schema::TYPE_STRING],
                 'comment' => ['type' => Doc\Schema::TYPE_STRING],
@@ -1381,7 +1381,7 @@ final class AssetController extends AbstractController
                 'id' => [
                     'type' => Doc\Schema::TYPE_INTEGER,
                     'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
                 'name' => ['type' => Doc\Schema::TYPE_STRING],
                 'comment' => ['type' => Doc\Schema::TYPE_STRING],

--- a/src/Glpi/Api/HL/Controller/ComponentController.php
+++ b/src/Glpi/Api/HL/Controller/ComponentController.php
@@ -141,7 +141,7 @@ class ComponentController extends AbstractController
             'id' => [
                 'type' => Doc\Schema::TYPE_INTEGER,
                 'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                'x-readonly' => true,
+                'readOnly' => true,
             ],
             'designation' => ['type' => Doc\Schema::TYPE_STRING],
             'comment' => ['type' => Doc\Schema::TYPE_STRING],
@@ -155,7 +155,7 @@ class ComponentController extends AbstractController
             'id' => [
                 'type' => Doc\Schema::TYPE_INTEGER,
                 'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                'x-readonly' => true,
+                'readOnly' => true,
             ],
             'itemtype' => ['type' => Doc\Schema::TYPE_STRING],
             'items_id' => ['type' => Doc\Schema::TYPE_INTEGER, 'format' => Doc\Schema::FORMAT_INTEGER_INT64],
@@ -172,7 +172,7 @@ class ComponentController extends AbstractController
             'id' => [
                 'type' => Doc\Schema::TYPE_INTEGER,
                 'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                'x-readonly' => true,
+                'readOnly' => true,
             ],
             'name' => ['type' => Doc\Schema::TYPE_STRING],
             'comment' => ['type' => Doc\Schema::TYPE_STRING],
@@ -183,7 +183,7 @@ class ComponentController extends AbstractController
             'id' => [
                 'type' => Doc\Schema::TYPE_INTEGER,
                 'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                'x-readonly' => true,
+                'readOnly' => true,
             ],
             'name' => ['type' => Doc\Schema::TYPE_STRING],
             'comment' => ['type' => Doc\Schema::TYPE_STRING],

--- a/src/Glpi/Api/HL/Controller/CustomAssetController.php
+++ b/src/Glpi/Api/HL/Controller/CustomAssetController.php
@@ -99,7 +99,7 @@ final class CustomAssetController extends AbstractController
                     'id' => [
                         'type' => Doc\Schema::TYPE_INTEGER,
                         'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                        'x-readonly' => true,
+                        'readOnly' => true,
                     ],
                     'name' => ['type' => Doc\Schema::TYPE_STRING],
                     'comment' => ['type' => Doc\Schema::TYPE_STRING],
@@ -177,7 +177,7 @@ final class CustomAssetController extends AbstractController
                     'date_mod' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
                     'custom_fields' => [
                         'type' => Doc\Schema::TYPE_OBJECT,
-                        'x-readonly' => true,
+                        'readOnly' => true,
                         'properties' => [],
                     ],
                 ],
@@ -212,7 +212,7 @@ final class CustomAssetController extends AbstractController
                     'id' => [
                         'type' => Doc\Schema::TYPE_INTEGER,
                         'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                        'x-readonly' => true,
+                        'readOnly' => true,
                     ],
                     'name' => ['type' => Doc\Schema::TYPE_STRING],
                     'comment' => ['type' => Doc\Schema::TYPE_STRING],
@@ -237,7 +237,7 @@ final class CustomAssetController extends AbstractController
                     'id' => [
                         'type' => Doc\Schema::TYPE_INTEGER,
                         'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                        'x-readonly' => true,
+                        'readOnly' => true,
                     ],
                     'name' => ['type' => Doc\Schema::TYPE_STRING],
                 ],
@@ -253,7 +253,7 @@ final class CustomAssetController extends AbstractController
                     'id' => [
                         'type' => Doc\Schema::TYPE_INTEGER,
                         'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                        'x-readonly' => true,
+                        'readOnly' => true,
                     ],
                     'name' => ['type' => Doc\Schema::TYPE_STRING],
                     'comment' => ['type' => Doc\Schema::TYPE_STRING],
@@ -306,7 +306,7 @@ final class CustomAssetController extends AbstractController
                     'id' => [
                         'type' => Doc\Schema::TYPE_INTEGER,
                         'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                        'x-readonly' => true,
+                        'readOnly' => true,
                     ],
                     'name' => ['type' => Doc\Schema::TYPE_STRING],
                 ],

--- a/src/Glpi/Api/HL/Controller/DropdownController.php
+++ b/src/Glpi/Api/HL/Controller/DropdownController.php
@@ -85,7 +85,7 @@ final class DropdownController extends AbstractController
                 'id' => [
                     'type' => Doc\Schema::TYPE_INTEGER,
                     'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
                 'name' => ['type' => Doc\Schema::TYPE_STRING],
                 'completename' => ['type' => Doc\Schema::TYPE_STRING],
@@ -120,7 +120,7 @@ final class DropdownController extends AbstractController
                 'id' => [
                     'type' => Doc\Schema::TYPE_INTEGER,
                     'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
                 'name' => ['type' => Doc\Schema::TYPE_STRING],
                 'completename' => ['type' => Doc\Schema::TYPE_STRING],
@@ -163,7 +163,7 @@ final class DropdownController extends AbstractController
             $schemas['State_Visibilities']['properties'][$visiblity] = [
                 'type' => Doc\Schema::TYPE_BOOLEAN,
                 'x-field' => 'is_visible',
-                'x-readonly' => true,
+                'readOnly' => true,
                 'x-join' => [
                     'table' => DropdownVisibility::getTable(),
                     'fkey' => 'id',
@@ -186,7 +186,7 @@ final class DropdownController extends AbstractController
                 'id' => [
                     'type' => Doc\Schema::TYPE_INTEGER,
                     'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
                 'name' => ['type' => Doc\Schema::TYPE_STRING],
                 'comment' => ['type' => Doc\Schema::TYPE_STRING],
@@ -204,7 +204,7 @@ final class DropdownController extends AbstractController
                 'id' => [
                     'type' => Doc\Schema::TYPE_INTEGER,
                     'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
                 'name' => ['type' => Doc\Schema::TYPE_STRING],
                 'comment' => ['type' => Doc\Schema::TYPE_STRING],

--- a/src/Glpi/Api/HL/Controller/ITILController.php
+++ b/src/Glpi/Api/HL/Controller/ITILController.php
@@ -115,7 +115,7 @@ final class ITILController extends AbstractController
                 'id' => [
                     'type' => Doc\Schema::TYPE_INTEGER,
                     'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
                 'name' => ['type' => Doc\Schema::TYPE_STRING],
                 'completename' => ['type' => Doc\Schema::TYPE_STRING],
@@ -132,7 +132,7 @@ final class ITILController extends AbstractController
             'id' => [
                 'type' => Doc\Schema::TYPE_INTEGER,
                 'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                'x-readonly' => true,
+                'readOnly' => true,
             ],
             'name' => ['type' => Doc\Schema::TYPE_STRING],
             'completename' => ['type' => Doc\Schema::TYPE_STRING],
@@ -174,7 +174,7 @@ final class ITILController extends AbstractController
                 'id' => [
                     'type' => Doc\Schema::TYPE_INTEGER,
                     'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
                 'name' => ['type' => Doc\Schema::TYPE_STRING],
                 'content' => ['type' => Doc\Schema::TYPE_STRING],
@@ -198,7 +198,7 @@ final class ITILController extends AbstractController
                 ],
                 'actiontime' => [
                     'type' => Doc\Schema::TYPE_INTEGER,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
                 'date_creation' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
                 'date_mod' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
@@ -214,7 +214,7 @@ final class ITILController extends AbstractController
                 'id' => [
                     'type' => Doc\Schema::TYPE_INTEGER,
                     'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
                 'name' => ['type' => Doc\Schema::TYPE_STRING],
                 'type' => ['type' => Doc\Schema::TYPE_STRING],
@@ -442,7 +442,7 @@ final class ITILController extends AbstractController
                 'id' => [
                     'type' => Doc\Schema::TYPE_INTEGER,
                     'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
                 'content' => ['type' => Doc\Schema::TYPE_STRING],
                 'is_private' => ['type' => Doc\Schema::TYPE_BOOLEAN],
@@ -490,7 +490,7 @@ final class ITILController extends AbstractController
                 'id' => [
                     'type' => Doc\Schema::TYPE_INTEGER,
                     'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
                 'name' => ['type' => Doc\Schema::TYPE_STRING],
                 'is_active' => ['type' => Doc\Schema::TYPE_BOOLEAN],
@@ -505,7 +505,7 @@ final class ITILController extends AbstractController
                 'id' => [
                     'type' => Doc\Schema::TYPE_INTEGER,
                     'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
                 'name' => ['type' => Doc\Schema::TYPE_STRING],
                 'comment' => ['type' => Doc\Schema::TYPE_STRING],
@@ -550,7 +550,7 @@ final class ITILController extends AbstractController
                 'id' => [
                     'type' => Doc\Schema::TYPE_INTEGER,
                     'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
                 'itemtype' => ['type' => Doc\Schema::TYPE_STRING,],
                 'items_id' => ['type' => Doc\Schema::TYPE_INTEGER, 'format' => Doc\Schema::FORMAT_INTEGER_INT64],
@@ -572,7 +572,7 @@ final class ITILController extends AbstractController
                 'id' => [
                     'type' => Doc\Schema::TYPE_INTEGER,
                     'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
                 'itemtype' => ['type' => Doc\Schema::TYPE_STRING],
                 'items_id' => ['type' => Doc\Schema::TYPE_INTEGER, 'format' => Doc\Schema::FORMAT_INTEGER_INT64],
@@ -588,7 +588,7 @@ final class ITILController extends AbstractController
                 'id' => [
                     'type' => Doc\Schema::TYPE_INTEGER,
                     'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
                 'requester' => self::getDropdownTypeSchema(class: User::class, full_schema: 'User'),
                 'approver' => self::getDropdownTypeSchema(class: User::class, field: 'users_id_validate', full_schema: 'User'),
@@ -667,7 +667,7 @@ final class ITILController extends AbstractController
                 'id' => [
                     'type' => Doc\Schema::TYPE_INTEGER,
                     'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
                 'name' => ['type' => Doc\Schema::TYPE_STRING],
                 'comment' => ['type' => Doc\Schema::TYPE_STRING],
@@ -705,7 +705,7 @@ final class ITILController extends AbstractController
                 'id' => [
                     'type' => Doc\Schema::TYPE_INTEGER,
                     'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
                 'name' => ['type' => Doc\Schema::TYPE_STRING],
                 'comment' => ['type' => Doc\Schema::TYPE_STRING],
@@ -743,7 +743,7 @@ final class ITILController extends AbstractController
                 'id' => [
                     'type' => Doc\Schema::TYPE_INTEGER,
                     'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
                 'name' => ['type' => Doc\Schema::TYPE_STRING],
                 'text' => ['type' => Doc\Schema::TYPE_STRING],
@@ -777,7 +777,7 @@ final class ITILController extends AbstractController
                 'id' => [
                     'type' => Doc\Schema::TYPE_INTEGER,
                     'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
                 'name' => ['type' => Doc\Schema::TYPE_STRING],
                 'comment' => ['type' => Doc\Schema::TYPE_STRING],
@@ -796,7 +796,7 @@ final class ITILController extends AbstractController
                 'id' => [
                     'type' => Doc\Schema::TYPE_INTEGER,
                     'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
                 'uuid' => ['type' => Doc\Schema::TYPE_STRING, 'pattern' => Doc\Schema::PATTERN_UUIDV4],
                 'name' => ['type' => Doc\Schema::TYPE_STRING],

--- a/src/Glpi/Api/HL/Controller/ManagementController.php
+++ b/src/Glpi/Api/HL/Controller/ManagementController.php
@@ -172,7 +172,7 @@ final class ManagementController extends AbstractController
                     'id' => [
                         'type' => Doc\Schema::TYPE_INTEGER,
                         'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                        'x-readonly' => true,
+                        'readOnly' => true,
                     ],
                     'name' => ['type' => Doc\Schema::TYPE_STRING],
                 ],
@@ -345,21 +345,21 @@ final class ManagementController extends AbstractController
                 'id' => [
                     'type' => Doc\Schema::TYPE_INTEGER,
                     'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
                 'itemtype' => [
                     'type' => Doc\Schema::TYPE_STRING,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
                 'items_id' => [
                     'type' => Doc\Schema::TYPE_INTEGER,
                     'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
                 'documents_id' => [
                     'type' => Doc\Schema::TYPE_INTEGER,
                     'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
                 'filepath' => [
                     'type' => Doc\Schema::TYPE_STRING,
@@ -377,16 +377,16 @@ final class ManagementController extends AbstractController
                 'id' => [
                     'type' => Doc\Schema::TYPE_INTEGER,
                     'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
                 'itemtype' => [
                     'type' => Doc\Schema::TYPE_STRING,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
                 'items_id' => [
                     'type' => Doc\Schema::TYPE_INTEGER,
                     'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
                 'comment' => ['type' => Doc\Schema::TYPE_STRING],
                 'entity' => self::getDropdownTypeSchema(Entity::class, full_schema: 'Entity'),

--- a/src/Glpi/Api/HL/Controller/ProjectController.php
+++ b/src/Glpi/Api/HL/Controller/ProjectController.php
@@ -112,7 +112,7 @@ final class ProjectController extends AbstractController
                     'id' => [
                         'type' => Doc\Schema::TYPE_INTEGER,
                         'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                        'x-readonly' => true,
+                        'readOnly' => true,
                     ],
                     'name' => ['type' => Doc\Schema::TYPE_STRING],
                     'comment' => ['type' => Doc\Schema::TYPE_STRING],
@@ -146,7 +146,7 @@ final class ProjectController extends AbstractController
                                 'id' => [
                                     'type' => Doc\Schema::TYPE_INTEGER,
                                     'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                                    'x-readonly' => true,
+                                    'readOnly' => true,
                                 ],
                                 'name' => ['type' => Doc\Schema::TYPE_STRING],
                                 'comment' => ['type' => Doc\Schema::TYPE_STRING],
@@ -230,7 +230,7 @@ final class ProjectController extends AbstractController
                     'id' => [
                         'type' => Doc\Schema::TYPE_INTEGER,
                         'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                        'x-readonly' => true,
+                        'readOnly' => true,
                     ],
                     'name' => ['type' => Doc\Schema::TYPE_STRING],
                     'comment' => ['type' => Doc\Schema::TYPE_STRING],

--- a/src/Glpi/Api/HL/Controller/RuleController.php
+++ b/src/Glpi/Api/HL/Controller/RuleController.php
@@ -86,9 +86,9 @@ final class RuleController extends AbstractController
                     'id' => [
                         'type' => Doc\Schema::TYPE_INTEGER,
                         'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                        'x-readonly' => true,
+                        'readOnly' => true,
                     ],
-                    'rule' => self::getDropdownTypeSchema(class: Rule::class, full_schema: 'Rule') + ['x-writeonly' => true],
+                    'rule' => self::getDropdownTypeSchema(class: Rule::class, full_schema: 'Rule') + ['writeOnly' => true],
                     'criteria' => [
                         'type' => Doc\Schema::TYPE_STRING,
                         'description' => 'The criteria to use. See /Rule/Collection/{collection}/CriteriaCriteria for a complete list of criteria.',
@@ -171,9 +171,9 @@ final class RuleController extends AbstractController
                     'id' => [
                         'type' => Doc\Schema::TYPE_INTEGER,
                         'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                        'x-readonly' => true,
+                        'readOnly' => true,
                     ],
-                    'rule' => self::getDropdownTypeSchema(class: Rule::class, full_schema: 'Rule') + ['x-writeonly' => true],
+                    'rule' => self::getDropdownTypeSchema(class: Rule::class, full_schema: 'Rule') + ['writeOnly' => true],
                     'action_type' => [
                         'type' => Doc\Schema::TYPE_STRING,
                         'description' => 'The action to perform. See /Rule/Collection/{collection}/ActionType for a complete list of actions.',
@@ -197,15 +197,15 @@ final class RuleController extends AbstractController
                 'id' => [
                     'type' => Doc\Schema::TYPE_INTEGER,
                     'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
                 'uuid' => [
                     'type' => Doc\Schema::TYPE_STRING,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
                 'sub_type' => [
                     'type' => Doc\Schema::TYPE_STRING,
-                    'x-writeonly' => true,
+                    'writeOnly' => true,
                 ],
                 'entity' => self::getDropdownTypeSchema(class: Entity::class, full_schema: 'Entity'),
                 'is_recursive' => ['type' => Doc\Schema::TYPE_BOOLEAN],
@@ -232,7 +232,7 @@ final class RuleController extends AbstractController
                 ],
                 'criteria' => [
                     'type' => Doc\Schema::TYPE_ARRAY,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                     'items' => [
                         'type' => Doc\Schema::TYPE_OBJECT,
                         'x-full-schema' => 'RuleCriteria',
@@ -247,7 +247,7 @@ final class RuleController extends AbstractController
                 ],
                 'actions' => [
                     'type' => Doc\Schema::TYPE_ARRAY,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                     'items' => [
                         'type' => Doc\Schema::TYPE_OBJECT,
                         'x-full-schema' => 'RuleAction',
@@ -263,12 +263,12 @@ final class RuleController extends AbstractController
                 'date_creation' => [
                     'type' => Doc\Schema::TYPE_STRING,
                     'format' => Doc\Schema::FORMAT_STRING_DATE_TIME,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
                 'date_mod' => [
                     'type' => Doc\Schema::TYPE_STRING,
                     'format' => Doc\Schema::FORMAT_STRING_DATE_TIME,
-                    'x-readonly' => true,
+                    'readOnly' => true,
                 ],
             ],
         ];

--- a/src/Glpi/Api/HL/Controller/SetupController.php
+++ b/src/Glpi/Api/HL/Controller/SetupController.php
@@ -60,7 +60,7 @@ final class SetupController extends AbstractController
                     'id' => [
                         'type' => Doc\Schema::TYPE_INTEGER,
                         'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                        'x-readonly' => true,
+                        'readOnly' => true,
                     ],
                     'name' => ['type' => Doc\Schema::TYPE_STRING],
                     'host' => ['type' => Doc\Schema::TYPE_STRING],
@@ -91,7 +91,7 @@ final class SetupController extends AbstractController
                     ],
                     'rootdn_password' => [
                         'type' => Doc\Schema::TYPE_STRING,
-                        'x-writeonly' => true,
+                        'writeOnly' => true,
                         'description' => 'The password of the user to bind to the directory',
                     ],
                     'login_field' => [

--- a/src/Glpi/Api/HL/Doc/Schema.php
+++ b/src/Glpi/Api/HL/Doc/Schema.php
@@ -453,9 +453,9 @@ class Schema implements ArrayAccess
             // Get value from original content by the array path $sk
             $cv = ArrayPathAccessor::getElementByArrayPath($content, $sk);
             if ($cv === null) {
-                if ($operation === 'read' && ($sv['x-writeonly'] ?? false)) {
+                if ($operation === 'read' && ($sv['writeOnly'] ?? false)) {
                     $ignored = true;
-                } elseif ($operation === 'write' && ($sv['x-readonly'] ?? false)) {
+                } elseif ($operation === 'write' && ($sv['readOnly'] ?? false)) {
                     $ignored = true;
                 }
             }

--- a/src/Glpi/Api/HL/OpenAPIGenerator.php
+++ b/src/Glpi/Api/HL/OpenAPIGenerator.php
@@ -87,7 +87,7 @@ final class OpenAPIGenerator
 
     private function getPublicVendorExtensions(): array
     {
-        return ['x-writeonly', 'x-readonly', 'x-full-schema', 'x-introduced', 'x-deprecated', 'x-removed'];
+        return ['writeOnly', 'readOnly', 'x-full-schema', 'x-introduced', 'x-deprecated', 'x-removed'];
     }
 
     private function cleanVendorExtensions(array $schema, ?string $parent_key = null): array
@@ -105,7 +105,7 @@ final class OpenAPIGenerator
             if ($parent_key === 'properties') {
                 if ($key === 'id') {
                     //Implicitly set the id property as read-only
-                    $value['x-readonly'] = true;
+                    $value['readOnly'] = true;
                 }
             }
             // If the value is an array

--- a/src/Glpi/Api/HL/ResourceAccessor.php
+++ b/src/Glpi/Api/HL/ResourceAccessor.php
@@ -128,7 +128,7 @@ final class ResourceAccessor
                 $prop_name = strstr($prop_name, '.', true);
                 $prop = $schema['properties'][$prop_name];
             } else {
-                if ($prop['x-readonly'] ?? false) {
+                if ($prop['readOnly'] ?? false) {
                     // Ignore properties marked as read-only
                     continue;
                 }

--- a/src/Glpi/Api/HL/Search.php
+++ b/src/Glpi/Api/HL/Search.php
@@ -172,7 +172,7 @@ final class Search
     private function getSelectCriteriaForProperty(string $prop_name, bool $distinct_groups = false): ?QueryExpression
     {
         $prop = $this->context->getFlattenedProperties()[$prop_name];
-        if ($prop['x-writeonly'] ?? false) {
+        if ($prop['writeOnly'] ?? false) {
             // Do not expose write-only fields
             return null;
         }

--- a/src/Glpi/Api/HL/Search/RecordSet.php
+++ b/src/Glpi/Api/HL/Search/RecordSet.php
@@ -100,7 +100,7 @@ final class RecordSet
         }
         $criteria['WHERE'] = [$id_field => $ids_to_fetch];
         foreach ($props_to_use as $prop_name => $prop) {
-            if ($prop['x-writeonly'] ?? false) {
+            if ($prop['writeOnly'] ?? false) {
                 // Property can only be written to, not read. We shouldn't be getting it here.
                 continue;
             }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Fixes #21166

Use official schema feature for specifying properties that are read-only or write-only instead of extensions. This allows better compatibility, which can be seen in Swagger UI where it automatically hides the read-only properties from request bodies and write-only properties from response bodies.

## Screenshots

Get User Response:
<img width="268" height="335" alt="Selection_599" src="https://github.com/user-attachments/assets/d2b646b9-718f-434d-87a3-2c1e57444ee2" />

Create User Request Body:
<img width="229" height="300" alt="Selection_600" src="https://github.com/user-attachments/assets/005abb1a-f668-4687-b183-be8e75b4a1a6" />

Not that the password fields, which can only be written to, do not show as part of the response schema.