### PR TITLE
Added decimal option to number input macro

### DIFF
--- a/templates/components/form/basic_inputs_macros.html.twig
+++ b/templates/components/form/basic_inputs_macros.html.twig
@@ -142,8 +142,12 @@
     {% endif %}
 
     {% if options.step != 'any' and options.step|round(0, 'floor') != options.step %}
-        {# Only format number if not a whole number #}
-        {% set value = call('Html::formatNumber', [value, true]) %}
+        {% if options.decimals is defined %}
+            {% set value = call('Html::formatNumber', [value, true, options.decimals]) %}
+        {% else %}
+            {# Only format number if not a whole number #}
+            {% set value = call('Html::formatNumber', [value, true]) %}
+        {% endif %}
     {% endif %}
 
     {{ _self.input(name, value, options|merge({'type': 'number'})) }}


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

- It fixes #21861, adding a decimal options, so a field can have a different number of decimals from the default.
- This adds a simple check on the Number Input if it has a decimals option, it adds its value to "Html::formatNumber" to show the specific number of decimals. This is useful when a field requires numerous decimals compared to other fields.

## Screenshots (if appropriate):
<img width="581" height="106" alt="image" src="https://github.com/user-attachments/assets/0b0f50e5-f7c9-4aef-8957-c497954afc37" />
<img width="320" height="376" alt="image" src="https://github.com/user-attachments/assets/f2d15991-106d-42a5-9acd-2736afdf2729" />
