### PR TITLE
fix sizing of icons on service-catalog

### DIFF
--- a/templates/components/illustration/custom_icon.html.twig
+++ b/templates/components/illustration/custom_icon.html.twig
@@ -37,4 +37,5 @@
     width="{{ width }}"
     height="{{ height }}"
     class="align-self-start"
+    style="max-width: initial;"
 />


### PR DESCRIPTION
## Description

Due to the last tabler release (👋🏽 @cconard96 😬), a global style is applied on all img (`max-width: 100%`)
To note, for the moment, I made the change applied on the local part to avoid to manage issues now

## Screenshots (if appropriate):

**Before:**
<img width="1305" height="278" alt="image" src="https://github.com/user-attachments/assets/664cc5fc-1732-4a7f-a20a-8edea35038c9" />


**After:**
<img width="1343" height="319" alt="image" src="https://github.com/user-attachments/assets/04dfe575-3f3e-415d-8763-2eddca30082c" />
