### PR TITLE
fix: php8.5 null array warning

### DIFF
--- a/phpunit/functional/TicketTest.php
+++ b/phpunit/functional/TicketTest.php
@@ -6862,7 +6862,7 @@ HTML,
             ],
         ];
 
-        foreach ([null => null, 'post-only' => 'postonly', 'tech' => 'tech'] as $login => $pass) {
+        foreach (['' => null, 'post-only' => 'postonly', 'tech' => 'tech'] as $login => $pass) {
             // usage of `check_view_rights` should produce the same result whoever is logged-in (used for notifications)
             yield [
                 'login'              => $login,


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

- It fix warning thrown from ci in php 8.5

This PR extends the previous https://github.com/glpi-project/glpi/pull/21769

## Failing CI

10: https://github.com/glpi-project/glpi/actions/runs/19229431059/job/54965416102#step:11:146

11: https://github.com/glpi-project/glpi/actions/runs/19229224074/job/54963733483#step:11:556

