### PR TITLE
FIX / Improve project creation via template with read-only preview of project tabs

### DIFF
--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -687,6 +687,27 @@ class CommonGLPI implements CommonGLPIInterface
                     return $ret;
                 }
 
+                // Check if we're creating an object from template and this is not the main tab
+                if ($withtemplate == 2 && $tabnum != 'main' && $item instanceof CommonDBTM) {
+                    // Display generic message for template creation
+                    $template = <<<HTML
+                    <div class="alert alert-warning d-flex">
+                        <div class="me-2">
+                            <i class="ti ti-info-circle"></i>
+                        </div>
+                        <div>
+                            <strong>%s</strong><br>
+                            %s
+                        </div>
+                    </div>
+                    HTML;
+                    echo sprintf(
+                        $template,
+                        __s('Creating from template'),
+                        __s('You are currently creating an object from a template. You need to save it, in the main tab, before editing data in other tabs.')
+                    );
+                }
+
                 if ($obj = getItemForItemtype($itemtype)) {
                     $options['tabnum'] = $tabnum;
                     $options['itemtype'] = $itemtype;

--- a/src/Item_Project.php
+++ b/src/Item_Project.php
@@ -86,10 +86,11 @@ class Item_Project extends CommonDBRelation
      * Print the HTML array for Items linked to a project
      *
      * @param Project $project
+     * @param int $withtemplate
      *
      * @return bool
      **/
-    public static function showForProject(Project $project): bool
+    public static function showForProject(Project $project, int $withtemplate = 0): bool
     {
         $instID = $project->getID();
 
@@ -169,7 +170,8 @@ class Item_Project extends CommonDBRelation
 
         TemplateRenderer::getInstance()->display('pages/tools/item_project.html.twig', [
             'item' => $project,
-            'can_edit' => $canedit,
+            'can_edit' => $canedit && $withtemplate != 2,
+            'withtemplate' => $withtemplate,
             'used' => $used,
             'datatable_params' => [
                 'is_tab' => true,
@@ -246,7 +248,7 @@ class Item_Project extends CommonDBRelation
         }
 
         if ($item instanceof Project) {
-            return self::showForProject($item);
+            return self::showForProject($item, $withtemplate);
         }
 
         if (

--- a/src/Itil_Project.php
+++ b/src/Itil_Project.php
@@ -111,7 +111,7 @@ class Itil_Project extends CommonDBRelation
                 return self::showForItil($item);
 
             case Project::class:
-                return self::showForProject($item);
+                return self::showForProject($item, $withtemplate);
         }
         return false;
     }
@@ -120,10 +120,11 @@ class Itil_Project extends CommonDBRelation
      * Show ITIL items for a project.
      *
      * @param Project $project
+     * @param int $withtemplate
      *
      * @return bool
      **/
-    public static function showForProject(Project $project): bool
+    public static function showForProject(Project $project, int $withtemplate = 0): bool
     {
         global $DB, $CFG_GLPI;
 
@@ -178,7 +179,7 @@ class Itil_Project extends CommonDBRelation
             ];
         }
 
-        if ($canedit) {
+        if ($canedit && $withtemplate != 2) {
             $twig_params = [
                 'btn_msg' => _x('button', 'Add'),
                 'used'    => $used,

--- a/src/KnowbaseItem_Item.php
+++ b/src/KnowbaseItem_Item.php
@@ -119,7 +119,7 @@ class KnowbaseItem_Item extends CommonDBRelation
         }
 
         $rand = mt_rand();
-        if ($canedit && $ok_state) {
+        if ($canedit && $ok_state && $withtemplate != 2) {
             if ($item::class !== KnowbaseItem::class) {
                 $visibility = KnowbaseItem::getVisibilityCriteria();
                 $condition = (isset($visibility['WHERE']) && count($visibility['WHERE'])) ? $visibility['WHERE'] : [];

--- a/src/Project.php
+++ b/src/Project.php
@@ -1422,14 +1422,15 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria, KanbanInter
     /**
      * Show team for a project
      * @param Project $project
+     * @param int $withtemplate
      * @return true
      **/
-    public function showTeam(Project $project)
+    public function showTeam(Project $project, $withtemplate = 0)
     {
         $ID      = $project->fields['id'];
         $canedit = $project->can($ID, UPDATE);
 
-        if ($canedit) {
+        if ($canedit && $withtemplate != 2) {
             $twig_params = [
                 'id' => $ID,
                 'label' => __('Add a team member'),

--- a/src/ProjectCost.php
+++ b/src/ProjectCost.php
@@ -97,7 +97,7 @@ class ProjectCost extends CommonDBChild
     public static function displayTabContentForItem(CommonGLPI $item, $tabnum = 1, $withtemplate = 0)
     {
         if ($item instanceof Project) {
-            return self::showForProject($item);
+            return self::showForProject($item, $withtemplate);
         }
         return false;
     }
@@ -317,7 +317,7 @@ class ProjectCost extends CommonDBChild
 
         $rand   = mt_rand();
 
-        if ($canedit) {
+        if ($canedit && $withtemplate != 2) {
             echo "<div id='viewcost" . $ID . "_$rand'></div>\n";
             echo "<script type='text/javascript' >\n";
             echo "function viewAddCost" . $ID . "_$rand(btn) {\n";

--- a/src/ProjectTask.php
+++ b/src/ProjectTask.php
@@ -1212,7 +1212,7 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
      *
      * @return void|false
      **/
-    public static function showFor($item)
+    public static function showFor($item, int $withtemplate = 0)
     {
         global $DB;
 
@@ -1276,7 +1276,7 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
         }
         $criteria['ORDERBY'] = [$_GET["sort"] . " $order"];
 
-        $canedit = $item::class === Project::class && $item->canEdit($ID);
+        $canedit = $item::class === Project::class && $item->canEdit($ID) && $withtemplate != 2;
 
         switch ($item::class) {
             case Project::class:
@@ -1289,7 +1289,7 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
                 return;
         }
 
-        if ($canedit) {
+        if ($canedit && $withtemplate != 2) {
             TemplateRenderer::getInstance()->display(
                 'components/tab/addlink_block.html.twig',
                 [
@@ -1299,7 +1299,7 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
             );
         }
 
-        if ($item::class === self::class && $item->can($ID, UPDATE)) {
+        if ($item::class === self::class && $item->can($ID, UPDATE) && $withtemplate != 2) {
             $twig_params = [
                 'projects_id' => $item->fields['projects_id'],
                 'projecttasks_id' => $ID,
@@ -1449,7 +1449,7 @@ TWIG, $twig_params);
         switch ($item::class) {
             case Project::class:
             case self::class:
-                self::showFor($item);
+                self::showFor($item, $withtemplate);
                 break;
         }
         return true;

--- a/src/ProjectTeam.php
+++ b/src/ProjectTeam.php
@@ -111,7 +111,7 @@ class ProjectTeam extends CommonDBRelation
 
         switch (get_class($item)) {
             case Project::class:
-                $item->showTeam($item);
+                $item->showTeam($item, $withtemplate);
         }
         return true;
     }


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

It fixes !40258
Replace #22265 
The project creation via templates workflow had a confusing UX where users could add elements as tasks and teams to templates, thinking they were creating actual projects.

This PR implements a comprehensive read-only preview of the project tabs when it is not registered :

<img width="1853" height="759" alt="tasks-project-read-only" src="https://github.com/user-attachments/assets/2f8b1628-57ef-40fe-ba64-2aa9436e5372" />




