### PR TITLE
Add new check on legacy API call for non class relateds assets

### DIFF
--- a/src/Glpi/Api/API.php
+++ b/src/Glpi/Api/API.php
@@ -1503,11 +1503,9 @@ abstract class API
 
         $sub_itemtype = getItemTypeForTable($option['table']);
 
-        if (
-            $sub_itemtype !== null
-            && (isset($option['joinparams']['beforejoin']['table'])
+        if ((isset($option['joinparams']['beforejoin']['table'])
             || empty($option['joinparams']))
-            && $option['linkfield'] != getForeignKeyFieldForItemType($sub_itemtype)
+            && ($sub_itemtype === null || $option['linkfield'] != getForeignKeyFieldForItemType($sub_itemtype))
             && $option['linkfield'] != $option['field']
         ) {
             $uid_parts[] = $option['linkfield'];

--- a/tests/web/APIRestTest.php
+++ b/tests/web/APIRestTest.php
@@ -490,7 +490,8 @@ class APIRestTest extends TestCase
             [
                 'itemtype' => 'AllAssets',
                 'headers'  => ['Session-Token' => $this->session_token],
-            ]
+            ],
+            [200, 206]
         );
 
         $this->assertIsArray($data);


### PR DESCRIPTION

## Description

- It fixes #21433
- Here is a brief description of what this PR does : 
Add null check in API::getSearchOptionUniqID() to prevent passing null to getForeignKeyFieldForItemType() when handling itemtypes like AllAsse


