### PR TITLE
Fix color field ID mismatch in template macros

### DIFF
--- a/templates/components/form/basic_inputs_macros.html.twig
+++ b/templates/components/form/basic_inputs_macros.html.twig
@@ -149,36 +149,44 @@
     {{ _self.input(name, value, options|merge({'type': 'number'})) }}
 {% endmacro %}
 
-
 {% macro color(name, value, options = {}) %}
     {% set options = {
-        id: name ~ '_' ~ (options.rand ?? random()),
+        id: '%id%',
     }|merge(options) %}
 
     {{ _self.input(name, value, options|merge({
         'type': 'text',
-        'input_addclass': 'rounded-0',
+        'input_addclass': 'rounded-0 js-spectrum-field',
     })) }}
+
     <script>
-        $(function () {
-            $("#{{ options.id|e('css')|e('js') }}").spectrum({
+    $(function () {
+        $(".js-spectrum-field").each(function () {
+            const el = $(this);
+            if (el.data("spectrum-initialized")) return;
+
+            el.spectrum({
                 showInput: true,
                 preferredFormat: "hex",
                 type: "text",
                 cancelText: "{{ __('Cancel')|e('js') }}",
                 chooseText: "{{ __('Validate')|e('js') }}",
                 change: function (color) {
-                    if (color !== null && color.getAlpha() !== 1) {
+                    if (color) {
                         let hex = color.toHexString();
-                        hex += ("0" + Math.round(parseFloat(color.getAlpha()) * 255).toString(16)).slice(-2);
+                        if (color.getAlpha && color.getAlpha() !== 1) {
+                            hex += ("0" + Math.round(color.getAlpha() * 255).toString(16)).slice(-2);
+                        }
                         this.value = hex;
                     }
                 }
             });
+
+            el.data("spectrum-initialized", true);
         });
+    });
     </script>
 {% endmacro %}
-
 
 {% macro password(name, value, options = {}) %}
     {{ _self.input(name, value, options|merge({'type': 'password'})) }}


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

It fixes !39937

The color picker no longer appears when clicking on the affected fields; only the color value in text (hexadecimal) is visible.
This issue was caused by an ID mismatch: different IDs were assigned by the color and field macros. The color macro script applied CSS and JS escaping on the ID for security reasons (see related PRs below), which created inconsistencies. 

This fix:

- Initializes the color pickers using a class instead of the dynamic ID

Links to related PRs : #21483  - #21246 
