### PR TITLE
Fix (API HL) - Allow uuid field to be set on Custom Assets creation/update

### DIFF
--- a/src/Glpi/Api/HL/Controller/CustomAssetController.php
+++ b/src/Glpi/Api/HL/Controller/CustomAssetController.php
@@ -105,7 +105,6 @@ final class CustomAssetController extends AbstractController
                         'x-version-introduced' => '2.2.0',
                         'type' => Doc\Schema::TYPE_STRING,
                         'format' => Doc\Schema::PATTERN_UUIDV4,
-                        'readOnly' => true,
                     ],
                     'name' => ['type' => Doc\Schema::TYPE_STRING],
                     'comment' => ['type' => Doc\Schema::TYPE_STRING],


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !40409 & complete https://github.com/glpi-project/glpi/pull/22096
- Here is a brief description of what this PR does

The `uuid` field on Custom Assets was marked as `readOnly` in the API schema, which prevented it from being set during POST/PATCH requests.

Unlike standard assets (Computer, Monitor, etc.) where UUID comes from inventory imports, and unlike ITIL tasks/Reminders which auto-generate UUID, Custom Assets need to accept UUID from API input to support external system synchronization.

This change removes the `readOnly` constraint on the `uuid` field for Custom Assets endpoints.