### PR TITLE
Fix(UI); fix UI with POST_ITEM_FORM

### DIFF
--- a/templates/components/form/buttons.html.twig
+++ b/templates/components/form/buttons.html.twig
@@ -36,9 +36,9 @@
 {% set id           = item.fields['id'] ?? -1 %}
 
 {% if item is defined %}
-         <div class="row">
-         {{ call_plugin_hook(constant('Glpi\\Plugin\\Hooks::POST_ITEM_FORM'), {'item': item, 'options': params}) }}
-         </div>
+
+     {{ call_plugin_hook(constant('Glpi\\Plugin\\Hooks::POST_ITEM_FORM'), {'item': item, 'options': params}) }}
+
 
     {% if canedit or item.canEdit(item.fields['id']) %}
       <div class="card-body mx-n2 border-top d-flex flex-row-reverse align-items-start flex-wrap">


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

In GLPI, form fields are typically wrapped inside `card-body` elements.

The advantage of using `card-body` is that when additional fields are injected via the `POST_ITEM_FORM` and `PRE_ITEM_FORM` hooks, and these fields are also placed inside a `card-body`, Bootstrap automatically adds a top border using the following CSS rule:

```css
.card-body + .card-body {
    border-top: var(--tblr-border-width) var(--tblr-border-style) var(--tblr-border-color);
}
```

(Example: with the “Tag” plugin displayed at the top)

<img width="1649" height="317" alt="image" src="https://github.com/user-attachments/assets/85164d9e-b184-4015-a580-157f23921bab" />

This results in a clean and visually consistent interface.

However, the `POST_ITEM_FORM` hook is currently wrapped inside a `<div>` with the `row` class:

```php
<div class="row">
   {{ call_plugin_hook(constant('Glpi\\Plugin\\Hooks::POST_ITEM_FORM'), {'item': item, 'options': params}) }}
</div>
```

In contrast, the `PRE_ITEM_FORM` hook is called directly, without any wrapping element:

```php
{{ call_plugin_hook(constant('Glpi\\Plugin\\Hooks::PRE_ITEM_FORM'), {'item': item, 'options': params ?? []}) }}
```

As a result, the rendering of elements added via `POST_ITEM_FORM` differs — the top border is missing, and there is noticeably more vertical spacing between sections (example below, with the “Tag” plugin displayed at the bottom).

<img width="1556" height="308" alt="image" src="https://github.com/user-attachments/assets/4ea56352-1bcf-495b-bb4b-3134fbdb514c" />


## Screenshots (if appropriate):


