### PR TITLE
Do not count linked forms in ticket "Items" tab

### DIFF
--- a/src/CommonItilObject_Item.php
+++ b/src/CommonItilObject_Item.php
@@ -538,7 +538,9 @@ TWIG, $twig_params);
 
             if ($item::class === static::$itemtype_1) {
                 if ($_SESSION['glpishow_count_on_tabs']) {
-                    $nb = static::countForMainItem($item);
+                    $nb = static::countForMainItem($item, [
+                        'itemtype' => $_SESSION["glpiactiveprofile"]["helpdesk_item_type"],
+                    ]);
                 }
                 return static::createTabEntry(_n('Item', 'Items', Session::getPluralNumber()), $nb, $item::class);
             } elseif ($_SESSION['glpishow_count_on_tabs'] && is_subclass_of(static::$itemtype_1, CommonITILObject::class)) {

--- a/tests/abstracts/AbstractCommonItilObject_ItemTest.php
+++ b/tests/abstracts/AbstractCommonItilObject_ItemTest.php
@@ -37,6 +37,7 @@ namespace tests\units;
 use CommonITILObject;
 use CommonItilObject_Item;
 use Computer;
+use Glpi\Form\Form;
 use User;
 
 abstract class AbstractCommonItilObject_ItemTest extends \DbTestCase
@@ -81,6 +82,18 @@ abstract class AbstractCommonItilObject_ItemTest extends \DbTestCase
         $this->assertEquals(
             '<span class="d-flex align-items-center"><i class="ti ti-package me-2"></i>Items <span class="badge glpi-badge">2</span></span>',
             $link->getTabNameForItem($itil_item),
+        );
+
+        // Adding a form should not increase the counter as it should only keep
+        // track assets
+        $this->createItem($this->getTestedClass(), [
+            $itil_itemtype::getForeignKeyField() => $itil_item->getID(),
+            'itemtype' => Form::class,
+            'items_id' => getItemByTypeName(Form::class, 'Request a service', true),
+        ]);
+        $this->assertEquals(
+            'Items 2', // 2 is the value from the last test, no change
+            strip_tags($link->getTabNameForItem($itil_item)),
         );
     }
 


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

When a ticket is created from a form, we link the form with the ticket:

<img width="1746" height="1139" alt="image" src="https://github.com/user-attachments/assets/730e59ad-8586-4157-8512-2be0c4331f06" />

This would increase the counter to the "Items" tab, but the form would not show up inside it.

<img width="1377" height="604" alt="image" src="https://github.com/user-attachments/assets/a94184a3-13e4-4371-9282-509b988b2663" />

I think it make sense for the form to not show up in the tab, because it is meant to contains assets and a form is not an asset.
If you look at the columns being displayed, they don't work for a form object:

<img width="1724" height="344" alt="image" src="https://github.com/user-attachments/assets/94b7bf3a-63d6-43fd-8989-c70625ece5b4" />

With that in mind, it is the counter that is incorrect: it should not count forms.

I've fixed it by applying a filter on `$_SESSION["glpiactiveprofile"]["helpdesk_item_type"]`, which is already what we are doing for the tab content.