### PR TITLE
Avoid creating root file for playwright

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ PLAYWRIGHT = docker run \
 	-it \
 	--rm \
 	--ipc=host \
+	--user=$(shell id -u):$(shell id -g) \
 	-v .:/app \
 	-w /app \
 	-p 9323:9323 \


### PR DESCRIPTION
Run the docker command with our users to avoid output file being created as root.


