### PR TITLE
Fix (HL API) - Add missing UUID property for CustomAsset schema

### DIFF
--- a/src/Glpi/Api/HL/Controller/CustomAssetController.php
+++ b/src/Glpi/Api/HL/Controller/CustomAssetController.php
@@ -102,7 +102,7 @@ final class CustomAssetController extends AbstractController
                         'readOnly' => true,
                     ],
                     'uuid' => [
-                        'x-version-introduced' => '2.1.1',
+                        'x-version-introduced' => '2.2.0',
                         'type' => Doc\Schema::TYPE_STRING,
                         'format' => Doc\Schema::PATTERN_UUIDV4,
                         'readOnly' => true,


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !40022
- Here is a brief description of what this PR does

The `UUID` property of custom Assets is missing when making a GET call via the HL API. This PR adds the missing property to the schema.

**Note**: I have a question about the value of the `x-version-introduced` attribute. Curtis may be able to confirm. 


