### PR TITLE
fix(itil): Linked itilobject should return the child entities itilobject

### DIFF
--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -1861,6 +1861,7 @@ HTML;
         $p_ajax = [
             'idtable'                         => '__VALUE__',
             'name'                            => $params['items_id_name'],
+            'aria_label'                      => $params['items_aria_label'],
             'entity_restrict'                 => $params['entity_restrict'],
             'showItemSpecificity'             => $params['showItemSpecificity'],
             'rand'                            => $params['rand'],

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -1814,6 +1814,7 @@ HTML;
         $params = [
             'itemtype_name'                         => 'itemtype',
             'items_id_name'                         => 'items_id',
+            'items_aria_label'                      => '',
             'itemtypes'                             => '',
             'default_itemtype'                      => 0,
             'default_items_id'                      => -1,

--- a/templates/components/itilobject/fields_panel.html.twig
+++ b/templates/components/itilobject/fields_panel.html.twig
@@ -471,7 +471,7 @@
 
    {% set linked_itilobjects_show = headers_states['linked_itilobjects'] is defined and headers_states['linked_itilobjects'] == "true" ? true : false %}
    {% set nb_linked_itilobjects = item.isNewItem() ? 0 : call('CommonITILObject_CommonITILObject::countAllLinks', [item.getType(), item.getId()]) %}
-   <section class="accordion-item" aria-label="{{ 'CommonITILObject_CommonITILObject'|itemtype_name(nb_linked_itilobjects) }} - section">
+   <section class="accordion-item" aria-label="{{ __('%s - section')|format('CommonITILObject_CommonITILObject'|itemtype_name(nb_linked_itilobjects)) }}">
       <div class="accordion-header" id="linked_itilobjects-heading" title="{{ 'CommonITILObject_CommonITILObject'|itemtype_name(nb_linked_itilobjects) }}" data-bs-toggle="tooltip">
          <button class="accordion-button {{ linked_itilobjects_show ? "" : "collapsed" }}" type="button" data-bs-toggle="collapse" data-bs-target="#linked_itilobjects" aria-expanded="true" aria-controls="linked_itilobjects">
             <i class="ti ti-link"></i>

--- a/templates/components/itilobject/fields_panel.html.twig
+++ b/templates/components/itilobject/fields_panel.html.twig
@@ -471,7 +471,7 @@
 
    {% set linked_itilobjects_show = headers_states['linked_itilobjects'] is defined and headers_states['linked_itilobjects'] == "true" ? true : false %}
    {% set nb_linked_itilobjects = item.isNewItem() ? 0 : call('CommonITILObject_CommonITILObject::countAllLinks', [item.getType(), item.getId()]) %}
-   <section class="accordion-item" aria-label="{{ 'CommonITILObject_CommonITILObject'|itemtype_name(nb_linked_itilobjects) }}">
+   <section class="accordion-item" aria-label="{{ 'CommonITILObject_CommonITILObject'|itemtype_name(nb_linked_itilobjects) }} - section">
       <div class="accordion-header" id="linked_itilobjects-heading" title="{{ 'CommonITILObject_CommonITILObject'|itemtype_name(nb_linked_itilobjects) }}" data-bs-toggle="tooltip">
          <button class="accordion-button {{ linked_itilobjects_show ? "" : "collapsed" }}" type="button" data-bs-toggle="collapse" data-bs-target="#linked_itilobjects" aria-expanded="true" aria-controls="linked_itilobjects">
             <i class="ti ti-link"></i>

--- a/templates/components/itilobject/fields_panel.html.twig
+++ b/templates/components/itilobject/fields_panel.html.twig
@@ -471,7 +471,7 @@
 
    {% set linked_itilobjects_show = headers_states['linked_itilobjects'] is defined and headers_states['linked_itilobjects'] == "true" ? true : false %}
    {% set nb_linked_itilobjects = item.isNewItem() ? 0 : call('CommonITILObject_CommonITILObject::countAllLinks', [item.getType(), item.getId()]) %}
-   <section class="accordion-item" data-testid="{{ '%s - section'|format('CommonITILObject_CommonITILObject'|itemtype_name(nb_linked_itilobjects)) }}">
+   <section class="accordion-item" data-testid="linked-itilobjects-section">
       <div class="accordion-header" id="linked_itilobjects-heading" title="{{ 'CommonITILObject_CommonITILObject'|itemtype_name(nb_linked_itilobjects) }}" data-bs-toggle="tooltip">
          <button class="accordion-button {{ linked_itilobjects_show ? "" : "collapsed" }}" type="button" data-bs-toggle="collapse" data-bs-target="#linked_itilobjects" aria-expanded="true" aria-controls="linked_itilobjects">
             <i class="ti ti-link"></i>

--- a/templates/components/itilobject/fields_panel.html.twig
+++ b/templates/components/itilobject/fields_panel.html.twig
@@ -471,7 +471,7 @@
 
    {% set linked_itilobjects_show = headers_states['linked_itilobjects'] is defined and headers_states['linked_itilobjects'] == "true" ? true : false %}
    {% set nb_linked_itilobjects = item.isNewItem() ? 0 : call('CommonITILObject_CommonITILObject::countAllLinks', [item.getType(), item.getId()]) %}
-   <section class="accordion-item" data-testid="linked-itilobjects-section">
+   <section class="accordion-item" aria-label="{{ 'CommonITILObject_CommonITILObject'|itemtype_name(nb_linked_itilobjects) }}" data-testid="linked-itilobjects-section">
       <div class="accordion-header" id="linked_itilobjects-heading" title="{{ 'CommonITILObject_CommonITILObject'|itemtype_name(nb_linked_itilobjects) }}" data-bs-toggle="tooltip">
          <button class="accordion-button {{ linked_itilobjects_show ? "" : "collapsed" }}" type="button" data-bs-toggle="collapse" data-bs-target="#linked_itilobjects" aria-expanded="true" aria-controls="linked_itilobjects">
             <i class="ti ti-link"></i>

--- a/templates/components/itilobject/fields_panel.html.twig
+++ b/templates/components/itilobject/fields_panel.html.twig
@@ -471,7 +471,7 @@
 
    {% set linked_itilobjects_show = headers_states['linked_itilobjects'] is defined and headers_states['linked_itilobjects'] == "true" ? true : false %}
    {% set nb_linked_itilobjects = item.isNewItem() ? 0 : call('CommonITILObject_CommonITILObject::countAllLinks', [item.getType(), item.getId()]) %}
-   <section class="accordion-item" aria-label="{{ __('%s - section')|format('CommonITILObject_CommonITILObject'|itemtype_name(nb_linked_itilobjects)) }}">
+   <section class="accordion-item" data-testid="{{ '%s - section'|format('CommonITILObject_CommonITILObject'|itemtype_name(nb_linked_itilobjects)) }}">
       <div class="accordion-header" id="linked_itilobjects-heading" title="{{ 'CommonITILObject_CommonITILObject'|itemtype_name(nb_linked_itilobjects) }}" data-bs-toggle="tooltip">
          <button class="accordion-button {{ linked_itilobjects_show ? "" : "collapsed" }}" type="button" data-bs-toggle="collapse" data-bs-target="#linked_itilobjects" aria-expanded="true" aria-controls="linked_itilobjects">
             <i class="ti ti-link"></i>

--- a/templates/components/itilobject/linked_itilobjects.html.twig
+++ b/templates/components/itilobject/linked_itilobjects.html.twig
@@ -49,17 +49,25 @@
                      ])|raw }}
                   </div>
                   <div class="col text-truncate">
