### PR TITLE
Display a warning on install pages when server is misconfigured

### DIFF
--- a/install/install.php
+++ b/install/install.php
@@ -33,6 +33,8 @@
  * ---------------------------------------------------------------------
  */
 
+require_once(__DIR__ . '/../front/_check_webserver_config.php');
+
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\System\Requirement\DbConfiguration;
 use Glpi\System\Requirement\DbEngine;

--- a/install/update.php
+++ b/install/update.php
@@ -33,6 +33,8 @@
  * ---------------------------------------------------------------------
  */
 
+require_once(__DIR__ . '/../front/_check_webserver_config.php');
+
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\Toolbox\VersionParser;
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

When the webserver is misconfigured, accessing directly the `/install/install.php` page result in an obscure error:
```
Fatal error: Uncaught Error: Class "Session" not found in C:\xampp\htdocs\glpi\install\install.php:483 Stack trace: #0 {main} thrown in C:\xampp\htdocs\glpi\install\install.php on line 483
```

As done for all the `/front/*` files (see #19520), we should display a proper error message.

It closes #21391.