### PR TITLE
Fix playwright lint

### DIFF
--- a/tests/e2e/fixtures/glpi_fixture.ts
+++ b/tests/e2e/fixtures/glpi_fixture.ts
@@ -97,10 +97,10 @@ export const test = baseTest.extend<{
 
         // Map id to expected playwright worker login
         const worker_prefix = Constants.E2E_WORKER_PREFIX;
-        let worker_index = id + 1;
-        let worker_index_string = worker_index > 10
+        const worker_index = id + 1;
+        const worker_index_string = worker_index > 10
             ? worker_index.toString()
-            : "0" + worker_index.toString() // Pad numbers < 10
+            : `0${worker_index.toString()}` // Pad numbers < 10
         ;
         const worker_login = worker_prefix + worker_index_string;
 


### PR DESCRIPTION
This errors were not caught because two PR were merged separately so the code from one PR was not linted by the other.