### PR TITLE
feat(forms): Allow plugins to define their own destination config fields

### DIFF
--- a/src/Glpi/Form/Destination/AbstractCommonITILFormDestination.php
+++ b/src/Glpi/Form/Destination/AbstractCommonITILFormDestination.php
@@ -295,7 +295,7 @@ abstract class AbstractCommonITILFormDestination implements FormDestinationInter
     {
         $template_class = $this->getTarget()->getTemplateClass();
 
-        return [
+        $core_fields = [
             new TitleField(),
             new ContentField(),
             new TemplateField($template_class),
@@ -313,6 +313,12 @@ abstract class AbstractCommonITILFormDestination implements FormDestinationInter
             new AssigneeField(),
             new LinkedITILObjectsField(),
         ];
+
+        // Add plugin config fields specific to this destination type
+        $plugin_fields = FormDestinationManager::getInstance()
+            ->getPluginConfigFieldsForDestination(static::class);
+
+        return array_merge($core_fields, $plugin_fields);
     }
 
     /**

--- a/src/Glpi/Form/Destination/AbstractCommonITILFormDestination.php
+++ b/src/Glpi/Form/Destination/AbstractCommonITILFormDestination.php
@@ -314,9 +314,9 @@ abstract class AbstractCommonITILFormDestination implements FormDestinationInter
             new LinkedITILObjectsField(),
         ];
 
-        // Add plugin config fields specific to this destination type
+        // Add plugin config fields specific to this common ITIL destination type
         $plugin_fields = FormDestinationManager::getInstance()
-            ->getPluginConfigFieldsForDestination(static::class);
+            ->getPluginCommonITILConfigFields(static::class);
 
         return array_merge($core_fields, $plugin_fields);
     }

--- a/src/Glpi/Form/Destination/FormDestinationManager.php
+++ b/src/Glpi/Form/Destination/FormDestinationManager.php
@@ -49,10 +49,10 @@ final class FormDestinationManager
     private array $plugins_destinations_types = [];
 
     /**
-     * @var array<class-string<FormDestinationInterface>, AbstractConfigField[]>
-     * Mapping of destination types to their additional config fields
+     * @var array<class-string<AbstractCommonITILFormDestination>, AbstractConfigField[]>
+     * Mapping of common ITIL destination types to their additional config fields
      */
-    private array $plugins_config_fields = [];
+    private array $plugins_common_itil_config_fields = [];
 
     /**
      * Private constructor (singleton)
@@ -153,36 +153,36 @@ final class FormDestinationManager
     }
 
     /**
-     * Register a config field from a plugin for a specific destination type
+     * Register a config field from a plugin for a specific common ITIL destination type
      *
-     * @param class-string<FormDestinationInterface> $destination_class The destination class
+     * @param class-string<AbstractCommonITILFormDestination> $destination_class The common ITIL destination class
      * @param AbstractConfigField $field The config field to register
      * @return void
      */
-    public function registerPluginConfigField(
+    public function registerPluginCommonITILConfigField(
         string $destination_class,
         AbstractConfigField $field
     ): void {
-        if (!isset($this->plugins_config_fields[$destination_class])) {
-            $this->plugins_config_fields[$destination_class] = [];
+        if (!isset($this->plugins_common_itil_config_fields[$destination_class])) {
+            $this->plugins_common_itil_config_fields[$destination_class] = [];
         }
-        $this->plugins_config_fields[$destination_class][] = $field;
+        $this->plugins_common_itil_config_fields[$destination_class][] = $field;
     }
 
     /**
-     * Get all registered plugin config fields for a specific destination type
+     * Get all registered plugin config fields for a specific common ITIL destination type
      *
-     * @param class-string<FormDestinationInterface> $destination_class The destination class
+     * @param class-string<AbstractCommonITILFormDestination> $destination_class The common ITIL destination class
      * @return AbstractConfigField[]
      */
-    public function getPluginConfigFieldsForDestination(string $destination_class): array
+    public function getPluginCommonITILConfigFields(string $destination_class): array
     {
         $config_fields = [];
-        foreach (array_keys($this->plugins_config_fields) as $dest_class) {
+        foreach (array_keys($this->plugins_common_itil_config_fields) as $dest_class) {
             if (is_a($destination_class, $dest_class, true)) {
                 $config_fields = array_merge(
                     $config_fields,
-                    $this->plugins_config_fields[$dest_class]
+                    $this->plugins_common_itil_config_fields[$dest_class]
                 );
             }
         }

--- a/src/Glpi/Form/Destination/FormDestinationManager.php
+++ b/src/Glpi/Form/Destination/FormDestinationManager.php
@@ -49,6 +49,12 @@ final class FormDestinationManager
     private array $plugins_destinations_types = [];
 
     /**
+     * @var array<class-string<FormDestinationInterface>, AbstractConfigField[]>
+     * Mapping of destination types to their additional config fields
+     */
+    private array $plugins_config_fields = [];
+
+    /**
      * Private constructor (singleton)
      */
     private function __construct() {}
@@ -144,5 +150,43 @@ final class FormDestinationManager
         FormDestinationInterface $type
     ): void {
         $this->plugins_destinations_types[] = $type;
+    }
+
+    /**
+     * Register a config field from a plugin for a specific destination type
+     *
+     * @param class-string<FormDestinationInterface> $destination_class The destination class
+     * @param AbstractConfigField $field The config field to register
+     * @return void
+     */
+    public function registerPluginConfigField(
+        string $destination_class,
+        AbstractConfigField $field
+    ): void {
+        if (!isset($this->plugins_config_fields[$destination_class])) {
+            $this->plugins_config_fields[$destination_class] = [];
+        }
+        $this->plugins_config_fields[$destination_class][] = $field;
+    }
+
+    /**
+     * Get all registered plugin config fields for a specific destination type
+     *
+     * @param class-string<FormDestinationInterface> $destination_class The destination class
+     * @return AbstractConfigField[]
+     */
+    public function getPluginConfigFieldsForDestination(string $destination_class): array
+    {
+        $config_fields = [];
+        foreach (array_keys($this->plugins_config_fields) as $dest_class) {
+            if (is_a($destination_class, $dest_class, true)) {
+                $config_fields = array_merge(
+                    $config_fields,
+                    $this->plugins_config_fields[$dest_class]
+                );
+            }
+        }
+
+        return $config_fields;
     }
 }

--- a/tests/cypress/e2e/form/form_plugins.cy.js
+++ b/tests/cypress/e2e/form/form_plugins.cy.js
@@ -117,4 +117,23 @@ describe('Form plugins', () => {
             "My computer name"
         );
     });
+
+    it('can configure destination config field from plugins', () => {
+        // Create and go to form
+        cy.createFormWithAPI().visitFormTab('Destinations');
+
+        // Add external ID field
+        cy.openAccordionItem('Destination fields accordion', 'Properties');
+        cy.findByRole('region', { 'name': 'External ID configuration' }).as("config");
+        cy.get('@config').getDropdownByLabelText('External ID').selectDropdownValue('Specific external ID');
+        cy.get('@config').findAllByRole('textbox', {name: 'Specific external ID'}).eq(-1).type("MY-EXTERNAL-ID");
+
+        // Save
+        cy.findByRole('button', {name: 'Update item'}).click();
+
+        // Validate value was saved
+        cy.openAccordionItem('Destination fields accordion', 'Properties');
+        cy.get('@config').getDropdownByLabelText('External ID').should('have.text', 'Specific external ID');
+        cy.get('@config').findAllByRole('textbox', {name: 'Specific external ID'}).eq(-1).should('have.value', "MY-EXTERNAL-ID");
+    });
 });

