### PR TITLE
Forbid links in home page tiles

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -3481,7 +3481,8 @@ JS;
         bool $toolbar = true,
         bool $statusbar = true,
         string $content_style = '',
-        bool $init_on_demand = false
+        bool $init_on_demand = false,
+        array $plugins_to_remove = [],
     ) {
         global $CFG_GLPI, $DB;
 
@@ -3540,7 +3541,11 @@ JS;
         if ($DB->use_utf8mb4) {
             $plugins[] = 'emoticons';
         }
-        $pluginsjs = json_encode($plugins);
+
+        // Remove specifics plugins if requested
+        $plugins = array_diff($plugins, $plugins_to_remove);
+
+        $pluginsjs = json_encode(array_values($plugins));
 
         $language_opts = '';
         if ($language !== 'en_GB') {

--- a/templates/components/form/basic_inputs_macros.html.twig
+++ b/templates/components/form/basic_inputs_macros.html.twig
@@ -337,6 +337,7 @@
         'content_style': "",
         'input_addclass': '',
         'additional_attributes': [],
+        'plugins_to_remove': [],
     }|merge(options) %}
 
     {% if options.fields_template.isMandatoryField(name)|default(false) %}
@@ -379,6 +380,7 @@
             options.statusbar,
             options.content_style,
             options.init_on_demand,
+            options.plugins_to_remove,
         ]) %}
    {% endif %}
    {% if options.enable_form_tags %}

--- a/templates/pages/admin/external_page_tile_config_fields.html.twig
+++ b/templates/pages/admin/external_page_tile_config_fields.html.twig
@@ -45,6 +45,7 @@
         full_width: true,
         is_horizontal: false,
         enable_richtext: true,
+        plugins_to_remove: ['link', 'autolink'],
     }
 ) }}
 

--- a/templates/pages/admin/glpi_page_tile_config_fields.html.twig
+++ b/templates/pages/admin/glpi_page_tile_config_fields.html.twig
@@ -45,6 +45,7 @@
         full_width: true,
         is_horizontal: false,
         enable_richtext: true,
+        plugins_to_remove: ['link', 'autolink'],
     }
 ) }}
 


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.

## Description

Since helpdesk home tiles are already links, it mess up the DOM if the user try to add another link inside:

<img width="377" height="359" alt="image" src="https://github.com/user-attachments/assets/9a7be511-8815-46c9-8b11-38ad64154409" />

I've removed the option from tinymce to add links in these specific editors.


