### PR TITLE
Fix hidden sections being rendered in tickets descriptions

### DIFF
--- a/tests/cypress/e2e/form/form_rendering.cy.js
+++ b/tests/cypress/e2e/form/form_rendering.cy.js
@@ -279,7 +279,7 @@ describe('Form rendering', () => {
 
     it('Items hidden by condition are ignored by destinations', () => {
         cy.login();
-        cy.importForm('form-with-a-hidden-question-2025-09-19.json').then((id) => {
+        cy.importForm('form-with-hidden-items.json').then((id) => {
             cy.visit(`/Form/Render/${id}`);
         });
 
@@ -288,14 +288,17 @@ describe('Form rendering', () => {
         cy.findByRole('button', {name : "Submit"}).click();
 
         // Go to created ticket
-        cy.findByRole('link', {name : "Form with a hidden question"}).click();
+        cy.findByRole('link', {name : "Form with hidden items"}).click();
 
         // Urgency should be set from the visible question value
         cy.getDropdownByLabelText('Urgency').should('have.text', "Very high");
 
         // Hidden question should not be referenced in the ticket description
+        cy.findByText('Visible section').should('exist');
         cy.findByText('1) Visible question').should('exist');
         cy.findByText('2) Hidden question').should('not.exist');
+        cy.findByText('Hidden section').should('not.exist');
+        cy.findByText('1) Visible question inside hidden section').should('not.exist');
     });
 
     it('test item question rendering with advanced configuration', () => {

--- a/tests/fixtures/forms/form-with-hidden-items.json
+++ b/tests/fixtures/forms/form-with-hidden-items.json
@@ -2,33 +2,50 @@
     "version": 1,
     "forms": [
         {
-            "id": 6,
-            "uuid": "6b3f29ac-f1a0-4959-bd01-a43e435d2818",
-            "name": "Form with a hidden question",
+            "id": 49,
+            "uuid": "7d9b903d-a51a-4dfa-8c3b-fad6631f7d92",
+            "name": "Form with hidden items",
             "header": null,
             "description": null,
-            "illustration": "",
             "entity_name": "Root entity > E2ETestEntity",
             "is_recursive": true,
             "is_active": false,
             "submit_button_visibility_strategy": "",
+            "illustration": "",
             "submit_button_conditions": [],
             "sections": [
                 {
-                    "id": 7,
-                    "uuid": "40c5e812-1f9b-4ce2-9920-8d9ed744997c",
-                    "name": "Premi\u00e8re section",
+                    "id": 87,
+                    "uuid": "895eb3dc-b4ee-4d90-9f63-5af7886e15ad",
+                    "name": "Visible section",
                     "description": null,
                     "rank": 0,
                     "visibility_strategy": "",
                     "conditions": []
+                },
+                {
+                    "id": 88,
+                    "uuid": "ca4864ae-6033-47ac-a61a-c3fcedac28cc",
+                    "name": "Hidden section",
+                    "description": "",
+                    "rank": 1,
+                    "visibility_strategy": "hidden_if",
+                    "conditions": [
+                        {
+                            "item_uuid": "5ad77d63-5a39-40a7-9802-e439e33cc98e",
+                            "item_type": "question",
+                            "value_operator": "visible",
+                            "logic_operator": "and",
+                            "value": ""
+                        }
+                    ]
                 }
             ],
             "comments": [],
             "questions": [
                 {
-                    "id": 35,
-                    "uuid": "ee89443c-f7f9-48bf-b9d6-a6781dcf9c32",
+                    "id": 332,
+                    "uuid": "5ad77d63-5a39-40a7-9802-e439e33cc98e",
                     "name": "Visible question",
                     "type": "Glpi\\Form\\QuestionType\\QuestionTypeUrgency",
                     "is_mandatory": false,
@@ -37,15 +54,15 @@
                     "description": "",
                     "default_value": 0,
                     "extra_data": null,
-                    "section_id": 7,
+                    "section_id": 87,
                     "visibility_strategy": "",
                     "validation_strategy": "",
                     "conditions": [],
                     "validation_conditions": []
                 },
                 {
-                    "id": 36,
-                    "uuid": "347367e4-b7f5-48fc-bb74-2ab3257f8cfc",
+                    "id": 333,
+                    "uuid": "9799d212-6900-48a8-9368-1168d356221b",
                     "name": "Hidden question",
                     "type": "Glpi\\Form\\QuestionType\\QuestionTypeUrgency",
                     "is_mandatory": false,
@@ -54,18 +71,35 @@
                     "description": "",
                     "default_value": 0,
                     "extra_data": null,
-                    "section_id": 7,
+                    "section_id": 87,
                     "visibility_strategy": "hidden_if",
                     "validation_strategy": "",
                     "conditions": [
                         {
-                            "item_uuid": "ee89443c-f7f9-48bf-b9d6-a6781dcf9c32",
+                            "item_uuid": "5ad77d63-5a39-40a7-9802-e439e33cc98e",
                             "item_type": "question",
                             "value_operator": "visible",
                             "logic_operator": "and",
-                            "value": null
+                            "value": ""
                         }
                     ],
+                    "validation_conditions": []
+                },
+                {
+                    "id": 334,
+                    "uuid": "d4ad39f6-0600-4b72-a59d-b3a16de38bab",
+                    "name": "Visible question inside hidden section",
+                    "type": "Glpi\\Form\\QuestionType\\QuestionTypeShortText",
+                    "is_mandatory": false,
+                    "vertical_rank": 0,
+                    "horizontal_rank": null,
+                    "description": "",
+                    "default_value": "",
+                    "extra_data": null,
+                    "section_id": 88,
+                    "visibility_strategy": "",
+                    "validation_strategy": "",
+                    "conditions": [],
                     "validation_conditions": []
                 }
             ],
@@ -84,7 +118,7 @@
             ],
             "destinations": [
                 {
-                    "id": 6,
+                    "id": 72,
                     "itemtype": "Glpi\\Form\\Destination\\FormDestinationTicket",
                     "name": "Ticket",
                     "config": [],
@@ -98,7 +132,9 @@
                     "itemtype": "Entity",
                     "name": "Root entity > E2ETestEntity"
                 }
-            ]
+            ],
+            "custom_types_requirements": [],
+            "plugin_requirements": []
         }
     ]
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Take a form like this, where only the first question is visible:
<img width="1351" height="891" alt="image" src="https://github.com/user-attachments/assets/f125df70-2065-4232-bd4d-bd1f40b275a7" />

It is rendered like this:
<img width="1057" height="322" alt="image" src="https://github.com/user-attachments/assets/18eb7c91-fa35-4a10-a61a-de88a0d77fc5" />

But the created ticket would contain the hidden section details:
<img width="777" height="322" alt="image" src="https://github.com/user-attachments/assets/69e9f5d7-4f43-48c5-bced-7b02b34959a4" />

After my fix, the output is as expected:
<img width="761" height="255" alt="image" src="https://github.com/user-attachments/assets/52b25bda-5c81-44a7-bd1f-b864dfc9b77b" />

