### PR TITLE
[Vue] PrimeVue components

### DIFF
--- a/.vue.webpack.config.js
+++ b/.vue.webpack.config.js
@@ -43,7 +43,7 @@ const config = {
             }
         ),
         new webpack.DefinePlugin({
-            __VUE_OPTIONS_API__: false, // We will only use composition API
+            __VUE_OPTIONS_API__: true, // We will only use composition API but some dependencies may require Options API (PrimeVue)
             __VUE_PROD_DEVTOOLS__: false,
             __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: false,
         }),

--- a/js/src/vue/CustomObject/FieldPreview/Field.vue
+++ b/js/src/vue/CustomObject/FieldPreview/Field.vue
@@ -1,4 +1,6 @@
 <script setup>
+    import {Button} from 'primevue';
+
     const props = defineProps({
         field_key: String,
         customfields_id: {
@@ -27,17 +29,17 @@
                 <slot name="field_markers"></slot>
             </div>
             <div v-if="is_active" class="col-auto btn-group shadow-none field-actions">
-                <button type="button" class="btn btn-ghost-secondary btn-sm edit-field" :title="__('Edit')">
+                <Button type="button" variant="ghost" size="small" class="edit-field" :title="__('Edit')">
                     <i class="ti ti-pencil"></i>
-                </button>
-                <button type="button" class="btn btn-ghost-danger btn-sm hide-field" :title="__('Hide')">
+                </Button>
+                <Button type="button" variant="ghost" size="small" severity="danger" class="hide-field" :title="__('Hide')">
                     <i class="ti ti-eye-off"></i>
-                </button>
+                </Button>
             </div>
             <div v-if="!is_active && customfields_id > 0" class="col-auto btn-group shadow-none field-actions">
-                <button type="button" class="btn btn-ghost-danger btn-sm purge-field" :title="_x('button', 'Delete permanently')">
+                <Button type="button" variant="ghost" size="small" severity="danger" class="purge-field" :title="_x('button', 'Delete permanently')">
                     <i class="ti ti-trash"></i>
-                </button>
+                </Button>
             </div>
         </div>
     </div>

--- a/js/src/vue/CustomObject/FieldPreview/Sidebar.vue
+++ b/js/src/vue/CustomObject/FieldPreview/Sidebar.vue
@@ -1,6 +1,7 @@
 <script setup>
     import Field from "./Field.vue";
     import {computed, ref, onMounted} from "vue";
+    import {InputText} from 'primevue';
 
     const props = defineProps({
         inactive_fields: Map,
@@ -40,7 +41,7 @@
 <template>
     <div class="h-100 d-flex col-auto flex-column p-2 px-3 fields-sidebar">
         <span class="fs-2">{{ __('Add more fields') }}</span>
-        <input type="text" class="form-control mb-3" name="search" :placeholder="__('Search')" v-model="search" />
+        <InputText class="mb-3" name="search" :placeholder="__('Search')" v-model="search" />
         <span v-if="unused_native_fields.size > 0" class="fs-3">{{ __('Native fields') }}</span>
         <Field v-for="[field_key, unused_field] of getMatched(unused_native_fields)" :key="field_key" :field_key="field_key"
                :is_active="false">

--- a/js/src/vue/FuzzySearch/Modal.vue
+++ b/js/src/vue/FuzzySearch/Modal.vue
@@ -1,6 +1,7 @@
 <script setup>
     /* global hotkeys, fuzzy */
     import {computed, ref, watch} from "vue";
+    import {Button, InputText} from 'primevue';
 
     let shortcut = `<kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>G</kbd>`;
     if (navigator.userAgent.includes('Mac')) {
@@ -103,14 +104,14 @@
                         <i class="ti ti-arrow-big-right me-2"></i>
                         {{ header_message }}
                     </h5>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    <Button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></Button>
                 </div>
                 <div class="modal-body">
                     <div class="alert alert-info d-flex" role="alert">
                         <i class="ti ti-alert-circle-filled fa-2x me-2"></i>
                         <p v-html="shortcut_message"></p>
                     </div>
-                    <input type="text" class="form-control" :placeholder="placeholder" v-model="input_text">
+                    <InputText :placeholder="placeholder" v-model="input_text"/>
                     <ul class="results list-group mt-2">
                         <li v-for="result in results" :key="result.index" class="list-group-item">
                             <a :href="result.original.url" v-html="result.string"></a>

--- a/js/src/vue/app.js
+++ b/js/src/vue/app.js
@@ -31,8 +31,9 @@
  * ---------------------------------------------------------------------
  */
 
-import { createApp } from 'vue/dist/vue.esm-bundler.js';
-import * as vue from "vue";
+import * as vue from "vue/dist/vue.esm-bundler.js";
+import PrimeVue from 'primevue/config';
+import primevue_style from './primevue_style.js';
 
 let existing_components = {};
 if (window.Vue !== undefined && window.Vue.components !== undefined) {
@@ -41,7 +42,11 @@ if (window.Vue !== undefined && window.Vue.components !== undefined) {
 window.Vue = {
     createApp: (...args) => {
         // pass arguments directly to createApp
-        const app = createApp(...args);
+        const app = vue.createApp(...args);
+        app.use(PrimeVue, {
+            unstyled: true,
+            pt: primevue_style,
+        });
         // add default global properties so they can be used within the templates
         app.config.globalProperties.__ = __;
         app.config.globalProperties._n = _n;

--- a/js/src/vue/primevue_style.js
+++ b/js/src/vue/primevue_style.js
@@ -1,0 +1,17 @@
+// PrimeVue passthrough style configuration to use Bootstrap/Tabler styles
+export default {
+    button: {
+        root: (options) => ({
+            class: [
+                'btn',
+                `btn-${options.props.variant === 'ghost' ? 'ghost-' : (options.props.variant === 'outline' ? 'outline-' : '')}${options.props.severity || 'primary'}`,
+                options.props.size === 'small' ? 'btn-sm' : (options.props.size === 'large' ? 'btn-lg' : ''),
+            ]
+        })
+    },
+    inputtext: {
+        root: () => ({
+            class: 'form-control',
+        })
+    }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
                 "monaco-editor": "^0.54.0",
                 "path-browserify": "^1.0.1",
                 "photoswipe": "^5.4.4",
+                "primevue": "^4.5.0",
                 "process": "^0.11.10",
                 "qtip2": "^3.0.3",
                 "rfs": "^10.0.0",
@@ -4311,6 +4312,65 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/popperjs"
+            }
+        },
+        "node_modules/@primeuix/styled": {
+            "version": "0.7.4",
+            "resolved": "https://registry.npmjs.org/@primeuix/styled/-/styled-0.7.4.tgz",
+            "integrity": "sha512-QSO/NpOQg8e9BONWRBx9y8VGMCMYz0J/uKfNJEya/RGEu7ARx0oYW0ugI1N3/KB1AAvyGxzKBzGImbwg0KUiOQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@primeuix/utils": "^0.6.1"
+            },
+            "engines": {
+                "node": ">=12.11.0"
+            }
+        },
+        "node_modules/@primeuix/styles": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@primeuix/styles/-/styles-2.0.1.tgz",
+            "integrity": "sha512-/9bhdkZDP6pY2HH5KfxGEDNGESjDCdCA23God7q8PqW3Xz1Gtz/8IMAEbpNe+O3I03qylRtEjL1n98J1mp+pRQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@primeuix/styled": "^0.7.4"
+            }
+        },
+        "node_modules/@primeuix/utils": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/@primeuix/utils/-/utils-0.6.3.tgz",
+            "integrity": "sha512-/SLNQSKQ73WbBIsflKVqbpVjCfFYvQO3Sf1LMheXyxh8JqxO4M63dzP56wwm9OPGuCQ6MYOd2AHgZXz+g7PZcg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.11.0"
+            }
+        },
+        "node_modules/@primevue/core": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/@primevue/core/-/core-4.5.0.tgz",
+            "integrity": "sha512-1wEmhoLg8IsgRuER8Ytxtk3C1RQCfcdjAww3sKamQkqTkWvPm/psn54LzQbnn6u2njvQF66pio3EzrLK3IllNw==",
+            "license": "MIT",
+            "dependencies": {
+                "@primeuix/styled": "^0.7.4",
+                "@primeuix/utils": "^0.6.2"
+            },
+            "engines": {
+                "node": ">=12.11.0"
+            },
+            "peerDependencies": {
+                "vue": "^3.5.0"
+            }
+        },
+        "node_modules/@primevue/icons": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/@primevue/icons/-/icons-4.5.0.tgz",
+            "integrity": "sha512-KVjtxAiTnyVmXhrjMlnDJqL6p33rnI4O5RSQbg7TwnFVXYaanVmjHZOQ2uq2euImleaRYeePuXBHGMPEGxOxYg==",
+            "license": "MIT",
+            "dependencies": {
+                "@primeuix/utils": "^0.6.2",
+                "@primevue/core": "4.5.0"
+            },
+            "engines": {
+                "node": ">=12.11.0"
             }
         },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
@@ -13744,6 +13804,22 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/primevue": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/primevue/-/primevue-4.5.0.tgz",
+            "integrity": "sha512-6Na39OPTNg03LE5gHxWMXrspbBC+sEKS/270qOg2Q2CzF3gcxZagESWRAA0IDRva/vaycElL9b8NUosFm41zIg==",
+            "license": "MIT",
+            "dependencies": {
+                "@primeuix/styled": "^0.7.4",
+                "@primeuix/styles": "^2.0.1",
+                "@primeuix/utils": "^0.6.2",
+                "@primevue/core": "4.5.0",
+                "@primevue/icons": "4.5.0"
+            },
+            "engines": {
+                "node": ">=12.11.0"
             }
         },
         "node_modules/process": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
         "monaco-editor": "^0.54.0",
         "path-browserify": "^1.0.1",
         "photoswipe": "^5.4.4",
+        "primevue": "^4.5.0",
         "process": "^0.11.10",
         "qtip2": "^3.0.3",
         "rfs": "^10.0.0",


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

POC for using [PrimeVue](https://primevue.org) for base components in Vue code.

I mentioned this Outline but to reiterate the reasoning for using this:
- WCAG 2.1 AA compliance by default.
- "Your component, not ours" philosophy including a flexible "[passthrough](https://primevue.org/passthrough)" API. Other component libraries tend to be too opinionated.
- Has components that can directly replace (or make replacements easier) of [Flatpickr](https://primevue.org/datepicker), Select2, [Photoswipe](https://primevue.org/galleria/), [spin.js](https://primevue.org/progressspinner/), FancyTree and [RateIT](https://primevue.org/rating/).
- Has unstyled mode so there are no default styles we need to override and we can drop-in Bootstrap/Tabler styles instead. It also means if we switch CSS frameworks for whatever reason later, it is easier to change out the classes/styles without trying to override default ones.

This is the same component library I chose for the [GLPI Vue frontend prototype](https://github.com/cconard96/glpi-vue).