### PR TITLE
Forms: fix location not being applied in tickets

### DIFF
--- a/src/Glpi/Form/Destination/CommonITILField/LocationFieldStrategy.php
+++ b/src/Glpi/Form/Destination/CommonITILField/LocationFieldStrategy.php
@@ -35,6 +35,7 @@
 
 namespace Glpi\Form\Destination\CommonITILField;
 
+use Glpi\Form\Answer;
 use Glpi\Form\AnswersSet;
 use Glpi\Form\QuestionType\QuestionTypeItemDropdown;
 use Location;
@@ -95,17 +96,20 @@ enum LocationFieldStrategy: string
     private function getLocationIDForLastValidAnswer(
         AnswersSet $answers_set,
     ): ?int {
-        $valid_answers = $answers_set->getAnswersByType(
+        $items_answers = $answers_set->getAnswersByType(
             QuestionTypeItemDropdown::class
         );
-
-        if (count($valid_answers) == 0) {
+        $location_answers = array_filter(
+            $items_answers,
+            fn(Answer $a) => ($a->getRawAnswer()['itemtype'] ?? '') === Location::class,
+        );
+        if (count($location_answers) == 0) {
             return null;
         }
 
-        $answer = end($valid_answers);
+        $answer = end($location_answers);
         $value = $answer->getRawAnswer();
-        if ($value['itemtype'] !== Location::getType() || !is_numeric($value['items_id'])) {
+        if (!is_numeric($value['items_id'])) {
             return null;
         }
 


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

The behavior of `LocationFieldStrategy::getLocationIDForLastValidAnswer` was incorrect, it was loading the last `QuestionTypeItemDropdown` THEN checking if it was targeting a location (and dropping the value if it wasn't).

This meant that if another `QuestionTypeItemDropdown` question was answered after the location, then the location value was lost.

The correct behavior is to simply take the last `QuestionTypeItemDropdown` which target a location.

## References 

Fix #21443


