### PR TITLE
Do not set session files path on CLI context

### DIFF
--- a/src/Glpi/Kernel/Listener/PostBootListener/SessionStart.php
+++ b/src/Glpi/Kernel/Listener/PostBootListener/SessionStart.php
@@ -79,15 +79,18 @@ class SessionStart implements EventSubscriberInterface
 
         Profiler::getInstance()->start('SessionStart::execute', Profiler::CATEGORY_BOOT);
 
-        // Always set the session files path, even when session is not started automatically here.
-        // It can indeed be started later manually and the path must be correctly set when it is done.
-        if (Session::canWriteSessionFiles()) {
-            Session::setPath();
-        } else {
-            \trigger_error(
-                sprintf('Unable to write session files on `%s`.', GLPI_SESSION_DIR),
-                E_USER_WARNING
-            );
+        if ($this->php_sapi !== 'cli') {
+            // Always set the session files path, even when session is not started automatically here.
+            // It can indeed be started later manually and the path must be correctly set when it is done,
+            // sessions will not be recoverable accross requests.
+            if (Session::canWriteSessionFiles()) {
+                Session::setPath();
+            } else {
+                \trigger_error(
+                    sprintf('Unable to write session files on `%s`.', GLPI_SESSION_DIR),
+                    E_USER_WARNING
+                );
+            }
         }
 
         if ($this->php_sapi === 'cli') {


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

It fixes #21380.

Since #20189, the session is no more started on CLI context. The `$_SESSION` variable is still used, but its content is not saved anyware and just vanishes at the end of the process execution. Therefore, we do not need to change the sessions files path with `session_save_path()`.
