### PR TITLE
Fix(Global): access rights to assets

### DIFF
--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -4253,7 +4253,7 @@ final class SQLProvider implements SearchProviderInterface
                 $COMMONWHERE .= getEntitiesRestrictRequest($LINK, $itemtable);
             } elseif (isset($CFG_GLPI["union_search_type"][$data['itemtype']])) {
                 // Will be replace below in Union/Recursivity Hack
-                $COMMONWHERE .= $LINK . " ADDDEFAULTWHERE ";
+                $COMMONWHERE .= $LINK . " ADDDEFAULTWHERE ENTITYRESTRICT ";
             } else {
                 $COMMONWHERE .= getEntitiesRestrictRequest(
                     $LINK,
@@ -4413,6 +4413,17 @@ final class SQLProvider implements SearchProviderInterface
                             Search::addDefaultWhere($ctype),
                             $query_num
                         );
+                        $query_num = str_replace(
+                            "ENTITYRESTRICT",
+                            getEntitiesRestrictRequest(
+                                ' AND ',
+                                $ctable,
+                                '',
+                                '',
+                                $citem->maybeRecursive()
+                            ),
+                            $query_num
+                        );
                         $data['sql']['count'][] = $query_num;
                     }
                 }
@@ -4542,6 +4553,17 @@ final class SQLProvider implements SearchProviderInterface
                     $tmpquery = str_replace(
                         "ADDDEFAULTWHERE",
                         Search::addDefaultWhere($ctype),
+                        $tmpquery
+                    );
+                    $tmpquery = str_replace(
+                        "ENTITYRESTRICT",
+                        getEntitiesRestrictRequest(
+                            ' AND ',
+                            $ctable,
+                            '',
+                            '',
+                            $citem->maybeRecursive()
+                        ),
                         $tmpquery
                     );
 

--- a/tests/functional/SearchTest.php
+++ b/tests/functional/SearchTest.php
@@ -1003,7 +1003,7 @@ class SearchTest extends DbTestCase
         }
 
         foreach ($itemtype_criteria as $itemtype => $criteria) {
-            if (empty($criteria)) {
+            if ($criteria === []) {
                 continue;
             }
 
@@ -2798,7 +2798,7 @@ class SearchTest extends DbTestCase
         $test_child_2    = getItemByTypeName('Entity', '_test_child_2', true);
         $test_child_3    = getItemByTypeName('Entity', '_test_child_3', true);
 
-        $data = $this->doSearch('AllAssets', [
+        $search_params = [
             'reset'      => 'reset',
             'is_deleted' => 0,
             'start'      => 0,
@@ -2811,7 +2811,8 @@ class SearchTest extends DbTestCase
                     'value'      => 'test',
                 ],
             ],
-        ]);
+        ];
+        $data = $this->doSearch('AllAssets', $search_params);
 
         $this->assertMatchesRegularExpression(
             "/OR\s*\(`glpi_entities`\.`completename`\s*LIKE '%test%'\s*\)/",
@@ -2853,6 +2854,26 @@ class SearchTest extends DbTestCase
                 $data['sql']['search']
             );
         }
+
+        $entities = [
+            $test_root,
+            $test_child_1,
+            $test_child_2,
+            $test_child_3,
+        ];
+        foreach ($entities as $entity) {
+            foreach ([true, false] as $is_recursive) {
+                \Session::loadEntity($entity, $is_recursive);
+                $data = $this->doSearch('AllAssets', $search_params);
+
+                // Check that all returned items are viewable
+                foreach ($data['data']['rows'] as $row) {
+                    $asset = new $row['TYPE']();
+                    $asset->getFromDB($row['id']);
+                    $this->assertTrue($asset->canViewItem());
+                }
+            }
+        }
     }
 
     public function testSearchWithNamespacedItem()
@@ -2867,8 +2888,8 @@ class SearchTest extends DbTestCase
         $this->login();
         $this->setEntity('_test_root_entity', true);
 
-        $CFG_GLPI['state_types'][] = 'SearchTest\\Computer';
-        $data = $this->doSearch('SearchTest\\Computer', $search_params);
+        $CFG_GLPI['state_types'][] = \SearchTest\Computer::class;
+        $data = $this->doSearch(\SearchTest\Computer::class, $search_params);
 
         $this->assertStringContainsString(
             "`glpi_computers`.`name` AS `ITEM_SearchTest\Computer_1`",


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes #21640

The Allassets result displayed assets that were inaccessible to the user.
_Error message “You don't have permission to perform this action.” when attempting to open them._

## Screenshots (if appropriate):

Before:
<img width="1453" height="332" alt="image" src="https://github.com/user-attachments/assets/725ce2d4-2af2-40b0-8f49-b575444b60f7" />

After:
<img width="1453" height="332" alt="image" src="https://github.com/user-attachments/assets/42ea8dd7-59d7-49c3-bc19-ebf95afb9d6c" />

