### PR TITLE
fix(forms): Fix question type selector ui

### DIFF
--- a/css/includes/components/form/_form-editor.scss
+++ b/css/includes/components/form/_form-editor.scss
@@ -426,7 +426,8 @@ input.value-selector {
         display: flex;
         flex-wrap: wrap;
 
-        &:not(:has(> :nth-child(2).d-none)) {
+        &:not(:has(> :nth-child(2).d-none)),
+        &:not(:has(> :nth-child(3).d-none)) {
             > div:not(:only-child) {
                 &:first-child {
                     .select2-selection {
@@ -471,7 +472,8 @@ input.value-selector {
             margin-right: auto;
         }
 
-        &:not(:has(> :nth-child(2).d-none)) {
+        &:not(:has(> :nth-child(2).d-none)),
+        &:not(:has(> :nth-child(3).d-none)) {
             > div:not(:only-child) {
                 &:first-child {
                     .select2-selection {


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.

## Description

Correction of the grouping of question type selection dropdowns.
Currently, when there is only one question type for a category, the question type selection dropdown is not displayed. This breaks the grouping of dropdowns when a question uses subtypes.
This behavior was discovered when attempting to integrate the `Field` question type into the `Fields` plugin.
We do not encounter this issue with core questions, as the only types that use subtypes are not alone in their category.

## Screenshots (if appropriate):

### Before 
<img width="774" height="204" alt="image" src="https://github.com/user-attachments/assets/6c44ad09-7fed-41f4-a96b-6a16e886226b" />

### After
<img width="774" height="204" alt="image" src="https://github.com/user-attachments/assets/deeacd88-0f9b-4d59-a310-c865f4619441" />
