### PR TITLE
ini_set restrictions should not be fatal most of the time

### DIFF
--- a/front/css.php
+++ b/front/css.php
@@ -38,14 +38,13 @@ require_once(__DIR__ . '/_check_webserver_config.php');
 use Glpi\Application\Environment;
 use Glpi\UI\ThemeManager;
 
-use function Safe\ini_set;
 use function Safe\preg_match;
 
 if (preg_match('~^css/glpi(\.scss)?$~', $_GET['file'] ?? '') === 1) {
     // Ensure to have enough memory to not reach memory limit.
     $max_memory = Html::MAIN_SCSS_COMPILATION_REQUIRED_MEMORY;
     if (Toolbox::getMemoryLimit() < ($max_memory * 1024 * 1024)) {
-        ini_set('memory_limit', sprintf('%dM', $max_memory));
+        Toolbox::safeIniSet('memory_limit', sprintf('%dM', $max_memory));
     }
 }
 

--- a/src/Glpi/Agent/Communication/AbstractRequest.php
+++ b/src/Glpi/Agent/Communication/AbstractRequest.php
@@ -61,7 +61,6 @@ use function Safe\gzinflate;
 use function Safe\gzuncompress;
 use function Safe\iconv;
 use function Safe\ini_get;
-use function Safe\ini_set;
 use function Safe\json_decode;
 use function Safe\json_encode;
 use function Safe\preg_match;
@@ -297,10 +296,10 @@ abstract class AbstractRequest
         $memory_limit       = (int) Toolbox::getMemoryLimit();
         $max_execution_time = ini_get('max_execution_time');
         if ($memory_limit > 0 && $memory_limit < (1024 * 1024 * 1024)) {
-            ini_set('memory_limit', '1024M');
+            Toolbox::safeIniSet('memory_limit', '1024M');
         }
         if ($max_execution_time > 0 && $max_execution_time < 300) {
-            ini_set('max_execution_time', '300');
+            Toolbox::safeIniSet('max_execution_time', '300');
         }
 
         if ($this->compression !== self::COMPRESS_NONE) {

--- a/src/Glpi/Api/HL/Middleware/CookieAuthMiddleware.php
+++ b/src/Glpi/Api/HL/Middleware/CookieAuthMiddleware.php
@@ -37,6 +37,7 @@ namespace Glpi\Api\HL\Middleware;
 
 use Session;
 
+use function Safe\ini_get;
 use function Safe\ini_set;
 
 class CookieAuthMiddleware extends AbstractMiddleware implements AuthMiddlewareInterface
@@ -50,7 +51,10 @@ class CookieAuthMiddleware extends AbstractMiddleware implements AuthMiddlewareI
         }
         // User could be authenticated by a cookie
         // Need to use cookies for session and start it manually
-        ini_set('session.use_cookies', '1');
+        $use_cookies = filter_var(ini_get('session.use_cookies'), FILTER_VALIDATE_BOOLEAN);
+        if ($use_cookies !== true) {
+            ini_set('session.use_cookies', '1');
+        }
         Session::start();
 
         if (($user_id = Session::getLoginUserID()) !== false) {

--- a/src/Glpi/Console/Build/CompileScssCommand.php
+++ b/src/Glpi/Console/Build/CompileScssCommand.php
@@ -48,7 +48,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Toolbox;
 
 use function Safe\file_put_contents;
-use function Safe\ini_set;
 use function Safe\mkdir;
 use function Safe\preg_match;
 use function Safe\preg_replace;
@@ -108,7 +107,7 @@ class CompileScssCommand extends Command
         // Ensure to have enough memory to not reach memory limit.
         $max_memory = Html::MAIN_SCSS_COMPILATION_REQUIRED_MEMORY;
         if (Toolbox::getMemoryLimit() < ($max_memory * 1024 * 1024)) {
-            ini_set('memory_limit', sprintf('%dM', $max_memory));
+            Toolbox::safeIniSet('memory_limit', sprintf('%dM', $max_memory));
         }
     }
 

--- a/src/Glpi/Console/Diagnostic/CheckSourceCodeIntegrityCommand.php
+++ b/src/Glpi/Console/Diagnostic/CheckSourceCodeIntegrityCommand.php
@@ -49,8 +49,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Toolbox;
 
-use function Safe\ini_set;
-
 class CheckSourceCodeIntegrityCommand extends AbstractCommand
 {
     protected $requires_db = false;
@@ -64,7 +62,7 @@ class CheckSourceCodeIntegrityCommand extends AbstractCommand
             // Ensure to have enough memory to not reach memory limit.
             $max_memory = 512;
             if (Toolbox::getMemoryLimit() < ($max_memory * 1024 * 1024)) {
-                ini_set('memory_limit', sprintf('%dM', $max_memory));
+                Toolbox::safeIniSet('memory_limit', sprintf('%dM', $max_memory));
             }
         }
     }

--- a/src/Glpi/Controller/Traits/AsyncOperationProgressControllerTrait.php
+++ b/src/Glpi/Controller/Traits/AsyncOperationProgressControllerTrait.php
@@ -36,9 +36,9 @@ namespace Glpi\Controller\Traits;
 
 use Glpi\Progress\StoredProgressIndicator;
 use Symfony\Component\HttpFoundation\StreamedResponse;
