### PR TITLE
Revert "Rework client-side language handling to improve availability"

### DIFF
--- a/lib/bundles/base.js
+++ b/lib/bundles/base.js
@@ -97,9 +97,6 @@ window._ = require('lodash');
 // add translation function into global scope
 // signature is almost the same as for PHP functions, but accept extra arguments for string variables
 window.i18n = require('gettext.js/lib/gettext').default({domain: 'glpi'});
-if (window.loadLocales !== undefined) {
-    await window.loadLocales();
-}
 
 const escape_msgid = function (msgid) {
     return msgid.replace(/%(\d+)\$/g, '%%$1\$');

--- a/src/Glpi/Application/View/Extension/FrontEndAssetsExtension.php
+++ b/src/Glpi/Application/View/Extension/FrontEndAssetsExtension.php
@@ -242,30 +242,36 @@ class FrontEndAssetsExtension extends AbstractExtension
             $locales_domains[$plugin] = Plugin::getPluginFilesVersion($plugin);
         }
 
-        $locales_json = json_encode(array_combine(array_keys($locales_domains), array_map(static fn($domain, $version) => Html::getPrefixedUrl(
-            '/front/locale.php'
-            . '?domain=' . $domain
-            . '&lang=' . $_SESSION['glpilanguage']
-            . '&v=' . FrontEnd::getVersionCacheKey($version)
-        ), array_keys($locales_domains), $locales_domains)));
+        $script = "
+            $(function() {
+                i18n.setLocale('" . \jsescape($_SESSION['glpilanguage']) . "');
+            });
 
-        $script = <<<JS
-            // Fetch locale JSON without jQuery to allow fetching before jQuery is loaded
-            async function loadLocales() {
-                const locales = $locales_json;
-                const promises = [];
-                for (const [domain, url] of Object.entries(locales)) {
-                    promises.push(window.fetch(url).then(response => {
-                        if (response.ok) {
-                            return response.json().then(data => {
-                                i18n.loadJSON(data, domain);
-                            });
+            $.fn.select2.defaults.set(
+                'language',
+                '" . \jsescape($CFG_GLPI['languages'][$_SESSION['glpilanguage']][2]) . "',
+            );
+        ";
+
+        foreach ($locales_domains as $locale_domain => $locale_version) {
+            $locales_path = Html::getPrefixedUrl(
+                '/front/locale.php'
+                . '?domain=' . $locale_domain
+                . '&lang=' . $_SESSION['glpilanguage']
+                . '&v=' . FrontEnd::getVersionCacheKey($locale_version)
+            );
+            $script .= "
+                $(function() {
+                    $.ajax({
+                        type: 'GET',
+                        url: '" . \jsescape($locales_path) . "',
+                        success: function(json) {
+                            i18n.loadJSON(json, '" . \jsescape($locale_domain) . "');
                         }
-                    }));
-                }
-                await Promise.all(promises);
-            }
-JS;
+                    });
+                });
+            ";
+        }
 
         return Html::scriptBlock($script);
     }

--- a/src/Html.php
+++ b/src/Html.php
@@ -1050,11 +1050,9 @@ TWIG,
 
         $theme = ThemeManager::getInstance()->getCurrentTheme();
         $lang = $_SESSION['glpilanguage'] ?? Session::getPreferredLanguage();
-        // Force lang to be BCP 47 compliant
-        $lang = str_replace('_', '-', $lang);
 
         $tpl_vars = [
-            'lang'               => $lang,
+            'lang'               => $CFG_GLPI["languages"][$lang][3],
             'title'              => $title,
             'theme'              => $theme,
             'is_anonymous_page'  => false,

--- a/templates/layout/parts/head.html.twig
+++ b/templates/layout/parts/head.html.twig
@@ -79,8 +79,6 @@
 
    {{ config_js() }}
 
-    {{ locales_js() }}
-
    {% for js_file in js_files %}
       <script type="text/javascript" src="{{ js_path(js_file.path, js_file.options ?? []) }}"></script>
    {% endfor %}
@@ -88,4 +86,6 @@
    {% for js_file in js_modules %}
       <script type="module" src="{{ js_path(js_file.path, js_file.options ?? []) }}"></script>
    {% endfor %}
+
+   {{ locales_js() }}
 </head>


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

This reverts commit 676cd4e4eacd990ed8029b071c60a0882109f699.

I concede. All the PR did after switching from a synchronous XMLHttpRequest to awaited async ones was create a different race condition. The synchronous request seemed to work properly, but the await in the plain JS file only likely paused the execution of that one script. When `js/src/app.js` was loaded, the translation functions were randomly not available.

I'm withdrawing all of the performance improvement/UX improvement proposals for a bugfix version since it may just cause more issues, and refer back to my original long-term proposal for frontend changes.