### PR TITLE
feat(rule): add support for dropdown group in dropdownActions like dropdownCriteria

### DIFF
--- a/src/Rule.php
+++ b/src/Rule.php
@@ -2894,7 +2894,7 @@ TWIG, $twig_params);
     }
 
     /**
-     * @return array<int|string, array|string> If the value is defined as a string, it will create a new section in the dropdown
+     * @return array<int|string, array<mixed>|string> If the value is defined as a string, it will create a new section in the dropdown
      */
     public function getCriterias()
     {
@@ -2911,7 +2911,7 @@ TWIG, $twig_params);
     }
 
     /**
-     * @return array<int|string, array|string> If the value is defined as a string (since GLPI 11.0.5), it will create a new section in the dropdown
+     * @return array<int|string, array<mixed>|string> If the value is defined as a string (since GLPI 11.0.5), it will create a new section in the dropdown
      */
     public function getActions()
     {


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description
Rule criteria can be grouped by categories (default category `Criteria` but actions didn't had the possibility to group them.

I've added the support for it (with the default group being empty named to match previous criteria grouping display).

## Screenshots (if appropriate):

### Criteria (already have group)
<img width="752" height="492" alt="Screenshot from 2025-12-10 11-17-43" src="https://github.com/user-attachments/assets/4734e52d-2a0c-4dcf-9515-ae066d96de1c" />

### Actions
- Current state : 
<img width="752" height="492" alt="image" src="https://github.com/user-attachments/assets/b0064b49-1c71-452c-8500-c9a2e0490b73" />

- This PR :
<img width="752" height="492" alt="Screenshot from 2025-12-10 11-17-54" src="https://github.com/user-attachments/assets/ec346456-46df-48af-808a-0cff973b9953" />


