### PR TITLE
Allow forms tags to be edited in tinymce; Refresh tag content on render

### DIFF
--- a/src/Glpi/Form/Destination/CommonITILField/ContentField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ContentField.php
@@ -100,10 +100,12 @@ final class ContentField extends AbstractConfigField implements DestinationField
             ) }}
 TWIG;
 
+
+        $tag_manager = new FormTagsManager();
         $twig = TemplateRenderer::getInstance();
         return $twig->renderFromStringTemplate($template, [
             'form_id'    => $form->fields['id'],
-            'value'      => $config->getValue(),
+            'value'      => $tag_manager->refreshTagsContent($config->getValue()),
             'input_name' => $input_name . "[" . SimpleValueConfig::VALUE . "]",
             'options'    => $display_options,
         ]);

--- a/src/Glpi/Form/Destination/CommonITILField/TitleField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/TitleField.php
@@ -112,10 +112,11 @@ final class TitleField extends AbstractConfigField implements DestinationFieldCo
             </script>
 TWIG;
 
+        $tag_manager = new FormTagsManager();
         $twig = TemplateRenderer::getInstance();
         return $twig->renderFromStringTemplate($template, [
             'form_id'    => $form->fields['id'],
-            'value'      => $config->getValue(),
+            'value'      => $tag_manager->refreshTagsContent($config->getValue()),
             'input_name' => $input_name . "[" . SimpleValueConfig::VALUE . "]",
             'options'    => $display_options,
         ]);

--- a/src/Glpi/Form/Tag/AnswerTagProvider.php
+++ b/src/Glpi/Form/Tag/AnswerTagProvider.php
@@ -86,6 +86,17 @@ final class AnswerTagProvider implements TagProviderInterface, TagWithIdValueInt
         return Question::class;
     }
 
