### PR TITLE
Fix custom asset picture label

### DIFF
--- a/templates/pages/admin/customobjects/main.html.twig
+++ b/templates/pages/admin/customobjects/main.html.twig
@@ -178,7 +178,7 @@
 
     {% if item.isField('picture') %}
         {% if item.fields['picture'] is not empty %}
-            {{ fields.imageField('picture', item.fields['picture']|picture_url, item.fields['label'], {
+            {{ fields.imageField('picture', item.fields['picture']|picture_url, _n('Picture', 'Pictures', 1), {
                 'clearable': (not item.isNewItem() and item.canUpdateItem())
             }) }}
         {% else %}


### PR DESCRIPTION


<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.


<img width="2075" height="965" alt="Capture d’écran du 2025-11-19 14-48-27" src="https://github.com/user-attachments/assets/bd1e8bc8-acb3-4ce2-966f-630cb691714d" />