### PR TITLE
[HLAPI] Improve search performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The present file will list all changes made to the project; according to the
 ### Added
 
 ### Changed
+- High-Level API performance improvements for both REST and GraphQL requests (3.3-10x performance uplift on average)
 
 ### Deprecated
 

--- a/src/Glpi/Api/HL/Doc/Schema.php
+++ b/src/Glpi/Api/HL/Doc/Schema.php
@@ -475,11 +475,9 @@ class Schema implements ArrayAccess
         return true;
     }
 
-    public function castProperties(array $content): array
+    public static function castProperties(array &$content, array $flattened_properties): void
     {
-        $flattened_schema = self::flattenProperties($this->toArray()['properties'], '', false);
-
-        foreach ($flattened_schema as $sk => $sv) {
+        foreach ($flattened_properties as $sk => $sv) {
             // Get value from original content by the array path $sk
             $path_arr = explode('.', $sk);
             $current = &$content;
@@ -489,6 +487,7 @@ class Schema implements ArrayAccess
                     $current = &$current[$path];
                 } else {
                     $no_match = true;
+                    break;
                 }
             }
             if ($no_match) {
@@ -510,7 +509,6 @@ class Schema implements ArrayAccess
                 $cv = date(DATE_RFC3339, strtotime($cv));
             }
         }
-        return $content;
     }
 
     /**

--- a/src/Glpi/Api/HL/GraphQLGenerator.php
+++ b/src/Glpi/Api/HL/GraphQLGenerator.php
@@ -146,13 +146,16 @@ final class GraphQLGenerator
 
         // Handle "internal" types that are used for object properties
         foreach ($schema['properties'] as $prop_name => $prop) {
-            if (isset($prop['x-full-schema'])) {
-                continue;
-            }
             if ($prop['type'] === Doc\Schema::TYPE_OBJECT) {
+                if (isset($prop['x-full-schema'])) {
+                    continue;
+                }
                 $namespaced_type = "{$schema_name}_{$prop_name}";
                 $types['_' . $namespaced_type] = $this->convertRESTPropertyToGraphQLType($prop, $namespaced_type);
             } elseif ($prop['type'] === Doc\Schema::TYPE_ARRAY) {
+                if (isset($prop['items']['x-full-schema'])) {
+                    continue;
+                }
                 $items = $prop['items'];
                 if ($items['type'] === Doc\Schema::TYPE_OBJECT) {
                     $namespaced_type = "{$schema_name}_{$prop_name}";

--- a/src/Glpi/Api/HL/Search/SearchContext.php
+++ b/src/Glpi/Api/HL/Search/SearchContext.php
@@ -54,6 +54,7 @@ final class SearchContext
      * @var array Cache of table names for foreign keys.
      */
     private array $fkey_tables = [];
+    private array $prop_to_join_names = [];
 
     public function __construct(array $schema, array $request_params)
     {
@@ -279,5 +280,20 @@ final class SearchContext
             }
         }
         return $this->fkey_tables[$fkey];
+    }
+
+    public function getJoinNameForProperty(string $prop_name): string
+    {
+        if (!isset($this->prop_to_join_names[$prop_name])) {
+            $joins = $this->getJoins();
+            $prop_name = str_replace(chr(0x1F), '.', $prop_name);
+            if (array_key_exists($prop_name, $joins)) {
+                $join_name = $prop_name;
+            } else {
+                $join_name = substr($prop_name, 0, strrpos($prop_name, '.'));
+            }
+            $this->prop_to_join_names[$prop_name] = $join_name;
+        }
+        return $this->prop_to_join_names[$prop_name];
     }
 }

--- a/src/Glpi/Toolbox/ArrayPathAccessor.php
+++ b/src/Glpi/Toolbox/ArrayPathAccessor.php
@@ -104,9 +104,6 @@ final class ArrayPathAccessor
         $path_array = explode($path_delimiter, $path);
         $current = &$array;
         foreach ($path_array as $key) {
-            if (!isset($current[$key])) {
-                $current[$key] = [];
-            }
             $current = &$current[$key];
         }
         $current = $value;


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

This PR addresses a few different points that cause HLAPI requests to take longer than expected, especially when not using GraphQL to reduce the fields to fetch and returning a large number of items at once.

The biggest point is hydration.
When the HLAPI does a search in the database, the process is to first fetch the main items and the foreign keys and then fetch the required data based on the foreign keys and merge them with the initial results (More information can be found in the [developer documentation](https://glpi-developer-documentation.readthedocs.io/en/master/devapi/hlapi/search.html)). The issue this PR resolves is that during the first query, the fields within the main table are fetched and then they are fetched a second time during the hydration step and it also drastically reduces the number of extra SQL queries required by properly batching them to do one request for a bunch of IDs.

Other optimizations addressed:
- Switch the query done for the total count to use `COUNT` instead of fetching real results and counting them in PHP.
- Reducing duplicate work done during the fixup/assembly stage where the SQL results are formatted to match the OpenAPI schema.
- Caching of he GraphQL document, saving a few ms each GraphQL request. I don't think the syntax tree can be cached, but the document before tokenization can be and is the recommended way to cache.
- Skipping validation of the GraphQL schema since the schema is built dynamically and it should be technically valid. Plus, the GraphQL schemas should be heavily tested at this point.
- Fixed issue that caused useless extra schemas to be created even when not used like "_Domain_group_tech" to save time parsing the schema.
- A few misc micro-optimizations done in code that may run thousands of times.

The result:
- 3.3-10x average performance uplift on regular REST results depending on the number of joined properties with more joins=less performance gain.
- 2-2.5x less overhead on GraphQL requests depending on the number of fields.
- A GraphQL request to fetch only the ID for every computer (2771 in DB) went from 1.38 seconds to 205ms (6.7x faster).

GraphQL may have more room for improvement as it turns out a lot of the work the GraphQL library does is already handled by the HLAPI search engine. The GraphQL library runs a `fieldResolver` function for each requested type and field when we only need to handle the type. The improvement from using GraphQL to request a lot less fields than the default REST requests make up for this overhead though.