### PR TITLE
change return of unglobalize() and unglobalizeItem()

### DIFF
--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -2434,15 +2434,12 @@ class CommonDBTM extends CommonGLPI
      * Unglobalize the item : duplicate item and connections.
      *
      * @see Asset_PeripheralAsset::unglobalizeItem()
-     * @return null
-     * @TODO Return a bool value (true on success, false on failure).
+     * @return bool true on success, false on failure
      */
     public function unglobalize()
     {
         // Wrapper only to standardize the usage of form actions in generic forms
-        Asset_PeripheralAsset::unglobalizeItem($this);
-
-        return null;
+        return Asset_PeripheralAsset::unglobalizeItem($this);
     }
 
     /**

--- a/tests/functional/Glpi/Asset/Asset_PeripheralAssetTest.php
+++ b/tests/functional/Glpi/Asset/Asset_PeripheralAssetTest.php
@@ -39,6 +39,7 @@ use Glpi\Asset\Capacity;
 use Glpi\Asset\Capacity\HasPeripheralAssetsCapacity;
 use Glpi\Features\Clonable;
 use Glpi\Tests\DbTestCase;
+use Monitor;
 use Toolbox;
 
 class Asset_PeripheralAssetTest extends DbTestCase
@@ -76,5 +77,22 @@ class Asset_PeripheralAssetTest extends DbTestCase
             $item = \getItemForItemtype($itemtype);
             $this->assertContains(Asset_PeripheralAsset::class, $item->getCloneRelations(), $itemtype);
         }
+    }
+
+    public function testUnglobalizeReturnsBoolean(): void
+    {
+        $monitor = $this->createItem(
+            Monitor::class,
+            [
+                'name' => 'Test Monitor',
+                'entities_id' => $this->getTestRootEntity(true),
+                'is_global' => 1,
+            ]
+        );
+
+        $result = $monitor->unglobalize();
+
+        $this->assertIsBool($result);
+        $this->assertTrue($result);
     }
 }


### PR DESCRIPTION
#22310 

In order to fix original issue error : 

- Asset_PeripheralAsset::unglobalizeItem() now return `bool` instead of void` (final class so cannot be extended, here changing signature of the method is considered as safe)

- CommonDBTM::unglobalize() return the result instead of `null` (also this was mentioned as TODO) here the change was only for signature in PHPDoc to avoid compatibility issues (see #21790 constraints). Also an early return pattern was added to properly track success/failure states and return appropriate boolean values, which wasn't possible with the original nested `if` structure that returned void.

- added a simple regression test
