### PR TITLE
Fix form questions drag and drop on chrome

### DIFF
--- a/js/modules/Forms/EditorController.js
+++ b/js/modules/Forms/EditorController.js
@@ -2330,17 +2330,17 @@ export class GlpiFormEditorController
                     // class that takes over. Manually adding "d-none" get us the
                     // desired effect.
                     $(e.detail.item).addClass('d-none');
+
+                    // If dragged item is active, store it to restore it later
+                    if ($(e.detail.item).is('[data-glpi-form-editor-active-question],[data-glpi-form-editor-active-comment]')) {
+                        $(e.detail.item).attr('data-glpi-form-editor-restore-active-state', '');
+                    }
+
+                    // Remove active states
+                    this.#setActiveItem(null);
                 }, 0);
 
                 $(this.#target).addClass("disable-focus").attr('data-glpi-form-editor-sorting', '');
-
-                // If dragged item is active, store it to restore it later
-                if ($(e.detail.item).is('[data-glpi-form-editor-active-question],[data-glpi-form-editor-active-comment]')) {
-                    $(e.detail.item).attr('data-glpi-form-editor-restore-active-state', '');
-                }
-
-                // Remove active states
-                this.#setActiveItem(null);
             });
 
         // Run the post move process if any item was dragged, even if it was not


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
       -> Can't test drag and drop with cypress.

## Description

Fix drag and drop issues on chrome, done by moving operations that changes the DOM inside the `setTimeout(() => {` wrapper.
This is still the same chrome engine issues as describe in the code comment before calling setTimeout.

## References

Fix #21252 


