### PR TITLE
Fix mandatory questions inside hidden sections

### DIFF
--- a/src/Glpi/Form/AnswersHandler/AnswersHandler.php
+++ b/src/Glpi/Form/AnswersHandler/AnswersHandler.php
@@ -108,6 +108,7 @@ final class AnswersHandler
             $questions_container->getQuestions(),
             fn($question) => $question->fields['is_mandatory']
                 && $visibility->isQuestionVisible($question->getID())
+                && $visibility->isSectionVisible($question->getSection()->getID())
         );
 
         foreach ($mandatory_questions as $question) {


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

When submitting a form, we do not take hidden questions into account when validating that mandatory questions are filled.

There was an edge case we missed, as sometimes it is not the question itself that will be marked as hidden but its parent section.

## References

Fix #21287

