### PR TITLE
Fix tinymce/bootstrap modal conflicts

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -1986,3 +1986,11 @@ $(document).on('click', 'div[data-glpi-tinymce-init-on-demand-render]', function
     });
 });
 
+// Prevent Bootstrap dialog from blocking focusin
+// See: https://www.tiny.cloud/docs/tinymce/latest/bootstrap-cloud/#usingtinymceinabootstrapdialog
+document.addEventListener('focusin', (e) => {
+    if (e.target.closest(".tox-tinymce, .tox-tinymce-aux, .moxman-window, .tam-assetmanager-root") !== null) {
+        e.stopImmediatePropagation();
+    }
+});
+


### PR DESCRIPTION
## Description

Some features of tiynmce do not work in bootstrap modals.
See https://www.tiny.cloud/docs/tinymce/latest/bootstrap-cloud/#usingtinymceinabootstrapdialog.

This was impacting the helpdesk form translations, for example it was not possible to add a link to a rich text translation.
