### PR TITLE
Fix form export using conditions on specifics db items

### DIFF
--- a/tests/fixtures/forms/comment-with-item-condition.json
+++ b/tests/fixtures/forms/comment-with-item-condition.json
@@ -1,0 +1,111 @@
+{
+    "version": 1,
+    "forms": [
+        {
+            "id": 187,
+            "uuid": "0acfe9c9-d3d1-43bc-8f86-d2b06fef4f7f",
+            "name": "Test form",
+            "header": "",
+            "description": "",
+            "entity_name": "Root entity > _test_root_entity",
+            "is_recursive": true,
+            "is_active": true,
+            "submit_button_visibility_strategy": "",
+            "illustration": "",
+            "submit_button_conditions": [],
+            "sections": [
+                {
+                    "id": 168,
+                    "uuid": "f2b0db69-40bf-4a89-a2b8-fbf623d37062",
+                    "name": "First section",
+                    "description": "",
+                    "rank": 0,
+                    "visibility_strategy": "",
+                    "conditions": []
+                }
+            ],
+            "comments": [
+                {
+                    "id": 31,
+                    "uuid": "2793d35b-62af-437b-a39e-3eca75fa9087",
+                    "name": "My comment",
+                    "description": "Glpi\\Form\\QuestionType\\QuestionTypeShortText",
+                    "vertical_rank": 0,
+                    "horizontal_rank": null,
+                    "section_id": 168,
+                    "visibility_strategy": "visible_if",
+                    "conditions": [
+                        {
+                            "item_uuid": "9cc1828e-97d1-4e2b-8f15-9cab6222fe47",
+                            "item_type": "question",
+                            "value_operator": "equals",
+                            "logic_operator": "and",
+                            "value": {
+                                "itemtype": "Computer",
+                                "items_id": "My computer"
+                            }
+                        }
+                    ]
+                }
+            ],
+            "questions": [
+                {
+                    "id": 212,
+                    "uuid": "9cc1828e-97d1-4e2b-8f15-9cab6222fe47",
+                    "name": "My item question",
+                    "type": "Glpi\\Form\\QuestionType\\QuestionTypeItem",
+                    "is_mandatory": false,
+                    "vertical_rank": 0,
+                    "horizontal_rank": null,
+                    "description": "",
+                    "default_value": null,
+                    "extra_data": {
+                        "itemtype": "Computer",
+                        "root_items_id": 0,
+                        "subtree_depth": 0,
+                        "selectable_tree_root": false
+                    },
+                    "section_id": 168,
+                    "visibility_strategy": "",
+                    "validation_strategy": "",
+                    "conditions": [],
+                    "validation_conditions": []
+                }
+            ],
+            "policies": [
+                {
+                    "strategy": "Glpi\\Form\\AccessControl\\ControlType\\AllowList",
+                    "config": {
+                        "user_ids": [
+                            "all"
+                        ],
+                        "group_ids": [],
+                        "profile_ids": []
+                    },
+                    "is_active": true
+                }
+            ],
+            "destinations": [
+                {
+                    "id": 172,
+                    "itemtype": "Glpi\\Form\\Destination\\FormDestinationTicket",
+                    "name": "Ticket",
+                    "config": [],
+                    "creation_strategy": "",
+                    "conditions": []
+                }
+            ],
+            "translations": [],
+            "data_requirements": [
+                {
+                    "itemtype": "Entity",
+                    "name": "Root entity > _test_root_entity"
+                },
+                {
+                    "itemtype": "Computer",
+                    "name": "My computer"
+                }
+            ]
+        }
+    ]
+}

