### PR TITLE
Fix missing es_CL language

### DIFF
--- a/inc/define.php
+++ b/inc/define.php
@@ -131,7 +131,7 @@ $CFG_GLPI['languages'] = [
     'be_BY'  => ['Belarussian',               'be_BY.mo',    'be',    'be', 'belarussian',          3],
     'is_IS'  => ['íslenska',                  'is_IS.mo',    'is',    'en', 'icelandic',            2],
     'eo'     => ['Esperanto',                 'eo.mo',       'eo',    'en', 'esperanto',            2],
-    'es_CL'  => ['Español chileno',           'es_CL',       'es',    'es', 'spanish chilean',      2],
+    'es_CL'  => ['Español chileno',           'es_CL.mo',       'es',    'es', 'spanish chilean',      2],
 ];
 
 $DEFAULT_PLURAL_NUMBER = 2;

--- a/phpunit/functional/DropdownTest.php
+++ b/phpunit/functional/DropdownTest.php
@@ -2078,4 +2078,11 @@ class DropdownTest extends DbTestCase
             return $result['id'] === \Supplier::class . '_' . $inactive_supplier->getID();
         }));
     }
+
+    public function testGetLanguages()
+    {
+        global $CFG_GLPI;
+
+        $this->assertCount(count($CFG_GLPI['languages']), \Dropdown::getLanguages());
+    }
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

Chilean Spanish language was missing from the dropdown because the MO file listed in the config was missing the extension. Since the file wasn't found, it was being excluded. A test was added to try to catch this kind of typo.

