### PR TITLE
Added an alert to specify that child locations are not transferred wi…

### DIFF
--- a/templates/pages/admin/transfer.html.twig
+++ b/templates/pages/admin/transfer.html.twig
@@ -79,7 +79,7 @@
       } %}
 
       {{ fields.smallTitle(__('General')) }}
-      {{ alerts.alert('warning', '', __('If a location has child locations, the child locations will not be transferred with the parent to avoid visibility and hierarchy issues.')) }}
+      {{ alerts.alert('warning', '', __('Child locations will not be transferred with the parent to avoid visibility and hierarchy issues.')) }}
       {{ fields.dropdownArrayField('keep_history', item.fields['keep_history'], keep_options, __('Historical'), {
          readonly: not can_change_options,
       }) }}


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !39724
- Here is a brief description of what this PR does
Added an alert to specify that children's locations are not transferred with their parents. This is to avoid any visibility issues with locations if there are links to certain objects.

## Screenshots (if appropriate):
<img width="1563" height="166" alt="image" src="https://github.com/user-attachments/assets/4e3730da-84e4-4c3c-8ba7-841fdc68dd78" />



