### PR TITLE
Fix select2 dropdown in form destinations

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -1688,7 +1688,7 @@ function setupAjaxDropdown(config) {
         minimumInputLength: 0,
         quietMillis: 100,
         dropdownAutoWidth: true,
-        dropdownParent: $('#' + field_id).closest('div.modal, div.offcanvas, div.dropdown-menu, body'),
+        dropdownParent: $('#' + field_id).closest('div.modal, div.offcanvas, div.dropdown-menu:not([data-select2-dont-use-as-parent]), body'),
         minimumResultsForSearch: config.ajax_limit_count,
         ajax: {
             url: config.url,
@@ -1792,7 +1792,7 @@ function setupAdaptDropdown(config)
         width: config.width,
         dropdownAutoWidth: true,
         dropdownCssClass: config.dropdown_css_class,
-        dropdownParent: $('#' + field_id).closest('div.modal, div.offcanvas, div.dropdown-menu, body'),
+        dropdownParent: $('#' + field_id).closest('div.modal, div.offcanvas, div.dropdown-menu:not([data-select2-dont-use-as-parent]), body'),
         quietMillis: 100,
         minimumResultsForSearch: config.ajax_limit_count,
         matcher: function (params, data) {

--- a/templates/pages/admin/form/form_destination_actions.html.twig
+++ b/templates/pages/admin/form/form_destination_actions.html.twig
@@ -99,6 +99,7 @@
         </button>
         <div
             class="dropdown-menu dropdown-menu-end dropdown-menu-card animate__animated animate__zoomIn"
+            data-select2-dont-use-as-parent
         >
             <div class="card visibility-dropdown-card" data-glpi-form-editor-on-click="stop-propagation">
                 <div class="card-body">


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

It seems like select2 doesn't like to be at the end of a bootstrap accordion.

Before:
<img width="787" height="309" alt="image" src="https://github.com/user-attachments/assets/187be6f0-c0af-40d8-a137-3c25a531ab9b" />

After:
<img width="810" height="416" alt="image" src="https://github.com/user-attachments/assets/3cdcd210-05ba-4b86-94e9-59e4bdaa801d" />

I've fixed it by blacklisting the parent div as a potential parent, thus forcing the the select2 div to attach to the document body (and thus it is not inside the accordion as far as the DOM is concerned, so the issue disappears).

Kinda hacky but it works and doesn't impact others select2 dropdowns.

## Reference

Internal support ticket: !40760
