### PR TITLE
fix(central): prevent widget overlap in personal view masonry layout

### DIFF
--- a/templates/components/masonry_grid.html.twig
+++ b/templates/components/masonry_grid.html.twig
@@ -60,25 +60,23 @@ $(function() {
        window.msnry_grid_{{ rand }}.layout();
    });
 
-   // Use MutationObserver to detect content changes
-   const observer = new MutationObserver(function(mutations) {
+   // Use MutationObserver with debouncing to detect content changes
+   const observer = new MutationObserver(window._.debounce(function(mutations) {
        requestAnimationFrame(function() {
            window.msnry_grid_{{ rand }}.layout();
        });
-   });
+   }, 150));
 
    observer.observe(document.getElementById('grid_{{ rand }}'), {
        childList: true,
-       subtree: true,
-       attributes: true,
-       characterData: true
+       subtree: true
    });
 
-   // Also handle window resize
-   $(window).on('resize', function() {
+   // Also handle window resize with debouncing
+   $(window).on('resize', window._.debounce(function() {
        requestAnimationFrame(function() {
            window.msnry_grid_{{ rand }}.layout();
        });
-   });
+   }, 150));
 });
 </script>


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !39652
- In the central dashboard **Personal View**, the **Public Reminders** widget intermittently overlaps the **Your Planning** widget, making the planning section unreadable.

## Screenshots (if appropriate):
<img width="769" height="404" alt="image" src="https://github.com/user-attachments/assets/720f0364-2b2b-4116-9f3f-57183b4532e9" />



