### PR TITLE
fix(task): status icon not rendered in searchoptions

### DIFF
--- a/src/Planning.php
+++ b/src/Planning.php
@@ -232,6 +232,11 @@ class Planning extends CommonGLPI
      */
     public static function getStatusIcon($status): string
     {
+        if (!is_numeric($status)) {
+            return '';
+        }
+
+        $status = intval($status);
         $label = htmlescape(self::getState($status));
         if (empty($label)) {
             return '';


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- Fixed the display of task statuses. The icons intended to represent each status were not displaying and were being replaced by status identifiers.

## Screenshots (if appropriate):

Before:
<img width="226" height="193" alt="image" src="https://github.com/user-attachments/assets/7fe2a761-117d-4387-b254-e05648f9beb0" />

After:
<img width="226" height="193" alt="image" src="https://github.com/user-attachments/assets/f4e8cfbe-271c-4ef6-8bde-a2604271ad62" />



