### PR TITLE
Fix (UI) - Display result count when single page with pagination on top

### DIFF
--- a/templates/components/pager.html.twig
+++ b/templates/components/pager.html.twig
@@ -115,7 +115,7 @@
 
     {% if short_display and nb_pages <= 1 %}
         <span class="text-muted mx-2 my-0 page-infos">
-            {{ __('Showing %s to %s of %s rows')|format(current_start, current_end, count) }}
+            {{ __('%s-%s of %s')|format(current_start, current_end, count) }}
         </span>
     {% endif %}
 


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes #22046 
- Here is a brief description of what this PR does

When the "Show search pagination above results" option is enabled and there is only one page of results, the result count was not displayed.

This happened because in `short_display` mode, the result count was only rendered inside the `{% if nb_pages > 1 %}` block. Now the count is displayed even when there's a single page.

## Screenshots (if appropriate):

Before :

<img width="393" height="140" alt="image" src="https://github.com/user-attachments/assets/bf96cd06-1a1f-45e0-9bb4-dc00e643bcb5" />


After : 

<img width="393" height="140" alt="image" src="https://github.com/user-attachments/assets/23b79cb0-fefa-47df-8533-592adc9aad5d" />
