### PR TITLE
Fix forms failure when a template use the "NOW" value

### DIFF
--- a/src/Glpi/Form/Destination/AbstractCommonITILFormDestination.php
+++ b/src/Glpi/Form/Destination/AbstractCommonITILFormDestination.php
@@ -35,6 +35,7 @@
 namespace Glpi\Form\Destination;
 
 use CommonITILObject;
+use DBmysql;
 use Exception;
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\PrepareForCloneInterface;
@@ -406,10 +407,11 @@ abstract class AbstractCommonITILFormDestination implements FormDestinationInter
 
     private function applyPredefinedTemplateFields(array $input): array
     {
-        $itemtype = $this->getTarget();
+        /** @var DBmysql $DB */
+        global $DB;
 
-        /** @var CommonITILObject $itil */
-        $itil = new $itemtype();
+        $itil = $this->getTarget();
+        $fields_definition = $DB->listFields($itil::getTable());
         $template = $itil->getITILTemplateToUse(
             entities_id: $input['entities_id'],
             itilcategories_id: $input['itilcategories_id'] ?? 0,
@@ -428,10 +430,32 @@ abstract class AbstractCommonITILFormDestination implements FormDestinationInter
             $input[$template_foreign_key] = $template->getID();
         }
 
-        $predefined_fields = $itemtype->getTemplateClass()::getPredefinedFields();
+        $predefined_fields = $itil->getTemplateClass()::getPredefinedFields();
+
         $fields = $predefined_fields->getPredefinedFields($template->fields['id']);
         foreach ($fields as $field => $value) {
-            $input[$field] = $value;
+            $field_definition = $fields_definition[$field] ?? null;
+            if (
+                $field_definition
+                && $value === "NOW"
+                && (
+                    $field_definition['Type'] == "timestamp"
+                    || $field_definition['Type'] == "date"
+                    || $field_definition['Type'] == "datetime"
+                )
+            ) {
+                // Handle specific "NOW" value
+                // Note: this should probably be handled directly by
+                // getPredefinedFields, but the change should not be done in a
+                // bugfixe releases as it might impact other features
+                if ($field_definition['Type'] == "date") {
+                    $input[$field] = Session::getCurrentDate();
+                } else {
+                    $input[$field] = Session::getCurrentTime();
+                }
+            } else {
+                $input[$field] = $value;
+            }
         }
 
         return $input;

--- a/tests/functional/Glpi/Form/Destination/CommonITILField/TemplateFieldTest.php
+++ b/tests/functional/Glpi/Form/Destination/CommonITILField/TemplateFieldTest.php
@@ -182,6 +182,35 @@ final class TemplateFieldTest extends AbstractDestinationFieldTest
         ];
     }
 
+    /**
+     * This test validate that a template using the special "NOW" value for
+     * date do not trigger an error.
+     */
+    public function testDefaultTemplateWithPredefinedOpeningDateField(): void
+    {
+        // Arrange: create a template using the "NOW" value
+        $default_template = (new Ticket())->getITILTemplateToUse(
+            entities_id: $_SESSION["glpiactive_entity"]
+        );
+        $this->createItem(
+            TicketTemplatePredefinedField::class,
+            [
+                'tickettemplates_id' => $default_template->getID(),
+                'num'                => 15, // Opening date
+                'value'              => "NOW",
+            ]
+        );
+
+        // Act: create a ticket, no errors should happen
+        $this->checkTemplateFieldConfiguration(
+            form: $this->createAndGetFormWithTicketDestination(),
+            config: new TemplateFieldConfig(
+                strategy: TemplateFieldStrategy::DEFAULT_TEMPLATE,
+            ),
+            expected_tickettemplates_id: $default_template->getID()
+        );
+    }
+
     private function checkTemplateFieldConfiguration(
         Form $form,
         TemplateFieldConfig $config,


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Adding a "NOW" predefined fields like this would lead to an SQL error when creating a ticket through an helpdesk form:

<img width="1450" height="427" alt="image" src="https://github.com/user-attachments/assets/6f855b7b-3256-48ef-b3ed-65de202fc7bb" />

## References

Fix #21267

