### PR TITLE
Some display fixes with RTL

### DIFF
--- a/css/includes/_base.scss
+++ b/css/includes/_base.scss
@@ -601,7 +601,7 @@ html[dir='rtl'] {
         border-right: var(--tblr-border-width);
     }
 
-    .input-group > :not(:first-child):not(.dropdown-menu):not(.valid-tooltip):not(.valid-feedback):not(.invalid-tooltip):not(.invalid-feedback) {
+    .input-group > :not(:first-child, .dropdown-menu, .valid-tooltip, .valid-feedback, .invalid-tooltip, .invalid-feedback) {
         margin-right: calc(-1 * var(--tblr-border-width));
         border-top-right-radius: 0;
         border-bottom-right-radius: 0;
@@ -609,7 +609,7 @@ html[dir='rtl'] {
         border-bottom-left-radius: var(--tblr-border-radius);
     }
 
-    .input-group:not(.has-validation) > :not(:last-child):not(.dropdown-toggle):not(.dropdown-menu):not(.form-floating), .input-group:not(.has-validation) > .dropdown-toggle:nth-last-child(n+3), .input-group:not(.has-validation) > .form-floating:not(:last-child) > .form-control, .input-group:not(.has-validation) > .form-floating:not(:last-child) > .form-select {
+    .input-group:not(.has-validation) > :not(:last-child, .dropdown-toggle, .dropdown-menu, .form-floating), .input-group:not(.has-validation) > .dropdown-toggle:nth-last-child(n+3), .input-group:not(.has-validation) > .form-floating:not(:last-child) > .form-control, .input-group:not(.has-validation) > .form-floating:not(:last-child) > .form-select {
         border-top-left-radius: 0;
         border-bottom-left-radius: 0;
     }

--- a/css/standalone/dashboard.scss
+++ b/css/standalone/dashboard.scss
@@ -1253,7 +1253,7 @@ $break_tablet: 1400px;
     }
 }
 
-html[dir=rtl] {
+html[dir="rtl"] {
     .dashboard {
         .card {
             text-align: right;


### PR DESCRIPTION
To be reviewed per commit. I'm pretty confident for first two ones, but not at all for 2 last ones :D

First commit solves #21567.

Before:
<img width="1660" height="841" alt="Capture d’écran du 2025-10-21 13-41-26" src="https://github.com/user-attachments/assets/995b3b91-36a0-433f-94b3-30edbbfa467e" />

After:
<img width="1660" height="841" alt="Capture d’écran du 2025-10-21 13-42-15" src="https://github.com/user-attachments/assets/90ddad44-f835-4099-a18e-8fe8a4c93d19" />

Second commit fix dropdown on dashboard. Before: 
<img width="282" height="73" alt="Capture d’écran du 2025-10-21 13-46-16" src="https://github.com/user-attachments/assets/83f2a305-d591-4ece-baeb-24691ad049e4" />

After:
<img width="282" height="73" alt="Capture d’écran du 2025-10-21 13-46-39" src="https://github.com/user-attachments/assets/97fea0c3-23da-4684-a774-c354633b1465" />

3rd commit fix a bit user info/menu block. Before:
<img width="364" height="82" alt="Capture d’écran du 2025-10-21 13-47-02" src="https://github.com/user-attachments/assets/c4f2eb98-2f21-49ea-bcfa-6d4fbfe8a006" />

After:
<img width="364" height="82" alt="Capture d’écran du 2025-10-21 13-48-16" src="https://github.com/user-attachments/assets/1606f29e-6bac-46e5-89ba-99f348faaf7b" />

4th and last commit tries to improve search bar with RTL. There is one problem remaining on the right border I've not been able to solve. Before:
<img width="364" height="82" alt="Capture d’écran du 2025-10-21 13-48-45" src="https://github.com/user-attachments/assets/62f4d812-5182-4ca1-9b88-80630ee3a6c0" />

After:
<img width="364" height="82" alt="Capture d’écran du 2025-10-21 13-49-09" src="https://github.com/user-attachments/assets/e53c1f41-2f8b-4541-abca-64983f6aab19" />

I first had in mind this should have just been fixed by the CSS framework, but their form input examples seems broken with RTL anyway.