### PR TITLE
Fix warning in Knowbase Comments

### DIFF
--- a/src/KnowbaseItem_Comment.php
+++ b/src/KnowbaseItem_Comment.php
@@ -141,13 +141,22 @@ class KnowbaseItem_Comment extends CommonDBTM
         foreach ($db_comments as $db_comment) {
             if (!isset($user_data_cache[$db_comment['users_id']])) {
                 $user = new User();
-                $user->getFromDB($db_comment['users_id']);
-                $user_data_cache[$db_comment['users_id']] = [
-                    'avatar' => User::getThumbnailURLForPicture($user->fields['picture']),
-                    'link'   => $user->getLinkURL(),
-                    'initials' => $user->getUserInitials(),
-                    'initials_bg_color' => $user->getUserInitialsBgColor(),
-                ];
+                if ($user->getFromDB($db_comment['users_id'])) {
+                    $user_data_cache[$db_comment['users_id']] = [
+                        'avatar' => User::getThumbnailURLForPicture($user->fields['picture']),
+                        'link'   => $user->getLinkURL(),
+                        'initials' => $user->getUserInitials(),
+                        'initials_bg_color' => $user->getUserInitialsBgColor(),
+                    ];
+                } else {
+                    // User has been deleted, use default values
+                    $user_data_cache[$db_comment['users_id']] = [
+                        'avatar' => User::getThumbnailURLForPicture(''),
+                        'link'   => '',
+                        'initials' => '',
+                        'initials_bg_color' => '#cccccc',
+                    ];
+                }
             }
             $db_comment['answers'] = self::getCommentsForKbItem($kbitem_id, $lang, $db_comment['id'], $user_data_cache);
             $db_comment['user_info'] = $user_data_cache[$db_comment['users_id']];


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !40806
- Here is a brief description of what this PR does

Fix warnings on the Comments tab of Knowbases. When a user posts a comment, and that same user then deletes it, several warnings appear.

## Screenshots (if appropriate):
<img width="642" height="279" alt="image" src="https://github.com/user-attachments/assets/55ca5729-72a9-41e5-98b0-129d63632b7f" />


