### PR TITLE
fix(infocoms): number formatting incompatible with decimal_number option

### DIFF
--- a/templates/components/form/fields_macros.html.twig
+++ b/templates/components/form/fields_macros.html.twig
@@ -157,13 +157,11 @@
 
 
 {% macro numberField(name, value, label = '', options = {}) %}
-   {% if options.step is not defined %}
-      {% set decimal_places = config('decimal_number') %}
-      {% set step_value = (10 ** (-decimal_places)) %}
-      {% set options = options|merge({'step': step_value}) %}
-   {% endif %}
+   {% set options = {
+        'step': 1,
+   }|merge(options) %}
 
-   {% if options.step|round(0, 'floor') != options.step %}
+   {% if options.step != 'any' and options.step|round(0, 'floor') != options.step %}
       {# Only format number if not a whole number #}
       {% set value = call('Html::formatNumber', [value, true]) %}
    {% endif %}

--- a/templates/components/infocom.html.twig
+++ b/templates/components/infocom.html.twig
@@ -173,6 +173,7 @@
                         _x('price', 'Value'),
                         {
                             'disabled': disabled,
+                            'step': '0.0001',
                         }
                      ) }}
 
@@ -182,6 +183,7 @@
                         __('Warranty extension value'),
                         {
                             'disabled': disabled,
+                            'step': '0.0001',
                         }
                      ) }}
 
@@ -229,7 +231,7 @@
                         'sink_coeff',
                         infocom.fields['sink_coeff'],
                         __('Amortization coefficient'),
-                        {'disabled': disabled}
+                        {'disabled': disabled, 'step': '0.0001'}
                      ) }}
 
                      {% if item.getType() not in infocom.getExcludedTypes()|merge(['Cartridge', 'Consumable', 'SoftwareLicense'])  %}

--- a/templates/pages/setup/general/general_setup.html.twig
+++ b/templates/pages/setup/general/general_setup.html.twig
@@ -92,7 +92,6 @@
         inline_field_options|merge({
             'min': 1,
             'max': 4,
-            'step': 1,
         })
     ) }}
 


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !40061
- This patch resolves a compatibility issue between number formatting and the decimal_number option in the infocoms module.

## Screenshots (if appropriate):

decimal_number configuration
<img width="253" height="50" alt="image" src="https://github.com/user-attachments/assets/9b1ffb1f-05ad-4da9-a3fa-4d442d7f2137" />

Before fix:
<img width="436" height="49" alt="image" src="https://github.com/user-attachments/assets/0b255e8c-cfaa-4306-b4b5-fed1017cf702" />

After fix:
<img width="440" height="48" alt="image" src="https://github.com/user-attachments/assets/8f6a1bde-925a-4256-881a-701904bd76b1" />


