### PR TITLE
fix(plugins): Use array_combine to associate plugin keys with their paths

### DIFF
--- a/src/Glpi/Application/View/Extension/FrontEndAssetsExtension.php
+++ b/src/Glpi/Application/View/Extension/FrontEndAssetsExtension.php
@@ -293,7 +293,10 @@ class FrontEndAssetsExtension extends AbstractExtension
             $cfg_glpi += Config::getSafeConfig(true);
         }
 
-        $plugins_path = \array_map(fn(string $plugin_key) => "/plugins/{$plugin_key}", Plugin::getPlugins());
+        $plugins_path = \array_combine(
+            Plugin::getPlugins(),
+            \array_map(fn(string $plugin_key) => "/plugins/{$plugin_key}", Plugin::getPlugins())
+        );
 
         $script = sprintf('window.CFG_GLPI = %s;', json_encode($cfg_glpi, JSON_PRETTY_PRINT))
             . "\n"


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description
Currently, the global JS variable `GLPI_PLUGINS_PATH` returns a list of paths for available plugins.
However, this list does not define keys for its values, which is problematic given that in previous versions we expected the key for each path to correspond to the name of the plugin.
This behavior is already present in the `getCoreVariablesForJavascript` method in `Html.php`.