### PR TITLE
Feature / Add event logging for massive delete/restore/purge actions

### DIFF
--- a/src/MassiveAction.php
+++ b/src/MassiveAction.php
@@ -34,6 +34,7 @@
  */
 
 use Glpi\Asset\CustomFieldDefinition;
+use Glpi\Event;
 use Glpi\Features\Clonable;
 use Glpi\Plugin\Hooks;
 use Glpi\Search\SearchOption;
@@ -1331,6 +1332,15 @@ class MassiveAction
                     if ($item->can($id, DELETE)) {
                         if ($item->delete(["id" => $id])) {
                             $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+
+                            // Log event for successful delete action
+                            Event::log(
+                                $id,
+                                strtolower($item->getType()),
+                                4,
+                                "inventory",
+                                sprintf(__('%s deletes an item by massive action'), $_SESSION["glpiname"])
+                            );
                         } else {
                             $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
                             $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));
@@ -1347,6 +1357,15 @@ class MassiveAction
                     if ($item->can($id, DELETE)) {
                         if ($item->restore(["id" => $id])) {
                             $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+
+                            // Log event for successful restore action
+                            Event::log(
+                                $id,
+                                strtolower($item->getType()),
+                                4,
+                                "inventory",
+                                sprintf(__('%s restores an item by massive action'), $_SESSION["glpiname"])
+                            );
                         } else {
                             $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
                             $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));
@@ -1399,6 +1418,19 @@ class MassiveAction
                         }
                         if ($item->delete($delete_array, $force)) {
                             $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+
+                            // Log event for successful purge action
+                            $purge_message = $force
+                                ? sprintf(__('%s purges an item by massive action'), $_SESSION["glpiname"])
+                                : sprintf(__('%s deletes an item by massive action'), $_SESSION["glpiname"]);
+
+                            Event::log(
+                                $id,
+                                strtolower($item->getType()),
+                                4,
+                                "inventory",
+                                $purge_message
+                            );
                         } else {
                             $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
                             $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));

--- a/src/MassiveAction.php
+++ b/src/MassiveAction.php
@@ -1350,7 +1350,7 @@ class MassiveAction
                         0,
                         strtolower($item->getType()),
                         4,
-                        "inventory",
+                        "massiveaction",
                         sprintf(__('%1$s deletes %2$d items by massive action'), $_SESSION["glpiname"], $deleted_count)
                     );
                 }
@@ -1379,7 +1379,7 @@ class MassiveAction
                         0,
                         strtolower($item->getType()),
                         4,
-                        "inventory",
+                        "massiveaction",
                         sprintf(__('%1$s restores %2$d items by massive action'), $_SESSION["glpiname"], $restored_count)
                     );
                 }
@@ -1449,7 +1449,7 @@ class MassiveAction
                         0,
                         strtolower($item->getType()),
                         4,
-                        "inventory",
+                        "massiveaction",
                         $purge_message
                     );
                 }

--- a/tests/functional/MassiveActionTest.php
+++ b/tests/functional/MassiveActionTest.php
@@ -1050,36 +1050,36 @@ class MassiveActionTest extends DbTestCase
                 'action' => 'delete',
                 'item_names' => ['Test Computer 1 for Delete', 'Test Computer 2 for Delete'],
                 'expected_message_pattern' => '/deletes 2 items by massive action/',
-                'setup_callback' => null // No special setup needed for delete
+                'setup_callback' => null, // No special setup needed for delete
             ],
             'computer_restore' => [
                 'itemtype' => 'Computer',
                 'action' => 'restore',
                 'item_names' => ['Test Computer 1 for Restore', 'Test Computer 2 for Restore'],
                 'expected_message_pattern' => '/restores 2 items by massive action/',
-                'setup_callback' => 'setupForRestore' // Need to delete items first
+                'setup_callback' => 'setupForRestore', // Need to delete items first
             ],
             'computer_purge' => [
                 'itemtype' => 'Computer',
                 'action' => 'purge',
                 'item_names' => ['Test Computer 1 for Purge', 'Test Computer 2 for Purge'],
                 'expected_message_pattern' => '/purges 2 items by massive action/',
-                'setup_callback' => null
+                'setup_callback' => null,
             ],
             'monitor_delete' => [
                 'itemtype' => 'Monitor',
                 'action' => 'delete',
                 'item_names' => ['Test Monitor 1 for Delete', 'Test Monitor 2 for Delete', 'Test Monitor 3 for Delete'],
                 'expected_message_pattern' => '/deletes 3 items by massive action/',
-                'setup_callback' => null
+                'setup_callback' => null,
             ],
             'single_item_delete' => [
                 'itemtype' => 'Computer',
                 'action' => 'delete',
                 'item_names' => ['Single Computer for Delete'],
                 'expected_message_pattern' => '/deletes 1 items by massive action/',
-                'setup_callback' => null
-            ]
+                'setup_callback' => null,
+            ],
         ];
     }
 
@@ -1118,13 +1118,13 @@ class MassiveActionTest extends DbTestCase
         global $DB;
         $DB->delete('glpi_events', [
             'type' => strtolower($item->getType()),
-            'service' => 'inventory'
+            'service' => 'inventory',
         ]);
 
         // Count events before action
         $events_before = countElementsInTable('glpi_events', [
             'type' => strtolower($item->getType()),
-            'service' => 'inventory'
+            'service' => 'inventory',
         ]);
 
         // Create mock MassiveAction
@@ -1144,7 +1144,7 @@ class MassiveActionTest extends DbTestCase
         // Count events after action
         $events_after = countElementsInTable('glpi_events', [
             'type' => strtolower($item->getType()),
-            'service' => 'inventory'
+            'service' => 'inventory',
         ]);
 
         // Verify one log entry was created
@@ -1162,10 +1162,10 @@ class MassiveActionTest extends DbTestCase
                 'FROM' => 'glpi_events',
                 'WHERE' => [
                     'type' => strtolower($item->getType()),
-                    'service' => 'inventory'
+                    'service' => 'inventory',
                 ],
                 'ORDER' => ['date DESC'],
-                'LIMIT' => 1
+                'LIMIT' => 1,
             ]);
 
             $this->assertCount(1, $iterator);
@@ -1200,13 +1200,13 @@ class MassiveActionTest extends DbTestCase
         global $DB;
         $DB->delete('glpi_events', [
             'type' => 'computer',
-            'service' => 'inventory'
+            'service' => 'inventory',
         ]);
 
         // Count events before action
         $events_before = countElementsInTable('glpi_events', [
             'type' => 'computer',
-            'service' => 'inventory'
+            'service' => 'inventory',
         ]);
 
         // Create mock MassiveAction that will fail (no rights)
@@ -1230,7 +1230,7 @@ class MassiveActionTest extends DbTestCase
         // Count events after action
         $events_after = countElementsInTable('glpi_events', [
             'type' => 'computer',
-            'service' => 'inventory'
+            'service' => 'inventory',
         ]);
 
         // Verify no log entry was created since no items were successfully processed


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !40347
- The delete/purge/restore actions on an asset performed via Massive Actions were not logged on the `glpi_events` table, unlike their counterparts performed from item forms. The ` MassiveAction::processMassiveActionsForOneItemtype() `is enhanced to log those events via Massive Actions, ensuring consistency with individual item actions.



