### PR TITLE
fix(transfer): contract was dissociated during computer transfer

### DIFF
--- a/phpunit/functional/TransferTest.php
+++ b/phpunit/functional/TransferTest.php
@@ -784,6 +784,8 @@ class TransferTest extends DbTestCase
         /* Test the computer transfer and verify that contract link is kept */
 
         //Prepare items to transfer
+        $transfer = new \Transfer();
+        $this->assertTrue($transfer->getFromDB(1));
         $item_to_transfer = [\Computer::class => [
             $computer->getID() => $computer->getID(),
         ],
@@ -795,6 +797,18 @@ class TransferTest extends DbTestCase
             'contracts_id' => $contract->getID(),
             'itemtype' => 'Computer',
         ])), 2);
+
+        $this->assertEquals(count($contract_item->find([
+            'contracts_id' => $contract->getID(),
+            'itemtype' => 'Computer',
+            'items_id' => $computer->getID(),
+        ])), 1);
+
+        $this->assertEquals(count($contract_item->find([
+            'contracts_id' => $contract->getID(),
+            'itemtype' => 'Computer',
+            'items_id' => $computer_deleted->getID(),
+        ])), 1);
 
         //Check that computer is now in destination entity
         $this->assertEquals(count($computer->find([

--- a/src/Transfer.php
+++ b/src/Transfer.php
@@ -2290,7 +2290,7 @@ class Transfer extends CommonDBTM
                     } else {
                         $need_clean_process = true;
                         $contract->getFromDB($item_ID);
-                        // No : search contract
+                        // No : search in target entity if existing contract
                         $contract_iterator = $DB->request([
                             'SELECT' => 'id',
                             'FROM'   => 'glpi_contracts',
@@ -2301,8 +2301,9 @@ class Transfer extends CommonDBTM
                         ]);
 
                         if (count($contract_iterator)) {
-                            $result = $iterator->current();
-                            $newcontractID = $item_ID;
+                            // Found existing contract
+                            $result = $contract_iterator->current();
+                            $newcontractID = $result['id'];
                             $this->addToAlreadyTransfer('Contract', $item_ID, $newcontractID);
                         }
 


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !39946
- If a contract and a computer are created in the same entity and linked, the link can be found in the computer's item tab. However, if you want to transfer the contract and computer to another entity, the link may be destroyed. If the contract is transferred first to the new target entity and then the computer is transferred, the link will be destroyed.

## Screenshots (if appropriate):


