### PR TITLE
fix: login a user for a private form

### DIFF
--- a/src/Glpi/Controller/Form/Utils/CanCheckAccessPolicies.php
+++ b/src/Glpi/Controller/Form/Utils/CanCheckAccessPolicies.php
@@ -35,6 +35,7 @@
 namespace Glpi\Controller\Form\Utils;
 
 use Glpi\Exception\Http\AccessDeniedHttpException;
+use Glpi\Exception\SessionExpiredException;
 use Glpi\Form\AccessControl\FormAccessControlManager;
 use Glpi\Form\AccessControl\FormAccessParameters;
 use Glpi\Form\Form;
@@ -59,12 +60,19 @@ trait CanCheckAccessPolicies
                 url_parameters: $url_parameters,
             );
         }
-
+        // If the user is not logged in and the form require a valid session,
+        // redirect him to the login page instead.
+        // Note that the session validity will still be checked by the `canAnswerForm`
+        if (
+            !Session::isAuthenticated()
+            && !$form_access_manager->allowUnauthenticatedAccess($form)
+        ) {
+            // Will trigger a redirection to the loggin page
+            throw new SessionExpiredException();
+        }
         // Must be authenticated here
         if (!$form_access_manager->canAnswerForm($form, $parameters)) {
-            if (!Session::isAuthenticated()) {
-                Session::checkLoginUser();
-            }
+
             throw new AccessDeniedHttpException();
         }
     }

--- a/tests/cypress/e2e/form/access_policies/direct_access.cy.js
+++ b/tests/cypress/e2e/form/access_policies/direct_access.cy.js
@@ -112,15 +112,10 @@ describe('Form access policy', () => {
         // Logout
         cy.logout();
 
-        // Visit the direct access URL
+        // Visit the direct access URL, the user should be directed to the login page
         cy.get('@direct_access_url').invoke('val').then((direct_access_url) => {
-            // Check if we can't access the form
-            cy.request({
-                url: direct_access_url,
-                failOnStatusCode: false,
-            }).then((response) => {
-                expect(response.status).to.eq(403);
-            });
+            cy.visit(direct_access_url);
+            cy.findByText("Your session has expired. Please log in again.").should("be.visible");
         });
     });
 


### PR DESCRIPTION
## Give direct access to private forms (add authentication check for users)

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- Use case:
  - Migrated a form from the old plugin that has a GLPI Object (Assistance - Tickets) to be picked
  - Setting Allow direct access (with Allow specifics users, groups or profiles set to "All users") resulted in a permission denied error
  - This small change uses the standard checkLoginUsers() method to make the form directly accessible
  - Once returned to the form I believe will check canAnswerForm() again so does not interfere with the Allows specifics users, groups or profiles