### PR TITLE
Fix service catalog breadcrumbs on central

### DIFF
--- a/js/modules/Forms/ServiceCatalogController.js
+++ b/js/modules/Forms/ServiceCatalogController.js
@@ -178,7 +178,7 @@ export class GlpiFormServiceCatalogController
             });
         }
 
-        const breadcrumbContainer = document.querySelector('.breadcrumb');
+        const breadcrumbContainer = document.querySelector('[data-breadcrumbs-container]');
         breadcrumbContainer.innerHTML = '';
 
         this.breadcrumb.forEach((item, index) => {

--- a/templates/pages/self-service/service_catalog.html.twig
+++ b/templates/pages/self-service/service_catalog.html.twig
@@ -40,7 +40,12 @@
 
 {% block content_title %}
     <div class="d-flex">
-        <ol class="breadcrumb breadcrumb-alternate" aria-label="{{ _n("Service catalog category", "Service catalog categories", get_plural_number()) }}" role="navigation">
+        <ol
+            data-breadcrumbs-container
+            class="breadcrumb breadcrumb-alternate"
+            aria-label="{{ _n("Service catalog category", "Service catalog categories", get_plural_number()) }}"
+            role="navigation"
+        >
             <li class="breadcrumb-item text-truncate active">
                 <a
                     href="?category=0"


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.

## Description

The service catalog breadcrumbs were displayed incorrectly on the central interface.

This is because is relied on a `.breadcrumb` css selector which was ambiguous.
This meant the service catalog breadcrumbs were not set in the correct position and were replacing the general navigation breadcrumbs.

I've replaced it by a dedicated data attribute.

Before:
<img width="1299" height="356" alt="image" src="https://github.com/user-attachments/assets/8a4bb095-0773-403f-97e6-8c9f10383a9e" />

After:
<img width="1346" height="361" alt="image" src="https://github.com/user-attachments/assets/33cdce53-47a5-4f54-8859-b3b2dc94a782" />




