### PR TITLE
Fix(Notifications): attached documents in private followup

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -7951,10 +7951,18 @@ abstract class CommonITILObject extends CommonDBTM
     /**
      * Returns criteria that can be used to get documents related to current instance.
      *
+     * @param bool      $bypass_rights  Whether to bypass rights checks (default: false)
+     * @param int|null  $user_id        ID of the user for rights checking (default: null = current session rights)
+     *
      * @return array
      */
-    public function getAssociatedDocumentsCriteria($bypass_rights = false): array
+    public function getAssociatedDocumentsCriteria($bypass_rights = false, ?int $user_id = null): array
     {
+        $user = new User();
+        if ($user_id > 0) {
+            $user = $user->getFromDB($user_id);
+        }
+
         $task_class = $this->getType() . 'Task';
         /** @var DBmysql $DB */
         global $DB; // Used to get subquery results - better performance
@@ -7973,7 +7981,7 @@ abstract class CommonITILObject extends CommonDBTM
                 ITILFollowup::getTableField('itemtype') => $this->getType(),
                 ITILFollowup::getTableField('items_id') => $this->getID(),
             ];
-            if (!$bypass_rights && !Session::haveRight(ITILFollowup::$rightname, ITILFollowup::SEEPRIVATE)) {
+            if (!$bypass_rights && !$user->hasRight(ITILFollowup::$rightname, ITILFollowup::SEEPRIVATE)) {
                 $fup_crits[] = [
                     'OR' => ['is_private' => 0, 'users_id' => Session::getLoginUserID()],
                 ];
@@ -8038,7 +8046,7 @@ abstract class CommonITILObject extends CommonDBTM
             $tasks_crit = [
                 $this->getForeignKeyField() => $this->getID(),
             ];
-            if (!$bypass_rights && !Session::haveRight($task_class::$rightname, CommonITILTask::SEEPRIVATE)) {
+            if (!$bypass_rights && !$user->hasRight($task_class::$rightname, CommonITILTask::SEEPRIVATE)) {
                 $tasks_crit[] = [
                     'OR' => ['is_private' => 0, 'users_id' => Session::getLoginUserID()],
                 ];

--- a/src/User.php
+++ b/src/User.php
@@ -7013,4 +7013,43 @@ HTML;
 
         return $input;
     }
+
+    /**
+     * User has right for given module and right.
+     *
+     * @param string  $module Module to check
+     * @param integer $right  Right to check
+     *
+     * @return boolean|int
+     **/
+    public function hasRight($module, $right)
+    {
+        global $DB;
+        if ($this->isNewItem()) {
+            return Session::haveRight($module, $right);
+        } else {
+            $iterator = $DB->request([
+                'SELECT' => 'rights',
+                'FROM'   => 'glpi_profilerights',
+                'JOIN'   => [
+                    'glpi_profiles_users' => [
+                        'ON' => [
+                            'glpi_profilerights'    => 'profiles_id',
+                            'glpi_profiles_users'   => 'profiles_id',
+                        ],
+                    ],
+                ],
+                'WHERE'  => [
+                    'glpi_profilerights.name'       => $module,
+                    'glpi_profilerights.rights'     => ['&', $right],
+                    'glpi_profiles_users.users_id'  => $this->getID(),
+                ]
+            ]);
+
+            if (count($iterator) > 0) {
+                return true;
+            }
+        }
+        return false;
+    }
 }


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !39340

It checks that the recipient user has the necessary permissions to view the documents in private follow-ups before attaching them to the notification.

## Screenshots (if appropriate):


