### PR TITLE
Business rule for assets : action to add a group in charge now supports multiple groups. (11/bf)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ The present file will list all changes made to the project; according to the
 - Fixed `id` property in dropdown/linked object properties in schemas in High-Level API showing as readOnly when they are writable.
 - Added High-Level API version 2.1. Make sure you are pinning your requests to a specific version (Ex: `/api.php/v2.0`) if needed to exclude endpoints/properties added in later versions. See version pinning in the getting started documentation `/api.php/getting-started`.
 - High-Level API responses for not found routes now correctly return a body including the standard error properties (status, title, detail). This is not controlled by the API version.
+- Business rule for assets : action to add a group in charge now supports multiple groups.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,9 @@ The present file will list all changes made to the project; according to the
 - Fixed `id` property in dropdown/linked object properties in schemas in High-Level API showing as readOnly when they are writable.
 - Added High-Level API version 2.1. Make sure you are pinning your requests to a specific version (Ex: `/api.php/v2.0`) if needed to exclude endpoints/properties added in later versions. See version pinning in the getting started documentation `/api.php/getting-started`.
 - High-Level API responses for not found routes now correctly return a body including the standard error properties (status, title, detail). This is not controlled by the API version.
-- Business rule for assets : action to add a group in charge now supports multiple groups.
+- Business rule for assets:
+  - action to add a group in charge now supports multiple groups.
+  - action to add a group for ownership now supports multiple groups.
 
 ### Deprecated
 

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -5811,14 +5811,6 @@ class CommonDBTM extends CommonGLPI
             $existing_data['_groups_id_tech'] = $this->input['_groups_id_tech'] ?? [];
 
             // retrieve existing _groups_id_tech & _groups_id
-            // api accept single value for $this->fields['groups_id'] -> format as array
-            if (isset($this->fields['groups_id']) && is_numeric($this->fields['groups_id'])) {
-                $this->fields['groups_id'] = [$this->fields['groups_id']];
-            }
-            if (isset($this->fields['groups_id_tech']) && is_numeric($this->fields['groups_id_tech'])) {
-                $this->fields['groups_id_tech'] = [$this->fields['groups_id_tech']];
-            }
-
             $existing_data['_groups_id'] = array_merge($existing_data['_groups_id'], $this->fields['groups_id'] ?? []); // on add fields['groups_id'] is not set
             $existing_data['_groups_id_tech'] = array_merge($existing_data['_groups_id_tech'], $this->fields['groups_id_tech'] ?? []);
 

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -5814,8 +5814,6 @@ class CommonDBTM extends CommonGLPI
             $existing_data['_groups_id'] = array_merge($existing_data['_groups_id'], $this->fields['groups_id'] ?? []); // on add fields['groups_id'] is not set
             $existing_data['_groups_id_tech'] = array_merge($existing_data['_groups_id_tech'], $this->fields['groups_id_tech'] ?? []);
 
