### PR TITLE
Fix groups filtering in helpdesk forms

### DIFF
--- a/src/Glpi/Form/QuestionType/AbstractQuestionTypeActors.php
+++ b/src/Glpi/Form/QuestionType/AbstractQuestionTypeActors.php
@@ -416,12 +416,13 @@ TWIG;
             question.getEndUserInputName(),
             value,
             {
-                'form_id'        : question.getForm().getId(),
-                'multiple'       : is_multiple_actors,
-                'allowed_types'  : allowed_types,
-                'aria_label'     : aria_label,
-                'mb'             : '',
-                'right_for_users': right_for_users,
+                'form_id'         : question.getForm().getId(),
+                'multiple'        : is_multiple_actors,
+                'allowed_types'   : allowed_types,
+                'aria_label'      : aria_label,
+                'mb'              : '',
+                'right_for_users' : right_for_users,
+                'group_conditions': group_conditions,
             }
         ]) %}
 
@@ -450,6 +451,7 @@ TWIG;
             'is_multiple_actors' => $is_multiple_actors,
             'aria_label'         => $question->fields['name'],
             'right_for_users'    => $this->getRightForUsers(),
+            'group_conditions'   => $this->getGroupConditions(),
         ]);
     }
 


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.

## Description

On actors questions, the parameters that filter the groups (showing only requester/watcher/assigned groups according to the question type) was not applied.

## References

* Fix #21635
* Fix #21480


