### PR TITLE
fix custom icons adapting to tile's description

### DIFF
--- a/templates/components/illustration/custom_icon.html.twig
+++ b/templates/components/illustration/custom_icon.html.twig
@@ -36,4 +36,5 @@
     {% endif %}
     width="{{ width }}"
     height="{{ height }}"
+    class="align-self-start"
 />


### PR DESCRIPTION
## Description

When using custom illustration with .png format in the service catalog, the image height follows the description on its side due to the parent set in display flex.

## Screenshots (if appropriate):

**Before:**
<img width="430" height="399" alt="image" src="https://github.com/user-attachments/assets/ea357f2c-20ea-4677-a239-a279f10a09ef" />

**After:**
<img width="430" height="401" alt="image" src="https://github.com/user-attachments/assets/5fb0a2c3-c02b-4cca-a6f2-925cf00f2975" />
