### PR TITLE
Fix : Category and Type unavailable in Ticket Template selectable fields

### DIFF
--- a/src/ITILTemplateField.php
+++ b/src/ITILTemplateField.php
@@ -131,7 +131,7 @@ abstract class ITILTemplateField extends CommonDBChild
      *
      * @return bool
      **/
-    public static function showForITILTemplate(ITILTemplate $tt, $withtemplate = 0): bool
+    public static function showForITILTemplate(ITILTemplate $tt, $withtemplate = 0, $withtypeandcategory = true): bool
     {
         global $DB, $CFG_GLPI;
 
@@ -141,7 +141,7 @@ abstract class ITILTemplateField extends CommonDBChild
             return false;
         }
         $canedit = $tt->canEdit($ID);
-        $fields  = $tt->getAllowedFieldsNames(true);
+        $fields  = $tt->getAllowedFieldsNames($withtypeandcategory);
         $fields  = array_diff_key($fields, static::getExcludedFields());
         $display_options = [
             'relative_dates' => true,

--- a/src/ITILTemplateHiddenField.php
+++ b/src/ITILTemplateHiddenField.php
@@ -73,6 +73,16 @@ abstract class ITILTemplateHiddenField extends ITILTemplateField
         return '';
     }
 
+    public static function displayTabContentForItem(CommonGLPI $item, $tabnum = 1, $withtemplate = 0)
+    {
+        if (!$item instanceof ITILTemplate) {
+            return false;
+        }
+
+        self::showForITILTemplate($item, $withtemplate, false);
+        return true;
+    }
+
 
     public function post_purgeItem()
     {


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes #21313
- Here is a brief description of what this PR does
In the list of fields that can be selected as Predefined/Mandatory and Hidden Fields for a Ticket Template, the category and type were no longer visible. (Whereas they were visible in version 10.)

## Screenshots (if appropriate):


