### PR TITLE
Fix template selection for simplified interface profiles

### DIFF
--- a/templates/pages/admin/profile/assistance_simple.html.twig
+++ b/templates/pages/admin/profile/assistance_simple.html.twig
@@ -39,7 +39,8 @@
     {{ fields.smallTitle(__('ITIL Templates')) }}
     {{ fields.dropdownField('TicketTemplate', 'tickettemplates_id', item.fields['tickettemplates_id'], __('Default ticket template'), {
         full_width: true,
-        condition: {entities_id: 0}|merge(is_multi_entities_mode() ? {is_recursive: 1} : {}),
+        entity: 0,
+        condition: {}|merge(is_multi_entities_mode() ? {is_recursive: 1} : {}),
         addicon: is_root_entity_active
     }) }}
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Fixes #21378
~Since Forms have completely replaced direct tickets for simplified interface users, there seems to be no need to have the default template option in the profile form.~

Edit: dropdown was left in place and fixed