### PR TITLE
Prevent webhooks to be executed during GLPI installation

### DIFF
--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -2185,8 +2185,6 @@ class Toolbox
      */
     public static function createSchema($lang = 'en_GB', ?DBmysql $database = null, ?AbstractProgressIndicator $progress_indicator = null)
     {
-        $_SESSION['is_creating_glpi_schema'] = true;
-
         if (null === $database) {
             // Use configured DB if no $db is defined in parameters
             if (!class_exists('DB', false)) {
@@ -2317,8 +2315,6 @@ class Toolbox
         $progress_indicator?->setProgressBarMessage('');
         $progress_indicator?->addMessage(MessageType::Success, __('Installation done.'));
         $progress_indicator?->finish();
-
-        unset($_SESSION['is_creating_glpi_schema']);
     }
 
 


### PR DESCRIPTION
Fix #22177.

This avoid 2.7 millions lines of errors being generated into the logs while installing GLPI ;)

Solution is a bit ugly with `$_SESSION` but probably can't do much better with the existing code structure.
