### PR TITLE
Fix service catalog tile right check

### DIFF
--- a/src/Glpi/Helpdesk/Tile/GlpiPageTile.php
+++ b/src/Glpi/Helpdesk/Tile/GlpiPageTile.php
@@ -184,10 +184,10 @@ final class GlpiPageTile extends CommonDBTM implements TileInterface, ProvideTra
     public function isAvailable(SessionInfo $session_info): bool
     {
         return match ($this->fields['page']) {
-            self::PAGE_SERVICE_CATALOG => $session_info->hasRight(
-                Ticket::$rightname,
-                CREATE,
-            ),
+            self::PAGE_SERVICE_CATALOG => $session_info
+                ->getCurrentEntity()
+                ->isServiceCatalogEnabled()
+            ,
             self::PAGE_FAQ             => true,
             self::PAGE_RESERVATION     => $session_info->hasRight(
                 'reservation',

--- a/src/Glpi/Session/SessionInfo.php
+++ b/src/Glpi/Session/SessionInfo.php
@@ -35,6 +35,8 @@
 
 namespace Glpi\Session;
 
+use Entity;
+use LogicException;
 use Profile;
 
 final class SessionInfo
@@ -75,6 +77,16 @@ final class SessionInfo
     public function getCurrentEntityId(): int
     {
         return $this->current_entity_id;
+    }
+
+    public function getCurrentEntity(): Entity
+    {
+        $entity = Entity::getById($this->current_entity_id);
+        if ($entity === false) {
+            throw new LogicException(); // Can't happen
+        }
+
+        return $entity;
     }
 
     public function hasRight(string $right, int $action): bool

--- a/tests/DbTestCase.php
+++ b/tests/DbTestCase.php
@@ -168,7 +168,7 @@ class DbTestCase extends GLPITestCase
                 $this->assertArrayHasKey(
                     $k,
                     $object->fields,
-                    "Object not created as expected, field '$k' not found in object " . get_class($object),
+                    "Object not created or updated as expected, field '$k' not found in object " . get_class($object),
                 );
 
                 if (is_array($v)) {
@@ -178,7 +178,7 @@ class DbTestCase extends GLPITestCase
                         $v,
                         $object->fields[$k],
                         "
-                    Object not created as expected
+                    Object not created or updated as expected
                     field '$k' value is '{$object->fields[$k]}' (" . gettype($object->fields[$k]) . ")
                     but was expected to be '$v' (" . gettype($v) . ")"
                     );

--- a/tests/functional/Glpi/Helpdesk/Tile/TilesManagerTest.php
+++ b/tests/functional/Glpi/Helpdesk/Tile/TilesManagerTest.php
@@ -53,6 +53,7 @@ use InvalidArgumentException;
 use Profile;
 use Session;
 use Ticket;
+use User;
 
 final class TilesManagerTest extends DbTestCase
 {
@@ -67,10 +68,7 @@ final class TilesManagerTest extends DbTestCase
     {
         // Arrange: create a self service profile
         $manager = $this->getManager();
-        $profile = $this->createItem(Profile::class, [
-            'name' => 'Helpdesk profile',
-            'interface' => 'helpdesk',
-        ]);
+        $profile = $this->createNewHelpdeskProfile();
 
         // Act: add two tile
         $manager->addTile($profile, ExternalPageTile::class, [
@@ -133,10 +131,7 @@ final class TilesManagerTest extends DbTestCase
         // Arrange: create a self service profile and mutliple form tiles
         $forms = [];
         $manager = $this->getManager();
-        $profile = $this->createItem(Profile::class, [
-            'name' => 'Helpdesk profile',
-            'interface' => 'helpdesk',
-        ]);
+        $profile = $this->createNewHelpdeskProfile();
         $this->addRightToProfile("Helpdesk profile", Ticket::$rightname, CREATE | CREATE);
 
         $builder = new FormBuilder("Inactive form");
@@ -175,10 +170,7 @@ final class TilesManagerTest extends DbTestCase
         // Arrange: create a self service profile and mutliple form tiles
         $forms = [];
         $manager = $this->getManager();
-        $profile = $this->createItem(Profile::class, [
-            'name' => 'Helpdesk profile',
-            'interface' => 'helpdesk',
-        ]);
+        $profile = $this->createNewHelpdeskProfile();
         $this->addRightToProfile("Helpdesk profile", Ticket::$rightname, CREATE | CREATE);
 
         $builder = new FormBuilder("Form without access policies");
@@ -218,10 +210,7 @@ final class TilesManagerTest extends DbTestCase
         // Arrange: create a self service profile and mutliple form tiles
         $forms = [];
         $manager = $this->getManager();
-        $profile = $this->createItem(Profile::class, [
-            'name' => 'Helpdesk profile',
-            'interface' => 'helpdesk',
-        ]);
+        $profile = $this->createNewHelpdeskProfile();
         $this->addRightToProfile("Helpdesk profile", Ticket::$rightname, CREATE | CREATE);
 
         $builder = new FormBuilder("Form inside current entity");
@@ -267,10 +256,7 @@ final class TilesManagerTest extends DbTestCase
     {
         // Arrange: create three tiles and modify their orders
         $manager = $this->getManager();
-        $profile = $this->createItem(Profile::class, [
-            'name' => 'Helpdesk profile',
-            'interface' => 'helpdesk',
-        ]);
+        $profile = $this->createNewHelpdeskProfile();
         $this->addRightToProfile("Helpdesk profile", Ticket::$rightname, CREATE | CREATE);
         $manager->addTile($profile, ExternalPageTile::class, [
             'title'        => "GLPI project",
@@ -328,10 +314,7 @@ final class TilesManagerTest extends DbTestCase
     {
         // Arrange: create three tiles
         $manager = $this->getManager();
-        $profile = $this->createItem(Profile::class, [
-            'name' => 'Helpdesk profile',
-            'interface' => 'helpdesk',
-        ]);
+        $profile = $this->createNewHelpdeskProfile();
         $this->addRightToProfile("Helpdesk profile", Ticket::$rightname, CREATE | CREATE);
         $profile_tile_id_1 = $manager->addTile($profile, ExternalPageTile::class, [
             'title'        => "GLPI project",
@@ -388,10 +371,7 @@ final class TilesManagerTest extends DbTestCase
     {
         // Arrange: create a profile with some tiles
         $manager = $this->getManager();
-        $profile = $this->createItem(Profile::class, [
-            'name' => 'Helpdesk profile',
-            'interface' => 'helpdesk',
-        ]);
+        $profile = $this->createNewHelpdeskProfile();
         $manager->addTile($profile, ExternalPageTile::class, [
             'title'        => "GLPI project",
             'description'  => "Link to GLPI project website",
@@ -435,10 +415,7 @@ final class TilesManagerTest extends DbTestCase
 
         // Arrange: create a self service profile without tiles
         $manager = $this->getManager();
-        $profile = $this->createItem(Profile::class, [
-            'name' => 'Helpdesk profile',
-            'interface' => 'helpdesk',
-        ]);
+        $profile = $this->createNewHelpdeskProfile();
         $this->addRightToProfile("Helpdesk profile", Ticket::$rightname, CREATE | CREATE);
 
         // Act: get tiles
@@ -460,10 +437,7 @@ final class TilesManagerTest extends DbTestCase
 
         // Arrange: create a self service profile without tiles
         $manager = $this->getManager();
-        $profile = $this->createItem(Profile::class, [
-            'name' => 'Helpdesk profile',
-            'interface' => 'helpdesk',
-        ]);
+        $profile = $this->createNewHelpdeskProfile();
         $this->addRightToProfile("Helpdesk profile", Ticket::$rightname, CREATE | CREATE);
 
         // Create a tile for the current entity
@@ -703,7 +677,7 @@ final class TilesManagerTest extends DbTestCase
         $this->assertTrue($this->tilesExist("Browse help articles", $tiles));
         $this->assertTrue($this->tilesExist("Make a reservation", $tiles));
         $this->assertTrue($this->tilesExist("See your tickets", $tiles));
-        $this->assertFalse($this->tilesExist("Create a ticket", $tiles));
+        $this->assertTrue($this->tilesExist("Create a ticket", $tiles));
         $this->assertFalse($this->tilesExist("Request a service", $tiles));
         $this->assertFalse($this->tilesExist("Report an issue", $tiles));
     }
@@ -740,5 +714,74 @@ final class TilesManagerTest extends DbTestCase
         $this->assertInstanceOf(FormTile::class, $types[0]);
         $this->assertInstanceOf(GlpiPageTile::class, $types[1]);
         $this->assertInstanceOf(ExternalPageTile::class, $types[2]);
+    }
+
+    public function testServiceCatalogTileIsVisibleIfServiceCatalogIsEnabled(): void
+    {
+        // Arrange: create a profile with a helpdesk tile
+        $manager = $this->getManager();
+        $profile = $this->createNewHelpdeskProfile();
+        $manager->addTile($profile, GlpiPageTile::class, [
+            'title'        => "Service catalog",
+            'description'  => "Go to service catalog",
+            'illustration' => "request-service",
+            'page'         => GlpiPageTile::PAGE_SERVICE_CATALOG,
+        ]);
+        $this->login();
+        $this->updateItem(Entity::class, $this->getTestRootEntity(only_id: true), [
+            'enable_helpdesk_service_catalog' => 1,
+        ]);
+        $this->createUserForProfile("test_user", $profile);
+
+        // Act: get tiles for our user
+        $this->login("test_user");
+        $session = Session::getCurrentSessionInfo();
+        $tiles = $manager->getVisibleTilesForSession($session);
+        $this->assertCount(1, $tiles);
+    }
+
+    public function testServiceCatalogTileIsDisabledIfServiceCatalogIsDisabled(): void
+    {
+        // Arrange: create a profile with a helpdesk tile and disable service catalog
+        $manager = $this->getManager();
+        $profile = $this->createNewHelpdeskProfile();
+        $manager->addTile($profile, GlpiPageTile::class, [
+            'title'        => "Service catalog",
+            'description'  => "Go to service catalog",
+            'illustration' => "request-service",
+            'page'         => GlpiPageTile::PAGE_SERVICE_CATALOG,
+        ]);
+        $this->login();
+        $this->updateItem(Entity::class, $this->getTestRootEntity(only_id: true), [
+            'enable_helpdesk_service_catalog' => 0,
+        ]);
+        $this->createUserForProfile("test_user", $profile);
+
+        // Act: get tiles for our user
+        $this->login("test_user");
+        $session = Session::getCurrentSessionInfo();
+        $tiles = $manager->getVisibleTilesForSession($session);
+        $this->assertCount(0, $tiles);
+    }
+
+    private function createNewHelpdeskProfile(): Profile
+    {
+        return $this->createItem(Profile::class, [
+            'name' => 'Helpdesk profile',
+            'interface' => 'helpdesk',
+        ]);
+    }
+
+    private function createUserForProfile(string $login, Profile $profile): void
+    {
+        $this->createItem(User::class, [
+            'name'          => $login,
+            'password'      => 'password',
+            'password2'     => 'password',
+            'profiles_id'   => $profile->getID(),
+            '_profiles_id'  => $profile->getID(),
+            '_entities_id'  => $this->getTestRootEntity(only_id: true),
+            '_is_recursive' => true,
+        ], ['password', 'password2']);
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

The service catalog tile was checking for the "create ticket" right, when it should instead check if the service catalog is enabled.

## References

Fix #22039.


