### PR TITLE
Enhancement / Add button to expand/collapse notes on notepad component

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -1965,11 +1965,11 @@ $(document).on('click', 'div[data-glpi-tinymce-init-on-demand-render]', function
 /**
  * Toggle all accordions in a notepad container
  *
- * @param {Element} button - The button that was clicked
+ * @param {Element} element - The element that was clicked (button or link)
  */
-window.toggleNotesAccordion = function(button) {
+window.toggleNotesAccordion = function(element) {
     // Find the accordion container (it's the sibling div after the firstbloc)
-    const firstbloc = button.closest('.firstbloc');
+    const firstbloc = element.closest('.firstbloc');
     const accordionContainer = firstbloc.parentElement.querySelector('.accordion');
 
     if (!accordionContainer) {
@@ -1978,9 +1978,9 @@ window.toggleNotesAccordion = function(button) {
     }
 
     const accordionElements = accordionContainer.querySelectorAll('.accordion-collapse');
-    const buttonText = button.querySelector('span');
-    const buttonIcon = button.querySelector('i');
-    const isExpanding = buttonText.textContent.includes(button.dataset.expandText);
+    const elementText = element.querySelector('span');
+    const elementIcon = element.querySelector('i');
+    const isExpanding = elementText.textContent.includes(element.dataset.expandText);
 
     accordionElements.forEach(function(accordion) {
         if (isExpanding) {
@@ -2000,20 +2000,25 @@ window.toggleNotesAccordion = function(button) {
         }
     });
 
-    // Update button text and icon
+    // Update element text and icon (if present)
     if (isExpanding) {
-        buttonText.textContent = button.dataset.collapseText;
-        button.title = button.dataset.collapseTitle;
-        buttonIcon.className = 'ti ti-arrows-minimize';
+        elementText.textContent = element.dataset.collapseText;
+        element.title = element.dataset.collapseTitle;
+        if (elementIcon) {
+            elementIcon.className = 'ti ti-arrows-minimize';
+        }
     } else {
-        buttonText.textContent = button.dataset.expandText;
-        button.title = button.dataset.expandTitle;
-        buttonIcon.className = 'ti ti-arrows-maximize';
+        elementText.textContent = element.dataset.expandText;
+        element.title = element.dataset.expandTitle;
+        if (elementIcon) {
+            elementIcon.className = 'ti ti-arrows-maximize';
+        }
     }
 };
 
-// Event listener for toggle all notes button
-$(document).on('click', '.toggle-all-notes', function() {
+// Event listener for toggle all notes button/link
+$(document).on('click', '.toggle-all-notes', function(e) {
+    e.preventDefault(); // Prevent default link behavior
     window.toggleNotesAccordion(this);
 });
 

--- a/js/common.js
+++ b/js/common.js
@@ -2005,13 +2005,13 @@ window.toggleNotesAccordion = function(element) {
         elementText.textContent = element.dataset.collapseText;
         element.title = element.dataset.collapseTitle;
         if (elementIcon) {
-            elementIcon.className = 'ti ti-arrows-minimize';
+            elementIcon.className = 'ti ti-eye';
         }
     } else {
         elementText.textContent = element.dataset.expandText;
         element.title = element.dataset.expandTitle;
         if (elementIcon) {
-            elementIcon.className = 'ti ti-arrows-maximize';
+            elementIcon.className = 'ti ti-eye-off';
         }
     }
 };

--- a/js/common.js
+++ b/js/common.js
@@ -1962,65 +1962,7 @@ $(document).on('click', 'div[data-glpi-tinymce-init-on-demand-render]', function
     });
 });
 
-/**
- * Toggle all accordions in a notepad container
- *
- * @param {Element} element - The element that was clicked (button or link)
- */
-window.toggleNotesAccordion = function(element) {
-    // Find the accordion container (it's the sibling div after the firstbloc)
-    const firstbloc = element.closest('.firstbloc');
-    const accordionContainer = firstbloc.parentElement.querySelector('.accordion');
 
-    if (!accordionContainer) {
-        console.warn('Accordion container not found');
-        return;
-    }
-
-    const accordionElements = accordionContainer.querySelectorAll('.accordion-collapse');
-    const elementText = element.querySelector('span');
-    const elementIcon = element.querySelector('i');
-    const isExpanding = elementText.textContent.includes(element.dataset.expandText);
-
-    accordionElements.forEach(function(accordion) {
-        if (isExpanding) {
-            accordion.classList.add('show');
-            const accordionButton = accordion.previousElementSibling.querySelector('.accordion-button');
-            if (accordionButton) {
-                accordionButton.classList.remove('collapsed');
-                accordionButton.setAttribute('aria-expanded', 'true');
-            }
-        } else {
-            accordion.classList.remove('show');
-            const accordionButton = accordion.previousElementSibling.querySelector('.accordion-button');
-            if (accordionButton) {
-                accordionButton.classList.add('collapsed');
-                accordionButton.setAttribute('aria-expanded', 'false');
-            }
-        }
-    });
-
-    // Update element text and icon (if present)
-    if (isExpanding) {
-        elementText.textContent = element.dataset.collapseText;
-        element.title = element.dataset.collapseTitle;
-        if (elementIcon) {
-            elementIcon.className = 'ti ti-eye';
-        }
-    } else {
-        elementText.textContent = element.dataset.expandText;
-        element.title = element.dataset.expandTitle;
-        if (elementIcon) {
-            elementIcon.className = 'ti ti-eye-off';
-        }
-    }
-};
-
-// Event listener for toggle all notes button/link
-$(document).on('click', '.toggle-all-notes', function(e) {
-    e.preventDefault(); // Prevent default link behavior
-    window.toggleNotesAccordion(this);
-});
 
 // Prevent Bootstrap dialog from blocking focusin
 // See: https://www.tiny.cloud/docs/tinymce/latest/bootstrap-cloud/#usingtinymceinabootstrapdialog

--- a/js/common.js
+++ b/js/common.js
@@ -2014,7 +2014,7 @@ window.toggleNotesAccordion = function(button) {
 
 // Event listener for toggle all notes button
 $(document).on('click', '.toggle-all-notes', function() {
-    toggleNotesAccordion(this);
+    window.toggleNotesAccordion(this);
 });
 
 // Prevent Bootstrap dialog from blocking focusin

--- a/js/common.js
+++ b/js/common.js
@@ -1962,6 +1962,61 @@ $(document).on('click', 'div[data-glpi-tinymce-init-on-demand-render]', function
     });
 });
 
