### PR TITLE
Fix (API) - Align Item_SoftwareVersion rights check between web UI and API

### DIFF
--- a/front/item_softwareversion.form.php
+++ b/front/item_softwareversion.form.php
@@ -37,7 +37,6 @@ use Glpi\Event;
 
 include('../inc/includes.php');
 
-Session::checkRight('software', UPDATE);
 $inst = new Item_SoftwareVersion();
 
 // From asset - Software tab (add form)
@@ -46,13 +45,13 @@ if (isset($_POST['add'])) {
         isset($_POST['itemtype']) && isset($_POST['items_id']) && $_POST['items_id']
         && isset($_POST['softwareversions_id']) && $_POST['softwareversions_id']
     ) {
-        if (
-            $inst->add([
-                'itemtype'        => $_POST['itemtype'],
-                'items_id'        => $_POST['items_id'],
-                'softwareversions_id' => $_POST['softwareversions_id'],
-            ])
-        ) {
+        $input = [
+            'itemtype'            => $_POST['itemtype'],
+            'items_id'            => $_POST['items_id'],
+            'softwareversions_id' => $_POST['softwareversions_id'],
+        ];
+        $inst->check(-1, CREATE, $input);
+        if ($inst->add($input)) {
             Event::log(
                 $_POST["items_id"],
                 $_POST['itemtype'],

--- a/phpunit/functional/Item_SoftwareVersionTest.php
+++ b/phpunit/functional/Item_SoftwareVersionTest.php
@@ -248,4 +248,56 @@ class Item_SoftwareVersionTest extends DbTestCase
             \Item_SoftwareVersion::countForSoftware($soft1->fields['id'])
         );
     }
+
+    public function testCanCreateRightsConsistency()
+    {
+        // Test that rights check requires proper rights on both linked items
+        // User needs UPDATE on software OR computer, AND VIEW on the other
+        $this->login();
+
+        $computer = getItemByTypeName('Computer', '_test_pc01');
+        $ver = getItemByTypeName('SoftwareVersion', '_test_softver_1', true);
+
+        $inst = new \Item_SoftwareVersion();
+        $input = [
+            'items_id'            => $computer->getID(),
+            'itemtype'            => 'Computer',
+            'softwareversions_id' => $ver,
+        ];
+
+        // With full rights (glpi user), can() should return true
+        $this->assertTrue($inst->can(-1, CREATE, $input));
+
+        // Save current profile rights
+        $original_software = $_SESSION['glpiactiveprofile']['software'] ?? 0;
+        $original_computer = $_SESSION['glpiactiveprofile']['computer'] ?? 0;
+
+        // Test case 1: Software UPDATE + Computer READ = should work
+        $_SESSION['glpiactiveprofile']['software'] = READ | UPDATE;
+        $_SESSION['glpiactiveprofile']['computer'] = READ;
+        $inst1 = new \Item_SoftwareVersion();
+        $this->assertTrue($inst1->can(-1, CREATE, $input), 'Software UPDATE + Computer READ should allow creation');
+
+        // Test case 2: Computer UPDATE + Software READ = should work
+        $_SESSION['glpiactiveprofile']['software'] = READ;
+        $_SESSION['glpiactiveprofile']['computer'] = READ | UPDATE;
+        $inst2 = new \Item_SoftwareVersion();
+        $this->assertTrue($inst2->can(-1, CREATE, $input), 'Computer UPDATE + Software READ should allow creation');
+
+        // Test case 3: Software UPDATE only (no computer rights) = should fail
+        $_SESSION['glpiactiveprofile']['software'] = READ | UPDATE;
+        $_SESSION['glpiactiveprofile']['computer'] = 0;
+        $inst3 = new \Item_SoftwareVersion();
+        $this->assertFalse($inst3->can(-1, CREATE, $input), 'Software UPDATE without Computer READ should deny creation');
+
+        // Test case 4: Computer UPDATE only (no software rights) = should fail
+        $_SESSION['glpiactiveprofile']['software'] = 0;
+        $_SESSION['glpiactiveprofile']['computer'] = READ | UPDATE;
+        $inst4 = new \Item_SoftwareVersion();
+        $this->assertFalse($inst4->can(-1, CREATE, $input), 'Computer UPDATE without Software READ should deny creation');
+
+        // Restore original rights
+        $_SESSION['glpiactiveprofile']['software'] = $original_software;
+        $_SESSION['glpiactiveprofile']['computer'] = $original_computer;
+    }
 }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !41081
- Here is a brief description of what this PR does

### Problem

The web UI form for installing software on assets was using a simple `Session::checkRight('software', UPDATE)` check, while the API was using the proper `CommonDBRelation::can()` method which validates rights on both linked items (the asset AND the software).

This inconsistency caused the following behavior:
- **Web UI**: User with only `software` UPDATE right could install software on any asset
- **API**: Same user would get "ERROR_GLPI_ADD - You don't have permission to perform this action" error

### Changes

Replace the basic `Session::checkRight()` with the standard `$inst->check(-1, CREATE, $input)` method to ensure consistent rights validation between web UI and API.

### Impact

Users who previously could install software via the web UI but not via the API will now have consistent behavior on both interfaces. Users lacking proper rights on the target asset will now also be denied in the web UI.