### PR TITLE
Fix(Notification): Visibility of send test errors

### DIFF
--- a/src/NotificationMailing.php
+++ b/src/NotificationMailing.php
@@ -105,7 +105,7 @@ class NotificationMailing implements NotificationInterface
         } catch (Exception $e) {
             return [
                 'success' => false,
-                'error'   => __('Cannot initialize mailer: ') . $e->getMessage(),
+                'error'   => sprintf(__('Cannot initialize mailer, error is: %s'), "\n" . $e->getMessage()),
                 'debug'   => null,
             ];
         }


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !41008

Send test errors were not displayed.
Previously, there was a 500 error and the modal was not displayed at all.

## Screenshots (if appropriate):

<img width="963" height="364" alt="image" src="https://github.com/user-attachments/assets/b8570c7a-aa63-4ab5-afe3-ab760773876c" />
