### PR TITLE
Fix undefined index on Twig template

### DIFF
--- a/templates/layout/parts/objectlock_message.html.twig
+++ b/templates/layout/parts/objectlock_message.html.twig
@@ -34,8 +34,7 @@
 {% import 'components/form/basic_inputs_macros.html.twig' as inputs %}
 
 {% macro forceUnlockButton(item, check_unlock_right) %}
-    {% set real_profile = session('glpilocksavedprofile')|default(null) %}
-    {% if not check_unlock_right or (real_profile != null and (real_profile[item.fields['itemtype']] ?? false) b-and constant('UNLOCK')) %}
+    {% if not check_unlock_right b-and constant('UNLOCK') %}
         <button type="button" class="btn btn-sm btn-primary ms-2 force-unlock-item">
             <i class="ti ti-lock-open"></i>
             <span>{{ __('Force unlock %1s #%2s')|format(item.fields['itemtype']|itemtype_name, item.fields['items_id']) }}</span>


### PR DESCRIPTION
fix #21522 (maybe).

I ran throw the following error:
```
[2025-10-28 10:29:55] glpi.CRITICAL:   *** Uncaught PHP Exception Twig\Error\RuntimeError: "Key "Computer" for sequence/mapping with keys "id, name, interface, is_default, helpdesk_hardware, helpdesk_item_type, use_mentions, ticket_status, date_mod, comment, problem_status, create_ticket_on_login, tickettemplates_id, changetemplates_id, problemtemplates_id, change_status, managed_domainrecordtypes, date_creation, 2fa_enforced, last_rights_update, agent, appliance, asset_a4software, asset_assetdefinition, asset_paxton, asset_server, asset_smartphone, backup, bookmark_public, budget, cable_management, calendar, cartridge, certificate, change, changevalidation, cluster, computer, config, consumable, contact_enterprise, contract, dashboard, database, databaseinstance, datacenter, defaultfilter, device, devicesimcard_pinpuk, document, domain, dropdown, dropdown_newdd, entity, externalevent, followup, form, global_validation, group, infocom, internet, inventory, itilcategory, itilfollowuptemplate, itiltemplate, itilvalidationtemplate, knowbase, knowbasecategory, license, line, lineoperator, link, location, locked_field, logs, monitor, networking, notification, oauth_client, password_update, pendingreason, peripheral, personalization, phone, planning, plugin_addressing, plugin_addressing_use_ping_in_equipment, plugin_example, plugin_glpiinventory_collect, plugin_glpiinventory_configuration, plugin_glpiinventory_credential, plugin_glpiinventory_credentialip, plugin_glpiinventory_deploymirror, plugin_glpiinventory_esx, plugin_glpiinventory_group, plugin_glpiinventory_iprange, plugin_glpiinventory_menu, plugin_glpiinventory_networkequipment, plugin_glpiinventory_package, plugin_glpiinventory_printer, plugin_glpiinventory_selfpackage, plugin_glpiinventory_task, plugin_glpiinventory_userinteractiontemplate, plugin_postfixadmin_domain, plugin_postfixadmin_domainmanagement, plugin_postfixadmin_mailboxes, printer, problem, profile, project, projecttask, queuednotification, recurrentchange, refusedequipment, reminder_public, reports, reservation, rssfeed_public, rule_asset, rule_change, rule_dictionnary_dropdown, rule_dictionnary_printer, rule_dictionnary_software, rule_import, rule_ldap, rule_location, rule_mailcollector, rule_problem, rule_softwarecategories, rule_ticket, search_config, show_group_hardware, slm, snmpcredential, software, solutiontemplate, state, statistic, system_logs, task, taskcategory, tasktemplate, ticket, ticketcost, ticketrecurrent, ticketvalidation, transfer, typedoc, unmanaged, user, entities" does not exist in "layout/parts/objectlock_message.html.twig" at line 38." at objectlock_message.html.twig line 38
  Backtrace :
  ...es/layout/parts/objectlock_message.html.twig:38 
  ...tes/18/18dac2b1f4e29db3d3574a062b8ee87c.php:224 Twig\Extension\CoreExtension::getAttribute()
  .../twig/twig/src/Extension/CoreExtension.php:2106 __TwigTemplate_107b3e08eff1aad164c2f366913beab8->{closure}()
  ...tes/18/18dac2b1f4e29db3d3574a062b8ee87c.php:218 Twig\Extension\CoreExtension::captureOutput()
  ...tes/18/18dac2b1f4e29db3d3574a062b8ee87c.php:143 __TwigTemplate_107b3e08eff1aad164c2f366913beab8->macro_forceUnlockButton()
  ./vendor/twig/twig/src/Template.php:402            __TwigTemplate_107b3e08eff1aad164c2f366913beab8->doDisplay()
  ./vendor/twig/twig/src/Template.php:358            Twig\Template->yield()
  ./vendor/twig/twig/src/TemplateWrapper.php:61      Twig\Template->display()
  .../Glpi/Application/View/TemplateRenderer.php:188 Twig\TemplateWrapper->display()
  ./src/ObjectLock.php:160                           Glpi\Application\View\TemplateRenderer->display()
  ./src/ObjectLock.php:274                           ObjectLock->lockObject()
  ./src/CommonGLPI.php:1270                          ObjectLock::manageObjectLock()
  ./src/CommonDBTM.php:6522                          CommonGLPI->display()
  :                                                  CommonDBTM::displayFullPageForItem()
```