### PR TITLE
fix: chart multiple number gradiant color not applied correctly

### DIFF
--- a/src/Dashboard/Widget.php
+++ b/src/Dashboard/Widget.php
@@ -444,12 +444,12 @@ HTML;
                 $color     = Toolbox::getFgColor($bgcolor);
 
                 $palette_style .= "
-               #chart-{$p['rand']} .line-$letter {
+               #chart-{$p['rand']} .line-$index {
                   background-color: $bgcolor;
                   color: $color;
                }
 
-               #chart-{$p['rand']} .line-$letter:hover {
+               #chart-{$p['rand']} .line-$index:hover {
                   background-color: $bgcolor_h;
                   font-weight: bold;
                }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description
Using `gradiant palette` for multiple number chart wouldn't work.

This fix is only for GLPI 10, as GLPI 11 has different palette and different lib usage : https://github.com/glpi-project/glpi/pull/22282 

## Screenshots (if appropriate):

### Before

<img width="1070" height="997" alt="Screenshot from 2025-12-08 15-22-18" src="https://github.com/user-attachments/assets/40ac55fe-59cd-44e8-9c19-82e59a69ad84" />

### After
<img width="1070" height="997" alt="Screenshot from 2025-12-08 15-22-45" src="https://github.com/user-attachments/assets/a1d96d22-5aee-47e5-aa79-60414a88565c" />
