### PR TITLE
Avoid translation calls during cache intialization

### DIFF
--- a/src/Glpi/Cache/CacheManager.php
+++ b/src/Glpi/Cache/CacheManager.php
@@ -424,7 +424,7 @@ class CacheManager
         }
         $scheme = $matches['scheme'];
 
-        return in_array($scheme, static::getAvailableAdapters(), true) ? $scheme : null;
+        return in_array($scheme, self::getAvailableAdaptersSchemes(), true) ? $scheme : null;
     }
 
     /**
@@ -533,7 +533,7 @@ PHP;
             return reset($schemes) === self::SCHEME_MEMCACHED;
         }
 
-        return in_array($this->extractScheme($dsn), static::getAvailableAdapters(), true);
+        return in_array($this->extractScheme($dsn), self::getAvailableAdaptersSchemes(), true);
     }
 
     /**
@@ -557,7 +557,7 @@ PHP;
      *
      * @return self::SCHEME_*[]
      */
-    public static function getAvailableAdapters(): array
+    private static function getAvailableAdaptersSchemes(): array
     {
         return [
             self::SCHEME_MEMCACHED,
@@ -567,20 +567,26 @@ PHP;
     }
 
     /**
-     * Returns the localized label of an available adapter.
+     * Returns a list of available adapters.
+     * Keys are adapter schemes (see self::SCHEME_*).
+     * Values are translated names.
      *
-     * @param self::SCHEME_* $scheme
-     *
-     * @return string
+     * @return array<self::SCHEME_*, string>
      */
-    public static function getAvailableAdapterLabel(string $scheme): string
+    public static function getAvailableAdapters(): array
     {
-        return match ($scheme) {
-            self::SCHEME_MEMCACHED  => __('Memcached'),
-            self::SCHEME_REDIS      => __('Redis (TCP)'),
-            self::SCHEME_REDISS     => __('Redis (TLS)'),
-            default => throw new InvalidArgumentException(sprintf('Invalid cache adapter scheme: "%s".', $scheme))
-        };
+        $adapters = [];
+
+        foreach (self::getAvailableAdaptersSchemes() as $scheme) {
+            $adapters[$scheme] = match ($scheme) {
+                self::SCHEME_MEMCACHED  => __('Memcached'),
+                self::SCHEME_REDIS      => __('Redis (TCP)'),
+                self::SCHEME_REDISS     => __('Redis (TLS)'),
+                default => throw new InvalidArgumentException(sprintf('Invalid cache adapter scheme: "%s".', $scheme))
+            };
+        }
+
+        return $adapters;
     }
 
     /**

--- a/src/Glpi/Cache/CacheManager.php
+++ b/src/Glpi/Cache/CacheManager.php
@@ -575,7 +575,7 @@ PHP;
      */
     public static function getAvailableAdapterLabel(string $scheme): string
     {
-        return match($scheme) {
+        return match ($scheme) {
             self::SCHEME_MEMCACHED  => __('Memcached'),
             self::SCHEME_REDIS      => __('Redis (TCP)'),
             self::SCHEME_REDISS     => __('Redis (TLS)'),

--- a/src/Glpi/Cache/CacheManager.php
+++ b/src/Glpi/Cache/CacheManager.php
@@ -424,7 +424,7 @@ class CacheManager
         }
         $scheme = $matches['scheme'];
 
-        return in_array($scheme, array_keys(static::getAvailableAdapters())) ? $scheme : null;
+        return in_array($scheme, static::getAvailableAdapters(), true) ? $scheme : null;
     }
 
     /**
@@ -533,7 +533,7 @@ PHP;
             return reset($schemes) === self::SCHEME_MEMCACHED;
         }
 
-        return in_array($this->extractScheme($dsn), array_keys(static::getAvailableAdapters()));
+        return in_array($this->extractScheme($dsn), static::getAvailableAdapters(), true);
     }
 
     /**
@@ -554,18 +554,33 @@ PHP;
 
     /**
      * Returns a list of available adapters.
-     * Keys are adapter schemes (see self::SCHEME_*).
-     * Values are translated names.
      *
-     * @return array
+     * @return self::SCHEME_*[]
      */
     public static function getAvailableAdapters(): array
     {
         return [
+            self::SCHEME_MEMCACHED,
+            self::SCHEME_REDIS,
+            self::SCHEME_REDISS,
+        ];
+    }
+
+    /**
+     * Returns the localized label of an available adapter.
+     *
+     * @param self::SCHEME_* $scheme
+     *
+     * @return string
+     */
+    public static function getAvailableAdapterLabel(string $scheme): string
+    {
+        return match($scheme) {
             self::SCHEME_MEMCACHED  => __('Memcached'),
             self::SCHEME_REDIS      => __('Redis (TCP)'),
             self::SCHEME_REDISS     => __('Redis (TLS)'),
-        ];
+            default => throw new InvalidArgumentException(sprintf('Invalid cache adapter scheme: "%s".', $scheme))
+        };
     }
 
     /**

--- a/src/Glpi/Console/Cache/ConfigureCommand.php
+++ b/src/Glpi/Console/Cache/ConfigureCommand.php
@@ -114,7 +114,7 @@ class ConfigureCommand extends AbstractCommand implements ConfigurationCommandIn
         $this->addUsage('--dsn=redis://redis.glpi-project.org:6379/glpi');
 
         $adapters = $this->cache_manager->getAvailableAdapters();
-        $adapters = array_combine($adapters, array_map(static fn($a) => $this->cache_manager::getAvailableAdapterLabel($a), $adapters));
+        $adapters = array_combine($adapters, array_map(fn($a) => $this->cache_manager::getAvailableAdapterLabel($a), $adapters));
         $help_lines = [
             sprintf(
                 __('Valid cache systems are: %s.'),

--- a/src/Glpi/Console/Cache/ConfigureCommand.php
+++ b/src/Glpi/Console/Cache/ConfigureCommand.php
@@ -114,7 +114,6 @@ class ConfigureCommand extends AbstractCommand implements ConfigurationCommandIn
         $this->addUsage('--dsn=redis://redis.glpi-project.org:6379/glpi');
 
         $adapters = $this->cache_manager->getAvailableAdapters();
-        $adapters = array_combine($adapters, array_map(fn($a) => $this->cache_manager::getAvailableAdapterLabel($a), $adapters));
         $help_lines = [
             sprintf(
                 __('Valid cache systems are: %s.'),

--- a/src/Glpi/Console/Cache/ConfigureCommand.php
+++ b/src/Glpi/Console/Cache/ConfigureCommand.php
@@ -114,6 +114,7 @@ class ConfigureCommand extends AbstractCommand implements ConfigurationCommandIn
         $this->addUsage('--dsn=redis://redis.glpi-project.org:6379/glpi');
 
         $adapters = $this->cache_manager->getAvailableAdapters();
+        $adapters = array_combine($adapters, array_map(static fn($a) => $this->cache_manager::getAvailableAdapterLabel($a), $adapters));
         $help_lines = [
             sprintf(
                 __('Valid cache systems are: %s.'),


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

As I was looking at performance a few weeks ago I noticed the GLPI profiler was showing cache initialization taking 100ms-350ms sometimes. After a lot of looking, I finally tracked it down to the translation functions of all things along with `xdebug.start_upon_error` (which I forgot about and never got working properly anyways). During the cache initialization, a few calls to `CacheManager::getAvailableAdapters` are made which tries making 3 `__` calls each. However, at this point in the boot process, the translator is not available yet. In fact the labels for the adapters are not required for the cache initialization. Even though the errors are caught and silently ignored, there is noticeable overhead with the xdebug configuration.

This change is not significant to most people but could save a few hundred ms on average on every request that boots the kernel for anyone that has xdebug configured.