### PR TITLE
Prevent enter key trigger delete

### DIFF
--- a/css/includes/components/_buttons-group.scss
+++ b/css/includes/components/_buttons-group.scss
@@ -62,3 +62,22 @@ which broke styles of btn-group > .btn-check
         @include button-check($value);
     }
 }
+
+.btn-group.flex-row-reverse > .btn {
+    border-radius: 0 !important;
+}
+
+.btn-group.flex-row-reverse > .btn:first-child {
+    border-top-right-radius: 4px !important;
+    border-bottom-right-radius: 4px !important;
+}
+
+.btn-group.flex-row-reverse > .btn:last-child {
+    border-top-left-radius: 4px !important;
+    border-bottom-left-radius: 4px !important;
+    border-right: unset !important;
+}
+
+.btn-group > .btn:not(:last-child):not(.dropdown-toggle), .btn-group > .btn-group:not(:last-child) > .btn {
+    border-right: unset !important;
+}

--- a/templates/components/itilobject/footer.html.twig
+++ b/templates/components/itilobject/footer.html.twig
@@ -127,35 +127,7 @@
             </button>
          {% else %}
 
-            <div class="btn-group" role="group" id="right-actions">
-               {% if item.canDeleteItem() %}
-                  {% if item.isDeleted() %}
-                     <button class="btn btn-outline-secondary" type="submit" name="restore" form="itil-form"
-                           title="{{ _x('button', 'Restore') }}">
-                        <i class="fas fa-trash-restore-alt"></i>
-                        <span class="d-none d-lg-block">{{ _x('button', 'Restore') }}</span>
-                     </button>
-
-                     <button class="btn btn-outline-danger" type="submit" name="purge" form="itil-form"
-                           title="{{ _x('button', 'Delete permanently') }}"
-                           onclick="return confirm('{{ __('Confirm the final deletion?') }}');">
-                        <i class="ti ti-trash"></i>
-                        <span class="d-none d-lg-block">{{ _x('button', 'Delete permanently') }}</span>
-                     </button>
-                  {% else %}
-                     <button class="btn btn-outline-danger" type="submit" name="delete" form="itil-form"
-                           title="{{ _x('button', 'Put in trashbin') }}"
-                           data-bs-toggle="tooltip" data-bs-placement="top">
-                        <i class="ti ti-trash"></i>
-                     </button>
-                  {% endif %}
-               {% endif %}
-
-               {% if canupdate %}
-                  {{ include('components/form/single-action.html.twig', {
-                     'onlyicon': true
-                  }) }}
-               {% endif %}
+            <div class="btn-group d-flex flex-row-reverse" role="group" id="right-actions">
 
                {% set is_locked = params['locked'] is defined and params['locked'] %}
                {% set display_save_btn = not is_locked and (canupdate or can_requester or canpriority or canassign or canassigntome) %}
@@ -166,6 +138,37 @@
                      <span class="d-none d-xl-block">{{ _x('button', 'Save') }}</span>
                   </button>
                {% endif %}
+
+               {% if canupdate %}
+                  {{ include('components/form/single-action.html.twig', {
+                     'onlyicon': true
+                  }) }}
+               {% endif %}
+
+               {% if item.canDeleteItem() %}
+                  {% if item.isDeleted() %}
+                     <button class="btn btn-outline-danger" type="submit" name="purge" form="itil-form"
+                           title="{{ _x('button', 'Delete permanently') }}"
+                           onclick="return confirm('{{ __('Confirm the final deletion?') }}');">
+                        <i class="ti ti-trash"></i>
+                        <span class="d-none d-lg-block">{{ _x('button', 'Delete permanently') }}</span>
+                     </button>
+
+                     <button class="btn btn-outline-secondary" type="submit" name="restore" form="itil-form"
+                           title="{{ _x('button', 'Restore') }}">
+                        <i class="fas fa-trash-restore-alt"></i>
+                        <span class="d-none d-lg-block">{{ _x('button', 'Restore') }}</span>
+                     </button>
+                  {% else %}
+                     <button class="btn btn-outline-danger" type="submit" name="delete" form="itil-form"
+                           title="{{ _x('button', 'Put in trashbin') }}"
+                           data-bs-toggle="tooltip" data-bs-placement="top">
+                        <i class="ti ti-trash"></i>
+                     </button>
+                  {% endif %}
+               {% endif %}
+
+
             </div>
 
          {% endif %}


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

### Follow : 
- https://github.com/glpi-project/glpi/pull/15765
- https://github.com/glpi-project/glpi/issues/19307


### Fix :  https://github.com/pluginsGLPI/fields/issues/1044

Moves the save button to 1st, to allow saving via the enter key.
Previously, when a text input was validated via the enter key, the ticket was deleted, as it was the 1st submit of the form.

### With the help of:

- https://github.com/glpi-project/glpi/pull/19443
- https://github.com/glpi-project/glpi/pull/20904
- https://github.com/glpi-project/glpi/pull/19516

### Screenshots (if appropriate):

Before : 

<img width="203" height="54" alt="image" src="https://github.com/user-attachments/assets/9370c3d6-f2ed-4b65-89f9-443501c3c1cc" />

<img width="434" height="58" alt="image" src="https://github.com/user-attachments/assets/5fe566ab-a783-4483-9176-6264fadb86cb" />


After : 

<img width="198" height="53" alt="image" src="https://github.com/user-attachments/assets/706d4e97-fcad-4ab4-90d1-4e3439cb09ce" />


<img width="432" height="56" alt="image" src="https://github.com/user-attachments/assets/a85ba8dc-e65d-41ca-b1e2-825a7805d392" />





