### PR TITLE
fix: missing colors for various charts

### DIFF
--- a/src/Glpi/Dashboard/Widget.php
+++ b/src/Glpi/Dashboard/Widget.php
@@ -511,28 +511,33 @@ HTML;
 
         $rand = (int) $p['rand'];
 
-        $palette_style = "";
+        $colors = self::getPalette($p['palette'], $i);
         if ($p['use_gradient']) {
-            $palette = self::getGradientPalette($p['color'], $i, false);
-            foreach ($palette['names'] as $index => $letter) {
-                $bgcolor   = $palette['colors'][$index];
-                $bgcolor_h = Toolbox::getFgColor($bgcolor, 10);
-                $color     = Toolbox::getFgColor($bgcolor);
+            $palette = self::getGradientPalette(
+                $p['color'],
+                $i,
+                false
+            );
+            $colors = $palette['colors'];
+        }
 
-                $palette_style .= "
-                    #chart-{$rand} .line-$letter {
+        $palette_style = "";
+        foreach ($colors as $index => $bgcolor) {
+            $bgcolor_h = Toolbox::getFgColor($bgcolor, 10);
+            $color     = Toolbox::getFgColor($bgcolor);
+
+            $palette_style .= "
+                    #chart-{$rand} .line-$index {
                         background-color: $bgcolor;
                         color: $color;
                     }
 
-                    #chart-{$rand} .line-$letter:hover {
+                    #chart-{$rand} .line-$index:hover {
                         background-color: $bgcolor_h;
                         font-weight: bold;
                     }
                 ";
-            }
         }
-
 
         $label = \htmlescape($p['label']);
         $alt = \htmlescape($p['alt']);


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description
This issue is only present on GLPI 11.x version.

A fix for GLPI 10.x is available here : https://github.com/glpi-project/glpi/pull/22287 (it only fix the Chart `multiple number`, the chart bar line didn't had any issues)

It fixes #22241

- Chart that was of type line (and the extending one) would not get any colors after the 10 from the colors palette.
- Chart `multiple number` had settings for the color palette but this wasn't applied at all.

## Screenshots (if appropriate):

### Line chart

#### Before

<img width="1367" height="409" alt="Screenshot from 2025-12-08 11-40-57" src="https://github.com/user-attachments/assets/576f103e-dc0e-42c2-9216-78457dc316da" />

#### After

<img width="1367" height="409" alt="Screenshot from 2025-12-08 11-40-30" src="https://github.com/user-attachments/assets/ae0982d9-ba51-4e13-9ec5-e005fe7971b0" />

### Multiple number

#### Before (Gradient mode enabled)

<img width="1367" height="1087" alt="Screenshot from 2025-12-08 11-51-46" src="https://github.com/user-attachments/assets/22411e26-f457-4681-8988-1e03550b8509" />

#### After (Gradient mode enabled)

<img width="1367" height="1087" alt="Screenshot from 2025-12-08 11-53-37" src="https://github.com/user-attachments/assets/7e95fe1b-0cd3-4548-9982-9e690010c0f1" />
