### PR TITLE
Do not block form migration when questions are missing

### DIFF
--- a/src/Glpi/Form/Destination/CommonITILField/AssociatedItemsField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/AssociatedItemsField.php
@@ -295,7 +295,7 @@ final class AssociatedItemsField extends AbstractConfigField implements Destinat
                     );
 
                     if ($mapped_item === null) {
-                        throw new InvalidArgumentException("Question '{$rawData['associate_question']}' not found in a target form");
+                        $mapped_item = ['items_id' => 0];
                     }
 
                     return new AssociatedItemsFieldConfig(

--- a/src/Glpi/Form/Destination/CommonITILField/EntityField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/EntityField.php
@@ -230,7 +230,7 @@ final class EntityField extends AbstractConfigField implements DestinationFieldC
                 );
 
                 if ($mapped_item === null) {
-                    throw new InvalidArgumentException("Question '{$rawData['destination_entity_value']}' not found in a target form");
+                    $mapped_item = ['items_id' => 0];
                 }
 
                 return new EntityFieldConfig(

--- a/src/Glpi/Form/Destination/CommonITILField/ITILActorField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ITILActorField.php
@@ -297,7 +297,7 @@ abstract class ITILActorField extends AbstractConfigField implements Destination
                             );
 
                             if ($mapped_item === null) {
-                                throw new InvalidArgumentException("Question '$id' not found in a target form");
+                                continue;
                             }
 
                             $specific_question_ids[] = $mapped_item['items_id'];

--- a/src/Glpi/Form/Destination/CommonITILField/ITILCategoryField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ITILCategoryField.php
@@ -154,7 +154,7 @@ final class ITILCategoryField extends AbstractConfigField implements Destination
                 );
 
                 if ($mapped_item === null) {
-                    throw new InvalidArgumentException("Question '{$rawData['category_question']}' not found in a target form");
+                    $mapped_item = ['items_id' => 0];
                 }
 
                 return new ITILCategoryFieldConfig(

--- a/src/Glpi/Form/Destination/CommonITILField/LocationField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/LocationField.php
@@ -197,7 +197,7 @@ final class LocationField extends AbstractConfigField implements DestinationFiel
                     );
 
                     if ($mapped_item === null) {
-                        throw new InvalidArgumentException("Question '{$rawData['location_question']}' not found in a target form");
+                        $mapped_item = ['items_id' => 0];
                     }
 
                     return new LocationFieldConfig(

--- a/src/Glpi/Form/Destination/CommonITILField/RequestTypeField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/RequestTypeField.php
@@ -158,7 +158,7 @@ final class RequestTypeField extends AbstractConfigField implements DestinationF
                 );
 
                 if ($mapped_item === null) {
-                    throw new InvalidArgumentException("Question '{$rawData['type_question']}' not found in a target form");
+                    $mapped_item = ['items_id' => 0];
                 }
 
                 return new RequestTypeFieldConfig(

--- a/src/Glpi/Form/Destination/CommonITILField/UrgencyField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/UrgencyField.php
@@ -162,7 +162,7 @@ final class UrgencyField extends AbstractConfigField implements DestinationField
                 );
 
                 if ($mapped_item === null) {
-                    throw new InvalidArgumentException("Question '{$rawData['urgency_question']}' not found in a target form");
+                    $mapped_item = ['items_id' => 0];
                 }
 
                 return new UrgencyFieldConfig(

--- a/src/Glpi/Form/Destination/CommonITILField/ValidationField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ValidationField.php
@@ -383,7 +383,7 @@ final class ValidationField extends AbstractConfigField implements DestinationFi
                         );
 
                         if ($mapped_item === null) {
-                            throw new InvalidArgumentException("Question '{$rawData['commonitil_validation_question']}' not found in a target form");
+                            $mapped_item = ['items_id' => 0];
                         }
 
                         $question_ids[] = $mapped_item['items_id'];


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Some formcreator targets may references questions that no longer exist:

<img width="305" height="84" alt="image" src="https://github.com/user-attachments/assets/c71f6250-29bc-473b-bd21-ba58b0d6e964" />

This trigger an error during the migration:

> The "Associated items" destination field configuration of the form cannot be imported : Question '229' not found in a target form

On formcreator, the form is still functional, just this specific setting is ignored.
We should do the same by importing the items id as `0` in this case.

It makes no difference for the user and allow the migration to be executed.

## References

Internal support ticket: !39700
