### PR TITLE
Fix (ProjectTask) - Allow linking tickets to closed project tasks

### DIFF
--- a/ajax/dropdownProjectTaskTicket.php
+++ b/ajax/dropdownProjectTaskTicket.php
@@ -41,14 +41,8 @@ header("Content-Type: text/html; charset=UTF-8");
 Html::header_nocache();
 
 if (isset($_POST["projects_id"])) {
-    $container_id = 'results_projects' . $_POST["rand"];
-
     if ($_POST["projects_id"] > 0) {
         $condition = ['glpi_projecttasks.projects_id' => $_POST['projects_id']];
-
-        if (isset($_POST['condition']) && is_array($_POST['condition'])) {
-            $condition = array_merge($condition, $_POST['condition']);
-        }
 
         $dropdown_params = [
             'itemtype'        => ProjectTask::getType(),

--- a/ajax/dropdownProjectTaskTicket.php
+++ b/ajax/dropdownProjectTaskTicket.php
@@ -46,7 +46,7 @@ if (isset($_POST["projects_id"])) {
     if ($_POST["projects_id"] > 0) {
 
         $condition = [
-            'glpi_projecttasks.projects_id' => $_POST['projects_id']
+            'glpi_projecttasks.projects_id' => $_POST['projects_id'],
         ];
 
         $finished_states_it = $DB->request(

--- a/ajax/dropdownProjectTaskTicket.php
+++ b/ajax/dropdownProjectTaskTicket.php
@@ -64,7 +64,7 @@ if (isset($_POST["projects_id"])) {
             $finished_states_ids[] = $state['id'];
         }
 
-        if (!empty($finished_states_ids)) {
+        if ($finished_states_ids !== []) {
             $condition['glpi_projecttasks.projectstates_id'] = ['NOT IN', $finished_states_ids];
         }
 

--- a/ajax/dropdownProjectTaskTicket.php
+++ b/ajax/dropdownProjectTaskTicket.php
@@ -41,22 +41,35 @@ header("Content-Type: text/html; charset=UTF-8");
 Html::header_nocache();
 
 if (isset($_POST["projects_id"])) {
-    $condition = ['glpi_projecttasks.projectstates_id' => ['<>', 3]];
+    $container_id = 'results_projects' . $_POST["rand"];
 
     if ($_POST["projects_id"] > 0) {
-        $condition['glpi_projecttasks.projects_id'] = $_POST['projects_id'];
+        $condition = ['glpi_projecttasks.projects_id' => $_POST['projects_id']];
+
+        // Filtrer les états de tâches terminées si nécessaire
+        if (isset($_POST['condition']) && is_array($_POST['condition'])) {
+            $condition = array_merge($condition, $_POST['condition']);
+        }
+
+        $dropdown_params = [
+            'itemtype'        => ProjectTask::getType(),
+            'entity_restrict' => Session::getMatchingActiveEntities($_POST['entity_restrict']),
+            'myname'          => $_POST["myname"],
+            'condition'       => $condition,
+            'rand'            => $_POST["rand"],
+        ];
+
+        if (isset($_POST["used"]) && !empty($_POST["used"])) {
+            $dropdown_params["used"] = $_POST["used"];
+        }
+
+        if (isset($_POST["displaywith"])) {
+            $dropdown_params["displaywith"] = $_POST["displaywith"];
+        }
+
+        $label = ProjectTask::getTypeName(1);
+
+        echo '<label class="form-label mb-0">' . htmlspecialchars($label) . '</label>';
+        ProjectTask::dropdown($dropdown_params);
     }
-
-    $p = ['itemtype'     => ProjectTask::getType(),
-        'entity_restrict' => Session::getMatchingActiveEntities($_POST['entity_restrict']),
-        'myname'          => $_POST["myname"],
-        'condition'       => $condition,
-        'rand'            => $_POST["rand"],
-    ];
-
-    if (isset($_POST["used"]) && !empty($_POST["used"])) {
-        $p["used"] = $_POST["used"];
-    }
-
-    ProjectTask::dropdown($p);
 }

--- a/ajax/dropdownProjectTaskTicket.php
+++ b/ajax/dropdownProjectTaskTicket.php
@@ -46,7 +46,6 @@ if (isset($_POST["projects_id"])) {
     if ($_POST["projects_id"] > 0) {
         $condition = ['glpi_projecttasks.projects_id' => $_POST['projects_id']];
 
-        // Filtrer les états de tâches terminées si nécessaire
         if (isset($_POST['condition']) && is_array($_POST['condition'])) {
             $condition = array_merge($condition, $_POST['condition']);
         }
@@ -59,7 +58,7 @@ if (isset($_POST["projects_id"])) {
             'rand'            => $_POST["rand"],
         ];
 
-        if (isset($_POST["used"]) && !empty($_POST["used"])) {
+        if (!empty($_POST["used"])) {
             $dropdown_params["used"] = $_POST["used"];
         }
 

--- a/src/Itil_Project.php
+++ b/src/Itil_Project.php
@@ -267,6 +267,17 @@ TWIG, $twig_params);
         $selfTable = self::getTable();
         $projectTable = Project::getTable();
 
+        // Get finished project states to filter them out from dropdown
+        $finished_states_it = $DB->request([
+            'SELECT' => ['id'],
+            'FROM'   => ProjectState::getTable(),
+            'WHERE'  => ['is_finished' => 1],
+        ]);
+        $finished_states_ids = [];
+        foreach ($finished_states_it as $state) {
+            $finished_states_ids[] = $state['id'];
+        }
+
         $iterator = $DB->request([
             'SELECT'          => [
                 "$selfTable.id AS linkid",
@@ -298,12 +309,20 @@ TWIG, $twig_params);
         }
 
         if ($canedit && !$itil->isSolved(true)) {
+            $project_conditions = [
+                'glpi_projects.is_template' => 0,
+            ];
+            if (count($finished_states_ids)) {
+                $project_conditions['glpi_projects.projectstates_id'] = ['NOT IN', $finished_states_ids];
+            }
+
             $twig_params = [
                 'btn_msg' => _x('button', 'Add'),
                 'used' => $used,
                 'itemtype' => $itil::class,
                 'items_id' => $ID,
                 'entities_id' => $itil->getEntityID(),
+                'project_conditions' => $project_conditions,
             ];
             // language=Twig
             echo TemplateRenderer::getInstance()->renderFromStringTemplate(<<<TWIG
@@ -319,7 +338,8 @@ TWIG, $twig_params);
                                         add_field_class: 'd-inline',
                                         no_label: true,
                                         used: used,
-                                        entity: entities_id
+                                        entity: entities_id,
+                                        condition: project_conditions
                                     }) }}
                                 </div>
                                 <div class="col-auto">

--- a/src/ProjectTask_Ticket.php
+++ b/src/ProjectTask_Ticket.php
@@ -276,31 +276,8 @@ class ProjectTask_Ticket extends CommonDBRelation
                 'entity_restrict' => $ticket->getEntityID(),
                 'used'            => $used,
                 'rand'            => $rand,
-                'myname'          => "projects",
+                'myname'          => "projecttasks",
             ];
-
-            if (count($finished_states_ids)) {
-                $where = [
-                    'OR'  => [
-                        'projectstates_id'   => $finished_states_ids,
-                        'is_template'        => 1,
-                    ],
-                ];
-            } else {
-                $where = ['is_template' => 1];
-            }
-
-            $excluded_projects_it = $DB->request(
-                [
-                    'SELECT' => ['id'],
-                    'FROM'   => Project::getTable(),
-                    'WHERE'  => $where,
-                ]
-            );
-            $excluded_projects_ids = [];
-            foreach ($excluded_projects_it as $excluded_project) {
-                $excluded_projects_ids[] = $excluded_project['id'];
-            }
 
             $dd_params = [
                 'used'        => $used,
@@ -312,9 +289,6 @@ class ProjectTask_Ticket extends CommonDBRelation
             $condition = [];
             if (count($finished_states_ids)) {
                 $condition['glpi_projecttasks.projectstates_id'] = $finished_states_ids;
-            }
-            if (count($excluded_projects_ids)) {
-                $condition['glpi_projecttasks.projects_id'] = $excluded_projects_ids;
             }
 
             if (count($condition)) {
@@ -328,17 +302,16 @@ class ProjectTask_Ticket extends CommonDBRelation
                 'source_items_id' => $ID,
                 'target_itemtype' => ProjectTask::class,
                 'dropdown_options' => [
-                    "itemtype" => Project::class,
+                    'label'       => Project::getTypeName(1),
+                    'itemtype' => Project::class,
                     'entity'      => $ticket->getEntityID(),
                     'entity_sons' => $ticket->isRecursive(),
-                    'condition'   => ['NOT' => ['glpi_projects.projectstates_id' => $finished_states_ids]],
+                    'condition'   => ['glpi_projects.is_template' => 0],
                 ],
                 'ajax_dropdown' => [
                     'toobserve' => "dropdown_projects_id$rand",
                     'toupdate' => [
                         "id" => "results_projects$rand",
-                        "itemtype" => ProjectTask::class,
-                        'params' => $dd_params,
                     ],
                     'url' => $CFG_GLPI["root_doc"] . "/ajax/dropdownProjectTaskTicket.php",
                     'params' => $p,

--- a/src/ProjectTask_Ticket.php
+++ b/src/ProjectTask_Ticket.php
@@ -272,27 +272,20 @@ class ProjectTask_Ticket extends CommonDBRelation
                 $finished_states_ids[] = $finished_state['id'];
             }
 
-            $p = ['projects_id'     => '__VALUE__',
+            $p = [
+                'projects_id'     => '__VALUE__',
                 'entity_restrict' => $ticket->getEntityID(),
                 'used'            => $used,
                 'rand'            => $rand,
                 'myname'          => "projecttasks",
             ];
 
-            $dd_params = [
-                'used'        => $used,
-                'entity'      => $ticket->getEntityID(),
-                'entity_sons' => $ticket->isRecursive(),
-                'displaywith' => ['id'],
+            $project_conditions = [
+                'glpi_projects.is_template' => 0,
             ];
 
-            $condition = [];
             if (count($finished_states_ids)) {
-                $condition['glpi_projecttasks.projectstates_id'] = $finished_states_ids;
-            }
-
-            if (count($condition)) {
-                $dd_params['condition'] = ['NOT' => $condition];
+                $project_conditions['glpi_projects.projectstates_id'] = ['NOT IN', $finished_states_ids];
             }
 
             echo TemplateRenderer::getInstance()->render('components/form/link_existing_or_new.html.twig', [
@@ -306,7 +299,7 @@ class ProjectTask_Ticket extends CommonDBRelation
                     'itemtype' => Project::class,
                     'entity'      => $ticket->getEntityID(),
                     'entity_sons' => $ticket->isRecursive(),
-                    'condition'   => ['glpi_projects.is_template' => 0],
+                    'condition'   => $project_conditions,
                 ],
                 'ajax_dropdown' => [
                     'toobserve' => "dropdown_projects_id$rand",

--- a/templates/components/form/link_existing_or_new.html.twig
+++ b/templates/components/form/link_existing_or_new.html.twig
@@ -35,58 +35,58 @@
 {% set rand = rand|default(random()) %}
 <div class="mb-3">
    <form id="{{ link_itemtype|lower ~ "_form" ~ rand }}" name="{{ link_itemtype|lower ~ "_form" ~ rand }}" method="post" action="{{ link_itemtype|itemtype_form_path }}">
-      {{ form_label }}
-      {{ fields.hiddenField(source_itemtype|itemtype_foreign_key, source_items_id) }}
-      {% set primary_dropdown_itemtype = dropdown_options['itemtype']|default(target_itemtype) %}
-      <div class="d-flex">
-         {% if link_types is defined and link_types is not empty %}
-            <div class="col-auto">
-               {{ fields.dropdownArrayField('link', link_types|first, link_types, '', {
-                  no_label: true,
-                  field_class: ''
-               }) }}
-            </div>
-         {% endif %}
-         <div class="col-auto">
-            {{ fields.dropdownField(primary_dropdown_itemtype, primary_dropdown_itemtype|itemtype_foreign_key, '', '', {
-               no_label: true,
-               field_class: '',
-               rand: rand
-            }|merge(dropdown_options)) }}
-            {% if ajax_dropdown is defined %}
-               {% do call('Ajax::updateItemOnSelectEvent', [
-                  ajax_dropdown['toobserve'],
-                  ajax_dropdown['toupdate']['id'],
-                  ajax_dropdown['url'],
-                  ajax_dropdown['params'],
-               ]) %}
-            {% endif %}
-            {% if ajax_dropdown is defined %}
-               <span id="{{ ajax_dropdown['toupdate']['id'] }}">
-                  {{ fields.dropdownField(ajax_dropdown['toupdate']['itemtype'], (ajax_dropdown['toupdate']['itemtype'])|itemtype_foreign_key, '', '', {
+      <div class="row">
+         <label class="col-form-label col-xxl-2">{{ form_label }}</label>
+         <div class="col-xxl-10">
+            {{ fields.hiddenField(source_itemtype|itemtype_foreign_key, source_items_id) }}
+            {% set primary_dropdown_itemtype = dropdown_options['itemtype']|default(target_itemtype) %}
+            <div class="d-flex flex-wrap align-items-center gap-2">
+               {% if link_types is defined and link_types is not empty %}
+                  {{ fields.dropdownArrayField('link', link_types|first, link_types, '', {
                      no_label: true,
+                     mb: '',
+                     field_class: ''
+                  }) }}
+               {% endif %}
+
+               {{ fields.dropdownField(
+                  primary_dropdown_itemtype,
+                  primary_dropdown_itemtype|itemtype_foreign_key,
+                  '',
+                  dropdown_options['label'] ?? '',
+                  {
+                     no_label: dropdown_options['label'] is defined ? false : true,
+                     mb: '',
                      field_class: '',
-                     rand: rand
-                  }|merge(ajax_dropdown['toupdate']['params'])) }}
-               </span>
-            {% endif %}
+                     rand: rand,
+                  }|merge(dropdown_options))
+               }}
+
+               {% if ajax_dropdown is defined %}
+                  {% do call('Ajax::updateItemOnSelectEvent', [
+                     ajax_dropdown['toobserve'],
+                     ajax_dropdown['toupdate']['id'],
+                     ajax_dropdown['url'],
+                     ajax_dropdown['params'],
+                  ]) %}
+                  <div id="{{ ajax_dropdown['toupdate']['id'] }}" style="display: none;" class="d-flex align-items-center gap-2"></div>
+               {% endif %}
+
+               <button class="btn btn-primary" type="submit" name="add">
+                  <i class="ti ti-link"></i>
+                  <span>{{ _x('button', 'Add') }}</span>
+               </button>
+
+               {% if create_link %}
+                  {% set target_form_path = (target_itemtype|itemtype_form_path ~ "?_" ~ source_itemtype|itemtype_foreign_key ~ "=" ~ source_items_id) %}
+                  {% set create_url = create_link['url'] is defined ? create_link['url'] : target_form_path %}
+                  <a href="{{ create_url }}" class="btn btn-primary">
+                     <i class="ti ti-plus"></i>
+                     <span>{{ button_label }}</span>
+                  </a>
+               {% endif %}
+            </div>
          </div>
-         <div class="col-auto">
-            <button class="btn btn-primary ms-1" type="submit" name="add">
-               <i class="{{ add_button_icon ?? 'ti ti-link' }}"></i>
-               <span>{{ add_button_label ?? _x('button', 'Add') }}</span>
-            </button>
-         </div>
-         {% if create_link %}
-         <div class="col-auto ms-4">
-               {% set target_form_path = (target_itemtype|itemtype_form_path ~ "?_" ~ source_itemtype|itemtype_foreign_key ~ "=" ~ source_items_id) %}
-               {% set create_url = create_link['url'] is defined ? create_link['url'] : target_form_path %}
-               <a href="{{ create_url }}" class="btn btn-primary">
-                  <i class="ti ti-plus"></i>
-                  <span>{{ button_label }}</span>
-               </a>
-         </div>
-         {% endif %}
       </div>
       {{ fields.csrfField() }}
    </form>

--- a/templates/components/form/link_existing_or_new.html.twig
+++ b/templates/components/form/link_existing_or_new.html.twig
@@ -59,15 +59,15 @@
                      mb: '',
                      field_class: '',
                      rand: rand,
-                  }|merge(dropdown_options))
-               }}
+                  }|merge(dropdown_options)
+               ) }}
 
                {% if ajax_dropdown is defined %}
                   {% do call('Ajax::updateItemOnSelectEvent', [
                      ajax_dropdown['toobserve'],
                      ajax_dropdown['toupdate']['id'],
                      ajax_dropdown['url'],
-                     ajax_dropdown['params'],
+                     ajax_dropdown['params']
                   ]) %}
                   <div id="{{ ajax_dropdown['toupdate']['id'] }}" style="display: none;" class="d-flex align-items-center gap-2"></div>
                {% endif %}


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !40409
- Here is a brief description of what this PR does

This PR improves the project task linking interface for tickets and ensures consistent behavior by filtering closed/finished projects and tasks.

### Issues Fixed
- Project dropdown now shows **only open projects** (closed/finished projects are filtered out)
- Project task dropdown now shows **only open tasks** (tasks with finished states are filtered out)
- Task dropdown only appears after selecting a project (better UX with cascading dropdowns)
- Tasks are properly filtered by the selected project
- Already linked tasks are excluded from the dropdown to prevent duplicates
- Fixed hardcoded project state IDs (now dynamically queries finished states)

## Screenshots (if appropriate):

<img width="802" height="433" alt="image" src="https://github.com/user-attachments/assets/cd24c4ae-4c25-4aa8-a218-9a87a165728c" />

<img width="958" height="438" alt="image" src="https://github.com/user-attachments/assets/b3c40726-32da-43f8-a604-39ca5102910c" />

