### PR TITLE
add shared instruction for copilot usage

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,7 @@ Follow GLPI’s latest coding standards and best practices: naming, indentation,
 Use the GLPI framework whenever possible.
 Do not use deprecated code.
 Do not use PHP features older than version 8.2.
-Do not use GLPI code or APIs older than version 10.0.
+Do not use GLPI code or APIs older than version 11.0.
 Never create .md or .txt files to explain changes.
 Never explain what you did.
 Do not add unnecessary comments or TODO notes.


### PR DESCRIPTION
## Description

cf: https://docs.github.com/copilot/how-tos/configure-custom-instructions/add-repository-instructions

Just to align usage for those who use copilot daily. I know some use it in the team, myself I use for non-critical things (outside GLPI for the moment).
More instructions and correction are welcome.
