### PR TITLE
Fix(datatable): title width

### DIFF
--- a/css/includes/_base.scss
+++ b/css/includes/_base.scss
@@ -347,6 +347,7 @@ body.in_modal {
 table {
     &.table thead th {
         font-size: 0.625rem;
+        white-space: initial;
     }
 
     tbody:not(:has(tr)) {


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !40321

The column titles no longer wrapped to the next line as they did in GLPI 10, which can result in very large columns.

## Screenshots (if appropriate):

GLPI 10:
<img width="956" height="132" alt="image" src="https://github.com/user-attachments/assets/ca74a09e-8a83-4c0b-a50e-f5dcb1ba87b3" />

GLPI 11 - before:
<img width="956" height="87" alt="image" src="https://github.com/user-attachments/assets/901adc48-bf4b-4660-8f39-ed769b11da88" />

GLPI 11 - after:
<img width="956" height="98" alt="image" src="https://github.com/user-attachments/assets/dc5ad52f-c54e-4a77-a1fa-bd475a7a8449" />
