### PR TITLE
Fix unexpected call to getForm on Form in form migration

### DIFF
--- a/src/Glpi/Form/Migration/FormMigration.php
+++ b/src/Glpi/Form/Migration/FormMigration.php
@@ -1405,10 +1405,10 @@ class FormMigration extends AbstractPluginMigration
 
                 // If no condition handler is found for the value operator, we skip this condition
                 if ($condition_handler === false) {
-                    /** @var Question|Comment|Section|FormDestination $item */
+                    /** @var Form|Question|Comment|Section|FormDestination $item */
                     $item = getItemForItemtype($target_item['itemtype']);
                     if ($item !== false && $item->getFromDB($target_item['items_id']) !== false) {
-                        $form = $item->getForm();
+                        $form = $item instanceof Form ? $item : $item->getForm();
                     } else {
                         $item = null;
                         $form = null;


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Fix unexpected call to getForm on an object that is already a Form instance.

## References

Fix #21417


