### PR TITLE
Improve migration of conditions on checkboxes

### DIFF
--- a/src/Glpi/Form/Condition/ConditionHandler/MultipleChoiceFromValuesConditionHandler.php
+++ b/src/Glpi/Form/Condition/ConditionHandler/MultipleChoiceFromValuesConditionHandler.php
@@ -79,8 +79,9 @@ final class MultipleChoiceFromValuesConditionHandler implements
     }
 
     #[Override]
-    public function convertConditionValue(string $value): int
+    public function convertConditionValue(string $value): array
     {
-        return array_search($value, $this->values, true) ?: 0;
+        $value = array_search($value, $this->values, true) ?: 0;
+        return [$value];
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

If you have this formcreator question:
<img width="1062" height="580" alt="image" src="https://github.com/user-attachments/assets/85128044-fa7f-45f2-a43e-d32e374631c6" />

An this condition on another question:
<img width="1091" height="172" alt="image" src="https://github.com/user-attachments/assets/4ecd0c30-2e46-4334-91e2-84dd0f3664ca" />

Then we would migrate it as "is equals to":
<img width="748" height="247" alt="image" src="https://github.com/user-attachments/assets/c0264cce-3846-487f-a8ea-1e437244f9a3" />

However, this is not how it actually works on formcreator, the real check is "contains" (which is not intuitive as the UI show "=").
To make sure the form works the same as in formcreator, it is now migrated as:

<img width="716" height="228" alt="image" src="https://github.com/user-attachments/assets/e8a5ca6f-7fc4-4fe0-967b-b52e6b95d886" />
