### PR TITLE
Fix dropdown custom field search options

### DIFF
--- a/src/Glpi/Asset/CustomFieldType/DropdownType.php
+++ b/src/Glpi/Asset/CustomFieldType/DropdownType.php
@@ -40,6 +40,8 @@ use Glpi\Asset\CustomFieldOption\BooleanOption;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
 
+use function Safe\preg_match;
+
 class DropdownType extends AbstractType
 {
     public static function getName(): string
@@ -155,7 +157,7 @@ TWIG, $twig_params);
             $opt['joinparams']['condition'] = [
                 QueryFunction::jsonContains([
                     'REFTABLE.custom_fields',
-                    QueryFunction::cast('NEWTABLE.id', 'JSON'),
+                    preg_match('/-MariaDB/', $DB->getVersion()) ? 'NEWTABLE.id' : QueryFunction::cast('NEWTABLE.id', 'JSON'),
                     new QueryExpression($DB::quoteValue('$."' . $this->custom_field->fields['id'] . '"')),
                 ]),
             ];

--- a/src/Glpi/Asset/CustomFieldType/DropdownType.php
+++ b/src/Glpi/Asset/CustomFieldType/DropdownType.php
@@ -155,7 +155,7 @@ TWIG, $twig_params);
             $opt['joinparams']['condition'] = [
                 QueryFunction::jsonContains([
                     'REFTABLE.custom_fields',
-                    'NEWTABLE.id',
+                    QueryFunction::cast('NEWTABLE.id', 'JSON'),
                     new QueryExpression($DB::quoteValue('$."' . $this->custom_field->fields['id'] . '"')),
                 ]),
             ];

--- a/src/Glpi/Asset/CustomFieldType/DropdownType.php
+++ b/src/Glpi/Asset/CustomFieldType/DropdownType.php
@@ -40,8 +40,6 @@ use Glpi\Asset\CustomFieldOption\BooleanOption;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
 
-use function Safe\preg_match;
-
 class DropdownType extends AbstractType
 {
     public static function getName(): string
@@ -155,11 +153,11 @@ TWIG, $twig_params);
             ];
         } else {
             $opt['joinparams']['condition'] = [
-                QueryFunction::jsonContains([
+                QueryFunction::jsonContains(
                     'REFTABLE.custom_fields',
-                    preg_match('/-MariaDB/', $DB->getVersion()) ? 'NEWTABLE.id' : QueryFunction::cast('NEWTABLE.id', 'JSON'),
-                    new QueryExpression($DB::quoteValue('$."' . $this->custom_field->fields['id'] . '"')),
-                ]),
+                    'NEWTABLE.id',
+                    '$."' . $this->custom_field->fields['id'] . '"'
+                ),
             ];
             $opt['forcegroupby'] = true;
             $opt['usehaving'] = true;

--- a/src/Glpi/Asset/CustomFieldType/DropdownType.php
+++ b/src/Glpi/Asset/CustomFieldType/DropdownType.php
@@ -155,7 +155,7 @@ TWIG, $twig_params);
             $opt['joinparams']['condition'] = [
                 QueryFunction::jsonContains([
                     'glpi_assets_assets.custom_fields',
-                    QueryFunction::cast('NEWTABLE.id', 'JSON'),
+                    'NEWTABLE.id',
                     new QueryExpression($DB::quoteValue('$."' . $this->custom_field->fields['id'] . '"')),
                 ]),
             ];

