### PR TITLE
Fix(Genericobject migration): error unicity contraint

### DIFF
--- a/src/Glpi/Migration/AbstractPluginMigration.php
+++ b/src/Glpi/Migration/AbstractPluginMigration.php
@@ -364,7 +364,6 @@ abstract class AbstractPluginMigration
 
         // Create a new item.
         $created = $item->add($input, options: $options);
-
         $this->addSessionMessagesToResult();
         if ($created === false) {
             throw new MigrationException(


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !40252
- Here is a brief description of what this PR does

Avoid this error when migrating from genericobject to the core:

```
glpi.ERROR:   *** MySQL query error: Duplicate entry '10-Glpi\CustomAsset\otherAsset-2981-2' for key 'glpi_groups_items.unicity' (1062) in SQL query "INSERT INTO `glpi_groups_items` (`groups_id`, `itemtype`, `items_id`, `type`) VALUES ('10', 'Glpi\\CustomAsset\\otherAsset', '2981', '2')".
  Backtrace :
  ./src/DBmysql.php:398                              
  ./src/DBmysql.php:1356                             DBmysql->doQuery()
  ./src/CommonDBTM.php:781                           DBmysql->insert()
  ./src/CommonDBTM.php:1386                          CommonDBTM->addToDB()
  .../Glpi/Migration/AbstractPluginMigration.php:366 CommonDBTM->add()
  .../Migration/GenericobjectPluginMigration.php:857 Glpi\Migration\AbstractPluginMigration->importItem()
  .../Migration/GenericobjectPluginMigration.php:261 Glpi\Migration\GenericobjectPluginMigration->importObjects()
  .../Glpi/Migration/AbstractPluginMigration.php:139 Glpi\Migration\GenericobjectPluginMigration->processMigration()
  ...Migration/AbstractPluginMigrationCommand.php:88 Glpi\Migration\AbstractPluginMigration->execute()
  ./vendor/symfony/console/Command/Command.php:326   Glpi\Console\Migration\AbstractPluginMigrationCommand->execute()
  ./vendor/symfony/console/Application.php:1088      Symfony\Component\Console\Command\Command->run()
  ./src/Glpi/Console/Application.php:330             Symfony\Component\Console\Application->doRunCommand()
  ./vendor/symfony/console/Application.php:324       Glpi\Console\Application->doRunCommand()
  ./vendor/symfony/console/Application.php:175       Symfony\Component\Console\Application->doRun()
  ./bin/console:144                                  Symfony\Component\Console\Application->run()
```

And the console command displayed:

```
sudo -u www-data php bin/console migration:genericobject_plugin_to_core --dry-run

[==>-------------------------]   9%
Importing "other" objects...
> 2 assets definitions successfully imported.
> 109 "other models" dropdown entries successfully imported.
> 28 "other types" dropdown entries successfully imported.
> 2 "account types" dropdown entries successfully imported.
The migration failed.
🛈 The display preferences and saved searches related to a `genericobject` object type must be recreated manually.
x An unexpected error occurred
x Migration was aborted due to errors, all changes have been reverted.
```

## Screenshots (if appropriate):


