### PR TITLE
Fix wrong date header form collected emails

### DIFF
--- a/src/MailCollector.php
+++ b/src/MailCollector.php
@@ -48,6 +48,7 @@ use Laminas\Mail\Storage\Message;
 use Laminas\Mail\Storage\Part;
 use Laminas\Mail\Storage\Writable\WritableInterface;
 use LitEmoji\LitEmoji;
+use Safe\Exceptions\DatetimeException;
 use Safe\Exceptions\IconvException;
 
 use function Safe\base64_decode;
@@ -1361,7 +1362,12 @@ class MailCollector extends CommonDBTM
 
         $reply_to_addr = $this->getEmailFromHeader($message, 'reply-to');
 
-        $date         = date("Y-m-d H:i:s", strtotime($message->getHeader('date', 'string')));
+        try {
+            $date         = date("Y-m-d H:i:s", strtotime($message->getHeader('date', 'string')));
+        } catch (DatetimeException $e) {
+            //wrong date, ignoring
+            $date = null;
+        }
         $mail_details = [];
 
         // Construct to and cc arrays

--- a/tests/emails-tests/35-message-with-some-invalid-headers.eml
+++ b/tests/emails-tests/35-message-with-some-invalid-headers.eml
@@ -1,5 +1,6 @@
 Date: Thu, 7 Jun 2018 12:05:51 +0200 (CEST)
 X-Invalid-Encoding: ⤏ is not a valid char ⤎
+Date: Wed, 22 Oct 2025 11:44:56 -0400 (GMT-04:00)
 From: Normal User <normal@glpi-project.org>
 To: GLPI debug <unittests@glpi-project.org>
 Subject: 35 - Message with some invalid headers


### PR DESCRIPTION
fix #21610

This restores v10 behavior (before safe date method throws exceptions)