### PR TITLE
Use example IP from RFC 5737 in locales

### DIFF
--- a/src/IPNetwork.php
+++ b/src/IPNetwork.php
@@ -329,7 +329,7 @@ class IPNetwork extends CommonImplicitTreeDropdown
         // Don't validate an empty network
         if (empty($input["network"])) {
             return [
-                'error' => __('Missing network property (In CIDR notation. Ex: 192.168.1.1/24)'),
+                'error' => sprintf(__('Missing network property (In CIDR notation. Ex: %s)'), '198.51.100.0/24'),
                 'input' => false,
             ];
         }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

See !211727.

Some vulnerability scanners may report the presence of `192.168.1.1` as an exposure of a private network IP address.

> A private IP (such as 10.x.x.x, 172.x.x.x, 192.168.x.x) or an Amazon EC2 private hostname (for example, ip-10-0-56-78) has been found in the HTTP response body. This information might be helpful for further attacks targeting internal systems.

In GLPI, this is due to the presence of an example of CIDR notation in an error message. I propose to use an example IP from the [RFC 5737](https://datatracker.ietf.org/doc/html/rfc5737#section-3) to prevent this false positive detection in vulnerability scans.
