### PR TITLE
fix(form): Quesion of type item throw 500 exception in the console

### DIFF
--- a/src/Glpi/Form/QuestionType/QuestionTypeItem.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeItem.php
@@ -395,6 +395,10 @@ class QuestionTypeItem extends AbstractQuestionType implements
             throw new InvalidArgumentException();
         }
 
+        if (!$question_config->getItemtype()) {
+            return parent::getConditionHandlers($question_config);
+        }
+
         return array_merge(
             parent::getConditionHandlers($question_config),
             [

--- a/tests/cypress/e2e/form/editor/editor.cy.js
+++ b/tests/cypress/e2e/form/editor/editor.cy.js
@@ -148,6 +148,42 @@ describe ('Form editor', () => {
         });
     });
 
+    it('can create an item question', () => {
+        cy.createFormWithAPI().visitFormTab('Form');
+
+        describe('create question', () => {
+            cy.addQuestion("My question");
+            cy.findByRole('region', {'name': 'Question details'}).within(() => {
+                cy.findByRole('checkbox', {'name': 'Mandatory'})
+                    .should('not.be.checked')
+                    .check()
+                ;
+                cy.findByLabelText("Question description")
+                    .awaitTinyMCE()
+                    .type("My question description")
+                ;
+            });
+
+            // We catch the ajax request when Item question type is selected
+            cy.intercept(
+                {
+                    method: 'POST',
+                    url: '/Form/Condition/Editor/SupportedValueOperators',
+                }
+            ).as('itemQuestionQuery');
+
+            cy.getDropdownByLabelText("Question type")
+                .selectDropdownValue("Item");
+
+            cy.wait('@itemQuestionQuery').then((interception) => {
+                assert.equal(interception.response.statusCode, 200);
+            });
+
+            // Save form and reload page to force new data to be displayed.
+            cy.saveFormEditorAndReload();
+        });
+    });
+
     it('can duplicate a question', () => {
         cy.createFormWithAPI().visitFormTab('Form');
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description
In a form when creating a question and selecting the question type to `Item` 500 exceptions would be thrown in the console 

## Screenshots:
<img width="3416" height="500" alt="image" src="https://github.com/user-attachments/assets/6e596140-1a9d-4c55-859c-f0d4418f6d49" />


