### PR TITLE
Fix copy/show disclosable fields buttons

### DIFF
--- a/templates/components/form/fields_macros.html.twig
+++ b/templates/components/form/fields_macros.html.twig
@@ -808,8 +808,9 @@
    {% if not options.include_field %}
       {{ field }}
    {% else %}
-      {% set id    = (options.id ?? '')|length > 0 and options.id != '%id%' ? options.id : (name|safe_dom_id ~ '_' ~ options.rand) %}
-      {% set field = field|replace({'%id%': id}) %}
+      {% set id    = ((options.id ?? '')|length > 0 and options.id != '%id%' ? options.id : (name ~ '_' ~ options.rand))|safe_dom_id %}
+      {# `\u0025id\u0025` is the escaped JS form of `%id%` #}
+      {% set field = field|replace({'%id%': id, '\\u0025id\\u0025': id}) %}
       {% set add_field_html = options.add_field_html|length > 0 ? options.add_field_html : '' %}
 
       {% if not options.fields_template.isHiddenField(name)|default(false) %}


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

The fields macros are generating some pieces of HTML using the basic fields macro with a `%id%` placeholder. This placeholder may be escaped in JS context. To handle this, we have to replaced the JS escaped form of `%id%` too.