### PR TITLE
feat(rule): add possibility for plugin to change the default rule test url

### DIFF
--- a/src/RuleCollection.php
+++ b/src/RuleCollection.php
@@ -2290,7 +2290,8 @@ TWIG, $twig_params);
         return $dictionnaries;
     }
 
-    public static function getRulesTestURL(): string {
+    public static function getRulesTestURL(): string
+    {
         $url = '';
         if ($plugin = isPluginItemType(static::class)) {
             $url .= "/plugins/" . $plugin['plugin'];


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] This change requires a documentation update. PR https://github.com/glpi-project/docdev/pull/188 for the documentation will be made ready once this one is merged 

## Description
- fix a case where for the test engine for plugin it wasn't using the GlpiPlugin namespace.
- add a `getRulesTestURL` static method so plugin can override the path to a custom one (like it's currently done inside the rule - using `getSearchURL`)
  - Another issue was that currently, the generated test path was using the plugin name with an uppercase but the plugin path is in lowercase making the links return a 404 with the Controller even if named it with the hardcoded name