### PR TITLE
fix: #21556 Missing pending reason search option for ITILFollowupTemplate/TaskTemplate

### DIFF
--- a/src/ITILFollowupTemplate.php
+++ b/src/ITILFollowupTemplate.php
@@ -114,6 +114,14 @@ class ITILFollowupTemplate extends AbstractITILChildTemplate
             'datatype'           => 'bool',
         ];
 
+        $tab[] = [
+            'id'                 => '7',
+            'name'               => PendingReason::getTypeName(1),
+            'field'              => 'name',
+            'table'              => getTableForItemType('PendingReason'),
+            'datatype'           => 'dropdown',
+        ];
+
         return $tab;
     }
 

--- a/src/TaskTemplate.php
+++ b/src/TaskTemplate.php
@@ -177,6 +177,14 @@ class TaskTemplate extends AbstractITILChildTemplate
             'datatype'           => 'specific',
         ];
 
+        $tab[] = [
+            'id'                 => '11',
+            'name'               => PendingReason::getTypeName(1),
+            'field'              => 'name',
+            'table'              => getTableForItemType('PendingReason'),
+            'datatype'           => 'dropdown',
+        ];
+
         return $tab;
     }
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

- It fixes #21556
- Add possibility to filter on pending reason for ITILFollowupTemplate/TaskTemplate

## Screenshots (if appropriate):
<img width="947" height="450" alt="image" src="https://github.com/user-attachments/assets/0565bb9c-434f-4789-8cc1-61b7bc5abb29" />

<img width="806" height="632" alt="image" src="https://github.com/user-attachments/assets/3ba2973c-ec24-466e-821c-110a7a48bb6e" />