--- a/tests/fixtures/forms/destination-with-item-condition.json
+++ b/tests/fixtures/forms/destination-with-item-condition.json
@@ -1,0 +1,111 @@
+{
+    "version": 1,
+    "forms": [
+        {
+            "id": 188,
+            "uuid": "26b2c52f-c707-4d0b-9a27-f9bde1bf86dc",
+            "name": "Test form",
+            "header": "",
+            "description": "",
+            "entity_name": "Root entity > _test_root_entity",
+            "is_recursive": true,
+            "is_active": true,
+            "submit_button_visibility_strategy": "",
+            "illustration": "",
+            "submit_button_conditions": [],
+            "sections": [
+                {
+                    "id": 169,
+                    "uuid": "ca091320-544f-41bd-8945-1c6d5cd8120d",
+                    "name": "First section",
+                    "description": "",
+                    "rank": 0,
+                    "visibility_strategy": "",
+                    "conditions": []
+                }
+            ],
+            "comments": [
+                {
+                    "id": 32,
+                    "uuid": "84bc1cd9-cab3-4f39-94d1-a26f7f65c97b",
+                    "name": "My comment",
+                    "description": "Glpi\\Form\\QuestionType\\QuestionTypeShortText",
+                    "vertical_rank": 0,
+                    "horizontal_rank": null,
+                    "section_id": 169,
+                    "visibility_strategy": "",
+                    "conditions": []
+                }
+            ],
+            "questions": [
+                {
+                    "id": 213,
+                    "uuid": "c235889c-9e37-4fe9-a520-c039a2be91ef",
+                    "name": "My item question",
+                    "type": "Glpi\\Form\\QuestionType\\QuestionTypeItem",
+                    "is_mandatory": false,
+                    "vertical_rank": 0,
+                    "horizontal_rank": null,
+                    "description": "",
+                    "default_value": null,
+                    "extra_data": {
+                        "itemtype": "Computer",
+                        "root_items_id": 0,
+                        "subtree_depth": 0,
+                        "selectable_tree_root": false
+                    },
+                    "section_id": 169,
+                    "visibility_strategy": "",
+                    "validation_strategy": "",
+                    "conditions": [],
+                    "validation_conditions": []
+                }
+            ],
+            "policies": [
+                {
+                    "strategy": "Glpi\\Form\\AccessControl\\ControlType\\AllowList",
+                    "config": {
+                        "user_ids": [
+                            "all"
+                        ],
+                        "group_ids": [],
+                        "profile_ids": []
+                    },
+                    "is_active": true
+                }
+            ],
+            "destinations": [
+                {
+                    "id": 173,
+                    "itemtype": "Glpi\\Form\\Destination\\FormDestinationTicket",
+                    "name": "Ticket",
+                    "config": [],
+                    "creation_strategy": "created_if",
+                    "conditions": [
+                        {
+                            "item_uuid": "c235889c-9e37-4fe9-a520-c039a2be91ef",
+                            "item_type": "question",
+                            "value_operator": "equals",
+                            "logic_operator": "and",
+                            "value": {
+                                "itemtype": "Computer",
+                                "items_id": "My computer"
+                            }
+                        }
+                    ]
+                }
+            ],
+            "translations": [],
+            "data_requirements": [
+                {
+                    "itemtype": "Entity",
+                    "name": "Root entity > _test_root_entity"
+                },
+                {
+                    "itemtype": "Computer",
+                    "name": "My computer"
+                }
+            ]
+        }
+    ]
+}

