### PR TITLE
Add custom mandatory message of number question

### DIFF
--- a/src/Glpi/Form/AnswersHandler/AnswersHandler.php
+++ b/src/Glpi/Form/AnswersHandler/AnswersHandler.php
@@ -46,6 +46,7 @@ use Glpi\Form\DelegationData;
 use Glpi\Form\Destination\AnswersSet_FormDestinationItem;
 use Glpi\Form\Destination\FormDestination;
 use Glpi\Form\Form;
+use Glpi\Form\QuestionType\CustomMandatoryMessageInterface;
 use Glpi\Form\Section;
 use Glpi\Form\ValidationResult;
 use Throwable;
@@ -113,7 +114,12 @@ final class AnswersHandler
                 || (is_string($answers[$question->getID()]) && empty(strip_tags($answers[$question->getID()])))
                 || (isset($answers[$question->getID()]['items_id']) && empty($answers[$question->getID()]['items_id']))
             ) {
-                $result->addError($question, __('This field is mandatory'));
+                $message = __('This field is mandatory');
+                $type = $question->getQuestionType();
+                if ($type instanceof CustomMandatoryMessageInterface) {
+                    $message = $type->getCustomMandatoryErrorMessage();
+                }
+                $result->addError($question, $message);
             }
         }
 

--- a/src/Glpi/Form/QuestionType/CustomMandatoryMessageInterface.php
+++ b/src/Glpi/Form/QuestionType/CustomMandatoryMessageInterface.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Form\QuestionType;
+
+interface CustomMandatoryMessageInterface
+{
+    public function getCustomMandatoryErrorMessage(): string;
+}

--- a/src/Glpi/Form/QuestionType/QuestionTypeNumber.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeNumber.php
@@ -40,7 +40,7 @@ use Glpi\Form\Condition\ConditionHandler\NumberConditionHandler;
 use Glpi\Form\Condition\UsedAsCriteriaInterface;
 use Override;
 
-final class QuestionTypeNumber extends AbstractQuestionTypeShortAnswer implements UsedAsCriteriaInterface
+final class QuestionTypeNumber extends AbstractQuestionTypeShortAnswer implements UsedAsCriteriaInterface, CustomMandatoryMessageInterface
 {
     #[Override]
     public function getInputType(): string
@@ -77,5 +77,19 @@ final class QuestionTypeNumber extends AbstractQuestionTypeShortAnswer implement
         ?JsonFieldInterface $question_config
     ): array {
         return array_merge(parent::getConditionHandlers($question_config), [new NumberConditionHandler()]);
+    }
+
+    #[Override]
+    public function getCustomMandatoryErrorMessage(): string
+    {
+        // On some browsers, filling text into a `number` input is allowed but
+        // the payload will be an empty string on the backend.
+        // In this case, the default mandatory message is not clear for the
+        // user because the input is filled on the client.
+        // The server has no idea this is the case because it receives an
+        // empty string.
+        // The simplest way to deal with this is to use a generic message that
+        // work for both cases (missing or wrong value).
+        return __('Please enter a valid number');
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Before:
<img width="356" height="177" alt="image" src="https://github.com/user-attachments/assets/2030483c-350f-4f33-9ac0-0ef1d03056b8" />

After:
<img width="354" height="173" alt="image" src="https://github.com/user-attachments/assets/982d48a1-a744-49b8-b959-eaabb0ffdf3e" />

Why? Because some browser deal with the `number` input type in strange ways.
On Firefox, the user is allowed to enter invalid chars but the value is replaced by an empty string when sent to the server.
This mean the backend think the answer is empty.

With this in mind, the simplest solution is to use a generic error message that works both for empty and missing values.