-                     <a href="{{ linked['itemtype']|itemtype_form_path(linked['items_id']) }}" class="col-9 overflow-hidden text-nowrap">
-                        <i class="{{ linked['itemtype']|itemtype_icon }}" title="{{ linked['itemtype']|itemtype_name }}" data-bs-toggle="tootlip"></i>
-                        {{ new_itilobject.getStatusIcon(new_itilobject.fields['status'])|raw }}
-                        <span title="{{ new_itilobject.fields['name'] }}" data-bs-toggle="tooltip">
-                     {{ new_itilobject.fields['name'] }}
-                  </span>
-                        ({{ new_itilobject.fields['id'] }})
-                     </a>
+                      {% set _content %}
+                          <i class="{{ linked['itemtype']|itemtype_icon }}" title="{{ linked['itemtype']|itemtype_name }}" data-bs-toggle="tootlip"></i>
+                          {{ new_itilobject.getStatusIcon(new_itilobject.fields['status'])|raw }}
+                          <span title="{{ new_itilobject.fields['name'] }}" data-bs-toggle="tooltip">
+                             {{ new_itilobject.fields['name'] }}
+                          </span>
+                          ({{ new_itilobject.fields['id'] }})
+                      {% endset %}
+
+                      {% if new_itilobject.canViewItem() %}
+                          <a href="{{ linked['itemtype']|itemtype_form_path(linked['items_id']) }}" class="col-9 overflow-hidden text-nowrap">
+                              {{ _content }}
+                          </a>
+                      {% else %}
+                          {{ _content }}
+                      {% endif %}
                   </div>
 
