### PR TITLE
Webhook - phpunit optimization

### DIFF
--- a/src/Webhook.php
+++ b/src/Webhook.php
@@ -1150,19 +1150,7 @@ class Webhook extends CommonDBTM implements FilterableInterface
                 return;
             }
 
-            $supported = self::getAPIItemtypeData();
-            $supported_types = [];
-            foreach ($supported as $categories) {
-                foreach ($categories as $types) {
-                    $supported_types = array_merge($supported_types, array_keys($types));
-                }
-            }
-
-            // Ignore raising if the item type is not supported
-            if (!in_array($item->getType(), $supported_types, true)) {
-                return;
-            }
-
+            // Get all active webhooks for the given event and item type
             $it = $DB->request([
                 'SELECT' => ['id', 'entities_id', 'is_recursive'],
                 'FROM' => self::getTable(),
@@ -1173,6 +1161,19 @@ class Webhook extends CommonDBTM implements FilterableInterface
                 ],
             ]);
             if ($it->count() === 0) {
+                return;
+            }
+
+            $supported = self::getAPIItemtypeData();
+            $supported_types = [];
+            foreach ($supported as $categories) {
+                foreach ($categories as $types) {
+                    $supported_types = array_merge($supported_types, array_keys($types));
+                }
+            }
+
+            // Ignore raising if the item type is not supported
+            if (!in_array($item->getType(), $supported_types, true)) {
                 return;
             }
 


### PR DESCRIPTION
## Description

- Replace #22382
- A few optimizations for phpunit execution time, found by gemini, but rewritten properly

base time for phpunit execution: ~50min

---
## Identified Bottlenecks

- **Expensive Webhook::raise initialization**: Even for internal objects like Ticket_User (linking a user to a ticket), Webhook::raise was initializing the entire API schema (~50ms) before checking if any webhooks were actually configured.
-> 45266d1d02818713230208067510b81edd791228
~37min, **significant gain**
