### PR TITLE
fix returns on PHPDoc only

### DIFF
--- a/src/ChangeTask.php
+++ b/src/ChangeTask.php
@@ -44,7 +44,7 @@ class ChangeTask extends CommonITILTask
     /**
      * Populate the planning with planned ticket tasks
      *
-     * @param $options array of possible options:
+     * @param array $options array of possible options:
      *    - who ID of the user (0 = undefined)
      *    - whogroup ID of the group of users (0 = undefined)
      *    - begin Date
@@ -76,7 +76,7 @@ class ChangeTask extends CommonITILTask
     /**
      * Populate the planning with not planned ticket tasks
      *
-     * @param $options array of possible options:
+     * @param array $options array of possible options:
      *    - who ID of the user (0 = undefined)
      *    - whogroup ID of the group of users (0 = undefined)
      *    - begin Date

--- a/src/Change_Problem.php
+++ b/src/Change_Problem.php
@@ -189,7 +189,6 @@ class Change_Problem extends CommonITILObject_CommonITILObject
                 'container'     => 'mass' . static::class . $rand,
             ],
         ]);
-
     }
 
     /**
@@ -282,6 +281,5 @@ class Change_Problem extends CommonITILObject_CommonITILObject
                 'container'     => 'mass' . static::class . $rand,
             ],
         ]);
-
     }
 }

--- a/src/Change_Problem.php
+++ b/src/Change_Problem.php
@@ -102,6 +102,7 @@ class Change_Problem extends CommonITILObject_CommonITILObject
      * Show tickets for a problem
      *
      * @param Problem $problem
+     * @return void|false
      **/
     public static function showForProblem(Problem $problem)
     {
@@ -194,6 +195,7 @@ class Change_Problem extends CommonITILObject_CommonITILObject
      * Show problems for a change
      *
      * @param Change $change object
+     * @return void|false
      **/
     public static function showForChange(Change $change)
     {

--- a/src/Change_Problem.php
+++ b/src/Change_Problem.php
@@ -102,7 +102,7 @@ class Change_Problem extends CommonITILObject_CommonITILObject
      * Show tickets for a problem
      *
      * @param Problem $problem
-     * @return false
+     * @return void
      **/
     public static function showForProblem(Problem $problem)
     {
@@ -110,7 +110,7 @@ class Change_Problem extends CommonITILObject_CommonITILObject
 
         $ID = $problem->getField('id');
         if (!$problem->can($ID, READ)) {
-            return false;
+            return;
         }
 
         $canedit = $problem->canEdit($ID);
@@ -190,14 +190,13 @@ class Change_Problem extends CommonITILObject_CommonITILObject
             ],
         ]);
 
-        return false;
     }
 
     /**
      * Show problems for a change
      *
      * @param Change $change object
-     * @return false
+     * @return void
      **/
     public static function showForChange(Change $change)
     {
@@ -205,7 +204,7 @@ class Change_Problem extends CommonITILObject_CommonITILObject
 
         $ID = $change->getField('id');
         if (!$change->can($ID, READ)) {
-            return false;
+            return;
         }
 
         $canedit = $change->canEdit($ID);
@@ -284,6 +283,5 @@ class Change_Problem extends CommonITILObject_CommonITILObject
             ],
         ]);
 
-        return false;
     }
 }

--- a/src/Change_Problem.php
+++ b/src/Change_Problem.php
@@ -102,7 +102,7 @@ class Change_Problem extends CommonITILObject_CommonITILObject
      * Show tickets for a problem
      *
      * @param Problem $problem
-     * @return void|false
+     * @return false
      **/
     public static function showForProblem(Problem $problem)
     {
@@ -189,13 +189,15 @@ class Change_Problem extends CommonITILObject_CommonITILObject
                 'container'     => 'mass' . static::class . $rand,
             ],
         ]);
+
+        return false;
     }
 
     /**
      * Show problems for a change
      *
      * @param Change $change object
-     * @return void|false
+     * @return false
      **/
     public static function showForChange(Change $change)
     {
@@ -281,5 +283,7 @@ class Change_Problem extends CommonITILObject_CommonITILObject
                 'container'     => 'mass' . static::class . $rand,
             ],
         ]);
