### PR TITLE
Fix weird drag and drop issues on chromium engine again

### DIFF
--- a/js/modules/Forms/EditorController.js
+++ b/js/modules/Forms/EditorController.js
@@ -2528,9 +2528,9 @@ export class GlpiFormEditorController
 
                     // Remove active states
                     this.#setActiveItem(null);
-                }, 0);
 
-                $(this.#target).addClass("disable-focus").attr('data-glpi-form-editor-sorting', '');
+                    $(this.#target).addClass("disable-focus").attr('data-glpi-form-editor-sorting', '');
+                }, 0);
             });
 
         // Run the post move process if any item was dragged, even if it was not


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Same issues as before, chrome doesn't like DOM styles changes during a drag event so it breaks drag and drop.
Wrapping the code in the previous `setInterval` block solves the issue once again.

This one was tricky because it only happens if you use a specific resolution and zoom level.

## References

Internal support ticket: !40443
