### PR TITLE
add: creation of 2 hooks for ITIL actors

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -364,6 +364,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
                 $actors[] = [
                     'itemtype' => $itemtype,
                     'items_id' => $items_id,
+                    'icon_name' => $params['icon_name'] ?: 'ti ti-user',
                 ] + $params;
             }
         };
@@ -539,6 +540,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
                     'use_notification'  => $user['use_notification'],
                     'default_email'     => UserEmail::getDefaultForUser($user['users_id']),
                     'alternative_email' => $user['alternative_email'],
+                    'icon_name'         => $user['alternative_email'] ? 'ti ti-mail' : '',
                 ]);
             }
         }
@@ -565,6 +567,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
                         'use_notification'  => $supplier['use_notification'],
                         'default_email'     => $supplier_obj->fields['email'],
                         'alternative_email' => $supplier['alternative_email'],
+                        'icon_name'         => $supplier['alternative_email'] ? 'ti ti-mail' : '',
                     ]);
                 }
             }

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -364,7 +364,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
                 $actors[] = [
                     'itemtype' => $itemtype,
                     'items_id' => $items_id,
-                    'icon_name' => $params['icon_name'] ?: 'ti ti-user',
+                    'icon_name' => $params['icon_name'] ?? 'ti ti-user',
                 ] + $params;
             }
         };

--- a/src/Glpi/Plugin/Hooks.php
+++ b/src/Glpi/Plugin/Hooks.php
@@ -613,7 +613,7 @@ class Hooks
      * - 'count' => Current displayed count
      *
      * The function is expected to modify the given array as needed and return it.
-     * @used-by templates/components/itilobject/actors/field.html.twig
+     * @used-by templates/components/itilobject/fields_panel.html.twig
      */
     public const POST_ITIL_ACTORS_COUNT = 'post_itil_actors_count';
 