--- a/tests/fixtures/plugins/tester/setup.php
+++ b/tests/fixtures/plugins/tester/setup.php
@@ -107,7 +107,7 @@ function plugin_init_tester(): void
     $destination_manager->registerPluginDestinationType(new ComputerDestination());
 
     // Register destination config field
-    $destination_manager->registerPluginConfigField(
+    $destination_manager->registerPluginCommonITILConfigField(
         FormDestinationTicket::class,
         new ExternalIDField()
     );

--- a/tests/fixtures/plugins/tester/setup.php
+++ b/tests/fixtures/plugins/tester/setup.php
@@ -34,6 +34,7 @@
 
 use Glpi\Form\AccessControl\FormAccessControlManager;
 use Glpi\Form\Destination\FormDestinationManager;
+use Glpi\Form\Destination\FormDestinationTicket;
 use Glpi\Form\QuestionType\QuestionTypesManager;
 use Glpi\Form\ServiceCatalog\HomeSearchManager;
 use Glpi\Form\ServiceCatalog\ServiceCatalogManager;
@@ -44,6 +45,7 @@ use GlpiPlugin\Tester\Form\CustomTile;
 use GlpiPlugin\Tester\Form\DayOfTheWeekPolicy;
 use GlpiPlugin\Tester\Form\QuestionTypeRange;
 use GlpiPlugin\Tester\Form\QuestionTypeColor;
+use GlpiPlugin\Tester\Form\ExternalIDField;
 use GlpiPlugin\Tester\Form\TesterCategory;
 use GlpiPlugin\Tester\MyPsr4Class;
 
@@ -103,6 +105,12 @@ function plugin_init_tester(): void
     // Register destination type
     $destination_manager = FormDestinationManager::getInstance();
     $destination_manager->registerPluginDestinationType(new ComputerDestination());
+
+    // Register destination config field
+    $destination_manager->registerPluginConfigField(
+        FormDestinationTicket::class,
+        new ExternalIDField()
+    );
 
     // Register custom tiles types
     $tiles_manager = TilesManager::getInstance();

--- a/tests/fixtures/plugins/tester/src/Form/ExternalIDField.php
+++ b/tests/fixtures/plugins/tester/src/Form/ExternalIDField.php
@@ -1,0 +1,161 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace GlpiPlugin\Tester\Form;
+
+use Glpi\Application\View\TemplateRenderer;
+use Glpi\DBAL\JsonFieldInterface;
+use Glpi\Form\AnswersSet;
+use Glpi\Form\Destination\AbstractConfigField;
+use Glpi\Form\Destination\CommonITILField\Category;
+use Glpi\Form\Destination\FormDestination;
+use Glpi\Form\Form;
+use Glpi\Form\QuestionType\QuestionTypeShortText;
+use InvalidArgumentException;
+use Override;
+
+final class ExternalIDField extends AbstractConfigField
+{
+    #[Override]
+    public function getLabel(): string
+    {
+        return __('External ID');
+    }
+
+    #[Override]
+    public function getConfigClass(): string
+    {
+        return ExternalIDFieldConfig::class;
+    }
+
+    #[Override]
+    public function getWeight(): int
+    {
+        return 1000;
+    }
+
+    #[Override]
+    public function getCategory(): Category
+    {
+        return Category::PROPERTIES;
+    }
+
+    #[Override]
+    public function getDefaultConfig(Form $form): ExternalIDFieldConfig
+    {
+        return new ExternalIDFieldConfig(
+            ExternalIDFieldStrategy::NO_EXTERNAL_ID
+        );
+    }
+
+    #[Override]
+    public function renderConfigForm(
+        Form $form,
+        FormDestination $destination,
+        JsonFieldInterface $config,
+        string $input_name,
+        array $display_options
+    ): string {
+        if (!$config instanceof ExternalIDFieldConfig) {
+            throw new InvalidArgumentException("Unexpected config class");
+        }
+
+        $twig = TemplateRenderer::getInstance();
+        return $twig->render('@tester/external_id_config_field.html.twig', [
+            // Possible configuration constant that will be used to to hide/show additional fields
+            'CONFIG_SPECIFIC_VALUE'  => ExternalIDFieldStrategy::SPECIFIC_VALUE->value,
+            'CONFIG_SPECIFIC_ANSWER' => ExternalIDFieldStrategy::SPECIFIC_ANSWER->value,
+
+            // General display options
+            'options' => $display_options,
+
+            // Specific additional config for SPECIFIC_VALUE strategy
+            'specific_value_extra_field' => [
+                'value'      => $config->getSpecificExternalID() ?? '',
+                'input_name' => $input_name . "[" . ExternalIDFieldConfig::SPECIFIC_EXTERNAL_ID . "]",
+                'aria_label' => __("Specific external ID"),
+            ],
+
+            // Specific additional config for SPECIFIC_ANSWER strategy
+            'specific_answer_extra_field' => [
+                'empty_label'     => __("Select a question..."),
+                'value'           => $config->getSpecificQuestionId(),
+                'input_name'      => $input_name . "[" . ExternalIDFieldConfig::SPECIFIC_QUESTION_ID . "]",
+                'possible_values' => $this->getShortTextQuestionsValuesForDropdown($form),
+            ],
+        ]);
+    }
+
+    #[Override]
+    public function applyConfiguratedValueToInputUsingAnswers(
+        JsonFieldInterface $config,
+        array $input,
+        AnswersSet $answers_set
+    ): array {
+        if (!$config instanceof ExternalIDFieldConfig) {
+            throw new InvalidArgumentException("Unexpected config class");
+        }
+
+        // Only one strategy is allowed
+        $strategy = current($config->getStrategies());
+
+        // Compute value according to strategy
+        $external_id = $strategy->getExternalID($config, $answers_set);
+
+        // Apply value
+        $input['externalid'] = $external_id;
+        return $input;
+    }
+
+    public function getStrategiesForDropdown(): array
+    {
+        $values = [];
+        foreach (ExternalIDFieldStrategy::cases() as $strategies) {
+            $values[$strategies->value] = $strategies->getLabel();
+        }
+        return $values;
+    }
+
+    private function getShortTextQuestionsValuesForDropdown(Form $form): array
+    {
+        $values = [];
+        $questions = $form->getQuestionsByType(QuestionTypeShortText::class);
+
+        foreach ($questions as $question) {
+            $values[$question->getId()] = $question->fields['name'];
+        }
+
+        return $values;
+    }
+}

--- a/tests/fixtures/plugins/tester/src/Form/ExternalIDFieldConfig.php
+++ b/tests/fixtures/plugins/tester/src/Form/ExternalIDFieldConfig.php
@@ -1,0 +1,104 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace GlpiPlugin\Tester\Form;
+
+use Glpi\DBAL\JsonFieldInterface;
+use Glpi\Form\Destination\ConfigFieldWithStrategiesInterface;
+use Override;
+
+final class ExternalIDFieldConfig implements
+    JsonFieldInterface,
+    ConfigFieldWithStrategiesInterface
+{
+    // Unique reference to hardcoded names used for serialization and forms input names
+    public const STRATEGY             = 'strategy';
+    public const SPECIFIC_EXTERNAL_ID = 'external_id';
+    public const SPECIFIC_QUESTION_ID = 'question_id';
+
+    public function __construct(
+        private ExternalIDFieldStrategy $strategy,
+        private ?string $SPECIFIC_EXTERNAL_ID = null,
+        private ?int $specific_question_id = null,
+    ) {}
+
+    #[Override]
+    public static function jsonDeserialize(array $data): self
+    {
+        $strategy = ExternalIDFieldStrategy::tryFrom($data[self::STRATEGY] ?? "");
+        if ($strategy === null) {
+            $strategy = ExternalIDFieldStrategy::NO_EXTERNAL_ID;
+        }
+
+        return new self(
+            strategy: $strategy,
+            SPECIFIC_EXTERNAL_ID: $data[self::SPECIFIC_EXTERNAL_ID] ?? null,
+            specific_question_id: $data[self::SPECIFIC_QUESTION_ID] ?? null
+        );
+    }
+
+    #[Override]
+    public function jsonSerialize(): array
+    {
+        return [
+            self::STRATEGY               => $this->strategy->value,
+            self::SPECIFIC_EXTERNAL_ID => $this->SPECIFIC_EXTERNAL_ID,
+            self::SPECIFIC_QUESTION_ID   => $this->specific_question_id,
+        ];
+    }
+
+    #[Override]
+    public static function getStrategiesInputName(): string
+    {
+        return self::STRATEGY;
+    }
+
+    /**
+     * @return array<ExternalIDFieldStrategy>
+     */
+    public function getStrategies(): array
+    {
+        return [$this->strategy];
+    }
+
+    public function getSpecificExternalID(): ?string
+    {
+        return $this->SPECIFIC_EXTERNAL_ID;
+    }
+
+    public function getSpecificQuestionID(): ?int
+    {
+        return $this->specific_question_id;
+    }
+}

--- a/tests/fixtures/plugins/tester/src/Form/ExternalIDFieldStrategy.php
+++ b/tests/fixtures/plugins/tester/src/Form/ExternalIDFieldStrategy.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2025 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------

--- a/tests/fixtures/plugins/tester/src/Form/ExternalIDFieldStrategy.php
+++ b/tests/fixtures/plugins/tester/src/Form/ExternalIDFieldStrategy.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace GlpiPlugin\Tester\Form;
+
+use Glpi\Form\AnswersSet;
+use GlpiPlugin\Tester\Form\ExternalIDFieldConfig;
+
+enum ExternalIDFieldStrategy: string
+{
+    case NO_EXTERNAL_ID  = 'no_external_id';
+    case SPECIFIC_VALUE  = 'specific_value';
+    case SPECIFIC_ANSWER = 'specific_answer';
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::NO_EXTERNAL_ID  => __("No external ID"),
+            self::SPECIFIC_VALUE   => __("Specific external ID"),
+            self::SPECIFIC_ANSWER  => __("From a specific question"),
+        };
+    }
+
+    public function getExternalID(
+        ExternalIDFieldConfig $config,
+        AnswersSet $answers_set,
+    ): ?string {
+        return match ($this) {
+            self::NO_EXTERNAL_ID => null,
+            self::SPECIFIC_VALUE   => $config->getSpecificExternalID(),
+            self::SPECIFIC_ANSWER  => $this->getExternalIDForSpecificAnswer(
+                $config->getSpecificQuestionID(),
+                $answers_set
+            ),
+        };
+    }
+
+    private function getExternalIDForSpecificAnswer(
+        ?int $question_id,
+        AnswersSet $answers_set,
+    ): ?string {
+        if ($question_id === null) {
+            return null;
+        }
+
+        $answer = $answers_set->getAnswerByQuestionId($question_id);
+        if ($answer === null) {
+            return null;
+        }
+
+        return $answer->getRawAnswer();
+    }
+}

