### PR TITLE
Do not output boot errors when serving JS files

### DIFF
--- a/src/Glpi/Error/ErrorDisplayHandler/HtmlErrorDisplayHandler.php
+++ b/src/Glpi/Error/ErrorDisplayHandler/HtmlErrorDisplayHandler.php
@@ -49,15 +49,11 @@ final class HtmlErrorDisplayHandler implements ErrorDisplayHandler
 
     public function canOutput(): bool
     {
-        if (\isCommandLine()) {
+        if (self::$currentRequest === null) {
             return false;
         }
 
-        // Need to fallback to `Request::createFromGlobals()` for errors that appears before the
-        // `onRequest` event.
-        $request = self::$currentRequest ?? Request::createFromGlobals();
-
-        return $request->getPreferredFormat() === 'html';
+        return self::$currentRequest->getPreferredFormat() === 'html';
     }
 
     public function displayErrorMessage(string $error_label, string $message, string $log_level): void

--- a/src/Glpi/Error/ErrorHandler.php
+++ b/src/Glpi/Error/ErrorHandler.php
@@ -90,8 +90,10 @@ final class ErrorHandler extends BaseErrorHandler
 
     /**
      * Indicates whether the error messages should be buffered instead of being displayed immediately.
+     * By default, messages are buffered only on Web context to prevent any output before headers are sent
+     * and to be able to NOT output them on specific context (JS/JSON response for instance).
      */
-    private static bool $is_buffer_active = true;
+    private static bool $is_buffer_active = (PHP_SAPI === 'cli');
 
     /**
      * @var list<array{error_label: string, message: string, log_level: string}>

--- a/src/Glpi/Kernel/Listener/RequestListener/FlushBootErrors.php
+++ b/src/Glpi/Kernel/Listener/RequestListener/FlushBootErrors.php
@@ -32,29 +32,24 @@
  * ---------------------------------------------------------------------
  */
 
-namespace Glpi\Kernel\Listener\PostBootListener;
+namespace Glpi\Kernel\Listener\RequestListener;
 
-use Glpi\Debug\Profiler;
 use Glpi\Error\ErrorHandler;
 use Glpi\Kernel\ListenersPriority;
-use Glpi\Kernel\PostBootEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
 
 final readonly class FlushBootErrors implements EventSubscriberInterface
 {
     public static function getSubscribedEvents(): array
     {
         return [
-            PostBootEvent::class => ['onPostBoot', ListenersPriority::POST_BOOT_LISTENERS_PRIORITIES[self::class]],
+            KernelEvents::REQUEST => ['onKernelRequest', ListenersPriority::REQUEST_LISTENERS_PRIORITIES[self::class]],
         ];
     }
 
-    public function onPostBoot(): void
+    public function onKernelRequest(): void
     {
-        Profiler::getInstance()->start('FlushBootErrors::execute', Profiler::CATEGORY_BOOT);
-
         ErrorHandler::disableBufferAndFlushMessages();
-
-        Profiler::getInstance()->stop('FlushBootErrors::execute');
     }
 }

--- a/src/Glpi/Kernel/ListenersPriority.php
+++ b/src/Glpi/Kernel/ListenersPriority.php
@@ -38,7 +38,6 @@ use Glpi\Kernel\Listener\PostBootListener\BootPlugins;
 use Glpi\Kernel\Listener\PostBootListener\CheckPluginsStates;
 use Glpi\Kernel\Listener\PostBootListener\CustomObjectsAutoloaderRegistration;
 use Glpi\Kernel\Listener\PostBootListener\CustomObjectsBoot;
-use Glpi\Kernel\Listener\PostBootListener\FlushBootErrors;
 use Glpi\Kernel\Listener\PostBootListener\InitializeCache;
 use Glpi\Kernel\Listener\PostBootListener\InitializeDbConnection;
 use Glpi\Kernel\Listener\PostBootListener\InitializePlugins;
@@ -50,6 +49,7 @@ use Glpi\Kernel\Listener\RequestListener\CatchInventoryAgentRequestListener;
 use Glpi\Kernel\Listener\RequestListener\CheckDatabaseStatusListener;
 use Glpi\Kernel\Listener\RequestListener\CheckMaintenanceListener;
 use Glpi\Kernel\Listener\RequestListener\ErrorHandlerRequestListener;
+use Glpi\Kernel\Listener\RequestListener\FlushBootErrors;
 use Glpi\Kernel\Listener\RequestListener\FrontEndAssetsListener;
 use Glpi\Kernel\Listener\RequestListener\LegacyItemtypeRouteListener;
 use Glpi\Kernel\Listener\RequestListener\LegacyRouterListener;
@@ -69,10 +69,6 @@ final class ListenersPriority
         CheckPluginsStates::class =>                  150,
         BootPlugins::class =>                         140,
         SessionStart::class =>                        130,
-
-        // Need to be after `SessionStart` to prevent headers to be sent before the session start.
-        FlushBootErrors::class =>                     125,
-
         LoadLanguage::class =>                        120,
         InitializePlugins::class =>                   110,
         CustomObjectsBoot::class =>                   100,
@@ -86,6 +82,11 @@ final class ListenersPriority
         // Static assets must be served without executing anything else.
         // Keep the listener on top priority.
         FrontEndAssetsListener::class      => 500,
+
+        // Front-end assets are served, buffered errors can be safely flushed.
+        // If displaying them breaks the output, it probably means that the request `Accept` header should be fixed
+        // to contain something else than `text/html`.
+        FlushBootErrors::class             => 495,
 
         // This listener will prevent accessing GLPI if the maintenance mode is active.
         // It must be executed right after the `FrontEndAssetsListener`, as nothing more than front-end assets


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Boot errors are currently buffered until the session is started, to prevent "headers already sent" issues if an error occurs before the session start. This does not prevent errors output to break JS files served by the `FrontEndAssetsListener`.

For instance, if a plugin cannot be loaded, it breaks the JS files served by GLPI:
<img width="1467" height="176" alt="image" src="https://github.com/user-attachments/assets/74464183-9cd5-4b14-8371-312fac993c7f" />
<img width="648" height="378" alt="image" src="https://github.com/user-attachments/assets/ae5bc1ac-5b86-4f00-b3a5-166a9e96253b" />

1. Errors should be flushed only on Web context (there is no reason to send headers in CLI context).
2. Buffered errors should be flushed later, after the front-end assets are served.