### PR TITLE
fix(forms): Fix parsing entries in the question subtype dropdown

### DIFF
--- a/js/modules/Forms/EditorController.js
+++ b/js/modules/Forms/EditorController.js
@@ -1966,13 +1966,21 @@ export class GlpiFormEditorController
             const new_sub_types = this.#question_subtypes_options[type].subtypes;
 
             // Copy the new sub types options into the dropdown
-            for (const category in new_sub_types) {
-                const optgroup = $(`<optgroup label="${_.escape(category)}"></optgroup>`);
-                for (const [sub_type, label] of Object.entries(new_sub_types[category])) {
-                    const option = $(`<option value="${_.escape(sub_type)}">${_.escape(label)}</option>`);
-                    optgroup.append(option);
+            for (const new_sub_type in new_sub_types) {
+                // If the sub type is an object, we have a category
+                if (typeof new_sub_types[new_sub_type] === 'object') {
+                    const optgroup = $(`<optgroup label="${_.escape(new_sub_type)}"></optgroup>`);
+                    for (const [sub_type, label] of Object.entries(new_sub_types[new_sub_type])) {
+                        const option = $(`<option value="${_.escape(sub_type)}">${_.escape(label)}</option>`);
+                        optgroup.append(option);
+                    }
+                    sub_types_select.append(optgroup);
+                    continue;
                 }
-                sub_types_select.append(optgroup);
+
+                // No category, just a single option
+                const option = $(`<option value="${_.escape(new_sub_type)}">${_.escape(new_sub_types[new_sub_type])}</option>`);
+                sub_types_select.append(option);
             }
 
             // Set the default sub type


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.

## Description

Fixed the option parsing mechanism for the subtype selection dropdown.
Currently, the algorithm expects there to be two levels in the table provided to sort entries by category.
Works very well for our use with core question types but does not work with questions implemented by plugins that implement sub-types without categories.

## Screenshots (if appropriate):

<img width="216" height="282" alt="image" src="https://github.com/user-attachments/assets/3b96e500-5ec5-4c7d-95a2-9550f140aa17" />
