### PR TITLE
Clear conditions

### DIFF
--- a/src/Glpi/Form/Comment.php
+++ b/src/Glpi/Form/Comment.php
@@ -169,6 +169,8 @@ final class Comment extends CommonDBChild implements
             unset($input['_conditions']);
         }
 
+        $input = $this->removeSavedConditionsIfAlwaysVisible($input);
+
         return $input;
     }
 

--- a/src/Glpi/Form/Condition/ConditionableCreationInterface.php
+++ b/src/Glpi/Form/Condition/ConditionableCreationInterface.php
@@ -37,4 +37,7 @@ namespace Glpi\Form\Condition;
 interface ConditionableCreationInterface extends ConditionableInterface
 {
     public function getConfiguredCreationStrategy(): CreationStrategy;
+
+    // TODO: uncomment on main to prevent BC breaks
+    // protected function removeSavedConditionsIfAlwaysCreated(array $input): array;
 }

--- a/src/Glpi/Form/Condition/ConditionableCreationTrait.php
+++ b/src/Glpi/Form/Condition/ConditionableCreationTrait.php
@@ -34,6 +34,8 @@
 
 namespace Glpi\Form\Condition;
 
+use function Safe\json_encode;
+
 trait ConditionableCreationTrait
 {
     use ConditionableTrait;
@@ -43,5 +45,20 @@ trait ConditionableCreationTrait
         $strategy_value = $this->fields['creation_strategy'] ?? "";
         $strategy = CreationStrategy::tryFrom($strategy_value);
         return $strategy ?? CreationStrategy::ALWAYS_CREATED;
+    }
+
+    protected function removeSavedConditionsIfAlwaysCreated(array $input): array
+    {
+        $strategy_field = 'creation_strategy';
+        $condition_field = $this->getConditionsFieldName();
+
+        if (
+            isset($input[$strategy_field])
+            && $input[$strategy_field] == CreationStrategy::ALWAYS_CREATED->value
+        ) {
+            $input[$condition_field] = json_encode([]);
+        }
+
+        return $input;
     }
 }

--- a/src/Glpi/Form/Condition/ConditionableValidationTrait.php
+++ b/src/Glpi/Form/Condition/ConditionableValidationTrait.php
@@ -34,6 +34,8 @@
 
 namespace Glpi\Form\Condition;
 
+use function Safe\json_encode;
+
 trait ConditionableValidationTrait
 {
     use ConditionableTrait {
@@ -75,5 +77,20 @@ trait ConditionableValidationTrait
         $strategy_value = $this->fields[$field_name] ?? "";
         $strategy = ValidationStrategy::tryFrom($strategy_value);
         return $strategy ?? ValidationStrategy::NO_VALIDATION;
+    }
+
+    protected function removeSavedConditionsIfNoValidation(array $input): array
+    {
+        $strategy_field = $this->getValidationStrategyFieldName();
+        $condition_field = $this->getValidationConditionsFieldName();
+
+        if (
+            isset($input[$strategy_field])
+            && $input[$strategy_field] == ValidationStrategy::NO_VALIDATION->value
+        ) {
+            $input[$condition_field] = json_encode([]);
+        }
+
+        return $input;
     }
 }

--- a/src/Glpi/Form/Condition/ConditionableVisibilityInterface.php
+++ b/src/Glpi/Form/Condition/ConditionableVisibilityInterface.php
@@ -49,4 +49,7 @@ interface ConditionableVisibilityInterface extends ConditionableInterface
      * @return string
      */
     public function getUUID(): string;
+
+    // TODO: uncomment on main to prevent BC breaks
+    // protected function removeSavedConditionsIfAlwaysVisible(array $input): array;
 }

--- a/src/Glpi/Form/Condition/ConditionableVisibilityTrait.php
+++ b/src/Glpi/Form/Condition/ConditionableVisibilityTrait.php
@@ -34,6 +34,8 @@
 
 namespace Glpi\Form\Condition;
 
+use function Safe\json_encode;
+
 trait ConditionableVisibilityTrait
 {
     use ConditionableTrait;
@@ -55,5 +57,20 @@ trait ConditionableVisibilityTrait
         $strategy_value = $this->fields[$field_name] ?? "";
         $strategy = VisibilityStrategy::tryFrom($strategy_value);
         return $strategy ?? VisibilityStrategy::ALWAYS_VISIBLE;
+    }
+
+    protected function removeSavedConditionsIfAlwaysVisible(array $input): array
+    {
+        $visibility_field = $this->getVisibilityStrategyFieldName();
+        $condition_field = $this->getConditionsFieldName();
+
+        if (
+            isset($input[$visibility_field])
+            && $input[$visibility_field] == VisibilityStrategy::ALWAYS_VISIBLE->value
+        ) {
+            $input[$condition_field] = json_encode([]);
+        }
+
+        return $input;
     }
 }

--- a/src/Glpi/Form/Destination/FormDestination.php
+++ b/src/Glpi/Form/Destination/FormDestination.php
@@ -284,6 +284,8 @@ final class FormDestination extends CommonDBChild implements ConditionableCreati
             unset($input['_conditions']);
         }
 
+        $input = $this->removeSavedConditionsIfAlwaysCreated($input);
+
         return $input;
     }
 

