### PR TITLE
Fix AllAsset exports

### DIFF
--- a/front/report.dynamic.php
+++ b/front/report.dynamic.php
@@ -42,6 +42,7 @@ if (!isset($_GET['item_type']) || !is_string($_GET['item_type']) || !is_a($_GET[
     return;
 }
 
+/** @var class-string<AllAssets|CommonDBTM> $itemtype */
 $itemtype = $_GET['item_type'];
 $item = getItemForItemtype($itemtype);
 if ($item instanceof AllAssets) {

--- a/src/Search.php
+++ b/src/Search.php
@@ -170,7 +170,7 @@ class Search
     /**
      * Display result table for search engine for a type
      *
-     * @param class-string<CommonGLPI> $itemtype Item type to manage
+     * @param class-string<AllAssets|CommonDBTM> $itemtype Item type to manage
      * @param array  $params       Search params passed to
      *                             prepareDatasForSearch function
      * @param array  $forcedisplay Array of columns to display (default empty


### PR DESCRIPTION
closes #22035

Reverts https://github.com/glpi-project/glpi/pull/20428/files#diff-fddc2770c1d35659f0f234f634611059929b024a59195e5abfd3ed24b97ef951: `$item` is already set when required; and in that case `AllAsset` is a valid item type.