### PR TITLE
Fix (Satisfaction Survey) - incorrect entity config inheritance for inquest_duration

### DIFF
--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -902,7 +902,7 @@ class Ticket extends CommonITILObject
                             ($item->fields['status'] == self::CLOSED)
                             && $satisfaction->getFromDB($_GET["id"])
                         ) {
-                            $duration = Entity::getUsedConfig('inquest_duration', $item->fields['entities_id']);
+                            $duration = Entity::getUsedConfig('inquest_config', $item->fields['entities_id'], 'inquest_duration');
                             $date2    = strtotime($satisfaction->fields['date_begin']);
                             if (
                                 ($duration == 0)


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !40685
- Here is a brief description of what this PR does

Fix satisfaction survey expiration check when child entities inherit configuration from parent entity.

### Issue
When a child entity inherits `inquest_duration` setting from its parent via `CONFIG_PARENT`, the value was incorrectly retrieved as 0 (database default) instead of the parent's configured value. This caused expired surveys to still display the survey form instead of showing the expiration message.

### Root Cause
`Entity::getUsedConfig('inquest_duration', ...)` was called with incorrect parameters. The reference field for inheritance detection is `inquest_config`, not `inquest_duration`. The method was unable to detect inheritance and returned the default value.

### Solution
Changed the method call to use correct parameters: `Entity::getUsedConfig('inquest_config', $entities_id, 'inquest_duration')` to properly traverse the entity hierarchy and retrieve the inherited value.