### PR TITLE
Set missing type in printerlogs table; closes #21822

### DIFF
--- a/install/migrations/update_11.0.2_to_11.0.3/printerlogs.php
+++ b/install/migrations/update_11.0.2_to_11.0.3/printerlogs.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+/**
+ * @var DBmysql $DB
+ */
+$DB->update('glpi_printerlogs', ['itemtype' => 'Printer'], ['itemtype' => '']);


### PR DESCRIPTION
Column is added in migration to v11; but no data is set; while it's required to be correctly used from the UI.

Migration won't run if database is already up-to-date because empty.sql is not changed - but that should not cause any problem IRL.