### PR TITLE
Fix - Ensure last_login is updated with current time instead of session

### DIFF
--- a/src/Auth.php
+++ b/src/Auth.php
@@ -676,6 +676,7 @@ class Auth extends CommonGLPI
 
                         if (self::checkPassword($cookie_token, $hash)) {
                             $this->user->fields['name'] = $user->fields['name'];
+                            // Use current time as session time may not be initialized yet or may be from previous session
                             $user->update(['id' => $user->getID(), 'last_login' => date("Y-m-d H:i:s")]);
                             return true;
                         } else {
@@ -924,6 +925,7 @@ class Auth extends CommonGLPI
                 }
                 // Reset to secure it
                 $this->user->fields['name']       = $login_name;
+                // Use current time as session time may not be initialized yet or may be from previous session
                 $this->user->fields["last_login"] = date("Y-m-d H:i:s");
             } else {
                 $this->addToError(__('Empty login or password'));
@@ -1009,6 +1011,7 @@ class Auth extends CommonGLPI
             $this->user->fields['is_deleted_ldap'] = 0;
 
             // Prepare data
+            // Use current time as session time may not be initialized yet or may be from previous session
             $this->user->fields["last_login"] = date("Y-m-d H:i:s");
             if ($this->extauth) {
                 $this->user->fields["_extauth"] = 1;


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !40709
- Here is a brief description of what this PR does

Fix `last_login` not updating correctly during authentication
The `last_login` field was previously updated using `$_SESSION["glpi_currenttime"]`. However, this session variable is initialized or updated in `Session::init()`, which is often called **after** the authentication process (`Auth::login()`) has already attempted to update the user record.

This caused issues where:

- In a new session, the variable might be unset or empty.
- In an existing session (e.g., "Remember me"), the variable held the timestamp of the previous session start, not the current login time.

This PR fixes the issue by using `date("Y-m-d H:i:s")` directly when updating the last_login field in **`Auth.php`**, ensuring the timestamp is always accurate and reflects the actual login time.