### PR TITLE
Fix form editor conditions on specific items being lost on save

### DIFF
--- a/templates/pages/admin/form/condition_configuration.html.twig
+++ b/templates/pages/admin/form/condition_configuration.html.twig
@@ -129,10 +129,11 @@
                             data-glpi-conditions-editor-value-operator
                         />
                         {% if condition.getValue() is iterable %}
+                            {% set original_loop_index = loop.index0 %}
                             {% for key, value in condition.getValue() %}
                                 <input
                                     type="hidden"
-                                    name="_conditions[{{ loop.index0 }}][value][{{ key }}]"
+                                    name="_conditions[{{ original_loop_index }}][value][{{ key }}]"
                                     value="{{ value }}"
                                     data-glpi-conditions-editor-value
                                 />


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.

## Description

Conditions like this one where sometimes lost when saving the form:

<img width="741" height="272" alt="image" src="https://github.com/user-attachments/assets/1aa84be4-b071-464d-a37b-d6c4ad01fe52" />

It would become empty like this:

<img width="741" height="264" alt="image" src="https://github.com/user-attachments/assets/dcd388d4-f756-4ed6-b161-ed94e58e15cb" />

This was because of a miss-named input:
<img width="963" height="221" alt="image" src="https://github.com/user-attachments/assets/b0d5d9ab-be55-4c33-94a3-6aca1efa2c97" />

You can see the last value is set for the `1` key instead of `0` like the other, so it is lost when saved.

This is simply because of a bad twig code that reused the `loop.index0` variable inside a nested for loop so it was overridden and no longer referring to the first loop: 

<img width="829" height="1057" alt="image" src="https://github.com/user-attachments/assets/37cbca98-93fe-43ff-8606-f64de1256776" />

Fixed by saving the value to a variable before starting the nested loop.

The input now has the correct name:

<img width="953" height="201" alt="image" src="https://github.com/user-attachments/assets/328db2ad-5074-4448-b266-e46ddf7ccc4e" />

## References 

Fix #22064.


