### PR TITLE
Fix search results fields reconciliation

### DIFF
--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -5093,7 +5093,7 @@ final class SQLProvider implements SearchProviderInterface
                 // Parse data
                 foreach ($newrow['raw'] as $key => $val) {
                     $matches = [];
-                    if (preg_match('/^ITEM(_(?<itemtype>[a-z][\w\\\]*))?_(?<num>\d+)(_(?<fieldname>.+))?$/i', $key, $matches)) {
+                    if (preg_match('/^ITEM(_(?<itemtype>[a-z][\w\\\]*?))?_(?<num>\d+)(_(?<fieldname>.+))?$/i', $key, $matches)) {
                         $j = (!empty($matches['itemtype']) ? $matches['itemtype'] . '_' : '') . $matches['num'];
                         $fieldname = $matches['fieldname'] ?? 'name';
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

If fixes #21295.

In GLPI 10.0, numeric chars were not allowed in itemtype names (regex was `/ITEM(_(\w[^\d]+))?_(\d+)(_(.+))?/`). Now they are allowed, we have to use a lazy quantifier in the regex to not capture the search option num with the itemtype.