### PR TITLE
Fix form import when location from question is empty

### DIFF
--- a/src/Glpi/Form/Destination/CommonITILField/LocationField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/LocationField.php
@@ -247,7 +247,10 @@ final class LocationField extends AbstractConfigField implements DestinationFiel
         DatabaseMapper $mapper,
     ): array {
         // Check if a location is defined
-        if (isset($config[LocationFieldConfig::SPECIFIC_LOCATION_ID])) {
+        if (
+            isset($config[LocationFieldConfig::SPECIFIC_LOCATION_ID])
+            && $config[LocationFieldConfig::SPECIFIC_LOCATION_ID] > 0
+        ) {
             // Insert id
             $config[LocationFieldConfig::SPECIFIC_LOCATION_ID] = $mapper->getItemId(
                 Location::class,
@@ -256,7 +259,10 @@ final class LocationField extends AbstractConfigField implements DestinationFiel
         }
 
         // Check if a specific question is defined
-        if (isset($config[LocationFieldConfig::SPECIFIC_QUESTION_ID])) {
+        if (
+            isset($config[LocationFieldConfig::SPECIFIC_QUESTION_ID])
+            && $config[LocationFieldConfig::SPECIFIC_QUESTION_ID] > 0
+        ) {
             // Insert id
             $config[LocationFieldConfig::SPECIFIC_QUESTION_ID] = $mapper->getItemId(
                 Question::class,

--- a/tests/fixtures/forms/form-with-empty-specific-question-for-location.json
+++ b/tests/fixtures/forms/form-with-empty-specific-question-for-location.json
@@ -1,0 +1,178 @@
+{
+    "version": 1,
+    "forms": [
+        {
+            "id": 7,
+            "uuid": "9d838782-3893-4c64-a1e5-b3f92cf3efb4",
+            "name": "Form with specific location",
+            "header": null,
+            "description": null,
+            "entity_name": "Root entity > _test_root_entity",
+            "is_recursive": true,
+            "is_active": false,
+            "submit_button_visibility_strategy": "always_visible",
+            "illustration": "",
+            "submit_button_conditions": [],
+            "sections": [
+                {
+                    "id": 25,
+                    "uuid": "d2794d7a-89cb-4288-9f07-db8d173f217e",
+                    "name": "First section",
+                    "description": null,
+                    "rank": 0,
+                    "visibility_strategy": "always_visible",
+                    "conditions": []
+                }
+            ],
+            "comments": [],
+            "questions": [
+                {
+                    "id": 135,
+                    "uuid": "f46f8254-02f2-4fb8-969f-c622b229a781",
+                    "name": "Text question",
+                    "type": "Glpi\\Form\\QuestionType\\QuestionTypeShortText",
+                    "is_mandatory": false,
+                    "vertical_rank": 0,
+                    "horizontal_rank": null,
+                    "description": "",
+                    "default_value": "",
+                    "extra_data": null,
+                    "section_id": 25,
+                    "visibility_strategy": "always_visible",
+                    "validation_strategy": "no_validation",
+                    "conditions": [],
+                    "validation_conditions": []
+                }
+            ],
+            "policies": [
+                {
+                    "strategy": "Glpi\\Form\\AccessControl\\ControlType\\AllowList",
+                    "config": {
+                        "user_ids": [
+                            "all"
+                        ],
+                        "group_ids": [],
+                        "profile_ids": []
+                    },
+                    "is_active": true
+                }
+            ],
+            "destinations": [
+                {
+                    "id": 43,
+                    "itemtype": "Glpi\\Form\\Destination\\FormDestinationTicket",
+                    "name": "Ticket",
+                    "config": {
+                        "glpi-form-destination-commonitilfield-titlefield": {
+                            "value": "<span class=\"border-yellow border-start border-3 bg-dark-lt\" data-form-tag=\"true\" data-form-tag-value=\"7\" data-form-tag-provider=\"Glpi\\Form\\Tag\\FormTagProvider\">#Form name: Form with specific location<\/span>"
+                        },
+                        "glpi-form-destination-commonitilfield-contentfield_auto": "1",
+                        "glpi-form-destination-commonitilfield-itilfollowupfield": {
+                            "strategy": "no_followup"
+                        },
+                        "glpi-form-destination-commonitilfield-itiltaskfield": {
+                            "strategy": "no_task"
+                        },
+                        "glpi-form-destination-commonitilfield-validationfield": {
+                            "strategy_configs": [
+                                {
+                                    "strategy": "no_validation",
+                                    "specific_validationtemplates_ids": [],
+                                    "specific_question_ids": [],
+                                    "specific_actors": [],
+                                    "specific_validation_step_id": null
+                                }
+                            ]
+                        },
+                        "glpi-form-destination-commonitilfield-templatefield": {
+                            "strategy": "default_template"
+                        },
+                        "glpi-form-destination-commonitilfield-entityfield": {
+                            "strategy": "form_filler"
+                        },
+                        "glpi-form-destination-commonitilfield-requesttypefield": {
+                            "strategy": "last_valid_answer"
+                        },
+                        "glpi-form-destination-commonitilfield-itilcategoryfield": {
+                            "strategy": "last_valid_answer"
+                        },
+                        "glpi-form-destination-commonitilfield-statusfield": {
+                            "value": "default_status"
+                        },
+                        "glpi-form-destination-commonitilfield-requestsourcefield": {
+                            "strategy": "from_template"
+                        },
+                        "glpi-form-destination-commonitilfield-urgencyfield": {
+                            "strategy": "last_valid_answer"
+                        },
+                        "glpi-form-destination-commonitilfield-locationfield": {
+                            "strategy": "specific_answer",
+                            "specific_question_id": "0"
+                        },
+                        "glpi-form-destination-commonitilfield-requesterfield": {
+                            "strategies": [
+                                "form_filler"
+                            ],
+                            "specific_itilactors_ids": null,
+                            "specific_question_ids": null
+                        },
+                        "glpi-form-destination-commonitilfield-observerfield": {
+                            "strategies": [
+                                "from_template"
+                            ],
+                            "specific_itilactors_ids": null,
+                            "specific_question_ids": null
+                        },
+                        "glpi-form-destination-commonitilfield-assigneefield": {
+                            "strategies": [
+                                "from_template"
+                            ],
+                            "specific_itilactors_ids": null,
+                            "specific_question_ids": null
+                        },
+                        "glpi-form-destination-commonitilfield-slattofield": {
+                            "strategy": "from_template"
+                        },
+                        "glpi-form-destination-commonitilfield-slattrfield": {
+                            "strategy": "from_template"
+                        },
+                        "glpi-form-destination-commonitilfield-olattofield": {
+                            "strategy": "from_template"
+                        },
+                        "glpi-form-destination-commonitilfield-olattrfield": {
+                            "strategy": "from_template"
+                        },
+                        "glpi-form-destination-commonitilfield-associateditemsfield": {
+                            "strategies": [
+                                "last_valid_answer"
+                            ],
+                            "specific_question_ids": null
+                        },
+                        "glpi-form-destination-commonitilfield-linkeditilobjectsfield": {
+                            "strategy_configs": [
+                                {
+                                    "strategy": null,
+                                    "linktype": "1",
+                                    "specific_destination_ids": [],
+                                    "specific_question_ids": [],
+                                    "specific_itilobject": []
+                                }
+                            ]
+                        }
+                    },
+                    "creation_strategy": "always_created",
+                    "conditions": []
+                }
+            ],
+            "translations": [],
+            "data_requirements": [
+                {
+                    "itemtype": "Entity",
+                    "name": "Root entity > _test_root_entity"
+                }
+            ],
+            "custom_types_requirements": [],
+            "plugin_requirements": []
+        }
+    ]
+}

--- a/tests/functional/Glpi/Form/Export/FormSerializerTest.php
+++ b/tests/functional/Glpi/Form/Export/FormSerializerTest.php
@@ -96,6 +96,7 @@ use GlpiPlugin\Tester\Form\QuestionTypeColor;
 use ITILCategory;
 use Location;
 use Monitor;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Ramsey\Uuid\Uuid;
 use Session;
 
@@ -2371,6 +2372,30 @@ final class FormSerializerTest extends DbTestCase
         $this->assertEmpty($preview_results->getFormsWithFatalErrors());
         $this->assertEmpty($preview_results->getSkippedForms());
         $this->assertCount(1, $preview_results->getValidForms());
+    }
+
+    public static function specificImportSucceedProvider(): array
+    {
+        // We just want to make sure that a few specific files do not throw any
+        // errors here, without any specific checks regarding the form content
+        // once imported.
+        return [
+            ['file' => 'form-with-empty-specific-question-for-location.json'],
+        ];
+    }
+
+    #[DataProvider('specificImportSucceedProvider')]
+    public function testSpecificImportsSucceed(string $file): void
+    {
+        $json = $this->getFormJson($file);
+
+        // Act: import the form
+        $mapper = new DatabaseMapper([$this->getTestRootEntity(true)]);
+        $results = self::$serializer->importFormsFromJson($json, $mapper);
+
+        // Assert: the import should succeed
+        $this->assertEmpty($results->getFailedFormImports());
+        $this->assertCount(1, $results->getImportedForms());
     }
 
     private function compareValuesForRelations(


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

The json of a form configured like this would throw an error when trying to be imported:

<img width="550" height="121" alt="image" src="https://github.com/user-attachments/assets/8210673d-2351-4ed5-bfc0-fce090dee130" />

Fixed by preventing the import mapping process to trigger if the value is empty.

## References

Internal support ticket: !41147

