### PR TITLE
Fix used scheme in SMTP connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The present file will list all changes made to the project; according to the
 #### Changes
 
 #### Deprecated
+- Usage of `MAIL_SMTPTLS` mode for SMTP configuration.
 
 #### Removed
 
@@ -303,7 +304,7 @@ The present file will list all changes made to the project; according to the
 - Usage of the `/marketplace` path for plugins URLs. All plugins URLs should now start with `/plugins`.
 - Usage of `GLPI_PLUGINS_PATH` javascript variable.
 - Usage of the `GLPI_FORCE_MAIL` constant.
-- Usage of `MAIL_SMTPSSL` constants.
+- Usage of `MAIL_SMTPSSL` mode for SMTP configuration.
 - Usage of `name` and `users_id_validate` parameter in `ajax/dropdownValidator.php`.
 - Usage of `users_id_validate` parameter in `front/commonitilvalidation.form.php`.
 - `front/ticket_ticket.form.php` script usage.

--- a/install/migrations/update_11.0.1_to_11.0.2/mailer.php
+++ b/install/migrations/update_11.0.1_to_11.0.2/mailer.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+/**
+ * @var DBmysql $DB
+ * @var Migration $migration
+ */
+$migration->addPostQuery(
+    $DB->buildUpdate(
+        Config::getTable(),
+        [
+            'value' => 1, // MAIL_SMTP
+        ],
+        [
+            'context' => 'core',
+            'name' => 'smtp_mode',
+            // deprecated MAIL_SMTPTLS
+            // `symfony/mailer` uses STARTTLS automatically when the server supports it
+            // and uses the `ssl://` scheme automatically when the port 465 is used
+            'value' => 3,
+        ]
+    )
+);

--- a/src/Config.php
+++ b/src/Config.php
@@ -385,9 +385,9 @@ class Config extends CommonDBTM
     {
         global $CFG_GLPI;
 
-        if (array_key_exists('smtp_mode', $input) && $input['smtp_mode'] === MAIL_SMTPSSL) {
+        if (array_key_exists('smtp_mode', $input) && in_array($input['smtp_mode'], [MAIL_SMTPSSL, MAIL_SMTPTLS], true)) {
             $input['smtp_mode'] = MAIL_SMTP;
-            Toolbox::deprecated('Usage of "MAIL_SMTPSSL" SMTP mode is deprecated. Switch to "MAIL_SMTP" mode.');
+            Toolbox::deprecated('Usage of "MAIL_SMTPTLS" and "MAIL_SMTPTLS" SMTP mode is deprecated. Switch to "MAIL_SMTP" mode.');
         }
 
         if (array_key_exists('smtp_mode', $input) && (int) $input['smtp_mode'] === MAIL_SMTPOAUTH) {

--- a/src/GLPIMailer.php
+++ b/src/GLPIMailer.php
@@ -149,8 +149,7 @@ class GLPIMailer
                 }
             }
             $dsn = sprintf(
-                '%s://%s%s:%s',
-                (((int) $CFG_GLPI['smtp_mode']) === MAIL_SMTPTLS ? 'smtps' : 'smtp'),
+                'smtp://%s%s:%s',
                 ($CFG_GLPI['smtp_username'] != '' ? sprintf(
                     '%s:%s@',
                     urlencode($CFG_GLPI['smtp_username']),

--- a/src/MailCollector.php
+++ b/src/MailCollector.php
@@ -1914,11 +1914,8 @@ class MailCollector extends CommonDBTM
 
             case MAIL_SMTP:
             case MAIL_SMTPSSL:
-                $content .= 'SMTP';
-                break;
-
             case MAIL_SMTPTLS:
-                $content .= 'SMTP+TLS';
+                $content .= 'SMTP';
                 break;
 
             case MAIL_SMTPOAUTH:

--- a/src/NotificationMailingSetting.php
+++ b/src/NotificationMailingSetting.php
@@ -135,7 +135,6 @@ class NotificationMailingSetting extends NotificationSetting
         $mail_methods = [
             MAIL_MAIL       => __('PHP'),
             MAIL_SMTP       => __('SMTP'),
-            MAIL_SMTPTLS    => __('SMTP+TLS'),
             MAIL_SMTPOAUTH  => __('SMTP+OAUTH'),
         ];
         $is_mail_function_available = true;


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

It follows #21124 and fixes #21676.

The fixed proposed in #21124 was not 100% valid due to a mistake made while reading the `symfony/mailer` code. Indeed, the `smtps` scheme in DSN forces the usage of the `ssl://` scheme, but in the code, it is conditioned by a `$tls` boolean, so I considered it was related to our `SMTP+TLS` configuration, see https://github.com/symfony/symfony/blob/d46e8e725e37766254261ad17c7ef1cb8cb4a7d4/src/Symfony/Component/Mailer/Transport/Smtp/Stream/SocketStream.php#L137-L140

In GLPI 10.0, with PHPMailer, the `smtps` was clearly identified associated with the `ssl://` usage (`ENCRYPTION_SMTPS = 'ssl'`), see https://github.com/PHPMailer/PHPMailer/blob/df16b615e371d81fb79e506277faea67a1be18f1/src/PHPMailer.php#L2153-L2156


Anyway, the `symfony/symfony` component will automatically use the `ssl://` scheme if the port `465` is used and will automatically use the `STARTTLS` command if the server supports it when the connection is not already secured by the `ssl://` connection.
Therefore, I propose to remove the `SMTP`/`SMTP+SSL`/`SMTP+TLS` distinction in GLPI to rely on the `symfony/symfony` component logic. This will prevent administrators to misconfigure their GLPI instance and will probably reduce support requests.

I tested this with the `smtp.google.com` server and validates that the connection is correctly initiated on both port 465 (with `ssl://` scheme) and 587 (with a `STARTTLS` command).