### PR TITLE
Handle generic object references in forms migrations

### DIFF
--- a/src/Glpi/Asset/AssetDefinitionManager.php
+++ b/src/Glpi/Asset/AssetDefinitionManager.php
@@ -398,6 +398,32 @@ final class AssetDefinitionManager extends AbstractDefinitionManager
         );
     }
 
+    public function getAssetClassNameFromLegacyClassName(string $legacy): ?string
+    {
+        /** @var \DBmysql $DB */
+        global $DB;
+
+        // Try to load glpi_plugin_genericobject_types row for this legacy item
+        if (!$DB->tableExists('glpi_plugin_genericobject_types')) {
+            return null;
+        }
+        $rows = $DB->request([
+            'FROM'  => 'glpi_plugin_genericobject_types',
+            'WHERE' => ['itemtype' => $legacy],
+        ]);
+        if (count($rows) !== 1) {
+            return null;
+        }
+
+        $row = $rows->current();
+        $name = $row['name'];
+        return AssetDefinition::getCustomObjectNamespace()
+            . "\\"
+            . $name
+            . AssetDefinition::getCustomObjectClassSuffix()
+        ;
+    }
+
     private function loadConcreteClass(AssetDefinition $definition): void
     {
         $rightname = $definition->getCustomObjectRightname();

--- a/src/Glpi/Form/QuestionType/QuestionTypeItem.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeItem.php
@@ -42,6 +42,7 @@ use ConsumableItem;
 use DbUtils;
 use Dropdown;
 use Glpi\Application\View\TemplateRenderer;
+use Glpi\Asset\AssetDefinitionManager;
 use Glpi\DBAL\JsonFieldInterface;
 use Glpi\Form\Condition\ConditionHandler\ItemAsTextConditionHandler;
 use Glpi\Form\Condition\ConditionHandler\ItemConditionHandler;
@@ -133,8 +134,15 @@ class QuestionTypeItem extends AbstractQuestionType implements
             $selectable_tree_root = (bool) $values['selectable_tree_root'];
         }
 
+        $itemtype = $rawData['itemtype'] ?? null;
+        // Replace generic object name with asset name if migrated
+        if (str_starts_with($itemtype, 'PluginGenericobject')) {
+            $manager = AssetDefinitionManager::getInstance();
+            $itemtype = $manager->getAssetClassNameFromLegacyClassName($itemtype);
+        }
+
         return (new QuestionTypeItemExtraDataConfig(
-            itemtype: $rawData['itemtype'] ?? null,
+            itemtype: $itemtype,
             root_items_id: $root_items_id,
             subtree_depth: $subtree_depth,
             selectable_tree_root: $selectable_tree_root


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Formcreator questions may reference data from the generic objects plugin:

<img width="1116" height="394" alt="image" src="https://github.com/user-attachments/assets/fd574df0-2b31-4144-8997-d7509403361e" />

Since this plugin is replaced by native custom assets in GLPI 11, we must look for the migrated itemtype instead.

## References

Internal support ticket: !39700
