### PR TITLE
add(plugin): Possibility to load all translation for a plugin

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -646,10 +646,25 @@ class Plugin extends CommonDBTM
      */
     public static function loadAllLang(string $plugin_key): void
     {
+        $available_languages = self::getAvailableLanguages($plugin_key);
+
+        foreach ($available_languages as $language) {
+            self::loadLang($plugin_key, $language);
+        }
+    }
+
+    /**
+     * Return available langcode for a plugin
+     *
+     * @param string $plugin_key
+     * @return array
+     */
+    public static function getAvailableLanguages(string $plugin_key): array
+    {
         $plugin_directory = self::getPhpDir($plugin_key);
         $locales_dir = $plugin_directory . '/locales/';
         if (!is_dir($locales_dir)) {
-            return;
+            return [];
         }
 
         // Scan locale files and extract available language codes
@@ -660,15 +675,13 @@ class Plugin extends CommonDBTM
             }
 
             // Extract language code from files like fr_FR.mo, en_GB.mo, ...
-            if (preg_match('/^([a-z]{2}_[A-Z]{2})\.(mo)$/', $locale_file, $matches)) {
+            if (preg_match('/^([a-z]{2}_[A-Z]{2})\.mo$/', $locale_file, $matches)) {
                 $language_code = $matches[1];
-                $available_languages[$language_code] = $language_code;
+                $available_languages[] = $language_code;
             }
         }
 
-        foreach ($available_languages as $language) {
-            self::loadLang($plugin_key, $language);
-        }
+        return $available_languages;
     }
 
     /**

--- a/tests/functional/PluginTest.php
+++ b/tests/functional/PluginTest.php
@@ -551,6 +551,13 @@ namespace tests\units {
             );
         }
 
+        public function testGetAvailablePluginsLanguages(): void
+        {
+            $plugin = 'tester';
+            $availableLanguages = Plugin::getAvailableLanguages($plugin);
+            $this->assertArraysEqualRecursive(['en_GB', 'fr_FR'], $availableLanguages);
+        }
+
         public function testLoadPluginLocales(): void
         {
             global $TRANSLATE;
@@ -561,9 +568,9 @@ namespace tests\units {
             $translation = $TRANSLATE->translate($string, $plugin, 'fr_FR');
             $this->assertEquals($string, $translation); // Translation not here
 
-            Plugin::loadAllLangs($plugin);
+            Plugin::loadAllLang($plugin);
             $translation = $TRANSLATE->translate($string, $plugin, 'fr_FR');
-            $this->assertEquals('ma traduction de plugin', $translation); // Translation not here
+            $this->assertEquals('ma traduction de plugin', $translation);
         }
 
         /**


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description
In some case a plugin could require to have his translation loaded so he can do some specific logic with them.

i.e: sending the translation to an external service, or listing the available langcode in the plugin page