### PR TITLE
fix(forms): save TinyMCE content before computing visibility

### DIFF
--- a/js/modules/Forms/RendererController.js
+++ b/js/modules/Forms/RendererController.js
@@ -472,6 +472,9 @@ export class GlpiFormRendererController
     }
 
     async #computeItemsVisibilities() {
+        // Update tinymce values
+        this.#saveTinymceEditors();
+
         const results = await this.#condition_engine.computeVisiblity(this.#target);
         this.#applyVisibilityResults(results);
         this.#enableActions();

--- a/tests/cypress/e2e/form/form_rendering.cy.js
+++ b/tests/cypress/e2e/form/form_rendering.cy.js
@@ -454,6 +454,27 @@ describe('Form rendering', () => {
             });
         });
     });
+
+    it('Submit button appears when rich text content is filled', () => {
+        cy.login();
+
+        // Import the form
+        cy.importForm('form_with_condition_on_richtext.json').then((form_id) => {
+            // Visit the form
+            cy.visit(`/Form/Render/${form_id}`);
+
+            // Assert submit button is hidden initially
+            cy.get('[data-glpi-form-renderer-actions]')
+                .find('button[data-glpi-form-renderer-action="submit"]')
+                .should('be.hidden');
+
+            // Fill the TinyMCE description
+            cy.findByLabelText('Description').awaitTinyMCE().type('Some content');
+
+            // Assert submit button is visible
+            cy.findByRole('button', { name: 'Submit' }).should('be.visible');
+        });
+    });
 });
 
 function addQuestionAndGetUuuid(name, type = null, subtype = null) {

--- a/tests/fixtures/forms/form_with_condition_on_richtext.json
+++ b/tests/fixtures/forms/form_with_condition_on_richtext.json
@@ -1,0 +1,68 @@
+{
+    "version": 1,
+    "forms": [
+        {
+            "id": 12345,
+            "uuid": "11111111-1111-1111-1111-111111111111",
+            "name": "Form with condition on rich text",
+            "header": null,
+            "description": null,
+            "entity_name": "Root entity > E2ETestEntity",
+            "is_recursive": true,
+            "is_active": true,
+            "submit_button_visibility_strategy": "visible_if",
+            "illustration": "",
+            "submit_button_conditions": [
+                {
+                    "item_uuid": "33333333-3333-3333-3333-333333333333",
+                    "item_type": "question",
+                    "value_operator": "not_empty",
+                    "logic_operator": "and",
+                    "value": ""
+                }
+            ],
+            "sections": [
+                {
+                    "id": 1,
+                    "uuid": "22222222-2222-2222-2222-222222222222",
+                    "name": "Main Section",
+                    "description": null,
+                    "rank": 0,
+                    "visibility_strategy": "",
+                    "conditions": []
+                }
+            ],
+            "comments": [],
+            "questions": [
+                {
+                    "id": 1,
+                    "uuid": "33333333-3333-3333-3333-333333333333",
+                    "name": "Description",
+                    "type": "Glpi\\Form\\QuestionType\\QuestionTypeLongText",
+                    "description": "",
+                    "default_value": "",
+                    "is_mandatory": false,
+                    "show_condition": "",
+                    "show_condition_value": "",
+                    "vertical_rank": 0,
+                    "horizontal_rank": null,
+                    "section_uuid": "22222222-2222-2222-2222-222222222222",
+                    "section_id": 1,
+                    "visibility_strategy": "",
+                    "validation_strategy": "",
+                    "conditions": [],
+                    "validation_conditions": []
+                }
+            ],
+            "policies": [],
+            "destinations": [],
+            "translations": [],
+            "data_requirements": [
+                {
+                    "itemtype": "Entity",
+                    "name": "Root entity > E2ETestEntity"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

- It fixes !41094

This PR ensures that the content of a `Long Answer` question has been correctly applied to the input tag so that it is sent correctly to the back end.
The current behavior is causing several issues related to visibility and validation conditions.
The expected behavior has been tested by integrating an E2E test.