### PR TITLE
fix(mailcollector): ask for the passwd only if one exists

### DIFF
--- a/ajax/mailcollector.php
+++ b/ajax/mailcollector.php
@@ -65,7 +65,9 @@ if (isset($_REQUEST['action'])) {
 
             if (!empty($input['mail_server'])) {
                 $input["host"] = Toolbox::constructMailServerConfig($input);
-                if (!isset($input['passwd'])) {
+                // In some case (like oauth imap) provide password is not possible
+                // So, ask for password only if there is one stored in database
+                if (!isset($input['passwd']) && !empty($mailcollector->fields['passwd'])) {
                     $exception = new AccessDeniedHttpException();
                     $exception->setMessageToDisplay(__('Password is required to list mail folders.'));
                     throw $exception;

--- a/templates/pages/setup/mailcollector/setup_form.html.twig
+++ b/templates/pages/setup/mailcollector/setup_form.html.twig
@@ -213,10 +213,13 @@
                   // Force empty value for server_mailbox
                   data += '&server_mailbox=';
 
-                  // Ask for password if missing
-                  if ($(this).closest('form').find('input[name=\"passwd\"]').val() == '') {
-                      var passwd = prompt(__('Please enter password to list folders'));
-                      data += '&passwd=' + encodeURIComponent(passwd);
+                  // In some case (like oauth imap) provide password is not possible
+                  // So, ask for password only if there is one stored in database
+                  var passwdField = $(this).closest('form').find('input[name="passwd"]');
+                  var hasStoredPassword = {{ (item.fields['passwd'] is defined and item.fields['passwd']) ? 'true' : 'false' }};
+                  if (hasStoredPassword && passwdField.val() == '') {
+                     var passwd = prompt(__('Please enter password to list folders'));
+                     data += '&passwd=' + encodeURIComponent(passwd);
                   }
 
                   glpi_ajax_dialog({


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] My feature works (self-test).

## Description

In some case (like oauth imap) provide password is not possible.
So, ask for password only if there is one stored in database.


