### PR TITLE
feat(makefile): Adding db-dump/db-restore commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,4 +50,4 @@ phpstan.neon
 /.phpunit.result.cache
 /phpunit/files/
 /phpunit/config
-/dump
+/.dump/

--- a/Makefile
+++ b/Makefile
@@ -114,19 +114,22 @@ db-update: ## Update local development's database
 .PHONY: db-update
 
 db-dump: ## Dump the database
-	@mkdir -p ./dump
-	@$(DB) sh -c 'mariadb-dump --user $$MARIADB_USER --password=$$MARIADB_PASSWORD $$MARIADB_DATABASE | gzip' > ./dump/dump_`date +%Y-%m-%d"_"%H_%M_%S`.sql.gz
+	@mkdir -p ./.dump; \
+	DUMP_FILE="./.dump/dump_`date +%Y-%m-%d"_"%H_%M_%S`.sql.gz"; \
+	printf $(_TITLE) "db-dump" "Dumping database to $$DUMP_FILE"; \
+	$(DB) sh -c 'mariadb-dump --user $$MARIADB_USER --password=$$MARIADB_PASSWORD $$MARIADB_DATABASE | gzip' > $$DUMP_FILE; \
+	printf $(_TITLE) "db-dump" "Database successfully dumped to $$DUMP_FILE"
 .PHONY: db-dump
 
-db-restore: ## Drop the database and restores it from a dump file, i.e: make db-restore f=./dump/dump.sql.gz
+db-restore: ## Drop the database and restores it from a dump file, i.e: make db-restore f=./.dump/dump.sql.gz
 	@$(eval f ?=)
 	@if [ -z "$(f)" ]; then \
-		printf $(_ERROR) "db-restore" "Please provide a file path, i.e: make db-restore f=./dump/dump.sql.gz"; \
+		printf $(_ERROR) "db-restore" "Please provide a file path, i.e: make db-restore f=./.dump/dump.sql.gz"; \
 		exit 1; \
 	fi
 	@printf $(_TITLE) "db-restore" "Dropping and recreating database..."
 	@$(DB) sh -c 'mariadb --user=$$MARIADB_USER --password=$$MARIADB_PASSWORD -e "DROP DATABASE IF EXISTS \`$$MARIADB_DATABASE\`; CREATE DATABASE \`$$MARIADB_DATABASE\`;"'
-	@printf $(_TITLE) "db-restore" "Restoring from $(f)..."
+	@printf $(_TITLE) "db-restore" "Restoring from $(f)"
 	@gunzip -c $(f) | $(COMPOSE) exec -T db sh -c 'mariadb --user=$$MARIADB_USER --password=$$MARIADB_PASSWORD $$MARIADB_DATABASE'
 .PHONY: db-restore
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description
- It add in the makefile a `db-dump` and `db-restore` command so dev can quickly dump and restore their databases.
- Updated the `sql` command so it run using the correct env var inside the docker