### PR TITLE
Add missing assetmodel max_power field in DB

### DIFF
--- a/install/migrations/update_11.0.3_to_11.0.5/assets.php
+++ b/install/migrations/update_11.0.3_to_11.0.5/assets.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * @var Migration $migration
+ */
+
+$migration->addField('glpi_assets_assetmodels', 'max_power', 'int');

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -10064,6 +10064,7 @@ CREATE TABLE `glpi_assets_assetmodels` (
   `depth` float NOT NULL DEFAULT '1',
   `power_connections` int NOT NULL DEFAULT '0',
   `power_consumption` int NOT NULL DEFAULT '0',
+  `max_power` int NOT NULL DEFAULT '0',
   `is_half_rack` tinyint NOT NULL DEFAULT '0',
   `picture_front` text,
   `picture_rear` text,

--- a/src/Glpi/Asset/AssetModel.php
+++ b/src/Glpi/Asset/AssetModel.php
@@ -292,6 +292,13 @@ abstract class AssetModel extends CommonDCModelDropdown
                 'min'    => 0,
             ];
             $fields[] = [
+                'name'   => 'max_power',
+                'type'   => 'integer',
+                'label'  => __('Max. power (in watts)'),
+                'unit'   => __('watts'),
+                'min'    => 0,
+            ];
+            $fields[] = [
                 'name'   => 'is_half_rack',
                 'type'   => 'bool',
                 'label'  => __('Is half rack'),


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Custom asset models do not have a "max_power" column in the database but was listed as an additional field. In development mode, this caused a Twig error to be shown when showing the model form when the custom asset definition had the "Racks" capacity enabled.

This PR was originally going to remove the invalid field, but it was changed to add it to the DB schema.