### PR TITLE
fix(forms-migration): Implement ITIL object relations migration

### DIFF
--- a/src/Glpi/Form/Migration/FormMigration.php
+++ b/src/Glpi/Form/Migration/FormMigration.php
@@ -35,6 +35,7 @@
 namespace Glpi\Form\Migration;
 
 use AbstractRightsDropdown;
+use Change_Item;
 use DBmysql;
 use DBmysqlIterator;
 use Entity;
@@ -79,6 +80,8 @@ use Glpi\Form\Section;
 use Glpi\ItemTranslation\CldrLanguage;
 use Glpi\Message\MessageType;
 use Glpi\Migration\AbstractPluginMigration;
+use Item_Problem;
+use Item_Ticket;
 use LogicException;
 use Override;
 use Throwable;
@@ -373,6 +376,9 @@ class FormMigration extends AbstractPluginMigration
             'glpi_plugin_formcreator_targets_actors' => [
                 'id', 'itemtype', 'items_id', 'actor_role', 'actor_type', 'actor_value', 'use_notification', 'uuid',
             ],
+            'glpi_plugin_formcreator_formanswers' => [
+                'id', 'plugin_formcreator_forms_id',
+            ],
         ];
 
         return $this->checkDbFieldsExists($formcreator_schema);
@@ -396,6 +402,15 @@ class FormMigration extends AbstractPluginMigration
             'configs' => $this->countRecords('glpi_plugin_formcreator_entityconfigs', [
                 'replace_helpdesk' => [-2, 2],
             ]),
+            'items_tickets_relations' => $this->countRecords('glpi_items_tickets', [
+                'itemtype' => 'PluginFormcreatorFormAnswer',
+            ]),
+            'changes_items_relations' => $this->countRecords('glpi_changes_items', [
+                'itemtype' => 'PluginFormcreatorFormAnswer',
+            ]),
+            'items_problems_relations' => $this->countRecords('glpi_items_problems', [
+                'itemtype' => 'PluginFormcreatorFormAnswer',
+            ]),
         ];
 
         // Set total progress steps
@@ -417,6 +432,7 @@ class FormMigration extends AbstractPluginMigration
         $this->processMigrationOfVisibilityConditions();
         $this->processMigrationOfValidationConditions();
         $this->processMigrationOfConfigs();
+        $this->processMigrationOfITILObjectsRelations();
 
         $this->progress_indicator?->setProgressBarMessage('');
         $this->progress_indicator?->finish();
@@ -1972,6 +1988,94 @@ class FormMigration extends AbstractPluginMigration
                     default => 1, // Helpdesk view was not replaced or Full service catalog -> Use GLPI default of showing ticket properties
                 },
             ], ['id' => $entity_config['entities_id']]);