--- a/src/Glpi/Plugin/Hooks.php
+++ b/src/Glpi/Plugin/Hooks.php
@@ -594,6 +594,30 @@ class Hooks
     public const POST_ITIL_INFO_SECTION  = 'post_itil_info_section';
 
     /**
+     * Register a function to edit or add actors inside the Actors fields panel.
+     * The function is called with the following parameters:
+     * - 'item' => The item for which the actors are shown
+     * - 'options' => An array of form parameters
+     * - 'actors' => The actors list, you can add is_editable => false field to disable the edit of this actor
+     *
+     * The function is expected to modify the given array as needed and return it.
+     * @used-by templates/components/itilobject/actors/field.html.twig
+     */
+    public const POST_ITIL_ACTORS_LOAD = 'post_itil_actors_load';
+
+    /**
+     * Register a function alter the displayed count of actors inside the fields panel.
+     * The function is called with the following parameters:
+     * - 'item' => The item for which the actors are shown
+     * - 'options' => An array of form parameters
+     * - 'count' => Current displayed count
+     *
+     * The function is expected to modify the given array as needed and return it.
+     * @used-by templates/components/itilobject/actors/field.html.twig
+     */
+    public const POST_ITIL_ACTORS_COUNT = 'post_itil_actors_count';
+
+    /**
      * Register a function to be called after an item is transferred to another entity.
      * The function is called with an array containing several properties including:
      * - 'type' => The type of the item being transferred.

--- a/templates/components/itilobject/actors/field.html.twig
+++ b/templates/components/itilobject/actors/field.html.twig
@@ -34,6 +34,8 @@
 
 {% set load_actors = params['load_actors'] ?? true %}
 {% set actors = load_actors ? item.getActorsForType(actortypeint, params) : [] %}
+{% set _hook_result = call_plugin_hook_func(constant('Glpi\\Plugin\\Hooks::POST_ITIL_ACTORS_LOAD'), {"item": item, 'options': params, 'actor_type': actortypeint, 'actors': actors}, true) %}
+{% set actors = _hook_result.actors ?? actors %}
 
 {% set required = false %}
 {% if itiltemplate.isMandatoryField('_users_id_' ~ actortype) or itiltemplate.isMandatoryField('_groups_id_' ~ actortype) or (actortype == 'assign' and itiltemplate.isMandatoryField('_suppliers_id_' ~ actortype)) %}
@@ -62,7 +64,9 @@
             data-use-notification="{{ actor_use_notification ? 1 : 0 }}"
             data-default-email="{{ actor['default_email'] ?? '' }}"
             data-alternative-email="{{ actor['alternative_email'] ?? '' }}"
-            {% if (actor['itemtype'] == 'User' and itiltemplate.isHiddenField('_users_id_' ~ actortype)) or (actor['itemtype'] == 'Group' and itiltemplate.isHiddenField('_groups_id_' ~ actortype)) %}
+            data-icon-name="{{ actor['icon_name'] ?? '' }}"
+            data-editable="{{ not (actor['is_editable'] is defined and not actor['is_editable']) }}"
+            {% if (actor['itemtype'] == 'User' and itiltemplate.isHiddenField('_users_id_' ~ actortype)) or (actor['itemtype'] == 'Group' and itiltemplate.isHiddenField('_groups_id_' ~ actortype) or (actor['is_editable'] is defined and not actor['is_editable']) ) %}
                disabled="disabled" style="display: none;"
             {% endif %}
             data-text="{{ actor['text'] }}" data-title="{{ actor['title'] }}" data-glpi-popover-source="content{{ unique_id }}">
@@ -97,16 +101,22 @@
             const title     = _.escape(element.data('title') ?? option.title ?? '');
             const use_notif = element.data('use-notification') ?? option.use_notification ?? 1;
             const alt_email = element.data('alternative-email') ?? option.alternative_email ?? '';
+            const editable  = element.data('editable') ?? option.editable ?? true;
+            let icon_name = element.data('icon-name') ?? option.editable;
 
             let icon = "";
             let fk   = "";
             switch (itemtype) {
                 case "User":
                     if (items_id == 0) {
-                        text = alt_email;
-                        icon = `<i class="ti ti-mail mx-1" title="{{ __('Direct email')|e('html')|e('js') }}"></i>`;
+                        text = alt_email ? alt_email : text;
+                        icon_name = icon_name ? icon_name : "ti ti-mail";
+                        const icon_title = title ? title : `{{ __('Direct email')|e('html')|e('js') }}`;
+
+                        icon = `<i class="${icon_name} mx-1" title="${icon_title}"></i>`;
                     } else {
-                        icon = `<i class="ti ti-user mx-1" title="{{ 'User'|itemtype_name|e('html')|e('js') }}"></i>`;
+                        icon_name = icon_name ? icon_name : "ti ti-user";
+                        icon = `<i class="${icon_name} mx-1" title="{{ 'User'|itemtype_name|e('html')|e('js') }}"></i>`;
                     }
                     if ("{{ actortype|e('js') }}" == "assign") {
                         fk = "users_id_assign";
@@ -135,7 +145,7 @@
             let actions = "";
             {% if canupdate %}
             if (['User', 'Supplier', 'Email'].includes(itemtype)
-                && is_selection) {
+                && is_selection && editable) {
                 const icon_class = use_notif ? "ti-bell-filled" : "ti-bell";
                 actions = `
                     <button class="btn btn-sm btn-ghost-secondary edit-notify-user"
@@ -305,6 +315,14 @@
         }).on('select2:open', () => {
             // Close popovers
             $('.popover').popover('hide');
+        }).on('select2:unselecting', (e) => {
+            // Prevent removing items that are not editable
+            const data = e.params.args.data;
+            const element = $(data.element);
+            const editable = element.data('editable') ?? data.editable ?? true;
+            if (!editable) {
+                e.preventDefault();
+            }
         });
 
         actor_select.parent().popover({

--- a/templates/components/itilobject/actors/field.html.twig
+++ b/templates/components/itilobject/actors/field.html.twig
@@ -66,7 +66,7 @@
             data-alternative-email="{{ actor['alternative_email'] ?? '' }}"
             data-icon-name="{{ actor['icon_name'] ?? '' }}"
             data-editable="{{ not (actor['is_editable'] is defined and not actor['is_editable']) }}"
-            {% if (actor['itemtype'] == 'User' and itiltemplate.isHiddenField('_users_id_' ~ actortype)) or (actor['itemtype'] == 'Group' and itiltemplate.isHiddenField('_groups_id_' ~ actortype) or (actor['is_editable'] is defined and not actor['is_editable']) ) %}
+            {% if (actor['itemtype'] == 'User' and itiltemplate.isHiddenField('_users_id_' ~ actortype)) or (actor['itemtype'] == 'Group' and itiltemplate.isHiddenField('_groups_id_' ~ actortype) or (actor['is_editable'] is defined and not actor['is_editable'])) %}
                disabled="disabled" style="display: none;"
             {% endif %}
             data-text="{{ actor['text'] }}" data-title="{{ actor['title'] }}" data-glpi-popover-source="content{{ unique_id }}">

--- a/templates/components/itilobject/fields_panel.html.twig
+++ b/templates/components/itilobject/fields_panel.html.twig
@@ -277,7 +277,12 @@
                 {{ __('Actors') }}
             </span>
             <span class="badge bg-secondary text-secondary-fg ms-2">
-               {{ item.countActors() }}
+                {% set actors_count = item.countActors() %}
+
+                {% set _hook_result = call_plugin_hook_func(constant('Glpi\\Plugin\\Hooks::POST_ITIL_ACTORS_COUNT'), {"item": item, 'options': params, 'count': actors_count}, true) %}
+                {% set actors_count = _hook_result.count ?? actors_count %}
+
+                {{ actors_count }}
             </span>
             {% if not (params['template_preview'] ?? false) and cancreateuser|default(false) and canupdate %}
                {{ include('components/user/create_user.html.twig') }}


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] This change requires a documentation update. (https://github.com/glpi-project/docdev/pull/187 - To merge once this PR is accepted)
- [ ] I have added tests that prove my fix is effective or that my feature works.

## Description

- Add the ability to change the ITIL Actor icon
- Gave the possibility to plugin to alter the count of Actors and to add (or alter) actors listing :  `POST_ITIL_ACTORS_LOAD` and `POST_ITIL_ACTORS_COUNT`

## Screenshots

<img width="500" height="323" alt="image" src="https://github.com/user-attachments/assets/e88b09e2-6a48-449b-b199-c684bbda21a2" />

- `Hook::POST_ITIL_ACTORS_COUNT` called by the section title to defined the number (2)
- `Hook::POST_ITIL_ACTORS_LOAD` called to virtually add the whatsapp user (with a custom actor icon to it)
