### PR TITLE
Fix rare form editor crash due to exponent number casted to infinite …

### DIFF
--- a/src/Glpi/Form/Condition/FormData.php
+++ b/src/Glpi/Form/Condition/FormData.php
@@ -199,7 +199,18 @@ final class FormData
             }
 
             $value = $condition_data['value'] ?? null;
-            if (is_string($value) && !empty($value) && json_validate($value)) {
+            if (
+                is_string($value)
+                && !empty($value)
+                && json_validate($value)
+                // Numbers are valid json so they will pass the json_validate
+                // check.
+                // There is no point decoding numbers, it can even lead to errors
+                // because they will be converted to unexpected values in some
+                // cases, like the `646012933e9268` string which is considered
+                // a number and will become an infinite value
+                && !is_numeric($value)
+            ) {
                 $value = json_decode($value, true);
             }
 

--- a/tests/functional/Glpi/Form/Destination/FormDestinationTest.php
+++ b/tests/functional/Glpi/Form/Destination/FormDestinationTest.php
@@ -193,11 +193,13 @@ final class FormDestinationTest extends DbTestCase
             name: "Radio",
             type: QuestionTypeRadio::class,
             extra_data: json_encode(
-                new QuestionTypeSelectableExtraDataConfig([
-                    '646012933e9268' => 'Option 1',
-                ],
+                new QuestionTypeSelectableExtraDataConfig(
+                    [
+                        '646012933e9268' => 'Option 1',
+                    ],
+                )
             )
-        ));
+        );
         $builder->setDestinationCondition(
             "Ticket",
             CreationStrategy::CREATED_IF,


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Fix a weird issue due to strings like `646012933e9268` being considered a number by PHP.

It happens because our `getUUID()` method will sometimes return a string that match this "scientist notation" format by chance.

## References

Internal support ticket: !41095


