### PR TITLE
Fix - Service Levels rule criterias

### DIFF
--- a/src/LevelAgreementLevel.php
+++ b/src/LevelAgreementLevel.php
@@ -218,15 +218,15 @@ abstract class LevelAgreementLevel extends RuleTicket
 
     public function getCriterias()
     {
-        $criterias = parent::getCriterias();
+        $criteria = parent::getCriterias();
 
-        unset($criterias['olas_id_ttr']);
-        unset($criterias['olas_id_tto']);
-        unset($criterias['slas_id_ttr']);
-        unset($criterias['slas_id_tto']);
-        $criterias['status']['name']    = __('Status');
-        $criterias['status']['type']    = 'dropdown_status';
-        return $criterias;
+        unset($criteria['olas_id_ttr']);
+        unset($criteria['olas_id_tto']);
+        unset($criteria['slas_id_ttr']);
+        unset($criteria['slas_id_tto']);
+        $criteria['status']['name']    = __('Status');
+        $criteria['status']['type']    = 'dropdown_status';
+        return $criteria;
     }
 
     public static function getExecutionTimes($options = [])


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !40319
- Here is a brief description of what this PR does

Fix incorrect method call in `LevelAgreementLevel::getCriterias()`.

The method was calling `parent::getActions()` instead of `parent::getCriterias()`, which caused the wrong set of fields to be returned for escalation level criteria.