--- a/tests/fixtures/plugins/tester/templates/external_id_config_field.html.twig
+++ b/tests/fixtures/plugins/tester/templates/external_id_config_field.html.twig
@@ -1,0 +1,64 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2025 Teclib' and contributors.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+{% import 'components/form/fields_macros.html.twig' as fields %}
+
+<div data-glpi-itildestination-field-config-display-condition="{{ CONFIG_SPECIFIC_VALUE }}">
+    {{ fields.textField(
+        specific_value_extra_field.input_name,
+        specific_value_extra_field.value,
+        "",
+        options|merge({
+            field_class: '',
+            mb: '',
+            no_label: true,
+            additional_attributes: {'aria-label': specific_value_extra_field.aria_label}
+        })
+    ) }}
+</div>
+
+<div data-glpi-itildestination-field-config-display-condition="{{ CONFIG_SPECIFIC_ANSWER }}">
+    {{ fields.dropdownArrayField(
+        specific_answer_extra_field.input_name,
+        specific_answer_extra_field.value,
+        specific_answer_extra_field.possible_values,
+        "",
+        options|merge({
+            field_class: '',
+            mb: '',
+            no_label: true,
+            display_emptychoice: true,
+            emptylabel: specific_answer_extra_field.empty_label,
+            aria_label: specific_answer_extra_field.empty_label,
+        })
+    ) }}
+</div>

--- a/tests/functional/Glpi/Form/Migration/TargetsMigrationTest.php
+++ b/tests/functional/Glpi/Form/Migration/TargetsMigrationTest.php
@@ -101,6 +101,9 @@ use Glpi\Form\Form;
 use Glpi\Form\Migration\FormMigration;
 use Glpi\Migration\PluginMigrationResult;
 use Glpi\Tests\FormTesterTrait;
+use GlpiPlugin\Tester\Form\ExternalIDField;
+use GlpiPlugin\Tester\Form\ExternalIDFieldConfig;
+use GlpiPlugin\Tester\Form\ExternalIDFieldStrategy;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Ticket;
 
@@ -210,6 +213,11 @@ final class TargetsMigrationTest extends DbTestCase
                                 strategy: null, // No specific strategy for linked ITIL objects
                             ),
                         ]),
+
+                        // Tester plugin fields
+                        ExternalIDField::getKey() => new ExternalIDFieldConfig(
+                            strategy: ExternalIDFieldStrategy::NO_EXTERNAL_ID
+                        ),
                     ],
                 ],
                 [


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Allow plugins to define their own destination config fields