### PR TITLE
Fix illustration titles (failing e2e tests)

### DIFF
--- a/src/Glpi/UI/IllustrationManager.php
+++ b/src/Glpi/UI/IllustrationManager.php
@@ -272,6 +272,7 @@ final class IllustrationManager
             // Cannot call `_x()` here as it results in an illegal empty translation `id` when strings are extracted.
             // see #21049
             $title = $TRANSLATE->translate("Icon\004" . ($icons[$icon_id]['title'] ?? ""), 'glpi');
+            $title = str_replace("Icon\004", "", $title);
         } catch (Throwable $e) {
             $title = '';
         }


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

The illustration e2e tests is failing because illustration names has been broken by #21049.

This issue only happens if an illustration is not translated, this is why the tests starting failing only recently.

<img width="361" height="60" alt="image" src="https://github.com/user-attachments/assets/e0f8651e-63d9-4301-ab44-7202b8484fa3" />

This is because `$TRANSLATE->translate()` and `_x()` do not behave similarly, with `translate` the context is added to the returned string if no translations were available.
