### PR TITLE
Fix `%id%` replacements in Twig macros

### DIFF
--- a/templates/components/form/fields_macros.html.twig
+++ b/templates/components/form/fields_macros.html.twig
@@ -809,8 +809,13 @@
       {{ field }}
    {% else %}
       {% set id    = ((options.id ?? '')|length > 0 and options.id != '%id%' ? options.id : (name ~ '_' ~ options.rand))|safe_dom_id %}
-      {# `\u0025id\u0025` is the escaped JS form of `%id%` #}
-      {% set field = field|replace({'%id%': id, '\\u0025id\\u0025': id}) %}
+      {# `%id%` may have been escaped by different filters #}
+      {% set field = field|replace({
+          ('%id%'|e('css')|e('js')): id,
+          ('%id%'|e('js')): id,
+          ('%id%'|e('css')): id,
+          ('%id%'): id,
+      }) %}
       {% set add_field_html = options.add_field_html|length > 0 ? options.add_field_html : '' %}
 
       {% if not options.fields_template.isHiddenField(name)|default(false) %}


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Alternative to #21649.

The fix proposed in #21649 is working, but after an investigation, I  figured out that the initial fix made in #21483 for the same purpose was not handling this case because the `%id%` string was escaped with a different filter. I guess thies issue may affect other fields, so I think it is preferable to have a centralized fix.