-            //            throw new \Exception('Ajouter aussi les valeurs issues de la bd');
-
             // Execute all defined rules with the specified condition (add or update)
             $output = $ruleasset->processAllRules($input, [], [], [
                 'condition' => $condition,

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -5811,6 +5811,14 @@ class CommonDBTM extends CommonGLPI
             $existing_data['_groups_id_tech'] = $this->input['_groups_id_tech'] ?? [];
 
             // retrieve existing _groups_id_tech & _groups_id
+            // api accept single value for $this->fields['groups_id'] -> format as array
+            if (is_numeric($this->fields['groups_id'])) {
+                $this->fields['groups_id'] = [$this->fields['groups_id']];
+            }
+            if (is_numeric($this->fields['groups_id_tech'])) {
+                $this->fields['groups_id_tech'] = [$this->fields['groups_id_tech']];
+            }
+
             $existing_data['_groups_id'] = array_merge($existing_data['_groups_id'], $this->fields['groups_id'] ?? []); // on add fields['groups_id'] is not set
             $existing_data['_groups_id_tech'] = array_merge($existing_data['_groups_id_tech'], $this->fields['groups_id_tech'] ?? []);
 

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -5807,8 +5807,8 @@ class CommonDBTM extends CommonGLPI
 
             // cache groups data from form in case it needs to be merged after rule processing
             // existing_data is user submited data (form) + database data
-            $existing_data['_groups_id'] = $this->input['_groups_id'] ?? [];
-            $existing_data['_groups_id_tech'] = $this->input['_groups_id_tech'] ?? [];
+            $existing_data['_groups_id'] = is_array($this->input['_groups_id'] ?? null) ? $this->input['_groups_id'] : [];
+            $existing_data['_groups_id_tech'] = is_array($this->input['_groups_id_tech'] ?? null) ? $this->input['_groups_id_tech'] : [];
 
             // retrieve existing _groups_id_tech & _groups_id
             $existing_data['_groups_id'] = array_merge(

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -5811,8 +5811,15 @@ class CommonDBTM extends CommonGLPI
             $existing_data['_groups_id_tech'] = $this->input['_groups_id_tech'] ?? [];
 
             // retrieve existing _groups_id_tech & _groups_id
-            $existing_data['_groups_id'] = array_merge($existing_data['_groups_id'], $this->fields['groups_id'] ?? []); // on add fields['groups_id'] is not set
-            $existing_data['_groups_id_tech'] = array_merge($existing_data['_groups_id_tech'], $this->fields['groups_id_tech'] ?? []);
+            $existing_data['_groups_id'] = array_merge(
+                $existing_data['_groups_id'],
+                is_array($this->fields['groups_id'] ?? null) ? $this->fields['groups_id'] : []
+            );
+
+            $existing_data['_groups_id_tech'] = array_merge(
+                $existing_data['_groups_id_tech'],
+                is_array($this->fields['groups_id_tech'] ?? null) ? $this->fields['groups_id_tech'] : []
+            );
 
             // Execute all defined rules with the specified condition (add or update)
             $output = $ruleasset->processAllRules($input, [], [], [

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -5812,10 +5812,10 @@ class CommonDBTM extends CommonGLPI
 
             // retrieve existing _groups_id_tech & _groups_id
             // api accept single value for $this->fields['groups_id'] -> format as array
-            if (is_numeric($this->fields['groups_id'])) {
+            if (isset($this->fields['groups_id']) && is_numeric($this->fields['groups_id'])) {
                 $this->fields['groups_id'] = [$this->fields['groups_id']];
             }
-            if (is_numeric($this->fields['groups_id_tech'])) {
+            if (isset($this->fields['groups_id_tech']) && is_numeric($this->fields['groups_id_tech'])) {
                 $this->fields['groups_id_tech'] = [$this->fields['groups_id_tech']];
             }
 

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -5845,7 +5845,7 @@ class CommonDBTM extends CommonGLPI
 
                             $preserve_user_input = $value[0]['_rule_action'] === 'append';
                             if ($preserve_user_input && !isset($existing_data[$field])) {
-                                throw new LogicException('Implemetation error : action defined with appendtoarray but value not backup before rule processing');
+                                throw new LogicException('Implemetation error: action was defined with appendtoarray but the value not backed up before rule processing');
                             }
                             // use value before rule processing
                             $this->input[$field] = $preserve_user_input ? $existing_data[$field] : [];

--- a/src/DomainRecord.php
+++ b/src/DomainRecord.php
@@ -352,18 +352,12 @@ class DomainRecord extends CommonDBChild implements AssignableItemInterface
     public function prepareInputForAdd($input)
     {
         $input = $this->prepareGroupFields($input);
-        if (empty($input)) {
-            return false;
-        }
         return $this->prepareInput($input, true);
     }
 
     public function prepareInputForUpdate($input)
     {
         $input = $this->prepareGroupFields($input);
-        if (empty($input)) {
-            return false;
-        }
         return $this->prepareInput($input);
     }
 

--- a/src/DomainRecord.php
+++ b/src/DomainRecord.php
@@ -352,7 +352,7 @@ class DomainRecord extends CommonDBChild implements AssignableItemInterface
     public function prepareInputForAdd($input)
     {
         $input = $this->prepareGroupFields($input);
-        if ($input === false) {
+        if (empty($input)) {
             return false;
         }
         return $this->prepareInput($input, true);
@@ -361,7 +361,7 @@ class DomainRecord extends CommonDBChild implements AssignableItemInterface
     public function prepareInputForUpdate($input)
     {
         $input = $this->prepareGroupFields($input);
-        if ($input === false) {
+        if (empty($input)) {
             return false;
         }
         return $this->prepareInput($input);

--- a/src/Glpi/Api/API.php
+++ b/src/Glpi/Api/API.php
@@ -1905,6 +1905,7 @@ abstract class API
                     //add current item
                     $message = '';
                     try {
+                        $item->fields = []; // reset fields which can be set by $item->can(), avoid side effects
                         $new_id = $item->add($object);
                         $message = $this->getGlpiLastMessage();
                     } catch (RuntimeException $e) {

--- a/src/Glpi/Features/AssignableItem.php
+++ b/src/Glpi/Features/AssignableItem.php
@@ -238,7 +238,11 @@ trait AssignableItem
         return $rights;
     }
 
-    /** @see AssignableItemInterface::prepareGroupFields() */
+    /**
+     * - set groups_id & groups_id_tech of $input as array (if they exist and are not arrays)
+     * - add _groups_id & _groups_id_tech in $input, which are copies of not underscored fields,
+     *  casted to int and fitered (values =< 0 are removed)
+     */
     public function prepareGroupFields(array $input)
     {
         $fields = ['groups_id', 'groups_id_tech'];
@@ -247,10 +251,12 @@ trait AssignableItem
                 if (!is_array($input[$field])) {
                     $input[$field] = [$input[$field]];
                 }
+
                 $input['_' . $field] = array_filter(array_map('intval', $input[$field] ?? []), static fn($v) => $v > 0);
                 unset($input[$field]);
             }
         }
+
         return $input;
     }
 

--- a/src/Glpi/Features/AssignableItem.php
+++ b/src/Glpi/Features/AssignableItem.php
@@ -241,8 +241,7 @@ trait AssignableItem
     /**
      * Update input with _groups_id & _groups_id_tech
      *
-     * - set _groups_id & _groups_id_tech as arrays from groups_id & groups_id_tech
-     *   cast to int and fitered (values =< 0 are removed)
+     * - set _groups_id & _groups_id_tech as arrays from groups_id & groups_id_tech (cast to int and fiter (values =< 0 are removed))
      * - remove groups_id & groups_id_tech from input
      */
     public function prepareGroupFields(array $input)

--- a/src/Glpi/Features/AssignableItem.php
+++ b/src/Glpi/Features/AssignableItem.php
@@ -306,7 +306,21 @@ trait AssignableItem
         ];
         foreach ($fields as $type => $field) {
             $existing_for_type = array_column(array_filter($existing_links, static fn($link) => $link['type'] === $type), 'groups_id');
+            $remove_old = true;
             if (array_key_exists($field, $this->input)) {
+                // in some cases, the existing groups must not be removed (e.g, a rule that append groups)
+                // each entry of $this->input[$field] can be either a single value or an array
+                // if it's an array, it's because of the 'appendtoarray' & 'appendtoarrayfield' keys are set in action definition, @see \RuleAsset::getActions()
+                if (isset($this->input[$field][0]) && is_array($this->input[$field][0])) {
+                    // remove old links unless '_rule_action' is set to 'append'
+                    if (!empty($this->input[$field][0]) && isset($this->input[$field][0]['_rule_action']) && $this->input[$field][0]['_rule_action'] == 'append') {
+                        $remove_old = false;
+                    }
+
+                    // transform input to a flat array of IDs, as if there were no 'appendtoarray' & 'appendtoarrayfield' keys
+                    $this->input[$field] = array_map(static fn($i) => $i[$field], $this->input[$field]); // field is for the value defined by appendtoarrayfield
+                }
+
                 $new_links = array_diff($this->input[$field], $existing_for_type);
                 $old_links = array_diff($existing_for_type, $this->input[$field]);
                 foreach ($new_links as $group_id) {
@@ -320,17 +334,19 @@ trait AssignableItem
                         ]
                     );
                 }
-                foreach ($old_links as $group_id) {
-                    $group_item = new Group_Item();
-                    $group_item->deleteByCriteria(
-                        [
-                            'itemtype' => static::class,
-                            'items_id' => $this->getID(),
-                            'groups_id' => $group_id,
-                            'type' => $type,
-                        ],
-                        true
-                    );
+                if ($remove_old) {
+                    foreach ($old_links as $group_id) {
+                        $group_item = new Group_Item();
+                        $group_item->deleteByCriteria(
+                            [
+                                'itemtype' => static::class,
+                                'items_id' => $this->getID(),
+                                'groups_id' => $group_id,
+                                'type' => $type,
+                            ],
+                            true
+                        );
+                    }
                 }
             }
         }

--- a/src/Glpi/Features/AssignableItem.php
+++ b/src/Glpi/Features/AssignableItem.php
@@ -239,9 +239,11 @@ trait AssignableItem
     }
 
     /**
-     * - set groups_id & groups_id_tech of $input as array (if they exist and are not arrays)
-     * - add _groups_id & _groups_id_tech in $input, which are copies of not underscored fields,
-     *  casted to int and fitered (values =< 0 are removed)
+     * Update input with _groups_id & _groups_id_tech
+     *
+     * - set _groups_id & _groups_id_tech as arrays from groups_id & groups_id_tech
+     *   cast to int and fitered (values =< 0 are removed)
+     * - remove groups_id & groups_id_tech from input
      */
     public function prepareGroupFields(array $input)
     {

--- a/src/Glpi/Features/AssignableItemInterface.php
+++ b/src/Glpi/Features/AssignableItemInterface.php
@@ -62,7 +62,7 @@ interface AssignableItemInterface
     /**
      * @param array $input
      *
-     * @return false|array
+     * @return array
      */
     public function prepareGroupFields(array $input);
 

--- a/src/RuleAsset.php
+++ b/src/RuleAsset.php
@@ -208,7 +208,7 @@ class RuleAsset extends Rule
         $actions['groups_id']['force_actions'] = ['assign', 'append', 'defaultfromuser', 'firstgroupfromuser'];
         $actions['groups_id']['appendto']      = $field;
         $actions['groups_id']['permitseveral'] = ['append'];
-        $actions['groups_id']['appendtoarray'] = ['_rule_action' => null]; // _rule_action will be set in executeActions()
+        $actions['groups_id']['appendtoarray'] = ['_rule_action' => null]; // _rule_action will be set in executeActions() for append action
         $actions['groups_id']['appendtoarrayfield'] = $field;
 
         $actions['users_id_tech']['table']      = 'glpi_users';
@@ -224,7 +224,7 @@ class RuleAsset extends Rule
         $actions['groups_id_tech']['appendto']  = $field;
         $actions['groups_id_tech']['force_actions'] = ['assign', 'append'];
         $actions['groups_id_tech']['permitseveral'] = ['append'];
-        $actions['groups_id_tech']['appendtoarray'] = ['_rule_action' => null]; // _rule_action will be set in executeActions()
+        $actions['groups_id_tech']['appendtoarray'] = ['_rule_action' => null]; // _rule_action will be set in executeActions()  for append action
         $actions['groups_id_tech']['appendtoarrayfield'] = $field;
 
         $actions['comment']['table']            = '';

--- a/src/RuleAsset.php
+++ b/src/RuleAsset.php
@@ -199,16 +199,20 @@ class RuleAsset extends Rule
         $actions['_affect_user_by_regex']['force_actions']     = ['regex_result'];
         $actions['_affect_user_by_regex']['duplicatewith']     = 'users_id';
 
+        // Group ownership assignment
         $actions['groups_id']['name']          = Group::getTypeName(1);
         $actions['groups_id']['type']          = 'dropdown';
         $actions['groups_id']['table']         = 'glpi_groups';
         $actions['groups_id']['condition']     = ['is_itemgroup' => 1];
-        $actions['groups_id']['force_actions'] = ['assign', 'defaultfromuser', 'firstgroupfromuser'];
+        $actions['groups_id']['force_actions'] = ['assign', 'append', 'defaultfromuser', 'firstgroupfromuser'];
+        $actions['groups_id']['appendto']      = '_groups_id';
+        $actions['groups_id']['permitseveral'] = ['append'];
 
         $actions['users_id_tech']['table']      = 'glpi_users';
         $actions['users_id_tech']['type']       = 'dropdown_users';
         $actions['users_id_tech']['name']       = __('Technician in charge');
 
+        // Group assignment (in charge)
         $actions['groups_id_tech']['name']      = __('Group in charge');
         $actions['groups_id_tech']['type']      = 'dropdown';
         $actions['groups_id_tech']['table']     = 'glpi_groups';

--- a/src/RuleAsset.php
+++ b/src/RuleAsset.php
@@ -213,6 +213,9 @@ class RuleAsset extends Rule
         $actions['groups_id_tech']['type']      = 'dropdown';
         $actions['groups_id_tech']['table']     = 'glpi_groups';
         $actions['groups_id_tech']['condition'] = ['is_assign' => 1];
+        $actions['groups_id_tech']['appendto']  = '_groups_id_tech';
+        $actions['groups_id_tech']['force_actions'] = ['assign', 'append'];
+        $actions['groups_id_tech']['permitseveral'] = ['append'];
 
         $actions['comment']['table']            = '';
         $actions['comment']['field']            = 'comment';

--- a/src/RuleAsset.php
+++ b/src/RuleAsset.php
@@ -200,26 +200,32 @@ class RuleAsset extends Rule
         $actions['_affect_user_by_regex']['duplicatewith']     = 'users_id';
 
         // Group ownership assignment
+        $field = '_groups_id';
         $actions['groups_id']['name']          = Group::getTypeName(1);
         $actions['groups_id']['type']          = 'dropdown';
         $actions['groups_id']['table']         = 'glpi_groups';
         $actions['groups_id']['condition']     = ['is_itemgroup' => 1];
         $actions['groups_id']['force_actions'] = ['assign', 'append', 'defaultfromuser', 'firstgroupfromuser'];
-        $actions['groups_id']['appendto']      = '_groups_id';
+        $actions['groups_id']['appendto']      = $field;
         $actions['groups_id']['permitseveral'] = ['append'];
+        $actions['groups_id']['appendtoarray'] = ['_rule_action' => null]; // _rule_action will be set in executeActions()
+        $actions['groups_id']['appendtoarrayfield'] = $field;
 
         $actions['users_id_tech']['table']      = 'glpi_users';
         $actions['users_id_tech']['type']       = 'dropdown_users';
         $actions['users_id_tech']['name']       = __('Technician in charge');
 
         // Group assignment (in charge)
+        $field = '_groups_id_tech';
         $actions['groups_id_tech']['name']      = __('Group in charge');
         $actions['groups_id_tech']['type']      = 'dropdown';
         $actions['groups_id_tech']['table']     = 'glpi_groups';
         $actions['groups_id_tech']['condition'] = ['is_assign' => 1];
-        $actions['groups_id_tech']['appendto']  = '_groups_id_tech';
+        $actions['groups_id_tech']['appendto']  = $field;
         $actions['groups_id_tech']['force_actions'] = ['assign', 'append'];
         $actions['groups_id_tech']['permitseveral'] = ['append'];
+        $actions['groups_id_tech']['appendtoarray'] = ['_rule_action' => null]; // _rule_action will be set in executeActions()
+        $actions['groups_id_tech']['appendtoarrayfield'] = $field;
 
         $actions['comment']['table']            = '';
         $actions['comment']['field']            = 'comment';
@@ -281,8 +287,8 @@ class RuleAsset extends Rule
                             && isset($actions[$action->fields["field"]]["appendtoarrayfield"])
                         ) {
                             $value = $actions[$action->fields["field"]]["appendtoarray"];
-                            $value[$actions[$action->fields["field"]]["appendtoarrayfield"]]
-                            = $action->fields["value"];
+                            $value["_rule_action"] = $action->fields["action_type"];
+                            $value[ $actions[$action->fields["field"]]["appendtoarrayfield"] ] = $action->fields["value"];
                         }
                         $output[$actions[$action->fields["field"]]["appendto"]][] = $value;
                         break;

--- a/tests/functional/Glpi/Features/AssignableItemTest.php
+++ b/tests/functional/Glpi/Features/AssignableItemTest.php
@@ -127,6 +127,32 @@ class AssignableItemTest extends \DbTestCase
     }
 
     /**
+     * Test form with an empty string as groups_id, as the form does in front
+     *
+     * Reproduce a bug despite the form doesn't really use these fields ("array_merge(): Argument #1 must be of type array, string given")
+     *
+     * @param class-string<AssignableItem> $class
+     **/
+    #[DataProvider('itemtypeProvider')]
+    public function testAddNoGroups(string $class): void
+    {
+        $this->login(); // login to bypass some rights checks (e.g. on domain records)
+
+        $input = $this->getMinimalCreationInput($class);
+        $item_1 = $this->createItem(
+            $class,
+            $input + [
+                $class::getNameField() => __FUNCTION__ . ' 1',
+                '_groups_id'             => '',
+                '_groups_id_tech'        => '',
+            ]
+        );
+
+        $this->assertEqualsCanonicalizing([], $item_1->fields['groups_id']);
+        $this->assertEqualsCanonicalizing([], $item_1->fields['groups_id_tech']);
+    }
+
+    /**
      * Test the loading item which still have integer values for groups_id/groups_id_tech (0 for no group).
      * The value should be automatically normalized to an array. If the group was '0', the array should be empty.
      *

--- a/tests/functional/Glpi/Features/AssignableItemTest.php
+++ b/tests/functional/Glpi/Features/AssignableItemTest.php
@@ -136,15 +136,15 @@ class AssignableItemTest extends \DbTestCase
     #[DataProvider('itemtypeProvider')]
     public function testAddNoGroups(string $class): void
     {
-        $this->login(); // login to bypass some rights checks (e.g. on domain records)
+        $this->login();
 
         $input = $this->getMinimalCreationInput($class);
+        assert(!array_key_exists('groups_id', $input), 'There should be no groups_id input for this test');
+        assert(!array_key_exists('groups_id_tech', $input), 'There should be no groups_id_tech input for this test');
         $item_1 = $this->createItem(
             $class,
             $input + [
                 $class::getNameField() => __FUNCTION__ . ' 1',
-                '_groups_id'             => '',
-                '_groups_id_tech'        => '',
             ]
         );
 

--- a/tests/functional/Glpi/Features/AssignableItemTest.php
+++ b/tests/functional/Glpi/Features/AssignableItemTest.php
@@ -87,7 +87,7 @@ class AssignableItemTest extends \DbTestCase
                 $class::getNameField() => __FUNCTION__ . ' 1',
                 'groups_id'            => [1, 2],
                 'groups_id_tech'       => [3],
-                'domains_id'            => getItemByTypeName(Domain::class, '_testDomain', true),
+
             ],
             [
                 'domains_id',

--- a/tests/functional/Glpi/Features/AssignableItemTest.php
+++ b/tests/functional/Glpi/Features/AssignableItemTest.php
@@ -54,7 +54,7 @@ class AssignableItemTest extends \DbTestCase
 
     /**
      * @param class-string<AssignableItem> $class
- */
+     */
     #[DataProvider('itemtypeProvider')]
     public function testClassUsesTrait(string $class): void
     {

--- a/tests/functional/Glpi/Features/AssignableItemTest.php
+++ b/tests/functional/Glpi/Features/AssignableItemTest.php
@@ -87,7 +87,6 @@ class AssignableItemTest extends \DbTestCase
                 $class::getNameField() => __FUNCTION__ . ' 1',
                 'groups_id'            => [1, 2],
                 'groups_id_tech'       => [3],
-
             ],
             [
                 'domains_id',
@@ -147,7 +146,6 @@ class AssignableItemTest extends \DbTestCase
             $class,
             $input + [
                 $class::getNameField() => __FUNCTION__,
-                'domains_id'            => getItemByTypeName(Domain::class, '_testDomain', true),
             ],
             [
                 'domains_id',
@@ -234,7 +232,6 @@ class AssignableItemTest extends \DbTestCase
                 $class::getNameField() => __FUNCTION__,
                 'groups_id'            => 1,
                 'groups_id_tech'       => 2,
-                'domains_id'            => getItemByTypeName(Domain::class, '_testDomain', true),
             ],
             [
                 // groups_id & groups_id_tech are returned as array

--- a/tests/functional/Glpi/Features/AssignableItemTest.php
+++ b/tests/functional/Glpi/Features/AssignableItemTest.php
@@ -87,6 +87,10 @@ class AssignableItemTest extends \DbTestCase
                 $class::getNameField() => __FUNCTION__ . ' 1',
                 'groups_id'            => [1, 2],
                 'groups_id_tech'       => [3],
+                'domains_id'            => getItemByTypeName(Domain::class, '_testDomain', true),
+            ],
+            [
+                'domains_id',
             ]
         );
         $this->assertEqualsCanonicalizing([1, 2], $item_1->fields['groups_id']);
@@ -143,6 +147,10 @@ class AssignableItemTest extends \DbTestCase
             $class,
             $input + [
                 $class::getNameField() => __FUNCTION__,
+                'domains_id'            => getItemByTypeName(Domain::class, '_testDomain', true),
+            ],
+            [
+                'domains_id',
             ]
         );
         $this->assertEquals([], $item->fields['groups_id']);
@@ -226,6 +234,7 @@ class AssignableItemTest extends \DbTestCase
                 $class::getNameField() => __FUNCTION__,
                 'groups_id'            => 1,
                 'groups_id_tech'       => 2,
+                'domains_id'            => getItemByTypeName(Domain::class, '_testDomain', true),
             ],
             [
                 // groups_id & groups_id_tech are returned as array

--- a/tests/functional/Glpi/Features/AssignableItemTest.php
+++ b/tests/functional/Glpi/Features/AssignableItemTest.php
@@ -87,9 +87,6 @@ class AssignableItemTest extends \DbTestCase
                 $class::getNameField() => __FUNCTION__ . ' 1',
                 'groups_id'            => [1, 2],
                 'groups_id_tech'       => [3],
-            ],
-            [
-                'domains_id',
             ]
         );
         $this->assertEqualsCanonicalizing([1, 2], $item_1->fields['groups_id']);
@@ -146,9 +143,6 @@ class AssignableItemTest extends \DbTestCase
             $class,
             $input + [
                 $class::getNameField() => __FUNCTION__,
-            ],
-            [
-                'domains_id',
             ]
         );
         $this->assertEquals([], $item->fields['groups_id']);

--- a/tests/functional/Glpi/Inventory/Assets/ProcessTest.php
+++ b/tests/functional/Glpi/Inventory/Assets/ProcessTest.php
@@ -192,6 +192,8 @@ class ProcessTest extends AbstractInventoryAsset
         $json = json_decode($data);
         //we change itemtype to our asset
         $json->itemtype = $classname;
+        dump($classname);
+        dump($json);
         $inventory = $this->doInventory($json);
 
         //check created asset

--- a/tests/functional/Glpi/Inventory/Assets/ProcessTest.php
+++ b/tests/functional/Glpi/Inventory/Assets/ProcessTest.php
@@ -192,8 +192,6 @@ class ProcessTest extends AbstractInventoryAsset
         $json = json_decode($data);
         //we change itemtype to our asset
         $json->itemtype = $classname;
-        dump($classname);
-        dump($json);
         $inventory = $this->doInventory($json);
 
         //check created asset

--- a/tests/functional/RuleAssetTest.php
+++ b/tests/functional/RuleAssetTest.php
@@ -678,7 +678,7 @@ class RuleAssetTest extends DbTestCase
     }
 
     /**
-     * Test to ensure the rule to assign groups (ownership) to asset preserve previously groups
+     * Test to ensure the rule to assign groups (ownership) preserve previously associated groups
      *
      * action : append
      * field: groups_id
@@ -713,11 +713,105 @@ class RuleAssetTest extends DbTestCase
         $associations = (new \Group_Item())->find([
             'items_id' => $computer->getID(),
             'itemtype' => $computer::getType(),
-            'groups_id' => [$initial_group->getID(), $group_for_rule->getID()],
             'type' => \Group_Item::GROUP_TYPE_TECH,
         ]);
         $fetched_group_ids = array_column($associations, 'groups_id');
         $this->assertEqualsCanonicalizing([$initial_group->getID(), $group_for_rule->getID()], $fetched_group_ids, 'Unexpected Asset associated owner groups');
+    }
+
+    /**
+     * Test to ensure the rule to assign groups (ownership) to asset preserve previously associated groups
+     *
+     * action : append
+     * field: groups_id
+     */
+    public function testAssignTechGroupWithRuleAndFormAtTheTimeOnUpdate(): void
+    {
+        $auth = $this->login();
+        $entity_id = $auth->user->fields['entities_id'];
+        $asset_name_to_trigger_rule = $this->getUniqueString();
+        // arrange - create 2 groups + create rule to associate a Computer with created groups
+        $group_for_form = $this->createItem(\Group::class, ['name' => $this->getUniqueString(), 'entities_id' => $entity_id]);
+        $group_for_rule = $this->createItem(\Group::class, ['name' => $this->getUniqueString()]);
+        $rule_builder = new RuleBuilder(__FUNCTION__, \RuleAsset::class);
+        $rule_builder->setEntity($entity_id);
+        $rule_builder->addCriteria('name', Rule::PATTERN_IS, $asset_name_to_trigger_rule);
+        $rule_builder->addAction('append', 'groups_id_tech', $group_for_rule->getID());
+        $rule_builder->setCondtion(\RuleAsset::ONUPDATE);
+        $this->createRule($rule_builder);
+
+        $computer = $this->createItem(
+            Computer::class,
+            [
+                'name' => $this->getUniqueString(),
+                'entities_id' => $entity_id,
+            ]
+        );
+
+        $this->updateItem(
+            Computer::class,
+            $computer->getID(),
+            [
+                'name' => $asset_name_to_trigger_rule,
+                'groups_id_tech'   => [$group_for_form->getID()],
+            ],
+            [
+                'groups_id_tech', // one group is added by rule, checkinput will fail
+            ]
+        );
+
+        // assert - check that the computer has the tech groups assigned
+        $associations = (new \Group_Item())->find([
+            'items_id' => $computer->getID(),
+            'itemtype' => $computer::getType(),
+            'type' => \Group_Item::GROUP_TYPE_TECH,
+        ]);
+        $fetched_group_ids = array_column($associations, 'groups_id');
+        $this->assertEqualsCanonicalizing([$group_for_form->getID(), $group_for_rule->getID()], $fetched_group_ids, 'Unexpected Asset associated owner groups');
+    }
+
+    /**
+     * Test to ensure the rule to assign groups (ownership) to asset preserve previously associated groups
+     *
+     * action : append
+     * field: groups_id
+     */
+    public function testAssignTechGroupWithRuleAndFormAtTheTimeOnCreate(): void
+    {
+        $auth = $this->login();
+        $entity_id = $auth->user->fields['entities_id'];
+        $asset_name_to_trigger_rule = $this->getUniqueString();
+        // arrange - create 2 groups + create rule to associate a Computer with created groups
+        $group_for_form = $this->createItem(\Group::class, ['name' => $this->getUniqueString(), 'entities_id' => $entity_id]);
+        $group_for_rule = $this->createItem(\Group::class, ['name' => $this->getUniqueString()]);
+        $rule_builder = new RuleBuilder(__FUNCTION__, \RuleAsset::class);
+        $rule_builder->setEntity($entity_id);
+        $rule_builder->addCriteria('name', Rule::PATTERN_IS, $asset_name_to_trigger_rule);
+        $rule_builder->addAction('append', 'groups_id_tech', $group_for_rule->getID());
+        $rule_builder->setCondtion(\RuleAsset::ONADD);
+        $this->createRule($rule_builder);
+
+        $computer = $this->createItem(
+            Computer::class,
+            [
+                'name' => $asset_name_to_trigger_rule,
+                'entities_id' => $entity_id,
+                'groups_id_tech'   => [$group_for_form->getID()],
+            ],
+            [
+                'groups_id_tech', // one group is added by rule, checkinput will fail
+            ]
+        );
+
+        // assert - check that the computer has the tech groups assigned
+        $associations = (new \Group_Item())->find([
+            'items_id' => $computer->getID(),
+            'itemtype' => $computer::getType(),
+            //            'groups_id' => [$group_for_form->getID(), $group_for_rule->getID()],
+            'type' => \Group_Item::GROUP_TYPE_TECH,
+        ]);
+        $fetched_group_ids = array_column($associations, 'groups_id');
+        $this->assertEqualsCanonicalizing([$group_for_form->getID(), $group_for_rule->getID()], $fetched_group_ids, 'Unexpected Asset associated owner groups');
     }
 
     /**

--- a/tests/functional/RuleAssetTest.php
+++ b/tests/functional/RuleAssetTest.php
@@ -39,6 +39,7 @@ use DbTestCase;
 use Generator;
 use Rule;
 use RuleAction;
+use RuleBuilder;
 use RuleCriteria;
 use SingletonRuleList;
 
@@ -636,6 +637,43 @@ class RuleAssetTest extends DbTestCase
         $this->assertTrue($update);
         $this->assertTrue($computer_em->getFromDB($computer_id));
         $this->assertEquals($locations_id, $computer_em->getField('locations_id'));
+    }
+
+    /**
+     * Test rule to assign tech groups to asset on creation
+     *
+     * action : append
+     * field: groups_id_tech
+     */
+    public function testAssignTechGroup(): void
+    {
+        $this->login();
+        // arrange - create 2 groups + create rule to associate a Computer with created groups
+        $tech_group_1 = $this->createItem(\Group::class, ['name' => 'tech group 1']);
+        $tech_group_2 = $this->createItem(\Group::class, ['name' => 'tech group 2']);
+        $rule_builder = new RuleBuilder(__FUNCTION__, \RuleAsset::class);
+        $rule_builder->setEntity(0);
+        $rule_builder->addCriteria('entities_id', Rule::PATTERN_IS, '0');
+        $rule_builder->addAction('append', 'groups_id_tech', $tech_group_1->getID());
+        $rule_builder->addAction('append', 'groups_id_tech', $tech_group_2->getID());
+        $rule_builder->setCondtion(\RuleAsset::ONADD);
+        $this->createRule($rule_builder);
+
+        // act - create a Computer
+        $computer = $this->createItem(Computer::class, [
+            'name'        => 'Computer',
+            'entities_id' => 0,
+        ]);
+
+        // assert - check that the computer has the tech groups assigned
+        $associations = (new \Group_Item())->find([
+            'items_id' => $computer->getID(),
+            'itemtype' => $computer::getType(),
+            'groups_id' => [$tech_group_1->getID(), $tech_group_2->getID()],
+        ]);
+        $fetched_group_ids = array_column($associations, 'groups_id');
+
+        $this->assertEqualsCanonicalizing([$tech_group_1->getID(), $tech_group_2->getID()], $fetched_group_ids, 'Unexpected Asset associated tech groups');
     }
 
     public function testGroupUserAssignFromDefaultUser()