--- a/tests/fixtures/forms/question-with-item-condition.json
+++ b/tests/fixtures/forms/question-with-item-condition.json
@@ -1,0 +1,116 @@
+{
+    "version": 1,
+    "forms": [
+        {
+            "id": 186,
+            "uuid": "5ba43fed-528d-4d79-bb2e-aa81803daa2f",
+            "name": "Test form",
+            "header": "",
+            "description": "",
+            "entity_name": "Root entity > _test_root_entity",
+            "is_recursive": true,
+            "is_active": true,
+            "submit_button_visibility_strategy": "",
+            "illustration": "",
+            "submit_button_conditions": [],
+            "sections": [
+                {
+                    "id": 167,
+                    "uuid": "5443115b-dcd8-43fa-afc4-d443295ddea2",
+                    "name": "First section",
+                    "description": "",
+                    "rank": 0,
+                    "visibility_strategy": "",
+                    "conditions": []
+                }
+            ],
+            "comments": [],
+            "questions": [
+                {
+                    "id": 210,
+                    "uuid": "8ff0d090-762f-4029-a910-8b110d3f2aea",
+                    "name": "My item question",
+                    "type": "Glpi\\Form\\QuestionType\\QuestionTypeItem",
+                    "is_mandatory": false,
+                    "vertical_rank": 0,
+                    "horizontal_rank": null,
+                    "description": "",
+                    "default_value": null,
+                    "extra_data": {
+                        "itemtype": "Computer",
+                        "root_items_id": 0,
+                        "subtree_depth": 0,
+                        "selectable_tree_root": false
+                    },
+                    "section_id": 167,
+                    "visibility_strategy": "",
+                    "validation_strategy": "",
+                    "conditions": [],
+                    "validation_conditions": []
+                },
+                {
+                    "id": 211,
+                    "uuid": "22351e03-f4fe-4d11-ae1e-ec91097a8089",
+                    "name": "My other question",
+                    "type": "Glpi\\Form\\QuestionType\\QuestionTypeShortText",
+                    "is_mandatory": false,
+                    "vertical_rank": 1,
+                    "horizontal_rank": null,
+                    "description": "",
+                    "default_value": "",
+                    "extra_data": null,
+                    "section_id": 167,
+                    "visibility_strategy": "visible_if",
+                    "validation_strategy": "",
+                    "conditions": [
+                        {
+                            "item_uuid": "8ff0d090-762f-4029-a910-8b110d3f2aea",
+                            "item_type": "question",
+                            "value_operator": "equals",
+                            "logic_operator": "and",
+                            "value": {
+                                "itemtype": "Computer",
+                                "items_id": "My computer"
+                            }
+                        }
+                    ],
+                    "validation_conditions": []
+                }
+            ],
+            "policies": [
+                {
+                    "strategy": "Glpi\\Form\\AccessControl\\ControlType\\AllowList",
+                    "config": {
+                        "user_ids": [
+                            "all"
+                        ],
+                        "group_ids": [],
+                        "profile_ids": []
+                    },
+                    "is_active": true
+                }
+            ],
+            "destinations": [
+                {
+                    "id": 171,
+                    "itemtype": "Glpi\\Form\\Destination\\FormDestinationTicket",
+                    "name": "Ticket",
+                    "config": [],
+                    "creation_strategy": "",
+                    "conditions": []
+                }
+            ],
+            "translations": [],
+            "data_requirements": [
+                {
+                    "itemtype": "Entity",
+                    "name": "Root entity > _test_root_entity"
+                },
+                {
+                    "itemtype": "Computer",
+                    "name": "My computer"
+                }
+            ]
+        }
+    ]
+}

