### PR TITLE
fix(profile): standardize simcard rights label

### DIFF
--- a/src/DeviceSimcard.php
+++ b/src/DeviceSimcard.php
@@ -113,13 +113,4 @@ class DeviceSimcard extends CommonDevice
     {
         return "ti ti-device-sim";
     }
-
-    public function getRights($interface = 'central')
-    {
-        $rights = parent::getRights($interface);
-        // Update labels to match other assets
-        $rights[READ] = __('View all');
-        $rights[UPDATE] = __('Update all');
-        return $rights;
-    }
 }

--- a/src/Item_DeviceSimcard.php
+++ b/src/Item_DeviceSimcard.php
@@ -191,4 +191,16 @@ class Item_DeviceSimcard extends Item_Devices implements AssignableItemInterface
             'msin' => 'equal',
         ];
     }
+
+    public function getRights($interface = 'central')
+    {
+        $rights = parent::getRights($interface);
+        // Update labels to match other assets
+        $rights[READ] = __('View all');
+        $rights[UPDATE] = __('Update all');
+        unset($rights[CREATE]);
+        unset($rights[DELETE]);
+        unset($rights[PURGE]);
+        return $rights;
+    }
 }

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -896,7 +896,7 @@ class Profile extends CommonDBTM implements LinkableToTilesInterface
                             $fn_get_rights(NetworkName::class, 'central', [
                                 'label' => __('Internet'),
                             ]),
-                            $fn_get_rights(DeviceSimcard::class, 'central', [
+                            $fn_get_rights(Item_DeviceSimcard::class, 'central', [
                                 'label' => __('Simcard PIN/PUK'),
                                 'field' => 'devicesimcard_pinpuk',
                             ]),


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !40406 and #21888
- In the Profiles > Assets configuration, the labels “read” and “update” for the Simcard PIN/PUK right were not consistent with those of the other rights, which resulted in a second column appearing.

## Screenshots (if appropriate):

Before fix:
<img width="1190" height="650" alt="annotely_image(16)" src="https://github.com/user-attachments/assets/49e32436-1286-48cf-b98c-76efd2389a3c" />

After fix:
<img width="641" height="582" alt="annotely_image(19)" src="https://github.com/user-attachments/assets/e40a2677-18bc-4550-ac0c-e266b288a0cb" />


