### PR TITLE
Fix PHP 8.5 deprecated call

### DIFF
--- a/src/CommonItilObject_Item.php
+++ b/src/CommonItilObject_Item.php
@@ -1690,7 +1690,11 @@ TWIG, $twig_params);
                         'display_emptychoice' => true,
                     ]
                 );
-                $found_type = isset($types[$itemtype]);
+
+                $found_type = false;
+                if ($itemtype !== null) {
+                    $found_type = isset($types[$itemtype]);
+                }
 
                 $p = [
                     'source_itemtype' => static::$itemtype_1,


### PR DESCRIPTION
Fix the following when viewing the "Items" tab of an ITIL object
```
[2025-12-11 07:56:55] glpi.INFO:   *** Deprecated: Using null as an array offset is deprecated, use an empty string instead at CommonItilObject_Item.php line 1693
  Backtrace :
  ./src/CommonItilObject_Item.php:1693               
  :                                                  CommonItilObject_Item::dropdownAllDevices()
  ...Application/View/Extension/PhpExtension.php:105 call_user_func_array()
  ...ates/28/28a5f66c23266f304df629218f967e82.php:80 Glpi\Application\View\Extension\PhpExtension->call()
  ./vendor/twig/twig/src/Template.php:402            __TwigTemplate_369ab43e1b42505b8f81ccd086fac815->doDisplay()
  ./vendor/twig/twig/src/Template.php:358            Twig\Template->yield()
  ./vendor/twig/twig/src/Template.php:373            Twig\Template->display()
  ./vendor/twig/twig/src/TemplateWrapper.php:51      Twig\Template->render()
  .../Glpi/Application/View/TemplateRenderer.php:206 Twig\TemplateWrapper->render()
  ./src/CommonItilObject_Item.php:426                Glpi\Application\View\TemplateRenderer->renderFromStringTemplate()
  ./src/CommonItilObject_Item.php:651                CommonItilObject_Item::showForObject()
  ./src/CommonGLPI.php:694                           CommonItilObject_Item::displayTabContentForItem()
  ./ajax/common.tabs.php:108                         CommonGLPI::displayStandardTab()
  ...Glpi/Controller/LegacyFileLoadController.php:64 require()
  ./vendor/symfony/http-kernel/HttpKernel.php:181    Glpi\Controller\LegacyFileLoadController->__invoke()
  ./vendor/symfony/http-kernel/HttpKernel.php:76     Symfony\Component\HttpKernel\HttpKernel->handleRaw()
  ./vendor/symfony/http-kernel/Kernel.php:197        Symfony\Component\HttpKernel\HttpKernel->handle()
  ./public/index.php:70                              Symfony\Component\HttpKernel\Kernel->handle()
```