### PR TITLE
Add itemtype and id to software merge entries

### DIFF
--- a/src/Software.php
+++ b/src/Software.php
@@ -963,7 +963,7 @@ class Software extends CommonDBTM implements TreeBrowseInterface, AssignableItem
         foreach ($iterator as $data) {
             $software->getFromDB($data["id"]);
             $entries[] = [
-                'itemtype' => 'Software',
+                'itemtype' => Software::class,
                 'id' => $data["id"],
                 'name' => $software->getLink(),
                 'entity' => $data["entity"],


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes #22352 
- Add missing parameters `id` and `itemtype` for massivaction template

## Screenshots (if appropriate):
<img width="379" height="148" alt="image" src="https://github.com/user-attachments/assets/7df197c4-c55c-42ca-bbc9-2cd400c2b822" />

Before no button was visible and after pr button is visible and does what it should (merge software entries).
