### PR TITLE
Fix PHP 8.5 deprecations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -164,6 +164,7 @@
             "patch -f -p1 -d vendor/michelf/php-markdown/ < tools/patches/michelf-php-markdown-php8-compat.patch || true",
             "patch -f -p1 -d vendor/psr/http-factory/ < tools/patches/psr-http-factory-php8.4-compat.patch || true",
             "patch -f -p1 -d vendor/scssphp/scssphp/ < tools/patches/scssphp-scssphp-php8.4-compat.patch || true",
+            "patch -f -p1 -d vendor/symfony/string/ < tools/patches/symfony-string-php8.5-compat.patch || true",
             "patch -f -p1 -d vendor/wapmorgan/unified-archive/ < tools/patches/wapmorgan-unified-archive-php-8.4-compat.patch || true",
             "patch -f -p1 -d vendor/wapmorgan/unified-archive/ < tools/patches/wapmorgan-unified-archive-php-8.5-compat.patch || true"
         ]

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -7456,7 +7456,7 @@ abstract class CommonITILObject extends CommonDBTM
                 'tu.type AS type',
             ],
             'FROM'      => "$users_table AS tu",
-            'LEFT JOIN' => [
+            'INNER JOIN' => [
                 User::getTable() . ' AS usr' => [
                     'ON' => [
                         'tu'  => 'users_id',
@@ -7475,7 +7475,7 @@ abstract class CommonITILObject extends CommonDBTM
                 'gt.type AS type',
             ],
             'FROM'      => "$groups_table AS gt",
-            'LEFT JOIN' => [
+            'INNER JOIN' => [
                 Group_User::getTable() . ' AS gu'   => [
                     'ON' => [
                         'gu'  => 'groups_id',

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -163,7 +163,7 @@ class Dropdown
         }
 
         $names = [];
-        if (!$params['multiple'] && isset($params['toadd'][$params['value']])) {
+        if (!$params['multiple'] && $params['value'] !== null && isset($params['toadd'][$params['value']])) {
             $name = $params['toadd'][$params['value']];
         } elseif (
             !$params['multiple']

--- a/src/Search.php
+++ b/src/Search.php
@@ -1724,7 +1724,7 @@ class Search
                         } else {
                             $newrow[$key] = $val;
                             // Add id to items list
-                            if ($key == 'id') {
+                            if ($key == 'id' && $val !== null) {
                                 $data['data']['items'][$val] = $i;
                             }
                         }
@@ -7824,7 +7824,7 @@ JAVASCRIPT;
                     return $data[$ID][0]['name'];
 
                 case "language":
-                    if (isset($CFG_GLPI['languages'][$data[$ID][0]['name']])) {
+                    if (isset($data[$ID][0]['name'], $CFG_GLPI['languages'][$data[$ID][0]['name']])) {
                         return $CFG_GLPI['languages'][$data[$ID][0]['name']][0];
                     }
                     return __('Default value');

--- a/templates/generic_show_form.html.twig
+++ b/templates/generic_show_form.html.twig
@@ -182,7 +182,7 @@
 
                      {% set type_itemtype = item.getTypeClass() %}
                      {% set type_fk = item.getTypeForeignKeyField() %}
-                     {% if item.isField(type_fk) %}
+                     {% if type_fk is not null and item.isField(type_fk) %}
                         {{ fields.dropdownField(
                            type_itemtype,
                            type_fk,
@@ -406,7 +406,7 @@
 
                      {% set model_itemtype = item.getModelClass() %}
                      {% set model_fk = item.getModelForeignKeyField() %}
-                     {% if item.isField(model_fk) %}
+                     {% if model_fk is not null and item.isField(model_fk) %}
                         {{ fields.dropdownField(
                            model_itemtype,
                            model_fk,

--- a/tools/patches/symfony-string-php8.5-compat.patch
+++ b/tools/patches/symfony-string-php8.5-compat.patch
@@ -1,0 +1,15 @@
+diff --git a/Slugger/AsciiSlugger.php b/Slugger/AsciiSlugger.php
+index 5eb7fc1..f61e1d2 100644
+--- a/Slugger/AsciiSlugger.php
++++ b/Slugger/AsciiSlugger.php
+@@ -123,8 +123,8 @@ class AsciiSlugger implements SluggerInterface, LocaleAwareInterface
+ 
+         if (\is_array($this->symbolsMap)) {
+             $map = null;
+-            if (isset($this->symbolsMap[$locale])) {
+-                $map = $this->symbolsMap[$locale];
++            if (isset($this->symbolsMap[$locale ?? ''])) {
++                $map = $this->symbolsMap[$locale ?? ''];
+             } else {
+                 $parent = self::getParentLocale($locale);
+                 if ($parent && isset($this->symbolsMap[$parent])) {


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

It fixes `Using null as an array offset is deprecated, use an empty string instead` deprecations triggered by the test suite.