### PR TITLE
revert show unsolved tickets in merge target dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The present file will list all changes made to the project; according to the
 ### Added
 
 ### Changed
+- It is again possible to "Merge as Followup" into resolved/closed tickets.
 
 ### Deprecated
 

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -2703,7 +2703,7 @@ class Ticket extends CommonITILObject
                     'name'         => "_mergeticket",
                     'used'         => $ma->getItems()['Ticket'],
                     'displaywith'  => ['id'],
-                    'rand'         => $rand
+                    'rand'         => $rand,
                 ];
                 echo "<table class='mx-auto'><tr>";
                 echo "<td><label for='dropdown__mergeticket$rand'>" . Ticket::getTypeName(1) . "</label></td><td colspan='3'>";

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -2703,12 +2703,7 @@ class Ticket extends CommonITILObject
                     'name'         => "_mergeticket",
                     'used'         => $ma->getItems()['Ticket'],
                     'displaywith'  => ['id'],
-                    'rand'         => $rand,
-                    'condition'    => [
-                        'NOT' => [
-                            'status' => array_merge(self::getSolvedStatusArray(), self::getClosedStatusArray()),
-                        ],
-                    ],
+                    'rand'         => $rand
                 ];
                 echo "<table class='mx-auto'><tr>";
                 echo "<td><label for='dropdown__mergeticket$rand'>" . Ticket::getTypeName(1) . "</label></td><td colspan='3'>";


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] My feature works.

## Description

Revert #19193
Ref support !39607


We have several customers reporting a regression in this feature for resolved and closed tickets.

In a typical use case:

- A ticket is resolved, and the solution validation notification is sent to the requester.
- A few days later, the automatic closure timer is triggered, the ticket is then closed.
- Finally, the requester replies with a message such as "Thank you!" (by email). This does not reopen the original ticket but instead creates a new one.

Customers were using the “Merge as Followups” feature to delete this new ticket and merge it as a follow-up to the closed ticket (without having to reopen the closed one).

This was, in my opinion, an important use case for the feature.

Regarding the original performance issue, I tested the feature on several large GLPI instances (>800k tickets), and searching by ID in the dropdown never took more than 5 seconds — which seems perfectly acceptable to me.


