### PR TITLE
Do not sort form access policies by active/inactive

### DIFF
--- a/src/Glpi/Form/AccessControl/FormAccessControlManager.php
+++ b/src/Glpi/Form/AccessControl/FormAccessControlManager.php
@@ -149,17 +149,14 @@ final class FormAccessControlManager
      */
     public function sortAccessControls(array $controls): array
     {
-        // Sort by is_active + strategy weight
-        usort($controls, function (FormAccessControl $a, FormAccessControl $b) {
-            if ($a->fields['is_active'] && !$b->fields['is_active']) {
-                return -1;
-            } elseif (!$a->fields['is_active'] && $b->fields['is_active']) {
-                return 1;
-            } else {
-                $strategy = $a->getStrategy();
-                return $strategy->getWeight() <=> $strategy->getWeight();
-            }
-        });
+        // Sort by strategy weight
+        usort(
+            $controls,
+            fn(
+                FormAccessControl $a,
+                FormAccessControl $b,
+            ): int => $a->getStrategy()->getWeight() <=> $b->getStrategy()->getWeight()
+        );
 
         return $controls;
     }

--- a/tests/functional/Glpi/Form/AccessControl/FormAccessControlManagerTest.php
+++ b/tests/functional/Glpi/Form/AccessControl/FormAccessControlManagerTest.php
@@ -151,7 +151,8 @@ final class FormAccessControlManagerTest extends DbTestCase
                 static::getInactiveAllowListAccessControl(),
                 static::getActiveDirectAccessControl(),
             ],
-            'expected' => [DirectAccess::class, AllowList::class],
+            // Active status no longer has an impact on the sort result
+            'expected' => [AllowList::class, DirectAccess::class],
         ];
         yield 'Form with two active access controls' => [
             'access_controls' => [


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

I've initially sorted the form access policies by active/inactive, which mean active policies are always at the top:

<img width="1149" height="444" alt="image" src="https://github.com/user-attachments/assets/d9b70133-7eda-4a87-af41-e7fef3639d6a" />

<img width="1140" height="440" alt="image" src="https://github.com/user-attachments/assets/09576f59-6142-4f01-9a1c-93d9623f0204" />

In the two screenshots above, you can see that the first policy is not the same.

This has been confusing for some users, I've been told by multiple people that they would prefer the settings to always be in the same order here.

So now the order will always be "Allow list" -> "Direct access", even if only "Direct access" is active:

<img width="1147" height="444" alt="image" src="https://github.com/user-attachments/assets/05b81dec-46c7-4f7a-8e9e-4c4f0b280fc4" />

I'm adding @orthagh as a reviewer to make sure it is OK for him too, as this may be a subjective change.
