### PR TITLE
Delete useless Twig param

### DIFF
--- a/src/Glpi/Controller/Form/Destination/GetDestinationFormController.php
+++ b/src/Glpi/Controller/Form/Destination/GetDestinationFormController.php
@@ -59,13 +59,11 @@ final class GetDestinationFormController extends AbstractController
             throw new AccessDeniedHttpException();
         }
 
-        $plugin_item_type = isPluginItemType($destination->fields['itemtype'] ?? '')['plugin'] ?? 'glpi';
         $twig = TemplateRenderer::getInstance()->render('pages/admin/form/form_destination_form.html.twig', [
             'destination' => $destination,
             'form' => $destination->getForm(),
             'can_update' => FormDestination::canUpdate() && $destination->canUpdateItem(),
             'concrete_destination' => $destination->getConcreteDestinationItem(),
-            '_source' => $plugin_item_type,
         ]);
         return new Response($twig);
     }

--- a/templates/pages/admin/form/form_destination_form.html.twig
+++ b/templates/pages/admin/form/form_destination_form.html.twig
@@ -36,7 +36,6 @@
         - `form`: Form
         - `can_update`: bool
         - `concrete_destination`: FormDestinationInterface|null
-        - `_source`: string
 #}
 
 {% set _source = destination.fields['itemtype']|itemtype_plugin_key|default('glpi') %}


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Follows #21468. The `_source` variable is always recomputed on template side. The passed value is never used.