### PR TITLE
phpunit long tests speedup

### DIFF
--- a/src/Glpi/Api/HL/OpenAPIGenerator.php
+++ b/src/Glpi/Api/HL/OpenAPIGenerator.php
@@ -81,6 +81,11 @@ final class OpenAPIGenerator
 
     private static array $component_schemas_cache = [];
 
+    public static function clearComponentSchemasCache(): void
+    {
+        self::$component_schemas_cache = [];
+    }
+
     public function __construct(Router $router, string $api_version)
     {
         $this->router = $router;

--- a/src/Glpi/Api/HL/OpenAPIGenerator.php
+++ b/src/Glpi/Api/HL/OpenAPIGenerator.php
@@ -80,7 +80,7 @@ final class OpenAPIGenerator
     private string $api_version;
 
     /**
-     * @var array<string, array<string, array>> $component_schemas_cache
+     * @var array<string, array<string, mixed>>
      */
     private static array $component_schemas_cache = [];
 

--- a/src/Glpi/Api/HL/OpenAPIGenerator.php
+++ b/src/Glpi/Api/HL/OpenAPIGenerator.php
@@ -79,6 +79,9 @@ final class OpenAPIGenerator
 
     private string $api_version;
 
+    /**
+     * @var array<string, array<string, array>>
+     */
     private static array $component_schemas_cache = [];
 
     public static function clearComponentSchemasCache(): void

--- a/src/Glpi/Api/HL/OpenAPIGenerator.php
+++ b/src/Glpi/Api/HL/OpenAPIGenerator.php
@@ -79,6 +79,8 @@ final class OpenAPIGenerator
 
     private string $api_version;
 
+    private static array $component_schemas_cache = [];
+
     public function __construct(Router $router, string $api_version)
     {
         $this->router = $router;
@@ -141,9 +143,8 @@ EOT;
 
     public static function getComponentSchemas(string $api_version): array
     {
-        static $cache = [];
-        if (isset($cache[$api_version])) {
-            return $cache[$api_version];
+        if (isset(self::$component_schemas_cache[$api_version])) {
+            return self::$component_schemas_cache[$api_version];
         }
 
         $schemas = [];
@@ -205,7 +206,7 @@ EOT;
             }
         }
 
-        return $cache[$api_version] = $schemas;
+        return self::$component_schemas_cache[$api_version] = $schemas;
     }
 
     private function getComponentReference(string $name, string $controller): ?array

--- a/src/Glpi/Api/HL/OpenAPIGenerator.php
+++ b/src/Glpi/Api/HL/OpenAPIGenerator.php
@@ -141,6 +141,11 @@ EOT;
 
     public static function getComponentSchemas(string $api_version): array
     {
+        static $cache = [];
+        if (isset($cache[$api_version])) {
+            return $cache[$api_version];
+        }
+
         $schemas = [];
 
         $controllers = Router::getInstance()->getControllers();
@@ -200,7 +205,7 @@ EOT;
             }
         }
 
-        return $schemas;
+        return $cache[$api_version] = $schemas;
     }
 
     private function getComponentReference(string $name, string $controller): ?array

--- a/src/Glpi/Api/HL/OpenAPIGenerator.php
+++ b/src/Glpi/Api/HL/OpenAPIGenerator.php
@@ -80,7 +80,7 @@ final class OpenAPIGenerator
     private string $api_version;
 
     /**
-     * @var array<string, array<string, array>>
+     * @var array<string, array<string, array>> $component_schemas_cache
      */
     private static array $component_schemas_cache = [];
 


### PR DESCRIPTION

The idea was to generate a junit xml report to identify slow tests and try to optimize to top 5 slowest tests. Only 2 had optimization possible:

Summary:

### 1. OpenAPIGenerator Optimization [73831d5](https://github.com/glpi-project/glpi/pull/22444/commits/73831d50ac71f7ef2d5b7297468e0bd459353a7a)
locally 155s -> 4s (97%)
- **File**: [OpenAPIGenerator.php](file:///var/www/html/glpi/11.0.git/src/Glpi/Api/HL/OpenAPIGenerator.php)
- **Change**: Implemented static caching for [getComponentSchemas](file:///var/www/html/glpi/11.0.git/src/Glpi/Api/HL/OpenAPIGenerator.php#142-210). This method was previously called multiple times during schema generation and resolution, leading to redundant calculations.
- **Impact**: Reduced [OpenAPIGeneratorTest](file:///var/www/html/glpi/11.0.git/tests/functional/Glpi/Api/HL/OpenAPIGeneratorTest.php#41-273) execution time from **155s** to **4s**.

### 2. Optimization of testSearchAllMeta [fe27e37](https://github.com/glpi-project/glpi/pull/22444/commits/fe27e373e7907085b4a5825c72187de961764d37)
locally 111s -> 13s (88%)
The testSearchAllMeta test in tests/functional/SearchTest.php currently performs redundant searches by testing every search option of every meta-itemtype for every base itemtype. Since the JOIN logic between a base and a meta itemtype is independent of the specific search option chosen from the meta itemtype, we can significantly reduce the number of doSearch calls.
