### PR TITLE
Fix `notification_to_myself` handling with manually collected emails

### DIFF
--- a/src/NotificationEvent.php
+++ b/src/NotificationEvent.php
@@ -159,7 +159,11 @@ class NotificationEvent extends CommonDBTM
                 $notify_me = false;
                 $emitter = null;
 
-                if (Session::isCron()) {
+                if (
+                    Session::isCron() // Ticket has been created by a crontask
+                    || isCommandLine() // Ticket has been created by a CLI command
+                    || isset($_SESSION['mailcollector_user']) // Ticket has been created by the mail collector (even manually)
+                ) {
                     // Cron notify me
                     $notify_me = true;
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

In #16813, someone mentioned that the `notification_to_myself` preference had a different behaviour wwhether the emails were collected by the cron script or were collected manually.

I did not take time to review the whole thread, and it is probably not the only problem, but at least, having a similar behaviour will permit to have consistent results when doing manual tests.