### PR TITLE
Fix(Marketplace): Fix error when extracting long path file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -202,7 +202,8 @@
             "patch -f -p1 -d vendor/laminas/laminas-mail/ < tools/patches/laminas-laminas-mail-address-no-length-check.patch || true",
             "patch -f -p1 -d vendor/laminas/laminas-mail/ < tools/patches/laminas-laminas-mail-invalid-header-ignore.patch || true",
             "patch -f -p1 -d vendor/scssphp/scssphp/ < tools/patches/scssphp-scssphp-php-8.5-compat.patch || true",
-            "patch -f -p1 -d vendor/wapmorgan/unified-archive/ < tools/patches/wapmorgan-unified-archive-php-8.5-compat.patch || true"
+            "patch -f -p1 -d vendor/wapmorgan/unified-archive/ < tools/patches/wapmorgan-unified-archive-php-8.5-compat.patch || true",
+            "patch -f -p1 -d vendor/wapmorgan/unified-archive/ < tools/patches/wapmorgan-unified-archive-fix-long-path.patch || true"
         ]
     }
 }

--- a/tools/patches/wapmorgan-unified-archive-fix-long-path.patch
+++ b/tools/patches/wapmorgan-unified-archive-fix-long-path.patch
@@ -1,0 +1,54 @@
+diff --git a/src/Drivers/TarByPhar.php b/src/Drivers/TarByPhar.php
+index 47f5304..2fa43bf 100644
+--- a/src/Drivers/TarByPhar.php
++++ b/src/Drivers/TarByPhar.php
+@@ -6,6 +6,7 @@ use FilesystemIterator;
+ use Phar;
+ use PharData;
+ use PharFileInfo;
++use RecursiveDirectoryIterator;
+ use RecursiveIteratorIterator;
+ use wapmorgan\UnifiedArchive\Abilities;
+ use wapmorgan\UnifiedArchive\ArchiveEntry;
+@@ -126,21 +127,34 @@ class TarByPhar extends BasicExtensionDriver
+      */
+     public function getArchiveInformation()
+     {
++        // Create a new ArchiveInformation object to hold metadata
+         $information = new ArchiveInformation();
+-        $stream_path_length = strlen('phar://'.$this->fileName.'/');
++
++        // Store the compressed archive size
+         $information->compressedFilesSize = filesize($this->fileName);
+-        /**
+-         * @var string $i
+-         * @var PharFileInfo $file
+-         */
+-        foreach (new RecursiveIteratorIterator($this->tar) as $i => $file) {
+-            $information->files[] = substr($file->getPathname(), $stream_path_length);
++
++        // Create a temporary folder to extract the TAR archive
++        // Use a shorter prefix to avoid exceeding OS path limits
++        // And extract the TAR archive to the temporary folder
++        $extractPath = GLPI_TMP_DIR . '/' . uniqid('tmp_tar_');
++        $this->tar->extractTo($extractPath);
++
++        // Iterate through all extracted files recursively
++        $iterator = new RecursiveIteratorIterator(
++            new RecursiveDirectoryIterator($extractPath, RecursiveDirectoryIterator::SKIP_DOTS)
++        );
++
++        foreach ($iterator as $file) {
++            /** @var SplFileInfo $file */
++            $relativePath = substr($file->getPathname(), strlen($extractPath) + 1);
++            $information->files[] = $relativePath;
+             $information->uncompressedFilesSize += $file->getSize();
+         }
+         $this->compressRatio = $information->compressedFilesSize > 0
+             ? $information->uncompressedFilesSize / $information->compressedFilesSize
+             : 0;
+         $this->pureFilesNumber = count($information->files);
++
+         return $information;
+     }
+


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

This PR addresses a runtime issue in the TAR extraction process where deeply nested or long file paths can trigger the following exception:

```
[2025-10-13 07:29:39] glpi.CRITICAL:   *** Uncaught PHP Exception RuntimeException: "Cannot access phar file entry '/glpiai/vendor/openai-php/client/src/Responses/Threads/Messages/Files/ThreadMessageFileListResponse.php' in archive './files/_tmp/glpi-glpiai-1.1.0.tar.bz2'" at TarByPhar.php line 138
```

This error comes from the **wapmorgan/unified-archive** library, used by GLPI (in `Glpi\Marketplace\Controller`) to read/unpack archives downloaded from the marketplace.

It is the **`RecursiveIteratorIterator`** function that throws an error when the path exceeds the character limit:

```php
foreach (new RecursiveIteratorIterator($this->tar) as $i => $file) {
    Toolbox::logDebug($file);
}
```

We can observe that `RecursiveIteratorIterator` eventually throws a **RuntimeException**:

```
phar://./files/_tmp/glpi-glpiai-1.1.0.tar.bz2/glpiai/vendor/openai-php/client/src/Responses/Models/RetrieveResponse.php
phar://./files/_tmp/glpi-glpiai-1.1.0.tar.bz2/glpiai/vendor/openai-php/client/src/Responses/Moderations/CreateResponse.php
phar://./files/_tmp/glpi-glpiai-1.1.0.tar.bz2/glpiai/vendor/openai-php/client/src/Responses/Moderations/CreateResponseCategory.php
phar://./files/_tmp/glpi-glpiai-1.1.0.tar.bz2/glpiai/vendor/openai-php/client/src/Responses/Moderations/CreateResponseResult.php
phar://./files/_tmp/glpi-glpiai-1.1.0.tar.bz2/glpiai/vendor/openai-php/client/src/Responses/StreamResponse.php
[2025-10-13 07:29:39] glpi.CRITICAL:   *** Uncaught PHP Exception RuntimeException: "Cannot access phar file entry '/glpiai/vendor/openai-php/client/src/Responses/Threads/Messages/Files/ThreadMessageFileListResponse.php' in archive './files/_tmp/glpi-glpiai-1.1.0.tar.bz2'" at TarByPhar.php line 138
```

The patch bypasses the `Phar` limitation by extracting the archive into a temporary folder before listing the files.

This exactly resolves the error we encountered with the GLPI plugin containing long file paths.


## Screenshots (if appropriate):


