### PR TITLE
Fix(MailCollector):  Use IMAP global folder names instead of localized display names in OAuth IMAP collector

### DIFF
--- a/templates/pages/setup/mailcollector/setup_form.html.twig
+++ b/templates/pages/setup/mailcollector/setup_form.html.twig
@@ -232,12 +232,12 @@
 
                   const li       = $(this);
                   const input_id = li.data('input-id');
-                  const folder   = li.children('.folder-name').html();
+                  const folder   = li.children('.folder-name').data('globalname');
 
                   let _label = '';
                   const _parents = li.parents('li').children('.folder-name');
                   for (i = _parents.length -1 ; i >= 0; i--) {
-                      _label += $(_parents[i]).html() + '/';
+                      _label += $(_parents[i]).data('globalname') + '/';
                   }
                   _label += folder;
 


### PR DESCRIPTION

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes https://github.com/pluginsGLPI/oauthimap/issues/114

This PR fixes an issue where the **OAuth IMAP plugin** fails to open folders when the mailbox language is not English (e.g., French, German, etc.).

Previously, the plugin used the **localized folder name** (e.g. “Boîte de réception”) instead of the **IMAP global name** (e.g. “INBOX”) when selecting folders.
This caused the collector to fail with:

```
Laminas\Mail\Storage\Exception\RuntimeException: cannot change folder, maybe it does not exist
```

Updated folder selection logic to rely on the **`data-globalname`** attribute instead of the localized display name (`local_name`).


## Screenshots (if appropriate):


