### PR TITLE
Expand JS Tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ phpstan.neon
 .env
 /resources/.illustrations_translations.php
 /.dump/
+/tests/js/coverage/
 
 # Playwright
 /tests/e2e/results/

--- a/js/cable.js
+++ b/js/cable.js
@@ -41,7 +41,7 @@ function refreshAssetBreadcrumb(itemtype, items_id, dom_to_update) {
             items_id: items_id,
             itemtype: itemtype,
         }
-    }).done((html_breadcrum) => {
+    }).then((html_breadcrum) => {
         $(`#${CSS.escape(dom_to_update)}`).empty();
         $(`#${CSS.escape(dom_to_update)}`).append(html_breadcrum);
     });
@@ -58,7 +58,7 @@ function refreshNetworkPortDropdown(itemtype, items_id, dom_to_update) {
             items_id: items_id,
             itemtype: itemtype,
         }
-    }).done((html_data) => {
+    }).then((html_data) => {
         $(`#${CSS.escape(dom_to_update)}`).empty();
         $(`#${CSS.escape(dom_to_update)}`).append(html_data);
     });
@@ -76,9 +76,18 @@ function refreshSocketDropdown(itemtype, items_id, socketmodels_id, dom_name) {
             socketmodels_id: socketmodels_id,
             dom_name: dom_name
         }
-    }).done((html_data) => {
+    }).then((html_data) => {
         const parent_dom = $(`select[name="${CSS.escape(dom_name)}"]`).parent().parent();
         parent_dom.empty();
         parent_dom.append(html_data);
     });
+}
+
+/* eslint-disable no-undef */
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = {
+        refreshAssetBreadcrumb,
+        refreshNetworkPortDropdown,
+        refreshSocketDropdown
+    };
 }

--- a/js/common.js
+++ b/js/common.js
@@ -59,6 +59,7 @@ var select2_configs = {};
  *
  * @param objet
  * @param statut