+/**
+ * Toggle all accordions in a notepad container
+ *
+ * @param {Element} button - The button that was clicked
+ */
+window.toggleNotesAccordion = function(button) {
+    // Find the accordion container (it's the sibling div after the firstbloc)
+    const firstbloc = button.closest('.firstbloc');
+    const accordionContainer = firstbloc.parentElement.querySelector('.accordion');
+
+    if (!accordionContainer) {
+        console.warn('Accordion container not found');
+        return;
+    }
+
+    const accordionElements = accordionContainer.querySelectorAll('.accordion-collapse');
+    const buttonText = button.querySelector('span');
+    const buttonIcon = button.querySelector('i');
+    const isExpanding = buttonText.textContent.includes(button.dataset.expandText);
+
+    accordionElements.forEach(function(accordion) {
+        if (isExpanding) {
+            accordion.classList.add('show');
+            const accordionButton = accordion.previousElementSibling.querySelector('.accordion-button');
+            if (accordionButton) {
+                accordionButton.classList.remove('collapsed');
+                accordionButton.setAttribute('aria-expanded', 'true');
+            }
+        } else {
+            accordion.classList.remove('show');
+            const accordionButton = accordion.previousElementSibling.querySelector('.accordion-button');
+            if (accordionButton) {
+                accordionButton.classList.add('collapsed');
+                accordionButton.setAttribute('aria-expanded', 'false');
+            }
+        }
+    });
+
+    // Update button text and icon
+    if (isExpanding) {
+        buttonText.textContent = button.dataset.collapseText;
+        button.title = button.dataset.collapseTitle;
+        buttonIcon.className = 'ti ti-arrows-minimize';
+    } else {
+        buttonText.textContent = button.dataset.expandText;
+        button.title = button.dataset.expandTitle;
+        buttonIcon.className = 'ti ti-arrows-maximize';
+    }
+};
+
+// Event listener for toggle all notes button
+$(document).on('click', '.toggle-all-notes', function() {
+    toggleNotesAccordion(this);
+});
+
 // Prevent Bootstrap dialog from blocking focusin
 // See: https://www.tiny.cloud/docs/tinymce/latest/bootstrap-cloud/#usingtinymceinabootstrapdialog
 document.addEventListener('focusin', (e) => {

--- a/js/common.js
+++ b/js/common.js
@@ -1962,8 +1962,6 @@ $(document).on('click', 'div[data-glpi-tinymce-init-on-demand-render]', function
     });
 });
 