--- a/src/Glpi/Asset/CustomFieldType/DropdownType.php
+++ b/src/Glpi/Asset/CustomFieldType/DropdownType.php
@@ -143,9 +143,9 @@ TWIG, $twig_params);
         if (!$multiple) {
             $opt['joinparams']['condition'] = [
                 new QueryExpression(
-                    'NEWTABLE.' . $DB->quoteName('id') . ' = ' . QueryFunction::jsonUnquote(
+                    'NEWTABLE.' . $DB::quoteName('id') . ' = ' . QueryFunction::jsonUnquote(
                         expression: QueryFunction::jsonExtract([
-                            'glpi_assets_assets.custom_fields',
+                            'REFTABLE.custom_fields',
                             new QueryExpression($DB::quoteValue('$."' . $this->custom_field->fields['id'] . '"')),
                         ])
                     )
@@ -154,7 +154,7 @@ TWIG, $twig_params);
         } else {
             $opt['joinparams']['condition'] = [
                 QueryFunction::jsonContains([
-                    'glpi_assets_assets.custom_fields',
+                    'REFTABLE.custom_fields',
                     'NEWTABLE.id',
                     new QueryExpression($DB::quoteValue('$."' . $this->custom_field->fields['id'] . '"')),
                 ]),

--- a/tests/functional/Glpi/Api/HL/Controller/CustomAssetControllerTest.php
+++ b/tests/functional/Glpi/Api/HL/Controller/CustomAssetControllerTest.php
@@ -101,9 +101,11 @@ class CustomAssetControllerTest extends HLAPITestCase
     public function testCRUD(): void
     {
         $this->api->autoTestCRUD('/Assets/Custom/Test01', [
-            'custom_fields' => ['teststring' => 'Test String A'],
-        ], [
-            'custom_fields' => ['teststring' => 'Test String A'],
+            'custom_fields' => [
+                'teststring' => 'Test String A',
+                'customtagmulti' => null,
+                'customtagsingle' => null,
+            ],
         ]);
     }
 

--- a/tests/functional/Glpi/Asset/CustomFieldDefinitionTest.php
+++ b/tests/functional/Glpi/Asset/CustomFieldDefinitionTest.php
@@ -661,7 +661,7 @@ class CustomFieldDefinitionTest extends DbTestCase
             'custom_customtagsingle' => getItemByTypeName('Glpi\\CustomDropdown\\CustomTagDropdown', 'Tag01', true),
             'custom_customtagmulti' => [
                 getItemByTypeName('Glpi\\CustomDropdown\\CustomTagDropdown', 'Tag01', true),
-                getItemByTypeName('Glpi\\CustomDropdown\\CustomTagDropdown', 'Tag02', true)
+                getItemByTypeName('Glpi\\CustomDropdown\\CustomTagDropdown', 'Tag02', true),
             ],
         ], ['custom_customtagsingle', 'custom_customtagmulti']);
 
@@ -684,8 +684,8 @@ class CustomFieldDefinitionTest extends DbTestCase
                     'field' => $multiple_dropdown_opt,
                     'searchtype' => 'contains',
                     'value' => 'Tag',
-                ]
-            ]
+                ],
+            ],
         ], [$single_dropdown_opt, $multiple_dropdown_opt]);
 
         $this->assertCount(1, $data['data']['rows']);

--- a/tests/functional/Glpi/Migration/GenericobjectPluginMigrationTest.php
+++ b/tests/functional/Glpi/Migration/GenericobjectPluginMigrationTest.php
@@ -93,6 +93,7 @@ class GenericobjectPluginMigrationTest extends DbTestCase
         parent::setUp();
 
         $DB->delete(AssetDefinition::getTable(), [new QueryExpression('true')]);
+        $DB->delete(DropdownDefinition::getTable(), [new QueryExpression('true')]);
 
         // Load it inside the test DB transaction to not have to clean it manually
         $queries = $DB->getQueriesFromFile(sprintf('%s/tests/fixtures/genericobject-migration/glpi-data.sql', GLPI_ROOT));

--- a/tests/src/autoload/functions.php
+++ b/tests/src/autoload/functions.php
@@ -728,7 +728,7 @@ function loadDataset()
                 'name' => 'Custom Tag',
                 'is_active' => 1,
                 'profiles' => ['4' => ALLSTANDARDRIGHT],
-            ]
+            ],
         ],
         'Glpi\\CustomDropdown\\CustomTagDropdown' => [
             [
@@ -783,7 +783,7 @@ function loadDataset()
                 'type' => 'Glpi\\Asset\\CustomFieldType\\DropdownType',
                 'itemtype' => 'Glpi\\CustomDropdown\\CustomTagDropdown',
                 'field_options' => '{"full_width":"0","readonly":"0","required":"0","multiple":"1"}',
-            ]
+            ],
         ],
         'Glpi\\CustomAsset\\Test01Asset' => [
             [

--- a/tests/src/autoload/functions.php
+++ b/tests/src/autoload/functions.php
@@ -721,6 +721,25 @@ function loadDataset()
                 'profiles' => ['4' => ALLSTANDARDRIGHT | READ_ASSIGNED | UPDATE_ASSIGNED | READ_OWNED | UPDATE_OWNED],
             ],
         ],