+ * @todo Remove - Not used. Not useful anyways.
 **/
 function setdisplay(objet, statut) {
 
@@ -72,6 +73,7 @@ function setdisplay(objet, statut) {
 
 /**
  * @param id
+ * @todo Remove - Not used. Not useful anyways.
 **/
 function cleandisplay(id) {
 
@@ -84,6 +86,7 @@ function cleandisplay(id) {
 
 /**
  * @param id
+ * @todo Remove - Not used. Not useful anyways.
 **/
 function cleanhide(id) {
 
@@ -97,6 +100,7 @@ function cleanhide(id) {
 /**
  * @param Type
  * @param Id
+ * @todo Remove - Not used. Not even sure what this was ever used for.
 **/
 function fillidfield(Type, Id) {
     window.opener.document.forms.helpdeskform.elements.items_id.value = Id;
@@ -151,6 +155,7 @@ function unMarkCheckboxes(container_id) {
  *
  * @param    select_object     DOM select object
  * @param    other_option_name the name of both the option and the text input field
+ * @note Used by src/Dropdown.php. Probably not actually used.
 **/
 function displayOtherSelectOptions(select_object, other_option_name) {
     if (select_object.options[select_object.selectedIndex].value == other_option_name) {
@@ -169,7 +174,7 @@ function displayOtherSelectOptions(select_object, other_option_name) {
  * Check all checkboxes inside the given element as the same state as a reference one (toggle this one before)
  * the given element is usaly a table or a div containing the table or tables
  *
- * @param {HTMLElement} reference
+ * @param {HTMLElement|string} reference
  * @param {string} container_id
 **/
 function checkAsCheckboxes(reference, container_id, checkboxes_selector = 'input[type="checkbox"]') {
@@ -227,6 +232,7 @@ $.fn.shiftSelectable = function() {
  * @param img_name         name attribut of the img item
  * @param img_src_close    url of the close img
  * @param img_src_open     url of the open img
+ * @todo Remove - Not very useful and only used by plugins since the removal of the old debug toolbar.
 **/
 function showHideDiv(id, img_name = '', img_src_close = '', img_src_open = '') {
     var _elt = $('#' + id);
@@ -271,6 +277,7 @@ function showHideDiv(id, img_name = '', img_src_close = '', img_src_open = '') {
  * @param img_name
  * @param img_src_yes
  * @param img_src_no
+ * @todo Remove - Not useful and only used by templates/components/search/controls.html.twig and that doesn't even use the img params so it is litterally just changing an input's value between 0 and 1...
 **/
 function toogle(id, img_name, img_src_yes, img_src_no) {
 
@@ -297,6 +304,7 @@ function toogle(id, img_name, img_src_yes, img_src_no) {
  * @param img_name
  * @param img_src_close
  * @param img_src_open
+ * @todo Remove - Not used and I am not sure what it was ever used for.
  */
 function toggleTableDisplay(tbl, img_name, img_src_close, img_src_open) {
 
@@ -333,10 +341,12 @@ function toggleTableDisplay(tbl, img_name, img_src_close, img_src_open) {
 
 
 /**
+ * Creates a form element and submits it with POST method (despite the function name) to the specified target with the specified fields
  * @since 0.84
  *
  * @param target
  * @param fields
+ * @deprecated Use real form HTML
 **/
 function submitGetLink(target, fields) {
 
@@ -412,6 +422,7 @@ function massiveUpdateCheckbox(criterion, reference) {
 
 /**
  * Timeline for itiobjects
+ * @todo Remove - Not used anymore
  */
 var filter_timeline = function() {
     $(document).on("click", '.filter_timeline li a', function(event) {
@@ -457,6 +468,7 @@ var read_more = function() {
 };
 
 // Responsive header
+//TODO Remove - Probably not used anymore
 if ($(window).width() <= 700) {
     var didScroll;
     var lastScrollTop = 0;
@@ -495,6 +507,9 @@ if ($(window).width() <= 700) {
     };
 }
 
+/**
+ * @todo Remove? The 'fold_menu' field/$_SESSION['glpifold_menu'] seem unused.
+ */
 var switchFoldMenu = function() {
     $.ajax({
         url: CFG_GLPI.root_doc + '/ajax/switchfoldmenu.php',
@@ -522,6 +537,7 @@ var switchFoldMenu = function() {
 };
 
 $(function() {
+    //TODO Remove. Only applies to legacy tables using .tab_cadre_fixehov class
     $("body").delegate('td','mouseover mouseleave', function(e) {
         var col = $(this).closest('tr').children().index($(this));
         var tr = $(this).closest('tr');
@@ -544,6 +560,7 @@ $(function() {
         }
     });
 
+    //TODO remove? See comment for switchFoldMenu()
     $('.reduce-menu').on('click', function(event) {
         event.preventDefault();
         event.stopPropagation();
@@ -558,6 +575,7 @@ $(function() {
         }
     });
 
+    //TODO Remove - Was for the old debug toolbar/panels
     // toggle debug panel
     $(document).on('click', '.see_debug', function() {
         $('body > .debug-panel').toggle();
@@ -640,7 +658,7 @@ var urlExists = function(url) {
 /**
  * Format a size to the last possible unit (o, Kio, Mio, etc)
  *
- * @param  {integer} size
+ * @param  {number} size
  * @return {string}  The formated size
  */
 var getSize = function (size) {
@@ -671,7 +689,7 @@ var getSize = function (size) {
 /**
  * Convert a integer index into an excel like alpha index (A, B, ..., AA, AB, ...)
  * @since  9.3
- * @param  integer index    the numeric index
+ * @param  {number} index    the numeric index
  * @return string           excel like string index
  */
 var getBijectiveIndex = function(index) {
@@ -686,6 +704,7 @@ var getBijectiveIndex = function(index) {
 
 /**
  * Stop propagation and navigation default for the specified event
+ * @todo Remove - Not useful and only used one place
  */
 var stopEvent = function(event) {
     event.preventDefault();
@@ -694,6 +713,7 @@ var stopEvent = function(event) {
 
 /**
  * Returns element height, including margins
+ * @todo Remove - Not used anywhere
 */
 function _eltRealSize(_elt) {
     var _s = 0;
@@ -856,7 +876,10 @@ var templateResult = function(result) {
     return _elt;
 };
 
-// delay function who reinit timer on each call
+/**
+ * delay function who reinit timer on each call
+ * @todo Remove - use lodash.debounce instead
+ */
 var typewatch = (function(){
     var timer = 0;
     return function(callback, ms){
@@ -1314,10 +1337,16 @@ $(
 );
 
 // case insentive :contains selector -> ":icontains"
+//TODO Remove. Used only by templates/pages/setup/dropdowns_list.html.twig. This kind of case-insensitive search can be done other ways.
 jQuery.expr.filters.icontains = function(elem, i, m) {
     return (elem.innerText || elem.textContent || "").toLowerCase().indexOf(m[3].toLowerCase()) > -1;
 };
 
+/**
+ * @param table
+ * @returns {string}
+ * @note Used by System Info page to copy the info on the page for use on GitHub.
+ */
 function tableToDetails(table) {
     let in_details = false;
     const section_els = $(table).find('.section-header, .section-content');
@@ -1328,11 +1357,11 @@ function tableToDetails(table) {
             if (in_details) {
                 details += '\n</pre></details>';
             }
-            details += `<details><summary>${_.escape(e.innerText)}</summary><pre>\n`;
+            details += `<details><summary>${_.escape(e.textContent)}</summary><pre>\n`;
             in_details = true;
         } else {
             if (in_details) {
-                details += _.escape(e.innerText);
+                details += _.escape(e.textContent);
             }
         }
     });
@@ -1969,3 +1998,24 @@ document.addEventListener('focusin', (e) => {
         e.stopImmediatePropagation();
     }
 });
+
+/* eslint-disable no-undef */
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = {
+        markCheckboxes,
+        unMarkCheckboxes,
+        checkAsCheckboxes,
+        selectAll,
+        deselectAll,
+        isImage,
+        getExtIcon,
+        getSize,
+        getBijectiveIndex,
+        getUuidV4,
+        setHasUnsavedChanges,
+        hasUnsavedChanges,
+        getFlatPickerLocale,
+        getAjaxCsrfToken,
+        tableToDetails,
+    };
+}

--- a/js/rack.js
+++ b/js/rack.js
@@ -261,3 +261,11 @@ var getHpos = function(x, is_half_rack, is_rack_rear) {
         return 2;
     }
 };
+
+/* eslint-disable no-undef */
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = {
+        initRack,
+        getHpos
+    };
+}

--- a/js/reservations.js
+++ b/js/reservations.js
@@ -51,7 +51,9 @@ var Reservations = function() {
 
     my.init = function(config) {
         my.id           = config.id || 0;
+        // FIXME The use of '||' means you cannot specify 'false' values. It should be '??' operator
         my.is_all       = config.is_all || true;
+        //FIXME 'rand' should not default to true, but to a unique value
         my.rand         = config.rand || true;
         my.is_tab       = config.is_tab || false;
         my.dom_id       = `reservations_planning_${my.rand}`;
@@ -306,3 +308,10 @@ var Reservations = function() {
           && date1.getDate() === date2.getDate();
     };
 };
+
+/* eslint-disable no-undef */
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = {
+        Reservations,
+    };
+}

--- a/tests/js/bootstrap.mjs
+++ b/tests/js/bootstrap.mjs
@@ -170,9 +170,25 @@ class AjaxMock {
             }
         }
         if (result !== undefined) {
+            if (settings.async === false) {
+                if (resolve_type === 'success' && settings.success) {
+                    settings.success(result);
+                } else if (resolve_type !== 'success' && settings.error) {
+                    settings.error(result);
+                }
+                return Promise.resolve();
+            }
             if (resolve_type === 'success') {
+                if (settings.success) {
+                    settings.success(result);
+                    return Promise.resolve();
+                }
                 result = Promise.resolve(result);
             } else {
+                if (settings.error) {
+                    settings.error(result);
+                    return Promise.resolve();
+                }
                 result = Promise.reject(result);
             }
             return result;
@@ -180,7 +196,7 @@ class AjaxMock {
             /* eslint-disable no-console */
             console.dir({
                 request_data: settings.data,
-                responses: window.AjaxMock.response_stack
+                responses: JSON.stringify(window.AjaxMock.response_stack)
             });
             throw `No mock response found for ${url}`;
         }

--- a/tests/js/cable.test.js
+++ b/tests/js/cable.test.js
@@ -1,0 +1,97 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+require('@jest/globals');
+const cable = require('/js/cable.js');
+
+describe('Cable', () => {
+    beforeEach(() => {
+        document.body.innerHTML = `
+            <div>
+                <span id="show_a_asset_breadcrumb">Default A</span>
+                <span id="show_b_asset_breadcrumb">Default B</span>
+                <span id="networkport_dropdown">Default Dropdown</span>
+                <div><div><select name="socket_select"></select></div></div>
+            </div>
+        `;
+    });
+    afterEach(() => {
+        window.AjaxMock.end();
+    });
+    it('refreshAssetBreadcrumb', async () => {
+        window.AjaxMock.start();
+        window.AjaxMock.addMockResponse(new window.AjaxMockResponse('//ajax/cable.php', 'GET', {
+            action: 'get_item_breadcrum',
+            itemtype: 'Computer',
+            items_id: '123',
+        }, () => {
+            return '<div>Breadcrumb HTML</div>';
+        }));
+        cable.refreshAssetBreadcrumb('Computer', 123, 'show_a_asset_breadcrumb');
+        await new Promise(process.nextTick);
+        expect(window.AjaxMock.isResponseStackEmpty()).toBeTrue();
+        expect(document.getElementById('show_a_asset_breadcrumb').innerHTML).toBe('<div>Breadcrumb HTML</div>');
+        expect(document.getElementById('show_b_asset_breadcrumb').innerHTML).toBe('Default B');
+    });
+    it('refreshNetworkPortDropdown', async () => {
+        window.AjaxMock.start();
+        window.AjaxMock.addMockResponse(new window.AjaxMockResponse('//ajax/cable.php', 'GET', {
+            action: 'get_networkport_dropdown',
+            itemtype: 'Computer',
+            items_id: '123',
+        }, () => {
+            return '<select><option>Port 1</option><option>Port 2</option></select>';
+        }));
+        cable.refreshNetworkPortDropdown('Computer', 123, 'networkport_dropdown');
+        await new Promise(process.nextTick);
+        expect(window.AjaxMock.isResponseStackEmpty()).toBeTrue();
+        expect(document.getElementById('networkport_dropdown').innerHTML).toBe('<select><option>Port 1</option><option>Port 2</option></select>');
+    });
+    it('refreshSocketDropdown', async () => {
+        window.AjaxMock.start();
+        window.AjaxMock.addMockResponse(new window.AjaxMockResponse('//ajax/cable.php', 'GET', {
+            action: 'get_socket_dropdown',
+            itemtype: 'Computer',
+            items_id: '123',
+            socketmodels_id: '456',
+            dom_name: 'socket_select'
+        }, () => {
+            return '<div><div><select name="socket_select"><option>Socket A</option><option>Socket B</option></select></div></div>';
+        }));
+        cable.refreshSocketDropdown('Computer', 123, 456, 'socket_select');
+        await new Promise(process.nextTick);
+        expect(window.AjaxMock.isResponseStackEmpty()).toBeTrue();
+        expect(document.querySelector('select[name="socket_select"]').innerHTML).toBe('<option>Socket A</option><option>Socket B</option>');
+        // make sure other elements are untouched
+        expect(document.getElementById('show_b_asset_breadcrumb').innerHTML).toBe('Default B');
+    });
+});

--- a/tests/js/common.test.js
+++ b/tests/js/common.test.js
@@ -1,0 +1,260 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+require('@jest/globals');
+const common = require('/js/common.js');
+
+describe('Common', () => {
+    beforeEach(() => {
+        document.body.innerHTML = ``;
+    });
+
+    afterEach(() => {
+        window.AjaxMock.end();
+    });
+
+    it('markCheckboxes', async () => {
+        document.body.innerHTML = `
+            <div id="containerA">
+                <input type="checkbox" name="check1" />
+                <input type="checkbox" name="check2" />
+                <input type="checkbox" name="check3" />
+            </div>
+            <div id="containerB">
+                <input type="checkbox" name="check4" />
+                <input type="checkbox" name="check5" />
+            </div>
+        `;
+        common.markCheckboxes('containerA');
+        const check1 = document.querySelector('input[name="check1"]');
+        const check2 = document.querySelector('input[name="check2"]');
+        const check3 = document.querySelector('input[name="check3"]');
+        const check4 = document.querySelector('input[name="check4"]');
+        const check5 = document.querySelector('input[name="check5"]');
+        expect(check1.checked).toBe(true);
+        expect(check2.checked).toBe(true);
+        expect(check3.checked).toBe(true);
+        expect(check4.checked).toBe(false);
+        expect(check5.checked).toBe(false);
+    });
+
+    it('unMarkCheckboxes', () => {
+        document.body.innerHTML = `
+            <div id="containerA">
+                <input type="checkbox" name="check1" checked />
+                <input type="checkbox" name="check2" checked />
+                <input type="checkbox" name="check3" checked />
+            </div>
+            <div id="containerB">
+                <input type="checkbox" name="check4" checked />
+                <input type="checkbox" name="check5" checked />
+            </div>
+        `;
+        common.unMarkCheckboxes('containerA');
+        const check1 = document.querySelector('input[name="check1"]');
+        const check2 = document.querySelector('input[name="check2"]');
+        const check3 = document.querySelector('input[name="check3"]');
+        const check4 = document.querySelector('input[name="check4"]');
+        const check5 = document.querySelector('input[name="check5"]');
+        expect(check1.checked).toBe(false);
+        expect(check2.checked).toBe(false);
+        expect(check3.checked).toBe(false);
+        expect(check4.checked).toBe(true);
+        expect(check5.checked).toBe(true);
+    });
+
+    it('checkAsCheckboxes', () => {
+        document.body.innerHTML = `
+            <div id="containerA">
+                <input type="checkbox" name="check1" checked />
+                <input type="checkbox" name="check2" />
+                <input type="checkbox" name="check3" checked />
+            </div>
+            <input type="checkbox" id="check4" name="check4" checked />
+        `;
+        common.checkAsCheckboxes('check4', 'containerA');
+        const check1 = document.querySelector('input[name="check1"]');
+        const check2 = document.querySelector('input[name="check2"]');
+        const check3 = document.querySelector('input[name="check3"]');
+        const check4 = document.getElementById('check4');
+        expect(check1.checked).toBe(true);
+        expect(check2.checked).toBe(true);
+        expect(check3.checked).toBe(true);
+        expect(check4.checked).toBe(true);
+
+        check4.checked = false;
+        common.checkAsCheckboxes('check4', 'containerA');
+        expect(check1.checked).toBe(false);
+        expect(check2.checked).toBe(false);
+        expect(check3.checked).toBe(false);
+        expect(check4.checked).toBe(false);
+
+        check4.checked = true;
+        common.checkAsCheckboxes(check4, 'containerA');
+        expect(check1.checked).toBe(true);
+        expect(check2.checked).toBe(true);
+        expect(check3.checked).toBe(true);
+        expect(check4.checked).toBe(true);
+
+        check4.checked = false;
+        common.checkAsCheckboxes(check4, 'containerB');
+        expect(check1.checked).toBe(true);
+        expect(check2.checked).toBe(true);
+        expect(check3.checked).toBe(true);
+        expect(check4.checked).toBe(false);
+    });
+
+    it('selectAll', () => {
+        document.body.innerHTML = `
+            <select id="mySelect" multiple>
+                <option value="1">Option 1</option>
+                <option value="2">Option 2</option>
+                <option value="3">Option 3</option>
+            </select>
+        `;
+        common.selectAll('mySelect');
+        const selectElement = document.getElementById('mySelect');
+        for (const option of selectElement.options) {
+            expect(option.selected).toBe(true);
+        }
+    });
+
+    it('deselectAll', () => {
+        document.body.innerHTML = `
+            <select id="mySelect" multiple>
+                <option value="1" selected>Option 1</option>
+                <option value="2" selected>Option 2</option>
+                <option value="3" selected>Option 3</option>
+            </select>
+        `;
+        common.deselectAll('mySelect');
+        const selectElement = document.getElementById('mySelect');
+        for (const option of selectElement.options) {
+            expect(option.selected).toBe(false);
+        }
+    });
+
+    it('isImage', () => {
+        expect(common.isImage({ type: 'image/gif'})).toBe(true);
+        expect(common.isImage({ type: 'image/jpeg'})).toBe(true);
+        expect(common.isImage({ type: 'image/jpg'})).toBe(true);
+        expect(common.isImage({ type: 'image/png'})).toBe(true);
+        expect(common.isImage({ type: 'image/notreally'})).toBe(false);
+        expect(common.isImage({ type: 'application/json'})).toBe(false);
+        expect(common.isImage({})).toBe(false);
+    });
+
+    it('getExtIcon', () => {
+        window.AjaxMock.start();
+        window.AjaxMock.addMockResponse(new window.AjaxMockResponse('//pics/icones/png-dist.png', 'HEAD', {}, () => ''));
+        expect(common.getExtIcon('png')).toBe(`<img src="${window.CFG_GLPI.root_doc}/pics/icones/png-dist.png" title="png">`);
+        expect(window.AjaxMock.isResponseStackEmpty()).toBeTrue();
+        window.AjaxMock.addMockResponse(new window.AjaxMockResponse('//pics/icones/fake-dist.png', 'HEAD', {}, () => '', false, 'error'));
+        expect(common.getExtIcon('fake')).toBe(`<img src="${window.CFG_GLPI.root_doc}/pics/icones/defaut-dist.png" title="fake">`);
+    });
+
+    it('getSize (Memory size formatting)', () => {
+        expect(common.getSize(500)).toBe('500B');
+        expect(common.getSize(2048)).toBe('2KiB');
+        expect(common.getSize(1048576)).toBe('1024KiB');
+        expect(common.getSize(1073741824)).toBe('1024MiB');
+        expect(common.getSize(1099511627776)).toBe('1024GiB');
+
+        expect(common.getSize(452345)).toBe('441.74KiB');
+        expect(common.getSize(3456789)).toBe('3.3MiB');
+        expect(common.getSize(7890123456)).toBe('7.35GiB');
+        expect(common.getSize(1234567890123)).toBe('1.12TiB');
+    });
+
+    it('getBijectiveIndex', () => {
+        expect(common.getBijectiveIndex(1)).toBe('A');
+        expect(common.getBijectiveIndex(26)).toBe('Z');
+        expect(common.getBijectiveIndex(27)).toBe('AA');
+        expect(common.getBijectiveIndex(52)).toBe('AZ');
+        expect(common.getBijectiveIndex(53)).toBe('BA');
+        expect(common.getBijectiveIndex(702)).toBe('ZZ');
+        expect(common.getBijectiveIndex(703)).toBe('AAA');
+    });
+
+    it('getUuidV4', () => {
+        const uuidSet = new Set();
+        const uuidV4Regex = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+        for (let i = 0; i < 10; i++) {
+            const uuid = common.getUuidV4();
+            expect(uuidV4Regex.test(uuid)).toBe(true);
+            expect(uuidSet.has(uuid)).toBe(false);
+            uuidSet.add(uuid);
+        }
+    });
+
+    it('setHasUnsavedChanges / hasUnsavedChanges', () => {
+        expect(common.hasUnsavedChanges()).toBe(false);
+        common.setHasUnsavedChanges(true);
+        expect(common.hasUnsavedChanges()).toBe(true);
+        common.setHasUnsavedChanges(false);
+        expect(common.hasUnsavedChanges()).toBe(false);
+    });
+
+    it('getFlatPickerLocale', () => {
+        expect(common.getFlatPickerLocale('en', 'GB')).toStrictEqual({
+            firstDayOfWeek: 1
+        });
+        expect(common.getFlatPickerLocale('en', 'US')).toBe('en');
+        expect(common.getFlatPickerLocale('fr', 'FR')).toBe('fr');
+        expect(common.getFlatPickerLocale('es', 'ES')).toBe('es');
+        expect(common.getFlatPickerLocale('de', 'DE')).toBe('de');
+    });
+
+    it('getAjaxCsrfToken', () => {
+        const csrf_meta = document.createElement('meta');
+        csrf_meta.setAttribute('property', 'glpi:csrf_token');
+        csrf_meta.setAttribute('content', 'dummy_csrf_token_value');
+        document.head.append(csrf_meta);
+        expect(common.getAjaxCsrfToken()).toBe('dummy_csrf_token_value');
+    });
+
+    it('tableToDetails', () => {
+        document.body.innerHTML = `
+            <div id="sysinfo">
+                <div class="accordion-item">
+                    <div class="accordion-header section-header">Section 1</div>
+                    <div class="accordion-body section-content">Section 1 Content</div>
+                </div>
+                <div class="accordion-item">
+                    <div class="accordion-header section-header">Section 2</div>
+                    <div class="accordion-body section-content">Section 2 Content</div>
+                </div>
+            </div>
+        `;
+        expect(common.tableToDetails('#sysinfo')).toBe("<details><summary>Section 1</summary><pre>\nSection 1 Content\n</pre></details><details><summary>Section 2</summary><pre>\nSection 2 Content\n</pre></details>");
+    });
+});

--- a/tests/js/jest.config.js
+++ b/tests/js/jest.config.js
@@ -31,18 +31,23 @@
  */
 
 module.exports = {
+    collectCoverage: true,
+    collectCoverageFrom: [
+        'js/**/*.{js,ts}',
+    ],
     projects: [
         {
             displayName: 'units',
-            testMatch: ['<rootDir>/*.test.js', '<rootDir>/modules/**/*.test.js'],
-            setupFilesAfterEnv: ["<rootDir>/jest-setup.mjs"],
-            setupFiles: ['<rootDir>/bootstrap.mjs'],
+            rootDir: './',
+            testMatch: ['<rootDir>/tests/js/*.test.js', '<rootDir>/tests/js/modules/**/*.test.js'],
+            setupFilesAfterEnv: ["<rootDir>/tests/js/jest-setup.mjs"],
+            setupFiles: ['<rootDir>/tests/js/bootstrap.mjs'],
             moduleDirectories: ['js/modules', 'tests/js/modules', 'node_modules'],
             moduleFileExtensions: ['js'],
             moduleNameMapper: {
-                '^/js/(.*)$': '<rootDir>/../../js/$1',
-                '^/build/(.*)$': '<rootDir>/../../public/build/$1',
-                '^/lib/(.*)$': '<rootDir>/../../public/lib/$1',
+                '^/js/(.*)$': '<rootDir>/js/$1',
+                '^/build/(.*)$': '<rootDir>/public/build/$1',
+                '^/lib/(.*)$': '<rootDir>/public/lib/$1',
             },
             transform: {},
             transformIgnorePatterns: [

--- a/tests/js/rack.test.js
+++ b/tests/js/rack.test.js
@@ -1,0 +1,48 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+require('@jest/globals');
+const rack = require('/js/rack.js');
+
+describe('Rack', () => {
+    it('getHpos', () => {
+        expect(rack.getHpos(0, false, true)).toBe(0);
+        expect(rack.getHpos(0, false, false)).toBe(0);
+        expect(rack.getHpos(9, false, false)).toBe(0);
+
+        expect(rack.getHpos(0, true, false)).toBe(1);
+        expect(rack.getHpos(1, true, false)).toBe(2);
+
+        expect(rack.getHpos(0, true, true)).toBe(2);
+        expect(rack.getHpos(1, true, true)).toBe(1);
+    });
+});

--- a/tests/js/reservations.test.js
+++ b/tests/js/reservations.test.js
@@ -1,0 +1,234 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+require("@jest/globals");
+const Reservations = require('/js/reservations.js').Reservations;
+
+describe('Reservations', () => {
+    beforeAll(() => {
+        document.body.innerHTML = '<div id="reservations_planning_1234"></div>';
+    });
+    beforeEach(() => {
+        jest.clearAllMocks();
+        window.AjaxMock.end();
+    });
+    it('init', () => {
+        const r = new Reservations();
+
+        // No config
+        r.init({});
+        expect(r).toSatisfy((instance) => {
+            return instance.id === 0
+                && instance.is_all === true
+                && instance.rand === true
+                && instance.is_tab === false
+                && instance.dom_id === 'reservations_planning_true'
+                && instance.currentv === 'dayGridMonth'
+                && instance.defaultDate.toDateString() === new Date().toDateString()
+                && instance.defaultPDate.toDateString() === new Date().toDateString()
+                && instance.can_reserve === true
+                && instance.now === null;
+        });
+
+        const r2 = new Reservations();
+        r2.init({
+            id: 5,
+            rand: '1234',
+            is_tab: true,
+            defaultDate: '2024-06-15',
+            can_reserve: false,
+            now: '2024-06-10T12:00:00',
+        });
+        expect(r2).toSatisfy((instance) => {
+            return instance.id === 5
+                && instance.rand === '1234'
+                && instance.is_tab === true
+                && instance.dom_id === 'reservations_planning_1234'
+                && instance.currentv === 'dayGridMonth'
+                && instance.defaultDate === '2024-06-15'
+                && instance.defaultPDate.toDateString() === new Date('2024-06-15').toDateString()
+                && instance.can_reserve === false
+                && instance.now === '2024-06-10T12:00:00';
+        });
+    });
+    it('displayPlanning', () => {
+        const r = new Reservations();
+        r.init({
+            id: 5,
+            rand: '1234',
+            is_tab: true,
+            defaultDate: '2024-06-15',
+            can_reserve: false,
+            now: '2024-06-10T12:00:00',
+        });
+        window.CFG_GLPI.planning_begin = '08:00:00';
+        window.CFG_GLPI.planning_end = '18:00:00';
+        window.FullCalendarLocales = {
+            'en-gb': {
+                code: "en-gb",
+            }
+        };
+        window.FullCalendar = {
+            Calendar: jest.fn().mockImplementation((dom, config) => {
+                expect(dom).toHaveProperty('id', 'reservations_planning_1234');
+                expect(config.now).toBe(r.now);
+                expect(config.defaultDate).toBe(r.defaultDate);
+                expect(config.defaultView).toBe(r.currentv);
+                expect(config.minTime).toBe('08:00:00');
+                expect(config.maxTime).toBe('18:00:00');
+                expect(config.plugins).toIncludeAllMembers(['dayGrid', 'interaction', 'list', 'timeGrid', 'resourceTimeline']);
+                expect(config.header).toBeObject();
+                expect(config.views).toContainAllKeys(['listFull', 'resourceWeek']);
+                return {
+                    setOption: jest.fn().mockImplementation((option, value) => {
+                        if (option === 'locale') {
+                            expect(value).toBe('en-gb');
+                        }
+                    }),
+                    render: jest.fn(),
+                };
+            })
+        };
+        r.displayPlanning();
+        expect(window.FullCalendar.Calendar).toHaveBeenCalledTimes(1);
+        expect(r.calendar).toBeDefined();
+        expect(r.calendar.render).toHaveBeenCalledTimes(1);
+        expect(r.calendar.setOption).toHaveBeenCalled();
+
+        jest.spyOn(Storage.prototype, 'getItem').mockImplementation((key) => {
+            if (key === 'fcDefaultViewReservation') {
+                return 'test';
+            }
+            return null;
+        });
+        window.FullCalendar = {
+            Calendar: jest.fn().mockImplementation((dom, config) => {
+                expect(config.defaultView).toBe('test');
+                return {
+                    setOption: jest.fn().mockImplementation((option, value) => {
+                        if (option === 'locale') {
+                            expect(value).toBe('en-gb');
+                        }
+                    }),
+                    render: jest.fn(),
+                };
+            })
+        };
+        r.displayPlanning();
+    });
+    it('dateAreSameDay', () => {
+        const r = new Reservations();
+        expect(r.dateAreSameDay(new Date('2024-06-10'), new Date('2024-06-10'))).toBe(true);
+        expect(r.dateAreSameDay(new Date('2024-06-10'), new Date('2024-06-11'))).toBe(false);
+        expect(r.dateAreSameDay(new Date('2024-06-10T12:00:00'), new Date('2024-06-10T23:59:59'))).toBe(true);
+    });
+    it('editEvent', () => {
+        const revert_fn = jest.fn();
+
+        window.AjaxMock.start();
+
+        // success
+        window.AjaxMock.addMockResponse(new window.AjaxMockResponse('//ajax/reservations.php', 'POST', {
+            action: 'update_event',
+            start: '2024-06-15T10:00:00.000Z',
+            end: '2024-06-15T12:00:00.000Z',
+            id: '42',
+        }, () => {
+            return '<div>Event Form HTML</div>';
+        }));
+
+        // success but missing HTML response
+        window.AjaxMock.addMockResponse(new window.AjaxMockResponse('//ajax/reservations.php', 'POST', {
+            action: 'update_event',
+            start: '2024-06-15T10:00:00.000Z',
+            end: '2024-06-15T12:00:00.000Z',
+            id: '43',
+        }, () => {
+            return '';
+        }));
+
+        // failure
+        window.AjaxMock.addMockResponse(new window.AjaxMockResponse('//ajax/reservations.php', 'POST', {
+            action: 'update_event',
+            start: '2024-06-15T10:00:00.000Z',
+            end: '2024-06-15T12:00:00.000Z',
+            id: '44',
+        }, () => {
+            return '';
+        }, false, 'error'));
+
+        const r = new Reservations();
+
+        // First call - success
+        r.editEvent({
+            event: {
+                start: new Date('2024-06-15T10:00:00.000Z'),
+                end: new Date('2024-06-15T12:00:00.000Z'),
+                id: 42,
+            },
+            revert: revert_fn
+        });
+        return new Promise(process.nextTick).then(() => {
+            expect(window.AjaxMock.isResponseStackEmpty()).toBeFalse();
+            expect(revert_fn).not.toHaveBeenCalled();
+
+            // Second call - success but missing HTML
+            r.editEvent({
+                event: {
+                    start: new Date('2024-06-15T10:00:00.000Z'),
+                    end: new Date('2024-06-15T12:00:00.000Z'),
+                    id: 43,
+                },
+                revert: revert_fn
+            });
+            return new Promise(process.nextTick);
+        }).then(() => {
+            expect(window.AjaxMock.isResponseStackEmpty()).toBeFalse();
+            expect(revert_fn).toHaveBeenCalledTimes(1);
+
+            // Third call - failure
+            r.editEvent({
+                event: {
+                    start: new Date('2024-06-15T10:00:00.000Z'),
+                    end: new Date('2024-06-15T12:00:00.000Z'),
+                    id: 44,
+                },
+                revert: revert_fn
+            });
+            return new Promise(process.nextTick);
+        }).then(() => {
+            expect(window.AjaxMock.isResponseStackEmpty()).toBeTrue();
+            expect(revert_fn).toHaveBeenCalledTimes(2);
+            window.AjaxMock.end();
+        });
+    });
+});


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

The current plain JS scripts are probably stable but adding these tests should still help, especially if they get redone in an upcoming version.
An additional perk is that it forces me to review the current functions in the scripts and I can identify which ones could be removed in the next major version rather than being migrated/refactored. For `common.js` there are at least 17% of functions that are unused or could be easily be replaced by better alternatives.

It isn't my intention to test everything, in fact it isn't even possible without complex mocks, but I've been caught up on the current test coverage and for Jest tests it has been sitting at around just 13% for a while now. I am not sure E2E tests cover a lot of it either. Even if they are changed to ESM/Vue code later, these tests are likely to still be useful.

Jest tests have been changed to output the code coverage now. Even though it isn't tracked in a central location, it would be nice to be able to see it at least in the CI runs.

The only code changes here are:
- Change `done` to `then` on jQuery AJAX calls for compatibility with the AJAX mock system in the tests. Functionality should remain the same.
- Change `innerText` to `textContent` as `innerText` is not implemented in JSDom. There *are* some [differences](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent#differences_from_innertext), but none that should matter in the context of the system information.
- Addition of CJS exports conditionally if `module.exports` is defined. In other words, some functions that are tested are exported using node's module system when in the test environment. This avoids the need to explicitly add the functions to the `window`. Should have no effect in the browser.