### PR TITLE
Fix - Service Levels rule criteria

### DIFF
--- a/src/LevelAgreementLevel.php
+++ b/src/LevelAgreementLevel.php
@@ -228,20 +228,15 @@ abstract class LevelAgreementLevel extends RuleTicket
     public function getCriterias()
     {
 
-        $actions = parent::getActions();
+        $criteria = parent::getCriterias();
 
-        unset($actions['olas_id']);
-        unset($actions['slas_id']);
-        // Could not be used as criteria
-        unset($actions['users_id_validate_requester_supervisor']);
-        unset($actions['users_id_validate_assign_supervisor']);
-        unset($actions['affectobject']);
-        unset($actions['groups_id_validate']);
-        unset($actions['users_id_validate']);
-        unset($actions['validation_percent']);
-        $actions['status']['name']    = __('Status');
-        $actions['status']['type']    = 'dropdown_status';
-        return $actions;
+        unset($criteria['olas_id']);
+        unset($criteria['slas_id']);
+        unset($criteria['slas_id_ttr']);
+        unset($criteria['slas_id_tto']);
+        $criteria['status']['name']    = __('Status');
+        $criteria['status']['type']    = 'dropdown_status';
+        return $criteria;
     }
 
 


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description
 Clone of https://github.com/glpi-project/glpi/pull/21973 for 10.0.x
- It fixes !40319
- Here is a brief description of what this PR does

Fix incorrect method call in `LevelAgreementLevel::getCriterias()`.

The method was calling `parent::getActions()` instead of `parent::getCriterias()`, which caused the wrong set of fields to be returned for escalation level criteria.

