### PR TITLE
Fix (NetworkPort) - Allow managing ports on accessible devices without global View All right

### DIFF
--- a/front/networkport.form.php
+++ b/front/networkport.form.php
@@ -43,7 +43,7 @@ use Glpi\Event;
 
 global $CFG_GLPI;
 
-Session::checkRight("networking", READ);
+Session::checkRightsOr("networking", [READ, CREATE, UPDATE]);
 
 $np  = new NetworkPort();
 $nn  = new NetworkPort_NetworkPort();

--- a/src/NetworkPort.php
+++ b/src/NetworkPort.php
@@ -114,6 +114,30 @@ class NetworkPort extends CommonDBChild
         return false;
     }
 
+    public static function canView(): bool
+    {
+        if (static::$rightname && Session::haveRight(static::$rightname, READ)) {
+            return true;
+        }
+        return static::canChild('canView');
+    }
+
+    public static function canCreate(): bool
+    {
+        if (static::$rightname && Session::haveRight(static::$rightname, CREATE)) {
+            return true;
+        }
+        return static::canChild('canUpdate');
+    }
+
+    public static function canUpdate(): bool
+    {
+        if (static::$rightname && Session::haveRight(static::$rightname, UPDATE)) {
+            return true;
+        }
+        return static::canChild('canUpdate');
+    }
+
     /**
      * @param string $property
      * @param mixed $value
@@ -1344,8 +1368,14 @@ class NetworkPort extends CommonDBChild
             $options['several'] = false;
         }
 
-        if (!self::canView()) {
-            return false;
+        if ($ID > 0) {
+            if (!self::canView()) {
+                return false;
+            }
+        } else {
+            if (!self::canCreate()) {
+                return false;
+            }
         }
 
         $recursiveItems = $this->recursivelyGetItems();

--- a/src/NetworkPort.php
+++ b/src/NetworkPort.php
@@ -1368,14 +1368,8 @@ class NetworkPort extends CommonDBChild
             $options['several'] = false;
         }
 
-        if ($ID > 0) {
-            if (!self::canView()) {
-                return false;
-            }
-        } else {
-            if (!self::canCreate()) {
-                return false;
-            }
+        if (($ID > 0 && !self::canView()) || !self::canCreate()) {
+            return false;
         }
 
         $recursiveItems = $this->recursivelyGetItems();


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !41036
- Here is a brief description of what this PR does

This PR fixes permission issues with NetworkPort management for users who have specific rights (Create, Update, Delete) on the networking module but lack the global "View All" right.

### Problem

When a user profile (e.g., Technician) has networking permissions like Create, Update, Delete but not "View All":
1. They could not access the network port form at all (access denied on `networkport.form.php`)
2. They could not view existing network ports attached to devices they have access to
3. The network port type dropdown was empty when trying to add a new port

The root cause was that:
- `front/networkport.form.php` strictly required the `READ` right
- `NetworkPort` class inherited permission checks from `CommonDBChild` that required global rights instead of delegating to parent item rights
- `NetworkPortInstantiation` subclasses (Ethernet, Wifi, etc.) couldn't be created because they depend on `NetworkPort::canCreate()`/`canUpdate()`

### Solution

1. **Relaxed entry point check** in `front/networkport.form.php`: Now accepts `READ`, `CREATE`, or `UPDATE` rights

2. **Added permission overrides** in `NetworkPort.php`:
   - `canView()`: Returns `true` if user has global `READ` right, otherwise delegates to parent item check via `canChild('canView')`
   - `canCreate()`: Returns `true` if user has global `CREATE` right, otherwise delegates to parent item check via `canChild('canUpdate')`
   - `canUpdate()`: Returns `true` if user has global `UPDATE` right, otherwise delegates to parent item check via `canChild('canUpdate')`

3. **Updated `showForm()` method**: Checks `canCreate()` for new ports and `canView()` for existing ones

### Testing

Added `testCanViewItemWithoutGlobalReadRight` test to verify that:
- Users without global READ right can still view network ports on devices they can access
- Permission checks correctly fall back to parent item rights


## Screenshots (if appropriate):

Tech profile rights : 

<img width="1308" height="179" alt="image" src="https://github.com/user-attachments/assets/15735f7b-12e8-4be8-8b5e-14bfc20a37c9" />


When you try to display a NetworkPort whose parent is assigned to you: 

<img width="810" height="317" alt="image" src="https://github.com/user-attachments/assets/0364cbec-6edb-45bb-bfff-aca34c8a30aa" />

Tech profile : 
<img width="274" height="126" alt="image" src="https://github.com/user-attachments/assets/94de62cf-0991-4118-ba31-086f15b72e10" />

Super-Admin profile : 
<img width="372" height="170" alt="image" src="https://github.com/user-attachments/assets/80711ae2-d02f-4339-83e0-2b6fc66f6785" />
