### PR TITLE
fix: twig error when accessing empty itil fields

### DIFF
--- a/templates/components/itilobject/fields/status.html.twig
+++ b/templates/components/itilobject/fields/status.html.twig
@@ -44,7 +44,7 @@
          'showtype': 'allowed',
          'width': '100%',
          'display': false,
-         'use_template_limits': itiltemplate.fields['id']
+         'use_template_limits': itiltemplate.fields['id'] ?? 0
       }|merge(field_options))|raw }}
 
       {% set validation_class = item.getValidationClassInstance() %}

--- a/templates/components/itilobject/mainform_open.html.twig
+++ b/templates/components/itilobject/mainform_open.html.twig
@@ -51,7 +51,7 @@
    <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}" />
    <input type="hidden" name="_skip_default_actor" value="1" />
 
-   {% if itiltemplate_key is defined %}
+   {% if itiltemplate_key is defined and itiltemplate.fields['id'] is defined %}
       <input type="hidden" name="{{ itiltemplate_key }}" value="{{ itiltemplate.fields['id'] }}" />
    {% endif %}
    {% if predefined_fields is defined %}


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] My feature works.

## Description

<img width="1215" height="377" alt="image" src="https://github.com/user-attachments/assets/37cb7c46-3cf6-4bfe-9d39-8c76971be1db" />

```
Key "id" does not exist as the sequence/mapping is empty in "components/itilobject/mainform_open.html.twig" at line 55.
In ./templates/components/itilobject/mainform_open.html.twig(55)
#0 ./files/_cache/11.0.2-dev-00000000-development/templates/ab/ab77edbb6b587bcb48f15b4e53fad3bc.php(106): Twig\Extension\CoreExtension::getAttribute()
#1 ./vendor/twig/twig/src/Template.php(402): __TwigTemplate_45b2e790470a1d4cde7a16fe2e9b6098->doDisplay()
#2 ./vendor/twig/twig/src/Template.php(358): Twig\Template->yield()
#3 ./vendor/twig/twig/src/Template.php(373): Twig\Template->display()
#4 ./vendor/twig/twig/src/TemplateWrapper.php(51): Twig\Template->render()
#5 ./vendor/twig/twig/src/Extension/CoreExtension.php(1520): Twig\TemplateWrapper->render()
#6 ./files/_cache/11.0.2-dev-00000000-development/templates/f3/f39b49c306eb38264602cd29f178e6aa.php(112): Twig\Extension\CoreExtension::include()
#7 ./vendor/twig/twig/src/Template.php(402): __TwigTemplate_80cec35d2fc3942e58f392ccbd7a2600->doDisplay()
#8 ./vendor/twig/twig/src/Template.php(358): Twig\Template->yield()
#9 ./vendor/twig/twig/src/TemplateWrapper.php(61): Twig\Template->display()
#10 ./src/Glpi/Application/View/TemplateRenderer.php(188): Twig\TemplateWrapper->display()
#11 ./src/Ticket.php(3766): Glpi\Application\View\TemplateRenderer->display()
#12 ./src/CommonGLPI.php(683): Ticket->showForm()
#13 ./ajax/common.tabs.php(108): CommonGLPI::displayStandardTab()
#14 ./src/Glpi/Controller/LegacyFileLoadController.php(64): require('...')
#15 ./vendor/symfony/http-kernel/HttpKernel.php(181): Glpi\Controller\LegacyFileLoadController->__invoke()
#16 ./vendor/symfony/http-kernel/HttpKernel.php(76): Symfony\Component\HttpKernel\HttpKernel->handleRaw()
#17 ./vendor/symfony/http-kernel/Kernel.php(197): Symfony\Component\HttpKernel\HttpKernel->handle()
#18 ./public/index.php(70): Symfony\Component\HttpKernel\Kernel->handle()
#19 {main}
```

