### PR TITLE
fix(kb): prevent interaction with disabled service catalog config fields

### DIFF
--- a/templates/pages/admin/form/service_catalog_tab.html.twig
+++ b/templates/pages/admin/form/service_catalog_tab.html.twig
@@ -34,23 +34,23 @@
 
 <form method="POST" action="{{ item.getFormURL() }}" data-submit-once>
     <div class="py-2 px-3 container-narrow ms-0">
+        <h2 class="d-flex align-items-center">
+            <i class="{{ icon }} me-2"></i>
+            {{ __("Service catalog configuration") }}
+            {% if item.isField('show_in_service_catalog') %}
+                <label class="form-check mb-0 ms-auto form-switch">
+                    <input type="hidden" value="0" name="show_in_service_catalog">
+                    <input aria-label="{{ __(" Active") }}" class="form-check-input" type="checkbox"
+                        name="show_in_service_catalog" value="1"
+                        onchange="$('[data-service-catalog-config]').css({'opacity': this.checked ? 1 : 0.5, 'pointer-events': this.checked ? 'auto' : 'none'})"
+                        {{ item.fields.show_in_service_catalog == true ? "checked" : "" }}
+                    >
+                </label>
+            {% endif %}
+        </h2>
         <section data-service-catalog-config
-            style="{{ item.fields.show_in_service_catalog|default(true) ? "" : "opacity: 0.5" }}"
+            style="{{ item.fields.show_in_service_catalog|default(true) ? '' : 'opacity: 0.5; pointer-events: none;' }}"
         >
-            <h2 class="d-flex align-items-center">
-                <i class="{{ icon }} me-2"></i>
-                {{ __("Service catalog configuration") }}
-                {% if item.isField('show_in_service_catalog') %}
-                    <label class="form-check mb-0 ms-auto form-switch">
-                        <input type="hidden" value="0" name="show_in_service_catalog">
-                        <input aria-label="{{ __(" Active") }}" class="form-check-input" type="checkbox"
-                            name="show_in_service_catalog" value="1"
-                            onchange="$('[data-service-catalog-config]').css('opacity', this.checked ? 1 : 0.5)"
-                            {{ item.fields.show_in_service_catalog == true ? "checked" : "" }}
-                        >
-                    </label>
-                {% endif %}
-            </h2>
             <div class="row">
                 <div class="col-lg-10 col-12">
                     {{ fields.textareaField(

--- a/tests/cypress/e2e/form/service_catalog/service_catalog_tab.cy.js
+++ b/tests/cypress/e2e/form/service_catalog/service_catalog_tab.cy.js
@@ -85,8 +85,17 @@ describe('Service catalog tab', () => {
         // Check that the service catalog configuration isn't active by default
         cy.findByRole('checkbox', {'name': 'Active'}).should('not.be.checked');
 
+        // Verify that content is not interactable when toggle is disabled
+        cy.get('[data-service-catalog-config]').should('have.css', 'pointer-events', 'none');
+        cy.get('[data-service-catalog-config]').should('have.css', 'opacity', '0.5');
+
         // Set values
         cy.findByRole('checkbox', {'name': 'Active'}).check();
+
+        // Verify that content becomes interactable when toggle is enabled
+        cy.get('[data-service-catalog-config]').should('have.css', 'pointer-events', 'auto');
+        cy.get('[data-service-catalog-config]').should('have.css', 'opacity', '1');
+
         cy.findByLabelText("Description").awaitTinyMCE().type('My description');
         cy.getDropdownByLabelText('Category').selectDropdownValue(category_dropdown_value);
         cy.findByRole('checkbox', {'name': 'Pin to top of the service catalog'}).check();


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

- It fixes #21948 

When the service catalog toggle is unchecked, form fields should not be interactable.
This PR adds pointer-events: none to the configuration section when disabled, while keeping the toggle itself clickable.

Also adds Cypress tests to verify that:
- Content becomes non-interactable when toggle is disabled for KnowbaseItems
- Content becomes interactable again when toggle is re-enabled
