### PR TITLE
Fix(Query): better check before handle WHERE or LEFT_JOIN clause

### DIFF
--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -2961,10 +2961,10 @@ HTML;
                 $where = array_merge($where, $post['condition']['WHERE']);
             } else {
                 foreach ($post['condition'] as $key => $value) {
-                    if (isset($value['LEFT JOIN'])) {
+                    if (is_array($value) && isset($value['LEFT JOIN'])) {
                         $ljoin = $value['LEFT JOIN'];
                     }
-                    if (isset($value['WHERE'])) {
+                    if (is_array($value) && isset($value['WHERE'])) {
                         $where = array_merge($where, $value['WHERE']);
                     } elseif (!is_numeric($key) && !in_array($key, ['AND', 'OR', 'NOT']) && !str_contains($key, '.')) {
                         // Ensure condition contains table name to prevent ambiguity with fields from `glpi_entities` table


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !40248
- It replace https://github.com/glpi-project/glpi/pull/21930

Fix 

```
glpi.CRITICAL: *** Uncaught PHP Exception Error: "Cannot use object of type Glpi\DBAL\QuerySubQuery as array" at
Dropdown.php line 2964 Backtrace : ./src/Dropdown.php:2964 ./ajax/getDropdownValue.php:48
Dropdown::getDropdownValue() ...Glpi/Controller/LegacyFileLoadController.php:64 require()
./vendor/symfony/http-kernel/HttpKernel.php:181 Glpi\Controller\LegacyFileLoadController->__invoke()
./vendor/symfony/http-kernel/HttpKernel.php:76 Symfony\Component\HttpKernel\HttpKernel->handleRaw()
./vendor/symfony/http-kernel/Kernel.php:197 Symfony\Component\HttpKernel\HttpKernel->handle()
./public/index.php:70 Symfony\Component\HttpKernel\Kernel->handle()
```

When attempting to select an asset to associate with a Network Port

<img width="1437" height="637" alt="image" src="https://github.com/user-attachments/assets/6bea616d-df21-4a57-9374-a0026f2e54a5" />


## Screenshots (if appropriate):


