### PR TITLE
Delete unused custom illustrations files

### DIFF
--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -52,6 +52,7 @@ use Glpi\Search\FilterableInterface;
 use Glpi\Search\SearchOption;
 use Glpi\Socket;
 use Glpi\Toolbox\UuidStore;
+use Glpi\UI\IllustrationManager;
 
 use function Safe\getimagesize;
 use function Safe\preg_grep;
@@ -2037,7 +2038,32 @@ class CommonDBTM extends CommonGLPI
      **/
     public function prepareInputForUpdate($input)
     {
+        $this->deleteUnusedCustomIllustrationFile($input);
+
         return $input;
+    }
+
+    private function deleteUnusedCustomIllustrationFile(array $input): void
+    {
+        if (
+            // This item support illustrations?
+            isset($this->fields['illustration'])
+            // An illustration was set before these changes?
+            && str_starts_with(
+                $this->fields['illustration'],
+                IllustrationManager::CUSTOM_ILLUSTRATION_PREFIX,
+            )
+            // A new illustration value exist in the input?
+            && isset($input['illustration'])
+            // The new illustration value is different?
+            && $input['illustration'] !== $this->fields['illustration']
+        ) {
+            $manager = (new IllustrationManager());
+            $id = $manager->getCustomIconIdFromPrefixedString(
+                $this->fields['illustration']
+            );
+            $manager->deleteCustomIllustrationFile($id);
+        }
     }
 
     /**


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Prevent unused illustrations files from polluting the ` files/_pictures/illustrations/` folder.
