### PR TITLE
Fix reservation modal display

### DIFF
--- a/js/reservations.js
+++ b/js/reservations.js
@@ -237,7 +237,7 @@ var Reservations = function() {
                             begin:  info.start.toISOString(),
                             end:    info.end.toISOString(),
                         },
-                        dialogclass: 'modal-lg',
+                        dialogclass: 'modal-xl',
                     });
                 }
 
@@ -258,7 +258,7 @@ var Reservations = function() {
                 glpi_ajax_dialog({
                     title: __("Edit reservation"),
                     url: `${ajaxurl}`,
-                    dialogclass: 'modal-lg',
+                    dialogclass: 'modal-xl',
                 });
             }
         });

--- a/src/Reservation.php
+++ b/src/Reservation.php
@@ -817,7 +817,7 @@ class Reservation extends CommonDBChild
                 $item = null;
 
                 if ($item = getItemForItemtype($r->fields["itemtype"])) {
-                    $type = $item::class;
+                    $type = $item::getTypeName(1);
 
                     if ($item->getFromDB($r->fields["items_id"])) {
                         $name = $item->getName();


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

It fixes #21255.

1. The asset type localized name is now displayed instead of the asset class name.
2. The modal is now larger.