### PR TITLE
Fix(Migration): fix skip orphaned relation items copy

### DIFF
--- a/src/Glpi/Migration/AbstractPluginMigration.php
+++ b/src/Glpi/Migration/AbstractPluginMigration.php
@@ -440,17 +440,17 @@ abstract class AbstractPluginMigration
                     (
                         \is_a($itemtype, CommonDBChild::class, true)
                         && $itemtype::$mustBeAttached
-                        && !$itemtype::getItemFromArray($itemtype::$itemtype, $itemtype::$items_id, $related_item_data)
+                        && !$itemtype::getItemFromArray($itemtype::$itemtype, $itemtype::$items_id, $related_item_data, getEmpty: false)
                     )
                     || (
                         \is_a($itemtype, CommonDBRelation::class, true)
                         && $itemtype::$mustBeAttached_1
-                        && !$itemtype::getItemFromArray($itemtype::$itemtype_1, $itemtype::$items_id_1, $related_item_data)
+                        && !$itemtype::getItemFromArray($itemtype::$itemtype_1, $itemtype::$items_id_1, $related_item_data, getEmpty: false)
                     )
                     || (
                         \is_a($itemtype, CommonDBRelation::class, true)
                         && $itemtype::$mustBeAttached_2
-                        && !$itemtype::getItemFromArray($itemtype::$itemtype_2, $itemtype::$items_id_2, $related_item_data)
+                        && !$itemtype::getItemFromArray($itemtype::$itemtype_2, $itemtype::$items_id_2, $related_item_data, getEmpty: false)
                     )
                 ) {
                     // A mandatory linked item does not exist, meaning that the original item was an orphaned relation.


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Fix : !39723

Currently debugging the handling of orphan links in **ImpactRelation**.

I noticed that the check to determine whether the source or destination exists (and skip if not) relies on the following function:

```php
public static function getItemFromArray(
    $itemtype,
    $items_id,
    array $array,
    $getFromDB = true,
    $getEmpty = true,
    $getFromDBOrEmpty = false
) {
```

By default, it loads an **empty object** if the item is not found in the database, and therefore does **not return `false`** when missing.

This seems to cause the skip logic for this relation to behave incorrectly.

Submitting the PR as-is to observe the behavior in the unit tests.


## Screenshots (if appropriate):


