### PR TITLE
fix(central): Ensure only valid pending reason are taken into account to display or not the warning message

### DIFF
--- a/src/Central.php
+++ b/src/Central.php
@@ -584,7 +584,7 @@ class Central extends CommonGLPI
             $notification = new Notification();
             if (
                 Config::getConfigurationValue('core', 'use_notifications')
-                && countElementsInTable('glpi_pendingreasons_items') > 0
+                && countElementsInTable('glpi_pendingreasons_items', ['pendingreasons_id' => ['>', 0]]) > 0
                 && !count($notification->find([
                     'itemtype' => 'Ticket',
                     'event'     => 'auto_reminder',


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes #21603

Currently, we display a warning message if pending reasons have been defined but notifications are not enabled.
However, the current system defines "empty" pending reasons when the user puts the ticket on pending using the toggle at the bottom of the followup or task form.
This fix strengthens the conditions for displaying the warning so that the reasons for waiting are considered "valid."