### PR TITLE
fix(config): prevent null value for required numeric option

### DIFF
--- a/templates/pages/setup/general/general_setup.html.twig
+++ b/templates/pages/setup/general/general_setup.html.twig
@@ -92,6 +92,7 @@
         inline_field_options|merge({
             'min': 1,
             'max': 4,
+            'required': true,
         })
     ) }}
 
@@ -148,6 +149,7 @@
         inline_field_options|merge({
             'min': 1,
             'max': 200,
+            'required': true,
         })
     ) }}
 
@@ -160,6 +162,7 @@
             'max': 200,
             'toadd': {'0': __('Never')},
             'width': 'auto',
+            'required': true,
         })
     ) }}
 </div>
@@ -215,6 +218,7 @@
             'min': 5,
             'max': 200,
             'step': 5,
+            'required': true,
         })
     ) }}
 
@@ -224,6 +228,7 @@
         __('Default characters limit (summary text boxes)'),
         inline_field_options|merge({
             'step': 50,
+            'required': true,
         })
     ) }}
 
@@ -235,6 +240,7 @@
             'min': 20,
             'max': 80,
             'step': 5,
+            'required': true,
         })
     ) }}
 


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !40964
- The numeric fields in the GLPI configuration are not required, which allows the user to enter an empty value. This can completely block GLPI, causing critical errors.

<img width="1324" height="42" alt="image" src="https://github.com/user-attachments/assets/d0054ccd-86f9-4998-accf-8ed975fb6838" />



