### PR TITLE
[HLAPI] Skip cookie auth if session already started

### DIFF
--- a/src/Glpi/Api/HL/Middleware/CookieAuthMiddleware.php
+++ b/src/Glpi/Api/HL/Middleware/CookieAuthMiddleware.php
@@ -43,6 +43,11 @@ class CookieAuthMiddleware extends AbstractMiddleware implements AuthMiddlewareI
 {
     public function process(MiddlewareInput $input, callable $next): void
     {
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            // session already started
+            $next($input);
+            return;
+        }
         // User could be authenticated by a cookie
         // Need to use cookies for session and start it manually
         ini_set('session.use_cookies', '1');


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Ran into issue working on a web app that uses GLPI authorization code flow. May fix #21165.
In some cases, it seems like a PHP session can already be started and that causes the `ini_set` to fail, not so silently anymore.