### PR TITLE
Add flatpicker for helpdesk forms

### DIFF
--- a/css/includes/components/form/_form-renderer.scss
+++ b/css/includes/components/form/_form-renderer.scss
@@ -152,6 +152,12 @@
             margin-top: .25rem;
             top: unset;
         }
+
+        // Handle input groups, the button next to the input also need to have
+        // the same border color.
+        .is-invalid + button {
+            border-color: red;
+        }
     }
 
     [data-glpi-form-renderer-section] {

--- a/js/modules/Forms/RendererController.js
+++ b/js/modules/Forms/RendererController.js
@@ -223,7 +223,17 @@ export class GlpiFormRendererController
 
                 // Add a tooltip with the error message
                 let targetElement;
-                if (inputFields.filter('[type="radio"], [type="checkbox"]').length > 0) {
+                let position = "append";
+                let extra_class = "";
+                if (inputFields.filter('.is-flatpicker').length > 0) {
+                    // Specifics instructions for flatpicker.
+                    // This is needed because it has an extra div that wrap the
+                    // input, we want the tooltip to be right after that wrappper
+                    // div.
+                    targetElement = inputFields.parent();
+                    position = "after";
+                    extra_class = "d-block";
+                } else if (inputFields.filter('[type="radio"], [type="checkbox"]').length > 0) {
                     // For radio/checkbox, find the first common parent
                     targetElement = inputFields.first().closest('.form-check').parent();
                     if (targetElement.length === 0) {
@@ -233,9 +243,12 @@ export class GlpiFormRendererController
                     targetElement = inputFields.parent();
                 }
 
-                targetElement.append(
-                    `<span id="${_.escape(errorId)}" class="invalid-tooltip">${_.escape(error.message)}</span>`
-                );
+                const content = `<span id="${_.escape(errorId)}" class="invalid-tooltip ${extra_class}">${_.escape(error.message)}</span>`;
+                if (position === "append") {
+                    targetElement.append(content);
+                } else {
+                    targetElement.after(content);
+                }
 
                 // Make sure the first error is inside the viewport so the user
                 // can see it properly.

--- a/src/Glpi/Form/QuestionType/QuestionTypeDateTime.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeDateTime.php
@@ -322,13 +322,13 @@ TWIG;
         Question $question,
     ): string {
         $template = <<<TWIG
-            <input
-                type="{{ input_type }}"
-                class="form-control w-50"
-                name="{{ question.getEndUserInputName() }}"
-                value="{{ default_value }}"
-                {{ question.fields.is_mandatory ? 'required' : '' }}
-            >
+            {% import 'components/form/basic_inputs_macros.html.twig' as inputs %}
+            {{ inputs.date(question.getEndUserInputName(), default_value, {
+                'enableTime': input_type != "date",
+                'noCalendar': input_type == "time",
+                'container_addclass': 'w-50',
+                'input_addclass': 'is-flatpicker',
+            }) }}
 TWIG;
 
         $twig = TemplateRenderer::getInstance();
@@ -388,4 +388,5 @@ TWIG;
 
     #[Override]
     public function beforeConversion(array $rawData): void {}
+
 }

--- a/templates/components/form/basic_inputs_macros.html.twig
+++ b/templates/components/form/basic_inputs_macros.html.twig
@@ -227,8 +227,10 @@
     {% set options = {
         'rand': random(),
         'enableTime': false,
+        'noCalendar': false,
         'checkIsExpired': false,
         'clearable': false,
+        'container_addclass': '',
         'input_addclass': '',
         'readonly': false,
         'disabled': false,
@@ -262,7 +264,13 @@
         {% endif %}
     {% endif %}
 
-    <div class="btn-group flex-grow-1 flatpickr d-flex" id="{{ options.id }}" data-bs-toggle="tooltip" data-bs-placement="bottom" title="{{ editable ? __('Enter or select a date') : _n('Date', 'Dates', 1) }}">
+    <div
+        class="btn-group flex-grow-1 flatpickr d-flex {{ options.container_addclass }}"
+        id="{{ options.id }}"
+        data-bs-toggle="tooltip"
+        data-bs-placement="bottom"
+        title="{{ editable ? __('Enter or select a date') : _n('Date', 'Dates', 1) }}"
+    >
         {{ _self.input(name, value, options|merge({
             'type': 'text',
             'id': options.id ~ '_input',
@@ -288,8 +296,19 @@
 
     {% if editable %}
         {% set locale = get_current_locale() %}
-        {% set date_format = options.enableTime ? 'Y-m-d H:i:S' : 'Y-m-d' %}
-        {% set alt_format = call('Toolbox::getDateFormat', ['js']) ~ (options.enableTime ? ' H:i:S' : '') %}
+        {% if options.enableTime and not options.noCalendar %}
+            {% set date_format = 'Y-m-d H:i:S' %}
+            {% set alt_format = call('Toolbox::getDateFormat', ['js']) ~ (options.enableTime ? ' H:i:S' : '') %}
+        {% elseif options.enableTime and options.noCalendar %}
+            {% set date_format = 'H:i:S' %}
+            {% set alt_format = (options.enableTime ? ' H:i:S' : '') %}
+        {% elseif not options.enableTime and not options.noCalendar %}
+            {% set date_format = 'Y-m-d' %}
+            {% set alt_format = call('Toolbox::getDateFormat', ['js']) %}
+        {% else %}
+            {# No time and no date, doesn't make sense so fallback to full format #}
+            {% set date_format = 'Y-m-d H:i:S' %}
+        {% endif %}
         <script>
             $(function() {
                 $("#{{ options.id|e('css')|e('js') }}").flatpickr({
@@ -299,6 +318,7 @@
                     altFormat: '{{ alt_format|e('js') }}',
                     enableTime: {{ options.enableTime ? "true" : "false" }},
                     enableSeconds: {{ options.enableTime ? "true" : "false" }},
+                    noCalendar: {{ options.noCalendar ? "true" : "false" }},
                     weekNumbers: true,
                     time_24hr: true,
                     allowInput: {{ options.readonly ? 'false' : 'true' }},


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Use a flatpicker input for rendered helpdesk forms instead of the native browser types:

<img width="569" height="508" alt="image" src="https://github.com/user-attachments/assets/44adc61a-8893-498e-90ff-6e8846c796bd" />

This required adding a new `noCalendar` options to the `date` macro to be able to display a time only input.

## References

Fix #21852