-
-
 // Prevent Bootstrap dialog from blocking focusin
 // See: https://www.tiny.cloud/docs/tinymce/latest/bootstrap-cloud/#usingtinymceinabootstrapdialog
 document.addEventListener('focusin', (e) => {

--- a/templates/components/notepad/form.html.twig
+++ b/templates/components/notepad/form.html.twig
@@ -53,8 +53,8 @@
                data-collapse-text="{{ __('Collapse all') }}"
                data-expand-title="{{ __('Expand all') }}"
                data-collapse-title="{{ __('Collapse all') }}">
-                <i class="ti ti-eye-off"></i>
-                <span>{{ __('Expand all') }}</span>
+                <i class="ti ti-eye"></i>
+                <span>{{ __('Collapse all') }}</span>
             </a>
         </small>
     {% endif %}
@@ -114,11 +114,11 @@
         <div class="accordion-item">
             <div class="accordion-header">
                 <button
-                    class="accordion-button collapsed d-flex align-self-center"
+                    class="accordion-button d-flex align-self-center"
                     type="button"
                     data-bs-toggle="collapse"
                     data-bs-target="#{{ id }}"
-                    aria-expanded="false"
+                    aria-expanded="true"
                     aria-controls="{{ id }}"
                     data-testid="note-container"
                 >
@@ -131,7 +131,7 @@
                 </button>
             </div>
 
-            <div id="{{ id }}" class="accordion-collapse collapse">
+            <div id="{{ id }}" class="accordion-collapse collapse show">
                 <div class="accordion-body pt-0">
                     <form action="{{ url }}" method="post" autocomplete="off" data-submit-once>
                         <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}" />

--- a/templates/components/notepad/form.html.twig
+++ b/templates/components/notepad/form.html.twig
@@ -38,7 +38,7 @@
 } %}
 
 <div class="firstbloc d-flex justify-content-between align-items-center">
-    <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#new-note-form">
+    <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#new-note-form" aria-label="{{ __('Add a note') }}">
         <i class="ti ti-link"></i>
         <span>{{ _x('button', 'Add a note') }}</span>
     </button>

--- a/templates/components/notepad/form.html.twig
+++ b/templates/components/notepad/form.html.twig
@@ -37,15 +37,28 @@
     is_horizontal: false,
 } %}
 
