### PR TITLE
Webhook: Can't edit the webhook configuration for `ITILFollowup` - multiple array exceptions

### DIFF
--- a/phpunit/functional/WebhookTest.php
+++ b/phpunit/functional/WebhookTest.php
@@ -301,17 +301,12 @@ JSON;
     public function testGetMonacoSuggestions()
     {
         $itemtypes = \Webhook::getItemtypesDropdownValues();
-        $noSuggestions = ['Document_Item'];
 
         foreach ($itemtypes as $types) {
             $this->assertIsArray($types);
             foreach ($types as $itemtype => $label) {
                 $suggestions = \Webhook::getMonacoSuggestions($itemtype);
-                if (in_array($itemtype, $noSuggestions)) {
-                    $this->assertEmpty($suggestions, "Suggestions for $itemtype should be empty");
-                } else {
-                    $this->assertNotEmpty($suggestions, "Missing suggestions for $itemtype");
-                }
+                $this->assertNotEmpty($suggestions, "Missing suggestions for $itemtype");
             }
         }
     }

--- a/src/Webhook.php
+++ b/src/Webhook.php
@@ -374,7 +374,6 @@ class Webhook extends CommonDBTM implements FilterableInterface
                         ChangeTask::class => ['parent' => Change::class],
                         ProblemTask::class => ['parent' => Problem::class],
                         ITILFollowup::class => [], // All main types can be the parent
-                        Document_Item::class => [],
                         ITILSolution::class => [],
                         TicketValidation::class => ['parent' => Ticket::class],
                     ],
@@ -384,6 +383,9 @@ class Webhook extends CommonDBTM implements FilterableInterface
                         Appliance::class, Budget::class, Certificate::class, Cluster::class, Contact::class,
                         Contract::class, Database::class, Datacenter::class, Document::class, Domain::class,
                         SoftwareLicense::class, Line::class, Supplier::class,
+                    ],
+                    'subtypes' => [
+                        Document_Item::class => ['parent' => Document::class],
                     ],
                 ],
             ];


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description
When creating a webhook for the `ITILFollowup` we got some exception about missing array key value (`parent`) or an array key allocation with the key being an array and not a string making the suggestion not working

## Screenshots:

<img width="1739" height="722" alt="image" src="https://github.com/user-attachments/assets/6975ae7a-5c3a-45c8-82d9-056df9e68620" />
