### PR TITLE
Migrate forms as single page render layout

### DIFF
--- a/phpunit/functional/Glpi/Form/Migration/FormMigrationTest.php
+++ b/phpunit/functional/Glpi/Form/Migration/FormMigrationTest.php
@@ -238,6 +238,9 @@ final class FormMigrationTest extends DbTestCase
                 $data
             )
         );
+
+        // migrated forms should always have single_page render_layout
+        $this->assertEquals('single_page', $form->fields['render_layout']);
     }
 
     public static function provideFormMigrationSections(): iterable

--- a/src/Glpi/Form/Migration/FormMigration.php
+++ b/src/Glpi/Form/Migration/FormMigration.php
@@ -441,6 +441,7 @@ class FormMigration extends AbstractPluginMigration
                     'is_recursive'          => $raw_form['is_recursive'],
                     'is_active'             => $raw_form['is_active'],
                     'is_deleted'            => $raw_form['is_deleted'],
+                    'render_layout'         => 'single_page',
                     '_from_migration'       =>  true,
                 ],
                 [


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

Fixes #21146

I haven't used the plugin much but it sounds like all forms in the plugin were shown as a single page, so for consistency the migrated forms should all use the single page layout by default.