-{% include 'components/tab/addlink_block.html.twig' with {
-    'add_link': 'javascript:return false;',
-    'button_label': _x('button', 'Add a note'),
-    'button_attributes': {
-        'data-bs-toggle': 'modal',
-        'data-bs-target': '#new-note-form',
-        'aria-label': __('Add a note'),
-    }
-} %}
+<div class="firstbloc d-flex justify-content-between align-items-center">
+    <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#new-note-form">
+        <i class="ti ti-link"></i>
+        <span>{{ _x('button', 'Add a note') }}</span>
+    </button>
+
+    {% if notes|length > 0 %}
+        <small class="me-2">
+            <a href="#" class="text-decoration-none text-secondary toggle-all-notes d-flex align-items-center gap-1"
+               style="cursor: pointer; transition: color 0.2s ease;"
+               onmouseover="this.style.color='#0d6efd'"
+               onmouseout="this.style.color=''"
+               data-expand-text="{{ __('Show all') }}"
+               data-collapse-text="{{ __('Collapse all') }}"
+               data-expand-title="{{ __('Show all') }}"
+               data-collapse-title="{{ __('Collapse all') }}">
+                <i class="ti ti-eye-off"></i>
+                <span>{{ __('Show all') }}</span>
+            </a>
+        </small>
+    {% endif %}
+</div>
 
 <div class="my-3">
     <div id="new-note-form" class="modal fade">

--- a/templates/components/notepad/form.html.twig
+++ b/templates/components/notepad/form.html.twig
@@ -49,12 +49,12 @@
                style="cursor: pointer; transition: color 0.2s ease;"
                onmouseover="this.style.color='#0d6efd'"
                onmouseout="this.style.color=''"
-               data-expand-text="{{ __('Show all') }}"
-               data-collapse-text="{{ __('Expand all') }}"
-               data-expand-title="{{ __('Show all') }}"
-               data-collapse-title="{{ __('Expand all') }}">
+               data-expand-text="{{ __('Expand all') }}"
+               data-collapse-text="{{ __('Collapse all') }}"
+               data-expand-title="{{ __('Expand all') }}"
+               data-collapse-title="{{ __('Collapse all') }}">
                 <i class="ti ti-eye-off"></i>
-                <span>{{ __('Show all') }}</span>
+                <span>{{ __('Expand all') }}</span>
             </a>
         </small>
     {% endif %}

--- a/templates/components/notepad/form.html.twig
+++ b/templates/components/notepad/form.html.twig
@@ -37,8 +37,8 @@
     is_horizontal: false,
 } %}
 
-<div class="firstbloc d-flex justify-content-between align-items-center">
-    <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#new-note-form" aria-label="{{ __('Add a note') }}">
+<div class="d-flex mb-3 justify-content-between align-items-center">
+    <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#new-note-form" aria-label="{{ _x('button', 'Add a note') }}">
         <i class="ti ti-link"></i>
         <span>{{ _x('button', 'Add a note') }}</span>
     </button>