+    #[Override]
+    public function getTagFromRawValue(string $value): ?Tag
+    {
+        $question = Question::getById((int) $value);
+        if (!$question) {
+            return null;
+        }
+
+        return $this->getTagForQuestion($question);
+    }
+
     public function getTagForQuestion(Question $question): Tag
     {
         return new Tag(

--- a/src/Glpi/Form/Tag/CommentDescriptionTagProvider.php
+++ b/src/Glpi/Form/Tag/CommentDescriptionTagProvider.php
@@ -79,6 +79,17 @@ final class CommentDescriptionTagProvider implements TagProviderInterface, TagWi
         return Comment::class;
     }
 
+    #[Override]
+    public function getTagFromRawValue(string $value): ?Tag
+    {
+        $comment = Comment::getById((int) $value);
+        if (!$comment) {
+            return null;
+        }
+
+        return $this->getDescriptionTagForComment($comment);
+    }
+
     public function getDescriptionTagForComment(Comment $comment): Tag
     {
         return new Tag(

--- a/src/Glpi/Form/Tag/CommentTitleTagProvider.php
+++ b/src/Glpi/Form/Tag/CommentTitleTagProvider.php
@@ -79,6 +79,17 @@ final class CommentTitleTagProvider implements TagProviderInterface, TagWithIdVa
         return Comment::class;
     }
 
+    #[Override]
+    public function getTagFromRawValue(string $value): ?Tag
+    {
+        $comment = Comment::getById((int) $value);
+        if (!$comment) {
+            return null;
+        }
+
+        return $this->getTitleTagForComment($comment);
+    }
+
     public function getTitleTagForComment(Comment $comment): Tag
     {
         return new Tag(

--- a/src/Glpi/Form/Tag/FormTagProvider.php
+++ b/src/Glpi/Form/Tag/FormTagProvider.php
@@ -73,6 +73,17 @@ final class FormTagProvider implements TagProviderInterface, TagWithIdValueInter
         return Form::class;
     }
 
+    #[Override]
+    public function getTagFromRawValue(string $value): ?Tag
+    {
+        $form = Form::getById((int) $value);
+        if (!$form) {
+            return null;
+        }
+
+        return $this->getTagForForm($form);
+    }
+
     public function getTagForForm(Form $form): Tag
     {
         return new Tag(

--- a/src/Glpi/Form/Tag/QuestionTagProvider.php
+++ b/src/Glpi/Form/Tag/QuestionTagProvider.php
@@ -79,6 +79,17 @@ final class QuestionTagProvider implements TagProviderInterface, TagWithIdValueI
         return Question::class;
     }
 
+    #[Override]
+    public function getTagFromRawValue(string $value): ?Tag
+    {
+        $question = Question::getById((int) $value);
+        if (!$question) {
+            return null;
+        }
+
+        return $this->getTagForQuestion($question);
+    }
+
     public function getTagForQuestion(Question $question): Tag
     {
         return new Tag(

--- a/src/Glpi/Form/Tag/SectionTagProvider.php
+++ b/src/Glpi/Form/Tag/SectionTagProvider.php
@@ -79,6 +79,17 @@ final class SectionTagProvider implements TagProviderInterface, TagWithIdValueIn
         return Section::class;
     }
 
+    #[Override]
+    public function getTagFromRawValue(string $value): ?Tag
+    {
+        $section = Section::getById((int) $value);
+        if (!$section) {
+            return null;
+        }
+
+        return $this->getTagForSection($section);
+    }
+
     public function getTagForSection(Section $section): Tag
     {
         return new Tag(

--- a/src/Glpi/Form/Tag/Tag.php
+++ b/src/Glpi/Form/Tag/Tag.php
@@ -55,7 +55,6 @@ final readonly class Tag
 
         // Build HTML representation of the tag.
         $properties = [
-            "contenteditable"        => "false",
             "data-form-tag"          => "true",
             "data-form-tag-value"    => $value,
             "data-form-tag-provider" => $provider::class,

--- a/src/Glpi/Form/Tag/TagProviderInterface.php
+++ b/src/Glpi/Form/Tag/TagProviderInterface.php
@@ -56,4 +56,6 @@ interface TagProviderInterface
         string $value,
         AnswersSet $answers_set
     ): string;
+
+    public function getTagFromRawValue(string $value): ?Tag;
 }

--- a/tests/cypress/e2e/form/form_tags.cy.js
+++ b/tests/cypress/e2e/form/form_tags.cy.js
@@ -123,7 +123,6 @@ describe('Form tags', () => {
         // Item has been inserted into rich text
         cy.get("@rich_text_editor")
             .findByText("#Question: Last name")
-            .should('have.attr', 'contenteditable', 'false')
             .should('have.attr', 'data-form-tag', 'true')
             .should('have.attr', 'data-form-tag-value', last_name_question_id)
         ;
@@ -134,7 +133,6 @@ describe('Form tags', () => {
         // Rich text content provided by autocompleted values should be displayed properly
         cy.findByRole('region', {name: 'Content configuration'}).awaitTinyMCE()
             .findByText("#Question: Last name")
-            .should('have.attr', 'contenteditable', 'false')
             .should('have.attr', 'data-form-tag', 'true')
             .should('have.attr', 'data-form-tag-value', last_name_question_id)
         ;

--- a/tests/functional/Glpi/Form/Tag/FormTagsManagerTest.php
+++ b/tests/functional/Glpi/Form/Tag/FormTagsManagerTest.php
@@ -260,6 +260,28 @@ final class FormTagsManagerTest extends DbTestCase
         $this->assertNotEmpty($providers);
     }
 
+    public function testTagsCanBeRefreshed(): void
+    {
+        // Arrange: create a form
+        $tag_provider = new FormTagProvider();
+        $form = $this->createItem(Form::class, ['name' => "My form name"]);
+        $tags = $tag_provider->getTags($form);
+        $tag = $tags[0];
+        $this->assertStringContainsString("My form name", $tag->html, );
+        $this->assertStringNotContainsString("My new form name", $tag->html);
+
+        // Act: update the form, then refresh the tag
+        $this->updateItem(Form::class, $form->getId(), [
+            'name' => "My new form name",
+        ]);
+        $tag_manager = new FormTagsManager();
+        $new_html = $tag_manager->refreshTagsContent($tag->html);
+
+        // Assert: the tag label was updated
+        $this->assertStringNotContainsString("My form name", $new_html);
+        $this->assertStringContainsString("My new form name", $new_html);
+    }
+
     private function createAndGetFormWithFirstAndLastNameQuestions(): Form
     {
         $builder = new FormBuilder();

--- a/tests/functional/Glpi/Form/Tag/TagTest.php
+++ b/tests/functional/Glpi/Form/Tag/TagTest.php
@@ -59,7 +59,7 @@ final class TagTest extends DbTestCase
 
         $expected = json_encode([
             'label' => 'Question: First name',
-            'html' => "<span contenteditable=\"false\" data-form-tag=\"true\" data-form-tag-value=\"$question_id\" data-form-tag-provider=\"$provider\" class=\"border-$color border-start border-3 bg-dark-lt\">#Question: First name</span>",
+            'html' => "<span data-form-tag=\"true\" data-form-tag-value=\"$question_id\" data-form-tag-provider=\"$provider\" class=\"border-$color border-start border-3 bg-dark-lt\">#Question: First name</span>",
         ]);
         $this->assertEquals($expected, json_encode($tag));
     }


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Form tags (see image below as a reminder) are rendered as custom html inside tinymce, with a `contenteditable=false` tag.

<img width="1055" height="205" alt="image" src="https://github.com/user-attachments/assets/b13b3208-453a-43f1-b94e-e145ac414073" />

The idea is that they are auto generated content so the user shouldn't be modifying them.

However, setting them as non editable make it inconvenient to work with them as tinymce will not let you select and delete them.
The only way to select them is to use keyboard shortcuts (ctrl + shift + left/right near the tag) which is not good for our users.

The solution is to set the content as editable BUT it mean users can edit the labels by accident, which is not something we want.
To fix that, I've implemented what I call "tag refresh", which mean each tag is regenerated when the form is rendered.

This add the following benefits:
* Tags label are always up to date (e.g a question name that has been modified since the tag was generated)
* Tags referring to deleted content are automatically deleted (e.g. a question that has been deleted from the form)
* We can change the structure of the tag as needed, as their html will be regenerated (cf an issue raised here: #20212)


