### PR TITLE
Filter actor questions in end users forms

### DIFF
--- a/src/Glpi/Form/Dropdown/FormActorsDropdown.php
+++ b/src/Glpi/Form/Dropdown/FormActorsDropdown.php
@@ -173,12 +173,15 @@ final class FormActorsDropdown extends AbstractRightsDropdown
                     'selection_text' => "$itemtype - $text",
                 ];
             }
-            $results[] = [
-                'itemtype' => $itemtype,
-                'text' => $itemtype::getTypeName(1),
-                'title' => $itemtype::getTypeName(1),
-                'children' => $new_group,
-            ];
+
+            if (count($new_group)) {
+                $results[] = [
+                    'itemtype' => $itemtype,
+                    'text' => $itemtype::getTypeName(1),
+                    'title' => $itemtype::getTypeName(1),
+                    'children' => $new_group,
+                ];
+            }
         }
 
         $ret = [

--- a/src/Glpi/Form/QuestionType/AbstractQuestionTypeActors.php
+++ b/src/Glpi/Form/QuestionType/AbstractQuestionTypeActors.php
@@ -416,11 +416,12 @@ TWIG;
             question.getEndUserInputName(),
             value,
             {
-                'form_id'      : question.getForm().getId(),
-                'multiple'     : is_multiple_actors,
-                'allowed_types': allowed_types,
-                'aria_label'   : aria_label,
-                'mb'           : ''
+                'form_id'        : question.getForm().getId(),
+                'multiple'       : is_multiple_actors,
+                'allowed_types'  : allowed_types,
+                'aria_label'     : aria_label,
+                'mb'             : '',
+                'right_for_users': right_for_users,
             }
         ]) %}
 
@@ -448,6 +449,7 @@ TWIG;
             'allowed_types'      => $this->getAllowedActorTypes(),
             'is_multiple_actors' => $is_multiple_actors,
             'aria_label'         => $question->fields['name'],
+            'right_for_users'    => $this->getRightForUsers(),
         ]);
     }
 


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
   -> can't be tested with PHPUnit.

## Description

Filter actors questions, the logic was already there but the `right_for_users` parameter was not supplied.

I've also removed empty header results (e.g. no "groups" header in the dropdown if no groups were found).

## References

Fix #21113.