### PR TITLE
display missing menu for anonymous faq view

### DIFF
--- a/templates/layout/parts/menu.html.twig
+++ b/templates/layout/parts/menu.html.twig
@@ -37,7 +37,7 @@
 
 <ul class="navbar-nav" id="menu_{{ rand }}">
 {% for firstlevel in menu %}
-   {% set firstlevel_active = menu[sector]['title']|default('') == firstlevel['title'] %}
+   {% set firstlevel_active = sector is defined and menu[sector] is defined and menu[sector]['title']|default('') == firstlevel['title'] %}
    {% set firstlevel_shown = firstlevel_active and is_vertical and is_menu_folded == false %}
    {% set has_subitems = false %}
    {% if firstlevel['content'] is defined %}

--- a/templates/layout/parts/page_header.html.twig
+++ b/templates/layout/parts/page_header.html.twig
@@ -122,6 +122,18 @@
                      {{ include('layout/parts/goto_button.html.twig') }}
                   </span>
                </div>
+               {% elseif menu|length > 0 %}
+               <div class="collapse navbar-collapse justify-content-center" id="navbar-menu">
+                  <ul class="navbar-nav">
+                     {% for item in menu %}
+                        <li class="nav-item">
+                           <a class="nav-link" href="{{ path(item['default']) }}">
+                              <span class="menu-label">{{ item['title'] }}</span>
+                           </a>
+                        </li>
+                     {% endfor %}
+                  </ul>
+               </div>
                {% endif %}
             {% endif %}
 

--- a/templates/layout/parts/page_header.html.twig
+++ b/templates/layout/parts/page_header.html.twig
@@ -115,7 +115,7 @@
                   {{ include('layout/parts/user_header.html.twig') }}
                </div>
 
-               {% if not anonymous or menu|length > 0 %}
+               {% if not anonymous or (menu|length > 0 and menu.home is not defined) %}
                <div class="collapse navbar-collapse justify-content-center" id="navbar-menu">
                   {{ include('layout/parts/menu.html.twig') }}
                   {% if not anonymous %}

--- a/templates/layout/parts/page_header.html.twig
+++ b/templates/layout/parts/page_header.html.twig
@@ -115,24 +115,14 @@
                   {{ include('layout/parts/user_header.html.twig') }}
                </div>
 
-               {% if not anonymous %}
+               {% if not anonymous or menu|length > 0 %}
                <div class="collapse navbar-collapse justify-content-center" id="navbar-menu">
                   {{ include('layout/parts/menu.html.twig') }}
+                  {% if not anonymous %}
                   <span class="ms-xl-2 d-inline-block mt-2 mt-xl-2">
                      {{ include('layout/parts/goto_button.html.twig') }}
                   </span>
-               </div>
-               {% elseif menu|length > 0 %}
-               <div class="collapse navbar-collapse justify-content-center" id="navbar-menu">
-                  <ul class="navbar-nav">
-                     {% for item in menu %}
-                        <li class="nav-item">
-                           <a class="nav-link" href="{{ path(item['default']) }}">
-                              <span class="menu-label">{{ item['title'] }}</span>
-                           </a>
-                        </li>
-                     {% endfor %}
-                  </ul>
+                  {% endif %}
                </div>
                {% endif %}
             {% endif %}


### PR DESCRIPTION
fixes #21901 

had to render menu inline : using template `{{ include('layout/parts/menu.html.twig') }}` because  template relies on variables like `sector` that are only available for authenticated users and generate twig error