@@ -264,11 +264,12 @@
  * @param {Element} element - The element that was clicked (button or link)
  */
 function toggleNotesAccordion(element) {
-    // Find the accordion container (it's the sibling div after the firstbloc)
-    const firstbloc = element.closest('.firstbloc');
-    const accordionContainer = firstbloc.parentElement.querySelector('.accordion');
+    // Find the accordion container - it's the next sibling div after the modal div
+    const buttonsContainer = element.closest('.d-flex.mb-3');
+    const modalContainer = buttonsContainer.nextElementSibling;
+    const accordionContainer = modalContainer.nextElementSibling;
 
-    if (!accordionContainer) {
+    if (!accordionContainer || !accordionContainer.classList.contains('accordion')) {
         console.warn('Accordion container not found');
         return;
     }

--- a/templates/components/notepad/form.html.twig
+++ b/templates/components/notepad/form.html.twig
@@ -324,8 +324,4 @@ function setupToggleButton() {
 }
 
 setupToggleButton();
-
-//try with DOMContentLoaded in case DOM is not ready
-document.addEventListener('DOMContentLoaded', function() {
-});
 </script>

--- a/templates/components/notepad/form.html.twig
+++ b/templates/components/notepad/form.html.twig
@@ -50,9 +50,9 @@
                onmouseover="this.style.color='#0d6efd'"
                onmouseout="this.style.color=''"
                data-expand-text="{{ __('Show all') }}"
-               data-collapse-text="{{ __('Collapse all') }}"
+               data-collapse-text="{{ __('Expand all') }}"
                data-expand-title="{{ __('Show all') }}"
-               data-collapse-title="{{ __('Collapse all') }}">
+               data-collapse-title="{{ __('Expand all') }}">
                 <i class="ti ti-eye-off"></i>
                 <span>{{ __('Show all') }}</span>
             </a>
@@ -256,3 +256,63 @@
         </div>
     {% endfor %}
 </div>
+
+<script>
+/**
+ * Toggle all accordions in a notepad container with Bootstrap transitions
+ *
+ * @param {Element} element - The element that was clicked (button or link)
+ */
+function toggleNotesAccordion(element) {
+    // Find the accordion container (it's the sibling div after the firstbloc)
+    const firstbloc = element.closest('.firstbloc');
+    const accordionContainer = firstbloc.parentElement.querySelector('.accordion');
+
+    if (!accordionContainer) {
+        console.warn('Accordion container not found');
+        return;
+    }
+
+    const accordionElements = accordionContainer.querySelectorAll('.accordion-collapse');
+    const elementText = element.querySelector('span');
+    const elementIcon = element.querySelector('i');
+    const isExpanding = elementText.textContent.includes(element.dataset.expandText);
+
+    // Use Bootstrap's native collapse methods for smooth transitions
+    accordionElements.forEach(function(accordion) {
+        const bsCollapse = new bootstrap.Collapse(accordion, { toggle: false });
+
+        if (isExpanding) {
+            bsCollapse.show();
+        } else {
+            bsCollapse.hide();
+        }
+    });
+
+    // Update element text and icon (if present)
+    if (isExpanding) {
+        elementText.textContent = element.dataset.collapseText;
+        element.title = element.dataset.collapseTitle;
+        if (elementIcon) {
+            elementIcon.className = 'ti ti-eye';
+        }
+    } else {
+        elementText.textContent = element.dataset.expandText;
+        element.title = element.dataset.expandTitle;
+        if (elementIcon) {
+            elementIcon.className = 'ti ti-eye-off';
+        }
+    }
+}
+
+// Event listener for toggle all notes button/link
+document.addEventListener('DOMContentLoaded', function() {
+    const toggleButton = document.querySelector('.toggle-all-notes');
+    if (toggleButton) {
+        toggleButton.addEventListener('click', function(e) {
+            e.preventDefault(); // Prevent default link behavior
+            toggleNotesAccordion(this);
+        });
+    }
+});
+</script>

--- a/templates/components/notepad/form.html.twig
+++ b/templates/components/notepad/form.html.twig
@@ -280,12 +280,16 @@ function toggleNotesAccordion(element) {
 
     // Use Bootstrap's native collapse methods for smooth transitions
     accordionElements.forEach(function(accordion) {
-        const bsCollapse = new bootstrap.Collapse(accordion, { toggle: false });
+        try {
+            const bsCollapse = new bootstrap.Collapse(accordion, { toggle: false });
 
-        if (isExpanding) {
-            bsCollapse.show();
-        } else {
-            bsCollapse.hide();
+            if (isExpanding) {
+                bsCollapse.show();
+            } else {
+                bsCollapse.hide();
+            }
+        } catch (error) {
+            console.error('Error with bootstrap.Collapse:', error);
         }
     });
 
@@ -306,13 +310,21 @@ function toggleNotesAccordion(element) {
 }
 
 // Event listener for toggle all notes button/link
-document.addEventListener('DOMContentLoaded', function() {
+function setupToggleButton() {
     const toggleButton = document.querySelector('.toggle-all-notes');
-    if (toggleButton) {
+
+    if (toggleButton && !toggleButton.hasAttribute('data-listener-added')) {
+        toggleButton.setAttribute('data-listener-added', 'true');
         toggleButton.addEventListener('click', function(e) {
-            e.preventDefault(); // Prevent default link behavior
+            e.preventDefault();
             toggleNotesAccordion(this);
         });
     }
+}
+
+setupToggleButton();
+
+//try with DOMContentLoaded in case DOM is not ready
+document.addEventListener('DOMContentLoaded', function() {
 });
 </script>

--- a/tests/e2e/pages/GlpiPage.ts
+++ b/tests/e2e/pages/GlpiPage.ts
@@ -175,9 +175,7 @@ export class GlpiPage
         await this.getButton("Update").click();
     }
 
-    public async doDeleteNote(
-        _index: number,
-    ): Promise<void> {
+    public async doDeleteNote(): Promise<void> {
         // Prepare to confirm delete dialog
         this.page.once('dialog', dialog => dialog.accept());
 

--- a/tests/e2e/pages/GlpiPage.ts
+++ b/tests/e2e/pages/GlpiPage.ts
@@ -176,7 +176,7 @@ export class GlpiPage
     }
 
     public async doDeleteNote(
-        index: number,
+        _index: number,
     ): Promise<void> {
         // Prepare to confirm delete dialog
         this.page.once('dialog', dialog => dialog.accept());

--- a/tests/e2e/pages/GlpiPage.ts
+++ b/tests/e2e/pages/GlpiPage.ts
@@ -148,11 +148,6 @@ export class GlpiPage
         await this.getButton(entity_name).click();
     }
 
-    public async doFocusNote(index: number): Promise<void>
-    {
-        await this.notes.nth(index).click();
-    }
-
     public async doAddNote(content: string): Promise<void>
     {
         await this.add_note_button.click();
@@ -164,9 +159,6 @@ export class GlpiPage
         index: number,
         content: string,
     ): Promise<void> {
-        // Select the target note
-        await this.doFocusNote(index);
-
         // Update content
         await this.getButton("Edit").click();
         await this.note_content_input.fill(content);
@@ -177,9 +169,6 @@ export class GlpiPage
         index: number,
         file: string,
     ): Promise<void> {
-        // Select the target note
-        await this.doFocusNote(index);
-
         // Add file to note
         await this.getButton("Edit").click();
         await this.doAddFileToUploadArea(file, this.page.getByRole('dialog'));
@@ -189,9 +178,6 @@ export class GlpiPage
     public async doDeleteNote(
         index: number,
     ): Promise<void> {
-        // Select the target note
-        await this.doFocusNote(index);
-
         // Prepare to confirm delete dialog
         this.page.once('dialog', dialog => dialog.accept());
 

--- a/tests/e2e/specs/Entity/notes.spec.ts
+++ b/tests/e2e/specs/Entity/notes.spec.ts
@@ -125,7 +125,6 @@ test('Can add a file to a note', async ({ page, profile, api }) => {
     await entity_page.doAddFileToNote(0, "uploads/bar.txt");
 
     // The note should now have a linked document
-    await entity_page.doFocusNote(0);
     await expect(entity_page.getLink('File extension bar.txt'))
         .toBeAttached()
     ;

--- a/tests/e2e/specs/Entity/notes.spec.ts
+++ b/tests/e2e/specs/Entity/notes.spec.ts
@@ -74,7 +74,7 @@ test('Can delete a note', async ({ page, profile, api }) => {
     // Go to the entity and delete the note
     await entity_page.goto(id, EntityPageTabs.Notes);
     await expect(entity_page.notes).toHaveCount(1);
-    await entity_page.doDeleteNote(0);
+    await entity_page.doDeleteNote();
 
     // The note is now deleted
     await expect(entity_page.notes).toHaveCount(0);


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

It fixes !41065

The issue was initially reported for project notes.
However, the fix has been implemented at the `Notepad`  class level by adding a toggle button, allowing notes to be collapsed and expanded across all components that use notes.

<img width="1448" height="879" alt="Capture d’écran du 2025-12-18 11-52-22" src="https://github.com/user-attachments/assets/047dbaac-9d20-42ab-8fd0-83b668b64c89" />

<img width="1448" height="879" alt="Capture d’écran du 2025-12-18 11-52-29" src="https://github.com/user-attachments/assets/a351e6a3-d80e-4f97-97d3-5d5ea8be70f0" />





