### PR TITLE
remove call showCheckPlanning in twig

### DIFF
--- a/templates/pages/assistance/planning/add_classic_event.html.twig
+++ b/templates/pages/assistance/planning/add_classic_event.html.twig
@@ -56,13 +56,7 @@
 
         {% set period_field %}
             {% if params.rand_user is defined %}
-                <span id="user_available{{ params.rand_user }}">
-                    {% do call('Planning::showCheckPlanning', [_post|merge({
-                        parent_itemtype: params.parent_itemtype|default(''),
-                        parent_items_id: params.parent_items_id|default(''),
-                        parent_fk_field: params.parent_fk_field|default(''),
-                    })]) %}
-                </span>
+                <span id="user_available{{ params.rand_user }}"></span>
             {% endif %}
 
             {% if default_delay <= 180000 %}


### PR DESCRIPTION

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.


## Description

- It fixes !40907
- Remove call to Planning::showCheckPlanning from Twig template, function no longer exists


