### PR TITLE
fix update of event dropdown in notification form

### DIFF
--- a/templates/pages/setup/notification/notification.html.twig
+++ b/templates/pages/setup/notification/notification.html.twig
@@ -34,42 +34,44 @@
 {% import 'components/form/fields_macros.html.twig' as fields %}
 
 {% block form_fields %}
-   {{ fields.textField('name', item.fields['name'], __('Name')) }}
-   {{ fields.textareaField('comment', item.fields['comment'], __('Comments')) }}
-   {{ fields.dropdownYesNo('is_active', item.fields['is_active'], __('Active')) }}
-   {{ fields.dropdownYesNo('allow_response', item.fields['allow_response'], __('Allow response')) }}
+    {{ fields.textField('name', item.fields['name'], __('Name')) }}
+    {{ fields.textareaField('comment', item.fields['comment'], __('Comments')) }}
+    {{ fields.dropdownYesNo('is_active', item.fields['is_active'], __('Active')) }}
+    {{ fields.dropdownYesNo('allow_response', item.fields['allow_response'], __('Allow response')) }}
 
-   {% if not has_profile_right('config', constant('UPDATE')) %}
-      {{ fields.htmlField('', item.fields['itemtype'], _n('Type', 'Types', 1)) }}
-   {% elseif call('Config::canUpdate') and item.getEntityID == 0 %}
-      {{ fields.dropdownItemTypes('itemtype', item.fields['itemtype'], _n('Type', 'Types', 1), {
-         types: config('notificationtemplates_types'),
-         rand: rand
-      }) }}
-   {% else %}
-      {% set types_root_entity_only = ['CronTask', 'DBConnection', 'User'] %}
-      {{ fields.dropdownItemTypes('itemtype', item.fields['itemtype'], _n('Type', 'Types', 1), {
-         types: config('notificationtemplates_types')|filter((v) => v not in types_root_entity_only),
-         rand: rand
-      }) }}
-   {% endif %}
-   {% do call('Ajax::updateItemOnSelectEvent', ['dropdown_itemtype' ~ rand, 'show_events', path('/ajax/dropdownNotificationEvent.php'), {
-      itemtype: '__VALUE__'
-   }]) %}
-   {% do call('Ajax::updateItemOnSelectEvent', ['dropdown_itemtype' ~ rand, 'show_templates', path('/ajax/dropdownNotificationTemplate.php'), {
-      itemtype: '__VALUE__'
-   }]) %}
-   <span id="show_events">
-      {{ fields.htmlField('', call('NotificationEvent::dropdownEvents', [item.fields['itemtype'], {
-         value: item.fields['event'],
-         display: false
-      }]), 'NotificationEvent'|itemtype_name(1)) }}
-   </span>
+    {% if not has_profile_right('config', constant('UPDATE')) %}
+        {{ fields.htmlField('', item.fields['itemtype'], _n('Type', 'Types', 1)) }}
+    {% elseif call('Config::canUpdate') and item.getEntityID == 0 %}
+        {{ fields.dropdownItemTypes('itemtype', item.fields['itemtype'], _n('Type', 'Types', 1), {
+            types: config('notificationtemplates_types'),
+            rand: rand
+        }) }}
+    {% else %}
+        {% set types_root_entity_only = ['CronTask', 'DBConnection', 'User'] %}
+        {{ fields.dropdownItemTypes('itemtype', item.fields['itemtype'], _n('Type', 'Types', 1), {
+            types: config('notificationtemplates_types')|filter((v) => v not in types_root_entity_only),
+            rand: rand
+        }) }}
+    {% endif %}
+    {% do call('Ajax::updateItemOnSelectEvent', ['dropdown_itemtype' ~ rand, 'show_events', path('/ajax/dropdownNotificationEvent.php'), {
+        itemtype: '__VALUE__'
+    }]) %}
+    {% do call('Ajax::updateItemOnSelectEvent', ['dropdown_itemtype' ~ rand, 'show_templates', path('/ajax/dropdownNotificationTemplate.php'), {
+        itemtype: '__VALUE__'
+    }]) %}
+    {% set events_field %}
+        <span id="show_events">
+            {% do call('NotificationEvent::dropdownEvents', [item.fields['itemtype'], {
+                value: item.fields['event'],
+            }]) %}
+        </span>
+    {% endset %}
+    {{ fields.htmlField('', events_field, 'NotificationEvent'|itemtype_name(1)) }}
 
-   {{ fields.dropdownArrayField('attach_documents', item.fields['attach_documents'], {
-      (constant('NotificationSetting::ATTACH_INHERIT')): __('Use global config'),
-      (constant('NotificationSetting::ATTACH_NO_DOCUMENT')): __('No documents'),
-      (constant('NotificationSetting::ATTACH_ALL_DOCUMENTS')): __('All documents'),
-      (constant('NotificationSetting::ATTACH_FROM_TRIGGER_ONLY')): __('Only documents related to the item that triggers the event'),
-   }, __('Add documents')) }}
+    {{ fields.dropdownArrayField('attach_documents', item.fields['attach_documents'], {
+        (constant('NotificationSetting::ATTACH_INHERIT')): __('Use global config'),
+        (constant('NotificationSetting::ATTACH_NO_DOCUMENT')): __('No documents'),
+        (constant('NotificationSetting::ATTACH_ALL_DOCUMENTS')): __('All documents'),
+        (constant('NotificationSetting::ATTACH_FROM_TRIGGER_ONLY')): __('Only documents related to the item that triggers the event'),
+    }, __('Add documents')) }}
 {% endblock %}


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Fixes #21116

Updating the itemtype in the notification form was replacing the entire field which included the field container and label with the new dropdown (just the select2 dropdown) which caused the form UI to appear broken.

Review without whitespace changes.
