### PR TITLE
Fix - Handle missing user fields in assignable types for plugin compatibility

### DIFF
--- a/src/Group.php
+++ b/src/Group.php
@@ -587,6 +587,10 @@ class Group extends CommonTreeDropdown
             if (!($item = getItemForItemtype($itemtype))) {
                 continue;
             }
+            if (!$item->isField($ufield)) {
+                // Skip items that don't have the required user field (plugins may have different field structures)
+                continue;
+            }
             if (!$item::canView()) {
                 continue;
             }

--- a/src/User.php
+++ b/src/User.php
@@ -4642,6 +4642,10 @@ HTML;
             if (!($item = getItemForItemtype($itemtype))) {
                 continue;
             }
+            if (!$item->isField($field_user)) {
+                // Skip items that don't have the required user field (plugins may have different field structures)
+                continue;
+            }
             if ($item::canView()) {
                 $itemtable = getTableForItemType($itemtype);
                 $relation_table = Group_Item::getTable();


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes https://github.com/pluginsGLPI/order/issues/470
- Here is a brief description of what this PR does

Fix SQL error "Unknown column 'users_id_tech'" when accessing tech tabs with plugins that don't implement the standard user field structure.

### Problem
GLPI core assumes all assignable types have a `users_id_tech` field for technician assignments. However, some plugins like the Order plugin only implement `users_id` and `users_id_delivery` fields, causing MySQL errors when the core tries to query non-existent fields.

### Solution
Added field existence checks using `isField()` method in both `Group::getDataItems()` and `User::showItems()` methods to skip items that don't have the required user field before constructing SQL queries.

### Changes
- **src/Group.php**: Added field validation in `getDataItems()` method
- **src/User.php**: Added field validation in `showItems()` method
- Both files include explanatory comments about plugin compatibility

## Screenshots (if appropriate):

<img width="1144" height="543" alt="image" src="https://github.com/user-attachments/assets/21374f37-ff59-4cec-8c8d-67d53bf2ab3b" />
