### PR TITLE
Enforce escaping in JS scripts (3/x)

### DIFF
--- a/js/modules/Dashboard/Dashboard.js
+++ b/js/modules/Dashboard/Dashboard.js
@@ -126,8 +126,8 @@ class GLPIDashboard {
         };
         options = Object.assign({}, default_options, options);
 
-        this.rand         = CSS.escape(options.rand);
-        this.elem_id      = "#dashboard-" + options.rand;
+        this.rand         = parseInt(options.rand);
+        this.elem_id      = "#dashboard-" + this.rand;
         this.element      = $(this.elem_id);
         this.elem_dom     = this.element[0];
         this.current_name = $(`${this.elem_id} .dashboard-select`).val() || options.current;

--- a/templates/central/widget_tab.html.twig
+++ b/templates/central/widget_tab.html.twig
@@ -67,7 +67,7 @@
             'params': this_obj.data('params')
          };
          this_obj.html('<span class="spinner-border ms-auto" role="status" aria-hidden="true"></span>')
-            .load('{{ path('/ajax/central.php') }}', params, function(response, status, xhr) {
+            .load(`${CFG_GLPI.root_doc}/ajax/central.php`, params, function(response, status, xhr) {
                const parent = this_obj.closest('.grid-item').parent();
 
                if (status === 'error' || !response) {

--- a/templates/components/datatable.html.twig
+++ b/templates/components/datatable.html.twig
@@ -105,7 +105,7 @@
                                 <div>
                                     <input class="form-check-input massive_action_checkbox" type="checkbox" id="checkall_{{ massiveactionparams['container'] }}"
                                         value="" aria-label="{{ __('Check all') }}"
-                                        onclick="checkAsCheckboxes(this, '{{ massiveactionparams['container'] }}', '.massive_action_checkbox');" />
+                                        onclick="checkAsCheckboxes(this, '{{ massiveactionparams['container']|e('js') }}', '.massive_action_checkbox');" />
                                 </div>
                             </th>
                         {% endif %}

--- a/templates/components/form/basic_inputs_macros.html.twig
+++ b/templates/components/form/basic_inputs_macros.html.twig
@@ -81,15 +81,15 @@
     {% set more_html %}
         {% if options.is_disclosable %}
             <div class="btn btn-outline-secondary"
-                 onmousedown="showDisclosablePasswordField('{{ options.id }}')"
-                 onmouseup="hideDisclosablePasswordField('{{ options.id }}')"
-                 onmouseout="hideDisclosablePasswordField('{{ options.id }}')">
+                 onmousedown="showDisclosablePasswordField('{{ options.id|e('js') }}')"
+                 onmouseup="hideDisclosablePasswordField('{{ options.id|e('js') }}')"
+                 onmouseout="hideDisclosablePasswordField('{{ options.id|e('js') }}')">
                 <i class="ti ti-eye disclose"></i>
             </div>
         {% endif %}
 
         {% if options.is_copyable %}
-            <div class="btn btn-outline-secondary" onclick="copyDisclosablePasswordFieldToClipboard('{{ options.id }}')">
+            <div class="btn btn-outline-secondary" onclick="copyDisclosablePasswordFieldToClipboard('{{ options.id|e('js') }}')">
                 <i class="ti ti-clipboard-copy disclose"></i>
             </div>
         {% endif %}
@@ -161,12 +161,12 @@
     })) }}
     <script>
         $(function () {
-            $("#{{ options.id }}").spectrum({
+            $("#{{ options.id|e('css')|e('js') }}").spectrum({
                 showInput: true,
                 preferredFormat: "hex",
                 type: "text",
-                cancelText: "{{ __('Cancel') }}",
-                chooseText: "{{ __('Validate') }}",
+                cancelText: "{{ __('Cancel')|e('js') }}",
+                chooseText: "{{ __('Validate')|e('js') }}",
                 change: function (color) {
                     if (color !== null && color.getAlpha() !== 1) {
                         let hex = color.toHexString();
@@ -277,18 +277,18 @@
     {% set alt_format = call('Toolbox::getDateFormat', ['js']) ~ (options.enableTime ? ' H:i:S' : '') %}
     <script>
         $(function() {
-            $("#{{ options.id }}").flatpickr({
+            $("#{{ options.id|e('css')|e('js') }}").flatpickr({
                 wrap: true,
                 altInput: true,
-                dateFormat: '{{ date_format }}',
-                altFormat: '{{ alt_format }}',
+                dateFormat: '{{ date_format|e('js') }}',
+                altFormat: '{{ alt_format|e('js') }}',
                 enableTime: {{ options.enableTime ? "true" : "false" }},
                 enableSeconds: {{ options.enableTime ? "true" : "false" }},
                 weekNumbers: true,
                 time_24hr: true,
                 allowInput: {{ options.readonly ? 'false' : 'true' }},
                 clickOpens: {{ options.readonly ? 'false' : 'true' }},
-                locale: getFlatPickerLocale("{{ locale['language'] }}", "{{ locale['region'] }}"),
+                locale: getFlatPickerLocale("{{ locale['language']|e('js') }}", "{{ locale['region']|e('js') }}"),
                 onClose(dates, currentdatestring, picker) {
                     picker.setDate(picker.altInput.value, true, picker.config.altFormat)
                 },
@@ -385,8 +385,8 @@
         <script>
             $(function() {
                 const form_tags = new GLPI.RichText.FormTags(
-                    tinymce.get('{{ options.id }}'),
-                    {{ options.form_tags_form_id }},
+                    tinymce.get('{{ options.id|e('js') }}'),
+                    {{ options.form_tags_form_id|json_encode|raw }},
                 );
                 form_tags.register();
             });
@@ -397,9 +397,9 @@
         <script>
             $(function() {
                 const user_mention = new GLPI.RichText.UserMention(
-                    tinymce.get('{{ options.id }}'),
-                    {{ options.entities_id }},
-                    '{{ idor_token('User', {'right': 'all', 'entity_restrict': options.entities_id}) }}',
+                    tinymce.get('{{ options.id|e('js') }}'),
+                    {{ options.entities_id|json_encode|raw }},
+                    '{{ idor_token('User', {'right': 'all', 'entity_restrict': options.entities_id|json_encode|raw}) }}',
                     {{ options.mention_options|json_encode|raw }}
                 );
                 user_mention.register();

--- a/templates/components/form/buttons.html.twig
+++ b/templates/components/form/buttons.html.twig
@@ -88,7 +88,7 @@
                      <span class="{{ span_cls }}">
                         <button class="btn btn-danger me-2" type="submit" name="purge"
                               value="1"
-                              onclick="return confirm('{{ __('Confirm the final deletion?') }}');">
+                              onclick="return confirm('{{ __('Confirm the final deletion?')|e('js') }}');">
                            <i class="ti ti-trash"></i>
                            <span>{{ _x('button', 'Delete permanently') }}</span>
                         </button>
@@ -108,7 +108,7 @@
                   {% if (not item.maybeDeleted() or item.useDeletedToLockIfDynamic()) %}
                      {% if item.can(id, constant('PURGE')) %}
                         <button class="btn btn-outline-danger me-2" type="submit" name="purge"
-                                onclick="return confirm('{{ __('Confirm the final deletion?') }}');"
+                                onclick="return confirm('{{ __('Confirm the final deletion?')|e('js') }}');"
                                 value="1">
                            <i class="ti ti-trash"></i>
                            <span>{{ _x('button', 'Delete permanently') }}</span>

--- a/templates/components/form/fields_macros.html.twig
+++ b/templates/components/form/fields_macros.html.twig
@@ -366,7 +366,7 @@
          {% if clearable %}
             <input type="hidden" name="_blank_{{ name }}" />
              {%- set clear_js -%}
-                 const blank_input = $('input[name=\'_blank_{{ name }}\']');
+                 const blank_input = $('input[name="_blank_{{ name|e('css')|e('js') }}"]');
                  blank_input.val(blank_input.val() ? '' : true);
                  if ($(this).closest('.picture_gallery_item').length) {
                     $(this).closest('.picture_gallery_item').hide();
@@ -629,7 +629,7 @@
     {{ _self.dropdownArrayField(name, value, {(value): value}, label, options) }}
     <script type="module">
         import('/js/modules/Form/WebIconSelector.js').then((m) => {
-            const dropdown_id = '{{ ('dropdown_' ~ name ~ options.rand)|replace({'[': '_', ']': '_'}) }}';
+            const dropdown_id = '{{ ('dropdown_' ~ name ~ options.rand)|replace({'[': '_', ']': '_'})|e('js') }}';
             const selector = new m.default(document.getElementById(dropdown_id));
             selector.init();
         });
@@ -1005,14 +1005,14 @@
     <script>
         $(() => {
             const editor_options = {{ options.single_line ? 'true' : 'false' }} ? window.GLPI.Monaco.getSingleLineEditorOptions() : {};
-            window.GLPI.Monaco.createEditor('{{ code_container_id }}', '{{ options.language }}', "{{ value|e('js') }}", {{ options.completions|json_encode|raw }}, editor_options).then(() => {
-                $('#{{ code_container_id }}').closest('form').on('formdata', (e) => {
+            window.GLPI.Monaco.createEditor('{{ code_container_id|e('js') }}', '{{ options.language|e('js') }}', "{{ value|e('js') }}", {{ options.completions|json_encode|raw }}, editor_options).then(() => {
+                $('#{{ code_container_id|e('css')|e('js') }}').closest('form').on('formdata', (e) => {
                     const editors = window.monaco.editor.getEditors().filter((editor) => {
-                        return editor._domElement.id === '{{ code_container_id }}';
+                        return editor._domElement.id === '{{ code_container_id|e('js') }}';
                     });
                     if (editors.length) {
-                        e.originalEvent.formData.delete('{{ name }}');
-                        e.originalEvent.formData.append('{{ name }}', editors[0].getValue());
+                        e.originalEvent.formData.delete('{{ name|e('js') }}');
+                        e.originalEvent.formData.append('{{ name|e('js') }}', editors[0].getValue());
                     }
                 });
             });
@@ -1095,9 +1095,9 @@
                         "/js/modules/IllustrationPicker/Controller.js"
                     );
                     new module.GlpiIllustrationPickerController(
-                        document.getElementById('{{ container_id }}'),
-                        document.getElementById('{{ modal_id }}'),
-                        "{{ custom_icon_prefix }}",
+                        document.getElementById('{{ container_id|e('js') }}'),
+                        document.getElementById('{{ modal_id|e('js') }}'),
+                        "{{ custom_icon_prefix|e('js') }}",
                     );
                 })();
             </script>

--- a/templates/components/form/inventory_info.html.twig
+++ b/templates/components/form/inventory_info.html.twig
@@ -120,12 +120,12 @@
             icon.addClass('icon-rotate');
             $.ajax({
                type: 'POST',
-               url: '{{ path('/ajax/agent.php') }}',
+               url: `${CFG_GLPI.root_doc}/ajax/agent.php`,
                timeout: 30000, // 30 seconds timeout
                dataType: 'json',
                data: {
-                  action: '{{ constant('Agent::ACTION_STATUS') }}',
-                  id: '{{ agent.fields['id'] }}'
+                  action: '{{ constant('Agent::ACTION_STATUS')|e('js') }}',
+                  id: {{ agent.getID() }}
                },
                success: function(json) {
                   $('#agent_status').text(json.answer);
@@ -141,12 +141,12 @@
             icon.addClass('icon-rotate');
             $.ajax({
                type: 'POST',
-               url: '{{ path('/ajax/agent.php') }}',
+               url: `${CFG_GLPI.root_doc}/ajax/agent.php`,
                timeout: 30000, // 30 seconds timeout
                dataType: 'json',
                data: {
-                  action: '{{ constant('Agent::ACTION_INVENTORY') }}',
-                  id: '{{ agent.fields['id'] }}'
+                  action: '{{ constant('Agent::ACTION_INVENTORY')|e('js') }}',
+                  id: {{ agent.getID() }}
                },
                success: function(json) {
                   $('#inventory_status').text(json.answer);

--- a/templates/components/form/networkname.html.twig
+++ b/templates/components/form/networkname.html.twig
@@ -71,7 +71,7 @@
                   {% if display_dissociate_btn %}
                      {% set unaffect_btn %}
                         <a class="btn btn-sm btn-outline-danger"
-                        onclick=" submitGetLink('{{ item.getFormURL }}', {'unaffect': 'unaffect', 'id': '{{ ID }}', '_glpi_csrf_token': '{{ csrf_token() }}', '_glpi_simple_form': '1'});">
+                        onclick=" submitGetLink('{{ item.getFormURL()|e('js')|e }}', {'unaffect': 'unaffect', 'id': '{{ ID|e('js')|e }}', '_glpi_csrf_token': '{{ csrf_token()|e('js')|e }}', '_glpi_simple_form': '1'});">
                            <span class="ti ti-unlink " title={{ _x('button', 'Dissociate') }}>
                               <span class="sr-only">{{ _x('button', 'Dissociate') }}</span>
                            </span>

--- a/templates/components/form/single-action.html.twig
+++ b/templates/components/form/single-action.html.twig
@@ -79,13 +79,13 @@ $(function () {
       var current_action = $(this).data('action');
 
       glpi_ajax_dialog({
-         url: '{{ path('/ajax/dropdownMassiveAction.php') }}',
+         url: `${CFG_GLPI.root_doc}/ajax/dropdownMassiveAction.php`,
          title: ma.actions[current_action],
          params: Object.assign(
             { action: current_action },
             ma
          ),
-         appendTo: '#massive_container_{{ rand }}',
+         appendTo: '#massive_container_{{ rand|e('css')|e('js') }}',
       });
    });
 });

--- a/templates/components/form/viewsubitem.html.twig
+++ b/templates/components/form/viewsubitem.html.twig
@@ -30,7 +30,7 @@
  # ---------------------------------------------------------------------
  #}
 
-{% set rand = rand|default(random()) %}
+{% set rand = rand|default(random())|safe_dom_id %}
 {% set subitem_container_id = subitem_container_id|default('viewsubitem' ~ rand) %}
 {% set ajax_form_submit = ajax_form_submit|default(false) %}
 {% set reload_tab = reload_tab|default(false) %}
@@ -58,7 +58,7 @@
 
 <script>
     function viewAddEditSubItem{{ rand }}(id) {
-        const modal_el = $('#{{ subitem_container_id ~ '_modal' }}');
+        const modal_el = $('#{{ (subitem_container_id ~ '_modal')|e('css')|e('js') }}');
         if (modal_el.length) {
             modal_el[0].addEventListener('shown.bs.modal', (event) => {
                 event.target.setAttribute('data-cy-ready', 'true');
@@ -70,19 +70,19 @@
         $('#{{ subitem_container_id }}').load('{{ path('/ajax/viewsubitem.php')|e('js') }}',{
             type: "{{ type|e('js') }}",
             parenttype: "{{ parenttype|e('js') }}",
-        {{ items_id }}: {{ id }},
-        id: id
-    }, () => {
+            '{{ items_id|e('js') }}': {{ id|json_encode|raw }},
+            id: id
+        }, () => {
             if (modal_el.length) {
                 modal_el.modal('show');
             }
         });
     }
     $(() => {
-        const modal_el = $('#{{ subitem_container_id ~ '_modal' }}');
+        const modal_el = $('#{{ (subitem_container_id ~ '_modal')|e('css')|e('js') }}');
 
         {% if datatable_id is defined %}
-            $('#{{ datatable_id }}').on('click', 'tbody tr', (e) => {
+            $('#{{ datatable_id|e('css')|e('js') }}').on('click', 'tbody tr', (e) => {
                 if ($(e.target).closest('td').find('.massive_action_checkbox').length > 0) {
                     return;
                 }
@@ -96,7 +96,7 @@
         $('#addsubitem{{ rand }}').on('click', (e) => {
             viewAddEditSubItem{{ rand }}(-1);
         });
-        const subitem_container = $('#{{ subitem_container_id }}');
+        const subitem_container = $('#{{ subitem_container_id|e('css')|e('js') }}');
         subitem_container.on('submit', 'form', (e) => {
             {% if ajax_form_submit %}
                 e.preventDefault();

--- a/templates/components/itilobject/actors/field.html.twig
+++ b/templates/components/itilobject/actors/field.html.twig
@@ -30,6 +30,8 @@
  # ---------------------------------------------------------------------
  #}
 
+{% set rand = rand|default(random())|safe_dom_id %}
+
 {% set load_actors = params['load_actors'] ?? true %}
 {% set actors = load_actors ? item.getActorsForType(actortypeint, params) : [] %}
 
@@ -162,7 +164,7 @@
             if (is_selection && itemtype == "User") {
                 const unique_id = "user_opt_" + actor_select.attr('data-actor-type') + "User" + items_id;
                 $.ajax({
-                    url: '{{ path('/ajax/comments.php') }}',
+                    url: `${CFG_GLPI.root_doc}/ajax/comments.php`,
                     type: 'POST',
                     data: {
                         'itemtype': 'User',
@@ -171,7 +173,7 @@
                 }).then((result) => {
                     {# `result` is a safe HTML string #}
                     if (result) {
-                        actor_select.parent().append('<' + `div id="content${_.escape(unique_id)}" style="display: none;">` + result + '<' + '/div>');
+                        actor_select.parent().append('<' + `div id="content${_.escape(unique_id)}" style="display: none;">${result}<` + '/div>');
                         option_element.attr('data-glpi-popover-source', `content${unique_id}`);
                     }
                 });
@@ -180,7 +182,7 @@
             if (is_selection && itemtype == "Group") {
                 const unique_id = "group_opt_" + actor_select.attr('data-actor-type') + "Group" + items_id;
                 $.ajax({
-                    url: '{{ path('/ajax/comments.php') }}',
+                    url: `${CFG_GLPI.root_doc}/ajax/comments.php`,
                     type: 'POST',
                     data: {
                         'itemtype': 'Group',
@@ -189,7 +191,7 @@
                 }).then((result) => {
                     {# `result` is a safe HTML string #}
                     if (result) {
-                        actor_select.parent().append('<' + `div id="content${_.escape(unique_id)}" style="display: none;">` + result + '<' + '/div>');
+                        actor_select.parent().append('<' + `div id="content${_.escape(unique_id)}" style="display: none;">${result}<` + '/div>');
                         option_element.attr('data-glpi-popover-source', `content${unique_id}`);
                     }
                 });
@@ -198,7 +200,7 @@
             if (is_selection && itemtype == "Supplier") {
                 const unique_id = "supplier_opt_" + actor_select.attr('data-actor-type') + "Supplier" + items_id;
                 $.ajax({
-                    url: '{{ path('/ajax/comments.php') }}',
+                    url: `${CFG_GLPI.root_doc}/ajax/comments.php`,
                     type: 'POST',
                     data: {
                         'itemtype': 'Supplier',
@@ -207,7 +209,7 @@
                 }).then((result) => {
                     {# `result` is a safe HTML string #}
                     if (result) {
-                        actor_select.parent().append('<' + `div id="content${_.escape(unique_id)}" style="display: none;">` + result + '<' + '/div>');
+                        actor_select.parent().append('<' + `div id="content${_.escape(unique_id)}" style="display: none;">${result}<` + '/div>');
                         option_element.attr('data-glpi-popover-source', `content${unique_id}`);
                     }
                 });
@@ -230,7 +232,7 @@
                 `);
                 option_element.append(existing_element);
 
-                $.get("{{ path('/ajax/actorinformation.php') }}", {
+                $.get(`${CFG_GLPI.root_doc}/ajax/actorinformation.php`, {
                     [fk]: items_id,
                     only_number: true,
                 }).done((number) => {
@@ -277,7 +279,7 @@
                 }
             },
             ajax: {
-                url: '{{ path('/ajax/actors.php') }}',
+                url: `${CFG_GLPI.root_doc}/ajax/actors.php`,
                 datatype: 'json',
                 type: 'POST',
                 delay:250,
@@ -286,16 +288,16 @@
                     return {
                         action: 'getActors',
                         actortype: actorytype,
-                        users_right: '{{ users_right ?? 'all' }}',
-                        entity_restrict: (window.actors.requester.length === 0 && is_new_item) ? -1 : {{ entities_id }},
+                        users_right: '{{ (users_right ?? 'all')|e('js') }}',
+                        entity_restrict: (window.actors.requester.length === 0 && is_new_item) ? -1 : {{ entities_id|json_encode|raw }},
                         searchText: params.term,
-                        _idor_token: '{{ idor_token(item.getType(), {'users_right': users_right ?? 'all'}) }}',
-                        itiltemplate_class: '{{ itiltemplate.getType() }}',
-                        itiltemplates_id: {{ itiltemplate.fields['id'] ?? 0 }},
-                        itemtype: '{{ item.getType() }}',
-                        items_id: {{ item.isNewItem() ? -1 : item.fields['id'] }},
+                        _idor_token: '{{ idor_token(item.getType(), {'users_right': users_right ?? 'all'})|e('js') }}',
+                        itiltemplate_class: '{{ itiltemplate.getType()|e('js') }}',
+                        itiltemplates_id: {{ (itiltemplate.fields['id'] ?? 0)|json_encode|raw }},
+                        itemtype: '{{ item.getType()|e('js') }}',
+                        items_id: {{ (item.isNewItem() ? -1 : item.fields['id'])|json_encode|raw }},
                         item: {{ safe_item_fields|json_encode|raw }},
-                        returned_itemtypes: {{ (returned_itemtypes ?? ['User', 'Group', 'Supplier'])|json_encode()|raw }},
+                        returned_itemtypes: {{ (returned_itemtypes ?? ['User', 'Group', 'Supplier'])|json_encode|raw }},
                         page: params.page || 1
                     };
                 },
@@ -416,10 +418,10 @@
         }, {capture: true})
 
         {% if itiltemplate.isHiddenField('_users_id_' ~ actortype) %}
-        $(".actor_entry[data-itemtype=\"User\"][data-actortype=\"{{ actortype }}\"]").parent().css("display", "none");
+        $(".actor_entry[data-itemtype=\"User\"][data-actortype=\"{{ actortype|e('css')|e('js') }}\"]").parent().css("display", "none");
         {% endif %}
         {% if itiltemplate.isHiddenField('_groups_id_' ~ actortype) %}
-        $(".actor_entry[data-itemtype=\"Group\"][data-actortype=\"{{ actortype }}\"]").parent().css("display", "none");
+        $(".actor_entry[data-itemtype=\"Group\"][data-actortype=\"{{ actortype|e('css')|e('js') }}\"]").parent().css("display", "none");
         {% endif %}
     </script>
 {% endif %}

--- a/templates/components/itilobject/actors/main.html.twig
+++ b/templates/components/itilobject/actors/main.html.twig
@@ -226,11 +226,11 @@
          {{ actortype }}: [
             {% for actor in item.getActorsForType(actortypeint, params) %}
             {
-               itemtype: "{{ actor['itemtype'] }}",
-               items_id: "{{ actor['items_id'] }}",
+               itemtype: "{{ actor['itemtype']|e('js') }}",
+               items_id: "{{ actor['items_id']|e('js') }}",
                use_notification: {{ (actor['use_notification'] ?? false) ? "1" : "0" }},
-               alternative_email: "{{ actor['alternative_email'] ?? '' }}",
-               default_email: "{{ actor['default_email'] ?? '' }}",
+               alternative_email: "{{ (actor['alternative_email'] ?? '')|e('js') }}",
+               default_email: "{{ (actor['default_email'] ?? '')|e('js') }}",
             },
             {% endfor %}
          ],
@@ -298,7 +298,7 @@
          fa_class = "fas";
       }
 
-      var actor_entry = $('.actor_entry[data-itemtype='+actor.itemtype+'][data-items-id='+actor.items_id+'][data-actortype='+actortype+']')
+      var actor_entry = $('.actor_entry[data-itemtype='+CSS.escape(actor.itemtype)+'][data-items-id='+parseInt(actor.items_id)+'][data-actortype='+CSS.escape(actortype)+']')
          .filter(function() {
             if(actor.items_id == 0 && actor.itemtype == "User") {
                return $(this).text().trim() === actor.alternative_email;

--- a/templates/components/itilobject/fields/global_validation.html.twig
+++ b/templates/components/itilobject/fields/global_validation.html.twig
@@ -30,6 +30,8 @@
  # ---------------------------------------------------------------------
  #}
 
+{% set rand = rand|default(random())|safe_dom_id %}
+
 {% import 'components/form/fields_macros.html.twig' as fields %}
 
 {% set validation = item.getValidationClassInstance() %}

--- a/templates/components/itilobject/fields/priority_matrix.html.twig
+++ b/templates/components/itilobject/fields/priority_matrix.html.twig
@@ -116,7 +116,7 @@
 $(function() {
    $('#dropdown_urgency{{ rand }}, #dropdown_impact{{ rand }}').on('change.select2', function (e) {
       $.ajax({
-         url: "{{ path('/ajax/priority.php') }}",
+         url: `${CFG_GLPI.root_doc}/ajax/priority.php`,
          datatype: 'json',
          data: {
             'urgency': $('#dropdown_urgency{{ rand }}').select2('data') ? $('#dropdown_urgency{{ rand }}').select2('data')[0].id : 0,

--- a/templates/components/itilobject/footer.html.twig
+++ b/templates/components/itilobject/footer.html.twig
@@ -174,7 +174,7 @@
 
                         <button class="btn btn-outline-danger btn-square" type="submit" name="purge" form="itil-form"
                               title="{{ _x('button', 'Delete permanently') }}"
-                              onclick="return confirm('{{ __('Confirm the final deletion?') }}');">
+                              onclick="return confirm('{{ __('Confirm the final deletion?')|e('js') }}');">
                            <i class="ti ti-trash"></i>
                            <span class="d-none d-lg-block">{{ _x('button', 'Delete permanently') }}</span>
                         </button>

--- a/templates/components/itilobject/timeline/form_followup.html.twig
+++ b/templates/components/itilobject/timeline/form_followup.html.twig
@@ -256,7 +256,7 @@
 
                   {% if subitem.can(subitem.fields['id'], constant('PURGE')) %}
                      <button class="btn btn-outline-danger me-2" type="submit" name="purge"
-                             onclick="return confirm('{{ __('Confirm the final deletion?') }}');">
+                             onclick="return confirm('{{ __('Confirm the final deletion?')|e('js') }}');">
                         <i class="ti ti-trash"></i>
                         <span>{{ _x('button', 'Delete permanently') }}</span>
                      </button>
@@ -272,12 +272,12 @@
       <script type="text/javascript">
          function itilfollowuptemplate_update{{ rand }}(value) {
             $.ajax({
-               url: '{{ path('/ajax/itilfollowup.php') }}',
+               url: `${CFG_GLPI.root_doc}/ajax/itilfollowup.php`,
                type: 'POST',
                data: {
                   itilfollowuptemplates_id: value,
-                  items_id: '{{ item.fields['id'] }}',
-                  itemtype: '{{ item.getType() }}'
+                  items_id: '{{ item.fields['id']|e('js') }}',
+                  itemtype: '{{ item.getType()|e('js') }}'
                }
             }).done(function (data) {
                var requesttypes_id = isNaN(parseInt(data.requesttypes_id))

--- a/templates/components/itilobject/timeline/form_solution.html.twig
+++ b/templates/components/itilobject/timeline/form_solution.html.twig
@@ -41,7 +41,7 @@
 {% set nokb = params['nokb'] is defined or (params['nokb'] ?? false) == true %}
 {% set noform = params['noform'] is defined or (params['noform'] ?? false) == true %}
 {% set disabled = (candedit == false) %}
-{% set rand = rand|default(random()) %}
+{% set rand = rand|default(random())|safe_dom_id %}
 
 {% set content_field_id = 'solution_content_' ~ rand %}
 
@@ -243,12 +243,12 @@
       <script type="text/javascript">
          function solutiontemplate_update{{ rand }}(value) {
             $.ajax({
-               url: '{{ path('/ajax/solution.php') }}',
+               url: `${CFG_GLPI.root_doc}/ajax/solution.php`,
                type: 'POST',
                data: {
                   solutiontemplates_id: value,
-                  items_id: '{{ item.fields['id'] }}',
-                  itemtype: '{{ item.getType() }}'
+                  items_id: '{{ item.fields['id']|e('js') }}',
+                  itemtype: '{{ item.getType()|e('js') }}'
                }
             }).done(function (data) {
                // set textarea content

--- a/templates/components/itilobject/timeline/form_task.html.twig
+++ b/templates/components/itilobject/timeline/form_task.html.twig
@@ -123,11 +123,11 @@
 
       <script type="text/javascript">
          function change_task_state(tasks_id, target) {
-            $.post('{{ path('/ajax/timeline.php') }}',
+            $.post(`${CFG_GLPI.root_doc}/ajax/timeline.php`,
                {'action':     'change_task_state',
                   'tasks_id':   tasks_id,
-                  'parenttype': '{{ item.getType() }}',
-                  '{{ item.getForeignKeyField() }}': {{ item.fields.id }}
+                  'parenttype': '{{ item.getType()|e('js') }}',
+                  '{{ item.getForeignKeyField()|e('js') }}': {{ item.fields.id|json_encode|raw }}
                })
                .done(function(response) {
                   $(target).closest('.timeline-item').find('.state')
@@ -156,12 +156,12 @@
       <script type="text/javascript">
          function itiltasktemplate_update{{ rand }}(value) {
             $.ajax({
-               url: '{{ path('/ajax/task.php') }}',
+               url: `${CFG_GLPI.root_doc}/ajax/task.php`,
                type: 'POST',
                data: {
                   tasktemplates_id: value,
-                  items_id: '{{ item.fields['id'] }}',
-                  itemtype: '{{ item.getType() }}'
+                  items_id: '{{ item.fields['id']|e('js') }}',
+                  itemtype: '{{ item.getType()|e('js') }}'
                }
             }).done(function (data) {
                 if (data.content !== undefined) {

--- a/templates/components/itilobject/timeline/form_task_main_form.html.twig
+++ b/templates/components/itilobject/timeline/form_task_main_form.html.twig
@@ -39,7 +39,7 @@
 ) %}
 {% set can_update_kb = can_update_kb|default(has_profile_right('knowbase', constant('UPDATE'))) %}
 {% set nokb = nokb|default(params['nokb'] is defined or (params['nokb'] ?? false) == true) %}
-{% set rand = rand|default(random()) %}
+{% set rand = rand|default(random())|safe_dom_id %}
 {% set formoptions = formoptions|default(params['formoptions'] ?? '') %}
 
 {# In some cases, we may already have an HTML form (massive actions) #}
@@ -253,20 +253,20 @@
                 <script type="text/javascript">
                     function showPlanUpdate{{ rand }}(e) {
                         $('#plan{{ rand }}').hide();
-                        $('#dropdown_state{{ rand }}').trigger('setValue', {{ session('glpiplanned_task_state') }});
-                        $('#viewplan{{ rand }}').load('{{ path('/ajax/planning.php') }}', {
+                        $('#dropdown_state{{ rand }}').trigger('setValue', {{ session('glpiplanned_task_state')|json_encode|raw }});
+                        $('#viewplan{{ rand }}').load(`${CFG_GLPI.root_doc}/ajax/planning.php`, {
                             action: "add_event_classic_form",
                             form: "followups", // Was followups for tasks before. Can't find where this is used.
-                            entity: {{ item.fields.entities_id }},
+                            entity: {{ item.fields.entities_id|json_encode|raw }},
                             rand_user: {{ random() }},
                             rand_group: {{ random() }},
-                            itemtype: "{{ subitem.type }}",
-                            items_id: {{ subitem.fields.id|default(-1) }},
-                            parent_itemtype: "{{ item.getType() }}",
-                            parent_items_id: {{ item.fields.id is empty ? 0 : item.fields.id }},
-                            parent_fk_field: "{{ item.getForeignKeyField() }}",
-                            begin: "{{ subitem.fields['begin'] }}",
-                            end: "{{ subitem.fields['end'] }}",
+                            itemtype: "{{ subitem.type|e('js') }}",
+                            items_id: {{ subitem.fields.id|default(-1)|json_encode|raw }},
+                            parent_itemtype: "{{ item.getType()|e('js') }}",
+                            parent_items_id: {{ (item.fields.id is empty ? 0 : item.fields.id)|json_encode|raw }},
+                            parent_fk_field: "{{ item.getForeignKeyField()|e('js') }}",
+                            begin: "{{ subitem.fields['begin']|e('js') }}",
+                            end: "{{ subitem.fields['end']|e('js') }}",
                         });
                     }
                 </script>
@@ -276,7 +276,7 @@
                         showPlanUpdate{{ rand }}();
                     </script>
                     <button id="unplan{{ rand }}" class="btn btn-outline-warning" type="submit" name="unplan"
-                            onclick="return confirm('{{ __('Confirm the deletion of planning?') }}');">
+                            onclick="return confirm('{{ __('Confirm the deletion of planning?')|e('js') }}');">
                         <i class="fas ti ti-calendar-off"></i>
                         <span>{{ __('Unplan') }}</span>
                     </button>
@@ -361,7 +361,7 @@
 
             {% if subitem.can(subitem.fields['id'], constant('PURGE')) %}
                 <button class="btn btn-outline-danger me-2" type="submit" name="purge"
-                        onclick="return confirm('{{ __('Confirm the final deletion?') }}');">
+                        onclick="return confirm('{{ __('Confirm the final deletion?')|e('js') }}');">
                 <i class="ti ti-trash"></i>
                 <span>{{ _x('button', 'Delete permanently') }}</span>
                 </button>

--- a/templates/components/itilobject/timeline/form_validation.html.twig
+++ b/templates/components/itilobject/timeline/form_validation.html.twig
@@ -33,6 +33,7 @@
 {% extends 'components/itilobject/timeline/form_timeline_item.html.twig' %}
 {% import 'components/form/fields_macros.html.twig' as fields %}
 
+{% set rand = rand|default(random())|safe_dom_id %}
 {% set params = params|default({}) %}
 
 {% block timeline_card %}
@@ -311,7 +312,7 @@
 
                     {% if subitem.can(subitem.fields['id'], constant('PURGE')) %}
                         <button class="btn btn-outline-danger me-2" type="submit" name="purge"
-                                onclick="return confirm('{{ __('Confirm the final deletion?') }}');">
+                                onclick="return confirm('{{ __('Confirm the final deletion?')|e('js') }}');">
                             <i class="ti ti-trash"></i>
                             <span>{{ _x('button', 'Delete permanently') }}</span>
                         </button>
@@ -332,12 +333,12 @@
          // --- fill form with template data
          function itilvalidationtemplate_update{{ rand }}(value) {
             $.ajax({
-               url: '{{ path('/ajax/itilvalidation.php') }}',
+               url: `${CFG_GLPI.root_doc}/ajax/itilvalidation.php`,
                type: 'POST',
                data: {
                   validationtemplates_id: value,
-                  items_id: '{{ item.fields['id'] }}',
-                  itemtype: '{{ item.getType() }}'
+                  items_id: '{{ item.fields['id']|e('js') }}',
+                  itemtype: '{{ item.getType()|e('js') }}'
                }
             }).done(function (data) {
                if (data.content !== undefined) {

--- a/templates/components/itilobject/timeline/timeline.html.twig
+++ b/templates/components/itilobject/timeline/timeline.html.twig
@@ -118,13 +118,13 @@
             <div class="col-auto todo-list-state {{ 'left' in item_position ? 'ms-auto order-sm-last' : '' }}">
                {% if entry_state is constant('Planning::TODO') %}
                   {% if can_edit_i %}
-                     <span class="state state_1" onclick="change_task_state({{ entry_i['id'] }}, this)" title="{{ __('To do') }}"></span>
+                     <span class="state state_1" onclick="change_task_state({{ entry_i['id']|json_encode|raw }}, this)" title="{{ __('To do') }}"></span>
                   {% else %}
                      <span class="state state_1" title="{{ __('To do') }}" style="cursor: not-allowed;"></span>
                   {% endif %}
                {% elseif entry_state is constant('Planning::DONE') %}
                   {% if can_edit_i %}
-                     <span class="state state_2" onclick="change_task_state({{ entry_i['id'] }}, this)" title="{{ __('Done') }}"></span>
+                     <span class="state state_2" onclick="change_task_state({{ entry_i['id']|json_encode|raw }}, this)" title="{{ __('Done') }}"></span>
                   {% else %}
                      <span class="state state_2" title="{{ __('Done') }}" style="cursor: not-allowed;"></span>
                   {% endif %}

--- a/templates/components/notepad/form.html.twig
+++ b/templates/components/notepad/form.html.twig
@@ -128,7 +128,7 @@
 
                             <span>
                                 <button class="btn btn-sm btn-ghost-danger delete-note" name="purge" type="submit" value="1"
-                                        onclick="return confirm('{{ __('Confirm the final deletion?') }}');"
+                                        onclick="return confirm('{{ __('Confirm the final deletion?')|e('js') }}');"
                                         data-id="{{ id }}">
                                     <i class="ti ti-trash"></i>
                                     <span>{{ __('Delete') }}</span>
@@ -193,7 +193,7 @@
 
                                     <div class="modal-footer">
                                         <button class="btn btn-outline-danger" type="submit" name="purge" value="1"
-                                                onclick="return confirm('{{ __('Confirm the final deletion?') }}');"
+                                                onclick="return confirm('{{ __('Confirm the final deletion?')|e('js') }}');"
                                                 data-bs-toggle="tooltip" data-bs-position="top"
                                                 title="{{ _x('button', 'Delete permanently') }}">
                                             <i class="ti ti-trash"></i>

--- a/templates/components/search/table.html.twig
+++ b/templates/components/search/table.html.twig
@@ -48,7 +48,7 @@
                <div>
                   <input class="form-check-input massive_action_checkbox" type="checkbox" id="checkall_{{ rand }}"
                         value="" aria-label="{{ __('Check all as') }}"
-                        onclick="checkAsCheckboxes(this, '{{ searchform_id }}', '.massive_action_checkbox');"
+                        onclick="checkAsCheckboxes(this, '{{ searchform_id|e('js') }}', '.massive_action_checkbox');"
                         form="{{ massive_action_form_id }}" />
                </div>
             </th>

--- a/templates/pages/admin/log_viewer.html.twig
+++ b/templates/pages/admin/log_viewer.html.twig
@@ -100,7 +100,7 @@
                     <button type="submit" name="action" value="empty"
                             class="btn btn-outline-secondary"
                             title="{{ __("Empty file") }}"
-                            onclick="return confirm('{{ __("Are you sure you want to clear this file?") }}')"
+                            onclick="return confirm('{{ __("Are you sure you want to clear this file?")|e('js') }}')"
                             data-bs-toggle="tooltip" data-bs-placement="bottom">
                         <i class="ti ti-file-off" aria-hidden="true"></i>
                     </button>
@@ -109,7 +109,7 @@
                     <button type="submit" name="action" value="delete"
                             class="btn btn-outline-secondary"
                             title="{{ __("Delete file") }}"
-                            onclick="return confirm('{{ __("Are you sure you want to delete this file?") }}')"
+                            onclick="return confirm('{{ __("Are you sure you want to delete this file?")|e('js') }}')"
                             data-bs-toggle="tooltip" data-bs-placement="bottom">
                         <i class="ti ti-trash-x" aria-hidden="true"></i>
                     </button>

--- a/templates/pages/admin/logs_list.html.twig
+++ b/templates/pages/admin/logs_list.html.twig
@@ -123,7 +123,7 @@
                                                         <button type="submit" name="action" value="empty"
                                                                      class="dropdown-item"
                                                                      title="{{ __("Empty file") }}"
-                                                                     onclick="return confirm('{{ __("Are you sure you want to clear this file?") }}')"
+                                                                     onclick="return confirm('{{ __("Are you sure you want to clear this file?")|e('js') }}')"
                                                                      data-bs-toggle="tooltip" data-bs-placement="bottom">
                                                             <i class="ti ti-file-off" aria-hidden="true"></i>
                                                             <span>{{ __("Empty file") }}</span>
@@ -135,7 +135,7 @@
                                                         <button type="submit" name="action" value="delete"
                                                                      class="dropdown-item"
                                                                      title="{{ __("Empty file") }}"
-                                                                     onclick="return confirm('{{ __("Are you sure you want to delete this file?") }}')"
+                                                                     onclick="return confirm('{{ __("Are you sure you want to delete this file?")|e('js') }}')"
                                                                      data-bs-toggle="tooltip" data-bs-placement="bottom">
                                                             <i class="ti ti-trash-x" aria-hidden="true"></i>
                                                             <span>{{ __("Delete file") }}</span>

--- a/templates/pages/assets/template_list.html.twig
+++ b/templates/pages/assets/template_list.html.twig
@@ -44,7 +44,7 @@
                     {% if template['can_delete'] %}
                         <input type="hidden" name="id" value="{{ template['id'] }}">
                         <button class="btn btn-danger me-2" type="submit" name="purge" value="1"
-                                onclick="return confirm('{{ __('Confirm the final deletion?') }}');">
+                                onclick="return confirm('{{ __('Confirm the final deletion?')|e('js') }}');">
                             <i class="ti ti-trash"></i>
                             <span>{{ _x('button', 'Delete permanently') }}</span>
                         </button>

--- a/templates/pages/tools/reminder.html.twig
+++ b/templates/pages/tools/reminder.html.twig
@@ -30,6 +30,8 @@
  # ---------------------------------------------------------------------
  #}
 
+{% set rand = rand|default(random())|safe_dom_id %}
+
 {% extends "generic_show_form.html.twig" %}
 {% import 'components/form/fields_macros.html.twig' as fields %}
 {% import 'components/form/basic_inputs_macros.html.twig' as inputs %}


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

This PR enforces the escaping in JS scripts, mainly for CSS selectors and JS/HTML concatenations. While this can prevent potential XSS and CSS selectors hijacking, I did not find any path to exploit them.

It also fixes potential invalid JS syntax issues with unexpected values.