### PR TITLE
Prevent Laminas Exception w/ bad CC when collecting mails

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -202,6 +202,7 @@
             "patch -f -p1 -d vendor/guzzlehttp/guzzle/ < tools/patches/guzzlehttp-guzzle-restrict-http-methods.patch || true",
             "patch -f -p1 -d vendor/laminas/laminas-mail/ < tools/patches/laminas-laminas-mail-address-no-length-check.patch || true",
             "patch -f -p1 -d vendor/laminas/laminas-mail/ < tools/patches/laminas-laminas-mail-invalid-header-ignore.patch || true",
+            "patch -f -p1 -d vendor/laminas/laminas-mail/ < tools/patches/laminas-laminas-mail-invalid-address-ignore.patch || true",
             "patch -f -p1 -d vendor/wapmorgan/unified-archive/ < tools/patches/wapmorgan-unified-archive-php-8.5-compat.patch || true"
         ]
     }

--- a/src/MailCollector.php
+++ b/src/MailCollector.php
@@ -982,7 +982,7 @@ class MailCollector extends CommonDBTM
         $blacklisted_emails   = Blacklist::getEmails();
         // Add name of the mailcollector as blacklisted
         $blacklisted_emails[] = $this->fields['name'];
-        if (Toolbox::inArrayCaseCompare($headers['from'], $blacklisted_emails)) {
+        if ($headers['from'] !== null && Toolbox::inArrayCaseCompare($headers['from'], $blacklisted_emails)) {
             $tkt['_blacklisted'] = true;
             return $tkt;
         }
@@ -1418,7 +1418,11 @@ class MailCollector extends CommonDBTM
             $h_tos   = $message->getHeader('to');
             if ($h_tos instanceof AbstractAddressList) {
                 foreach ($h_tos->getAddressList() as $address) {
-                    $mailto = Toolbox::strtolower($address->getEmail());
+                    $email = $address->getEmail();
+                    if ($email === null) {
+                        continue;
+                    }
+                    $mailto = Toolbox::strtolower($email);
                     if ($mailto === $this->fields['name']) {
                         $to = $mailto;
                     }
@@ -1432,7 +1436,11 @@ class MailCollector extends CommonDBTM
             $h_ccs   = $message->getHeader('cc');
             if ($h_ccs instanceof AbstractAddressList) {
                 foreach ($h_ccs->getAddressList() as $address) {
-                    $ccs[] = Toolbox::strtolower($address->getEmail());
+                    $email = $address->getEmail();
+                    if ($email === null) {
+                        continue;
+                    }
+                    $ccs[] = Toolbox::strtolower($email);
                 }
             }
         }
@@ -1450,7 +1458,7 @@ class MailCollector extends CommonDBTM
         }
 
         $mail_details = [
-            'from'       => Toolbox::strtolower($sender_email),
+            'from'       => $sender_email !== null ? Toolbox::strtolower($sender_email) : null,
             'subject'    => $subject,
             'reply-to'   => $reply_to_addr !== null ? Toolbox::strtolower($reply_to_addr) : null,
             'to'         => $to !== null ? Toolbox::strtolower($to) : null,

--- a/tests/emails-tests/49-invalid-cc-email-address.eml
+++ b/tests/emails-tests/49-invalid-cc-email-address.eml
@@ -1,0 +1,10 @@
+Date: Wed, 11 Dec 2025 10:00:00 +0100
+From: Normal User <normal@glpi-project.org>
+To: GLPI debug <unittests@glpi-project.org>
+CC: } <}>
+Subject: 49 - Message with invalid CC email address
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+This message has an invalid CC email address that should not crash the mail collector.

--- a/tests/emails-tests/50-all-invalid-addresses.eml
+++ b/tests/emails-tests/50-all-invalid-addresses.eml
@@ -1,0 +1,10 @@
+Date: Wed, 18 Dec 2025 10:00:00 +0100
+From: < >
+To: GLPI debug <unittests@glpi-project.org>
+CC: {{{
+Subject: 50 - Message with all invalid addresses
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+This message has all invalid addresses (From and CC) to test the case where no valid address can be extracted.

--- a/tests/imap/MailCollectorTest.php
+++ b/tests/imap/MailCollectorTest.php
@@ -748,6 +748,15 @@ class MailCollectorTest extends DbTestCase
             'Invalid address "} <}>"',
             LogLevel::WARNING
         );
+        // 50-all-invalid-addresses.eml - All addresses are invalid (From and CC)
+        $this->hasPhpLogRecordThatContains(
+            'Invalid address "< >"',
+            LogLevel::WARNING
+        );
+        $this->hasPhpLogRecordThatContains(
+            'Invalid address "{{{"',
+            LogLevel::WARNING
+        );
 
         // Check error log and clean it (to prevent test failure, see GLPITestCase::afterTestMethod()).
         foreach ($expected_logged_errors as $error_message => $error_level) {
@@ -755,7 +764,7 @@ class MailCollectorTest extends DbTestCase
         }
 
         $total_count                     = count(glob(GLPI_ROOT . '/tests/emails-tests/*.eml'));
-        $expected_refused_count          = 13;
+        $expected_refused_count          = 14;
         $expected_error_count            = 1;
         $expected_blacklist_count        = 1;
         $expected_expected_already_seen  = 0;
@@ -798,6 +807,13 @@ class MailCollectorTest extends DbTestCase
                 'subject' => 'Test email without To header that should be refused',
                 'from'    => 'unknown@glpi-project.org',
                 'to'      => '', // Empty string, not NULL
+                'reason'  => \NotImportedEmail::USER_UNKNOWN,
+            ],
+            [
+                // 50-all-invalid-addresses.eml - All addresses (From and CC) are invalid
+                'subject' => '50 - Message with all invalid addresses',
+                'from'    => '', // Empty string, From address is invalid
+                'to'      => 'unittests@glpi-project.org',
                 'reason'  => \NotImportedEmail::USER_UNKNOWN,
             ],
         ];

