### PR TITLE
Fix form export with entity question special default value

### DIFF
--- a/src/Glpi/Form/QuestionType/QuestionTypeItem.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeItem.php
@@ -675,7 +675,7 @@ class QuestionTypeItem extends AbstractQuestionType implements
         // Stop here if value is invalid or empty
         $itemtype = $extra_data_config[QuestionTypeItemExtraDataConfig::ITEMTYPE] ?? "";
         $root_id = $extra_data_config[QuestionTypeItemDropdownExtraDataConfig::ROOT_ITEMS_ID] ?? 0;
-        if ($root_id == 0 || !is_a($itemtype, CommonDBTM::class, true)) {
+        if ($root_id <= 0 || !is_a($itemtype, CommonDBTM::class, true)) {
             return $fallback;
         }
 
@@ -708,6 +708,9 @@ class QuestionTypeItem extends AbstractQuestionType implements
         if (
             !(getItemForItemtype($itemtype) instanceof CommonDBTM)
             || empty($name)
+            // Both these values represent the root entity, no need to map it
+            || $name == 0
+            || $name == -1
         ) {
             return $fallback;
         }

--- a/tests/functional/Glpi/Form/Export/FormSerializerTest.php
+++ b/tests/functional/Glpi/Form/Export/FormSerializerTest.php
@@ -89,6 +89,7 @@ use Location;
 use Monitor;
 use Ramsey\Uuid\Uuid;
 use Session;
+use function Safe\json_encode;
 
 final class FormSerializerTest extends \DbTestCase
 {
@@ -1680,6 +1681,25 @@ final class FormSerializerTest extends \DbTestCase
             "data-form-tag-value=\"{$imported_comment_2->getID()}\" data-form-tag-provider=\"Glpi\Form\Tag\CommentDescriptionTagProvider\"",
             $imported_destination->getConfig()[ContentField::getKey()]['value'],
         );
+    }
+
+    public function testWithFormWithSpecialNegativeIdForRootEntity(): void
+    {
+        // Arrange: create a form with a -1 value for root_items_id
+        $builder = new FormBuilder("My form");
+        $extra_data = new QuestionTypeItemExtraDataConfig(
+            itemtype: Entity::class,
+            root_items_id: -1,
+        );
+        $builder->addQuestion(
+            name: "Entity",
+            type: QuestionTypeItem::class,
+            extra_data: json_encode($extra_data)
+        );
+        $form = $this->createForm($builder);
+
+        // Act: export the form, no error should happen
+        $this->exportAndImportForm($form);
     }
 
     private function compareValuesForRelations(


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

The `root_items_id: -1` special value for entity question was not taken into account correctly by the export feature and was causing an error.

<img width="1458" height="133" alt="image" src="https://github.com/user-attachments/assets/71428911-b95a-4823-b3cd-6d0687713f99" />



