### PR TITLE
Fix PHPUnit web tests execution inside dev container

### DIFF
--- a/.docker/app/Dockerfile
+++ b/.docker/app/Dockerfile
@@ -4,6 +4,9 @@ FROM ghcr.io/glpi-project/glpi-development-env:$PHP_VERSION
 
 USER root
 
+# Use apache configuration suitable for GLPI 10.x
+RUN cp /etc/apache2/sites-available/glpi-10.x.conf /etc/apache2/sites-available/000-default.conf
+
 # Allow extra PHP configuration to be placed in a dedicated folder than can serve
 # as a volume
 ENV PHP_INI_SCAN_DIR "/usr/local/etc/php/conf.d/:/usr/local/etc/php/custom_conf.d/"

--- a/.github/actions/test_tests-web.sh
+++ b/.github/actions/test_tests-web.sh
@@ -2,6 +2,4 @@
 set -e -u -x -o pipefail
 
 php -S localhost:8088 phpunit/router.php &>/dev/null &
-bin/console config:set --config-dir=./tests/config --context=inventory enabled_inventory 1
 vendor/bin/phpunit phpunit/web
-bin/console config:set --config-dir=./tests/config --context=inventory enabled_inventory 0

--- a/phpunit/APIBaseClass.php
+++ b/phpunit/APIBaseClass.php
@@ -1758,14 +1758,26 @@ abstract class APIBaseClass extends TestCase
 
     public function testUndisclosedNotificationContent()
     {
+        global $DB;
+
+        $user = getItemByTypeName('User', TU_USER);
+
         // Enable notifications
         Config::setConfigurationValues('core', [
             'use_notifications' => '1',
             'notifications_mailing' => '1',
         ]);
 
+        // Empty existing notifications
+        $DB->delete(
+            QueuedNotification::getTable(),
+            [
+                'itemtype' => User::class,
+                'items_id' => $user->getID(),
+            ]
+        );
+
         // Trigger a notification sending
-        $user = getItemByTypeName('User', TU_USER);
         $this->query(
             'lostPassword',
             [
@@ -1795,6 +1807,12 @@ abstract class APIBaseClass extends TestCase
             [
                 'itemtype' => QueuedNotification::class,
                 'headers'  => ['Session-Token' => $data['session_token']],
+                'query'     => [
+                    'searchText' => [
+                        'itemtype' => User::class,
+                        'items_id' => $user->getID(),
+                    ],
+                ],
             ],
             200
         );
@@ -1821,6 +1839,18 @@ abstract class APIBaseClass extends TestCase
                 'headers'  => ['Session-Token' => $data['session_token']],
                 'query'    => [
                     'reset'         => 'reset',
+                    'criteria'      => [
+                        [
+                            'field'      => 20,
+                            'searchtype' => 'equals',
+                            'value'      => User::class,
+                        ],
+                        [
+                            'field'      => 21,
+                            'searchtype' => 'equals',
+                            'value'      => $user->getID(),
+                        ],
+                    ],
                     'forcedisplay'  => [12, 13],
                 ],
             ],

--- a/phpunit/web/Glpi/Inventory/InventoryTest.php
+++ b/phpunit/web/Glpi/Inventory/InventoryTest.php
@@ -34,6 +34,7 @@
 
 namespace tests\units\Glpi\Inventory;
 
+use Config;
 use GuzzleHttp;
 
 class InventoryTest extends \GLPITestCase
@@ -47,6 +48,11 @@ class InventoryTest extends \GLPITestCase
 
         $this->http_client = new GuzzleHttp\Client();
         $this->base_uri    = trim($CFG_GLPI['url_base'], "/") . "/";
+
+        // Enable inventory
+        Config::setConfigurationValues('inventory', [
+            'enabled_inventory' => '1',
+        ]);
 
         parent::setUp();
     }

--- a/phpunit/web/Glpi/Inventory/RequestTest.php
+++ b/phpunit/web/Glpi/Inventory/RequestTest.php
@@ -34,6 +34,7 @@
 
 namespace tests\units\Glpi\Inventory;
 
+use Config;
 use GuzzleHttp;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\Response;
@@ -49,6 +50,11 @@ class RequestTest extends \GLPITestCase
 
         $this->http_client = new GuzzleHttp\Client();
         $this->base_uri    = trim($CFG_GLPI['url_base'], "/") . "/";
+
+        // Enable inventory
+        Config::setConfigurationValues('inventory', [
+            'enabled_inventory' => '1',
+        ]);
 
         parent::setUp();
     }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Combined with https://github.com/glpi-project/docker-images/pull/226, it makes web test execution possible with the `make phpunit c='phpunit/web'` command.

Web tests will still affect the database state and it will probably make some `phpunit/functional` tests fail, but this will not be addressed in this PR. It could probably be handled by having a dedicated entity for this test suite, as we have for the e2e tests.