### PR TITLE
Translate login events only on GLPI UI

### DIFF
--- a/src/Auth.php
+++ b/src/Auth.php
@@ -1129,21 +1129,21 @@ class Auth extends CommonGLPI
             if ($this->auth_succeded) {
                 //TRANS: %1$s is the login of the user and %2$s its IP address
                 Event::log(0, "system", 3, "login", sprintf(
-                    __('%1$s log in from IP %2$s'),
+                    '%1$s log in from IP %2$s',
                     $login_name,
                     $ip
                 ));
             } else {
                 if ($this->denied_by_rule) {
                     Event::log(0, "system", 3, "login", sprintf(
-                        __('Login for %1$s denied by authorization rules from IP %2$s'),
+                        'Login for %1$s denied by authorization rules from IP %2$s',
                         $login_name,
                         $ip
                     ));
                 } else {
                     //TRANS: %1$s is the login of the user and %2$s its IP address
                     Event::log(0, "system", 3, "login", sprintf(
-                        __('Failed login for %1$s from IP %2$s'),
+                        'Failed login for %1$s from IP %2$s',
                         $login_name,
                         $ip
                     ));

--- a/src/Glpi/Event.php
+++ b/src/Glpi/Event.php
@@ -600,15 +600,15 @@ class Event extends CommonDBTM
 
             return '<i class="text-muted me-1 ' . \htmlescape($icon) . '"></i><span>' . \htmlescape($display_value) . '</span>';
         } elseif ($field === 'message') {
-            $message = $values['message'];
+            $message = $values['message'] ?? '';
 
             // List of known standards for dynamic translation
             $message_patterns = [
-                '/Failed login for (.*) from IP (.*)/' 
+                '/Failed login for (.*) from IP (.*)/'
                     => __('Failed login for %1$s from IP %2$s'),
-                '/Login for (.*) denied by authorization rules from IP (.*)/' 
+                '/Login for (.*) denied by authorization rules from IP (.*)/'
                     => __('Login for %1$s denied by authorization rules from IP %2$s'),
-                '/(.*) log in from IP (.*)/' 
+                '/(.*) log in from IP (.*)/'
                     => __('%1$s log in from IP %2$s'),
             ];
 

--- a/src/Glpi/Event.php
+++ b/src/Glpi/Event.php
@@ -609,9 +609,9 @@ class Event extends CommonDBTM
                 '/Login for (.*) denied by authorization rules from IP (.*)/' 
                     => __('Login for %1$s denied by authorization rules from IP %2$s'),
                 '/(.*) log in from IP (.*)/' 
-                    => __('%1$s log in from IP %2$s')
+                    => __('%1$s log in from IP %2$s'),
             ];
-            
+
             foreach ($message_patterns as $pattern => $translation) {
                 if (preg_match($pattern, $message, $matches)) {
                     // $matches[1] is the login, $matches[2] is the IP

--- a/src/Glpi/Event.php
+++ b/src/Glpi/Event.php
@@ -360,30 +360,12 @@ class Event extends CommonDBTM
             'rows'   => [],
         ];
 
-        // List of known standards for dynamic translation
-        $message_patterns = [
-            '/Failed login for (.*) from IP (.*)/' 
-                => __('Failed login for %1$s from IP %2$s'),
-            '/Login for (.*) denied by authorization rules from IP (.*)/' 
-                => __('Login for %1$s denied by authorization rules from IP %2$s'),
-            '/(.*) log in from IP (.*)/' 
-                => __('%1$s log in from IP %2$s')
-        ];
-
         foreach ($iterator as $data) {
             $items_id = $data['items_id'];
             $type     = $data['type'];
             $date     = $data['date'];
             $service  = $data['service'];
             $message  = $data['message'];
-            
-            foreach ($message_patterns as $pattern => $translation) {
-                if (preg_match($pattern, $message, $matches)) {
-                    // $matches[1] is the login, $matches[2] is the IP
-                    $message = sprintf($translation, $matches[1], $matches[2]);
-                    break; 
-                }
-            }
 
             $itemtype = "&nbsp;";
             if (isset($logItemtype[$type])) {
@@ -486,7 +468,7 @@ class Event extends CommonDBTM
             'table'         => self::getTable(),
             'field'         => 'message',
             'name'          => __('Message'),
-            'datatype'      => 'text',
+            'datatype'      => 'specific',
             'massiveaction' => false,
         ];
 
@@ -617,6 +599,27 @@ class Event extends CommonDBTM
             }
 
             return '<i class="text-muted me-1 ' . \htmlescape($icon) . '"></i><span>' . \htmlescape($display_value) . '</span>';
+        } elseif ($field === 'message') {
+            $message = $values['message'];
+
+            // List of known standards for dynamic translation
+            $message_patterns = [
+                '/Failed login for (.*) from IP (.*)/' 
+                    => __('Failed login for %1$s from IP %2$s'),
+                '/Login for (.*) denied by authorization rules from IP (.*)/' 
+                    => __('Login for %1$s denied by authorization rules from IP %2$s'),
+                '/(.*) log in from IP (.*)/' 
+                    => __('%1$s log in from IP %2$s')
+            ];
+            
+            foreach ($message_patterns as $pattern => $translation) {
+                if (preg_match($pattern, $message, $matches)) {
+                    // $matches[1] is the login, $matches[2] is the IP
+                    return sprintf($translation, $matches[1], $matches[2]);
+                }
+            }
+
+            return \htmlescape($message);
         }
         return parent::getSpecificValueToDisplay($field, $values, $options);
     }

