### PR TITLE
fix(forms): Remove unnecessary margin from horizontal layouts in form rendering

### DIFF
--- a/css/includes/components/form/_form-renderer.scss
+++ b/css/includes/components/form/_form-renderer.scss
@@ -83,8 +83,6 @@
 
         &:has(> :nth-child(2)) {
             &> section {
-                margin-bottom: 0 !important;
-
                 .col-12.col-sm-6 {
                     width: 100%;
                 }


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.

## Description

Fixed a margin error in the form rendering interface.

## Screenshots (if appropriate):

Before :
<img width="996" height="516" alt="image" src="https://github.com/user-attachments/assets/9e8f7391-7c18-4c89-9e5b-90726137027e" />
After :
<img width="996" height="557" alt="image" src="https://github.com/user-attachments/assets/907dccd3-0922-4aac-a896-eb7361663313" />
