### PR TITLE
Fix(cronQueuedNotification): memory limit

### DIFF
--- a/src/QueuedNotification.php
+++ b/src/QueuedNotification.php
@@ -660,6 +660,11 @@ class QueuedNotification extends CommonDBTM
         }
         $cron_status = 0;
 
+        $memory_limit       = (int) Toolbox::getMemoryLimit();
+        if ($memory_limit > 0 && $memory_limit < (512 * 1024 * 1024)) {
+            ini_set('memory_limit', '512M');
+        }
+
         // Send notifications at least 1 minute after adding in queue to be sure that process on it is finished
         $send_time = date("Y-m-d H:i:s", strtotime("+1 minutes"));
 


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !40941

When sending large emails, the queuednotification action remains stuck in “running” mode due to a memory issue:

`glpiphplog.CRITICAL:   *** PHP Error (1): Allowed memory size of 268435456 bytes exhausted (tried to allocate 41448743 bytes) in /var/www/glpi/vendor/phpmailer/phpmailer/src/PHPMailer.php at line 3634`

## Screenshots (if appropriate):


