### PR TITLE
Management of duplicate documents during entity transfer

### DIFF
--- a/src/Transfer.php
+++ b/src/Transfer.php
@@ -40,6 +40,7 @@ use Glpi\Error\ErrorHandler;
 use Glpi\Plugin\Hooks;
 use Glpi\Socket;
 use Glpi\Toolbox\URL;
+use Glpi\DBAL\QuerySubQuery;
 
 /**
  * Transfer engine.
@@ -2424,13 +2425,8 @@ final class Transfer extends CommonDBTM
                 // Update links
                 if ($ID == $newID) {
                     if ($item_ID != $newdocID) {
-                        // Get timeline_position to check for duplicates
-                        $current_entry = $DB->request([
-                            'SELECT' => ['timeline_position'],
-                            'FROM'   => 'glpi_documents_items',
-                            'WHERE'  => ['id' => $data['id']],
-                        ])->current();
-
+                        Toolbox::logDebug('ICI');
+                        var_dump('ICI');
                         // Check if the target relation already exists
                         $existing = $DB->request([
                             'COUNT'  => 'cpt',
@@ -2439,7 +2435,11 @@ final class Transfer extends CommonDBTM
                                 'documents_id'      => $newdocID,
                                 'itemtype'          => $itemtype,
                                 'items_id'          => $newID,
-                                'timeline_position' => $current_entry['timeline_position'],
+                                'timeline_position' => new QuerySubQuery([
+                                    'SELECT' => 'timeline_position',
+                                    'FROM'   => 'glpi_documents_items',
+                                    'WHERE'  => ['id' => $data['id']],
+                                ]),
                                 'NOT'               => ['id' => $data['id']],
                             ],
                         ])->current();

--- a/src/Transfer.php
+++ b/src/Transfer.php
@@ -2485,7 +2485,7 @@ final class Transfer extends CommonDBTM
                                     'documents_id'      => $newdocID,
                                     'items_id'          => $newID,
                                     'itemtype'          => $itemtype,
-                                    'timeline_position' => $current_entry['timeline_position'],
+                                    'timeline_position' => $existing['timeline_position'],
                                 ]
                             );
                         }

--- a/src/Transfer.php
+++ b/src/Transfer.php
@@ -36,11 +36,11 @@
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\Asset\Asset_PeripheralAsset;
 use Glpi\Asset\AssetDefinitionManager;
+use Glpi\DBAL\QuerySubQuery;
 use Glpi\Error\ErrorHandler;
 use Glpi\Plugin\Hooks;
 use Glpi\Socket;
 use Glpi\Toolbox\URL;
-use Glpi\DBAL\QuerySubQuery;
 
 /**
  * Transfer engine.
@@ -2425,8 +2425,6 @@ final class Transfer extends CommonDBTM
                 // Update links
                 if ($ID == $newID) {
                     if ($item_ID != $newdocID) {
-                        Toolbox::logDebug('ICI');
-                        var_dump('ICI');
                         // Check if the target relation already exists
                         $existing = $DB->request([
                             'COUNT'  => 'cpt',

--- a/tests/functional/TransferTest.php
+++ b/tests/functional/TransferTest.php
@@ -1037,11 +1037,11 @@ class TransferTest extends DbTestCase
     {
         $this->login();
 
-        $sourceEntity = (int)getItemByTypeName('Entity', '_test_root_entity', true);
-        $destinationEntity = (int)getItemByTypeName('Entity', '_test_child_2', true);
+        $sourceEntity = (int) getItemByTypeName('Entity', '_test_root_entity', true);
+        $destinationEntity = (int) getItemByTypeName('Entity', '_test_child_2', true);
 
         $document = new \Document();
-        $docId = (int)$document->add([
+        $docId = (int) $document->add([
             'name' => 'duplicate_document.pdf',
             'entities_id' => $destinationEntity,
             'filename' => 'duplicate_document.pdf',
@@ -1049,7 +1049,7 @@ class TransferTest extends DbTestCase
         $this->assertGreaterThan(0, $docId);
 
         $ticketSource = new \Ticket();
-        $ticketSourceId = (int)$ticketSource->add([
+        $ticketSourceId = (int) $ticketSource->add([
             'name' => 'source_ticket',
             'content' => 'source ticket content',
             'entities_id' => $sourceEntity,
@@ -1057,7 +1057,7 @@ class TransferTest extends DbTestCase
         $this->assertGreaterThan(0, $ticketSourceId);
 
         $ticketDestination = new \Ticket();
-        $ticketDestinationId = (int)$ticketDestination->add([
+        $ticketDestinationId = (int) $ticketDestination->add([
             'name' => 'destination_ticket',
             'content' => 'destination ticket content',
             'entities_id' => $destinationEntity,
@@ -1065,7 +1065,7 @@ class TransferTest extends DbTestCase
         $this->assertGreaterThan(0, $ticketDestinationId);
 
         $docItemSource = new \Document_Item();
-        $docItemSourceId = (int)$docItemSource->add([
+        $docItemSourceId = (int) $docItemSource->add([
             'documents_id' => $docId,
             'itemtype' => \Ticket::class,
             'items_id' => $ticketSourceId,
@@ -1074,7 +1074,7 @@ class TransferTest extends DbTestCase
         $this->assertGreaterThan(0, $docItemSourceId);
 
         $docItemDestination = new \Document_Item();
-        $docItemDestinationId = (int)$docItemDestination->add([
+        $docItemDestinationId = (int) $docItemDestination->add([
             'documents_id' => $docId,
             'itemtype' => \Ticket::class,
             'items_id' => $ticketDestinationId,
@@ -1117,10 +1117,10 @@ class TransferTest extends DbTestCase
     {
         $this->login();
 
-        $sourceEntity = (int)getItemByTypeName('Entity', '_test_root_entity', true);
+        $sourceEntity = (int) getItemByTypeName('Entity', '_test_root_entity', true);
 
         $document = new \Document();
-        $docId = (int)$document->add([
+        $docId = (int) $document->add([
             'name' => 'unlink_document.pdf',
             'entities_id' => $sourceEntity,
             'filename' => 'unlink_document.pdf',
@@ -1128,7 +1128,7 @@ class TransferTest extends DbTestCase
         $this->assertGreaterThan(0, $docId);
 
         $ticket = new \Ticket();
-        $ticketId = (int)$ticket->add([
+        $ticketId = (int) $ticket->add([
             'name' => 'unlink_ticket',
             'content' => 'unlink ticket content',
             'entities_id' => $sourceEntity,
@@ -1136,7 +1136,7 @@ class TransferTest extends DbTestCase
         $this->assertGreaterThan(0, $ticketId);
 
         $docItem = new \Document_Item();
-        $docItemId = (int)$docItem->add([
+        $docItemId = (int) $docItem->add([
             'documents_id' => $docId,
             'itemtype' => \Ticket::class,
             'items_id' => $ticketId,


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.


## Description

- It fixes !40431

When transferring a ticket to another entity, if a document is already linked to the same object in the destination entity, a SQL duplicate error occurs.

This error is caused by the unique constraint on the glpi_documents_items table, applied to the columns (documents_id, itemtype, items_id, timeline_position).

Modification of the transferDocuments method in Transfer.php.

Before each UPDATE: check whether the target relationship already exists :
- If it does: delete the existing entry instead of updating it
- If it does not: perform the UPDATE as usual

Before each INSERT: check whether the relationship already exists :
- If it does: skip the insertion (no error)
- If it does not: perform the INSERT as usual



