### PR TITLE
Do not force session cookie params in CLI context

### DIFF
--- a/src/Glpi/Application/SystemConfigurator.php
+++ b/src/Glpi/Application/SystemConfigurator.php
@@ -274,6 +274,11 @@ final class SystemConfigurator
 
     private function setSessionConfiguration(): void
     {
+        if (PHP_SAPI === 'cli') {
+            // Adapting session cookie params is useless in CLI mode.
+            return;
+        }
+
         // Set secure cookie config
         $target_configs = [
             'session.use_trans_sid'     => false,


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

While investigating on #21320, I figured out that there is no need to force the session cookie params in CLI mode, as the cookies will never be reused.