### PR TITLE
chore(forms): Expose publicly editor controller loading state method

### DIFF
--- a/js/modules/Forms/EditorController.js
+++ b/js/modules/Forms/EditorController.js
@@ -1766,7 +1766,7 @@ export class GlpiFormEditorController
      * @param {jQuery} question Question element
      * @param {boolean} isLoading Whether to set or remove loading state
      */
-    #setQuestionTypeSpecificLoadingState(question, isLoading) {
+    setQuestionTypeSpecificLoadingState(question, isLoading) {
         const specificContent = question.find("[data-glpi-form-editor-question-type-specific]");
 
         if (isLoading) {
@@ -1821,12 +1821,12 @@ export class GlpiFormEditorController
             .find(`option[data-glpi-form-editor-question-type="${CSS.escape(category)}"]`);
 
         // Set loading state for question type specific content
-        this.#setQuestionTypeSpecificLoadingState(question, true);
+        this.setQuestionTypeSpecificLoadingState(question, true);
 
         // Check if the change is allowed based on existing conditions
         if (!(await this.#checkItemConditionDependenciesForNewQuestionType(question, new_options.first().val()))) {
             // Remove loading state before reverting
-            this.#setQuestionTypeSpecificLoadingState(question, false);
+            this.setQuestionTypeSpecificLoadingState(question, false);
 
             // Revert to previous value if change is not allowed
             const previous_category = question.find('[data-glpi-form-editor-on-change="change-question-type-category"]').data('previous-value');
@@ -1838,7 +1838,7 @@ export class GlpiFormEditorController
         }
 
         // Remove loading state after successful check
-        this.#setQuestionTypeSpecificLoadingState(question, false);
+        this.setQuestionTypeSpecificLoadingState(question, false);
 
         // Remove current types options
         const types_select = question
@@ -1881,12 +1881,12 @@ export class GlpiFormEditorController
         }
 
         // Set loading state for question type specific content
-        this.#setQuestionTypeSpecificLoadingState(question, true);
+        this.setQuestionTypeSpecificLoadingState(question, true);
 
         // Check if the change is allowed based on existing conditions
         if (!(await this.#checkItemConditionDependenciesForNewQuestionType(question, type))) {
             // Remove loading state before reverting
-            this.#setQuestionTypeSpecificLoadingState(question, false);
+            this.setQuestionTypeSpecificLoadingState(question, false);
 
             // Revert to previous value if change is not allowed
             const previous_type = question.find('[data-glpi-form-editor-on-change="change-question-type"]').data('previous-value');
@@ -1898,7 +1898,7 @@ export class GlpiFormEditorController
         }
 
         // Remove loading state after successful check
-        this.#setQuestionTypeSpecificLoadingState(question, false);
+        this.setQuestionTypeSpecificLoadingState(question, false);
 
         // Extracted default value
         const extracted_default_value = this.#options[old_type].extractDefaultValue(question);


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.

## Description

Making the `setQuestionTypeSpecificLoadingState` method public, which allows it to be called directly by plugins.