### PR TITLE
fix: warnings at installation `url_base` is not defined

### DIFF
--- a/src/Glpi/Api/HL/Router.php
+++ b/src/Glpi/Api/HL/Router.php
@@ -158,17 +158,17 @@ EOT;
                 'api_version' => '1',
                 'version'    => '1.0.0',
                 'description' => str_replace(PHP_EOL, ' ', $low_level_api_description),
-                'endpoint'   => $CFG_GLPI['url_base'] . '/api.php/v1',
+                'endpoint'   => ($CFG_GLPI['url_base'] ?? '') . '/api.php/v1',
             ],
             [
                 'api_version' => '2',
                 'version' => '2.0.0',
-                'endpoint' => $CFG_GLPI['url_base'] . '/api.php/v2.0',
+                'endpoint' => ($CFG_GLPI['url_base'] ?? '') . '/api.php/v2.0',
             ],
             [
                 'api_version' => '2',
                 'version' => '2.1.0',
-                'endpoint' => $CFG_GLPI['url_base'] . '/api.php/v2.1',
+                'endpoint' => ($CFG_GLPI['url_base'] ?? '') . '/api.php/v2.1',
             ],
         ];
     }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description
At the first installation we are getting around 500 warnings in the console making user think the install failed.
To reproduce it you can do a fresh install of GLPI.

I guess they are triggered by Webhook calls (I think we talk about disabling them in the installation context)

## Screenshots (if appropriate):

<img width="1111" height="922" alt="image" src="https://github.com/user-attachments/assets/2669b7ad-fccb-4b71-8041-47a26e3789e5" />

