### PR TITLE
copy to clipboard

### DIFF
--- a/templates/components/form/basic_inputs_macros.html.twig
+++ b/templates/components/form/basic_inputs_macros.html.twig
@@ -81,15 +81,15 @@
     {% set more_html %}
         {% if options.is_disclosable %}
             <div class="btn btn-outline-secondary"
-                 onmousedown="showDisclosablePasswordField('{{ options.id|e('js') }}')"
-                 onmouseup="hideDisclosablePasswordField('{{ options.id|e('js') }}')"
-                 onmouseout="hideDisclosablePasswordField('{{ options.id|e('js') }}')">
+                 onmousedown="showDisclosablePasswordField('{{ options.id }}')"
+                 onmouseup="hideDisclosablePasswordField('{{ options.id }}')"
+                 onmouseout="hideDisclosablePasswordField('{{ options.id }}')">
                 <i class="ti ti-eye disclose"></i>
             </div>
         {% endif %}
 
         {% if options.is_copyable %}
-            <div class="btn btn-outline-secondary" onclick="copyDisclosablePasswordFieldToClipboard('{{ options.id|e('js') }}')">
+            <div class="btn btn-outline-secondary" onclick="copyDisclosablePasswordFieldToClipboard('{{ options.id }}')">
                 <i class="ti ti-clipboard-copy disclose"></i>
             </div>
         {% endif %}


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

The |e('js') filter was removed from the js calls using options.id, as it altered the HTML element’s identifier, preventing the “copy to clipboard” button from working properly.

The filter was originally added in the “Enforce escaping in JS scripts (3/x)” PR, but in this specific case, options.id does not contain user-provided data and is not injected into executable code.

Removing the escaping restores the expected behavior while remaining safe from a security standpoint.

- It fixes !39830
- Here is a brief description of what this PR does

## Screenshots (if appropriate):

<img width="748" height="316" alt="image" src="https://github.com/user-attachments/assets/55427493-967f-490f-92b1-f5c953b3888e" />



