### PR TITLE
FIX / Replace wrong validation tag in notification template tags list

### DIFF
--- a/src/NotificationTargetTicket.php
+++ b/src/NotificationTargetTicket.php
@@ -953,7 +953,7 @@ class NotificationTargetTicket extends NotificationTargetCommonITILObject
             $allowed_validation[] = $key;
         }
 
-        $tags = ['validation.validationstatus'
+        $tags = ['validation.storestatus'
                      => ['text'           => __('Status value in database'),
                          'allowed_values' => $allowed_validation,
                      ],


### PR DESCRIPTION

## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !41149
 Inconsistency between `validation.validationstatus` listed in UI and `validation.storestatus` implemented in code.
