### PR TITLE
xywh attributes are missing when equals 0 on gridstack

### DIFF
--- a/js/modules/Dashboard/Dashboard.js
+++ b/js/modules/Dashboard/Dashboard.js
@@ -374,9 +374,9 @@ class GLPIDashboard {
                     dashboard:    this.current_name,
                     gridstack_id: item.attr('gs-id'),
                     card_id:      card_opt.card_id,
-                    x:            item.attr('gs-x'),
-                    y:            item.attr('gs-y'),
-                    width:        item.attr('gs-w'),
+                    x:            item.attr('gs-x') ?? 0,
+                    y:            item.attr('gs-y') ?? 0,
+                    width:        item.attr('gs-w') ?? 1,
                     height:       item.attr('gs-h') ?? 1,
                     card_options: card_opt,
                 },
@@ -759,8 +759,8 @@ class GLPIDashboard {
             return gs_id ? {
                 gridstack_id: $(v).attr('gs-id'),
                 card_id: options.card_id,
-                x: $(v).attr('gs-x'),
-                y: $(v).attr('gs-y'),
+                x: $(v).attr('gs-x') ?? 0,
+                y: $(v).attr('gs-y') ?? 0,
                 width: $(v).attr('gs-w'),
                 height: $(v).attr('gs-h') ?? 1,
                 card_options: options

--- a/src/Glpi/Dashboard/Item.php
+++ b/src/Glpi/Dashboard/Item.php
@@ -69,6 +69,13 @@ class Item extends CommonDBChild
         foreach ($di_iterator as $item) {
             unset($item['id']);
             $item['card_options'] = importArrayFromDB($item['card_options']);
+
+            // [x,y, width, height] may have been nulled in DB
+            $item['x']      = (int) ($item['x'] ?? 0);
+            $item['y']      = (int) ($item['y'] ?? 0);
+            $item['width']  = (int) ($item['width'] ?? 0);
+            $item['height'] = (int) ($item['height'] ?? 0);
+
             $items[] = $item;
         }
 


### PR DESCRIPTION
## Description

- [x,y,w,h] are not present anymore in gridstack items when equal to 0 (why ?) and so saving set the data to null in DB

probably fix #21239

