### PR TITLE
Fix network port metrics graphs : Apply forced height for network metrics graph

### DIFF
--- a/css/legacy/includes/_styles.scss
+++ b/css/legacy/includes/_styles.scss
@@ -1146,6 +1146,11 @@
       height: 500px;
    }
 
+   .dashboard.netports_metrics .g-chart .chart {
+      flex:none;
+      height: 500px;
+   }
+
    .uploadbar {
       height: 18px;
       text-align: center;


### PR DESCRIPTION
## Description

- It fixes #21518
- Here is a brief description of what this PR does : apply same workaround than for .dashboard.printer_barchart to .dashboard.netports_metrics

Note: this fix need an assets rebuild

## Screenshots (if appropriate): 
<img width="1139" height="842" alt="image" src="https://github.com/user-attachments/assets/747e15e0-a752-470c-b21a-762a30a53a02" />



