### PR TITLE
add verification methods for adding or updating a plug

### DIFF
--- a/src/Item_Plug.php
+++ b/src/Item_Plug.php
@@ -165,6 +165,43 @@ class Item_Plug extends CommonDBRelation
         return true;
     }
 
+    public function prepareInputForAdd($input)
+    {
+        return $this->prepareInput($input);
+    }
+
+    public function prepareInputForUpdate($input)
+    {
+        return $this->prepareInput($input);
+    }
+
+    /**
+     * Prepares input (for update and add)
+     *
+     * @param array $input Input data
+     *
+     * @return false|array
+     */
+    private function prepareInput($input)
+    {
+        // Check number_plugs requirement
+        if (
+            isset($input['number_plugs'])
+            || $this->isNewItem()
+        ) {
+            if (!isset($input['number_plugs']) || $input['number_plugs'] === '' || $input['number_plugs'] < 1) {
+                Session::addMessageAfterRedirect(
+                    __s('A number of plugs is required'),
+                    true,
+                    ERROR
+                );
+                return false;
+            }
+        }
+
+        return $input;
+    }
+
     public function getForbiddenStandardMassiveAction()
     {
         $forbidden   = parent::getForbiddenStandardMassiveAction();

--- a/src/Item_Plug.php
+++ b/src/Item_Plug.php
@@ -122,6 +122,7 @@ class Item_Plug extends CommonDBRelation
                     'id'     => 'number_plugs',
                     'type'   => 'number',
                     'min'    => 1,
+                    'required' => true,
                 ]
             );
             echo "</td><td>";
@@ -184,6 +185,19 @@ class Item_Plug extends CommonDBRelation
      */
     private function prepareInput(array $input): false|array
     {
+        // Check plugs_id requirement
+        if (
+            $this->isNewItem()
+            && (!isset($input['plugs_id']) || $input['plugs_id'] <= 0)
+        ) {
+            Session::addMessageAfterRedirect(
+                __s('A plug must be selected'),
+                true,
+                ERROR
+            );
+            return false;
+        }
+
         // Check number_plugs requirement
         if (
             ($this->isNewItem() || isset($input['number_plugs']))

--- a/src/Item_Plug.php
+++ b/src/Item_Plug.php
@@ -182,21 +182,19 @@ class Item_Plug extends CommonDBRelation
      *
      * @return false|array
      */
-    private function prepareInput($input)
+    private function prepareInput(array $input): false|array
     {
         // Check number_plugs requirement
         if (
-            isset($input['number_plugs'])
-            || $this->isNewItem()
+            ($this->isNewItem() || isset($input['number_plugs']))
+            && (!isset($input['number_plugs']) || $input['number_plugs'] === '' || $input['number_plugs'] < 1)
         ) {
-            if (!isset($input['number_plugs']) || $input['number_plugs'] === '' || $input['number_plugs'] < 1) {
-                Session::addMessageAfterRedirect(
-                    __s('A number of plugs is required'),
-                    true,
-                    ERROR
-                );
-                return false;
-            }
+            Session::addMessageAfterRedirect(
+                __s('A number of plugs is required'),
+                true,
+                ERROR
+            );
+            return false;
         }
 
         return $input;

--- a/tests/functional/Glpi/Asset/Capacity/HasPlugCapacityTest.php
+++ b/tests/functional/Glpi/Asset/Capacity/HasPlugCapacityTest.php
@@ -160,6 +160,7 @@ class HasPlugCapacityTest extends DbTestCase
                 'itemtype' => $item_1::class,
                 'items_id' => $item_1->getID(),
                 'plugs_id' => $plug_1->getID(),
+                'number_plugs' => 1,
             ]
         );
         $plug_item_2 = $this->createItem(
@@ -168,6 +169,7 @@ class HasPlugCapacityTest extends DbTestCase
                 'itemtype' => $item_2::class,
                 'items_id' => $item_2->getID(),
                 'plugs_id' => $plug_2->getID(),
+                'number_plugs' => 1,
             ]
         );
 
@@ -247,7 +249,9 @@ class HasPlugCapacityTest extends DbTestCase
     {
         yield [
             'target_classname'   => Plug::class,
+            'target_fields'      => [],
             'relation_classname' => Item_Plug::class,
+            'relation_fields'    => ['number_plugs' => 1],
         ];
     }
 
@@ -255,8 +259,10 @@ class HasPlugCapacityTest extends DbTestCase
     {
         yield [
             'target_classname'   => Plug::class,
-            'relation_classname' => Item_Plug::class,
             'expected'           => '%d plugs attached to %d assets',
+            'target_fields'      => [],
+            'relation_classname' => Item_Plug::class,
+            'relation_fields'    => ['number_plugs' => 1],
         ];
     }
 }

--- a/tests/functional/Item_PlugTest.php
+++ b/tests/functional/Item_PlugTest.php
@@ -80,14 +80,39 @@ class Item_PlugTest extends DbTestCase
         }
     }
 
