### PR TITLE
Lazy load uncommon CFG_GLPI values

### DIFF
--- a/src/Glpi/Application/View/Extension/FrontEndAssetsExtension.php
+++ b/src/Glpi/Application/View/Extension/FrontEndAssetsExtension.php
@@ -324,10 +324,9 @@ class FrontEndAssetsExtension extends AbstractExtension
                     // Hydrate the missing config via a synchronous AJAX call
                     $.ajax({
                         type: 'GET',
-                        url: CFG_GLPI.root_doc + '/ajax/config.php',
+                        url: CFG_GLPI.root_doc + '/Session/Config/' + prop,
                         async: false,
                         dataType: 'json',
-                        data: { key: prop },
                         success: (value) => {
                             target[prop] = value;
                         },

--- a/src/Glpi/Controller/Session/ConfigController.php
+++ b/src/Glpi/Controller/Session/ConfigController.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2025 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -33,17 +32,29 @@
  * ---------------------------------------------------------------------
  */
 
+namespace Glpi\Controller\Session;
+
+use Config;
+use Glpi\Controller\AbstractController;
 use Glpi\Exception\Http\NotFoundHttpException;
+use Glpi\Http\Firewall;
+use Glpi\Security\Attribute\SecurityStrategy;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
 
-use function Safe\json_encode;
-
-Session::checkLoginUser();
-Session::writeClose();
-
-header("Content-Type: application/json; charset=UTF-8");
-$safe_config = Config::getSafeConfig(true);
-if (!isset($_GET['key']) || !array_key_exists($_GET['key'], $safe_config)) {
-    throw new NotFoundHttpException();
+final class ConfigController extends AbstractController
+{
+    #[Route("/Session/Config/{key}", name: "get_config_value")]
+    #[SecurityStrategy(Firewall::STRATEGY_AUTHENTICATED)]
+    public function content(Request $request): Response
+    {
+        $safe_config = Config::getSafeConfig(true);
+        $key = $request->get('key');
+        if (!array_key_exists($key, $safe_config)) {
+            throw new NotFoundHttpException();
+        }
+        return new JsonResponse($safe_config[$key]);
+    }
 }
-
-echo json_encode($safe_config[$_GET['key']]);


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

One of a few possible optimizations to improve GLPI performance. I only consider this a short-term optimization when there are better ways to handle this and it is not a substantial optimization on its own.

Dumping the entire safe CFG_GLPI array in a JS script on the page is excessive.
We only really use the "root_doc" config in most places.
Even in plugins as far as I can see, there are very few non-"root_doc" uses of this variable.
Instead of dumping the entire config, I replaced it with a proxy to transparently lazy-load missing values.
This would be a synchronous call but it was necessary to not break existing code and the need to fetch additional configs should only rarely come up.
I believe the faster initial page loads would be worth it.

Tested in production env.
Seeing approximately 8kb (compressed size) less transferred per page and approximately 30ms less page download times.
Seeing "Time to DOM interactive" and "Time to DOM complete" metrics a 100-200ms lower on average but this can vary a lot.
Minor performance improvements and data usage reductions should be seen across the entire app for initial page loads.