### PR TITLE
Prevent empty form translations for question default values

### DIFF
--- a/src/Glpi/Form/QuestionType/QuestionTypeShortText.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeShortText.php
@@ -80,12 +80,17 @@ final class QuestionTypeShortText extends AbstractQuestionTypeShortAnswer implem
     #[Override]
     public function listTranslationsHandlers(Question $question): array
     {
+        $default_value = $question->fields['default_value'] ?? '';
+        if (empty($default_value)) {
+            return [];
+        }
+
         return [
             new TranslationHandler(
                 item: $question,
                 key: Question::TRANSLATION_KEY_DEFAULT_VALUE,
                 name: __('Default value'),
-                value: $question->fields['default_value'] ?? '',
+                value: $default_value,
             ),
         ];
     }


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Some question default values were added to the translations even if empty:
<img width="1179" height="432" alt="image" src="https://github.com/user-attachments/assets/d84c79cc-fe76-416d-a8e6-2101c1a2bd46" />



