### PR TITLE
Add extra info on item copy failure

### DIFF
--- a/src/Glpi/Migration/AbstractPluginMigration.php
+++ b/src/Glpi/Migration/AbstractPluginMigration.php
@@ -418,6 +418,8 @@ abstract class AbstractPluginMigration
             ]);
 
             foreach ($iterator as $related_item_data) {
+                $origin_id = $related_item_data[$itemtype::getIndexName()] ?? '?';
+
                 unset($related_item_data[$itemtype::getIndexName()]);
 
                 foreach ($replacements as $replacement) {
@@ -444,7 +446,7 @@ abstract class AbstractPluginMigration
                             $itemtype::getTypeName(1),
                             $related_item_data[$itemtype::getNameField()] ?? NOT_AVAILABLE,
                         ),
-                        'Copy operation failed.'
+                        sprintf('Copy operation failed for itemtype `%s` (%s).', $itemtype, $origin_id)
                     );
                 }
             }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

There are some `prepareInputForAdd` methods that returns a `false` value without adding any message to the session. This makes pretty hard to understand why there is a failure in the `genericobject` plugin migration, see #21289.

Adding the itemtype to the exception message may help to understand the issue, adn adding the ID may help to ask for a database extract.