### PR TITLE
Fix race condition when creating illustrations directory

### DIFF
--- a/src/Glpi/UI/IllustrationManager.php
+++ b/src/Glpi/UI/IllustrationManager.php
@@ -274,8 +274,17 @@ final class IllustrationManager
 
     private function validateOrInitCustomContentDir(string $dir): void
     {
-        if (!file_exists($dir)) {
+        if (file_exists($dir)) {
+            return;
+        }
+
+        try {
             mkdir($dir);
+        } catch (FilesystemException $e) {
+            // Race condition: directory may have been created by another concurrent request
+            if (!file_exists($dir)) {
+                throw $e;
+            }
         }
     }
 


### PR DESCRIPTION
I've noticed that the first or second playwright test always fail on the CI, then work without issue on the first retry:

<img width="1052" height="541" alt="image" src="https://github.com/user-attachments/assets/be516306-caae-42db-8364-79d13f26d412" />

This is caused by a race condition when trying to create a directory:

<img width="1219" height="582" alt="image" src="https://github.com/user-attachments/assets/26cb356f-46d3-4f2a-a265-6dd30ca92f19" />

This should fix it.

Could be done in the bugfix branch instead but doing it on this branch help me validate that it worked by looking at the CI result (and anyway the playwright branch should be merged tomorrow if all goes well).