### PR TITLE
Fix form checkbox deletion being accidentally triggered

### DIFF
--- a/src/Glpi/Form/QuestionType/AbstractQuestionTypeSelectable.php
+++ b/src/Glpi/Form/QuestionType/AbstractQuestionTypeSelectable.php
@@ -381,6 +381,7 @@ TWIG;
                     data-glpi-form-editor-question-option-order
                 >
                 <button
+                    type="button"
                     class="btn btn-sm btn-icon btn-ghost-secondary {{ value ? '' : 'd-none' }}"
                     aria-label="{{ translations.remove_option }}"
                     data-glpi-form-editor-question-extra-details


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.

## Description

This button was triggered accidentally when pressing enter as it had the default `submit` type.
Setting the type to `button` solves the issue.

## References

Fix #21534


