### PR TITLE
Fix unexpected user dropdown value in forms

### DIFF
--- a/src/Glpi/Form/QuestionType/QuestionTypeItem.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeItem.php
@@ -61,6 +61,7 @@ use PDU;
 use Session;
 use Software;
 use TicketRecurrent;
+use User;
 
 use function Safe\json_decode;
 use function Safe\json_encode;
@@ -212,7 +213,20 @@ class QuestionTypeItem extends AbstractQuestionType implements
             return 0;
         }
 
-        return (int) $config->getItemsId();
+        $default_value = (int) $config->getItemsId();
+
+        // Fallback to 0 instead of -1 for the empty value as it is already used
+        // as the "Current logged-in user" special value.
+        $extra_config = $question->getExtraDataConfig();
+        if (!$extra_config instanceof QuestionTypeItemExtraDataConfig) {
+            throw new LogicException();
+        }
+
+        if ($extra_config->getItemtype() === User::class) {
+            $default_value = $default_value == -1 ? 0 : $default_value;
+        }
+
+        return $default_value;
     }
 
     #[Override]

--- a/templates/pages/admin/form/question_type/item/administration_template.html.twig
+++ b/templates/pages/admin/form/question_type/item/administration_template.html.twig
@@ -44,6 +44,7 @@
         {
             'init'               : init,
             'no_label'           : true,
+            'right'              : 'all',
             'width'              : '100%',
             'mb'                 : '',
             'comments'           : false,


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.

## Description

Fix two minors issues:
* We use -1 as the default value, it was conflicting with the `Current logged-in user` feature
* The `rights` parameter was missing, preventing all users from being selectable as the default value

Before:
<img width="539" height="140" alt="image" src="https://github.com/user-attachments/assets/5c338886-4f04-48af-bedb-d53ba88dbf2b" />

After:
<img width="536" height="207" alt="image" src="https://github.com/user-attachments/assets/6cf6dabb-76e8-4239-ab05-192c48cc7dab" />



