### PR TITLE
Fix array to string warning

### DIFF
--- a/templates/pages/admin/form/condition_handler_templates/input.html.twig
+++ b/templates/pages/admin/form/condition_handler_templates/input.html.twig
@@ -32,7 +32,7 @@
 
 <input
     class="me-2 form-control value-selector flex-grow-1 min-width-200"
-    value="{{ input_value }}"
+    value="{{ input_value is array ? "" : input_value }}"
     name="{{ input_name }}"
     placeholder="{{ __("Enter a value...") }}"
     data-glpi-conditions-editor-value


### PR DESCRIPTION
## Checklist before requesting a review

- [X I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.

## Description

Fix this warning:
<img width="784" height="421" alt="499760348-c6a8a37c-b330-4cb3-8d69-742e6449bab7" src="https://github.com/user-attachments/assets/149b33ef-235d-473b-bc3c-afda57fb8886" />

This happens when switching operators, if the previous operator was used an array as a value and we try to apply it to a new operator that expect a simple string as a value.

In this case, resetting the value to an empty string is OK as the previous value doesn't make sense for this new operator so there is not point to keep it.