--- a/tests/web/APIRestTest.php
+++ b/tests/web/APIRestTest.php
@@ -694,6 +694,41 @@ class APIRestTest extends TestCase
         $this->createNote($computers_id);
     }
 
+    /**
+     * Api accept an array for groups_id & groups_id_tech but also a single id
+     */
+    public function testCreateComputerWithGroupWithSingleId(): void
+    {
+        // act : query to create a Computer associated with a group and a tech group
+        $group_own = getItemByTypeName(\Group::class, '_test_group_1', true);
+        $group_tech = getItemByTypeName(\Group::class, '_test_group_2', true);
+        $response = $this->query(
+            'createItems',
+            [
+                'verb'     => 'POST',
+                'itemtype' => 'Computer',
+                'headers'  => ['Session-Token' => $this->session_token, 'accept' => 'application/json'],
+                'json'     => ['input' => [
+                    'name' => "My single computer 2 " . rand(0, 999999),
+                    "groups_id" => $group_own,
+                    "groups_id_tech" => $group_tech,
+                ]],
+            ],
+            201
+        );
+
+        // assert
+        $id_created_item = $response['id'];
+        $asset = new Computer();
+        $this->assertTrue($asset->getFromDB($id_created_item), 'Fail to retrieve created asset #' . $id_created_item);
+
+        $this->assertCount(1, $asset->fields['groups_id']);
+        $this->assertContains($group_own, $asset->fields['groups_id']);
+
+        $this->assertCount(1, $asset->fields['groups_id_tech']);
+        $this->assertContains($group_tech, $asset->fields['groups_id_tech']);
+    }
+
     public function testCreateItems()
     {
         $data = $this->query(


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] This change requires a documentation update.

## Description

- It fixes #20837 : Business rule for assets : action to add a group in charge now supports multiple groups.



