### PR TITLE
Remove second db update confirmation screen / rework install screen contrast

### DIFF
--- a/css/install.scss
+++ b/css/install.scss
@@ -154,6 +154,11 @@ h3 {
 
 .alert:not(.alert-important) {
     color: #000;
+
+    .text-muted,
+    .alert-icon {
+        color: inherit !important;
+    }
 }
 
 /** Tabler override for install **/

--- a/install/update.php
+++ b/install/update.php
@@ -36,7 +36,6 @@
 require_once(__DIR__ . '/../front/_check_webserver_config.php');
 
 use Glpi\Application\View\TemplateRenderer;
-use Glpi\Toolbox\VersionParser;
 
 /**
  * @var bool $HEADER_LOADED
@@ -119,31 +118,19 @@ echo "<div id='logo_bloc'></div>";
 echo "<h2>" . __s('GLPI setup') . "</h2>";
 echo "<br><h3>" . __s('Upgrade') . "</h3>";
 
-if (($_SESSION['can_process_update'] ?? false) === false) {
-    // Unexpected direct access to the form
+if (
+    ($_SESSION['can_process_update'] ?? false) === false
+    || (empty($_POST["continuer"]) && empty($_POST["from_update"]) && empty($_POST["post_update_step"]))
+) {
+    // Unexpected direct access to the form without proper entry point
     echo "<div class='center'>";
-    echo "<h3><span class='migred'>" . __s('Impossible to accomplish an update by this way!') . "</span>";
+    echo "<h3><span class='migred'>" . __s('Impossible to accomplish an update by this way!') . "</span></h3>";
     echo "<p>";
     echo "<a class='btn btn-primary' href='../index.php'>
         " . __s('Go back to GLPI') . "
      </a></p>";
     echo "</div>";
-} elseif (empty($_POST["continuer"]) && empty($_POST["from_update"]) && empty($_POST["post_update_step"])) {
-    // step 1    avec bouton de confirmation
-    echo "<div class='center'>";
-    echo "<h3 class='my-4'><span class='migred p-2'>" . sprintf(__s('Caution! You will update the GLPI database named: %s'), htmlescape($DB->dbdefault)) . "</h3>";
-
-    echo "<form action='update.php' method='post'>";
-    if (!VersionParser::isStableRelease(GLPI_VERSION)) {
-        echo Config::agreeUnstableMessage(VersionParser::isDevVersion(GLPI_VERSION));
-    }
-    echo "<button type='submit' class='btn btn-primary' name='continuer' value='1'>
-     " . __s('Continue') . "
-     <i class='fas fa-chevron-right ms-1'></i>
-  </button>";
-    Html::closeForm();
-    echo "</div>";
-} elseif (!empty($_POST["continuer"])) {
+} elseif (!empty($_POST["continuer"]) || !empty($_POST["from_update"])) {
     // Step 2
     if ($DB->connected) {
         echo "<h3>" . __s('Database connection successful') . "</h3>";

--- a/install/update.php
+++ b/install/update.php
@@ -128,7 +128,7 @@ if (($_SESSION['can_process_update'] ?? false) === false) {
         " . __s('Go back to GLPI') . "
      </a></p>";
     echo "</div>";
-} elseif (empty($_POST["continuer"]) && empty($_POST["from_update"]) && empty($_POST["post_update_step"])) {
+} elseif (empty($_POST["continuer"]) && empty($_POST["post_update_step"])) {
     // Step 1: Confirmation screen (needed for install wizard flow)
     echo "<div class='center'>";
     echo "<h3 class='my-4'><span class='migred p-2'>" . sprintf(__s('Caution! You will update the GLPI database named: %s'), htmlescape($DB->dbdefault)) . "</span></h3>";
@@ -143,7 +143,7 @@ if (($_SESSION['can_process_update'] ?? false) === false) {
       </button>";
     Html::closeForm();
     echo "</div>";
-} elseif (!empty($_POST["continuer"]) || !empty($_POST["from_update"])) {
+} elseif (!empty($_POST["continuer"])) {
     // Step 2
     if ($DB->connected) {
         echo "<h3>" . __s('Database connection successful') . "</h3>";

--- a/install/update.php
+++ b/install/update.php
@@ -36,6 +36,7 @@
 require_once(__DIR__ . '/../front/_check_webserver_config.php');
 
 use Glpi\Application\View\TemplateRenderer;
+use Glpi\Toolbox\VersionParser;
 
 /**
  * @var bool $HEADER_LOADED
@@ -118,10 +119,7 @@ echo "<div id='logo_bloc'></div>";
 echo "<h2>" . __s('GLPI setup') . "</h2>";
 echo "<br><h3>" . __s('Upgrade') . "</h3>";
 
-if (
-    ($_SESSION['can_process_update'] ?? false) === false
-    || (empty($_POST["continuer"]) && empty($_POST["from_update"]) && empty($_POST["post_update_step"]))
-) {
+if (($_SESSION['can_process_update'] ?? false) === false) {
     // Unexpected direct access to the form without proper entry point
     echo "<div class='center'>";
     echo "<h3><span class='migred'>" . __s('Impossible to accomplish an update by this way!') . "</span></h3>";
@@ -129,6 +127,21 @@ if (
     echo "<a class='btn btn-primary' href='../index.php'>
         " . __s('Go back to GLPI') . "
      </a></p>";
+    echo "</div>";
+} elseif (empty($_POST["continuer"]) && empty($_POST["from_update"]) && empty($_POST["post_update_step"])) {
+    // Step 1: Confirmation screen (needed for install wizard flow)
+    echo "<div class='center'>";
+    echo "<h3 class='my-4'><span class='migred p-2'>" . sprintf(__s('Caution! You will update the GLPI database named: %s'), htmlescape($DB->dbdefault)) . "</span></h3>";
+
+    echo "<form action='update.php' method='post'>";
+    if (!VersionParser::isStableRelease(GLPI_VERSION)) {
+        echo Config::agreeUnstableMessage(VersionParser::isDevVersion(GLPI_VERSION));
+    }
+    echo "<button type='submit' class='btn btn-primary' name='continuer' value='1'>
+         " . __s('Continue') . "
+         <i class='fas fa-chevron-right ms-1'></i>
+      </button>";
+    Html::closeForm();
     echo "</div>";
 } elseif (!empty($_POST["continuer"]) || !empty($_POST["from_update"])) {
     // Step 2

--- a/install/update.php
+++ b/install/update.php
@@ -68,7 +68,7 @@ function showSecurityKeyCheckForm(): void
     global $DB;
 
     echo '<form action="update.php" method="post">';
-    echo '<input type="hidden" name="continuer" value="1" />';
+    echo '<input type="hidden" name="continue" value="1" />';
     echo '<input type="hidden" name="missing_key_warning_shown" value="1" />';
     echo Html::hidden('_glpi_csrf_token', ['value' => Session::getNewCSRFToken()]);
     echo '<div class="text-center">';
@@ -128,7 +128,7 @@ if (($_SESSION['can_process_update'] ?? false) === false) {
         " . __s('Go back to GLPI') . "
      </a></p>";
     echo "</div>";
-} elseif (empty($_POST["continuer"]) && empty($_POST["post_update_step"])) {
+} elseif (empty($_POST["continue"]) && empty($_POST["post_update_step"])) {
     // Step 1: Confirmation screen (needed for install wizard flow)
     echo "<div class='center'>";
     echo "<h3 class='my-4'><span class='migred p-2'>" . sprintf(__s('Caution! You will update the GLPI database named: %s'), htmlescape($DB->dbdefault)) . "</span></h3>";
@@ -137,13 +137,13 @@ if (($_SESSION['can_process_update'] ?? false) === false) {
     if (!VersionParser::isStableRelease(GLPI_VERSION)) {
         echo Config::agreeUnstableMessage(VersionParser::isDevVersion(GLPI_VERSION));
     }
-    echo "<button type='submit' class='btn btn-primary' name='continuer' value='1'>
+    echo "<button type='submit' class='btn btn-primary' name='continue' value='1'>
          " . __s('Continue') . "
          <i class='fas fa-chevron-right ms-1'></i>
       </button>";
     Html::closeForm();
     echo "</div>";
-} elseif (!empty($_POST["continuer"])) {
+} elseif (!empty($_POST["continue"])) {
     // Step 2
     if ($DB->connected) {
         echo "<h3>" . __s('Database connection successful') . "</h3>";

--- a/templates/install/agree_unstable.html.twig
+++ b/templates/install/agree_unstable.html.twig
@@ -48,7 +48,7 @@
 </div>
 <script>
    $(function() {
-       $('[name=from_update]').on('click', function(event){
+       $('[name="continuer"]').on('click', function(event){
            if (!$('#agree_unstable').is(':checked')) {
                event.preventDefault();
                alert('{{ __('Please check the unstable version checkbox.') }}');

--- a/templates/install/agree_unstable.html.twig
+++ b/templates/install/agree_unstable.html.twig
@@ -48,7 +48,7 @@
 </div>
 <script>
    $(function() {
-       $('[name="continuer"]').on('click', function(event){
+       $('[name="continue"]').on('click', function(event){
            if (!$('#agree_unstable').is(':checked')) {
                event.preventDefault();
                alert('{{ __('Please check the unstable version checkbox.') }}');

--- a/templates/install/update.need_update.html.twig
+++ b/templates/install/update.need_update.html.twig
@@ -49,13 +49,15 @@
                     {% if not is_outdated %}
                         <form method="post" action="{{ path('install/update.php') }}" class="p-2">
                             {{ fields.csrfField() }}
+                            <input type="hidden" name="from_update" value="1">
+                            <input type="hidden" name="continuer" value="1">
                             {% if not is_stable_release %}
                                 {% include 'install/agree_unstable.html.twig' with {'is_dev': is_dev_version} only %}
                             {% endif %}
                             <p class="my-2 alert alert-important alert-warning">
                                 {{ __('The GLPI codebase has been updated. The update of the GLPI database is necessary.') }}
                             </p>
-                            <button type="submit" name="from_update" value="1" class="btn btn-primary">
+                            <button type="submit" class="btn btn-primary">
                                 <i class="ti ti-check"></i>{{ _x('button', 'Upgrade') }}
                             </button>
                         </form>

--- a/templates/install/update.need_update.html.twig
+++ b/templates/install/update.need_update.html.twig
@@ -55,7 +55,7 @@
                             <p class="my-2 alert alert-important alert-warning">
                                 {{ __('The GLPI codebase has been updated. The update of the GLPI database is necessary.') }}
                             </p>
-                            <button type="submit" name="from_update" class="btn btn-primary">
+                            <button type="submit" name="from_update" value="1" class="btn btn-primary">
                                 <i class="ti ti-check"></i>{{ _x('button', 'Upgrade') }}
                             </button>
                         </form>

--- a/templates/install/update.need_update.html.twig
+++ b/templates/install/update.need_update.html.twig
@@ -50,14 +50,13 @@
                         <form method="post" action="{{ path('install/update.php') }}" class="p-2">
                             {{ fields.csrfField() }}
                             <input type="hidden" name="from_update" value="1">
-                            <input type="hidden" name="continuer" value="1">
                             {% if not is_stable_release %}
                                 {% include 'install/agree_unstable.html.twig' with {'is_dev': is_dev_version} only %}
                             {% endif %}
                             <p class="my-2 alert alert-important alert-warning">
                                 {{ __('The GLPI codebase has been updated. The update of the GLPI database is necessary.') }}
                             </p>
-                            <button type="submit" class="btn btn-primary">
+                            <button type="submit" name="continuer" value="1" class="btn btn-primary">
                                 <i class="ti ti-check"></i>{{ _x('button', 'Upgrade') }}
                             </button>
                         </form>

--- a/templates/install/update.need_update.html.twig
+++ b/templates/install/update.need_update.html.twig
@@ -56,7 +56,7 @@
                             <p class="my-2 alert alert-important alert-warning">
                                 {{ __('The GLPI codebase has been updated. The update of the GLPI database is necessary.') }}
                             </p>
-                            <button type="submit" name="continuer" value="1" class="btn btn-primary">
+                            <button type="submit" name="continue" value="1" class="btn btn-primary">
                                 <i class="ti ti-check"></i>{{ _x('button', 'Upgrade') }}
                             </button>
                         </form>


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

- It fixes #19269 

Remove second db upgrade confirmation screen. Only one validation on requirements screen now.

<img width="1015" height="899" alt="image" src="https://github.com/user-attachments/assets/b4c4e974-9c9b-4a03-aa65-dd771c090e2c" />


## Screenshots (if appropriate): 

modified contrast on install/update screen 
<img width="830" height="325" alt="image" src="https://github.com/user-attachments/assets/04dae255-abe6-4ab0-9f98-dfa787ff3d4f" />

**For a quick test :**

Simulate DB update : 

```
UPDATE glpi_configs
SET value = '10.0.0@fakehash'
WHERE name = 'dbversion' AND context = 'core';

```
Simulate installation : 

`mv /Developer/glpi11/config/config_db.php /Developer/glpi11/config/config_db.php.bak`


