### PR TITLE
Fix(AuthLDAP): connection with inactive server

### DIFF
--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -3060,7 +3060,9 @@ class AuthLDAP extends CommonDBTM
      */
     public function connect()
     {
-
+        if ($this->fields['is_active'] != 1) {
+            return false;
+        }
         return $this->connectToServer(
             $this->fields['host'],
             $this->fields['port'],


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !40322

When a user (originally authenticated via LDAP but now linked to an external authentication method, such as SCIM) attempts to log in, GLPI still attempts to synchronize them from the LDAP server, even if that server is disabled in the configuration.

In this scenario, the user was historically created via LDAP and later migrated to SCIM. The LDAP server was simply disabled in GLPI because it is no longer accessible. As a result, during each login attempt, GLPI tries to reach the inactive LDAP server, causing a 1 minute timeout delay before the user is finally authenticated.

More broadly, if a server is disabled, GLPI should not attempt to connect to it at all.

```
glpiphplog.WARNING:   *** PHP User Warning (512): Unable to bind to LDAP server `*****` with RDN `*****`
error: Can't contact LDAP server (-1) in .../src/AuthLDAP.php at line 3190
  Backtrace :
  src/AuthLDAP.php:3190                              trigger_error()
  src/AuthLDAP.php:3048                              AuthLDAP::connectToServer()
  src/User.php:1524                                  AuthLDAP->connect()
  src/User.php:1013                                  User->syncLdapPhoto()
  src/CommonDBTM.php:1616                            User->prepareInputForUpdate()
  src/User.php:6019                                  CommonDBTM->update()
  src/Auth.php:1094                                  User->getAuthToken()
  marketplace/oauthsso/src/LoginFeature.php:271      Auth->login()
  ...e/oauthsso/front/authorization.callback.php:118 GlpiPlugin\Oauthsso\LoginFeature::handleAuthorizationCallback()
```

## Screenshots (if appropriate):