--- a/tests/imap/MailCollectorTest.php
+++ b/tests/imap/MailCollectorTest.php
@@ -729,8 +729,6 @@ class MailCollectorTest extends DbTestCase
         $this->collector->maxfetch_emails = 1000; // Be sure to fetch all mails from test suite
 
         $expected_logged_errors = [
-            // 05-empty-from.eml
-            'The input is not a valid email address. Use the basic format local-part@hostname' => LogLevel::ERROR,
             // 17-malformed-email.eml
             'Header with Name date or date not found' => LogLevel::ERROR,
         ];
@@ -740,6 +738,16 @@ class MailCollectorTest extends DbTestCase
             'Invalid header "X-Invalid-Encoding"',
             LogLevel::WARNING
         );
+        // 05-empty-from.eml - Invalid address caught by Laminas patch
+        $this->hasPhpLogRecordThatContains(
+            'Invalid address "<>"',
+            LogLevel::WARNING
+        );
+        // 49-invalid-cc-email-address.eml - Invalid CC address caught by Laminas patch
+        $this->hasPhpLogRecordThatContains(
+            'Invalid address "} <}>"',
+            LogLevel::WARNING
+        );
 
         // Check error log and clean it (to prevent test failure, see GLPITestCase::afterTestMethod()).
         foreach ($expected_logged_errors as $error_message => $error_level) {
@@ -747,8 +755,8 @@ class MailCollectorTest extends DbTestCase
         }
 
         $total_count                     = count(glob(GLPI_ROOT . '/tests/emails-tests/*.eml'));
-        $expected_refused_count          = 12;
-        $expected_error_count            = 2;
+        $expected_refused_count          = 13;
+        $expected_error_count            = 1;
         $expected_blacklist_count        = 1;
         $expected_expected_already_seen  = 0;
 
@@ -865,6 +873,7 @@ class MailCollectorTest extends DbTestCase
                     '43 - Korean encoding issue',
                     '44 - Hebrew encoding issue',
                     '47 - Missing charset parameter',
+                    '49 - Message with invalid CC email address',
                 ],
             ],
             // Mails having "normal" user as observer

--- a/tools/patches/laminas-laminas-mail-invalid-address-ignore.patch
+++ b/tools/patches/laminas-laminas-mail-invalid-address-ignore.patch
@@ -1,0 +1,22 @@
+diff --git a/src/Header/AbstractAddressList.php b/src/Header/AbstractAddressList.php
+index 1234567..abcdefg 100644
+--- a/src/Header/AbstractAddressList.php
++++ b/src/Header/AbstractAddressList.php
+@@ -118,7 +118,16 @@ abstract class AbstractAddressList implements HeaderInterface
+                     ],
+                     $value
+                 );
+-                return empty($value) ? null : Address::fromString($value, $comments);
++                if (empty($value)) {
++                    return null;
++                }
++                try {
++                    return Address::fromString($value, $comments);
++                } catch (\Laminas\Mail\Exception\InvalidArgumentException $e) {
++                    // Invalid email address, ignore it and add a warning
++                    trigger_error(sprintf('Invalid address "%s"', $value), E_USER_WARNING);
++                    return null;
++                }
+             },
+             $values
+         );

--- a/tools/patches/laminas-laminas-mail-invalid-address-ignore.patch
+++ b/tools/patches/laminas-laminas-mail-invalid-address-ignore.patch
@@ -14,7 +14,7 @@ index 1234567..abcdefg 100644
 +                    return Address::fromString($value, $comments);
 +                } catch (\Laminas\Mail\Exception\InvalidArgumentException $e) {
 +                    // Invalid email address, ignore it and add a warning
-+                    trigger_error(sprintf('Invalid address "%s"', $value), E_USER_WARNING);
++                    trigger_error($e->getMessage(), E_USER_WARNING);
 +                    return null;
 +                }
              },

--- a/tools/patches/laminas-laminas-mail-invalid-address-ignore.patch
+++ b/tools/patches/laminas-laminas-mail-invalid-address-ignore.patch
@@ -14,7 +14,7 @@ index 1234567..abcdefg 100644
 +                    return Address::fromString($value, $comments);
 +                } catch (\Laminas\Mail\Exception\InvalidArgumentException $e) {
 +                    // Invalid email address, ignore it and add a warning
-+                    trigger_error($e->getMessage(), E_USER_WARNING);
++                    trigger_error(sprintf('Invalid address "%s"', $value), E_USER_WARNING);
 +                    return null;
 +                }
              },


### PR DESCRIPTION
#19037 
- Handle case where an unuasal CC fields is consumed by collector


