### PR TITLE
Fix(Dashboard): prevent null value for width

### DIFF
--- a/js/modules/Dashboard/Dashboard.js
+++ b/js/modules/Dashboard/Dashboard.js
@@ -761,7 +761,7 @@ class GLPIDashboard {
                 card_id: options.card_id,
                 x: $(v).attr('gs-x') ?? 0,
                 y: $(v).attr('gs-y') ?? 0,
-                width: $(v).attr('gs-w'),
+                width: $(v).attr('gs-w') ?? 1,
                 height: $(v).attr('gs-h') ?? 1,
                 card_options: options
             } : null;


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes internal request (our support)

During the dashboard update (tile movement, resizing), all relevant information (position X, Y, width, height, etc.) is sent via AJAX to GLPI to update the database. However, the width is not sent for elements with a width equal to 1, which leads to null values being stored in the database and results in a broken dashboard display. This PR addresses this issue.

## Screenshots (if appropriate):


