### PR TITLE
Prevent error when profile cannot associate any item with tickets

### DIFF
--- a/src/CommonItilObject_Item.php
+++ b/src/CommonItilObject_Item.php
@@ -539,9 +539,14 @@ TWIG, $twig_params);
 
             if ($item::class === static::$itemtype_1) {
                 if ($_SESSION['glpishow_count_on_tabs']) {
-                    $nb = static::countForMainItem($item, [
-                        'itemtype' => $_SESSION["glpiactiveprofile"]["helpdesk_item_type"],
-                    ]);
+                    $nb = count($_SESSION["glpiactiveprofile"]["helpdesk_item_type"]) > 0
+                        ? static::countForMainItem(
+                            $item,
+                            [
+                                'itemtype' => $_SESSION["glpiactiveprofile"]["helpdesk_item_type"],
+                            ]
+                        )
+                        : 0;
                 }
                 return static::createTabEntry(_n('Item', 'Items', Session::getPluralNumber()), $nb, $item::class);
             } elseif ($_SESSION['glpishow_count_on_tabs'] && is_subclass_of(static::$itemtype_1, CommonITILObject::class)) {


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Since #21942, profiles with no itemtype defined in "Associable items to tickets, changes and problems" cannot open the ticket/change/problem page anymore due to an error. This PR fixes this.

It fixes #22200