### PR TITLE
fix(form): self service warning on page refresh

### DIFF
--- a/src/Glpi/Form/Condition/FormData.php
+++ b/src/Glpi/Form/Condition/FormData.php
@@ -185,7 +185,7 @@ final class FormData
     private function parseRawConditionsData(array $conditions_data): void
     {
         foreach ($conditions_data as $condition_data) {
-            $item_key = $condition_data['item'];
+            $item_key = $condition_data['item'] ?? '';
 
             if ($item_key == '') {
                 // Item has not yet been selected.


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

- It fixes #21566

A warning was appearing when the self service user refresh a form page

## Screenshots (if appropriate):

<img width="1793" height="953" alt="image" src="https://github.com/user-attachments/assets/6831198b-e087-4cd4-a9c0-2cd26c4925dd" />
