### PR TITLE
fix(AllAssets): resolve SQL error caused by invalid table name

### DIFF
--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -1179,11 +1179,11 @@ final class SQLProvider implements SearchProviderInterface
         if (preg_match('/^\$\$\$\$([0-9]+)$/', $val, $regs)) {
             $criteria = [
                 'OR' => [
-                    "table.id" => [$nott ? "<>" : "=", $regs[1]],
+                    $table . ".id" => [$nott ? "<>" : "=", $regs[1]],
                 ],
             ];
             if ((int) $regs[1] === 0) {
-                $criteria['OR'][] = ["table.id" =>  "IS NULL"];
+                $criteria['OR'][] = [$table . ".id" =>  "IS NULL"];
             }
             return $criteria;
         }

--- a/src/State.php
+++ b/src/State.php
@@ -220,7 +220,7 @@ class State extends CommonTreeDropdown
                 'start'    => 0,
                 'criteria' => [
                     '0' => [
-                        'value' => $data['id'],
+                        'value' => '$$$$' . $data['id'],
                         'searchtype' => 'contains',
                         'field' => 31,
                     ],


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !39950
- An SQL error occurs when displaying the list of AllAsset search options.
When the user accesses the Tools > Reports menu, selects the report by status, and then clicks on a status to display all items associated with that status, an SQL error occurs.

## Screenshots (if appropriate):
<img width="1916" height="990" alt="image" src="https://github.com/user-attachments/assets/b529d6ae-6fdb-4836-ab4c-a9f6967bfc87" />

After fix:
<img width="1313" height="344" alt="image" src="https://github.com/user-attachments/assets/ed25d861-1058-45e6-9ea2-1d8ea990f248" />



