### PR TITLE
Use raw LDAP fields values in LDAP import feature

### DIFF
--- a/front/ldap.import.php
+++ b/front/ldap.import.php
@@ -53,7 +53,6 @@ if (($_REQUEST['action'] ?? 'show') === 'show') {
 
     if (
         isset($_REQUEST['authldaps_id'])
-        && $_REQUEST['authldaps_id'] !== NOT_AVAILABLE
         && (int) $_REQUEST['authldaps_id'] !== 0
         && (isset($_REQUEST['search']) || isset($_REQUEST['start']) || isset($_REQUEST['glpilist_limit']))
     ) {

--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -3577,7 +3577,7 @@ TWIG, $twig_params);
                 // Use default from the current entity or global default
                 $entity = new Entity();
                 $entity->getFromDB($_SESSION['glpiactive_entity']);
-                $_REQUEST['authldaps_id'] = $entity->getField('authldaps_id');
+                $_REQUEST['authldaps_id'] = $entity->fields['authldaps_id'];
                 if ((int) $_REQUEST['authldaps_id'] <= 0) {
                     $defaultAuth = Auth::getDefaultAuth();
                     if ($defaultAuth instanceof AuthLDAP) {
@@ -3654,22 +3654,22 @@ TWIG, $twig_params);
 
             if (
                 $entity->getFromDB($_REQUEST['entities_id'])
-                && ($entity->getField('authldaps_id') > 0)
+                && $entity->fields['authldaps_id'] > 0
             ) {
                 $authldap->getFromDB($_REQUEST['authldaps_id']);
 
                 if ($_REQUEST['authldaps_id'] === 0) {
                     // authldaps_id wasn't submitted by the user -> take entity config
-                    $_REQUEST['authldaps_id'] = $entity->getField('authldaps_id');
+                    $_REQUEST['authldaps_id'] = $entity->fields['authldaps_id'];
                 }
 
-                $_REQUEST['basedn']       = $entity->getField('ldap_dn');
+                $_REQUEST['basedn']       = $entity->fields['ldap_dn'];
 
                 // No dn specified in entity : use standard one
-                $_REQUEST['basedn'] ??= $authldap->getField('basedn');
+                $_REQUEST['basedn'] ??= $authldap->fields['basedn'];
 
-                if ($entity->getField('entity_ldapfilter') !== 0) {
-                    $_REQUEST['entity_filter'] = $entity->getField('entity_ldapfilter');
+                if ((string) $entity->fields['entity_ldapfilter'] !== '') {
+                    $_REQUEST['entity_filter'] = $entity->fields['entity_ldapfilter'];
                 }
             } else {
                 if (
@@ -3686,7 +3686,7 @@ TWIG, $twig_params);
 
                 if ($_REQUEST['authldaps_id'] > 0) {
                     $authldap->getFromDB($_REQUEST['authldaps_id']);
-                    $_REQUEST['basedn'] = $authldap->getField('basedn');
+                    $_REQUEST['basedn'] = $authldap->fields['basedn'];
                 }
             }
 
@@ -3704,7 +3704,7 @@ TWIG, $twig_params);
 
                     if ($_REQUEST['authldaps_id'] > 0) {
                         $authldap->getFromDB($_REQUEST['authldaps_id']);
-                        $_REQUEST['basedn'] = $authldap->getField('basedn');
+                        $_REQUEST['basedn'] = $authldap->fields['basedn'];
                     }
                 }
             }
@@ -3713,7 +3713,7 @@ TWIG, $twig_params);
                 || $_REQUEST['ldap_filter'] === ''
             ) {
                 $authldap->getFromDB($_REQUEST['authldaps_id']);
-                $_REQUEST['basedn']      = $authldap->getField('basedn');
+                $_REQUEST['basedn']      = $authldap->fields['basedn'];
                 $_REQUEST['ldap_filter'] = self::buildLdapFilter($authldap);
             }
         }
@@ -3726,7 +3726,7 @@ TWIG, $twig_params);
         ) {
             $_REQUEST['authldaps_id'] = $servers[0]['id'];
             $authldap->getFromDB($_REQUEST['authldaps_id']);
-            $_REQUEST['basedn']      = $authldap->getField('basedn');
+            $_REQUEST['basedn']      = $authldap->fields['basedn'];
             if (($_REQUEST['ldap_filter'] ?? '') === '') {
                 $_REQUEST['ldap_filter'] = self::buildLdapFilter($authldap);
             }
@@ -3816,14 +3816,14 @@ TWIG, $twig_params);
                 }
             }
         } else {
-            $filter = "(" . $authldap->getField("login_field") . "=*)";
+            $filter = "(" . $authldap->fields["login_field"] . "=*)";
         }
 
         // If time restriction
         $begin_date = $_REQUEST['begin_date'] ?? null;
         $end_date   = $_REQUEST['end_date'] ?? null;
         $filter    .= self::addTimestampRestrictions($begin_date, $end_date);
-        $ldap_condition = $authldap->getField('condition');
+        $ldap_condition = $authldap->fields['condition'];
         // Add entity filter and filter filled in directory's configuration form
         return  "(&" . ($_REQUEST['entity_filter'] ?? '') . " $filter $ldap_condition)";
     }
@@ -4018,7 +4018,7 @@ TWIG, $twig_params);
         /** @var CommonDBTM $item */
         if (
             !$withtemplate
-            && $item->can($item->getField('id'), READ)
+            && $item->can($item->getID(), READ)
         ) {
             $ong     = [];
             $ong[1]  = self::createTabEntry(_x('button', 'Test'), 0, $item::class, "ti ti-stethoscope"); // test connexion


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Using `CommonDBTM::getField()` to compute LDAP DN/filters is not a good idea. Indeed, we do not want `N/A` to be used as fallback value.

It should fix #21971, or at least make the error more relevant.