### PR TITLE
Undefined variable token trying to change own password

### DIFF
--- a/templates/password_form.html.twig
+++ b/templates/password_form.html.twig
@@ -65,7 +65,7 @@
             }) }}
         {% endif %}
         {% if token is defined or type == 'update' %}
-            <input type="hidden" name="password_forget_token" value="{{ token }}" />
+            <input type="hidden" name="password_forget_token" value="{{ token ?? '' }}" />
             {{ fields.passwordField('password', '', __('New password'), {
                 full_width: true,
                 clearable: false,


### PR DESCRIPTION
```
Variable "token" does not exist in "password_form.html.twig" at line 68.
In ./templates/password_form.html.twig(68)
#0 /tmp/glpi_cache/11.0.3-dev-00000000-development/templates/dc/dc3231cad521c7cfc1044e68bc3f9252.php(111): __TwigTemplate_8b4e590f2e1007140c5f197b69ba24b4->{closure}()
#1 ./vendor/twig/twig/src/Template.php(402): __TwigTemplate_8b4e590f2e1007140c5f197b69ba24b4->doDisplay()
#2 ./vendor/twig/twig/src/Template.php(358): Twig\Template->yield()
#3 ./vendor/twig/twig/src/Template.php(373): Twig\Template->display()
#4 ./vendor/twig/twig/src/TemplateWrapper.php(51): Twig\Template->render()
#5 ./vendor/twig/twig/src/Extension/CoreExtension.php(1520): Twig\TemplateWrapper->render()
#6 /tmp/glpi_cache/11.0.3-dev-00000000-development/templates/fb/fb9c5cb28953f74429c327628341b27c.php(57): Twig\Extension\CoreExtension::include()
#7 ./vendor/twig/twig/src/Template.php(402): __TwigTemplate_43fe3f1d28f1c96462c2c5ba60f58ea7->doDisplay()
#8 ./vendor/twig/twig/src/Template.php(358): Twig\Template->yield()
#9 ./vendor/twig/twig/src/TemplateWrapper.php(61): Twig\Template->display()
#10 ./src/Glpi/Application/View/TemplateRenderer.php(188): Twig\TemplateWrapper->display()
#11 ./src/User.php(5009): Glpi\Application\View\TemplateRenderer->display()
#12 ./front/updatepassword.php(111): User->showPasswordUpdateForm()
#13 ./src/Glpi/Controller/LegacyFileLoadController.php(64): require('...')
#14 ./vendor/symfony/http-kernel/HttpKernel.php(181): Glpi\Controller\LegacyFileLoadController->__invoke()
#15 ./vendor/symfony/http-kernel/HttpKernel.php(76): Symfony\Component\HttpKernel\HttpKernel->handleRaw()
#16 ./vendor/symfony/http-kernel/Kernel.php(197): Symfony\Component\HttpKernel\HttpKernel->handle()
#17 ./public/index.php(70): Symfony\Component\HttpKernel\Kernel->handle()
#18 {main}
```