### PR TITLE
Prevent form tags from clipping when the line overflow

### DIFF
--- a/css/includes/components/_richtext.scss
+++ b/css/includes/components/_richtext.scss
@@ -116,4 +116,5 @@ body.mce-content-body {
     background: rgb(0, 0, 0, 20%);
     border-radius: 3px;
     padding: 5px;
+    line-height: 32px;
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.

## Description

Very long lines would cause some clipping when wrapping the content.

Before:
<img width="1090" height="168" alt="image" src="https://github.com/user-attachments/assets/d7472ff8-330a-4b95-b5bd-dcf192297a82" />

After:
<img width="1072" height="213" alt="image" src="https://github.com/user-attachments/assets/7da940e1-9903-4b1b-b407-e4ed423a5370" />



