### PR TITLE
Fix(Marketplace): Fix error when extracting long path file from archive

### DIFF
--- a/src/Glpi/Marketplace/Controller.php
+++ b/src/Glpi/Marketplace/Controller.php
@@ -214,7 +214,8 @@ class Controller extends CommonGLPI
             // @phpstan-ignore argument.type (see https://github.com/wapmorgan/UnifiedArchive/pull/54)
             ? Formats::getFormatDriver($format, [Abilities::OPEN, Abilities::EXTRACT_CONTENT])
             : null;
-        if (!($driver instanceof BasicDriver)) {
+
+        if (!is_a($driver, BasicDriver::class, true)) {
             Session::addMessageAfterRedirect(
                 htmlescape(sprintf(__('Plugin archive format is not supported by your system : %s.'), $format)),
                 false,


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

replace : https://github.com/wapmorgan/UnifiedArchive/pull/53

This PR addresses a runtime issue in the TAR extraction process where deeply nested or long file paths can trigger the following exception:

```
[2025-10-13 07:29:39] glpi.CRITICAL:   *** Uncaught PHP Exception RuntimeException: "Cannot access phar file entry '/glpiai/vendor/openai-php/client/src/Responses/Threads/Messages/Files/ThreadMessageFileListResponse.php' in archive './files/_tmp/glpi-glpiai-1.1.0.tar.bz2'" at TarByPhar.php line 138
```

The issue here is trigerred because we use `UnifiedArchive::open()` that created an instance of UnifiedArchive that scans the archive. This scan is useless in our context. 

## Screenshots (if appropriate):