-                  {% if canupdate %}
+                  {% if new_itilobject.canDeleteItem() %}
                      <div class="col-auto">
                         <button type="submit"
                                 form="linked_itilobjects_{{ main_rand }}"

--- a/templates/components/itilobject/linked_itilobjects.html.twig
+++ b/templates/components/itilobject/linked_itilobjects.html.twig
@@ -39,7 +39,7 @@
       <div class="list-group list-group-flush list-group-hoverable">
          {% for id, linked in linked_itilobjects %}
             {% set new_itilobject = get_item(linked['itemtype'], linked['items_id']) %}
-            <div class="list-group-item" aria-label="Linked item group - {{ new_itilobject.fields['name'] }}">
+            <div class="list-group-item" aria-label="{{ __('Linked item group - %s')|format(new_itilobject.fields['name']) }}">
                <div class="row">
                   <div class="col-auto">
                      {{ call('CommonITILObject_CommonITILObject::getLinkName', [
@@ -104,14 +104,14 @@
          ]) %}
          {% do call('Dropdown::showSelectItemFromItemtypes', [{
             'items_id_name': '_link[items_id_2]',
-            'items_aria_label': 'ITIL item selector',
+            'items_aria_label': __('ITIL item selector'),
             'itemtype_name': '_link[itemtype_2]',
             'itemtypes': ['Ticket', 'Change', 'Problem'],
             'checkright': true,
             'entity_restrict': session('glpiactiveentities'),
             'default_itemtype': params['_link']['itemtype_2'] ?? '',
             'default_items_id': params['_link']['items_id_2'] ?? '',
-            'aria_label': 'ITIL type selector',
+            'aria_label': __('ITIL type selector'),
          }]) %}
       </span>
    </div>

--- a/templates/components/itilobject/linked_itilobjects.html.twig
+++ b/templates/components/itilobject/linked_itilobjects.html.twig
@@ -108,7 +108,7 @@
             'itemtype_name': '_link[itemtype_2]',
             'itemtypes': ['Ticket', 'Change', 'Problem'],
             'checkright': true,
-            'entity_restrict': session('glpiactiveentities'),
+            'entity_restrict': item.isRecursive() ? item.getEntityID() : call('getSonsOf', ['glpi_entities', item.getEntityID()]),
             'default_itemtype': params['_link']['itemtype_2'] ?? '',
             'default_items_id': params['_link']['items_id_2'] ?? '',
             'aria_label': __('ITIL type selector'),

--- a/templates/components/itilobject/linked_itilobjects.html.twig
+++ b/templates/components/itilobject/linked_itilobjects.html.twig
@@ -99,7 +99,7 @@
             'itemtype_name': '_link[itemtype_2]',
             'itemtypes': ['Ticket', 'Change', 'Problem'],
             'checkright': true,
-            'entity_restrict': session('glpiactive_entity'),
+            'entity_restrict': session('glpiactiveentities'),
             'default_itemtype': params['_link']['itemtype_2'] ?? '',
             'default_items_id': params['_link']['items_id_2'] ?? ''
          }]) %}

