### PR TITLE
Fix (API HL) - JOIN alias in user schema generates missing column error

### DIFF
--- a/src/Glpi/Api/HL/Controller/AdministrationController.php
+++ b/src/Glpi/Api/HL/Controller/AdministrationController.php
@@ -75,7 +75,7 @@ final class AdministrationController extends AbstractController
                                     'glpi_profiles_users' => [
                                         'ON' => [
                                             'glpi_profiles_users' => 'users_id',
-                                            'glpi_users' => 'id',
+                                            '_' => 'id',
                                         ],
                                     ],
                                 ],


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !40125
- Here is a brief description of what this PR does

This PR fixes a **GraphQL/HL API** bug causing SQL errors when querying users for users that cannot view all entities. The User schema used the **physical table** name in a `LEFT JOIN` instead of the query table **alias ('_')**, which produced invalid SQL (unknown column `glpi_users.id`).
The change updates the JOIN to use the correct table alias so queries build valid SQL and the GraphQL User endpoint works consistently.