### PR TITLE
Fix client side locales

### DIFF
--- a/front/locale.php
+++ b/front/locale.php
@@ -63,14 +63,14 @@ if (!isset($CFG_GLPI['languages'][$requested_language])) {
     // Fallback to default language if requested one is not available
     $requested_language = Session::getPreferredLanguage();
 }
-$requested_language = $CFG_GLPI['languages'][$requested_language][1];
+$requested_language_file = $CFG_GLPI['languages'][$requested_language][1];
 
 // Default response to send if locales cannot be loaded.
 // Prevent JS error for plugins that does not provide any translation files
 $default_response = json_encode(
     [
         '' => [
-            'language'     => $requested_language,
+            'language'     => $requested_language_file,
             'plural-forms' => 'nplurals=2; plural=(n != 1);',
         ],
     ]
@@ -79,7 +79,7 @@ $default_response = json_encode(
 // Get messages from translator component
 $messages = null;
 try {
-    $messages = $TRANSLATE->getAllMessages($_GET['domain']);
+    $messages = $TRANSLATE->getAllMessages($_GET['domain'], $requested_language);
 } catch (Throwable $e) {
     // Error may happen when overrided translation files does not use same plural rules as GLPI.
     ErrorHandler::logCaughtException($e);
@@ -92,7 +92,7 @@ if (!($messages instanceof TextDomain)) {
 }
 
 // Extract headers from main po file
-$po_file = GLPI_ROOT . '/locales/' . preg_replace('/\.mo$/', '.po', $requested_language);
+$po_file = GLPI_ROOT . '/locales/' . preg_replace('/\.mo$/', '.po', $requested_language_file);
 $po_file_handle = fopen(
     $po_file,
     'rb'

--- a/tests/functional/Glpi/Front/LocaleTest.php
+++ b/tests/functional/Glpi/Front/LocaleTest.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Front;
+
+use DbTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+class LocaleTest extends DbTestCase
+{
+    public static function frontLocaleFileProvider(): iterable
+    {
+        yield ['en_GN', 'Active'];
+        yield ['fr_FR', 'Activé'];
+    }
+
+    #[DataProvider('frontLocaleFileProvider')]
+    public function testFrontLocaleFile(string $locale, string $expected): void
+    {
+        global $TRANSLATE;
+
+        // Arrange: load languages
+        $TRANSLATE->addTranslationFile('gettext', GLPI_I18N_DIR . '/en_GB.mo', 'glpi', 'en_GB');
+        $TRANSLATE->addTranslationFile('gettext', GLPI_I18N_DIR . '/fr_FR.mo', 'glpi', 'fr_FR');
+
+        // Act: render locale file
+        $_GET['lang'] = $locale;
+        $_GET['domain'] = 'glpi';
+        ob_start();
+        include(GLPI_ROOT . '/front/locale.php');
+        $locales = ob_get_clean();
+
+        // Assert: locales should be translated to expected string
+        $locales = json_decode($locales, true);
+        $this->assertEquals($expected, $locales['Active']);
+    }
+}


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

I don't know since when, but client side locales are not working at all.
The requested language is never sent to the `$TRANSLATE->getAllMessages()` call, so it always return translation for the  `en_US` language.

<img width="733" height="270" alt="image" src="https://github.com/user-attachments/assets/470c0233-a0d4-4a36-ab8d-74f2d93cad13" />

It should fix the e2e failures.