--- a/templates/components/itilobject/linked_itilobjects.html.twig
+++ b/templates/components/itilobject/linked_itilobjects.html.twig
@@ -39,7 +39,7 @@
       <div class="list-group list-group-flush list-group-hoverable">
          {% for id, linked in linked_itilobjects %}
             {% set new_itilobject = get_item(linked['itemtype'], linked['items_id']) %}
-            <div class="list-group-item" aria-label="{{ __('Linked item group - %s')|format(new_itilobject.fields['name']) }}">
+            <div class="list-group-item" data-testid="{{ 'Linked item group - %s'|format(new_itilobject.fields['name']) }}">
                <div class="row">
                   <div class="col-auto">
                      {{ call('CommonITILObject_CommonITILObject::getLinkName', [

--- a/templates/components/itilobject/linked_itilobjects.html.twig
+++ b/templates/components/itilobject/linked_itilobjects.html.twig
@@ -39,7 +39,7 @@
       <div class="list-group list-group-flush list-group-hoverable">
          {% for id, linked in linked_itilobjects %}
             {% set new_itilobject = get_item(linked['itemtype'], linked['items_id']) %}
-            <div class="list-group-item" data-testid="{{ 'Linked item group - %s'|format(new_itilobject.fields['name']) }}">
+            <div class="list-group-item" data-testid="{{ 'linked-item-group-%s'|format(new_itilobject.fields['id']) }}">
                <div class="row">
                   <div class="col-auto">
                      {{ call('CommonITILObject_CommonITILObject::getLinkName', [

--- a/templates/components/itilobject/linked_itilobjects.html.twig
+++ b/templates/components/itilobject/linked_itilobjects.html.twig
@@ -39,7 +39,7 @@
       <div class="list-group list-group-flush list-group-hoverable">
          {% for id, linked in linked_itilobjects %}
             {% set new_itilobject = get_item(linked['itemtype'], linked['items_id']) %}
-            <div class="list-group-item">
+            <div class="list-group-item" aria-label="Linked item group - {{ new_itilobject.fields['name'] }}">
                <div class="row">
                   <div class="col-auto">
                      {{ call('CommonITILObject_CommonITILObject::getLinkName', [
@@ -104,12 +104,14 @@
          ]) %}
          {% do call('Dropdown::showSelectItemFromItemtypes', [{
             'items_id_name': '_link[items_id_2]',
+            'items_aria_label': 'ITIL item selector',
             'itemtype_name': '_link[itemtype_2]',
             'itemtypes': ['Ticket', 'Change', 'Problem'],
             'checkright': true,
             'entity_restrict': session('glpiactiveentities'),
             'default_itemtype': params['_link']['itemtype_2'] ?? '',
-            'default_items_id': params['_link']['items_id_2'] ?? ''
+            'default_items_id': params['_link']['items_id_2'] ?? '',
+            'aria_label': 'ITIL type selector',
          }]) %}
       </span>
    </div>

--- a/templates/components/itilobject/linked_itilobjects.html.twig
+++ b/templates/components/itilobject/linked_itilobjects.html.twig
@@ -67,7 +67,7 @@
                       {% endif %}
                   </div>
 
-                  {% if new_itilobject.canDeleteItem() %}
+                  {% if canupdate %}
                      <div class="col-auto">
                         <button type="submit"
                                 form="linked_itilobjects_{{ main_rand }}"

--- a/templates/layout/parts/profile_selector_form.html.twig
+++ b/templates/layout/parts/profile_selector_form.html.twig
@@ -41,7 +41,7 @@
 
     {% if is_recursive %}
         <form method="POST" action="{{ path('/Session/ChangeEntity') }}">
-            <button class="btn btn-outline p-0 ms-1">
+            <button class="btn btn-link p-0 bg-transparent">
                 <i
                     class="ti ti-chevrons-down"
                     data-bs-toggle="tooltip"

--- a/templates/layout/parts/profile_selector_form.html.twig
+++ b/templates/layout/parts/profile_selector_form.html.twig
@@ -41,7 +41,7 @@
 
     {% if is_recursive %}
         <form method="POST" action="{{ path('/Session/ChangeEntity') }}">
-            <button class="btn btn-link p-0 bg-transparent">
+            <button class="btn btn-outline p-0 ms-1">
                 <i
                     class="ti ti-chevrons-down"
                     data-bs-toggle="tooltip"

--- a/tests/cypress/e2e/ITILObject/ticket_form.cy.js
+++ b/tests/cypress/e2e/ITILObject/ticket_form.cy.js
@@ -392,40 +392,40 @@ describe("Ticket Form", () => {
 
     it('Link a ticket with another one that is in a child entity', () => {
         cy.visit(`/front/ticket.form.php?id=${test_tickets_id}`);
-        cy.findByLabelText('Linked assistance objects - section').click();
-        cy.findByLabelText('Linked assistance objects - section').findByText('Add').click();
+        cy.findByTestId('Linked assistance objects - section').click();
+        cy.findByTestId('Linked assistance objects - section').findByText('Add').click();
         // We have to scroll otherwise cypress doesn't see the dropdown
-        cy.findByLabelText('Linked assistance objects - section').scrollIntoView({ offset: { top: 150 } });
+        cy.findByTestId('Linked assistance objects - section').scrollIntoView({ offset: { top: 150 } });
         cy.getDropdownByLabelText('ITIL type selector').selectDropdownValue('Tickets');
-        cy.findByLabelText('Linked assistance objects - section').scrollIntoView({ offset: { top: 150 } });
+        cy.findByTestId('Linked assistance objects - section').scrollIntoView({ offset: { top: 150 } });
         cy.getDropdownByLabelText('ITIL item selector').selectDropdownValue(`Child ticket - ${child_ticket_id}`);
 
         cy.findByRole('button', { name: 'Save' }).click();
 
         // We should now see it in the linked items
-        cy.findByLabelText('Linked item group - Child ticket').should('exist');
-        cy.findByLabelText('Linked item group - Child ticket').findByLabelText('Unlink').should('exist');
+        cy.findByTestId('Linked item group - Child ticket').should('exist');
+        cy.findByTestId('Linked item group - Child ticket').findByLabelText('Unlink').should('exist');
 
         cy.visit(`/front/ticket.form.php?id=${child_ticket_id}`);
-        cy.findByLabelText('Linked item group - Test ticket').should('exist');
-        cy.findByLabelText('Linked item group - Test ticket').findByRole('link').should('exist');
-        cy.findByLabelText('Linked item group - Test ticket').findByLabelText('Unlink').should('exist');
+        cy.findByTestId('Linked item group - Test ticket').should('exist');
+        cy.findByTestId('Linked item group - Test ticket').findByRole('link').should('exist');
+        cy.findByTestId('Linked item group - Test ticket').findByLabelText('Unlink').should('exist');
 
         // Switching to Sub-entity level
         cy.openEntitySelector();
         cy.get('.fancytree-expander[role=button]:visible').as('toggle_tree').click(); // From entities_selector tests.
         cy.findByRole('gridcell', {'name': "E2ETestSubEntity1"}).findByRole('button').click();
-        cy.findByLabelText('Linked item group - Test ticket').should('exist');
-        cy.findByLabelText('Linked item group - Test ticket').findByRole('link').should('not.exist');
-        cy.findByLabelText('Linked item group - Test ticket').findByLabelText('Unlink').should('not.exist');
+        cy.findByTestId('Linked item group - Test ticket').should('exist');
+        cy.findByTestId('Linked item group - Test ticket').findByRole('link').should('not.exist');
+        cy.findByTestId('Linked item group - Test ticket').findByLabelText('Unlink').should('exist');
 
         // We check that a child problem can only see the child ticket and not the root ones
         cy.visit(`/front/problem.form.php`);
-        cy.findByLabelText('Linked assistance objects - section').findByText('Add').click();
+        cy.findByTestId('Linked assistance objects - section').findByText('Add').click();
         // We have to scroll otherwise cypress doesn't see the dropdown
-        cy.findByLabelText('Linked assistance objects - section').scrollIntoView({ offset: { top: 150 } });
+        cy.findByTestId('Linked assistance objects - section').scrollIntoView({ offset: { top: 150 } });
         cy.getDropdownByLabelText('ITIL type selector').selectDropdownValue('Tickets');
-        cy.findByLabelText('Linked assistance objects - section').scrollIntoView({ offset: { top: 150 } });
+        cy.findByTestId('Linked assistance objects - section').scrollIntoView({ offset: { top: 150 } });
         cy.getDropdownByLabelText('ITIL item selector').hasDropdownValue(`Child ticket - ${child_ticket_id}`);
         cy.getDropdownByLabelText('ITIL item selector').hasDropdownValue(`Test ticket`, false);
     });

--- a/tests/cypress/e2e/ITILObject/ticket_form.cy.js
+++ b/tests/cypress/e2e/ITILObject/ticket_form.cy.js
@@ -392,40 +392,40 @@ describe("Ticket Form", () => {
 
     it('Link a ticket with another one that is in a child entity', () => {
         cy.visit(`/front/ticket.form.php?id=${test_tickets_id}`);
-        cy.findByTestId('Linked assistance objects - section').click();
-        cy.findByTestId('Linked assistance objects - section').findByText('Add').click();
+        cy.findByTestId('linked-itilobjects-section').click();
+        cy.findByTestId('linked-itilobjects-section').findByText('Add').click();
         // We have to scroll otherwise cypress doesn't see the dropdown
-        cy.findByTestId('Linked assistance objects - section').scrollIntoView({ offset: { top: 150 } });
+        cy.findByTestId('linked-itilobjects-section').scrollIntoView({ offset: { top: 150 } });
         cy.getDropdownByLabelText('ITIL type selector').selectDropdownValue('Tickets');
-        cy.findByTestId('Linked assistance objects - section').scrollIntoView({ offset: { top: 150 } });
+        cy.findByTestId('linked-itilobjects-section').scrollIntoView({ offset: { top: 150 } });
         cy.getDropdownByLabelText('ITIL item selector').selectDropdownValue(`Child ticket - ${child_ticket_id}`);
 
         cy.findByRole('button', { name: 'Save' }).click();
 
         // We should now see it in the linked items
-        cy.findByTestId('Linked item group - Child ticket').should('exist');
-        cy.findByTestId('Linked item group - Child ticket').findByLabelText('Unlink').should('exist');
+        cy.findByTestId(`linked-item-group-${child_ticket_id}`).should('exist');
+        cy.findByTestId(`linked-item-group-${child_ticket_id}`).findByLabelText('Unlink').should('exist');
 
         cy.visit(`/front/ticket.form.php?id=${child_ticket_id}`);
-        cy.findByTestId('Linked item group - Test ticket').should('exist');
-        cy.findByTestId('Linked item group - Test ticket').findByRole('link').should('exist');
-        cy.findByTestId('Linked item group - Test ticket').findByLabelText('Unlink').should('exist');
+        cy.findByTestId(`linked-item-group-${test_tickets_id}`).should('exist');
+        cy.findByTestId(`linked-item-group-${test_tickets_id}`).findByRole('link').should('exist');
+        cy.findByTestId(`linked-item-group-${test_tickets_id}`).findByLabelText('Unlink').should('exist');
 
         // Switching to Sub-entity level
         cy.openEntitySelector();
         cy.get('.fancytree-expander[role=button]:visible').as('toggle_tree').click(); // From entities_selector tests.
         cy.findByRole('gridcell', {'name': "E2ETestSubEntity1"}).findByRole('button').click();
-        cy.findByTestId('Linked item group - Test ticket').should('exist');
-        cy.findByTestId('Linked item group - Test ticket').findByRole('link').should('not.exist');
-        cy.findByTestId('Linked item group - Test ticket').findByLabelText('Unlink').should('exist');
+        cy.findByTestId(`linked-item-group-${test_tickets_id}`).should('exist');
+        cy.findByTestId(`linked-item-group-${test_tickets_id}`).findByRole('link').should('not.exist');
+        cy.findByTestId(`linked-item-group-${test_tickets_id}`).findByLabelText('Unlink').should('exist');
 
         // We check that a child problem can only see the child ticket and not the root ones
         cy.visit(`/front/problem.form.php`);
-        cy.findByTestId('Linked assistance objects - section').findByText('Add').click();
+        cy.findByTestId('linked-itilobjects-section').findByText('Add').click();
         // We have to scroll otherwise cypress doesn't see the dropdown
-        cy.findByTestId('Linked assistance objects - section').scrollIntoView({ offset: { top: 150 } });
+        cy.findByTestId('linked-itilobjects-section').scrollIntoView({ offset: { top: 150 } });
         cy.getDropdownByLabelText('ITIL type selector').selectDropdownValue('Tickets');
-        cy.findByTestId('Linked assistance objects - section').scrollIntoView({ offset: { top: 150 } });
+        cy.findByTestId('linked-itilobjects-section').scrollIntoView({ offset: { top: 150 } });
         cy.getDropdownByLabelText('ITIL item selector').hasDropdownValue(`Child ticket - ${child_ticket_id}`);
         cy.getDropdownByLabelText('ITIL item selector').hasDropdownValue(`Test ticket`, false);
     });

--- a/tests/cypress/e2e/ITILObject/ticket_form.cy.js
+++ b/tests/cypress/e2e/ITILObject/ticket_form.cy.js
@@ -418,5 +418,15 @@ describe("Ticket Form", () => {
         cy.findByLabelText('Linked item group - Test ticket').should('exist');
         cy.findByLabelText('Linked item group - Test ticket').findByRole('link').should('not.exist');
         cy.findByLabelText('Linked item group - Test ticket').findByLabelText('Unlink').should('not.exist');
+
+        // We check that a child problem can only see the child ticket and not the root ones
+        cy.visit(`/front/problem.form.php`);
+        cy.findByLabelText('Linked assistance objects - section').findByText('Add').click();
+        // We have to scroll otherwise cypress doesn't see the dropdown
+        cy.findByLabelText('Linked assistance objects - section').scrollIntoView({ offset: { top: 150 } });
+        cy.getDropdownByLabelText('ITIL type selector').selectDropdownValue('Tickets');
+        cy.findByLabelText('Linked assistance objects - section').scrollIntoView({ offset: { top: 150 } });
+        cy.getDropdownByLabelText('ITIL item selector').hasDropdownValue(`Child ticket - ${child_ticket_id}`);
+        cy.getDropdownByLabelText('ITIL item selector').hasDropdownValue(`Test ticket`, false);
     });
 });

--- a/tests/cypress/support/commands/select2.d.ts
+++ b/tests/cypress/support/commands/select2.d.ts
@@ -35,5 +35,6 @@ declare namespace Cypress {
     interface Chainable<Subject> {
         getDropdownByLabelText(value: string): Chainable<any>
         selectDropdownValue(new_value: string): Chainable<any>
+        hasDropdownValue(expected_value: string, should_exist: boolean = true): Chainable<any>
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes #21545 by returning the child entities itilobject so user can link them in the dropdown

## Screenshots:

### Linked item selector
- Before

  [Screencast from 2025-10-29 09-34-01.webm](https://github.com/user-attachments/assets/b4dc3f8a-002a-48cf-a3a5-c0af9e0cf2b9)

- After

  [Screencast from 2025-10-29 09-19-31.webm](https://github.com/user-attachments/assets/3a26b195-8a81-4934-8438-c6b873a6ceb2)
