### PR TITLE
Fix(RuleRight): remove useless fields for RuleRight Form

### DIFF
--- a/src/RuleRight.php
+++ b/src/RuleRight.php
@@ -411,6 +411,7 @@ class RuleRight extends Rule
             'match_operators' => $this->getRulesMatch(),
             'conditions' => static::getConditionsArray(),
             'rand' => mt_rand(),
+            'short' => false,
             'test_url' => $CFG_GLPI["root_doc"] . "/front/rule.test.php",
             'params' => [
                 'canedit' => $canedit,

--- a/templates/pages/admin/rules/ruleright_form.html.twig
+++ b/templates/pages/admin/rules/ruleright_form.html.twig
@@ -34,6 +34,8 @@
 {% import 'components/form/fields_macros.html.twig' as fields %}
 
 {% block more_fields %}
-    {{ fields.dropdownField('Profile', 'profiles_id', 0, 'Profile'|itemtype_name) }}
-    {{ fields.dropdownYesNo('is_recursive', 0, __('Recursive')) }}
+    {% if short|default(false) %}
+        {{ fields.dropdownField('Profile', 'profiles_id', 0, 'Profile'|itemtype_name) }}
+        {{ fields.dropdownYesNo('is_recursive', 0, __('Recursive')) }}
+    {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Since the UI refactor of rules:

[https://github.com/glpi-project/glpi/pull/17203](https://github.com/glpi-project/glpi/pull/17203)

The form for authorization rules contains two additional fields that do not work and do not appear to be used. Their presence in this location seems rather odd.

<img width="1662" height="429" alt="image" src="https://github.com/user-attachments/assets/9dd8ee6b-1449-4c45-a87c-8bcd4cd97c69" />  

An initial inconsistency had been detected and fixed here:

[https://github.com/glpi-project/glpi/pull/19656/files#diff-186234e2e73b65f55a4e8779745ad83d0863119d64b860b3f80260509049f3d0](https://github.com/glpi-project/glpi/pull/19656/files#diff-186234e2e73b65f55a4e8779745ad83d0863119d64b860b3f80260509049f3d0)

However, these two fields are now displayed systematically.


## Screenshots (if appropriate):


