### PR TITLE
Change log viewer to use system_logs right

### DIFF
--- a/front/logs.php
+++ b/front/logs.php
@@ -37,7 +37,7 @@ require_once(__DIR__ . '/_check_webserver_config.php');
 
 use Glpi\System\Log\LogViewer;
 
-Session::checkRight("logs", READ);
+Session::checkRight("system_logs", READ);
 
 Html::header(
     LogViewer::getTypeName(Session::getPluralNumber()),

--- a/src/Glpi/System/Log/LogViewer.php
+++ b/src/Glpi/System/Log/LogViewer.php
@@ -47,7 +47,7 @@ final class LogViewer extends CommonGLPI
      */
     private $log_parser;
 
-    public static $rightname = 'logs';
+    public static $rightname = 'system_logs';
 
     public function __construct()
     {


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Make Log Viewer check `system_logs` right instead of `logs`. Not sure how I missed this in #16286.

