### PR TITLE
Better composer audit config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -112,7 +112,15 @@
         },
         "sort-packages": true,
         "audit": {
-            "abandoned": "report"
+            "block-abandoned": false,
+            "block-insecure": false,
+            "ignore-abandoned": {
+                "container-interop/container-interop": "Used by `laminas/laminas-mail`",
+                "laminas/laminas-loader": "Used by `laminas/laminas-mail`",
+                "laminas/laminas-mail": "No replacement package found yet",
+                "laminas/laminas-mime": "Used by `laminas/laminas-mail`",
+                "true/punycode": "Replacement done in GLPI 11.0"
+            }
         }
     },
     "autoload": {


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

1. Do not block anymore the `composer install` command when a vulnerable package is detected. We have a dedicated workflow to detect them and we do not want our CI to be blocked when a security advisory is published for one of our dependencies.
2. List known abandoned packages, and remove the `"abandoned": "report"`, so the future audits will detect newly abandoned packages.