--- a/src/Glpi/Form/Form.php
+++ b/src/Glpi/Form/Form.php
@@ -374,6 +374,8 @@ final class Form extends CommonDBTM implements
             unset($input['_submit_button_conditions']);
         }
 
+        $input = $this->removeSavedConditionsIfAlwaysVisible($input);
+
         return $input;
     }
 

--- a/src/Glpi/Form/Question.php
+++ b/src/Glpi/Form/Question.php
@@ -401,6 +401,9 @@ final class Question extends CommonDBChild implements BlockInterface, Conditiona
             }
         }
 
+        $input = $this->removeSavedConditionsIfAlwaysVisible($input);
+        $input = $this->removeSavedConditionsIfNoValidation($input);
+
         return $input;
     }
 

--- a/src/Glpi/Form/Section.php
+++ b/src/Glpi/Form/Section.php
@@ -144,6 +144,8 @@ final class Section extends CommonDBChild implements ConditionableVisibilityInte
             unset($input['_conditions']);
         }
 
+        $input = $this->removeSavedConditionsIfAlwaysVisible($input);
+
         return $input;
     }
 

--- a/tests/functional/Glpi/Form/CommentTest.php
+++ b/tests/functional/Glpi/Form/CommentTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Form;
+
+use DbTestCase;
+use Glpi\Form\Comment;
+use Glpi\Form\Condition\LogicOperator;
+use Glpi\Form\Condition\Type;
+use Glpi\Form\Condition\ValueOperator;
+use Glpi\Form\Condition\VisibilityStrategy;
+use Glpi\Form\QuestionType\QuestionTypeShortText;
+use Glpi\Tests\FormBuilder;
+use Glpi\Tests\FormTesterTrait;
+
+final class CommentTest extends DbTestCase
+{
+    use FormTesterTrait;
+
+    public function testConditionsDataAreCleanedWhenStrategyIsReset(): void
+    {
+        // Arrange: create a form with visibility conditions on a comment
+        $builder = new FormBuilder();
+        $builder->addQuestion("My question", QuestionTypeShortText::class);
+        $builder->addComment("My comment");
+        $builder->setCommentVisibility("My comment", VisibilityStrategy::VISIBLE_IF, [
+            [
+                'logic_operator' => LogicOperator::AND,
+                'item_name'      => "My question",
+                'item_type'      => Type::QUESTION,
+                'value_operator' => ValueOperator::EQUALS,
+                'value'          => "Yes",
+            ],
+        ]);
+        $form = $this->createForm($builder);
+
+        // Act: reset the comment's visibility strategy
+        $comment_id = $this->getCommentId($form, "My comment");
+        $comment = $this->updateItem(Comment::class, $comment_id, [
+            'visibility_strategy' => VisibilityStrategy::ALWAYS_VISIBLE->value,
+        ]);
+
+        // Assert: the conditions should be deleted
+        $this->assertEmpty($comment->getConfiguredConditionsData());
+    }
+}

--- a/tests/functional/Glpi/Form/Destination/FormDestinationTest.php
+++ b/tests/functional/Glpi/Form/Destination/FormDestinationTest.php
@@ -37,6 +37,10 @@ namespace tests\units\Glpi\Form\Destination;
 use CommonGLPI;
 use DBmysql;
 use DbTestCase;
+use Glpi\Form\Condition\CreationStrategy;
+use Glpi\Form\Condition\LogicOperator;
+use Glpi\Form\Condition\Type;
+use Glpi\Form\Condition\ValueOperator;
 use Glpi\Form\Destination\FormDestination;
 use Glpi\Form\Destination\FormDestinationTicket;
 use Glpi\Form\Form;
@@ -151,6 +155,32 @@ final class FormDestinationTest extends DbTestCase
             "This form is invalid, it must create at least one item.",
             $content
         );
+    }
+
+    public function testConditionsDataAreCleanedWhenStrategyIsReset(): void
+    {
+        // Arrange: create a form with creation conditions on a destination
+        $builder = new FormBuilder();
+        $builder->addQuestion("My question", QuestionTypeShortText::class);
+        $builder->setDestinationCondition("Ticket", CreationStrategy::CREATED_IF, [
+            [
+                'logic_operator' => LogicOperator::AND,
+                'item_name'      => "My question",
+                'item_type'      => Type::QUESTION,
+                'value_operator' => ValueOperator::EQUALS,
+                'value'          => "Yes",
+            ],
+        ]);
+        $form = $this->createForm($builder);
+
+        // Act: reset the destiantion's creation strategy
+        $destination_id = $this->getDestinationId($form, "Ticket");
+        $destination = $this->updateItem(FormDestination::class, $destination_id, [
+            'creation_strategy' => CreationStrategy::ALWAYS_CREATED->value,
+        ]);
+
+        // Assert: the conditions should be deleted
+        $this->assertEmpty($destination->getConfiguredConditionsData());
     }
 
     private function createAndGetFormWithFourDestinations(): Form


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

When updating a form/question/comment/section/destination and :
* Visibility strategy is set to "always visible"
* Creation strategy is set to "always created"
* Validation strategy is set to "no validation"

Then we delete the associated condition data.

This avoid the user seing old data if he switch back to the another strategy later on, as it will now have been cleaned.
