### PR TITLE
Fix dashboard fake provider random numbers generation

### DIFF
--- a/src/Glpi/Dashboard/FakeProvider.php
+++ b/src/Glpi/Dashboard/FakeProvider.php
@@ -52,7 +52,6 @@ final class FakeProvider extends Provider
     {
         // xxh32 is pretty fast and produces a 8 bytes string that has an hexadecimal integer representation lower than `PHP_INT_MAX`
         return (int) abs((int) hexdec(hash('xxh32', $string)) % $max);
-
     }
 
     /**


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

`xxh3` produces a 16 bytes strings, with a maximum hexadecimal value of `double(1.8446744073709552E+19)`, that is higher than `PHP_INT_MAX`.
`xxh32` produces a 8 bytes string, with a maximum hexadecimal value of `int(4294967295)`, that is lower than `PHP_INT_MAX` .
Therefore, using `xxh32` instead of `xxh3` permits to ensure that the random number generation will not fail with a `float xxx is not representable as an int`.

It fixes #22116.