### PR TITLE
fix(forms): handle select2 lazy loading when duplicating questions in section

### DIFF
--- a/js/modules/Forms/EditorController.js
+++ b/js/modules/Forms/EditorController.js
@@ -1544,7 +1544,7 @@ export class GlpiFormEditorController
         // Look for select2 to init
         copy.find("select").each(function() {
             let selected_values;
-            if (is_from_duplicate_action) {
+            if (is_from_duplicate_action && $(this).hasClass("select2-hidden-accessible")) {
                 // Retrieve selected values
                 selected_values = $(this).select2("data");
 
@@ -1593,10 +1593,14 @@ export class GlpiFormEditorController
                     && config !== undefined
                 ) {
                     config.field_id = new_id;
-                    select2_to_init.push(config);
+                    window.select2_configs[new_id] = config;
 
-                    if (selected_values) {
-                        select2_values_to_restore[new_id] = selected_values;
+                    if ($(this).attr('data-glpi-loaded') !== 'false') {
+                        select2_to_init.push(config);
+
+                        if (selected_values) {
+                            select2_values_to_restore[new_id] = selected_values;
+                        }
                     }
                 }
             }

--- a/tests/cypress/e2e/form/editor/editor.cy.js
+++ b/tests/cypress/e2e/form/editor/editor.cy.js
@@ -331,6 +331,9 @@ describe ('Form editor', () => {
         cy.addQuestion("Second question");
         cy.addQuestion("Third question");
 
+        // Set question types to "Item" to test select2 duplication
+        cy.findAllByRole('option', {'name': 'New question'}).eq(-1).changeQuestionType('Item');
+
         // Duplicate second section
         cy.get('@sections').eq(1).as('second_section');
         cy.get('@second_section')
@@ -345,8 +348,29 @@ describe ('Form editor', () => {
         cy.findAllByRole('region', {'name': 'Section details'}).as('sections_details');
         cy.get('@sections_details').should('have.length', 3);
 
-        // Section 2 and 3 should be identical
-        [1, 2].forEach((section_index) => {
+        // Duplicate the third section (trying duplication of questions with lazy loaded select2)
+        cy.get('@sections').eq(2).as('third_section');
+        cy.get('@third_section')
+            .findByRole('button', {'name': "More actions"})
+            .click()
+        ;
+        cy.findByRole('button', {'name': "Duplicate section"}).click();
+
+        // There should now be 4 sections
+        cy.findAllByRole('region', {'name': 'Form section'}).as('sections_containers');
+        cy.findAllByRole('region', {'name': 'Section details'}).as('sections_details');
+        cy.get('@sections_details').should('have.length', 4);
+
+        // Check lazy loaded select2 in duplicated section
+        cy.get('@sections_containers').eq(-1).as('fourth_section');
+        cy.get('@fourth_section').findByRole('option', { 'name': 'Third question' }).within(() => {
+            cy.getDropdownByLabelText('Select an item').should('exist');
+            cy.findByRole('region', { 'name': 'Question details' }).click();
+            cy.getDropdownByLabelText('Question type').should('exist');
+        });
+
+        // Section 2, 3 and 4 should be identical
+        [1, 2, 3].forEach((section_index) => {
             cy.get('@sections_containers').eq(section_index).as('section_container');
             cy.get('@sections_details').eq(section_index).as('section_detail');
 


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

When duplicating a form section containing questions with lazy-loaded select2 dropdowns, an error prevented the section from being duplicated.
The error occurred because the logic expected the select2s to be initialized, but they are not initialized until the question has been focused. This is why we do not encounter the problem when duplicating a question directly.

The fix takes lazy loading into account and ensures that this behavior is maintained on duplicated questions.