### PR TITLE
fix(forms): condition computation to handle null answers in form visibility

### DIFF
--- a/src/Glpi/Form/Condition/Engine.php
+++ b/src/Glpi/Form/Condition/Engine.php
@@ -314,10 +314,6 @@ final class Engine
             $answer = $this->computeItemVisibility($question ?? $item);
         }
 
-        if (($answer ?? null) === null) {
-            return false;
-        }
-
         $condition_handler = array_filter(
             $item->getConditionHandlers($config ?? null),
             fn(ConditionHandlerInterface $handler): bool => in_array(

--- a/src/Glpi/Form/Condition/Engine.php
+++ b/src/Glpi/Form/Condition/Engine.php
@@ -275,6 +275,7 @@ final class Engine
     {
         // Find relevant answer using the question's id
         $type = $condition->getItemType();
+        $answer = null;
         switch ($type) {
             case Type::QUESTION:
                 $question = Question::getByUuid($condition->getItemUuid());

--- a/tests/functional/Glpi/Form/Condition/EngineTest.php
+++ b/tests/functional/Glpi/Form/Condition/EngineTest.php
@@ -620,6 +620,138 @@ final class EngineTest extends DbTestCase
         ];
     }
 
+    public static function conditionsWithEmptyOperatorOnNullAnswer(): iterable
+    {
+        // Test case: A question with "VISIBLE_IF ... IS EMPTY" condition on a
+        // source question that has no answer (null value).
+        // This simulates the initial form load where no answers are provided.
+        // The condition should evaluate to true because null is considered empty.
+        $form_visible_if_empty = new FormBuilder();
+        $form_visible_if_empty->addQuestion("Source Question", QuestionTypeShortText::class);
+        $form_visible_if_empty->addQuestion("Conditional Question", QuestionTypeShortText::class);
+        $form_visible_if_empty->setQuestionVisibility(
+            "Conditional Question",
+            VisibilityStrategy::VISIBLE_IF,
+            [
+                [
+                    'logic_operator' => LogicOperator::AND,
+                    'item_name'      => "Source Question",
+                    'item_type'      => Type::QUESTION,
+                    'value_operator' => ValueOperator::EMPTY,
+                    'value'          => null,
+                ],
+            ]
+        );
+
+        yield 'VISIBLE_IF EMPTY with null answer should be visible' => [
+            'form' => $form_visible_if_empty,
+            'input' => [
+                'answers' => [
+                    // Source question has no answer (simulating initial form load)
+                ],
+            ],
+            'expected_output' => [
+                'questions' => [
+                    'Source Question'      => true,
+                    'Conditional Question' => true,
+                ],
+            ],
+        ];
+
+        yield 'VISIBLE_IF EMPTY with empty string answer should be visible' => [
+            'form' => $form_visible_if_empty,
+            'input' => [
+                'answers' => [
+                    'Source Question' => '',
+                ],
+            ],
+            'expected_output' => [
+                'questions' => [
+                    'Source Question'      => true,
+                    'Conditional Question' => true,
+                ],
+            ],
+        ];
+
+        yield 'VISIBLE_IF EMPTY with non-empty answer should be hidden' => [
+            'form' => $form_visible_if_empty,
+            'input' => [
+                'answers' => [
+                    'Source Question' => 'some value',
+                ],
+            ],
+            'expected_output' => [
+                'questions' => [
+                    'Source Question'      => true,
+                    'Conditional Question' => false,
+                ],
+            ],
+        ];
+
+        // Test case: A question with "HIDDEN_IF ... IS EMPTY" condition
+        $form_hidden_if_empty = new FormBuilder();
+        $form_hidden_if_empty->addQuestion("Source Question", QuestionTypeShortText::class);
+        $form_hidden_if_empty->addQuestion("Conditional Question", QuestionTypeShortText::class);
+        $form_hidden_if_empty->setQuestionVisibility(
+            "Conditional Question",
+            VisibilityStrategy::HIDDEN_IF,
+            [
+                [
+                    'logic_operator' => LogicOperator::AND,
+                    'item_name'      => "Source Question",
+                    'item_type'      => Type::QUESTION,
+                    'value_operator' => ValueOperator::EMPTY,
+                    'value'          => null,
+                ],
+            ]
+        );
+
+        yield 'HIDDEN_IF EMPTY with null answer should be hidden' => [
+            'form' => $form_hidden_if_empty,
+            'input' => [
+                'answers' => [
+                    // Source question has no answer (simulating initial form load)
+                ],
+            ],
+            'expected_output' => [
+                'questions' => [
+                    'Source Question'      => true,
+                    'Conditional Question' => false,
+                ],
+            ],
+        ];
+
+        yield 'HIDDEN_IF EMPTY with empty string answer should be hidden' => [
+            'form' => $form_hidden_if_empty,
+            'input' => [
+                'answers' => [
+                    'Source Question' => '',
+                ],
+            ],
+            'expected_output' => [
+                'questions' => [
+                    'Source Question'      => true,
+                    'Conditional Question' => false,
+                ],
+            ],
+        ];
+
+        yield 'HIDDEN_IF EMPTY with non-empty answer should be visible' => [
+            'form' => $form_hidden_if_empty,
+            'input' => [
+                'answers' => [
+                    'Source Question' => 'some value',
+                ],
+            ],
+            'expected_output' => [
+                'questions' => [
+                    'Source Question'      => true,
+                    'Conditional Question' => true,
+                ],
+            ],
+        ];
+    }
+
     #[DataProvider('conditionsOnForm')]
     #[DataProvider('conditionsOnQuestions')]
     #[DataProvider('conditionsOnComments')]
@@ -627,6 +759,7 @@ final class EngineTest extends DbTestCase
     #[DataProvider('firstSectionShouldAlwaysBeVisible')]
     #[DataProvider('conditionsOnQuestionWithNullExtraData')]
     #[DataProvider('conditionsOnQuestionsWithNotVisibleQuestionAsSource')]
+    #[DataProvider('conditionsWithEmptyOperatorOnNullAnswer')]
     public function testComputation(
         FormBuilder $form,
         array $input,


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

- It fixes !41094

When a form is initially loaded (before any user input), questions without default values have a null answer. Visibility conditions using the `Is Empty` or `Is Not Empty` operators did not evaluate correctly in this scenario.

For example, a question configured to be `Visible if [Question X] Is Empty` would incorrectly remain hidden on initial form load, even though the source question was indeed empty.