### PR TITLE
remove dashboard easter egg

### DIFF
--- a/js/modules/Dashboard/Dashboard.js
+++ b/js/modules/Dashboard/Dashboard.js
@@ -1153,18 +1153,6 @@ class GLPIDashboard {
         }
     }
 
-    easter() {
-        const items = $(this.elem_id+" .grid-stack .grid-stack-item .card");
-
-        setInterval(() => {
-            const color = "#"+((1<<24)*Math.random()|0).toString(16);
-            const no_item = Math.floor(Math.random() * items.length);
-            const item = items[no_item];
-            $(item).css('background-color', color);
-        }, 10);
-    }
-
-
     /**
      * init filters of the dashboard
      */

--- a/tests/js/modules/Dashboard/Dashboard.test.js
+++ b/tests/js/modules/Dashboard/Dashboard.test.js
@@ -95,32 +95,6 @@ describe('Dashboard', () => {
         expect(window.GLPIDashboard).toBeDefined();
     });
 
-    /**
-     * Super important feature to test.
-     */
-    test('\x1b[31mE\x1b[33ma\x1b[32ms\x1b[36mt\x1b[34me\x1b[35mr\x1b[0m', () => {
-        expect(true).toBe(true);
-        // Legacy fake timers needed to support setInterval
-        jest.useFakeTimers('legacy');
-
-        const dashboard = new GLPIDashboard({'rand': '12345'});
-        dashboard.easter();
-
-        let colors = ['', '', ''];
-        const new_colors = ['', '', ''];
-
-        for (let i = 0; i < 10; i++) {
-            jest.advanceTimersByTime(30);
-
-            $('.grid-stack-item .card').each((i, elem) => {
-                new_colors[i] = $(elem).css('background-color');
-            });
-            // At least one color should be different
-            expect(new_colors).not.toEqual(colors);
-            colors = [...new_colors];
-        }
-    });
-
     test('saveMarkdown', () => {
         const dashboard = new GLPIDashboard({'rand': '12345'});
         $('body').find('.grid-stack-item').first().append(`<textarea name="markdown">test</textarea>`);


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

When the dashboard feature was made, there was an easter egg that let you flash the cards in different colors.
When I made the jest tests for the dashboard I added a test for it as a joke.

Unfortunately:
- The easter egg isn't able to be triggered anymore since it relied on directly calling it from the console and the dashboard functions are not exposed in the global scope anymore.
- The test isn't so funny when it randomly fails a process that takes over an hour.