### PR TITLE
Fix assignable items filtering in cron context

### DIFF
--- a/src/Glpi/Features/AssignableItem.php
+++ b/src/Glpi/Features/AssignableItem.php
@@ -109,7 +109,7 @@ trait AssignableItem
     public static function getAssignableVisiblityCriteria(
         ?string $item_table_reference = null
     ): array {
-        if (Session::isCron()) {
+        if (Session::isCron() || Session::isRightChecksDisabled()) {
             $criteria = [new QueryExpression('1')];
         } elseif (Session::getCurrentInterface() === "central") {
             $criteria = self::getAssignableVisiblityCriteriaForCentral($item_table_reference);


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

It should fix https://github.com/glpi-project/glpi-inventory-plugin/issues/792.

The `glpiinventory` plugin uses the search engine in cron context. This is not an expected usecase, but we could consider that there is no reason to rely on current user/groups to filter results in the cron context.