### PR TITLE
Fix solve/close dates stats computations

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -5479,6 +5479,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
             isset($this->fields['id'])
             && !empty($this->fields['date'])
             && !empty($this->fields['solvedate'])
+            && $this->fields['solvedate'] !== 'NULL'
         ) {
             $calendars_id = $this->getCalendar();
             $calendar     = new Calendar();
@@ -5521,6 +5522,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
             isset($this->fields['id'])
             && !empty($this->fields['date'])
             && !empty($this->fields['closedate'])
+            && $this->fields['closedate'] !== 'NULL'
         ) {
             $calendars_id = $this->getCalendar();
             $calendar     = new Calendar();

--- a/tests/functional/TicketTest.php
+++ b/tests/functional/TicketTest.php
@@ -9281,6 +9281,7 @@ HTML,
         ]);
 
         // Create a ticket
+        $this->setCurrentTime('2025-10-06 11:26:34'); // be sure to be on monday
         $ticket = $this->createItem(
             Ticket::class,
             [
@@ -9291,6 +9292,7 @@ HTML,
         );
 
         // Add a solution
+        $this->setCurrentTime('2025-10-07 09:12:48'); // add some time to consistent stats
         $solution = $this->createItem(
             ITILSolution::class,
             [
@@ -9302,10 +9304,13 @@ HTML,
 
         $this->assertTrue($ticket->getFromDB($ticket->getID()));
         $this->assertEquals(Ticket::SOLVED, $ticket->fields['status']);
+        $this->assertEquals(27974, $ticket->fields['solve_delay_stat']);
+        $this->assertEquals(0, $ticket->fields['close_delay_stat']);
         $this->assertTrue($solution->getFromDB($solution->getID()));
         $this->assertSame(CommonITILValidation::WAITING, $solution->fields['status']);
 
         // Refuse the solution
+        $this->setCurrentTime('2025-10-07 10:47:10'); // add some time to consistent stats
         $this->createItem(
             ITILFollowup::class,
             [
@@ -9319,13 +9324,22 @@ HTML,
 
         $this->assertTrue($ticket->getFromDB($ticket->getID()));
         $this->assertEquals(Ticket::INCOMING, $ticket->fields['status']);
+        $this->assertEquals(0, $ticket->fields['solve_delay_stat']);
+        $this->assertEquals(0, $ticket->fields['close_delay_stat']);
         $this->assertTrue($solution->getFromDB($solution->getID()));
         $this->assertSame(CommonITILValidation::REFUSED, $solution->fields['status']);
 
         // Close the ticket
+        $this->setCurrentTime('2025-10-08 14:17:31'); // add some time to consistent stats
         $this->updateItem(Ticket::class, $ticket->getID(), ['status' => Ticket::CLOSED]);
 
+        $this->assertTrue($ticket->getFromDB($ticket->getID()));
+        $this->assertEquals(Ticket::CLOSED, $ticket->fields['status']);
+        $this->assertEquals(76595, $ticket->fields['solve_delay_stat']);
+        $this->assertEquals(76595, $ticket->fields['close_delay_stat']);
+
         // Reopen the ticket
+        $this->setCurrentTime('2025-10-08 14:24:05'); // add some time to consistent stats
         $this->createItem(
             ITILFollowup::class,
             [
@@ -9339,5 +9353,7 @@ HTML,
 
         $this->assertTrue($ticket->getFromDB($ticket->getID()));
         $this->assertEquals(Ticket::INCOMING, $ticket->fields['status']);
+        $this->assertEquals(0, $ticket->fields['solve_delay_stat']);
+        $this->assertEquals(0, $ticket->fields['close_delay_stat']);
     }
 }

--- a/tests/functional/TicketTest.php
+++ b/tests/functional/TicketTest.php
@@ -34,8 +34,11 @@
 
 namespace tests\units;
 
+use Calendar;
+use CalendarSegment;
 use CommonITILActor;
 use CommonITILObject;
+use CommonITILValidation;
 use Computer;
 use Contract;
 use CronTask;
@@ -49,13 +52,18 @@ use Group;
 use Group_Ticket;
 use Group_User;
 use ITILCategory;
+use ITILFollowup;
+use ITILSolution;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Profile;
 use Profile_User;
 use ProfileRight;
 use Psr\Log\LogLevel;
+use Rule;
 use Search;
 use Session;
+use SLA;
+use SLM;
 use Supplier;
 use Supplier_Ticket;
 use Symfony\Component\DomCrawler\Crawler;
@@ -567,7 +575,7 @@ class TicketTest extends DbTestCase
             ]
         );
 
-        $followup = new \ITILFollowup();
+        $followup = new ITILFollowup();
         $followup->add([
             'itemtype'  => $ticket::getType(),
             'items_id' => $ticket_id,
@@ -610,7 +618,7 @@ class TicketTest extends DbTestCase
             ])
         );
 
-        $solution = new \ITILSolution();
+        $solution = new ITILSolution();
         $this->assertGreaterThan(
             0,
             (int) $solution->add([
@@ -1234,7 +1242,7 @@ class TicketTest extends DbTestCase
 
         $uid = getItemByTypeName('User', TU_USER, true);
         //add a followup to the ticket
-        $fup = new \ITILFollowup();
+        $fup = new ITILFollowup();
         $this->assertGreaterThan(
             0,
             (int) $fup->add([
@@ -1335,7 +1343,7 @@ class TicketTest extends DbTestCase
 
         $uid = getItemByTypeName('User', TU_USER, true);
         //add a followup to the ticket
-        $fup = new \ITILFollowup();
+        $fup = new ITILFollowup();
         $this->assertGreaterThan(
             0,
             (int) $fup->add([
@@ -1738,7 +1746,7 @@ class TicketTest extends DbTestCase
 
         $uid = getItemByTypeName('User', TU_USER, true);
         //add a followup to the ticket
-        $fup = new \ITILFollowup();
+        $fup = new ITILFollowup();
         $this->assertGreaterThan(
             0,
             (int) $fup->add([
@@ -1959,7 +1967,7 @@ class TicketTest extends DbTestCase
 
         $uid = getItemByTypeName('User', TU_USER, true);
         //add a followup to the ticket
-        $fup = new \ITILFollowup();
+        $fup = new ITILFollowup();
         $this->assertGreaterThan(
             0,
             (int) $fup->add([
@@ -2320,7 +2328,7 @@ class TicketTest extends DbTestCase
         );
 
         //add a followup to the ticket
-        $fup = new \ITILFollowup();
+        $fup = new ITILFollowup();
         $this->assertGreaterThan(
             0,
             (int) $fup->add([
@@ -2583,7 +2591,7 @@ class TicketTest extends DbTestCase
             $uid = getItemByTypeName('User', $users_name, true);
 
             // ITILFollowup
-            $fup = new \ITILFollowup();
+            $fup = new ITILFollowup();
             $this->assertGreaterThan(
                 0,
                 (int) $fup->add([
@@ -3166,7 +3174,7 @@ class TicketTest extends DbTestCase
                     'password' => 'tech',
                     'rights'   => [
                         'task' => \READ,
-                        'followup' => \READ + \ITILFollowup::ADDALLITEM,
+                        'followup' => \READ + ITILFollowup::ADDALLITEM,
                     ],
                 ],
                 'expected' => true, // has enough rights so can take into account
@@ -3180,7 +3188,7 @@ class TicketTest extends DbTestCase
                     'password' => 'tech',
                     'rights'   => [
                         'task' => \READ,
-                        'followup' => \READ + \ITILFollowup::ADDMY,
+                        'followup' => \READ + ITILFollowup::ADDMY,
                     ],
                 ],
                 'expected' => true, // has enough rights so can take into account
@@ -3194,7 +3202,7 @@ class TicketTest extends DbTestCase
                     'password' => 'tech',
                     'rights'   => [
                         'task' => \READ,
-                        'followup' => \READ + \ITILFollowup::ADD_AS_GROUP,
+                        'followup' => \READ + ITILFollowup::ADD_AS_GROUP,
                     ],
                 ],
                 'expected' => true, // has enough rights so can take into account
@@ -3715,7 +3723,7 @@ class TicketTest extends DbTestCase
 
     public function testLocationAssignment()
     {
-        $rule = new \Rule();
+        $rule = new Rule();
         $rule->getFromDBByCrit([
             'sub_type' => 'RuleTicket',
             'name' => 'Ticket location from user',
@@ -3926,7 +3934,7 @@ class TicketTest extends DbTestCase
         ]);
 
         $task = new \TicketTask();
-        $fup = new \ITILFollowup();
+        $fup = new ITILFollowup();
         $task->add([
             'tickets_id'   => $ticket2,
             'content'      => 'ticket 2 task 1',
@@ -4193,7 +4201,7 @@ class TicketTest extends DbTestCase
         $this->assertEquals(0, (int) $failure_count);
 
         // Add a followup to the child ticket
-        $followup = new \ITILFollowup();
+        $followup = new ITILFollowup();
         $this->assertGreaterThan(
             0,
             $followup->add([
@@ -4444,7 +4452,7 @@ HTML,
             ],
             [
                 'profiles_id' => getItemByTypeName('Profile', 'Self-Service', true),
-                'name'        => \ITILFollowup::$rightname,
+                'name'        => ITILFollowup::$rightname,
             ]
         );
 
@@ -4458,11 +4466,11 @@ HTML,
         $DB->update(
             'glpi_profilerights',
             [
-                'rights' => \ITILFollowup::ADDMY,
+                'rights' => ITILFollowup::ADDMY,
             ],
             [
                 'profiles_id' => getItemByTypeName('Profile', 'Self-Service', true),
-                'name'        => \ITILFollowup::$rightname,
+                'name'        => ITILFollowup::$rightname,
             ]
         );
 
@@ -4498,7 +4506,7 @@ HTML,
             ],
             [
                 'profiles_id' => getItemByTypeName('Profile', 'Self-Service', true),
-                'name'        => \ITILFollowup::$rightname,
+                'name'        => ITILFollowup::$rightname,
             ]
         );
 
@@ -4529,11 +4537,11 @@ HTML,
         $DB->update(
             'glpi_profilerights',
             [
-                'rights' => \ITILFollowup::ADDMY,
+                'rights' => ITILFollowup::ADDMY,
             ],
             [
                 'profiles_id' => getItemByTypeName('Profile', 'Self-Service', true),
-                'name'        => \ITILFollowup::$rightname,
+                'name'        => ITILFollowup::$rightname,
             ]
         );
 
@@ -4569,7 +4577,7 @@ HTML,
             ],
             [
                 'profiles_id' => getItemByTypeName('Profile', 'Self-Service', true),
-                'name'        => \ITILFollowup::$rightname,
+                'name'        => ITILFollowup::$rightname,
             ]
         );
 
@@ -4612,11 +4620,11 @@ HTML,
         $DB->update(
             'glpi_profilerights',
             [
-                'rights' => \ITILFollowup::ADD_AS_GROUP,
+                'rights' => ITILFollowup::ADD_AS_GROUP,
             ],
             [
                 'profiles_id' => getItemByTypeName('Profile', 'Self-Service', true),
-                'name'        => \ITILFollowup::$rightname,
+                'name'        => ITILFollowup::$rightname,
             ]
         );
 
@@ -4630,11 +4638,11 @@ HTML,
         $DB->update(
             'glpi_profilerights',
             [
-                'rights' => \ITILFollowup::ADD_AS_GROUP | \ITILFollowup::ADDMY,
+                'rights' => ITILFollowup::ADD_AS_GROUP | ITILFollowup::ADDMY,
             ],
             [
                 'profiles_id' => getItemByTypeName('Profile', 'Self-Service', true),
-                'name'        => \ITILFollowup::$rightname,
+                'name'        => ITILFollowup::$rightname,
             ]
         );
 
@@ -4670,7 +4678,7 @@ HTML,
             ],
             [
                 'profiles_id' => getItemByTypeName('Profile', 'Self-Service', true),
-                'name'        => \ITILFollowup::$rightname,
+                'name'        => ITILFollowup::$rightname,
             ]
         );
 
@@ -4701,11 +4709,11 @@ HTML,
         $DB->update(
             'glpi_profilerights',
             [
-                'rights' => \ITILFollowup::ADD_AS_TECHNICIAN,
+                'rights' => ITILFollowup::ADD_AS_TECHNICIAN,
             ],
             [
                 'profiles_id' => getItemByTypeName('Profile', 'Self-Service', true),
-                'name'        => \ITILFollowup::$rightname,
+                'name'        => ITILFollowup::$rightname,
             ]
         );
 
@@ -4741,7 +4749,7 @@ HTML,
             ],
             [
                 'profiles_id' => getItemByTypeName('Profile', 'Self-Service', true),
-                'name'        => \ITILFollowup::$rightname,
+                'name'        => ITILFollowup::$rightname,
             ]
         );
 
@@ -4784,11 +4792,11 @@ HTML,
         $DB->update(
             'glpi_profilerights',
             [
-                'rights' => \ITILFollowup::ADD_AS_TECHNICIAN,
+                'rights' => ITILFollowup::ADD_AS_TECHNICIAN,
             ],
             [
                 'profiles_id' => getItemByTypeName('Profile', 'Self-Service', true),
-                'name'        => \ITILFollowup::$rightname,
+                'name'        => ITILFollowup::$rightname,
             ]
         );
 
@@ -4843,11 +4851,11 @@ HTML,
         $DB->update(
             'glpi_profilerights',
             [
-                'rights' => \ITILFollowup::ADD_AS_OBSERVER,
+                'rights' => ITILFollowup::ADD_AS_OBSERVER,
             ],
             [
                 'profiles_id' => getItemByTypeName('Profile', 'Self-Service', true),
-                'name'        => \ITILFollowup::$rightname,
+                'name'        => ITILFollowup::$rightname,
             ]
         );
 
@@ -4898,11 +4906,11 @@ HTML,
         $DB->update(
             'glpi_profilerights',
             [
-                'rights' => \ITILFollowup::ADD_AS_OBSERVER | \ITILFollowup::ADD_AS_GROUP,
+                'rights' => ITILFollowup::ADD_AS_OBSERVER | ITILFollowup::ADD_AS_GROUP,
             ],
             [
                 'profiles_id' => getItemByTypeName('Profile', 'Self-Service', true),
-                'name'        => \ITILFollowup::$rightname,
+                'name'        => ITILFollowup::$rightname,
             ]
         );
 
@@ -6024,7 +6032,7 @@ HTML,
         $this->assertTrue((bool) $ticket->needReopen());
 
         // force a reopen
-        $followup = new \ITILFollowup();
+        $followup = new ITILFollowup();
         $followup->add([
             'itemtype'   => 'Ticket',
             'items_id'   => $tickets_id,
@@ -6906,8 +6914,8 @@ HTML,
         $entity_id = 0;
 
         $ticket = new Ticket();
-        $fup = new \ITILFollowup();
-        $sol = new \ITILSolution();
+        $fup = new ITILFollowup();
+        $sol = new ITILSolution();
 
         //create a ticket
         $ticket_id = $ticket->add([
@@ -7296,7 +7304,7 @@ HTML,
         );
 
         $this->createItem(
-            \ITILFollowup::class,
+            ITILFollowup::class,
             [
                 'itemtype'      => Ticket::class,
                 'items_id'      => $ticket->getID(),
@@ -7306,7 +7314,7 @@ HTML,
         );
 
         $this->createItem(
-            \ITILFollowup::class,
+            ITILFollowup::class,
             [
                 'itemtype'      => Ticket::class,
                 'items_id'      => $ticket->getID(),
@@ -7318,7 +7326,7 @@ HTML,
         );
 
         $this->createItem(
-            \ITILFollowup::class,
+            ITILFollowup::class,
             [
                 'itemtype'   => Ticket::class,
                 'items_id'   => $ticket->getID(),
@@ -7586,7 +7594,7 @@ HTML,
                 array_values(
                     array_filter(
                         $timeline,
-                        fn($entry) => $entry['type'] === \ITILFollowup::class
+                        fn($entry) => $entry['type'] === ITILFollowup::class
                     )
                 ),
             );
@@ -8042,13 +8050,13 @@ HTML,
         );
 
         $calendar = $this->createItem(
-            \Calendar::class,
+            Calendar::class,
             [
                 'name' => __FUNCTION__,
             ]
         );
 
-        $segments = $this->createItems(\CalendarSegment::class, [
+        $segments = $this->createItems(CalendarSegment::class, [
             ['calendars_id' => $calendar->getID(), 'day' => 0, 'begin' => '00:00:00', 'end' => '24:00:00'],
             ['calendars_id' => $calendar->getID(), 'day' => 1, 'begin' => '00:00:00', 'end' => '24:00:00'],
             ['calendars_id' => $calendar->getID(), 'day' => 2, 'begin' => '00:00:00', 'end' => '24:00:00'],
@@ -8059,13 +8067,13 @@ HTML,
         ]);
 
         $calendar2 = $this->createItem(
-            \Calendar::class,
+            Calendar::class,
             [
                 'name' => __FUNCTION__,
             ]
         );
 
-        $segments2 = $this->createItems(\CalendarSegment::class, [
+        $segments2 = $this->createItems(CalendarSegment::class, [
             ['calendars_id' => $calendar2->getID(), 'day' => 0, 'begin' => '08:00:00', 'end' => '17:00:00'],
             ['calendars_id' => $calendar2->getID(), 'day' => 1, 'begin' => '08:00:00', 'end' => '17:00:00'],
             ['calendars_id' => $calendar2->getID(), 'day' => 2, 'begin' => '08:00:00', 'end' => '17:00:00'],
@@ -8076,20 +8084,20 @@ HTML,
         ]);
 
         $calendar3 = $this->createItem(
-            \Calendar::class,
+            Calendar::class,
             [
                 'name' => __FUNCTION__,
             ]
         );
 
         $calendar4 = $this->createItem(
-            \Calendar::class,
+            Calendar::class,
             [
                 'name' => __FUNCTION__,
             ]
         );
 
-        $segmetns4 = $this->createItems(\CalendarSegment::class, [
+        $segmetns4 = $this->createItems(CalendarSegment::class, [
             ['calendars_id' => $calendar4->getID(), 'day' => 1, 'begin' => '08:00:00', 'end' => '17:00:00'],
             ['calendars_id' => $calendar4->getID(), 'day' => 2, 'begin' => '08:00:00', 'end' => '17:00:00'],
             ['calendars_id' => $calendar4->getID(), 'day' => 4, 'begin' => '08:00:00', 'end' => '17:00:00'],
@@ -8790,7 +8798,7 @@ HTML,
 
         yield [
             'profilerights' => [
-                'followup' => \ITILFollowup::ADDMYTICKET,
+                'followup' => ITILFollowup::ADDMYTICKET,
                 'ticket'   => 0,
                 'document' => 0,
             ],
@@ -8817,7 +8825,7 @@ HTML,
 
         yield [
             'profilerights' => [
-                'followup' => \ITILFollowup::ADDMYTICKET,
+                'followup' => ITILFollowup::ADDMYTICKET,
                 'ticket'   => UPDATE,
                 'document' => 0,
             ],
@@ -8826,7 +8834,7 @@ HTML,
 
         yield [
             'profilerights' => [
-                'followup' => \ITILFollowup::ADDMYTICKET,
+                'followup' => ITILFollowup::ADDMYTICKET,
                 'ticket'   => 0,
                 'document' => CREATE,
             ],
@@ -8924,7 +8932,7 @@ HTML,
         );
 
         $rule = $this->createItem(
-            \Rule::class,
+            Rule::class,
             [
                 'entities_id' => 0,
                 'name' => 'Rule name',
@@ -8945,7 +8953,7 @@ HTML,
         $this->createItem(\RuleCriteria::class, [
             'rules_id' => $rule->getID(),
             'criteria' => 'name',
-            'condition' => \Rule::PATTERN_CONTAIN,
+            'condition' => Rule::PATTERN_CONTAIN,
             'pattern' => 'ITILsolution',
         ]);
 
@@ -8981,7 +8989,7 @@ HTML,
 
         $this->assertTrue($queue->delete(['id' => $queue->getID()], true));
 
-        $solution = new \ITILSolution();
+        $solution = new ITILSolution();
         $this->assertTrue($solution->getFromDBByCrit([
             'items_id' => $ticket->getID(),
             'itemtype' => Ticket::class,
@@ -8990,7 +8998,7 @@ HTML,
 
         // Test Notification for solved ticket with solution template rule at update
         $this->updateItem(
-            \ITILSolution::class,
+            ITILSolution::class,
             $solution->getID(),
             [
                 'status' => 3,
@@ -9025,9 +9033,9 @@ HTML,
             ],
             ['status']
         );
-        $solution = new \ITILSolution();
+        $solution = new ITILSolution();
         $this->createItem(
-            \ITILSolution::class,
+            ITILSolution::class,
             [
                 'items_id' => $ticket->getID(),
                 'itemtype' => Ticket::class,
@@ -9228,5 +9236,108 @@ HTML,
         $this->assertCount(2, $linked_contracts);
         $this->assertContains($contract_1->getID(), array_column($linked_contracts, 'contracts_id'));
         $this->assertContains($contract_2->getID(), array_column($linked_contracts, 'contracts_id'));
+    }
+
+    /**
+     * Ensure that there is no error triggered when refusing solutions or reopening tickets
+     * with a SLA assigned on a specific calendar.
+     * @see https://github.com/glpi-project/glpi/pull/21337
+     */
+    public function testTicketUnsolveWithSLA()
+    {
+        $this->login();
+
+        $entity_id = getItemByTypeName('Entity', '_test_root_entity', true);
+
+        // Create a calendar with working hours from 8 a.m. to 7 p.m. Monday to Friday
+        $calendar = $this->createItem(Calendar::class, ['name' => 'Calendar']);
+        $this->createItems(CalendarSegment::class, [
+            ['calendars_id' => $calendar->getID(), 'day' => 1, 'begin' => '08:00:00', 'end' => '18:00:00'],
+            ['calendars_id' => $calendar->getID(), 'day' => 2, 'begin' => '08:00:00', 'end' => '18:00:00'],
+            ['calendars_id' => $calendar->getID(), 'day' => 3, 'begin' => '08:00:00', 'end' => '18:00:00'],
+            ['calendars_id' => $calendar->getID(), 'day' => 4, 'begin' => '08:00:00', 'end' => '18:00:00'],
+            ['calendars_id' => $calendar->getID(), 'day' => 5, 'begin' => '08:00:00', 'end' => '18:00:00'],
+        ]);
+
+        // Create SLM/SLA
+        $slm = $this->createItem(SLM::class, [
+            'name'                => 'SLM',
+            'entities_id'         => $entity_id,
+            'is_recursive'        => true,
+            'use_ticket_calendar' => false,
+            'calendars_id'        => $calendar->getID(),
+        ]);
+        $sla = $this->createItem(SLA::class, [
+            'name'                => 'SLA TTR',
+            'entities_id'         => $entity_id,
+            'is_recursive'        => true,
+            'type'                => SLM::TTR,
+            'number_time'         => 4,
+            'calendars_id'        => $calendar->getID(),
+            'definition_time'     => 'hour',
+            'end_of_working_day'  => false,
+            'slms_id'             => $slm->getID(),
+            'use_ticket_calendar' => false,
+        ]);
+
+        // Create a ticket
+        $ticket = $this->createItem(
+            Ticket::class,
+            [
+                'name'          => __FUNCTION__,
+                'content'       => __FUNCTION__,
+                'slas_id_ttr'   => $sla->getID(),
+            ]
+        );
+
+        // Add a solution
+        $solution = $this->createItem(
+            ITILSolution::class,
+            [
+                'itemtype'  => Ticket::class,
+                'items_id'  => $ticket->getID(),
+                'content'   => __FUNCTION__,
+            ]
+        );
+
+        $this->assertTrue($ticket->getFromDB($ticket->getID()));
+        $this->assertEquals(Ticket::SOLVED, $ticket->fields['status']);
+        $this->assertTrue($solution->getFromDB($solution->getID()));
+        $this->assertSame(CommonITILValidation::WAITING, $solution->fields['status']);
+
+        // Refuse the solution
+        $this->createItem(
+            ITILFollowup::class,
+            [
+                'itemtype'      => Ticket::class,
+                'items_id'      => $ticket->getID(),
+                'add_reopen'    => '1',
+                'content'       => __FUNCTION__,
+            ],
+            ['add_reopen']
+        );
+
+        $this->assertTrue($ticket->getFromDB($ticket->getID()));
+        $this->assertEquals(Ticket::INCOMING, $ticket->fields['status']);
+        $this->assertTrue($solution->getFromDB($solution->getID()));
+        $this->assertSame(CommonITILValidation::REFUSED, $solution->fields['status']);
+
+        // Close the ticket
+        $this->updateItem(Ticket::class, $ticket->getID(), ['status' => Ticket::CLOSED]);
+
+        // Reopen the ticket
+        $this->createItem(
+            ITILFollowup::class,
+            [
+                'itemtype'      => Ticket::class,
+                'items_id'      => $ticket->getID(),
+                'add_reopen'    => '1',
+                'content'       => __FUNCTION__,
+            ],
+            ['add_reopen']
+        );
+
+        $this->assertTrue($ticket->getFromDB($ticket->getID()));
+        $this->assertEquals(Ticket::INCOMING, $ticket->fields['status']);
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

It fixes #21229.

We should probably remove usages of the `"NULL"` strings in our whole codebase, but it is massively used and may have unexpected side effects, so I propose to just handle this specific case for the moment.

For information, these values are defined here: https://github.com/glpi-project/glpi/blob/077736c7c28b6dacfafcb7aa6d828f2ae43b90b6/src/CommonITILObject.php#L2301-L2310

Setting a `null` value instead of the `"NULL"` string would change the result of every following `isset()` test, and I am not really able to predict how the code will behave with this.