### PR TITLE
Fix planning tooltip focus check

### DIFF
--- a/js/planning.js
+++ b/js/planning.js
@@ -611,12 +611,12 @@ var GLPIPlanning  = {
                 disable_qtip = false;
             });
 
-        window.onblur = function() {
+        $(window).on('blur', () => {
             window_focused = false;
-        };
-        window.onfocus = function() {
+        });
+        $(window).on('focus', () => {
             window_focused = true;
-        };
+        });
 
         //window.calendar = calendar; // Required as object is not accessible by forms callback
         GLPIPlanning.calendar.render();


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

fixes #20733

QTip tooltips on events in planning view are blocked from showing if it detects the window losing focus. It seems that at least tinyMCE (I thought opening select2 caused it randomly too) can sometimes steal focus and it doesn't get restored properly. This blurs the window and qtip tooltips will not show until something triggers focus on the window again.

The focus check tracks back to https://github.com/glpi-project/glpi/pull/448#issuecomment-185225869.

The issue seems to be based on the usage of `onblur` and `onfocus` on the window object which replace any existing listeners rather than adding new listeners. Switching to jQuery `$.on` seems to resolve the issue.