### PR TITLE
fix: warning undefined array key thown on a ticket creation

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -8357,8 +8357,6 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
      */
     public function getITILTemplateFromInput(array $input = []): ?ITILTemplate
     {
-        $entid = $input['entities_id'] ?? $this->fields['entities_id'];
-
         $type = null;
         if (isset($input['type'])) {
             $type = $input['type'];
@@ -8370,6 +8368,8 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
         if (is_null($categid)) {
             return null;
         }
+
+        $entid = $input['entities_id'] ?? $this->fields['entities_id'] ?? -1;
         return $this->getITILTemplateToUse(0, $type, $categid, $entid);
     }
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

A warning undefined array key could be thrown at a ticket is creation we now fallback to the getITITemplateToUse default value.

This issue was reported in https://github.com/pluginsGLPI/tag/issues/302
