### PR TITLE
Prevent BC-break on `getAssociatedDocumentsCriteria()` signature

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -7957,12 +7957,17 @@ abstract class CommonITILObject extends CommonDBTM
      * Returns criteria that can be used to get documents related to current instance.
      *
      * @param bool      $bypass_rights  Whether to bypass rights checks (default: false)
-     * @param User|null $user           User for rights checking (default: null = current session rights)
+     * @FIXME uncomment @param User|null $user           User for rights checking (default: null = current session rights)
      *
      * @return array
      */
-    public function getAssociatedDocumentsCriteria($bypass_rights = false, ?User $user = null): array
+    public function getAssociatedDocumentsCriteria($bypass_rights = false/*, ?User $user = null*/): array
     {
+        $user = null;
+        if (func_num_args() == 2) {
+            $user = func_get_arg(1);
+        }
+
         $user_id = $user ? $user->getID() : Session::getLoginUserID();
 
         $task_class = $this->getType() . 'Task';


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

In #21225, the signature of the `CommonITILObject::getAssociatedDocumentsCriteria()` method changed. It introduces a BC-break: overrides signatures must be updated. We should avoid methods signatures changes in bugfixes version. To handle this, the solution is to rely on `func_get_arg()` to get additional params not declared in the method signature.

It fixes the following error:
```
PHP Fatal error:  Declaration of GlpiPlugin\Releases\Release::getAssociatedDocumentsCriteria($bypass_rights = false): array must be compatible with CommonITILObject::getAssociatedDocumentsCriteria($bypass_rights = false, ?User $user = null): array
```