### PR TITLE
fix(api):  wrong url for legacy doc

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -597,7 +597,7 @@ class Config extends CommonDBTM
             'getting_started_doc_url' => $getting_started_doc,
             'endpoint_doc_url' => $endpoint_doc,
             'api_url' => $current_version['endpoint'],
-            'legacy_doc_url' => $legacy_version['endpoint'],
+            'legacy_doc_url' => $legacy_version['endpoint'] . '/',
             'legacy_api_url' => $legacy_version['endpoint'],
         ]);
         if ($CFG_GLPI['enable_api']) {


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.


## Description
The legacy doc url was missing a trailing slash sending the user to the wrong page

## Screenshots (if appropriate):
<img width="1235" height="219" alt="image" src="https://github.com/user-attachments/assets/50ceced4-7e58-4565-b723-d0eaf438e221" />


