### PR TITLE
Contextual search on form not possible, conflict between offcanvas an…

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -1712,7 +1712,7 @@ function setupAjaxDropdown(config) {
         minimumInputLength: 0,
         quietMillis: 100,
         dropdownAutoWidth: true,
-        dropdownParent: $('#' + field_id).closest('div.modal, div.dropdown-menu, body'),
+        dropdownParent: $('#' + field_id).closest('div.modal, div.offcanvas, div.dropdown-menu, body'),
         minimumResultsForSearch: config.ajax_limit_count,
         ajax: {
             url: config.url,
@@ -1816,7 +1816,7 @@ function setupAdaptDropdown(config)
         width: config.width,
         dropdownAutoWidth: true,
         dropdownCssClass: config.dropdown_css_class,
-        dropdownParent: $('#' + field_id).closest('div.modal, div.dropdown-menu, body'),
+        dropdownParent: $('#' + field_id).closest('div.modal, div.offcanvas, div.dropdown-menu, body'),
         quietMillis: 100,
         minimumResultsForSearch: config.ajax_limit_count,
         matcher: function (params, data) {


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # !39758
- It seems that the contextual search cannot be used when configuring the "Helpdesk Home" view.
The field is not clickable.
There is a conflict between the offcanvas and the dropdown.

## Screenshots (if appropriate):
<img width="392" height="481" alt="image" src="https://github.com/user-attachments/assets/f97706f9-8d12-4318-89b6-6e59d76f197d" />



