### PR TITLE
Fix composer cache path

### DIFF
--- a/.github/workflows/audit_dependencies.yml
+++ b/.github/workflows/audit_dependencies.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ${{ env.APP_CONTAINER_HOME }}/.composer/cache/
+            ${{ env.APP_CONTAINER_HOME }}/.cache/composer/
             ${{ env.APP_CONTAINER_HOME }}/.npm/_cacache/
           key: "app_home_deps-${{ matrix.php-version }}-${{ hashFiles('composer.lock', 'package-lock.json') }}"
           restore-keys: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ${{ env.APP_CONTAINER_HOME }}/.composer/cache/
+            ${{ env.APP_CONTAINER_HOME }}/.cache/composer/
             ${{ env.APP_CONTAINER_HOME }}/.npm/_cacache/
           key: "app_home_deps-${{ matrix.php-version }}-${{ hashFiles('composer.lock', 'package-lock.json') }}"
           restore-keys: |
@@ -171,7 +171,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ${{ env.APP_CONTAINER_HOME }}/.composer/cache/
+            ${{ env.APP_CONTAINER_HOME }}/.cache/composer/
             ${{ env.APP_CONTAINER_HOME }}/.npm/_cacache/
           key: "app_home_deps-${{ matrix.php-version }}-${{ hashFiles('composer.lock', 'package-lock.json') }}"
           restore-keys: |
@@ -245,7 +245,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ${{ env.APP_CONTAINER_HOME }}/.composer/cache/
+            ${{ env.APP_CONTAINER_HOME }}/.cache/composer/
             ${{ env.APP_CONTAINER_HOME }}/.npm/_cacache/
           key: "app_home_deps-8.3-${{ hashFiles('composer.lock', 'package-lock.json') }}"
           restore-keys: |

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ${{ env.APP_CONTAINER_HOME }}/.composer/cache/
+            ${{ env.APP_CONTAINER_HOME }}/.cache/composer/
             ${{ env.APP_CONTAINER_HOME }}/.npm/_cacache/
           key: "app_home_deps-${{ matrix.php-version }}-${{ hashFiles('composer.lock', 'package-lock.json') }}"
           restore-keys: |


### PR DESCRIPTION
## Description

I think our cache path is wrong, when checking mine locally it is `~/.cache/composer`, not `~/.composer/cache`

<img width="576" height="117" alt="image" src="https://github.com/user-attachments/assets/39cbc296-736c-476f-9adc-905f1658f17f" />

Checking the CI output seems to confirm it, as the full composer dependencies are always downloaded:

<img width="1011" height="629" alt="image" src="https://github.com/user-attachments/assets/540c2828-c83a-4ff0-9fc2-b8d1440522c1" />

After these changes, the download step is skipped:

<img width="1049" height="592" alt="image" src="https://github.com/user-attachments/assets/16208d65-d9e3-4faf-b373-8dda59b20f6e" />

Note that it almost doesn't change anything regarding the execution time, the total time seems unchanged.