### PR TITLE
fix(forms): Use ConditionValueTransformerInterface for complex mandatory answers

### DIFF
--- a/tests/functional/Glpi/Form/AnswersHandler/AnswersHandlerTest.php
+++ b/tests/functional/Glpi/Form/AnswersHandler/AnswersHandlerTest.php
@@ -36,6 +36,7 @@ namespace tests\units\Glpi\Form\AnswersHandler;
 
 use CommonITILObject;
 use DbTestCase;
+use Entity;
 use Glpi\Form\Answer;
 use Glpi\Form\AnswersHandler\AnswersHandler;
 use Glpi\Form\Condition\CreationStrategy;
@@ -50,12 +51,17 @@ use Glpi\Form\Destination\FormDestinationTicket;
 use Glpi\Form\Form;
 use Glpi\Form\Question;
 use Glpi\Form\QuestionType\QuestionTypeEmail;
+use Glpi\Form\QuestionType\QuestionTypeItem;
+use Glpi\Form\QuestionType\QuestionTypeItemDropdown;
+use Glpi\Form\QuestionType\QuestionTypeItemDropdownExtraDataConfig;
+use Glpi\Form\QuestionType\QuestionTypeItemExtraDataConfig;
 use Glpi\Form\QuestionType\QuestionTypeLongText;
 use Glpi\Form\QuestionType\QuestionTypeNumber;
 use Glpi\Form\QuestionType\QuestionTypeShortText;
 use Glpi\Form\ValidationResult;
 use Glpi\Tests\FormBuilder;
 use Glpi\Tests\FormTesterTrait;
+use Location;
 use PHPUnit\Framework\Attributes\DataProvider;
 use User;
 
@@ -231,6 +237,78 @@ class AnswersHandlerTest extends DbTestCase
             'expectedErrors' => [
                 'Mandatory Name' => 'This field is mandatory',
             ],
+        ];
+
+        $mandatory_entity_question_form_buidler = (new FormBuilder("Mandatory Item Question Type Test Form"))
+            ->addQuestion(
+                "Mandatory Entity Question",
+                QuestionTypeItem::class,
+                extra_data: json_encode(
+                    new QuestionTypeItemExtraDataConfig(itemtype: Entity::class)
+                ),
+                is_mandatory: true
+            );
+
+        yield 'Empty entity question - should be invalid with empty choice selected' => [
+            'builder' => $mandatory_entity_question_form_buidler,
+            'answers' => [
+                'Mandatory Entity Question' => [
+                    'itemtype' => Entity::class,
+                    'items_id' => -1, // Empty choice
+                ],
+            ],
+            'expectedIsValid' => false,
+            'expectedErrors' => [
+                'Mandatory Entity Question' => 'This field is mandatory',
+            ],
+        ];
+
+        yield 'Filled entity question - should be valid' => [
+            'builder' => $mandatory_entity_question_form_buidler,
+            'answers' => [
+                'Mandatory Entity Question' => [
+                    'itemtype' => Entity::class,
+                    'items_id' => 0, // Root entity
+                ],
+            ],
+            'expectedIsValid' => true,
+            'expectedErrors' => [],
+        ];
+
+        $mandatory_location_question_form_builder = (new FormBuilder("Mandatory Dropdown Item Question Type Test Form"))
+            ->addQuestion(
+                "Mandatory Location Question",
+                QuestionTypeItemDropdown::class,
+                extra_data: json_encode(
+                    new QuestionTypeItemDropdownExtraDataConfig(itemtype: Location::class)
+                ),
+                is_mandatory: true
+            );
+
+        yield 'Empty location dropdown question - should be invalid with empty choice selected' => [
+            'builder' => $mandatory_location_question_form_builder,
+            'answers' => [
+                'Mandatory Location Question' => [
+                    'itemtype' => Location::class,
+                    'items_id' => -1, // Empty choice
+                ],
+            ],
+            'expectedIsValid' => false,
+            'expectedErrors' => [
+                'Mandatory Location Question' => 'This field is mandatory',
+            ],
+        ];
+
+        yield 'Filled location dropdown question - should be valid' => [
+            'builder' => $mandatory_location_question_form_builder,
+            'answers' => [
+                'Mandatory Location Question' => [
+                    'itemtype' => Location::class,
+                    'items_id' => 1,
+                ],
+            ],
+            'expectedIsValid' => true,
+            'expectedErrors' => [],
         ];
 
         // Conditonnal validation form builder


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Use the value returned by `transformConditionValueForComparisons` from `ConditionValueTransformerInterface` to correctly handle mandatory questions.
Currently, some questions are considered filled when they are not; for example, item type questions that use the value -1 to represent their empty value.