+use Toolbox;
 
 use function Safe\fastcgi_finish_request;
-use function Safe\ini_set;
 use function Safe\ob_end_clean;
 use function Safe\session_write_close;
 
@@ -53,7 +53,7 @@ trait AsyncOperationProgressControllerTrait
         StoredProgressIndicator $progress_indicator,
         callable $operation_callable
     ): StreamedResponse {
-        ini_set('max_execution_time', '300'); // Allow up to 5 minutes to prevent unexpected timeout
+        Toolbox::safeIniSet('max_execution_time', '300'); // Allow up to 5 minutes to prevent unexpected timeout
         session_write_close(); // Prevent the session file lock to block the progress check requests
 
         // Be sure to disable the output buffering.

--- a/src/Glpi/Error/ErrorHandler.php
+++ b/src/Glpi/Error/ErrorHandler.php
@@ -44,8 +44,7 @@ use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 use Symfony\Component\ErrorHandler\ErrorHandler as BaseErrorHandler;
 use Throwable;
-
-use function Safe\ini_set;
+use Toolbox;
 
 /**
  * @phpstan-ignore class.extendsFinalByPhpDoc
@@ -296,7 +295,7 @@ final class ErrorHandler extends BaseErrorHandler
      */
     private function disableNativeErrorDisplaying(): void
     {
-        ini_set('display_errors', 'Off');
+        Toolbox::safeIniSet('display_errors', 'Off');
     }
 
     private static function cleanPaths(string $message): string

--- a/src/Glpi/Kernel/Listener/PostBootListener/SessionStart.php
+++ b/src/Glpi/Kernel/Listener/PostBootListener/SessionStart.php
@@ -45,6 +45,7 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Request;
 
+use function Safe\ini_get;
 use function Safe\ini_set;
 
 /**
@@ -106,7 +107,10 @@ class SessionStart implements EventSubscriberInterface
             if ($this->php_sapi !== 'cli') {
                 // Stateless endpoints will often have to start their own PHP session (based on a token for instance).
                 // Be sure to not use cookies defined in the request or to send a cookie in the response.
-                ini_set('session.use_cookies', 0);
+                $use_cookies = filter_var(ini_get('session.use_cookies'), FILTER_VALIDATE_BOOLEAN);
+                if ($use_cookies !== false) {
+                    ini_set('session.use_cookies', '0');
+                }
             }
 
             // The session base vars must always be defined.

--- a/src/Glpi/Marketplace/Controller.php
+++ b/src/Glpi/Marketplace/Controller.php
@@ -52,7 +52,6 @@ use wapmorgan\UnifiedArchive\Drivers\Basic\BasicDriver;
 use wapmorgan\UnifiedArchive\Exceptions\ArchiveExtractionException;
 use wapmorgan\UnifiedArchive\Formats;
 
-use function Safe\ini_set;
 use function Safe\ob_end_clean;
 use function Safe\ob_start;
 use function Safe\parse_url;
@@ -226,7 +225,7 @@ class Controller extends CommonGLPI
         // Upgrade memory limit to 512M, which should be enough.
         $memory_limit = (int) Toolbox::getMemoryLimit();
         if ($memory_limit > 0 && $memory_limit < (512 * 1024 * 1024)) {
-            ini_set('memory_limit', '512M');
+            Toolbox::safeIniSet('memory_limit', '512M');
         }
 
         // clean dir in case of update

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -60,6 +60,7 @@ use Safe\Exceptions\CurlException;
 use Safe\Exceptions\ErrorfuncException;
 use Safe\Exceptions\FilesystemException;
 use Safe\Exceptions\ImageException;
+use Safe\Exceptions\InfoException;
 use Safe\Exceptions\JsonException;
 use Safe\Exceptions\PcreException;
 use Safe\Exceptions\UrlException;
@@ -97,6 +98,7 @@ use function Safe\imagepng;
 use function Safe\imagesavealpha;
 use function Safe\imagewebp;
 use function Safe\ini_get;
+use function Safe\ini_set;
 use function Safe\json_decode;
 use function Safe\json_encode;
 use function Safe\mb_convert_encoding;
@@ -3462,5 +3464,25 @@ class Toolbox
     public static function cleanPaths(string $message): string
     {
         return ErrorUtils::cleanPaths($message);
+    }
+
+    public static function safeIniSet(
+        string $name,
+        string|int $value,
+        string $loglvl = LogLevel::WARNING
+    ): void {
+        try {
+            ini_set($name, $value);
+        } catch (InfoException $e) {
+            self::log(
+                $loglvl,
+                [sprintf(
+                    'Unable to set `%s` to `%s`. This may be caused by a `php_admin_flag` or a `php_admin_value` directive in your web server configuration. Try to use `php_flag` or `php_value` instead. Error is: %s',
+                    $name,
+                    $value,
+                    $e->getMessage()
+                )],
+            );
+        }
     }
 }


### PR DESCRIPTION
closes #21357

When `ini_set` fails to set a memory limit or a timeout, user will deal with another error if something goes wrong; therefore `ini_set` restrictions should not be fatal.

For now, I've replaced all occurrences but maybe session cookies related ones (at least) should still be fatal unless setting is correctly set in `php.ini`?