+
+        return false;
     }
 }

--- a/src/Change_Ticket.php
+++ b/src/Change_Ticket.php
@@ -206,6 +206,7 @@ class Change_Ticket extends CommonITILObject_CommonITILObject
      * Show tickets for a change
      *
      * @param Change $change
+     * @return void|false
      **/
     public static function showForChange(Change $change)
     {
@@ -307,6 +308,7 @@ class Change_Ticket extends CommonITILObject_CommonITILObject
      * Show changes for a ticket
      *
      * @param Ticket $ticket object
+     * @return void|false
      **/
     public static function showForTicket(Ticket $ticket)
     {

--- a/src/Change_Ticket.php
+++ b/src/Change_Ticket.php
@@ -206,7 +206,7 @@ class Change_Ticket extends CommonITILObject_CommonITILObject
      * Show tickets for a change
      *
      * @param Change $change
-     * @return void|false
+     * @return void
      **/
     public static function showForChange(Change $change)
     {
@@ -214,7 +214,7 @@ class Change_Ticket extends CommonITILObject_CommonITILObject
 
         $ID = $change->getField('id');
         if (!$change->can($ID, READ)) {
-            return false;
+            return;
         }
 
         $canedit = $change->canEdit($ID);
@@ -308,7 +308,7 @@ class Change_Ticket extends CommonITILObject_CommonITILObject
      * Show changes for a ticket
      *
      * @param Ticket $ticket object
-     * @return void|false
+     * @return void
      **/
     public static function showForTicket(Ticket $ticket)
     {
@@ -316,7 +316,7 @@ class Change_Ticket extends CommonITILObject_CommonITILObject
 
         $ID = $ticket->getField('id');
         if (!$ticket->can($ID, READ)) {
-            return false;
+            return;
         }
 
         $canedit = $ticket->canEdit($ID);

--- a/src/CommonITILRecurrent.php
+++ b/src/CommonITILRecurrent.php
@@ -44,7 +44,7 @@ use function Safe\strtotime;
  */
 abstract class CommonITILRecurrent extends CommonDropdown
 {
-    /** @use Clonable<CommonITILRecurrent> */
+    /** @use Clonable<static> */
     use Clonable;
 
     /**

--- a/src/CommonITILRecurrent.php
+++ b/src/CommonITILRecurrent.php
@@ -44,6 +44,7 @@ use function Safe\strtotime;
  */
 abstract class CommonITILRecurrent extends CommonDropdown
 {
+    /** @use Clonable<CommonITILRecurrent> */
     use Clonable;
 
     /**

--- a/src/ProblemTask.php
+++ b/src/ProblemTask.php
@@ -43,7 +43,7 @@ class ProblemTask extends CommonITILTask
     /**
      * Populate the planning with planned problem tasks
      *
-     * @param $options  array of possible options:
+     * @param array $options  array of possible options:
      *    - who         ID of the user (0 = undefined)
      *    - whogroup    ID of the group of users (0 = undefined)
      *    - begin Date
@@ -75,7 +75,7 @@ class ProblemTask extends CommonITILTask
     /**
      * Populate the planning with not planned problem tasks
      *
-     * @param $options  array of possible options:
+     * @param array $options  array of possible options:
      *    - who         ID of the user (0 = undefined)
      *    - whogroup    ID of the group of users (0 = undefined)
      *    - begin Date

--- a/src/Problem_Ticket.php
+++ b/src/Problem_Ticket.php
@@ -191,7 +191,7 @@ class Problem_Ticket extends CommonITILObject_CommonITILObject
      * Show tickets for a problem
      *
      * @param Problem $problem
-     * @return void|false
+     * @return false
      **/
     public static function showForProblem(Problem $problem)
     {
@@ -261,13 +261,15 @@ class Problem_Ticket extends CommonITILObject_CommonITILObject
                 'extraparams'      => ['problems_id' => $problem->getID()],
             ],
         ]);
+
+        return false;
     }
 
     /**
      * Show problems for a ticket
      *
      * @param Ticket $ticket object
-     * @return void|false
+     * @return false
      **/
     public static function showForTicket(Ticket $ticket)
     {
@@ -333,6 +335,8 @@ class Problem_Ticket extends CommonITILObject_CommonITILObject
                 'container'     => 'mass' . static::class . $rand,
             ],
         ]);
+
+        return false;
     }
 
     /**

--- a/src/Problem_Ticket.php
+++ b/src/Problem_Ticket.php
@@ -261,7 +261,6 @@ class Problem_Ticket extends CommonITILObject_CommonITILObject
                 'extraparams'      => ['problems_id' => $problem->getID()],
             ],
         ]);
-
     }
 
     /**
@@ -334,7 +333,6 @@ class Problem_Ticket extends CommonITILObject_CommonITILObject
                 'container'     => 'mass' . static::class . $rand,
             ],
         ]);
-
     }
 
     /**

--- a/src/Problem_Ticket.php
+++ b/src/Problem_Ticket.php
@@ -191,6 +191,7 @@ class Problem_Ticket extends CommonITILObject_CommonITILObject
      * Show tickets for a problem
      *
      * @param Problem $problem
+     * @return void|false
      **/
     public static function showForProblem(Problem $problem)
     {
@@ -266,6 +267,7 @@ class Problem_Ticket extends CommonITILObject_CommonITILObject
      * Show problems for a ticket
      *
      * @param Ticket $ticket object
+     * @return void|false
      **/
     public static function showForTicket(Ticket $ticket)
     {

--- a/src/Problem_Ticket.php
+++ b/src/Problem_Ticket.php
@@ -191,14 +191,14 @@ class Problem_Ticket extends CommonITILObject_CommonITILObject
      * Show tickets for a problem
      *
      * @param Problem $problem
-     * @return false
+     * @return void
      **/
     public static function showForProblem(Problem $problem)
     {
         $ID = $problem->getField('id');
 
         if (!static::canView() || !$problem->can($ID, READ)) {
-            return false;
+            return;
         }
 
         $canedit = $problem->canEdit($ID);
@@ -262,14 +262,13 @@ class Problem_Ticket extends CommonITILObject_CommonITILObject
             ],
         ]);
 
