### PR TITLE
Enhance search result status area display

### DIFF
--- a/src/CronTask.php
+++ b/src/CronTask.php
@@ -1951,8 +1951,15 @@ TWIG, ['msg' => __('Last run list')]);
     /**
      * @return void
      * @used-by templates/components/search/controls.html.twig
+     *
+     * @TODO Remove it in GLPI 12.0.
      */
-    public static function showSearchStatusArea()
+    public static function showSearchStatusArea() {}
+
+    /**
+     * @return void
+     */
+    public static function displayPreSearchResultsContent(): void
     {
         global $CFG_GLPI;
 

--- a/src/Glpi/Search/Output/AbstractSearchOutput.php
+++ b/src/Glpi/Search/Output/AbstractSearchOutput.php
@@ -35,6 +35,7 @@
 
 namespace Glpi\Search\Output;
 
+use CommonDBTM;
 use CommonGLPI;
 
 /**
@@ -56,6 +57,14 @@ abstract class AbstractSearchOutput
     {
         return $params;
     }
+
+    /**
+     * Display any content prior to the search results.
+     *
+     * @param class-string<CommonDBTM> $itemtype
+     * @return void
+     */
+    public static function displayPreSearchResultsContent(string $itemtype): void {}
 
     /**
      * Display the search results

--- a/src/Glpi/Search/Output/HTMLSearchOutput.php
+++ b/src/Glpi/Search/Output/HTMLSearchOutput.php
@@ -84,6 +84,13 @@ class HTMLSearchOutput extends AbstractSearchOutput
         }
     }
 
+    public static function displayPreSearchResultsContent(string $itemtype): void
+    {
+        if (\method_exists($itemtype, 'displaySearchStatusAreaContent')) {
+            $itemtype::displaySearchStatusAreaContent();
+        }
+    }
+
     public function displayData(array $data, array $params = [])
     {
         global $CFG_GLPI;

--- a/src/Glpi/Search/SearchEngine.php
+++ b/src/Glpi/Search/SearchEngine.php
@@ -627,6 +627,8 @@ final class SearchEngine
             $search_input_class::showGenericSearch($itemtype, $params);
         }
 
+        $output::displayPreSearchResultsContent($itemtype);
+
         $params = $output::prepareInputParams($itemtype, $params);
         $item = getItemForItemtype($itemtype);
         if ((int) $params['browse'] === 1 && $item instanceof TreeBrowseInterface) {

--- a/src/MailCollector.php
+++ b/src/MailCollector.php
@@ -1977,8 +1977,15 @@ class MailCollector extends CommonDBTM
     /**
      * @return void
      * @used-by templates/components/search/controls.html.twig
+     *
+     * @TODO Remove it in GLPI 12.0.
      */
-    public static function showSearchStatusArea()
+    public static function showSearchStatusArea() {}
+
+    /**
+     * @return void
+     */
+    public static function displayPreSearchResultsContent(): void
     {
         $errors  = getAllDataFromTable(self::getTable(), ['errors' => ['>', 0]]);
         $collector = new self();

--- a/templates/components/search/status_area.html.twig
+++ b/templates/components/search/status_area.html.twig
@@ -30,7 +30,7 @@
  # ---------------------------------------------------------------------
  #}
 
-<div class="status-area">
+<div class="status-area mb-3">
     <span class="alert alert-warning p-1 m-0">
         <i class="ti ti-alert-triangle me-2"></i>
         <span>{{ status_message|raw }}</span>


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

The purpose of this PR is to make the search results status area more visible, as it may contain important messages.

Before:
<img width="1267" height="258" alt="Capture d’écran du 2025-12-08 14-20-58" src="https://github.com/user-attachments/assets/0baf6927-d5f4-4d17-95dc-50ba09a892a2" />

After:
<img width="1267" height="258" alt="Capture d’écran du 2025-12-08 14-19-55" src="https://github.com/user-attachments/assets/88396438-4ce3-4430-8c68-e83796b32841" />
