### PR TITLE
fix(forms): preselect active entity when resolving Entity issues during form import

### DIFF
--- a/templates/pages/admin/form/import/step3_resolve_issues.html.twig
+++ b/templates/pages/admin/form/import/step3_resolve_issues.html.twig
@@ -75,7 +75,7 @@
                                 {{ fields.dropdownField(
                                     issue.itemtype,
                                     'replacements[' ~ replacement_index ~ '][replacement_id]',
-                                    issue.replacement_id|default(''),
+                                    issue.replacement_id|default(issue.itemtype == 'Entity' ? session('glpiactive_entity') : 0),
                                     '',
                                     {
                                         'field_class': 'col-12',

--- a/tests/cypress/e2e/form/serializer/import.cy.js
+++ b/tests/cypress/e2e/form/serializer/import.cy.js
@@ -102,7 +102,9 @@ describe ('Import forms', () => {
         cy.get("@issues").eq(1).within(() => {
             cy.findByText("Missing entity").should('exist');
             cy.document().within(() => {
-                cy.getDropdownByLabelText("Replacement value for 'Missing entity'").selectDropdownValue("»E2ETestEntity");
+                cy.getDropdownByLabelText("Replacement value for 'Missing entity'")
+                    .should('have.text', 'Root entity > E2ETestEntity')
+                    .selectDropdownValue("»E2ETestEntity");
             });
         });
         cy.get("@issues").eq(2).within(() => {


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

- It fixes !40892
 
When resolving missing entities during form import, the dropdown now defaults to the user's active entity instead of an empty selection.
Since an empty string is not a numeric value, it was replaced by the empty value: 0.
However, in the case of an entity selection, the value 0 corresponds to the root entity ID.
This bug also allows forms to be imported into the root entity (which is not necessarily accessible by the current user).