### PR TITLE
fix(forms): Fixed CONTAINS and NOT_CONTAINS value operators in string-based condition handlers

### DIFF
--- a/src/Glpi/Form/Condition/ConditionHandler/ConditionHandlerInterface.php
+++ b/src/Glpi/Form/Condition/ConditionHandler/ConditionHandlerInterface.php
@@ -66,6 +66,13 @@ interface ConditionHandlerInterface
      */
     public function getTemplateParameters(ConditionData $condition): array;
 
+    /**
+     * Applies the given value operator to the two given values.
+     * @param mixed         $a        Input value
+     * @param ValueOperator $operator The operator to apply
+     * @param mixed         $b        Condition value
+     * @return bool Result of the operation
+     */
     public function applyValueOperator(
         mixed $a,
         ValueOperator $operator,

--- a/src/Glpi/Form/Condition/ConditionHandler/StringConditionHandler.php
+++ b/src/Glpi/Form/Condition/ConditionHandler/StringConditionHandler.php
@@ -94,8 +94,8 @@ class StringConditionHandler implements ConditionHandlerInterface
         return match ($operator) {
             ValueOperator::EQUALS          => $a === $b,
             ValueOperator::NOT_EQUALS      => $a !== $b,
-            ValueOperator::CONTAINS        => str_contains($b, $a),
-            ValueOperator::NOT_CONTAINS    => !str_contains($b, $a),
+            ValueOperator::CONTAINS        => str_contains($a, $b),
+            ValueOperator::NOT_CONTAINS    => !str_contains($a, $b),
 
             // Length comparison operators
             ValueOperator::LENGTH_GREATER_THAN           => mb_strlen($a) > intval($b),

--- a/tests/functional/Glpi/Form/Condition/ConditionHandler/RichTextConditionHandlerTest.php
+++ b/tests/functional/Glpi/Form/Condition/ConditionHandler/RichTextConditionHandlerTest.php
@@ -137,14 +137,14 @@ final class RichTextConditionHandlerTest extends AbstractConditionHandler
             'question_type'      => $type,
             'condition_operator' => ValueOperator::CONTAINS,
             'condition_value'    => "Exact answer",
-            'submitted_answer'   => "<p>Exact</p>",
+            'submitted_answer'   => "<p>Exact answer</p>",
             'expected_result'    => true,
         ];
         yield "Contains check - case 3 for $type" => [
             'question_type'      => $type,
             'condition_operator' => ValueOperator::CONTAINS,
-            'condition_value'    => "Exact answer",
-            'submitted_answer'   => "<p>answer</p>",
+            'condition_value'    => "answer",
+            'submitted_answer'   => "<p>Exact answer</p>",
             'expected_result'    => true,
         ];
         yield "Contains check - case 4 for $type" => [
@@ -174,14 +174,14 @@ final class RichTextConditionHandlerTest extends AbstractConditionHandler
             'question_type'      => $type,
             'condition_operator' => ValueOperator::NOT_CONTAINS,
             'condition_value'    => "Exact answer",
-            'submitted_answer'   => "<p>Exact</p>",
+            'submitted_answer'   => "<p>Exact answer</p>",
             'expected_result'    => false,
         ];
         yield "Not contains check - case 3 for $type" => [
             'question_type'      => $type,
             'condition_operator' => ValueOperator::NOT_CONTAINS,
-            'condition_value'    => "Exact answer",
-            'submitted_answer'   => "<p>answer</p>",
+            'condition_value'    => "answer",
+            'submitted_answer'   => "<p>Exact answer</p>",
             'expected_result'    => false,
         ];
         yield "Not contains check - case 4 for $type" => [

--- a/tests/functional/Glpi/Form/Condition/ConditionHandler/StringConditionHandlerTest.php
+++ b/tests/functional/Glpi/Form/Condition/ConditionHandler/StringConditionHandlerTest.php
@@ -141,15 +141,15 @@ final class StringConditionHandlerTest extends AbstractConditionHandler
             yield "Contains check - case 2 for $type" => [
                 'question_type'      => $type,
                 'condition_operator' => ValueOperator::CONTAINS,
-                'condition_value'    => "Exact answer",
-                'submitted_answer'   => "Exact",
+                'condition_value'    => "Exact",
+                'submitted_answer'   => "Exact answer",
                 'expected_result'    => true,
             ];
             yield "Contains check - case 3 for $type" => [
                 'question_type'      => $type,
                 'condition_operator' => ValueOperator::CONTAINS,
-                'condition_value'    => "Exact answer",
-                'submitted_answer'   => "answer",
+                'condition_value'    => "answer",
+                'submitted_answer'   => "Exact answer",
                 'expected_result'    => true,
             ];
             yield "Contains check - case 4 for $type" => [
@@ -162,8 +162,8 @@ final class StringConditionHandlerTest extends AbstractConditionHandler
             yield "Contains check - case 5 for $type" => [
                 'question_type'      => $type,
                 'condition_operator' => ValueOperator::CONTAINS,
-                'condition_value'    => "Exact answer",
-                'submitted_answer'   => "exact ANSWER",
+                'condition_value'    => "exact ANSWER",
+                'submitted_answer'   => "Exact answer",
                 'expected_result'    => true,
             ];
 
@@ -178,15 +178,15 @@ final class StringConditionHandlerTest extends AbstractConditionHandler
             yield "Not contains check - case 2 for $type" => [
                 'question_type'      => $type,
                 'condition_operator' => ValueOperator::NOT_CONTAINS,
-                'condition_value'    => "Exact answer",
-                'submitted_answer'   => "Exact",
+                'condition_value'    => "Exact",
+                'submitted_answer'   => "Exact answer",
                 'expected_result'    => false,
             ];
             yield "Not contains check - case 3 for $type" => [
                 'question_type'      => $type,
                 'condition_operator' => ValueOperator::NOT_CONTAINS,
-                'condition_value'    => "Exact answer",
-                'submitted_answer'   => "answer",
+                'condition_value'    => "answer",
+                'submitted_answer'   => "Exact answer",
                 'expected_result'    => false,
             ];
             yield "Not contains check - case 4 for $type" => [
@@ -199,8 +199,8 @@ final class StringConditionHandlerTest extends AbstractConditionHandler
             yield "Not contains check - case 5 for $type" => [
                 'question_type'      => $type,
                 'condition_operator' => ValueOperator::NOT_CONTAINS,
-                'condition_value'    => "Exact answer",
-                'submitted_answer'   => "exact ANSWER",
+                'condition_value'    => "exact ANSWER",
+                'submitted_answer'   => "Exact answer",
                 'expected_result'    => false,
             ];
 


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

This pull request updates the logic for string and rich text condition handlers to correctly apply the "contains" and "not contains" operators, and adjusts the associated tests to match the new behavior. The main change ensures that the submitted answer is checked for containing the condition value, rather than the reverse, improving the accuracy of condition evaluations.