### PR TITLE
fix(infocom): remove number_format for value field

### DIFF
--- a/templates/components/infocom.html.twig
+++ b/templates/components/infocom.html.twig
@@ -179,7 +179,7 @@
 
                      {{ fields.numberField(
                         'warranty_value',
-                        infocom.fields['warranty_value']|formatted_number,
+                        infocom.fields['warranty_value'],
                         __('Warranty extension value'),
                         {
                             'disabled': disabled,


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !39683
- The value field of the infocoms is of type numberField and not of type textField, which does not allow the number corresponding to the value of this field to be formatted.

## Screenshots (if appropriate):

Before:
<img width="472" height="52" alt="image" src="https://github.com/user-attachments/assets/2730eb51-8d90-4ef0-baba-235eeea5745e" />

After:
<img width="472" height="52" alt="image" src="https://github.com/user-attachments/assets/bb41e588-bd70-4252-bc7e-87489d7c1973" />