--- a/tests/fixtures/forms/section-with-item-condition.json
+++ b/tests/fixtures/forms/section-with-item-condition.json
@@ -1,0 +1,108 @@
+{
+    "version": 1,
+    "forms": [
+        {
+            "id": 185,
+            "uuid": "7c3f91b8-238d-4dee-9f1b-0dba47fbf5f8",
+            "name": "Test form",
+            "header": "",
+            "description": "",
+            "entity_name": "Root entity > _test_root_entity",
+            "is_recursive": true,
+            "is_active": true,
+            "submit_button_visibility_strategy": "",
+            "illustration": "",
+            "submit_button_conditions": [],
+            "sections": [
+                {
+                    "id": 165,
+                    "uuid": "145e3f8e-e4bf-4e8b-a29a-fa05775b99b0",
+                    "name": "Section 1",
+                    "description": "",
+                    "rank": 0,
+                    "visibility_strategy": "",
+                    "conditions": []
+                },
+                {
+                    "id": 166,
+                    "uuid": "26eaf51b-8829-47cf-beeb-12df9b1bcec8",
+                    "name": "Section 2",
+                    "description": "",
+                    "rank": 1,
+                    "visibility_strategy": "visible_if",
+                    "conditions": [
+                        {
+                            "item_uuid": "eb83233e-884e-4816-afb0-917c7bad815b",
+                            "item_type": "question",
+                            "value_operator": "equals",
+                            "logic_operator": "and",
+                            "value": {
+                                "itemtype": "Computer",
+                                "items_id": "My computer"
+                            }
+                        }
+                    ]
+                }
+            ],
+            "comments": [],
+            "questions": [
+                {
+                    "id": 209,
+                    "uuid": "eb83233e-884e-4816-afb0-917c7bad815b",
+                    "name": "My item question",
+                    "type": "Glpi\\Form\\QuestionType\\QuestionTypeItem",
+                    "is_mandatory": false,
+                    "vertical_rank": 0,
+                    "horizontal_rank": null,
+                    "description": "",
+                    "default_value": null,
+                    "extra_data": {
+                        "itemtype": "Computer",
+                        "root_items_id": 0,
+                        "subtree_depth": 0,
+                        "selectable_tree_root": false
+                    },
+                    "section_id": 165,
+                    "visibility_strategy": "",
+                    "validation_strategy": "",
+                    "conditions": [],
+                    "validation_conditions": []
+                }
+            ],
+            "policies": [
+                {
+                    "strategy": "Glpi\\Form\\AccessControl\\ControlType\\AllowList",
+                    "config": {
+                        "user_ids": [
+                            "all"
+                        ],
+                        "group_ids": [],
+                        "profile_ids": []
+                    },
+                    "is_active": true
+                }
+            ],
+            "destinations": [
+                {
+                    "id": 170,
+                    "itemtype": "Glpi\\Form\\Destination\\FormDestinationTicket",
+                    "name": "Ticket",
+                    "config": [],
+                    "creation_strategy": "",
+                    "conditions": []
+                }
+            ],
+            "translations": [],
+            "data_requirements": [
+                {
+                    "itemtype": "Entity",
+                    "name": "Root entity > _test_root_entity"
+                },
+                {
+                    "itemtype": "Computer",
+                    "name": "My computer"
+                }
+            ]
+        }
+    ]
+}

--- a/tests/fixtures/forms/submit-with-item-condition.json
+++ b/tests/fixtures/forms/submit-with-item-condition.json
@@ -1,0 +1,99 @@
+{
+    "version": 1,
+    "forms": [
+        {
+            "id": 184,
+            "uuid": "8ffcd60e-46b7-4859-ac4b-d96bc2a8d93c",
+            "name": "Test form",
+            "header": "",
+            "description": "",
+            "entity_name": "Root entity > _test_root_entity",
+            "is_recursive": true,
+            "is_active": true,
+            "submit_button_visibility_strategy": "visible_if",
+            "illustration": "",
+            "submit_button_conditions": [
+                {
+                    "item_uuid": "736730f6-fbbf-4331-b67f-dc2e78e9ad2e",
+                    "item_type": "question",
+                    "value_operator": "equals",
+                    "logic_operator": "and",
+                    "value": {
+                        "itemtype": "Computer",
+                        "items_id": "My computer"
+                    }
+                }
+            ],
+            "sections": [
+                {
+                    "id": 164,
+                    "uuid": "abbd5ace-3930-4522-b8ae-fad181c90ac0",
+                    "name": "First section",
+                    "description": "",
+                    "rank": 0,
+                    "visibility_strategy": "",
+                    "conditions": []
+                }
+            ],
+            "comments": [],
+            "questions": [
+                {
+                    "id": 208,
+                    "uuid": "736730f6-fbbf-4331-b67f-dc2e78e9ad2e",
+                    "name": "My item question",
+                    "type": "Glpi\\Form\\QuestionType\\QuestionTypeItem",
+                    "is_mandatory": false,
+                    "vertical_rank": 0,
+                    "horizontal_rank": null,
+                    "description": "",
+                    "default_value": null,
+                    "extra_data": {
+                        "itemtype": "Computer",
+                        "root_items_id": 0,
+                        "subtree_depth": 0,
+                        "selectable_tree_root": false
+                    },
+                    "section_id": 164,
+                    "visibility_strategy": "",
+                    "validation_strategy": "",
+                    "conditions": [],
+                    "validation_conditions": []
+                }
+            ],
+            "policies": [
+                {
+                    "strategy": "Glpi\\Form\\AccessControl\\ControlType\\AllowList",
+                    "config": {
+                        "user_ids": [
+                            "all"
+                        ],
+                        "group_ids": [],
+                        "profile_ids": []
+                    },
+                    "is_active": true
+                }
+            ],
+            "destinations": [
+                {
+                    "id": 169,
+                    "itemtype": "Glpi\\Form\\Destination\\FormDestinationTicket",
+                    "name": "Ticket",
+                    "config": [],
+                    "creation_strategy": "",
+                    "conditions": []
+                }
+            ],
+            "translations": [],
+            "data_requirements": [
+                {
+                    "itemtype": "Computer",
+                    "name": "My computer"
+                },
+                {
+                    "itemtype": "Entity",
+                    "name": "Root entity > _test_root_entity"
+                }
+            ]
+        }
+    ]
+}

