### PR TITLE
Remove back to top button

### DIFF
--- a/css/includes/components/_floating-buttons.scss
+++ b/css/includes/components/_floating-buttons.scss
@@ -31,27 +31,6 @@
  * ---------------------------------------------------------------------
  */
 
-.floating-buttons {
-    position: fixed;
-    bottom: 50px;
-    left: 50%;
-    z-index: 99999;
-
-    #backtotop {
-        cursor: pointer;
-
-        &:hover {
-            opacity: 0.8;
-        }
-    }
-}
-
-body.debug-active {
-    .floating-buttons {
-        bottom: 100px;
-    }
-}
-
 #maintenance-float {
     top: 0;
     left: 250px;

--- a/js/common.js
+++ b/js/common.js
@@ -692,33 +692,6 @@ var stopEvent = function(event) {
     event.stopPropagation();
 };
 
-$(() => {
-    /**
-     * Back to top implementation
-     */
-    if ($('#backtotop').length) {
-        var scrollTrigger = 100, // px
-            backToTop = function () {
-                var scrollTop = $(window).scrollTop();
-                if (scrollTop > scrollTrigger) {
-                    $('#backtotop').addClass('d-md-block');
-                } else {
-                    $('#backtotop').removeClass('d-md-block');
-                }
-            };
-        backToTop();
-        $(window).on('scroll', function () {
-            backToTop();
-        });
-        $('#backtotop').on('click', function (e) {
-            e.preventDefault();
-            $('html,body').animate({
-                scrollTop: 0
-            }, 700);
-        });
-    }
-});
-
 /**
  * Returns element height, including margins
 */

--- a/templates/layout/parts/page_footer.html.twig
+++ b/templates/layout/parts/page_footer.html.twig
@@ -39,14 +39,6 @@
       </div> {# .page-wrapper #}
    </div> {# .page #}
 
-   <div class="floating-buttons d-inline-flex">
-      <span class="btn btn-secondary d-none me-1" id="backtotop">
-         <i class="ti ti-arrow-up" title="{{ __('Back to top of the page') }}">
-            <span class="visually-hidden">{{ __('Top of the page') }}</span>
-         </i>
-      </span>
-   </div>
-
    {% if config('maintenance_mode') %}
       <div id="maintenance-float">
          <a href="{{ path('front/config.form.php?forcetab=Config$5') }}">{{ __('MAINTENANCE MODE') }}</a>


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

fixes #22108

~Raise back to top button so it shows 50px above the bottom instead of 10px to allow a reasonable amount of interactable area for elements on the bottom of the page. With this change, there should be no elements that are always blocked even if there is a small margin at the bottom of the page.~

~The goal was to leave at least the minimum target size for WCAG AA to interact with the elements at the bottom of pages.~
~https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum~

PR switched to remove the button completely.