-        return false;
     }
 
     /**
      * Show problems for a ticket
      *
      * @param Ticket $ticket object
-     * @return false
+     * @return void
      **/
     public static function showForTicket(Ticket $ticket)
     {
@@ -277,7 +276,7 @@ class Problem_Ticket extends CommonITILObject_CommonITILObject
         $ID = $ticket->getField('id');
 
         if (!static::canView() || !$ticket->can($ID, READ)) {
-            return false;
+            return;
         }
 
         $canedit = $ticket->can($ID, UPDATE);
@@ -336,7 +335,6 @@ class Problem_Ticket extends CommonITILObject_CommonITILObject
             ],
         ]);
 
-        return false;
     }
 
     /**

--- a/src/TicketTask.php
+++ b/src/TicketTask.php
@@ -43,7 +43,7 @@ class TicketTask extends CommonITILTask
     /**
      * Populate the planning with planned ticket tasks
      *
-     * @param $options   array of possible options:
+     * @param array $options   array of possible options:
      *    - who          ID of the user (0 = undefined)
      *    - whogroup     ID of the group of users (0 = undefined)
      *    - begin        Date
@@ -60,7 +60,7 @@ class TicketTask extends CommonITILTask
     /**
      * Populate the planning with planned ticket tasks
      *
-     * @param $options   array of possible options:
+     * @param array $options   array of possible options:
      *    - who          ID of the user (0 = undefined)
      *    - whogroup     ID of the group of users (0 = undefined)
      *    - begin        Date


### PR DESCRIPTION
This a rework on the declined previous PR : https://github.com/glpi-project/glpi/pull/22002

It fixes #21794 after creating a new branch based on up-to-date 11.0/bugfixes

Only PHPDoc annotations.

Got a doubt though on showFor* methods in `src/Change_Ticket.php` and `src/Change_Problem.php` : PHPStan accept ONLY `void|false` but adding a `return;` statement could be an option (`return` + `void` is rejected by PHPStan so i'm open to any suggestion on those cases).