### PR TITLE
Prevent the "Setup -> dropdown" menu entry to be generated if empty

### DIFF
--- a/src/CommonDropdown.php
+++ b/src/CommonDropdown.php
@@ -91,6 +91,11 @@ abstract class CommonDropdown extends CommonDBTM
 
         $menu = [];
         if (static::class === 'CommonDropdown') {
+            $dps = Dropdown::getStandardDropdownItemTypes();
+            if ($dps === []) {
+                return [];
+            }
+
             $menu['title']             = static::getTypeName(Session::getPluralNumber());
             $menu['shortcut']          = 'n';
             $menu['page']              = '/front/dropdown.php';
@@ -112,7 +117,6 @@ abstract class CommonDropdown extends CommonDBTM
                 ],
             ];
 
-            $dps = Dropdown::getStandardDropdownItemTypes();
             foreach ($dps as $tab) {
                 foreach ($tab as $key => $val) {
                     /** @var class-string<CommonDropdown> $key */


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

The "dropdown" menu entry is still generated even if no dropdowns are visible, which lead to an error:

<img width="2166" height="501" alt="image" src="https://github.com/user-attachments/assets/40c19dc4-7fa8-4f74-91a0-2cbc57792af3" />

## References

Internal support ticket: !39852