+        'Glpi\\Dropdown\\DropdownDefinition' => [
+            [
+                'system_name' => 'CustomTag',
+                'icon' => 'ti ti-tag',
+                'name' => 'Custom Tag',
+                'is_active' => 1,
+                'profiles' => ['4' => ALLSTANDARDRIGHT],
+            ]
+        ],
+        'Glpi\\CustomDropdown\\CustomTagDropdown' => [
+            [
+                'name' => 'Tag01',
+                'entities_id' => '_test_root_entity',
+            ],
+            [
+                'name' => 'Tag02',
+                'entities_id' => '_test_root_entity',
+            ],
+        ],
         'Glpi\\CustomAsset\\Test02AssetType' => [
             [
                 'name' => 'Test02Type01',
@@ -749,17 +768,35 @@ function loadDataset()
                 'type' => 'Glpi\\Asset\\CustomFieldType\\StringType',
                 'field_options' => '{"full_width":"0","readonly":"0","required":"0"}',
             ],
+            [
+                'system_name' => 'customtagsingle',
+                'assets_assetdefinitions_id' => 'Test01',
+                'label' => 'Single Custom Tag',
+                'type' => 'Glpi\\Asset\\CustomFieldType\\DropdownType',
+                'itemtype' => 'Glpi\\CustomDropdown\\CustomTagDropdown',
+                'field_options' => '{"full_width":"0","readonly":"0","required":"0"}',
+            ],
+            [
+                'system_name' => 'customtagmulti',
+                'assets_assetdefinitions_id' => 'Test01',
+                'label' => 'Multi Custom Tag',
+                'type' => 'Glpi\\Asset\\CustomFieldType\\DropdownType',
+                'itemtype' => 'Glpi\\CustomDropdown\\CustomTagDropdown',
+                'field_options' => '{"full_width":"0","readonly":"0","required":"0","multiple":"1"}',
+            ]
         ],
         'Glpi\\CustomAsset\\Test01Asset' => [
             [
                 'name' => 'TestA',
                 'entities_id' => '_test_root_entity',
                 'custom_teststring' => 'Test String A',
+                'custom_customtagsingle' => 'Tag01',
             ],
             [
                 'name' => 'TestB',
                 'entities_id' => '_test_root_entity',
                 'custom_teststring' => 'Test String B',
+                'custom_customtagmulti' => ['Tag01', 'Tag02'],
             ],
         ],
         'Glpi\\CustomAsset\\Test02Asset' => [

--- a/tests/src/autoload/functions.php
+++ b/tests/src/autoload/functions.php
@@ -792,7 +792,7 @@ function loadDataset()
                 'name' => 'TestA',
                 'entities_id' => '_test_root_entity',
                 'custom_teststring' => 'Test String A',
-                'custom_customtagsingle' => "1"
+                'custom_customtagsingle' => "1",
             ],
             [
                 'name' => 'TestB',

--- a/tests/src/autoload/functions.php
+++ b/tests/src/autoload/functions.php
@@ -732,10 +732,12 @@ function loadDataset()
         ],
         'Glpi\\CustomDropdown\\CustomTagDropdown' => [
             [
+                'id' => 1,
                 'name' => 'Tag01',
                 'entities_id' => '_test_root_entity',
             ],
             [
+                'id' => 2,
                 'name' => 'Tag02',
                 'entities_id' => '_test_root_entity',
             ],
@@ -766,7 +768,7 @@ function loadDataset()
                 'assets_assetdefinitions_id' => 'Test01',
                 'label' => 'Test String',
                 'type' => 'Glpi\\Asset\\CustomFieldType\\StringType',
-                'field_options' => '{"full_width":"0","readonly":"0","required":"0"}',
+                'field_options' => ["full_width" => "0", "readonly" => "0", "required" => "0"],
             ],
             [
                 'system_name' => 'customtagsingle',
@@ -774,7 +776,7 @@ function loadDataset()
                 'label' => 'Single Custom Tag',
                 'type' => 'Glpi\\Asset\\CustomFieldType\\DropdownType',
                 'itemtype' => 'Glpi\\CustomDropdown\\CustomTagDropdown',
-                'field_options' => '{"full_width":"0","readonly":"0","required":"0"}',
+                'field_options' => ["full_width" => "0", "readonly" => "0", "required" => "0"],
             ],
             [
                 'system_name' => 'customtagmulti',
@@ -782,7 +784,7 @@ function loadDataset()
                 'label' => 'Multi Custom Tag',
                 'type' => 'Glpi\\Asset\\CustomFieldType\\DropdownType',
                 'itemtype' => 'Glpi\\CustomDropdown\\CustomTagDropdown',
-                'field_options' => '{"full_width":"0","readonly":"0","required":"0","multiple":"1"}',
+                'field_options' => ["full_width" => "0", "readonly" => "0", "required" => "0", "multiple" => "1"],
             ],
         ],
         'Glpi\\CustomAsset\\Test01Asset' => [
@@ -790,13 +792,13 @@ function loadDataset()
                 'name' => 'TestA',
                 'entities_id' => '_test_root_entity',
                 'custom_teststring' => 'Test String A',
-                'custom_customtagsingle' => 'Tag01',
+                'custom_customtagsingle' => "1"
             ],
             [
                 'name' => 'TestB',
                 'entities_id' => '_test_root_entity',
                 'custom_teststring' => 'Test String B',
-                'custom_customtagmulti' => ['Tag01', 'Tag02'],
+                'custom_customtagmulti' => [0 => "1", 1 => "2"],
             ],
         ],
         'Glpi\\CustomAsset\\Test02Asset' => [


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

Fixes #21162
Fix condition for dropdown custom field search option joins when multiple selection are allowed.
Fix usage of `glpi_assets_assets` table instead of `REFTABLE` in join conditions.
Add dropdown custom fields (single and multiple) to test dataset for automatic search tests to take them into account.