### PR TITLE
Fix form migration with actors question without default value

### DIFF
--- a/src/Glpi/Form/QuestionType/AbstractQuestionTypeActors.php
+++ b/src/Glpi/Form/QuestionType/AbstractQuestionTypeActors.php
@@ -229,7 +229,7 @@ abstract class AbstractQuestionTypeActors extends AbstractQuestionType implement
     #[Override]
     public function convertDefaultValue(array $rawData): mixed
     {
-        $users_ids = json_decode($rawData['default_values'] ?? []);
+        $users_ids = json_decode($rawData['default_values'] ?? "[]");
         return ['users_ids' => $users_ids];
     }
 

--- a/tests/functional/Glpi/Form/Migration/FormMigrationTest.php
+++ b/tests/functional/Glpi/Form/Migration/FormMigrationTest.php
@@ -3877,4 +3877,24 @@ final class FormMigrationTest extends DbTestCase
             $itil_object->getLinkedItems()
         );
     }
+
+    public function testFormMigrationActorsWithNullDefaultValue(): void
+    {
+        global $DB;
+
+        // Arrange: create a form with an actor question without a default value
+        $this->createSimpleFormcreatorForm('Actor test with null default value', [
+            [
+                'name'      => 'Actor',
+                'fieldtype' => 'actor',
+            ],
+        ]);
+
+        // Act: execute migration
+        $migration = new FormMigration($DB, FormAccessControlManager::getInstance());
+        $result = $migration->execute();
+
+        // Assert: migration should be done without error
+        $this->assertTrue($result->isFullyProcessed());
+    }
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

We were trying to call json_decode on an array instead of a string so it lead to an error.

## References

Fix #22245


