### PR TITLE
Fix (Proxy) - Encode proxy credentials for special characters

### DIFF
--- a/src/Marketplace/Api/Plugins.php
+++ b/src/Marketplace/Api/Plugins.php
@@ -78,10 +78,13 @@ class Plugins
 
         // add proxy string if configured in glpi
         if (!empty($CFG_GLPI["proxy_name"])) {
-            $proxy_creds      = !empty($CFG_GLPI["proxy_user"])
-                ? $CFG_GLPI["proxy_user"] . ":" . (new \GLPIKey())->decrypt($CFG_GLPI["proxy_passwd"]) . "@"
-                : "";
-            $proxy_string     = "http://{$proxy_creds}" . $CFG_GLPI['proxy_name'] . ":" . $CFG_GLPI['proxy_port'];
+            $proxy_creds = "";
+            if (!empty($CFG_GLPI["proxy_user"])) {
+                $proxy_user = rawurlencode($CFG_GLPI["proxy_user"]);
+                $proxy_pass = rawurlencode((new \GLPIKey())->decrypt($CFG_GLPI["proxy_passwd"]));
+                $proxy_creds = $proxy_user . ":" . $proxy_pass . "@";
+            }
+            $proxy_string = "http://{$proxy_creds}" . $CFG_GLPI['proxy_name'] . ":" . $CFG_GLPI['proxy_port'];
             $options['proxy'] = $proxy_string;
         }
 


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !39929
- Here is a brief description of what this PR does

When using a proxy username containing special characters (such as @), Marketplace API requests failed with a cURL error like:

```php
[2025-10-29 10:49:55] glpiphplog.DEBUG: Glpi\Marketplace\Api\Plugins::request() in /home/user/glpi/src/Marketplace/Api/Plugins.php line 136
Array
  (
      [title] => Plugins API error
      [exception] => cURL error 5: Unsupported proxy syntax in 'http://testuser@test.com:test123@127.0.0.1:8888': Port number was not a decimal number between 0 and 65535 (see https://curl.haxx.se/libcurl/c/libcurl-errors.html) for https://services.glpi-network.com/api/marketplace/plugins
      [request] => GET /api/marketplace/plugins HTTP/1.1
  Host: services.glpi-network.com
  Accept: application/json
  User-Agent: GLPI/10.0.18 (installation-mode:GIT)
  X-Registration-Key: xxxxxxx
  X-Glpi-Network-Uid: xxxxxxx
  X-Range: 0-199
  )
```
or

```php
[2025-10-23 12:07:02] glpiphplog.DEBUG: Glpi\Marketplace\Api\Plugins::request() in /home/user/glpi/src/Marketplace/Api/Plugins.php line 136
Array
  (
      [title] => Plugins API error
      [exception] => cURL error 5: Could not resolve proxy: serveurs.xxxxx.fr (see https://curl.haxx.se/libcurl/c/libcurl-errors.html) for https://services.glpi-network.com/api/marketplace/tags/top
      [request] => GET /api/marketplace/tags/top HTTP/1.1
  Host: services.glpi-network.com
  Accept: application/json
  User-Agent: GLPI/10.0.18 (installation-mode:TARBALL)
  X-Registration-Key: xxxxxxx
```

This happened because the proxy credentials were not URL-encoded, causing the @ character to be misinterpreted as a separator in the proxy URL, leading to an invalid proxy string.

This PR fixes the issue by encoding the proxy username and password with rawurlencode before building the proxy URL, ensuring special characters are handled correctly and Marketplace API requests succeed when such credentials are used.

## Screenshots (if appropriate):

<img width="957" height="211" alt="image" src="https://github.com/user-attachments/assets/ba7059aa-8bee-4834-b1b4-a9383a7d73ef" />


