### PR TITLE
Prevent genericobject migration to alter initial data

### DIFF
--- a/src/Glpi/Migration/AbstractPluginMigration.php
+++ b/src/Glpi/Migration/AbstractPluginMigration.php
@@ -581,7 +581,7 @@ abstract class AbstractPluginMigration
         if ($excluded_relations !== []) {
             $itemtype_column_criteria[] = [
                 'NOT' => [
-                    'table_name' => \array_map(fn(string $classname) => $classname::getTable(), $excluded_relations),
+                    'table_name' => \array_map(fn(string $classname) => \getTableForItemType($classname), $excluded_relations),
                 ],
             ];
         }

--- a/src/Glpi/Migration/GenericobjectPluginMigration.php
+++ b/src/Glpi/Migration/GenericobjectPluginMigration.php
@@ -578,6 +578,9 @@ class GenericobjectPluginMigration extends AbstractPluginMigration
                     // These cannot be migrated this way, as a specific SO IDs mapping have to be applied.
                     DisplayPreference::class,
                     SavedSearch::class,
+
+                    // Ignore self reference in the `genericobject` plugin table
+                    'PluginGenericobjectType',
                 ],
             );
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

The `genericobject` plugin, in its GLPI 11.0 compatible version, perform a database cleaning based on the `glpi_plugin_genericobject_types.itemtype` column values. There is no reason to update this column during the migration, therefore we can let it keeping its initial value. Also, changing it would result in unexpected results if the migration is executed a second time.