### PR TITLE
Handle monolog level values in `GLPI_LOG_LEVEL`

### DIFF
--- a/src/Glpi/Error/ErrorHandler.php
+++ b/src/Glpi/Error/ErrorHandler.php
@@ -39,6 +39,7 @@ use Glpi\Error\ErrorDisplayHandler\CliDisplayHandler;
 use Glpi\Error\ErrorDisplayHandler\ConsoleErrorDisplayHandler;
 use Glpi\Error\ErrorDisplayHandler\ErrorDisplayHandler;
 use Glpi\Error\ErrorDisplayHandler\HtmlErrorDisplayHandler;
+use Monolog\Logger;
 use Override;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
@@ -273,8 +274,12 @@ final class ErrorHandler extends BaseErrorHandler
         // Define base reporting level
         $reporting_level = E_ALL;
 
+        // Convert error level to PSR log level
+        $monolog_level = Logger::toMonologLevel(GLPI_LOG_LVL);
+        $psr_level     = $monolog_level->toPsrLogLevel();
+
         // Compute max error level that should be reported
-        $env_report_value = self::PSR_ERROR_LEVEL_VALUES[GLPI_LOG_LVL];
+        $env_report_value = self::PSR_ERROR_LEVEL_VALUES[$psr_level];
 
         foreach (self::ERROR_LEVEL_MAP as $value => $log_level) {
             $psr_level_value = self::PSR_ERROR_LEVEL_VALUES[$log_level];


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

With the proposed changes, all of the following `GLPI_LOG_LVL` definitions will be possible:
```php
define('GLPI_LOG_LVL', 'debug');
define('GLPI_LOG_LVL', 'DEBUG');
define('GLPI_LOG_LVL', \Psr\Log\LogLevel::DEBUG);
define('GLPI_LOG_LVL', \Monolog\Level::Debug);
define('GLPI_LOG_LVL', \Monolog\Level::Debug->value);
define('GLPI_LOG_LVL', \Monolog\Level::Debug->name);
```

Also, if an invalid value is used, the error message will be easier to understand:
```
// define('GLPI_LOG_LVL', 'invalid');

Fatal error: Uncaught Psr\Log\InvalidArgumentException: Level "invalid" is not defined, use one of: DEBUG, INFO, NOTICE, WARNING, ERROR, CRITICAL, ALERT, EMERGENCY in /var/www/glpi/vendor/monolog/monolog/src/Monolog/Logger.php:503
Stack trace:
#0 /var/www/glpi/vendor/monolog/monolog/src/Monolog/Handler/AbstractHandler.php(60): Monolog\Logger::toMonologLevel('invalid')
#1 /var/www/glpi/vendor/monolog/monolog/src/Monolog/Handler/AbstractHandler.php(38): Monolog\Handler\AbstractHandler->setLevel('invalid')
#2 /var/www/glpi/vendor/monolog/monolog/src/Monolog/Handler/StreamHandler.php(52): Monolog\Handler\AbstractHandler->__construct('invalid', true)
#3 /var/www/glpi/src/Glpi/Log/AbstractLogHandler.php(43): Monolog\Handler\StreamHandler->__construct('/var/www/glpi/f...', 'invalid')
#4 /var/www/glpi/src/Glpi/Log/ErrorLogHandler.php(47): Glpi\Log\AbstractLogHandler->__construct('/var/www/glpi/f...')
#5 /var/www/glpi/src/Glpi/Application/SystemConfigurator.php(319): Glpi\Log\ErrorLogHandler->__construct()
#6 /var/www/glpi/src/Glpi/Application/SystemConfigurator.php(63): Glpi\Application\SystemConfigurator->initLogger()
#7 /var/www/glpi/src/Glpi/Kernel/Kernel.php(71): Glpi\Application\SystemConfigurator->__construct('/var/www/glpi', NULL)
#8 /var/www/glpi/public/index.php(66): Glpi\Kernel\Kernel->__construct()
#9 {main} thrown in /var/www/glpi/vendor/monolog/monolog/src/Monolog/Logger.php on line 503
```

It fixes #21959.