--- a/tests/functional/Glpi/Form/Export/FormSerializerTest.php
+++ b/tests/functional/Glpi/Form/Export/FormSerializerTest.php
@@ -1684,6 +1684,385 @@ final class FormSerializerTest extends \DbTestCase
         );
     }
 
+    public function testItemsIdsInSubmitConditionAreHandledByExport(): void
+    {
+        // Arrange: create a form with a condition on a specific item id
+        $computer = $this->createItem(Computer::class, [
+            'name' => 'My computer',
+            'entities_id' => $this->getTestRootEntity(only_id: true),
+        ]);
+        $builder = new FormBuilder();
+        $builder->addQuestion(
+            name: "My item question",
+            type: QuestionTypeItem::class,
+            extra_data: json_encode(new QuestionTypeItemExtraDataConfig(
+                itemtype: Computer::class
+            )),
+        );
+        $builder->setSubmitButtonVisibility(
+            strategy: VisibilityStrategy::VISIBLE_IF,
+            conditions: [
+                [
+                    'logic_operator' => LogicOperator::AND,
+                    'item_name'      => "My item question",
+                    'item_type'      => Type::QUESTION,
+                    'value_operator' => ValueOperator::EQUALS,
+                    'value'          => [
+                        'itemtype' => Computer::class,
+                        'items_id' => $computer->getId(),
+                    ],
+                ],
+            ],
+        );
+        $form = $this->createForm($builder);
+
+        // Act: export the form
+        $json = $this->exportForm($form);
+
+        // Assert: make sure the items_id was replaced in the condition
+        // and that a data requirement was added
+        $data = json_decode($json, associative: true);
+        $this->assertEquals([
+            'itemtype' => Computer::class,
+            'name' => 'My computer',
+        ], $data['forms'][0]['data_requirements'][0]);
+        $this->assertEquals([
+            'itemtype' => Computer::class,
+            'items_id' => 'My computer',
+        ], $data['forms'][0]['submit_button_conditions'][0]['value']);
+    }
+
+    public function testItemsIdsInSectionConditionAreHandledByExport(): void
+    {
+        // Arrange: create a form with a condition on a specific item id
+        $computer = $this->createItem(Computer::class, [
+            'name' => 'My computer',
+            'entities_id' => $this->getTestRootEntity(only_id: true),
+        ]);
+        $builder = new FormBuilder();
+        $builder->addSection("Section 1");
+        $builder->addQuestion(
+            name: "My item question",
+            type: QuestionTypeItem::class,
+            extra_data: json_encode(new QuestionTypeItemExtraDataConfig(
+                itemtype: Computer::class
+            )),
+        );
+        $builder->addSection("Section 2");
+        $builder->setSectionVisibility(
+            section_name: "Section 2",
+            strategy: VisibilityStrategy::VISIBLE_IF,
+            conditions: [
+                [
+                    'logic_operator' => LogicOperator::AND,
+                    'item_name'      => "My item question",
+                    'item_type'      => Type::QUESTION,
+                    'value_operator' => ValueOperator::EQUALS,
+                    'value'          => [
+                        'itemtype' => Computer::class,
+                        'items_id' => $computer->getId(),
+                    ],
+                ],
+            ],
+        );
+        $form = $this->createForm($builder);
+
+        // Act: export the form
+        $json = $this->exportForm($form);
+
+        // Assert: make sure the items_id was replaced in the condition
+        // and that a data requirement was added
+        $data = json_decode($json, associative: true);
+        $this->assertEquals([
+            'itemtype' => Computer::class,
+            'name' => 'My computer',
+        ], $data['forms'][0]['data_requirements'][1]);
+        $this->assertEquals([
+            'itemtype' => Computer::class,
+            'items_id' => 'My computer',
+        ], $data['forms'][0]['sections'][1]['conditions'][0]['value']);
+    }
+
+    public function testItemsIdsInQuestionConditionAreHandledByExport(): void
+    {
+        // Arrange: create a form with a condition on a specific item id
+        $computer = $this->createItem(Computer::class, [
+            'name' => 'My computer',
+            'entities_id' => $this->getTestRootEntity(only_id: true),
+        ]);
+        $builder = new FormBuilder();
+        $builder->addQuestion(
+            name: "My item question",
+            type: QuestionTypeItem::class,
+            extra_data: json_encode(new QuestionTypeItemExtraDataConfig(
+                itemtype: Computer::class
+            )),
+        );
+        $builder->addQuestion("My other question", QuestionTypeShortText::class);
+        $builder->setQuestionVisibility(
+            question_name: "My other question",
+            strategy: VisibilityStrategy::VISIBLE_IF,
+            conditions: [
+                [
+                    'logic_operator' => LogicOperator::AND,
+                    'item_name'      => "My item question",
+                    'item_type'      => Type::QUESTION,
+                    'value_operator' => ValueOperator::EQUALS,
+                    'value'          => [
+                        'itemtype' => Computer::class,
+                        'items_id' => $computer->getId(),
+                    ],
+                ],
+            ],
+        );
+        $form = $this->createForm($builder);
+
+        // Act: export the form
+        $json = $this->exportForm($form);
+
+        // Assert: make sure the items_id was replaced in the condition
+        // and that a data requirement was added
+        $data = json_decode($json, associative: true);
+        $this->assertEquals([
+            'itemtype' => Computer::class,
+            'name' => 'My computer',
+        ], $data['forms'][0]['data_requirements'][1]);
+        $this->assertEquals([
+            'itemtype' => Computer::class,
+            'items_id' => 'My computer',
+        ], $data['forms'][0]['questions'][1]['conditions'][0]['value']);
+    }
+
+    public function testItemsIdsInCommentConditionAreHandledByExport(): void
+    {
+        // Arrange: create a form with a condition on a specific item id
+        $computer = $this->createItem(Computer::class, [
+            'name' => 'My computer',
+            'entities_id' => $this->getTestRootEntity(only_id: true),
+        ]);
+        $builder = new FormBuilder();
+        $builder->addQuestion(
+            name: "My item question",
+            type: QuestionTypeItem::class,
+            extra_data: json_encode(new QuestionTypeItemExtraDataConfig(
+                itemtype: Computer::class
+            )),
+        );
+        $builder->addComment("My comment", QuestionTypeShortText::class);
+        $builder->setCommentVisibility(
+            comment_name: "My comment",
+            strategy: VisibilityStrategy::VISIBLE_IF,
+            conditions: [
+                [
+                    'logic_operator' => LogicOperator::AND,
+                    'item_name'      => "My item question",
+                    'item_type'      => Type::QUESTION,
+                    'value_operator' => ValueOperator::EQUALS,
+                    'value'          => [
+                        'itemtype' => Computer::class,
+                        'items_id' => $computer->getId(),
+                    ],
+                ],
+            ],
+        );
+        $form = $this->createForm($builder);
+
+        // Act: export the form
+        $json = $this->exportForm($form);
+
+        // Assert: make sure the items_id was replaced in the condition
+        // and that a data requirement was added
+        $data = json_decode($json, associative: true);
+        $this->assertEquals([
+            'itemtype' => Computer::class,
+            'name' => 'My computer',
+        ], $data['forms'][0]['data_requirements'][1]);
+        $this->assertEquals([
+            'itemtype' => Computer::class,
+            'items_id' => 'My computer',
+        ], $data['forms'][0]['comments'][0]['conditions'][0]['value']);
+    }
+
+    public function testItemsIdsInDestinationConditionAreHandledByExport(): void
+    {
+        // Arrange: create a form with a condition on a specific item id
+        $computer = $this->createItem(Computer::class, [
+            'name' => 'My computer',
+            'entities_id' => $this->getTestRootEntity(only_id: true),
+        ]);
+        $builder = new FormBuilder();
+        $builder->addQuestion(
+            name: "My item question",
+            type: QuestionTypeItem::class,
+            extra_data: json_encode(new QuestionTypeItemExtraDataConfig(
+                itemtype: Computer::class
+            )),
+        );
+        $builder->addComment("My comment", QuestionTypeShortText::class);
+        $builder->setDestinationCondition(
+            destination_name: "Ticket",
+            strategy: CreationStrategy::CREATED_IF,
+            conditions: [
+                [
+                    'logic_operator' => LogicOperator::AND,
+                    'item_name'      => "My item question",
+                    'item_type'      => Type::QUESTION,
+                    'value_operator' => ValueOperator::EQUALS,
+                    'value'          => [
+                        'itemtype' => Computer::class,
+                        'items_id' => $computer->getId(),
+                    ],
+                ],
+            ],
+        );
+        $form = $this->createForm($builder);
+
+        // Act: export the form
+        $json = $this->exportForm($form);
+
+        // Assert: make sure the items_id was replaced in the condition
+        // and that a data requirement was added
+        $data = json_decode($json, associative: true);
+        $this->assertEquals([
+            'itemtype' => Computer::class,
+            'name' => 'My computer',
+        ], $data['forms'][0]['data_requirements'][1]);
+        $this->assertEquals([
+            'itemtype' => Computer::class,
+            'items_id' => 'My computer',
+        ], $data['forms'][0]['destinations'][0]['conditions'][0]['value']);
+    }
+
+    public function testItemsNamesInSubmitConditionAreHandledByImport(): void
+    {
+        // Arrange: create the expected computer
+        $computer = $this->createItem(Computer::class, [
+            'name' => 'My computer',
+            'entities_id' => $this->getTestRootEntity(only_id: true),
+        ]);
+
+        // Act: import form
+        $json = $this->getFormJson('submit-with-item-condition.json');
+        $result = self::$serializer->importFormsFromJson(
+            json: $json,
+            mapper: new DatabaseMapper([$this->getTestRootEntity(true)]),
+        );
+
+        // Assert: condition should be updated with the computer id
+        $form = $result->getImportedForms()[0];
+        $condition_value = $form->getConfiguredConditionsData()[0]->getValue();
+        $this->assertEquals([
+            "itemtype" => Computer::class,
+            "items_id" => $computer->getID(),
+        ], $condition_value);
+    }
+
+    public function testItemsNamesInSectionConditionAreHandledByImport(): void
+    {
+        // Arrange: create the expected computer
+        $computer = $this->createItem(Computer::class, [
+            'name' => 'My computer',
+            'entities_id' => $this->getTestRootEntity(only_id: true),
+        ]);
+
+        // Act: import form
+        $json = $this->getFormJson('section-with-item-condition.json');
+        $result = self::$serializer->importFormsFromJson(
+            json: $json,
+            mapper: new DatabaseMapper([$this->getTestRootEntity(true)]),
+        );
+
+        // Assert: condition should be updated with the computer id
+        $form = $result->getImportedForms()[0];
+        $sections = $form->getSections();
+        next($sections);  // Go to second question
+        $section = current($sections);
+        $condition_value = $section->getConfiguredConditionsData()[0]->getValue();
+        $this->assertEquals([
+            "itemtype" => Computer::class,
+            "items_id" => $computer->getID(),
+        ], $condition_value);
+    }
+
+    public function testItemsNamesInQuestionConditionAreHandledByImport(): void
+    {
+        // Arrange: create the expected computer
+        $computer = $this->createItem(Computer::class, [
+            'name' => 'My computer',
+            'entities_id' => $this->getTestRootEntity(only_id: true),
+        ]);
+
+        // Act: import form
+        $json = $this->getFormJson('question-with-item-condition.json');
+        $result = self::$serializer->importFormsFromJson(
+            json: $json,
+            mapper: new DatabaseMapper([$this->getTestRootEntity(true)]),
+        );
+
+        // Assert: condition should be updated with the computer id
+        $form = $result->getImportedForms()[0];
+        $questions = $form->getQuestions();
+        next($questions);  // Go to second question
+        $question = current($questions);
+        $condition_value = $question->getConfiguredConditionsData()[0]->getValue();
+        $this->assertEquals([
+            "itemtype" => Computer::class,
+            "items_id" => $computer->getID(),
+        ], $condition_value);
+    }
+
+    public function testItemsNamesInCommentConditionAreHandledByImport(): void
+    {
+        // Arrange: create the expected computer
+        $computer = $this->createItem(Computer::class, [
+            'name' => 'My computer',
+            'entities_id' => $this->getTestRootEntity(only_id: true),
+        ]);
+
+        // Act: import form
+        $json = $this->getFormJson('comment-with-item-condition.json');
+        $result = self::$serializer->importFormsFromJson(
+            json: $json,
+            mapper: new DatabaseMapper([$this->getTestRootEntity(true)]),
+        );
+
+        // Assert: condition should be updated with the computer id
+        $form = $result->getImportedForms()[0];
+        $comments = $form->getFormComments();
+        $comment = current($comments);
+        $condition_value = $comment->getConfiguredConditionsData()[0]->getValue();
+        $this->assertEquals([
+            "itemtype" => Computer::class,
+            "items_id" => $computer->getID(),
+        ], $condition_value);
+    }
+
+    public function testItemsNamesInDestinationConditionAreHandledByImport(): void
+    {
+        // Arrange: create the expected computer
+        $computer = $this->createItem(Computer::class, [
+            'name' => 'My computer',
+            'entities_id' => $this->getTestRootEntity(only_id: true),
+        ]);
+
+        // Act: import form
+        $json = $this->getFormJson('destination-with-item-condition.json');
+        $result = self::$serializer->importFormsFromJson(
+            json: $json,
+            mapper: new DatabaseMapper([$this->getTestRootEntity(true)]),
+        );
+
+        // Assert: condition should be updated with the computer id
+        $form = $result->getImportedForms()[0];
+        $destinations = $form->getDestinations();
+        $destination = current($destinations);
+        $condition_value = $destination->getConfiguredConditionsData()[0]->getValue();
+        $this->assertEquals([
+            "itemtype" => Computer::class,
+            "items_id" => $computer->getID(),
+        ], $condition_value);
+    }
+
     public function testWithFormWithSpecialNegativeIdForRootEntity(): void
     {
         // Arrange: create a form with a -1 value for root_items_id

--- a/tests/src/FormTesterTrait.php
+++ b/tests/src/FormTesterTrait.php
@@ -751,4 +751,10 @@ trait FormTesterTrait
             ]);
         }
     }
+
+    protected function getFormJson(string $filename): string
+    {
+        $path = FIXTURE_DIR . "/forms/$filename";
+        return file_get_contents($path);
+    }
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Conditions like this one:

<img width="835" height="321" alt="image" src="https://github.com/user-attachments/assets/d26ce9c4-7246-44e0-bd6f-afd124b95841" />

Would be exported as:

<img width="529" height="225" alt="image" src="https://github.com/user-attachments/assets/724601c7-799d-4e60-a9ee-6b9e8e9092d6" />

This is incorrect, the items id should be replaced by the item name (as the id is not guaranteed to exist on another GLPI's instance).

Don't worry about the big diff, 95% is new fixtures json files and a lot of tests.

There's 5 places where conditions can exist (submit button, questions, sections, comments and destinations) so thats:
* 5 new test cases for export (checking that the json file include the item name, not the id) 
* 5 new test cases for import (checking that a json file containing names is imported with the correct ids).
