### PR TITLE
change value dropdown to name

### DIFF
--- a/phpunit/functional/RuleRightCollectionTest.php
+++ b/phpunit/functional/RuleRightCollectionTest.php
@@ -372,7 +372,7 @@ class RuleRightCollectionTest extends DbTestCase
             $xmlERuleCriteria = $xmlERule->addChild('rulecriteria');
             $xmlERuleCriteria->criteria = $rule_data['criteria']['field'];
             $xmlERuleCriteria->condition = $rule_data['criteria']['condition'];
-            $xmlERuleCriteria->pattern = $itemtype ? $itemtype->fields['name'] : $rule_data['criteria']['value'];
+            $xmlERuleCriteria->pattern = $itemtype ? $itemtype->getID() : $rule_data['criteria']['value'];
         }
         if (isset($rule_data['action'])) {
             $xmlERuleCriteria = $xmlERule->addChild('ruleaction');

--- a/src/RuleCollection.php
+++ b/src/RuleCollection.php
@@ -1075,14 +1075,6 @@ JAVASCRIPT;
 
                 $available_criteria = $rule->getCriterias();
                 $crit               = $criteria['criteria'];
-
-                foreach ($available_criteria as $key => $criterion_def) {
-                    if (isset($criterion_def['id']) && $criterion_def['id'] == $crit) {
-                        $crit = $key;
-                        break;
-                    }
-                }
-
                 if (self::isCriteraADropdown($available_criteria, $criteria['condition'], $crit)) {
                     $criteria['pattern'] = Dropdown::getDropdownName(
                         $available_criteria[$crit]['table'],


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

A client reported an issue when exporting and re-importing business rules for tickets in an environment where ITIL categories were translated.
During export, the XML file contained the translated value of the ITIL category (depending on the user interface language), but during import, the rule engine only recognized the original (non-translated) category name.
As a result, importing rules failed when the export and import were performed in different languages.
The export process has been adjusted to always include the category name (fields["name"]), regardless of the interface language used at the time of export.

- It fixes !39802

Change:
The XML export now returns the label (fields['name']) for dropdown references instead of the ID.
This improves readability and consistency with other export formats.

Modifications:
Updated the expected test in phpunit/functional/RuleRightCollectionTest.php to use fields['name'] when building the expected XML output.

## Screenshots (if appropriate):


