### PR TITLE
Hide duration time on problem/change creation

### DIFF
--- a/templates/components/itilobject/fields_panel.html.twig
+++ b/templates/components/itilobject/fields_panel.html.twig
@@ -233,7 +233,7 @@
                ) }}
             {% endif %}
 
-            {% if (item.getType() == 'Ticket' and item.isNewItem()) or (item.getType() != 'Ticket' and not item.isNewItem()) %}
+            {% if (item.getType() == 'Ticket' and item.isNewItem()) or not item.isNewItem() %}
                {{ fields.dropdownTimestampField(
                   'actiontime',
                   item.fields['actiontime'],


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.


## Description

- It fixes !40563

This condition displays actiontime only for:
- Ticket creation
- Problem/Change edit mode

The “total duration” fields are hidden during Change and Problem creation to avoid any confusion.

## Screenshots (if appropriate):

<img width="475" height="55" alt="image" src="https://github.com/user-attachments/assets/e857ba9b-9a92-4762-8871-3bd831260f27" />

