### PR TITLE
Disallow return of a deleted user 

### DIFF
--- a/src/Auth.php
+++ b/src/Auth.php
@@ -663,7 +663,11 @@ class Auth extends CommonGLPI
             case self::API:
                 if ($CFG_GLPI['enable_api_login_external_token']) {
                     $user = new User();
-                    if ($user->getFromDBbyToken($_REQUEST['user_token'], 'api_token')) {
+                    if ($user->getFromDBByCrit([
+                        $user->getTable() . '.api_token' => $_REQUEST['user_token'],
+                        'is_deleted' => 0,
+                        'is_active' => 1,
+                    ])) {
                         $this->user->fields['name'] = $user->fields['name'];
                         return true;
                     }
@@ -819,7 +823,11 @@ class Auth extends CommonGLPI
                 // Used for log when login process failed
                 $login_name                        = $this->user->fields['name'];
                 $this->auth_succeded               = true;
-                $this->user_present                = $this->user->getFromDBbyName($login_name, true);
+                $this->user_present                = $this->user->getFromDBByCrit([
+                    'name' => $login_name,
+                    'is_deleted' => 0,
+                    'is_active' => 1,
+                ]);
                 $this->extauth                     = 1;
                 $user_dn                           = false;
 

--- a/src/Auth.php
+++ b/src/Auth.php
@@ -819,7 +819,7 @@ class Auth extends CommonGLPI
                 // Used for log when login process failed
                 $login_name                        = $this->user->fields['name'];
                 $this->auth_succeded               = true;
-                $this->user_present                = $this->user->getFromDBbyName($login_name);
+                $this->user_present                = $this->user->getFromDBbyName($login_name, true);
                 $this->extauth                     = 1;
                 $user_dn                           = false;
 

--- a/src/AuthMail.php
+++ b/src/AuthMail.php
@@ -332,7 +332,11 @@ TWIG, $twig_params);
             );
             if ($auth->auth_succeded) {
                 $auth->extauth      = 1;
-                $auth->user_present = $auth->user->getFromDBbyName($login);
+                $auth->user_present = $auth->user->getFromDBByCrit([
+                    'name' => $login,
+                    'is_deleted' => 0,
+                    'is_active' => 1,
+                ]);
                 $auth->user->getFromIMAP($mail_method, Toolbox::decodeFromUtf8($login));
                 // Update the authentication method for the current user
                 $auth->user->fields["authtype"] = Auth::MAIL;

--- a/src/User.php
+++ b/src/User.php
@@ -573,21 +573,13 @@ class User extends CommonDBTM implements TreeBrowseInterface
     /**
      * Retrieve a user from the database using its login.
      *
-     * @param string  $name        Login of the user
-     * @param boolean $only_active If true, only return active users (is_deleted=0, is_active=1)
+     * @param string $name Login of the user
      *
      * @return boolean
      */
-    public function getFromDBbyName($name, $only_active = false)
+    public function getFromDBbyName($name)
     {
-        $criteria = ['name' => (string) $name];
-
-        if ($only_active) {
-            $criteria['is_deleted'] = 0;
-            $criteria['is_active'] = 1;
-        }
-
-        return $this->getFromDBByCrit($criteria);
+        return $this->getFromDBByCrit(['name' => (string) $name]);
     }
 
     /**
@@ -807,11 +799,7 @@ class User extends CommonDBTM implements TreeBrowseInterface
             return false;
         }
 
-        return $this->getFromDBByCrit([
-            $this->getTable() . ".$field" => $token,
-            'is_deleted' => 0,
-            'is_active' => 1,
-        ]);
+        return $this->getFromDBByCrit([$this->getTable() . ".$field" => $token]);
     }
 
     public static function unsetUndisclosedFields(&$fields)
@@ -2559,7 +2547,11 @@ class User extends CommonDBTM implements TreeBrowseInterface
         }
 
         // Load data from any potential existing user
-        $this->getFromDBbyName($this->fields['name'], true);
+        $this->getFromDBByCrit([
+            'name' => $this->fields['name'],
+            'is_deleted' => 0,
+            'is_active' => 1,
+        ]);
 
         if (count($a_field) == 0) {
             return true;

--- a/src/User.php
+++ b/src/User.php
@@ -573,13 +573,21 @@ class User extends CommonDBTM implements TreeBrowseInterface
     /**
      * Retrieve a user from the database using its login.
      *
-     * @param string $name Login of the user
+     * @param string  $name        Login of the user
+     * @param boolean $only_active If true, only return active users (is_deleted=0, is_active=1)
      *
      * @return boolean
      */
-    public function getFromDBbyName($name)
+    public function getFromDBbyName($name, $only_active = false)
     {
-        return $this->getFromDBByCrit(['name' => (string) $name]);
+        $criteria = ['name' => (string) $name];
+
+        if ($only_active) {
+            $criteria['is_deleted'] = 0;
+            $criteria['is_active'] = 1;
+        }
+
+        return $this->getFromDBByCrit($criteria);
     }
 
     /**
@@ -799,7 +807,11 @@ class User extends CommonDBTM implements TreeBrowseInterface
             return false;
         }
 
-        return $this->getFromDBByCrit([$this->getTable() . ".$field" => $token]);
+        return $this->getFromDBByCrit([
+            $this->getTable() . ".$field" => $token,
+            'is_deleted' => 0,
+            'is_active' => 1,
+        ]);
     }
 
     public static function unsetUndisclosedFields(&$fields)
@@ -2547,7 +2559,7 @@ class User extends CommonDBTM implements TreeBrowseInterface
         }
 
         // Load data from any potential existing user
-        $this->getFromDBbyName($this->fields['name']);
+        $this->getFromDBbyName($this->fields['name'], true);
 
         if (count($a_field) == 0) {
             return true;

--- a/tests/functional/AuthDeletedUserTest.php
+++ b/tests/functional/AuthDeletedUserTest.php
@@ -57,7 +57,7 @@ class AuthDeletedUserTest extends DbTestCase
 
         $this->ssovariable = $this->createItem(SsoVariable::class, [
             'name' => 'REMOTE_USER',
-            'comment' => 'Test SSO variable'
+            'comment' => 'Test SSO variable',
         ]);
 
         $this->original_ssovariables_id = $CFG_GLPI["ssovariables_id"] ?? null;
@@ -103,7 +103,7 @@ class AuthDeletedUserTest extends DbTestCase
         Session::destroy();
 
         $this->updateItem(User::class, $user->getID(), [
-            'is_deleted' => 1
+            'is_deleted' => 1,
         ]);
 
         $_SERVER['REMOTE_USER'] = $username;
@@ -131,7 +131,7 @@ class AuthDeletedUserTest extends DbTestCase
         ]);
 
         $this->updateItem(User::class, $first_user->getID(), [
-            'is_deleted' => 1
+            'is_deleted' => 1,
         ]);
 
         $second_user = $this->createItem(User::class, [

--- a/tests/functional/AuthDeletedUserTest.php
+++ b/tests/functional/AuthDeletedUserTest.php
@@ -1,0 +1,200 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units;
+
+use Auth;
+use DbTestCase;
+use Profile;
+use Session;
+use SsoVariable;
+use User;
+
+/**
+ * Test for SSO authentication with deleted and inactive users
+ */
+class AuthDeletedUserTest extends DbTestCase
+{
+    private $ssovariable;
+    private $original_ssovariables_id;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        global $CFG_GLPI;
+
+        $this->ssovariable = $this->createItem(SsoVariable::class, [
+            'name' => 'REMOTE_USER',
+            'comment' => 'Test SSO variable'
+        ]);
+
+        $this->original_ssovariables_id = $CFG_GLPI["ssovariables_id"] ?? null;
+        $CFG_GLPI["ssovariables_id"] = $this->ssovariable->getID();
+    }
+
+    public function tearDown(): void
+    {
+        global $CFG_GLPI;
+
+        if ($this->original_ssovariables_id !== null) {
+            $CFG_GLPI["ssovariables_id"] = $this->original_ssovariables_id;
+        } else {
+            unset($CFG_GLPI["ssovariables_id"]);
+        }
+
+        if (isset($_SERVER['REMOTE_USER'])) {
+            unset($_SERVER['REMOTE_USER']);
+        }
+
+        parent::tearDown();
+    }
+
+    /**
+     * Test that a deleted user cannot authenticate via SSO
+     */
+    public function testSSOFailsWithDeletedUser()
+    {
+        $this->login();
+
+        $username = 'test_sso_deleted_' . mt_rand();
+        $user = $this->createItem(User::class, [
+            'name' => $username,
+            'authtype' => Auth::EXTERNAL,
+            '_profiles_id' => Profile::getDefault(),
+        ]);
+
+        $_SERVER['REMOTE_USER'] = $username;
+        $auth = new Auth();
+        $result = $auth->login('', '', false);
+        $this->assertTrue($result);
+
+        Session::destroy();
+
+        $this->updateItem(User::class, $user->getID(), [
+            'is_deleted' => 1
+        ]);
+
+        $_SERVER['REMOTE_USER'] = $username;
+        $auth2 = new Auth();
+        $result2 = $auth2->login('', '', false);
+
+        $this->assertFalse($result2);
+        $this->assertFalse(Session::getLoginUserID());
+    }
+
+    /**
+     * Test SSO authentication with deleted and active user with same name
+     */
+    public function testSSOSucceedsWithDeletedAndActiveUserSameName()
+    {
+        $this->login();
+
+        $username = 'user@domain.com';
+
+        $first_user = $this->createItem(User::class, [
+            'name' => $username,
+            'authtype' => Auth::EXTERNAL,
+            'auths_id' => 1,
+            '_profiles_id' => Profile::getDefault(),
+        ]);
+
+        $this->updateItem(User::class, $first_user->getID(), [
+            'is_deleted' => 1
+        ]);
+
+        $second_user = $this->createItem(User::class, [
+            'name' => $username,
+            'authtype' => Auth::EXTERNAL,
+            'auths_id' => 0,
+            '_profiles_id' => Profile::getDefault(),
+        ]);
+
+        $users = getAllDataFromTable(User::getTable(), ['name' => $username]);
+        $this->assertCount(2, $users);
+
+        $deleted_count = 0;
+        $active_count = 0;
+        foreach ($users as $user_data) {
+            if ($user_data['is_deleted'] == 1) {
+                $deleted_count++;
+            } else {
+                $active_count++;
+            }
+        }
+        $this->assertEquals(1, $deleted_count);
+        $this->assertEquals(1, $active_count);
+
+        Session::destroy();
+
+        $_SERVER['REMOTE_USER'] = $username;
+        $auth = new Auth();
+        $result = $auth->login('', '', false);
+
+        $this->assertTrue($result);
+
+        $logged_user_id = Session::getLoginUserID();
+        $this->assertEquals($second_user->getID(), $logged_user_id);
+
+        $logged_user = new User();
+        $logged_user->getFromDB($logged_user_id);
+        $this->assertEquals(0, $logged_user->fields['is_deleted']);
+        $this->assertEquals(1, $logged_user->fields['is_active']);
+    }
+
+    /**
+     * Test that an inactive user cannot authenticate via SSO
+     */
+    public function testSSOFailsWithInactiveUser()
+    {
+        $this->login();
+
+        $username = 'test_sso_inactive_' . mt_rand();
+        $user = $this->createItem(User::class, [
+            'name' => $username,
+            'authtype' => Auth::EXTERNAL,
+            '_profiles_id' => Profile::getDefault(),
+            'is_active' => 0,
+        ]);
+
+        Session::destroy();
+
+        $_SERVER['REMOTE_USER'] = $username;
+        $auth = new Auth();
+        $result = $auth->login('', '', false);
+
+        $this->assertFalse($result);
+        $this->assertFalse(Session::getLoginUserID());
+    }
+}


### PR DESCRIPTION
- It fixes #21896 and #20073

- Here is a brief description of what this PR does :

Added `$only_active` parameter to `User::getFromDBbyName()` to filter on `is_deleted=0` and `is_active=1`. Applied in `getFromSSO()` and `validateLogin()` to prevent `TooManyResultsException` when a deleted and active user share the same name.

Also fixed `getFromDBbyToken()` to filter active users, preventing deleted/inactive users from authenticating via API token.

