### PR TITLE
Allow actors to be selected from items questions

### DIFF
--- a/src/Glpi/Form/Destination/CommonITILField/AssigneeField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/AssigneeField.php
@@ -37,8 +37,11 @@ namespace Glpi\Form\Destination\CommonITILField;
 use Glpi\Form\Form;
 use Glpi\Form\QuestionType\QuestionTypeAssignee;
 use Glpi\Form\QuestionType\QuestionTypeEmail;
+use Group;
 use Override;
 use Session;
+use Supplier;
+use User;
 
 final class AssigneeField extends ITILActorField
 {
@@ -46,6 +49,12 @@ final class AssigneeField extends ITILActorField
     public function getAllowedQuestionType(): array
     {
         return [new QuestionTypeAssignee(), new QuestionTypeEmail()];
+    }
+
+    #[Override]
+    public function getAllowedQuestionItemTypes(): array
+    {
+        return [User::class, Group::class, Supplier::class];
     }
 
     #[Override]

--- a/src/Glpi/Form/Destination/CommonITILField/ITILActorFieldStrategy.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ITILActorFieldStrategy.php
@@ -38,6 +38,7 @@ namespace Glpi\Form\Destination\CommonITILField;
 use Glpi\Form\AnswersSet;
 use Glpi\Form\QuestionType\AbstractQuestionTypeActors;
 use Glpi\Form\QuestionType\QuestionTypeEmail;
+use Glpi\Form\QuestionType\QuestionTypeItem;
 use Group;
 use Session;
 use Ticket;
@@ -265,6 +266,28 @@ enum ITILActorFieldStrategy: string
                     ],
                 ];
             }
+        } elseif ($answer->getType() instanceof QuestionTypeItem) {
+            $value = $answer->getRawAnswer();
+            if (
+                !in_array(
+                    $value['itemtype'],
+                    $itil_actor_field->getAllowedActorTypes()
+                ) || !is_numeric($value['items_id'])
+            ) {
+                return null;
+            }
+
+            $item = getItemForItemtype($value['itemtype']);
+            if (!$item->getFromDB($value['items_id'])) {
+                return null;
+            }
+
+            return [
+                [
+                    'itemtype' => $value['itemtype'],
+                    'items_id' => (int) $value['items_id'],
+                ],
+            ];
         }
 
         return null;

--- a/src/Glpi/Form/Destination/CommonITILField/ObserverField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ObserverField.php
@@ -37,8 +37,10 @@ namespace Glpi\Form\Destination\CommonITILField;
 use Glpi\Form\Form;
 use Glpi\Form\QuestionType\QuestionTypeEmail;
 use Glpi\Form\QuestionType\QuestionTypeObserver;
+use Group;
 use Override;
 use Session;
+use User;
 
 final class ObserverField extends ITILActorField
 {
@@ -46,6 +48,12 @@ final class ObserverField extends ITILActorField
     public function getAllowedQuestionType(): array
     {
         return [new QuestionTypeObserver(), new QuestionTypeEmail()];
+    }
+
+    #[Override]
+    public function getAllowedQuestionItemTypes(): array
+    {
+        return [User::class, Group::class];
     }
 
     #[Override]

--- a/src/Glpi/Form/Destination/CommonITILField/RequesterField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/RequesterField.php
@@ -37,8 +37,10 @@ namespace Glpi\Form\Destination\CommonITILField;
 use Glpi\Form\Form;
 use Glpi\Form\QuestionType\QuestionTypeEmail;
 use Glpi\Form\QuestionType\QuestionTypeRequester;
+use Group;
 use Override;
 use Session;
+use User;
 
 final class RequesterField extends ITILActorField
 {
@@ -46,6 +48,12 @@ final class RequesterField extends ITILActorField
     public function getAllowedQuestionType(): array
     {
         return [new QuestionTypeRequester(), new QuestionTypeEmail()];
+    }
+
+    #[Override]
+    public function getAllowedQuestionItemTypes(): array
+    {
+        return [User::class, Group::class];
     }
 
     #[Override]

--- a/tests/functional/Glpi/Form/Destination/CommonITILField/AssigneeFieldTest.php
+++ b/tests/functional/Glpi/Form/Destination/CommonITILField/AssigneeFieldTest.php
@@ -45,6 +45,8 @@ use Glpi\Form\Form;
 use Glpi\Form\QuestionType\QuestionTypeActorsExtraDataConfig;
 use Glpi\Form\QuestionType\QuestionTypeAssignee;
 use Glpi\Form\QuestionType\QuestionTypeEmail;
+use Glpi\Form\QuestionType\QuestionTypeItem;
+use Glpi\Form\QuestionType\QuestionTypeItemExtraDataConfig;
 use Glpi\Tests\FormBuilder;
 use Group;
 use Override;
@@ -279,6 +281,14 @@ final class AssigneeFieldTest extends AbstractActorFieldTest
             ],
             "Assignee email 1" => 'test1@test.test',
             "Assignee email 2" => 'test2@test.test',
+            "User question 1" => [
+                'itemtype' => User::class,
+                'items_id' => $user1->getID(),
+            ],
+            "User question 2" => [
+                'itemtype' => User::class,
+                'items_id' => $user2->getID(),
+            ],
         ];
 
         // Using answer from first assignee question
@@ -354,6 +364,23 @@ final class AssigneeFieldTest extends AbstractActorFieldTest
                 ['items_id' => 0, 'alternative_email' => 'test2@test.test'],
                 ['items_id' => $group->getID()],
                 ['items_id' => $supplier->getID()],
+            ]
+        );
+
+        // Using answers from user questions
+        $this->sendFormAndAssertTicketActors(
+            form: $form,
+            config: new AssigneeFieldConfig(
+                strategies: [ITILActorFieldStrategy::SPECIFIC_ANSWERS],
+                specific_question_ids: [
+                    $this->getQuestionId($form, "User question 1"),
+                    $this->getQuestionId($form, "User question 2"),
+                ]
+            ),
+            answers: $answers,
+            expected_actors: [
+                ['items_id' => $user1->getID()],
+                ['items_id' => $user2->getID()],
             ]
         );
     }
@@ -859,7 +886,20 @@ final class AssigneeFieldTest extends AbstractActorFieldTest
             json_encode((new QuestionTypeActorsExtraDataConfig(true))->jsonSerialize())
         );
         $builder->addQuestion("Assignee email 1", QuestionTypeEmail::class);
-        $builder->addQuestion("Assignee email 2", QuestionTypeEmail::class, );
+        $builder->addQuestion("Assignee email 2", QuestionTypeEmail::class);
+
+        $item_config = new QuestionTypeItemExtraDataConfig(itemtype: User::class);
+        $item_config = json_encode($item_config);
+        $builder->addQuestion(
+            name: "User question 1",
+            type: QuestionTypeItem::class,
+            extra_data: $item_config,
+        );
+        $builder->addQuestion(
+            name: "User question 2",
+            type: QuestionTypeItem::class,
+            extra_data: $item_config,
+        );
         return $this->createForm($builder);
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Items questions on users/groups/suppliers like this one are supposed to be able to be able to be used as ticket actors:

<img width="582" height="219" alt="image" src="https://github.com/user-attachments/assets/8b6a9c3f-e089-4f5f-bd1d-67cbe83ceef6" />

<img width="551" height="121" alt="image" src="https://github.com/user-attachments/assets/c6e15b7f-236c-4bf1-9015-e1c0685a7b3e" />

It was missing from the possible configurations, only emails and actors questions would be found.

## References

Fix #21376


