### PR TITLE
test ubicloud runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
     if: github.repository == 'glpi-project/glpi' || github.event_name != 'schedule'
     name: "Test on PHP ${{ matrix.php-version }} using ${{ matrix.db-image }}"
     needs: "generate-tests-matrix"
-    runs-on: "ubicloud-standard-2"
+    runs-on: "buildjet-2vcpu-ubuntu-2204"
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -233,7 +233,7 @@ jobs:
     # Do not run scheduled tests on tier repositories
     if: github.repository == 'glpi-project/glpi' || github.event_name != 'schedule'
     name: "E2E and web tests using latest PHP and MariaDB versions"
-    runs-on: "ubicloud-standard-2"
+    runs-on: "buildjet-2vcpu-ubuntu-2204"
     timeout-minutes: 90
     env:
       COMPOSE_FILE: ".github/actions/docker-compose-app.yml:.github/actions/docker-compose-services.yml"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
     if: github.repository == 'glpi-project/glpi' || github.event_name != 'schedule'
     name: "Test on PHP ${{ matrix.php-version }} using ${{ matrix.db-image }}"
     needs: "generate-tests-matrix"
-    runs-on: "ubicloud-standard-8"
+    runs-on: "ubicloud-standard-2"
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -233,7 +233,7 @@ jobs:
     # Do not run scheduled tests on tier repositories
     if: github.repository == 'glpi-project/glpi' || github.event_name != 'schedule'
     name: "E2E and web tests using latest PHP and MariaDB versions"
-    runs-on: "ubicloud-standard-8"
+    runs-on: "ubicloud-standard-2"
     timeout-minutes: 90
     env:
       COMPOSE_FILE: ".github/actions/docker-compose-app.yml:.github/actions/docker-compose-services.yml"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
     if: github.repository == 'glpi-project/glpi' || github.event_name != 'schedule'
     name: "Test on PHP ${{ matrix.php-version }} using ${{ matrix.db-image }}"
     needs: "generate-tests-matrix"
-    runs-on: "ubuntu-latest"
+    runs-on: "ubicloud-standard-2"
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -233,7 +233,7 @@ jobs:
     # Do not run scheduled tests on tier repositories
     if: github.repository == 'glpi-project/glpi' || github.event_name != 'schedule'
     name: "E2E and web tests using latest PHP and MariaDB versions"
-    runs-on: "ubuntu-latest"
+    runs-on: "ubicloud-standard-2"
     timeout-minutes: 90
     env:
       COMPOSE_FILE: ".github/actions/docker-compose-app.yml:.github/actions/docker-compose-services.yml"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
     if: github.repository == 'glpi-project/glpi' || github.event_name != 'schedule'
     name: "Test on PHP ${{ matrix.php-version }} using ${{ matrix.db-image }}"
     needs: "generate-tests-matrix"
-    runs-on: "buildjet-2vcpu-ubuntu-2204"
+    runs-on: "ubicloud-standard-2"
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -233,7 +233,7 @@ jobs:
     # Do not run scheduled tests on tier repositories
     if: github.repository == 'glpi-project/glpi' || github.event_name != 'schedule'
     name: "E2E and web tests using latest PHP and MariaDB versions"
-    runs-on: "buildjet-2vcpu-ubuntu-2204"
+    runs-on: "ubicloud-standard-2"
     timeout-minutes: 90
     env:
       COMPOSE_FILE: ".github/actions/docker-compose-app.yml:.github/actions/docker-compose-services.yml"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
     if: github.repository == 'glpi-project/glpi' || github.event_name != 'schedule'
     name: "Test on PHP ${{ matrix.php-version }} using ${{ matrix.db-image }}"
     needs: "generate-tests-matrix"
-    runs-on: "ubicloud-standard-2"
+    runs-on: "ubicloud-standard-8"
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -233,7 +233,7 @@ jobs:
     # Do not run scheduled tests on tier repositories
     if: github.repository == 'glpi-project/glpi' || github.event_name != 'schedule'
     name: "E2E and web tests using latest PHP and MariaDB versions"
-    runs-on: "ubicloud-standard-2"
+    runs-on: "ubicloud-standard-8"
     timeout-minutes: 90
     env:
       COMPOSE_FILE: ".github/actions/docker-compose-app.yml:.github/actions/docker-compose-services.yml"


### PR DESCRIPTION
## Description

Quick test to benchmark ubicloud performance on CI with various setting
Results:

- Github : phpunit ~50min; e2e ~ 70min
- [Premium] standard-2: phpunit ~40min; e2e ~60min
- [Premium] standard-8: phpunit ~30min; e2e ~60min
- [Classic] standard-2: TODO
- [Classic] standard-8: TODO

*Premium = AMD Ryzen 9 7950X3D, Classic = EPYC 9454P, premium are claimed to be 1.8x faster (but 2x price)*