### PR TITLE
check if document category is set

### DIFF
--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -5598,6 +5598,7 @@ class CommonDBTM extends CommonGLPI
                     //TRANS: Default document to files attached to tickets : %d is the ticket id
                     $input2["name"] = addslashes(sprintf(__('Document Ticket %d'), $this->getID()));
                     $input2["tickets_id"] = $this->getID();
+                    $input2['itemtype'] = Ticket::class;
                 }
 
                 if (isset($input['_tag'][$key])) {
@@ -5607,7 +5608,6 @@ class CommonDBTM extends CommonGLPI
 
                 $input2["entities_id"]             = $entities_id;
                 $input2["is_recursive"]            = $is_recursive;
-                $input2["documentcategories_id"]   = $CFG_GLPI["documentcategories_id_forticket"];
                 $input2["_only_if_upload_succeed"] = 1;
                 $input2["_filename"]               = [$file];
                 if (isset($this->input[$prefixUploadName][$key])) {


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

- It fixes !40246
- If a default document category is configured for tickets, it is also applied to documents added to the knowledge base.


- Explanation of the tests :

The tests cover different situations where a document is added in GLPI, in order to verify when the default document category for tickets should be applied.

1. Case: Adding a document to an object other than a Ticket using rich-text drag-and-drop / file selection

Test: testDefaultDocumentCategoryForOtherCommonDBTM()
A document is added to a KnowbaseItem (before and after configuring the setting).
In all situations, documentcategories_id must remain 0.
→ The default document category should not apply to objects other than Ticket/TicketFollowup.

2. Case: Adding a document through the Document form (Document::add)

Test: testDefaultDocumentCategoryFromDocumentForm()
A document is added by passing itemtype=Ticket and items_id=x.
Without a configured default category → the category stays 0.
With a configured default category → documentcategories_id becomes the configured category.
→ If a document is added through the Document form for a Ticket, the default category must be applied.

3. Case: Adding a document during Ticket creation using rich-text drag-and-drop / file selection
Test: testDefaultDocumentCategoryForTicket()
A document is uploaded during ticket creation.
Before configuration → category = 0
After configuration → category = configured category
→ Documents uploaded during Ticket creation must use the configured default category.