--- a/src/Glpi/Event.php
+++ b/src/Glpi/Event.php
@@ -360,12 +360,30 @@ class Event extends CommonDBTM
             'rows'   => [],
         ];
 
+        // List of known standards for dynamic translation
+        $message_patterns = [
+            '/Failed login for (.*) from IP (.*)/' 
+                => __('Failed login for %1$s from IP %2$s'),
+            '/Login for (.*) denied by authorization rules from IP (.*)/' 
+                => __('Login for %1$s denied by authorization rules from IP %2$s'),
+            '/(.*) log in from IP (.*)/' 
+                => __('%1$s log in from IP %2$s')
+        ];
+
         foreach ($iterator as $data) {
             $items_id = $data['items_id'];
             $type     = $data['type'];
             $date     = $data['date'];
             $service  = $data['service'];
             $message  = $data['message'];
+            
+            foreach ($message_patterns as $pattern => $translation) {
+                if (preg_match($pattern, $message, $matches)) {
+                    // $matches[1] is the login, $matches[2] is the IP
+                    $message = sprintf($translation, $matches[1], $matches[2]);
+                    break; 
+                }
+            }
 
             $itemtype = "&nbsp;";
             if (isset($logItemtype[$type])) {

--- a/src/Glpi/Event.php
+++ b/src/Glpi/Event.php
@@ -55,6 +55,7 @@ use Toolbox;
 
 use function Safe\ob_get_clean;
 use function Safe\ob_start;
+use function Safe\preg_match;
 
 /**
  * Event Class


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [] I have added tests that prove my fix is effective or that my feature works.
- [] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable): https://forum.glpi-project.org/viewtopic.php?id=283065
- Here is a brief description of what this PR does:

This PR logs the login events in English in the DB and the ``files\_log\event.log`` instead of relying on the Web user browser language. This allows for implementing Fail2Ban ([1](https://github.com/nofusscomputing/ansible_role_glpi/tree/2865f3c65685ea0e24b349c3e53c0126322446b9/templates), [2](https://github.com/nofusscomputing/ansible_role_glpi/blob/2865f3c65685ea0e24b349c3e53c0126322446b9/tasks/install.yaml)) and other security mechanisms independent of the language that the user logs in to GLPI to log and protect against brute-force attacks, while still providing the translation to the user in the GLPI UI.

## Screenshots (if appropriate):

<img width="1439" height="370" alt="image" src="https://github.com/user-attachments/assets/5f76cd54-13c0-49ce-9eee-f339b7edfe08" />

<img width="1566" height="265" alt="image" src="https://github.com/user-attachments/assets/aef4ac5a-585f-4a6f-8b6b-58f5a429008f" />

But in the Administration > Logs > Event Logs, it's shown in the current GLPI user language:

<img width="1175" height="207" alt="image" src="https://github.com/user-attachments/assets/c6e0039f-0b13-4f9e-b718-271259053f71" />

In Administration > Logs > events.log, it's shown in English since the log information is saved in English in the DB and the ``event.log`` log file.
