### PR TITLE
Do not output warning in CLI context on production env

### DIFF
--- a/front/cron.php
+++ b/front/cron.php
@@ -61,9 +61,6 @@ if (PHP_SAPI === 'cli') {
 
     require_once dirname(__DIR__) . '/vendor/autoload.php';
 
-    $kernel = new Kernel();
-    $kernel->boot();
-
     // Handle the `--debug` argument
     $debug = array_search('--debug', $_SERVER['argv']);
     if ($debug) {
@@ -72,6 +69,9 @@ if (PHP_SAPI === 'cli') {
         $_SERVER['argv'] = array_values($_SERVER['argv']);
         $_SERVER['argc']--;
     }
+
+    $kernel = new Kernel();
+    $kernel->boot();
 
     if ($is_superuser) {
         // Keep this warning after the GLPI Kernel boot to prevent issues with session path definition

--- a/src/Glpi/Console/Application.php
+++ b/src/Glpi/Console/Application.php
@@ -55,6 +55,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Toolbox;
@@ -108,6 +109,12 @@ class Application extends BaseApplication
     public function __construct(private Kernel $kernel)
     {
         global $DB, $CFG_GLPI;
+
+        // preconfigure the output to correctly handle kernel boot errors
+        $input = new ArgvInput();
+        $output = new ConsoleOutput();
+        parent::configureIO($input, $output);
+        ConsoleErrorDisplayHandler::setOutput($output);
 
         parent::__construct('GLPI CLI', GLPI_VERSION);
 

--- a/src/Glpi/Error/ErrorDisplayHandler/CliDisplayHandler.php
+++ b/src/Glpi/Error/ErrorDisplayHandler/CliDisplayHandler.php
@@ -34,6 +34,9 @@
 
 namespace Glpi\Error\ErrorDisplayHandler;
 
+use Glpi\Application\Environment;
+use Session;
+
 final class CliDisplayHandler implements ErrorDisplayHandler
 {
     public function canOutput(): bool
@@ -49,6 +52,13 @@ final class CliDisplayHandler implements ErrorDisplayHandler
 
     public function displayErrorMessage(string $error_label, string $message, string $log_level): void
     {
+        $is_env_with_debug_tools = Environment::get()->shouldEnableExtraDevAndDebugTools();
+        $is_debug_mode = isset($_SESSION['glpi_use_mode']) && $_SESSION['glpi_use_mode'] == Session::DEBUG_MODE;
+        if (!$is_debug_mode && !$is_env_with_debug_tools) {
+            // Do not display messages if debug mode is not active and if the environment should not enable debug tools.
+            return;
+        }
+
         /**
          * CLI context, no XSS possible.
          *

--- a/src/Glpi/Error/ErrorDisplayHandler/ConsoleErrorDisplayHandler.php
+++ b/src/Glpi/Error/ErrorDisplayHandler/ConsoleErrorDisplayHandler.php
@@ -34,7 +34,9 @@
 
 namespace Glpi\Error\ErrorDisplayHandler;
 
+use Glpi\Application\Environment;
 use Psr\Log\LogLevel;
+use Session;
 use Symfony\Component\Console\Output\OutputInterface;
 
 final class ConsoleErrorDisplayHandler implements ErrorDisplayHandler
@@ -63,7 +65,15 @@ final class ConsoleErrorDisplayHandler implements ErrorDisplayHandler
                 $verbosity = OutputInterface::VERBOSITY_QUIET;
                 break;
             case LogLevel::WARNING:
-                $verbosity = OutputInterface::VERBOSITY_NORMAL;
+                $is_env_with_debug_tools = Environment::get()->shouldEnableExtraDevAndDebugTools();
+                $is_debug_mode = isset($_SESSION['glpi_use_mode']) && $_SESSION['glpi_use_mode'] == Session::DEBUG_MODE;
+                if (!$is_debug_mode && !$is_env_with_debug_tools) {
+                    // If debug mode is not active and if the environment should not enable debug tools,
+                    // display warnings only when verbose mode is activated.
+                    $verbosity = OutputInterface::VERBOSITY_VERBOSE;
+                } else {
+                    $verbosity = OutputInterface::VERBOSITY_NORMAL;
+                }
                 break;
             case LogLevel::NOTICE:
             case LogLevel::INFO:

--- a/src/Glpi/Error/ErrorDisplayHandler/HtmlErrorDisplayHandler.php
+++ b/src/Glpi/Error/ErrorDisplayHandler/HtmlErrorDisplayHandler.php
@@ -53,16 +53,6 @@ final class HtmlErrorDisplayHandler implements ErrorDisplayHandler
             return false;
         }
 
-        $is_env_with_debug_tools = Environment::get()->shouldEnableExtraDevAndDebugTools();
-        $is_debug_mode = isset($_SESSION['glpi_use_mode']) && $_SESSION['glpi_use_mode'] == Session::DEBUG_MODE;
-
-        if (
-            !$is_env_with_debug_tools // error messages are always displayed in environments with debug tools
-            && !$is_debug_mode // error messages are always displayed in debug mode
-        ) {
-            return false;
-        }
-
         // Need to fallback to `Request::createFromGlobals()` for errors that appears before the
         // `onRequest` event.
         $request = self::$currentRequest ?? Request::createFromGlobals();
@@ -72,6 +62,13 @@ final class HtmlErrorDisplayHandler implements ErrorDisplayHandler
 
     public function displayErrorMessage(string $error_label, string $message, string $log_level): void
     {
+        $is_env_with_debug_tools = Environment::get()->shouldEnableExtraDevAndDebugTools();
+        $is_debug_mode = isset($_SESSION['glpi_use_mode']) && $_SESSION['glpi_use_mode'] == Session::DEBUG_MODE;
+        if (!$is_debug_mode && !$is_env_with_debug_tools) {
+            // Do not display messages if debug mode is not active and if the environment should not enable debug tools.
+            return;
+        }
+
         echo \sprintf(
             '<div class="alert alert-important alert-danger glpi-debug-alert"><span class="fw-bold">%s: </span>%s</div>',
             \htmlescape($error_label),

--- a/src/Glpi/Error/ErrorHandler.php
+++ b/src/Glpi/Error/ErrorHandler.php
@@ -167,7 +167,7 @@ final class ErrorHandler extends BaseErrorHandler
         foreach (self::getOutputHandlers() as $handler) {
             if ($handler->canOutput()) {
                 $handler->displayErrorMessage($error_label, $message, $log_level);
-                break; // Only one display per handler
+                break; // Stop after the first available handler
             }
         }
     }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

1. In the console context, in production env, the warnings will now be visible only in verbose mode, to mimic the UI behaviour that displays warnings only on debug mode.
2. In the cron CLI context, in production env, the error messages will now be visible only when the `--debug` option is used, to mimic the UI behaviour.
3. In console context, any error triggered during the kernel boot was not handled by the `ConsoleErrorDisplayHandler`, because its `$output` property was not set at this moment, and it was fallbacking to the `CliDisplayHandler`. I set it with a preconfigured output instance in the console application constructor to fix this.
4. I moved the debug mode initialization before the kernel boot in the cron context, to be sure it is already defined when an error is triggered during the kernel boot.
5. I moved the debug/dev filtering in the `displayErrorMessage()` instead of the `canOutput()`, to be sure to not fallback to an unexpected handler, see https://github.com/glpi-project/glpi/blob/2fb12438727e9cb55f2a89f8f0d166fc4e739b04/src/Glpi/Error/ErrorHandler.php#L167-L172