### PR TITLE
remove class on preference config modal

### DIFF
--- a/templates/components/search/displaypreference_config.html.twig
+++ b/templates/components/search/displaypreference_config.html.twig
@@ -60,7 +60,7 @@
             <div class="pt-3">
                 {% if available_to_add|length > 0 %}
                     {% set add_opt_btn %}
-                        <button type="button" name="add_opt" class="btn btn-primary ms-sm-1 mt-2 mt-sm-0">
+                        <button type="button" name="add_opt" class="btn btn-primary w-100 w-sm-auto ms-sm-1 mt-2 mt-sm-0">
                             <i class="ti ti-plus"></i>
                             <span>{{ _x('button', 'Add') }}</span>
                         </button>
@@ -77,7 +77,7 @@
                     {% endset %}
 
                     <div class="d-flex justify-content-between mb-2">
-                        <div class="row g-0 flex-fill">
+                        <div class="row g-0 flex-fill mw-100">
                             <div class="col-12 col-sm">
                                 {{ fields.dropdownArrayField('num', null, available_to_add, '', {
                                     field_class: 'd-flex',


### PR DESCRIPTION
## Description

- It fixes #21710
- Here is a brief description of what this PR does : removed a class that produce weird behavior of a button.

**Before :** 

<img width="1095" height="385" alt="image" src="https://github.com/user-attachments/assets/ead5169f-6407-4523-bd8e-c2c035a1f327" />

**After :** 

<img width="1095" height="385" alt="image" src="https://github.com/user-attachments/assets/23f55a84-7c45-433d-8b34-9ab36f1dc45d" />


Tested in Chrome and Firefox.


