### PR TITLE
fix(form): fix field positioning with PRE_ITEM_FORM and POST_ITEM_FORM hook

### DIFF
--- a/templates/pages/admin/form/form_editor.html.twig
+++ b/templates/pages/admin/form/form_editor.html.twig
@@ -253,6 +253,9 @@
                                                 'full_width'    : true,
                                             }
                                         ) }}
+
+                                        {{ call_plugin_hook(constant('Glpi\\Plugin\\Hooks::POST_ITEM_FORM'), {'item': item, 'options': params}) }}
+
                                     </div>
                                 </section>
                             </section>
@@ -397,8 +400,6 @@
     {% endif %}
 
     {# TODO: add bootstrap tooltips on each buttons #}
-
-    {{ call_plugin_hook(constant('Glpi\\Plugin\\Hooks::POST_ITEM_FORM'), {'item': item, 'options': params}) }}
 
     {# Move section modal #}
     {{ include('pages/admin/form/move_section_modal.html.twig') }}


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

The PRE_ITEM_FORM hook for forms was incorrectly positioned: it did not target the form in the right-hand section, but rather the top of the page. Example illustrated with the Tag plugin:

## Screenshots (if appropriate):

Before:
<img width="1665" height="521" alt="image" src="https://github.com/user-attachments/assets/b1e74749-8eea-41c5-bcff-ad77f4327ec2" />

PRE_ITEM_FORM:
<img width="1665" height="521" alt="image" src="https://github.com/user-attachments/assets/754c4014-5733-479e-a2b8-bf225650eef8" />

POST_ITEM_FORM:
<img width="1654" height="433" alt="image" src="https://github.com/user-attachments/assets/27c6b500-b183-4d53-9a69-d650b426331c" />



