### PR TITLE
Fix types in ITIL items forms

### DIFF
--- a/ajax/commonitilobject_item.php
+++ b/ajax/commonitilobject_item.php
@@ -42,7 +42,7 @@ Html::header_nocache();
 // See: change_item.php, item_problem.php, item_ticket.php and item_ticketrecurrent.php
 $obj ??= null;
 $item_obj ??= null;
-$valid_obj = $obj instanceof CommonITILObject || $obj instanceof TicketRecurrent;
+$valid_obj = $obj instanceof CommonITILObject || $obj instanceof CommonITILRecurrent;
 if (!$valid_obj || !($item_obj instanceof CommonItilObject_Item)) {
     throw new BadRequestHttpException();
 }

--- a/src/CommonItilObject_Item.php
+++ b/src/CommonItilObject_Item.php
@@ -180,7 +180,7 @@ abstract class CommonItilObject_Item extends CommonDBRelation
     /**
      * Print the HTML ajax associated item add
      *
-     * @param CommonITILObject|TicketRecurrent $obj  object holding the item
+     * @param CommonITILObject|CommonITILRecurrent $obj  object holding the item
      * @param array $options
      *    - id                  : ID of the object holding the items
      *    - _users_id_requester : ID of the requester user
@@ -188,7 +188,7 @@ abstract class CommonItilObject_Item extends CommonDBRelation
      *
      * @return void|false
      */
-    protected static function displayItemAddForm(CommonITILObject|TicketRecurrent $obj, array $options = [])
+    protected static function displayItemAddForm(CommonITILObject|CommonITILRecurrent $obj, array $options = [])
     {
         if (!(is_a($obj, static::$itemtype_1))) {
             return false;
@@ -373,11 +373,11 @@ abstract class CommonItilObject_Item extends CommonDBRelation
     /**
      * Print the HTML array for Items linked to a ITIL object
      *
-     * @param CommonITILObject|TicketRecurrent $obj
+     * @param CommonITILObject|CommonITILRecurrent $obj
      *
      * @return bool|void
      **/
-    protected static function showForObject(CommonITILObject|TicketRecurrent $obj)
+    protected static function showForObject(CommonITILObject|CommonITILRecurrent $obj)
     {
         if (!(is_a($obj, static::$itemtype_1))) {
             return false;
@@ -1783,7 +1783,7 @@ TWIG, $twig_params);
     /**
      * Print the HTML ajax associated item add
      *
-     * @param CommonITILObject|TicketRecurrent $object
+     * @param CommonITILObject|CommonITILRecurrent $object
      * @param array $options   array of possible options:
      *    - id                  : ID of the ticket
      *    - _users_id_requester : ID of the requester user
@@ -1791,7 +1791,7 @@ TWIG, $twig_params);
      *
      * @return void
      **/
-    public static function itemAddForm(CommonITILObject|TicketRecurrent $object, $options = [])
+    public static function itemAddForm(CommonITILObject|CommonITILRecurrent $object, $options = [])
     {
         if (!(is_a($object, static::$itemtype_1))) {
             return;

--- a/src/Item_TicketRecurrent.php
+++ b/src/Item_TicketRecurrent.php
@@ -53,7 +53,7 @@ class Item_TicketRecurrent extends CommonItilObject_Item
         return _n('Ticket recurrent item', 'Ticket recurrent items', $nb);
     }
 
-    public static function itemAddForm(CommonDBTM $ticketrecurrent, $options = [])
+    public static function itemAddForm(CommonITILObject|CommonITILRecurrent $ticketrecurrent, $options = [])
     {
         parent::displayItemAddForm($ticketrecurrent, $options);
     }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Alternative to #22119.

It makes the signature of `Item_TicketRecurrent::itemAddForm()` identical to the overriden `CommonItilObject_Item::itemAddForm()` method and widen `TicketRecurrent` to its parent `CommonITILRecurrent` class.