### PR TITLE
How will the user interact with ticket satisfaction through GLPI 11?

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -10703,7 +10703,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
             in_array($item->fields['status'], static::getClosedStatusArray())
             && $satisfaction->getFromDB($item->getID())
         ) {
-            $satisfaction->showSatisactionForm($item);
+            $satisfaction->showSatisfactionForm($item);
         } else {
             echo "<p class='center b'>" . __s('No generated survey') . "</p>";
         }
@@ -10736,7 +10736,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
         }
 
         ob_start();
-        $satisfaction->showSatisactionForm($this);
+        $satisfaction->showSatisfactionForm($this);
         return trim((string) ob_get_clean());
     }
 

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -671,6 +671,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
             'canassign'               => $canupdate,
             'can_requester'           => $this->canRequesterUpdateItem(),
             'has_pending_reason'      => PendingReason_Item::getForItem($this) !== false,
+            'helpdesk_satisfaction'   => $this->getHelpdeskSatisfactionHtml(),
         ]);
 
         return true;
@@ -10706,6 +10707,37 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
         } else {
             echo "<p class='center b'>" . __s('No generated survey') . "</p>";
         }
+    }
+
+    /**
+     * Render the satisfaction form for helpdesk interface when available.
+     */
+    protected function getHelpdeskSatisfactionHtml(): string
+    {
+        if (Session::getCurrentInterface() !== 'helpdesk') {
+            return '';
+        }
+
+        if ($this->isNewItem()) {
+            return '';
+        }
+
+        if (!in_array($this->fields['status'], static::getClosedStatusArray(), true)) {
+            return '';
+        }
+
+        $satisfaction = static::getSatisfactionClassInstance();
+        if ($satisfaction === null) {
+            return '';
+        }
+
+        if (!$satisfaction->getFromDB($this->getID())) {
+            return '';
+        }
+
+        ob_start();
+        $satisfaction->showSatisactionForm($this);
+        return trim((string) ob_get_clean());
     }
 
     /**

--- a/src/CommonITILSatisfaction.php
+++ b/src/CommonITILSatisfaction.php
@@ -135,7 +135,7 @@ abstract class CommonITILSatisfaction extends CommonDBTM
      *
      * @param CommonITILObject $item The item this satisfaction is for
      **/
-    public function showSatisactionForm($item)
+    public function showSatisfactionForm($item)
     {
         $options             = [];
         $options['colspan']  = 1;

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -3794,6 +3794,7 @@ JAVASCRIPT;
                 'show_tickets_properties_on_helpdesk',
                 Session::getActiveEntity(),
             ),
+            'helpdesk_satisfaction'     => $this->getHelpdeskSatisfactionHtml(),
         ]);
 
         return true;

--- a/templates/components/itilobject/itilsatisfaction.html.twig
+++ b/templates/components/itilobject/itilsatisfaction.html.twig
@@ -33,15 +33,19 @@
 {% import "components/alerts_macros.html.twig" as alerts %}
 {% import "components/form/fields_macros.html.twig" as fields %}
 
+{% set is_helpdesk = (get_current_interface() == 'helpdesk') %}
+{% set field_orientation_opts = {
+    'full_width': true,
+    'is_horizontal': not is_helpdesk
+} %}
+
 {% block more_fields %}
     {% if url is defined %}
         {{ fields.htmlField(
             '',
             '<a href="' ~ url|escape ~ '">' ~ url|escape ~ '</a>',
             __('External survey'),
-            {
-                full_width: true
-            }
+            field_orientation_opts
         ) }}
 
     {% else %}
@@ -56,9 +60,7 @@
                 '',
                 '',
                 __('No response given'),
-                {
-                    full_width: true
-                }
+                field_orientation_opts
             ) }}
         {% else %}
             {{ fields.hiddenField(
@@ -83,20 +85,18 @@
                 'satisfaction',
                 select_dom,
                 __('Satisfaction with the resolution of the %s')|format(parent_item.getTypeName(1)),
-                {
-                    'full_width': true,
-                    'input_class': 'col-xxl-7 text-start',
-                }
+                field_orientation_opts|merge({
+                    'input_class': is_helpdesk ? '' : 'col-xxl-7 text-start'
+                })
             ) }}
 
             {{ fields.textareaField(
                 'comment',
                 item.fields['comment'],
                 _n('Comment', 'Comments', get_plural_number()),
-                {
-                    'full_width': true,
+                field_orientation_opts|merge({
                     'readonly': expired,
-                }
+                })
             ) }}
 
             {% if item.fields['date_answered'] > 0 %}
@@ -105,10 +105,9 @@
                     'date_answered',
                     item.fields['date_answered'],
                     __('Response date to the satisfaction survey.'),
-                    {
-                        'full_width': true,
+                    field_orientation_opts|merge({
                         'readonly' : true
-                    }
+                    })
                 ) }}
 
             {% endif %}

--- a/templates/components/itilobject/layout.html.twig
+++ b/templates/components/itilobject/layout.html.twig
@@ -116,6 +116,31 @@
    <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}" />
 </form>
 
+{% if is_helpdesk and helpdesk_satisfaction is defined and helpdesk_satisfaction|trim is not empty %}
+   {% set satisfaction_panel_id = 'helpdesk-satisfaction-' ~ rand %}
+   <button
+      class="btn btn-primary position-fixed bottom-0 end-0 mb-3 me-3 z-3 helpdesk-satisfaction-trigger"
+      type="button"
+      data-bs-toggle="offcanvas"
+      data-bs-target="#{{ satisfaction_panel_id }}"
+      aria-controls="{{ satisfaction_panel_id }}"
+      title="{{ __('Satisfaction survey') }}"
+   >
+      <i class="ti ti-star me-1"></i>
+      <span class="d-none d-sm-inline">{{ __('Satisfaction survey') }}</span>
+   </button>
+
+   <div class="offcanvas offcanvas-end helpdesk-satisfaction-panel" tabindex="-1" id="{{ satisfaction_panel_id }}" aria-labelledby="{{ satisfaction_panel_id }}-label" data-bs-scroll="true">
+      <div class="offcanvas-header">
+         <h5 class="offcanvas-title" id="{{ satisfaction_panel_id }}-label">{{ __('Satisfaction survey') }}</h5>
+         <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="{{ __('Close') }}"></button>
+      </div>
+      <div class="offcanvas-body overflow-auto">
+         {{ helpdesk_satisfaction|raw }}
+      </div>
+   </div>
+{% endif %}
+
 <script type="text/javascript">
 $(function() {
    $(document).on("click", ".switch-panel-width", function() {


### PR DESCRIPTION
Fixes #21263

This is my first time contributing to the project.

## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

- Restore the self-service satisfaction survey by reusing the dedicated rendering helper in `CommonITILObject` and renamed it to showSatisfactionForm.
- Surface the survey via a floating button that opens a Bootstrap off-canvas panel in the helpdesk layout, keeping the ticket view uncluttered.
- Switch the satisfaction form to a vertical layout in the self-service interface while preserving the existing horizontal presentation in the central interface.
- Manual smoke check: verified that a closed helpdesk ticket displays the new off-canvas survey and that the central interface remains unchanged.

## Not working
 - Using the link from an email goes to the ticket form without automatically opening the survey panel.