### PR TITLE
Forms: fix ticket validation template content not being applied

### DIFF
--- a/src/Glpi/Form/Destination/CommonITILField/ValidationField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ValidationField.php
@@ -165,11 +165,19 @@ final class ValidationField extends AbstractConfigField implements DestinationFi
             if (!empty($validations)) {
                 foreach ($validations as $validation) {
                     $input['_add_validation'] = 0;
-                    $validation_target = [
-                        'validatortype'   => $validation['itemtype'],
-                        'itemtype_target' => $validation['itemtype'],
-                        'items_id_target' => $validation['items_id'],
-                    ];
+                    if (isset($validation['_template_id'])) {
+                        // Let the template compute the values
+                        $validation_target = [
+                            '_template_id' => $validation['_template_id'],
+                        ];
+                    } else {
+                        // Manual values
+                        $validation_target = [
+                            'validatortype'   => $validation['itemtype'],
+                            'itemtype_target' => $validation['itemtype'],
+                            'items_id_target' => $validation['items_id'],
+                        ];
+                    }
 
                     if ($strategy_config->getSpecificValidationStepId() > 0) {
                         $validation_target['validationsteps_id'] = $strategy_config->getSpecificValidationStepId();

--- a/src/Glpi/Form/Destination/CommonITILField/ValidationFieldStrategy.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ValidationFieldStrategy.php
@@ -37,7 +37,6 @@ namespace Glpi\Form\Destination\CommonITILField;
 
 use Glpi\Form\AnswersSet;
 use ITILValidationTemplate;
-use ITILValidationTemplate_Target;
 
 enum ValidationFieldStrategy: string
 {
@@ -132,17 +131,9 @@ enum ValidationFieldStrategy: string
                 continue;
             }
 
-            $targets = ITILValidationTemplate_Target::getTargets($validation_template_id);
-            if (empty($targets)) {
-                continue;
-            }
-
-            foreach ($targets as $target) {
-                $actors[] = [
-                    'itemtype' => $target['itemtype'],
-                    'items_id' => $target['items_id'],
-                ];
-            }
+            $actors[] = [
+                '_template_id' => $validation_template->getId(),
+            ];
         }
 
         return $actors;

--- a/tests/functional/Glpi/Form/Destination/CommonITILField/ValidationFieldTest.php
+++ b/tests/functional/Glpi/Form/Destination/CommonITILField/ValidationFieldTest.php
@@ -144,9 +144,21 @@ final class ValidationFieldTest extends AbstractDestinationFieldTest
         $form = $this->createAndGetFormWithMultipleActorsQuestions();
         $users = $this->createAndGetUserActors();
         $groups = $this->createAndGetGroupActors();
+        $step = $this->createAndGetValidationStep();
         $templates = [
-            $this->createITILValidationTemplate(User::class, $users[0]->getID()),
-            $this->createITILValidationTemplate(Group::class, $groups[0]->getID()),
+            $this->createITILValidationTemplate(
+                itemtype: User::class,
+                items_id: $users[0]->getID(),
+                step_id: $step->getID(),
+                // Use a variable to make sure they are computed
+                content: "Test comment for user: {{ itemtype }}",
+            ),
+            $this->createITILValidationTemplate(
+                itemtype: Group::class,
+                items_id: $groups[0]->getID(),
+                step_id: $step->getID(),
+                content: "Test comment for group",
+            ),
         ];
 
         // With no answers
@@ -166,13 +178,22 @@ final class ValidationFieldTest extends AbstractDestinationFieldTest
                 [
                     'itemtype_target' => 'User',
                     'items_id_target' => $users[0]->getID(),
+                    'comment_submission' => "<p>Test comment for user: Ticket</p>",
+                    'validationsteps_id' => $step->getID(),
                 ],
                 [
                     'itemtype_target' => 'Group',
                     'items_id_target' => $groups[0]->getID(),
+                    'comment_submission' => "<p>Test comment for group</p>",
+                    'validationsteps_id' => $step->getID(),
                 ],
             ],
-            keys_to_be_considered: ['itemtype_target', 'items_id_target']
+            keys_to_be_considered: [
+                'itemtype_target',
+                'items_id_target',
+                'comment_submission',
+                'validationsteps_id',
+            ]
         );
 
         // With answers
@@ -365,11 +386,19 @@ final class ValidationFieldTest extends AbstractDestinationFieldTest
         $form = $this->createAndGetFormWithMultipleActorsQuestions();
         $users = $this->createAndGetUserActors();
         $groups = $this->createAndGetGroupActors();
-        $templates = [
-            $this->createITILValidationTemplate(User::class, $users[3]->getID()),
-            $this->createITILValidationTemplate(Group::class, $groups[2]->getID()),
-        ];
         $first_validation_step = $this->createAndGetValidationStep();
+        $templates = [
+            $this->createITILValidationTemplate(
+                itemtype: User::class,
+                items_id: $users[3]->getID(),
+                step_id: $first_validation_step->getID(),
+            ),
+            $this->createITILValidationTemplate(
+                itemtype: Group::class,
+                items_id: $groups[2]->getID(),
+                step_id: $first_validation_step->getID(),
+            ),
+        ];
         $second_validation_step = $this->createAndGetValidationStep();
         $third_validation_step = $this->createAndGetValidationStep();
 
@@ -383,7 +412,6 @@ final class ValidationFieldTest extends AbstractDestinationFieldTest
                         $templates[0]->getID(),
                         $templates[1]->getID(),
                     ],
-                    specific_validation_step_id: $first_validation_step->getID()
                 ),
                 new ValidationFieldStrategyConfig(
                     strategy: ValidationFieldStrategy::SPECIFIC_ACTORS,
@@ -692,14 +720,19 @@ final class ValidationFieldTest extends AbstractDestinationFieldTest
         return $groups;
     }
 
-    private function createITILValidationTemplate(string $itemtype, int $items_id): ITILValidationTemplate
-    {
+    private function createITILValidationTemplate(
+        string $itemtype,
+        int $items_id,
+        ?int $step_id = null,
+        ?string $content = null,
+    ): ITILValidationTemplate {
         return $this->createItem(ITILValidationTemplate::class, [
             'name'               => 'ITIL Validation Template',
             'entities_id'        => $this->getTestRootEntity()->getID(),
-            'validationsteps_id' => $this->createAndGetValidationStep()->getID(),
+            'validationsteps_id' => $step_id ?? $this->createAndGetValidationStep()->getID(),
             'itemtype_target'    => $itemtype,
             'items_id_target'    => $items_id,
+            'content'            => $content,
         ], ['itemtype_target', 'items_id_target']);
     }
 


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Validation templates can have a predefined content:

<img width="1926" height="573" alt="image" src="https://github.com/user-attachments/assets/aa952445-529f-4595-b689-57b175f3a1a0" />

And a form can apply one or multiple validation templates:

<img width="1100" height="129" alt="image" src="https://github.com/user-attachments/assets/9efbea29-34fc-4092-9bd6-31530528ab4d" />

One of our partner reported that the template content was not applied correctly on the created ticket:
<img width="892" height="492" alt="image" src="https://github.com/user-attachments/assets/cc040397-8bfb-42de-8e2b-5257b6d2eeea" />

I've fixed it, you can now see the content being applied (and I've made sure that variables are computed as well):

<img width="916" height="571" alt="image" src="https://github.com/user-attachments/assets/de6ef27e-41fa-4e32-a3ed-beb5b869c38b" />

## References

Internal support ticket: !40740
