### PR TITLE
Form migration: Handle null values for `show_value`

### DIFF
--- a/src/Glpi/Form/Migration/FormMigration.php
+++ b/src/Glpi/Form/Migration/FormMigration.php
@@ -1377,7 +1377,10 @@ class FormMigration extends AbstractPluginMigration
                 continue;
             }
 
-            $value = $raw_condition['show_value'];
+            // The value can be null for formcreator, make sure to fallback to
+            // an empty string
+            $value = $raw_condition['show_value'] ?? "";
+
             $value_operator = $this->getValueOperatorFromLegacy(
                 $raw_condition['show_condition'],
                 $value,

--- a/tests/functional/Glpi/Form/Migration/FormMigrationTest.php
+++ b/tests/functional/Glpi/Form/Migration/FormMigrationTest.php
@@ -3501,6 +3501,49 @@ final class FormMigrationTest extends DbTestCase
         ], $condition_data->getValue());
     }
 
+    public function testFormWithNullShowValueCondition(): void
+    {
+        /** @var \DBmysql $DB */
+        global $DB;
+
+        // Arrange: create a form with a condition without a show_value
+        $id = $this->createSimpleFormcreatorForm(
+            name: "Form with null show value",
+            questions: [
+                [
+                    'name'      => 'My text question',
+                    'fieldtype' => 'dropdown',
+                    'itemtype'  => ITILCategory::class,
+                    'values'    => "{\"show_ticket_categories\":\"incident\",\"show_tree_depth\":\"0\",\"show_tree_root\":\"0\",\"selectable_tree_root\":\"0\",\"entity_restrict\":0}",
+                ],
+                [
+                    'name'        => 'My other question',
+                    'fieldtype' => 'text',
+                    'show_rule'   => 2,
+                    '_conditions' => [
+                        [
+                            'plugin_formcreator_questions_id' => 'My text question',
+                            'show_condition'                  => 2,
+                            'show_value'                      => null,
+                            'show_logic'                      => 1,
+                        ],
+                    ],
+                ],
+            ],
+        );
+
+        // Act: import the form
+        $migration = new FormMigration(
+            db: $DB,
+            formAccessControlManager: FormAccessControlManager::getInstance(),
+            specificFormsIds: [$id],
+        );
+        $result = $migration->execute();
+
+        // Assert: make sure the import didn't fail
+        $this->assertFalse($result->hasErrors());
+    }
+
     protected function createSimpleFormcreatorForm(
         string $name,
         array $questions,


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

The `glpi_plugin_formcreator_sections.show_value` column can be null and our migration tool wasn't happy with it.

## References

Fix #21670

