### PR TITLE
Fix disabled notifications for form fillers

### DIFF
--- a/src/Glpi/Form/Destination/CommonITILField/ITILActorFieldStrategy.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ITILActorFieldStrategy.php
@@ -125,7 +125,11 @@ enum ITILActorFieldStrategy: string
         }
 
         $delegation = $answers_set->getDelegation();
-        if (Ticket::canDelegateeCreateTicket($delegation->users_id ?? $user_id)) {
+
+        if (
+            $delegation->users_id !== null
+            && Ticket::canDelegateeCreateTicket($delegation->users_id)
+        ) {
             return [
                 [
                     'itemtype' => User::class,

--- a/tests/functional/Glpi/Form/Destination/CommonITILField/RequesterFieldTest.php
+++ b/tests/functional/Glpi/Form/Destination/CommonITILField/RequesterFieldTest.php
@@ -129,7 +129,14 @@ final class RequesterFieldTest extends AbstractActorFieldTest
             form: $form,
             config: $form_filler_config,
             answers: [],
-            expected_actors: [['items_id' => $auth->getUser()->getID()]]
+            expected_actors: [
+                [
+                    'items_id' => $auth->getUser()->getID(),
+                    'itemtype' => User::class,
+                    // Make sure notifications are enabled
+                    'use_notification' => 1,
+                ],
+            ]
         );
     }
 


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

The check for delegation was not strict enough, the `if` block should not be executed if delegation is not set.

<img width="675" height="429" alt="image" src="https://github.com/user-attachments/assets/da71e239-a565-4404-b873-90da0a598fe6" />


## References

Fix #21303


