### PR TITLE
fix(notification): Prevent image overflow in notification

### DIFF
--- a/src/NotificationEventMailing.php
+++ b/src/NotificationEventMailing.php
@@ -378,7 +378,7 @@ class NotificationEventMailing extends NotificationEventAbstract
                                 // 'cid' must be identical as second arg used in `embedFromPath` method
                                 // Symfony/Mime will then replace it by an auto-generated value
                                 // see Symfony\Mime\Email::prepareParts()
-                                'src="cid:' . $filename . '"',
+                                'src="cid:' . $filename . '" style="max-width: 100%; height: auto;"',
                                 'href="' . htmlescape($CFG_GLPI['url_base'] . '/front/document.send.php?docid=' . $docID) . '$1"',
                             ],
                             $current->fields['body_html']

--- a/src/NotificationTemplate.php
+++ b/src/NotificationTemplate.php
@@ -294,7 +294,6 @@ class NotificationTemplate extends CommonDBTM
                          <meta name='viewport' content='width=device-width, initial-scale=1' />
                          <title>" . htmlescape($lang['subject']) . "</title>
                          <style type='text/css'>
-                           img { max-width: 100%; height: auto; }
                            {$css}
                          </style>
                         </head>


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !40718
- An image that was too wide could extend beyond its container. The problem only occurs when the email is received by the email client (Gmail, Outlook), but in the notification queue, the image is formatted correctly. This is because some email clients modify the HTML sent, in particular the tag classes, which are either modified or deleted. 

## Screenshots (if appropriate):

Email in notification queue before and after fix
<img width="1416" height="670" alt="image" src="https://github.com/user-attachments/assets/7639bb56-6864-4a1f-94cb-365ef95b2683" />


Email before fix
<img width="1416" height="670" alt="image" src="https://github.com/user-attachments/assets/e37e8037-4fd8-43ac-8361-3f2e0e24fae2" />


Email after fix
<img width="1323" height="706" alt="image" src="https://github.com/user-attachments/assets/d8437356-708c-4b99-ab20-6cd81ee88be7" />


