### PR TITLE
Invalidate the JS importmap cache when GLPI URL changes

### DIFF
--- a/src/Glpi/Application/ImportMapGenerator.php
+++ b/src/Glpi/Application/ImportMapGenerator.php
@@ -143,7 +143,7 @@ class ImportMapGenerator
         ];
 
         // Try to get GLPI core modules from cache first
-        $core_cache_key = 'js_import_map_core';
+        $core_cache_key = 'js_import_map_core_' . \sha1($this->root_doc);
         $core_modules = [];
 
         if ($should_use_cache) {
@@ -175,7 +175,7 @@ class ImportMapGenerator
                 isset($this->registered_plugin_modules[$plugin_key])
                 && !empty($this->registered_plugin_modules[$plugin_key])
             ) {
-                $plugin_cache_key = 'js_import_map_plugin_' . $plugin_key;
+                $plugin_cache_key = 'js_import_map_plugin_' . $plugin_key . '_' . \sha1($this->root_doc);
                 $plugin_modules = null;
 
                 // Try to get plugin modules from cache


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

The URLs contained in the importmap are corresponding to the full path of the JS files, including the GLPI root path. When this GLPI root path change, the cache should not be reused.
As it depends on the server configuration, we cannot know whenever we have to trigger the cache invalidation, so I propose to add the GLPI root path in the cache key to handle this.