### PR TITLE
Add plugin hint for 'fields' question type during form migration

### DIFF
--- a/src/Glpi/Form/Migration/TypesConversionMapper.php
+++ b/src/Glpi/Form/Migration/TypesConversionMapper.php
@@ -93,6 +93,7 @@ final class TypesConversionMapper
             "ip"         => "advancedforms",
             "hostname"   => "advancedforms",
             "tag"        => "tag",
+            "fields"     => "fields",
         };
     }
 

--- a/tests/functional/Glpi/Form/Migration/FormMigrationTest.php
+++ b/tests/functional/Glpi/Form/Migration/FormMigrationTest.php
@@ -3285,6 +3285,10 @@ final class FormMigrationTest extends DbTestCase
             'type' => 'tag',
             'expected_message' => 'The "tag" question type is available in the "tag" plugin: https://plugins.glpi-project.org/#/plugin/tag',
         ];
+        yield [
+            'type' => 'fields',
+            'expected_message' => 'The "fields" question type is available in the "fields" plugin: https://plugins.glpi-project.org/#/plugin/fields',
+        ];
     }
 
     #[DataProvider('pluginHintsProvider')]


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Continuation of #21325.
Added the "fields" question type supported by the "fields" plugin.