### PR TITLE
manualy revert #16033, fix #21232

### DIFF
--- a/src/CommonITILTask.php
+++ b/src/CommonITILTask.php
@@ -435,6 +435,8 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
 
     public function assignTechFromtask(array $input): void
     {
+        Toolbox::deprecated(version: '11.1.0');
+
         //if user or group assigned to CommonITIL task, add it to the main item
         $item = static::getItilObjectItemInstance();
         $itemData = [
@@ -643,9 +645,6 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
             );
         }
 
-        // Assign technician to main item  from task
-        self::assignTechFromtask($this->input);
-
         parent::post_updateItem($history);
     }
 
@@ -840,9 +839,6 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
             $this->getType(),
             Log::HISTORY_ADD_SUBITEM
         );
-
-        // Assign technician to main item  from task
-        self::assignTechFromtask($this->input);
 
         if ($this->input["_job"]->getType() == 'Ticket') {
             self::addToMergedTickets();

--- a/tests/functional/CommonITILTaskTestCase.php
+++ b/tests/functional/CommonITILTaskTestCase.php
@@ -42,63 +42,6 @@ abstract class CommonITILTaskTestCase extends DbTestCase
     /** @return class-string<\CommonITILTask> */
     abstract protected static function getTaskClass(): string;
 
-    public function testAddTechToItilFromTask()
-    {
-        $task_class = static::getTaskClass();
-        $itil_class = $task_class::getItilObjectItemType();
-
-        $itil = new $itil_class();
-        $ticket_id = $itil->add([
-            'name'        => "Test tech task",
-            'content'     => "Test tech task",
-            'entities_id' => getItemByTypeName('Entity', '_test_root_entity', true),
-            'date'        => $_SESSION['glpi_currenttime'],
-        ]);
-
-        $id = $ticket_id;
-        $task = new $task_class();
-        $type_user = new $itil->userlinkclass();
-        $task_content = "<p> Test task content </p>";
-
-        $foreignkey = getForeignKeyFieldForItemType($task->getItilObjectItemType());
-        // Add a task
-        $task_id = $task->add([
-            $foreignkey => $id,
-            'users_id' => 4,
-            'content' => $task_content,
-            'state' => 1,
-            'users_id_tech' => 4,
-        ]);
-        $this->assertCount(1, $task->find(['id' => $task_id]));
-
-        $this->assertCount(
-            1,
-            $type_user->find([
-                $foreignkey => $id,
-                'users_id' => 4,
-                'type' => \CommonITILActor::ASSIGN,
-            ])
-        );
-
-        $this->assertTrue(
-            $task->update([
-                'id' => $task_id,
-                $foreignkey => $id,
-                'users_id' => 3,
-                'users_id_tech' => 3,
-            ])
-        );
-
-        $this->assertCount(
-            1,
-            $type_user->find([
-                $foreignkey => $id,
-                'users_id' => 3,
-                'type' => \CommonITILActor::ASSIGN,
-            ])
-        );
-    }
-
     public function testAddMyAsRecipient()
     {
         global $DB;


### PR DESCRIPTION
## Description

- Remove the forced behavior of auto assign tech in ticket from task, there are a lot of (justified) complaints in #21232
- The behavior will be implemented again in the incoming plugin moreoptions by @Lainow 

I did a manual revert, as the initial commit 74a22aa5039965341b5e34bbab1c868a2f3d1f9c start to be old and conflicting