+
+            $this->progress_indicator?->advance();
+        }
+    }
+
+    private function processMigrationOfITILObjectsRelations(): void
+    {
+        $this->updateProgressWithMessage(__('Updating relations between forms and ITIL objects...'));
+
+        // Migrate Item_Ticket relations
+        $this->migrateITILObjectRelations(
+            'glpi_items_tickets',
+            'tickets_id',
+            Item_Ticket::class
+        );
+
+        // Migrate Change_Item relations
+        $this->migrateITILObjectRelations(
+            'glpi_changes_items',
+            'changes_id',
+            Change_Item::class
+        );
+
+        // Migrate Item_Problem relations
+        $this->migrateITILObjectRelations(
+            'glpi_items_problems',
+            'problems_id',
+            Item_Problem::class
+        );
+    }
+
+    /**
+     * Migrate ITIL object relations from FormCreator to GLPI forms
+     *
+     * @param string $table The source table name (e.g., 'glpi_items_tickets')
+     * @param string $itil_fk The foreign key field for the ITIL object (e.g., 'tickets_id')
+     * @param class-string $relation_class The relation class to use (e.g., Item_Ticket::class)
+     */
+    private function migrateITILObjectRelations(
+        string $table,
+        string $itil_fk,
+        string $relation_class
+    ): void {
+        $formanswers_links = $this->db->request([
+            'SELECT' => [
+                "$table.id",
+                "$table.$itil_fk",
+                'glpi_plugin_formcreator_formanswers.plugin_formcreator_forms_id',
+            ],
+            'FROM' => $table,
+            'JOIN' => [
+                'glpi_plugin_formcreator_formanswers' => [
+                    'ON' => [
+                        $table                                => 'items_id',
+                        'glpi_plugin_formcreator_formanswers' => 'id',
+                    ],
+                ],
+                'glpi_plugin_formcreator_forms' => [
+                    'ON' => [
+                        'glpi_plugin_formcreator_formanswers' => 'plugin_formcreator_forms_id',
+                        'glpi_plugin_formcreator_forms'       => 'id',
+                    ],
+                ],
+            ],
+            'WHERE' => [
+                "$table.itemtype" => 'PluginFormcreatorFormAnswer',
+            ] + $this->getFormWhereCriteria(),
+        ]);
+
+        foreach ($formanswers_links as $formanswers_link) {
+            $form_id = $this->validateItemExists(
+                'PluginFormcreatorForm',
+                $formanswers_link['plugin_formcreator_forms_id']
+            );
+
+            $this->importItem(
+                $relation_class,
+                [
+                    'itemtype' => Form::class,
+                    'items_id' => $form_id,
+                    $itil_fk   => $formanswers_link[$itil_fk],
+                ],
+                [
+                    'itemtype' => Form::class,
+                    'items_id' => $form_id,
+                    $itil_fk   => $formanswers_link[$itil_fk],
+                ]
+            );
 
             $this->progress_indicator?->advance();
         }

--- a/tests/functional/Glpi/Form/Migration/FormMigrationTest.php
+++ b/tests/functional/Glpi/Form/Migration/FormMigrationTest.php
@@ -35,6 +35,7 @@
 namespace tests\units\Glpi\Form\Migration;
 
 use AbstractRightsDropdown;
+use Change;
 use Computer;
 use Entity;
 use Glpi\DBAL\QueryExpression;
@@ -96,6 +97,8 @@ use Location;
 use LogicException;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Attributes\DataProvider;
+use Problem;
+use Ticket;
 
 final class FormMigrationTest extends DbTestCase
 {
@@ -3780,5 +3783,98 @@ final class FormMigrationTest extends DbTestCase
             throw new LogicException();
         }
         $this->assertEquals(Category::class, $config->getItemtype());
+    }
+
+    public static function provideITILObjectsRelationsMigration(): iterable
+    {
+        yield 'Item_Ticket relation' => [
+            'itil_class'     => Ticket::class,
+            'relation_table' => 'glpi_items_tickets',
+            'itil_fk'        => 'tickets_id',
+        ];
+
+        yield 'Change_Item relation' => [
+            'itil_class'     => Change::class,
+            'relation_table' => 'glpi_changes_items',
+            'itil_fk'        => 'changes_id',
+        ];
+
+        yield 'Item_Problem relation' => [
+            'itil_class'     => Problem::class,
+            'relation_table' => 'glpi_items_problems',
+            'itil_fk'        => 'problems_id',
+        ];
+    }
+
+    #[DataProvider('provideITILObjectsRelationsMigration')]
+    public function testMigrationOfITILObjectsRelations(
+        string $itil_class,
+        string $relation_table,
+        string $itil_fk
+    ): void {
+        /** @var \DBmysql $DB */
+        global $DB;
+
+        $form_name = "Form to test $itil_class relations";
+
+        // Arrange: create a form with a short text question
+        $form_id = $this->createSimpleFormcreatorForm(
+            name: $form_name,
+            questions: [
+                [
+                    'name'      => 'My short text question',
+                    'fieldtype' => 'text',
+                ],
+            ],
+            ticket_destinations: [
+                [
+                    'name'    => 'Ticket destination',
+                    'content' => 'My content',
+                ],
+            ]
+        );
+
+        // Arrange: create a formanswers
+        $DB->insert('glpi_plugin_formcreator_formanswers', [
+            'plugin_formcreator_forms_id' => $form_id,
+        ]);
+        $formanswers_id = $DB->insertId();
+
+        // Arrange: create an ITIL object and link it to the form
+        $itil_object = $this->createItem($itil_class, [
+            'name'    => "$itil_class for form migration test",
+            'content' => "$itil_class content",
+        ]);
+        $DB->insert($relation_table, [
+            'itemtype' => 'PluginFormcreatorFormAnswer',
+            'items_id' => $formanswers_id,
+            $itil_fk   => $itil_object->getID(),
+        ]);
+
+        // Act: execute migration
+        $migration = new FormMigration($DB, FormAccessControlManager::getInstance());
+        $result = new PluginMigrationResult();
+        $this->setPrivateProperty($migration, 'result', $result);
+        $this->assertTrue($this->callPrivateMethod($migration, 'processMigration'));
+
+        // Get migrated form ID
+        $migrated_form_id = getItemByTypeName(Form::class, $form_name, true);
+
+        // Assert: verify a new relationship exists between the ITIL object and the migrated form
+        $relation = $DB->request([
+            'SELECT' => ['id'],
+            'FROM'   => $relation_table,
+            'WHERE'  => [
+                'itemtype' => Form::class,
+                'items_id' => $migrated_form_id,
+                $itil_fk   => $itil_object->getID(),
+            ],
+        ]);
+        $this->assertEquals(1, $relation->count());
+
+        $this->assertEquals(
+            [Form::class => [$migrated_form_id => $migrated_form_id]],
+            $itil_object->getLinkedItems()
+        );
     }
 }

--- a/tests/glpi-formcreator-migration-data.sql
+++ b/tests/glpi-formcreator-migration-data.sql
@@ -578,6 +578,31 @@ CREATE TABLE `glpi_plugin_formcreator_entityconfigs` (
   `service_catalog_home` int(11) NOT NULL DEFAULT -2,
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`entities_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=8 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC
+) ENGINE=InnoDB AUTO_INCREMENT=8 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+
+--
+-- Table structure for table `glpi_plugin_formcreator_formanswers`
+--
+
+DROP TABLE IF EXISTS `glpi_plugin_formcreator_formanswers`;
+CREATE TABLE `glpi_plugin_formcreator_formanswers` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) NOT NULL DEFAULT '',
+  `entities_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `is_recursive` tinyint(1) NOT NULL DEFAULT 0,
+  `plugin_formcreator_forms_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `requester_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `users_id_validator` int(10) unsigned NOT NULL DEFAULT 0 COMMENT 'User in charge of validation',
+  `groups_id_validator` int(10) unsigned NOT NULL DEFAULT 0 COMMENT 'Group in charge of validation',
+  `request_date` timestamp NULL DEFAULT NULL,
+  `status` int(11) NOT NULL DEFAULT 101,
+  `comment` mediumtext DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `plugin_formcreator_forms_id` (`plugin_formcreator_forms_id`),
+  KEY `entities_id_is_recursive` (`entities_id`,`is_recursive`),
+  KEY `requester_id` (`requester_id`),
+  KEY `users_id_validator` (`users_id_validator`),
+  KEY `groups_id_validator` (`groups_id_validator`)
+) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 -- Dump completed on 2025-01-21 11:41:32


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes #21840

This PR enhances the migration process for the FormCreator plugin by adding support for migrating relationships between forms and ITIL objects (Tickets, Changes, and Problems).