-    public function testNumberPlugsValidation()
+    public function testPlugsIdAndNumberPlugsValidation()
     {
         $plug = $this->createItem(Plug::class, ['name' => 'Test plug']);
         $computer = $this->createItem(Computer::class, ['name' => 'Test computer', 'entities_id' => 0]);
 
         $item_plug = new Item_Plug();
 
-        // Empty number_plugs should fail
+        $item_plug->getEmpty();
+        $this->assertFalse($item_plug->add([
+            'itemtype' => Computer::class,
+            'items_id' => $computer->getID(),
+            'number_plugs' => 1,
+        ]));
+        $this->hasSessionMessages(ERROR, ['A plug must be selected']);
+
+        $item_plug->getEmpty();
+        $this->assertFalse($item_plug->add([
+            'plugs_id' => 0,
+            'itemtype' => Computer::class,
+            'items_id' => $computer->getID(),
+            'number_plugs' => 1,
+        ]));
+        $this->hasSessionMessages(ERROR, ['A plug must be selected']);
+
+        $item_plug->getEmpty();
+        $this->assertFalse($item_plug->add([
+            'plugs_id' => -1,
+            'itemtype' => Computer::class,
+            'items_id' => $computer->getID(),
+            'number_plugs' => 1,
+        ]));
+        $this->hasSessionMessages(ERROR, ['A plug must be selected']);
+
         $item_plug->getEmpty();
         $this->assertFalse($item_plug->add([
             'plugs_id' => $plug->getID(),
@@ -97,7 +122,6 @@ class Item_PlugTest extends DbTestCase
         ]));
         $this->hasSessionMessages(ERROR, ['A number of plugs is required']);
 
-        // Valid number_plugs should succeed
         $item_plug->getEmpty();
         $this->assertGreaterThan(0, $item_plug->add([
             'plugs_id' => $plug->getID(),

--- a/tests/functional/Item_PlugTest.php
+++ b/tests/functional/Item_PlugTest.php
@@ -34,11 +34,13 @@
 
 namespace tests\units;
 
+use Computer;
 use Glpi\Asset\Capacity;
 use Glpi\Asset\Capacity\HasPlugCapacity;
 use Glpi\Features\Clonable;
 use Glpi\Tests\DbTestCase;
 use Item_Plug;
+use Plug;
 use Toolbox;
 
 class Item_PlugTest extends DbTestCase
@@ -76,5 +78,32 @@ class Item_PlugTest extends DbTestCase
             $item = \getItemForItemtype($itemtype);
             $this->assertContains(Item_Plug::class, $item->getCloneRelations(), $itemtype);
         }
+    }
+
+    public function testNumberPlugsValidation()
+    {
+        $plug = $this->createItem(Plug::class, ['name' => 'Test plug']);
+        $computer = $this->createItem(Computer::class, ['name' => 'Test computer', 'entities_id' => 0]);
+
+        $item_plug = new Item_Plug();
+
+        // Empty number_plugs should fail
+        $item_plug->getEmpty();
+        $this->assertFalse($item_plug->add([
+            'plugs_id' => $plug->getID(),
+            'itemtype' => 'Computer',
+            'items_id' => $computer->getID(),
+            'number_plugs' => '',
+        ]));
+        $this->hasSessionMessages(ERROR, ['A number of plugs is required']);
+
+        // Valid number_plugs should succeed
+        $item_plug->getEmpty();
+        $this->assertGreaterThan(0, $item_plug->add([
+            'plugs_id' => $plug->getID(),
+            'itemtype' => 'Computer',
+            'items_id' => $computer->getID(),
+            'number_plugs' => 1,
+        ]));
     }
 }

--- a/tests/functional/Item_PlugTest.php
+++ b/tests/functional/Item_PlugTest.php
@@ -91,7 +91,7 @@ class Item_PlugTest extends DbTestCase
         $item_plug->getEmpty();
         $this->assertFalse($item_plug->add([
             'plugs_id' => $plug->getID(),
-            'itemtype' => 'Computer',
+            'itemtype' => Computer::class,
             'items_id' => $computer->getID(),
             'number_plugs' => '',
         ]));
@@ -101,7 +101,7 @@ class Item_PlugTest extends DbTestCase
         $item_plug->getEmpty();
         $this->assertGreaterThan(0, $item_plug->add([
             'plugs_id' => $plug->getID(),
-            'itemtype' => 'Computer',
+            'itemtype' => Computer::class,
             'items_id' => $computer->getID(),
             'number_plugs' => 1,
         ]));


### PR DESCRIPTION
Fixes #22280 

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

Add `prepareInputForAdd()` and `prepareInputForUpdate()` methods for `Item_Plug`, both calling new `prepareInput() `method with simple verification logic. Also a simple test is provided for non regression.

