### PR TITLE
Fix(GenericObjectMigration): Prevent automatic infocom generation during InfoCom update

### DIFF
--- a/src/Infocom.php
+++ b/src/Infocom.php
@@ -478,8 +478,10 @@ class Infocom extends CommonDBChild
 
         //One date or more has changed
         if ($add_or_update) {
-            if (!$infocom->getFromDBforDevice($itemtype, $changes['id']) && $CFG_GLPI["auto_create_infocoms"]) {
-                $infocom->add($tmp);
+            if (!$infocom->getFromDBforDevice($itemtype, $changes['id'])) {
+                if ($CFG_GLPI["auto_create_infocoms"]) {
+                    $infocom->add($tmp);
+                }
             } else {
                 $tmp['id'] = $infocom->fields['id'];
                 $infocom->update($tmp);


### PR DESCRIPTION


## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Same as https://github.com/glpi-project/glpi/pull/20633

But for the next step:

```php
if (
    ($options['disable_infocom_creation'] ?? false) !== true
    && Infocom::canApplyOn($this)
    && isset($this->input['states_id'])
    && (!isset($this->input['is_template'])
        || !$this->input['is_template'])
    && !($this->input['clone'] ?? false)
) {
    // Check whether Infocom dates must be automatically managed
    Infocom::manageDateOnStatusChange($this);
}
```

At this stage, **GLPI** checks whether the `states_id` key is present in the input.
If so, it attempts to update the **Infocom** data based on the status change.

This update process includes determining whether the Infocom records should be updated—or created if they do not already exist—according to the new state.


## Screenshots (if appropriate):


