### PR TITLE
Do not remove service catalog for users that cant create tickets

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -1488,10 +1488,7 @@ TWIG,
             throw new RuntimeException("Cant load current entity");
         }
 
-        if (
-            Session::haveRight("ticket", CREATE)
-            && $entity->isServiceCatalogEnabled()
-        ) {
+        if ($entity->isServiceCatalogEnabled()) {
             $menu['create_ticket'] = [
                 'default' => ServiceCatalog::getSearchURL(false),
                 'title'   => __('Create a ticket'),


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.

## Description

The "service catalog" menu entry was only added for users that are allowed to create tickets.

However, this does not make sense because the service catalog may also contain links to KB articles (and things added by plugins) so I've removed this right check.

This made me wonder if we should instead remove the forms that create at least one ticket from the service catalog if the user is not allowed to create ticket.

But again it does not make sense because forms can also create change and problems and we have no self service rights for that (so why would we check it for ticket but not for problems/changes?).

It is probably better to just rely on the existing visibility configuration for a form: if a user is allowed to see a given form then let it be and create the needed items when the form is submitted.

Now, with all that in mind the "Create ticket" right become a bit useless for the self service.
I've added a backlog entry to remove it and maybe replace it by a dedicated "See service catalog" right instead.

## References

Internal support ticket: !39852


