### PR TITLE
Forms: do not migrate empty radio values from formcreator

### DIFF
--- a/src/Glpi/Form/QuestionType/AbstractQuestionTypeSelectable.php
+++ b/src/Glpi/Form/QuestionType/AbstractQuestionTypeSelectable.php
@@ -228,6 +228,10 @@ TWIG;
     {
         $values = json_decode($rawData['values'] ?? '[]', true) ?? [];
 
+        // Formcreator may include some empty values, remove them
+        $values = array_filter($values, fn($v) => $v !== "");
+        $values = array_values($values); // Re-index keys
+
         // Convert array values to use index + 1 as keys
         $options = [];
         foreach ($values as $index => $value) {

--- a/tests/functional/Glpi/Form/Migration/FormMigrationTest.php
+++ b/tests/functional/Glpi/Form/Migration/FormMigrationTest.php
@@ -1284,7 +1284,7 @@ final class FormMigrationTest extends DbTestCase
                 'name'                           => 'Test form migration for radio question - Question',
                 'fieldtype'                      => 'radios',
                 'default_values'                 => '1',
-                'values'                         => json_encode(['1', '2', '3']),
+                'values'                         => json_encode(['1', '2', '', '3', '']),
             ]
         ));
 


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Formcreator allow any values, including empty lines.

<img width="1103" height="561" alt="image" src="https://github.com/user-attachments/assets/1c93df82-ba6e-4309-968a-7c5a37323c35" />

We can probably remove them during the migration as they are useless and users may think it is a bug.
