### PR TITLE
Properly handle empty path in plugins URLs

### DIFF
--- a/src/Glpi/Http/Firewall.php
+++ b/src/Glpi/Http/Firewall.php
@@ -178,7 +178,7 @@ final class Firewall
         if (preg_match(Plugin::PLUGIN_RESOURCE_PATTERN, $path, $path_matches) === 1) {
             return $this->computeFallbackStrategyForPlugin(
                 $path_matches['plugin_key'],
-                $path_matches['plugin_resource']
+                $path_matches['plugin_resource'] ?: '/'
             );
         }
 

--- a/src/Glpi/Http/SessionManager.php
+++ b/src/Glpi/Http/SessionManager.php
@@ -96,7 +96,7 @@ class SessionManager
         $path_matches = [];
         if (preg_match(Plugin::PLUGIN_RESOURCE_PATTERN, $path, $path_matches) === 1) {
             $plugin_key      = $path_matches['plugin_key'];
-            $plugin_resource = $path_matches['plugin_resource'];
+            $plugin_resource = $path_matches['plugin_resource'] ?: '/';
 
             foreach (self::$plugins_statelass_paths[$plugin_key] ?? [] as $pattern) {
                 if (preg_match($pattern, $plugin_resource) === 1) {

--- a/src/Glpi/Kernel/Listener/RequestListener/PluginsRouterListener.php
+++ b/src/Glpi/Kernel/Listener/RequestListener/PluginsRouterListener.php
@@ -93,7 +93,14 @@ final readonly class PluginsRouterListener implements EventSubscriberInterface
         $router = $this->plugin_container->get('glpi_plugin_router');
 
         try {
-            $matches = $router->matchRequest($request);
+            $request_to_match = $request;
+            if ($route_matches['plugin_resource'] === '') {
+                // Append `/` to the requested path, to be able to match routes attached to the `/` path.
+                $server = $request->server->all();
+                $server['REQUEST_URI'] = \str_replace($request->getPathInfo(), $request->getPathInfo() . '/', $server['REQUEST_URI']);
+                $request_to_match = $request->duplicate(server: $server);
+            }
+            $matches = $router->matchRequest($request_to_match);
         } catch (ResourceNotFoundException) {
             // No route found, let Symfony do the rest of the work.
             return;

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -134,9 +134,9 @@ class Plugin extends CommonDBTM
      * Regex pattern that matches a plugin resource path.
      * This pattern will capture:
      *      `plugin_key`: the plugin key;
-     *      `plugin_resource`: the resource path relative to the plugin.
+     *      `plugin_resource`: the resource path relative to the plugin, may be empty when URL points to the plugin dir (e.g. `/plugins/myplugin`).
      */
-    public const PLUGIN_RESOURCE_PATTERN = '#^/(?:plugins|marketplace)/(?<plugin_key>[^/]+)(?<plugin_resource>/.*)$#';
+    public const PLUGIN_RESOURCE_PATTERN = '#^/(?:plugins|marketplace)/(?<plugin_key>[^/]+)(?<plugin_resource>/.*|)$#';
 
     /**
      * Plugin key validation pattern.

--- a/tests/functional/Glpi/Http/FirewallTest.php
+++ b/tests/functional/Glpi/Http/FirewallTest.php
@@ -145,6 +145,7 @@ class FirewallTest extends \DbTestCase
                     $plugin_path_prefix . '/myplugin/css.php'             => $default_for_plugins_legacy,
                     $plugin_path_prefix . '/myplugin/index.php'           => $default_for_plugins_legacy,
                     // matches the `/public/index.php` legacy script
+                    $plugin_path_prefix . '/myplugin'                     => $default_for_plugins_legacy,
                     $plugin_path_prefix . '/myplugin/'                    => $default_for_plugins_legacy,
                     $plugin_path_prefix . '/myplugin/PluginRoute'         => $default_for_symfony_routes,
 
@@ -153,6 +154,7 @@ class FirewallTest extends \DbTestCase
                     $plugin_path_prefix . '/pluginb/front/a/b.php'        => $default_for_plugins_legacy,
                     $plugin_path_prefix . '/pluginb/front/foo.php'        => $default_for_plugins_legacy,
                     $plugin_path_prefix . '/pluginb/Route/To/Something'   => $default_for_symfony_routes,
+                    $plugin_path_prefix . '/pluginb'                      => $default_for_symfony_routes,
                     $plugin_path_prefix . '/pluginb/'                     => $default_for_symfony_routes,
                     // outside the public dir, the file will not be served and the router will try to match a symfony route
                     $plugin_path_prefix . '/pluginb/test.php'             => $default_for_symfony_routes,

--- a/tests/functional/Glpi/Http/SessionManagerTest.php
+++ b/tests/functional/Glpi/Http/SessionManagerTest.php
@@ -209,7 +209,11 @@ class SessionManagerTest extends \DbTestCase
 
         foreach (['', '/glpi', '/path/to/app'] as $root_doc) {
             // Check an URL matching the index URL
+            $request = $this->getMockedRequest($root_doc, '/plugins/myplugin');
+            $this->assertEquals(true, $instance->isResourceStateless($request));
             $request = $this->getMockedRequest($root_doc, '/plugins/myplugin/');
+            $this->assertEquals(true, $instance->isResourceStateless($request));
+            $request = $this->getMockedRequest($root_doc, '/marketplace/myplugin');
             $this->assertEquals(true, $instance->isResourceStateless($request));
             $request = $this->getMockedRequest($root_doc, '/marketplace/myplugin/');
             $this->assertEquals(true, $instance->isResourceStateless($request));


### PR DESCRIPTION
## Checklist before requesting a review

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

It fixes the handling of empty paths in plugins URLs, e.g. `http://glpi.local/plugins/glpiinventory`.