### PR TITLE
fix(forms): Support for all CommonTreeDropdown for advanced configuration for Item questions

### DIFF
--- a/css/includes/components/form/_form-editor.scss
+++ b/css/includes/components/form/_form-editor.scss
@@ -545,7 +545,7 @@ html {
     }
 }
 
-[data-glpi-form-editor-active-question]:has([data-glpi-form-editor-advanced-question-configuration]) {
+[data-glpi-form-editor-active-question]:has([data-glpi-form-editor-advanced-question-configuration-visible]) {
     .input-group > * {
         &:first-child:has(.select2-selection) {
             .select2-selection {

--- a/js/modules/Forms/ItemAdvancedConfig.js
+++ b/js/modules/Forms/ItemAdvancedConfig.js
@@ -34,10 +34,14 @@ export class GlpiFormItemAdvancedConfig {
     // Static instance for singleton pattern
     static instance = null;
 
+    #common_tree_dropdown_itemtypes = [];
+
     /**
      * Constructor for the Item Advanced Configuration
+     *
+     * @param {Array} common_tree_dropdown_itemtypes - List of itemtypes that are CommonTreeDropdown
      */
-    constructor() {
+    constructor(common_tree_dropdown_itemtypes = []) {
         // Prevent multiple initializations
         if (GlpiFormItemAdvancedConfig.instance !== null) {
             return GlpiFormItemAdvancedConfig.instance;
@@ -48,6 +52,9 @@ export class GlpiFormItemAdvancedConfig {
 
         // Store instance
         GlpiFormItemAdvancedConfig.instance = this;
+
+        // Store the itemtypes that are CommonTreeDropdown
+        this.#common_tree_dropdown_itemtypes = common_tree_dropdown_itemtypes;
     }
 
     /**
@@ -92,11 +99,13 @@ export class GlpiFormItemAdvancedConfig {
         const dropdown_container = container.closest('[data-glpi-form-editor-advanced-question-configuration]')
             .parents('[data-glpi-form-editor-question-extra-details]');
 
-        // Show button only for 'Entity' sub-type
-        if (new_sub_type === 'Entity') {
+        // Show button only for sub-type that are CommonTreeDropdown
+        if (this.#common_tree_dropdown_itemtypes.includes(new_sub_type)) {
             dropdown_container.show();
+            dropdown_container.attr('data-glpi-form-editor-advanced-question-configuration-visible', 'true');
         } else {
             dropdown_container.hide();
+            dropdown_container.removeAttr('data-glpi-form-editor-advanced-question-configuration-visible');
         }
     }
 }

--- a/src/Glpi/Form/QuestionType/QuestionTypeItem.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeItem.php
@@ -310,15 +310,25 @@ class QuestionTypeItem extends AbstractQuestionType implements
             $itemtype = current(current($this->getAllowedItemtypes()));
         }
 
+        $common_tree_dropdowns = [];
+        foreach ($this->getAllowedItemtypes() as $types) {
+            foreach ($types as $type) {
+                if (is_a($type, CommonTreeDropdown::class, true)) {
+                    $common_tree_dropdowns[$type] = $type;
+                }
+            }
+        }
+
         $twig = TemplateRenderer::getInstance();
         return $twig->render(
             'pages/admin/form/question_type/item/advanced_configuration.html.twig',
             [
-                'question'             => $question,
-                'itemtype'             => $itemtype,
-                'root_items_id'        => $this->getRootItemsId($question),
-                'subtree_depth'        => $this->getSubtreeDepth($question),
-                'selectable_tree_root' => $this->isSelectableTreeRoot($question),
+                'question'              => $question,
+                'itemtype'              => $itemtype,
+                'root_items_id'         => $this->getRootItemsId($question),
+                'subtree_depth'         => $this->getSubtreeDepth($question),
+                'selectable_tree_root'  => $this->isSelectableTreeRoot($question),
+                'common_tree_dropdowns' => $common_tree_dropdowns,
             ]
         );
     }

--- a/templates/pages/admin/form/question_type/item/advanced_configuration.html.twig
+++ b/templates/pages/admin/form/question_type/item/advanced_configuration.html.twig
@@ -83,7 +83,7 @@
 
         <script>
             import("/js/modules/Forms/ItemAdvancedConfig.js").then((m) => {
-                new m.GlpiFormItemAdvancedConfig().updateAdvancedConfigVisibility(
+                new m.GlpiFormItemAdvancedConfig({{ common_tree_dropdowns|keys|json_encode|raw }}).updateAdvancedConfigVisibility(
                     $('[data-glpi-form-editor-item-dropdown-advanced-configuration="{{ rand }}"]'),
                     '{{ itemtype }}'
                 );

--- a/templates/pages/admin/form/question_type/item_dropdown/advanced_configuration.html.twig
+++ b/templates/pages/admin/form/question_type/item_dropdown/advanced_configuration.html.twig
@@ -37,7 +37,7 @@
 {% set rand = random() %}
 
 {% block dropdown_content %}
-    <div data-glpi-form-editor-item-dropdown-advanced-configuration>
+    <div data-glpi-form-editor-item-dropdown-advanced-configuration data-glpi-form-editor-advanced-question-configuration-visible>
         {{ fields.dropdownArrayField(
             'extra_data[categories_filter]',
             '',


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.

## Description

Added support for advanced configuration for all `CommonTreeDropdown` elements in `Item` questions.
Fixed a minor UI bug that broke the dropdown borders even when the button to display advanced options was hidden.