### PR TITLE
Fix(User): Auto-lock Mode always active

### DIFF
--- a/templates/pages/setup/general/preferences_setup.html.twig
+++ b/templates/pages/setup/general/preferences_setup.html.twig
@@ -378,10 +378,10 @@
 
    {% if get_current_interface() == 'central' and config('lock_use_lock_item') %}
       {{ fields.smallTitle(__('Item locks'), 'ti ti-lock') }}
-      {{ fields.dropdownYesNo('lock_autolock_mode', config('lock_autolock_mode'), __('Auto-lock Mode'), field_options) }}
+      {{ fields.dropdownYesNo('lock_autolock_mode', config['lock_autolock_mode'], __('Auto-lock Mode'), field_options) }}
       {{ fields.dropdownYesNo(
          'lock_directunlock_notification',
-         config('lock_directunlock_notification'),
+         config['lock_directunlock_notification'],
          __('Direct Notification (requester for unlock will be the notification sender)'),
          field_options
       ) }}


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !40983

For a user, therefore the Settings tab, the value always displayed Yes.

## Screenshots (if appropriate):

<img width="1292" height="179" alt="image" src="https://github.com/user-attachments/assets/848f52ee-3a2f-4171-bc04-74bc478f84bc" />

