### PR TITLE
render qrcodes as png and double its size

### DIFF
--- a/src/BarcodeManager.php
+++ b/src/BarcodeManager.php
@@ -50,12 +50,11 @@ class BarcodeManager
         $qrcode = $barcode->getBarcodeObj(
             'QRCODE,H',
             $CFG_GLPI["url_base"] . $item->getLinkURL(),
-            -2,
-            -2,
+            200,
+            200,
             'black',
-            [-2, -2, -2, -2]
-        )->setBackgroundColor('white')
-        ->setSize(200, 200, [10, 10, 10, 10]);
+            [10, 10, 10, 10]
+        )->setBackgroundColor('white');
         return $qrcode;
     }
 

--- a/src/BarcodeManager.php
+++ b/src/BarcodeManager.php
@@ -54,7 +54,8 @@ class BarcodeManager
             -2,
             'black',
             [-2, -2, -2, -2]
-        )->setBackgroundColor('white');
+        )->setBackgroundColor('white')
+        ->setSize(200, 200, [10, 10, 10, 10]);
         return $qrcode;
     }
 
@@ -63,7 +64,7 @@ class BarcodeManager
         $barcode_manager = new self();
         $qrcode = $barcode_manager->generateQRCode($item);
         if ($qrcode) {
-            return $qrcode->getHtmlDiv();
+            return "<img src=\"data:image/png;base64," . base64_encode($qrcode->getPngData()) . "\" />";
         }
         return false;
     }


### PR DESCRIPTION
## Description

- Render QRCodes as png (instead divs) to allow download
- double its size also

## Screenshots (if appropriate):

<img width="1059" height="727" alt="image" src="https://github.com/user-attachments/assets/2c59dea5-0d69-4497-b72f-8e797ed2d609" />

