### PR TITLE
Deprecate unsafe method execution in dropdown controller

### DIFF
--- a/src/Glpi/Controller/DropdownFormController.php
+++ b/src/Glpi/Controller/DropdownFormController.php
@@ -49,7 +49,7 @@ use Toolbox;
 use function Safe\ob_get_clean;
 use function Safe\ob_start;
 
-final class DropdownFormController extends AbstractController
+class DropdownFormController extends AbstractController
 {
     public function __invoke(Request $request): Response
     {
@@ -176,6 +176,7 @@ final class DropdownFormController extends AbstractController
         if (isset($input['execute']) && isset($input['_method'])) {
             $method = 'execute' . $input['_method'];
             if (method_exists($dropdown, $method)) {
+                Toolbox::deprecated('Defining method to execute throught `execute` and `_method` inputs is deprecated for security reasons. Please use a dedicated controller action instead.');
                 \call_user_func([&$dropdown, $method], $input);
 
                 return new RedirectResponse(Html::getBackUrl());


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Building the name of a method to execute using request inputs is not safe. There is currently no security issue with this, in both GLPI and in public plugins downloadable from the plugin catalog, but it is still preferable to deprecate this way to do and remove it in a future GLPI version.

Also, we do not use it in GLPI. It was used before #17203, but if we restore a similar controller action in #21180 to fix the corresponding form, the best way would be to create a dedicated controller that extends the `DropdownController` to implement a specific action.