### PR TITLE
fix(forms): Fix JS error when switching form Long answer question type multiple times

### DIFF
--- a/src/Glpi/Form/QuestionType/QuestionTypeLongText.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeLongText.php
@@ -72,7 +72,7 @@ final class QuestionTypeLongText extends AbstractQuestionType implements
                     const inst = tinyMCE.get(textarea.attr('id'));
 
                     let content = inst ? inst.getContent() : textarea.val() || "";
-                    let tmp = document.createElement("DIV");
+                    const tmp = document.createElement("DIV");
                     tmp.innerHTML = content;
                     content = tmp.textContent || tmp.innerText || "";
 

--- a/src/Glpi/Form/QuestionType/QuestionTypeLongText.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeLongText.php
@@ -71,19 +71,15 @@ final class QuestionTypeLongText extends AbstractQuestionType implements
                         .find('[name="default_value"], [data-glpi-form-editor-original-name="default_value"]');
                     const inst = tinyMCE.get(textarea.attr('id'));
 
-                    if (inst) {
-                        let content = inst.getContent();
-                        let tmp = document.createElement("DIV");
-                        tmp.innerHTML = content;
-                        content = tmp.textContent || tmp.innerText || "";
+                    let content = inst ? inst.getContent() : textarea.val() || "";
+                    let tmp = document.createElement("DIV");
+                    tmp.innerHTML = content;
+                    content = tmp.textContent || tmp.innerText || "";
 
-                        return new GlpiFormEditorConvertedExtractedDefaultValue(
-                            GlpiFormEditorConvertedExtractedDefaultValue.DATATYPE.STRING,
-                            content
-                        );
-                    }
-
-                    return '';
+                    return new GlpiFormEditorConvertedExtractedDefaultValue(
+                        GlpiFormEditorConvertedExtractedDefaultValue.DATATYPE.STRING,
+                        content
+                    );
                 },
                 "convertDefaultValue": function (question, value) {
                     const GlpiFormEditorConvertedExtractedDefaultValue = $("[data-glpi-form-editor-container]")

--- a/tests/cypress/e2e/form/form_convert_default_values.cy.js
+++ b/tests/cypress/e2e/form/form_convert_default_values.cy.js
@@ -232,4 +232,33 @@ describe('Convert default value form', () => {
         // Check if the default value is still the same
         cy.getDropdownByLabelText('Default option').should('have.text', 'Option 2');
     });
+
+    it('test convert default value between long text (tinymce not init) and short text types', () => {
+        // Arrange: Create a long text with default value, save and reload the form
+        const default_value = 'Default value for long text question';
+
+        // Set question name
+        cy.findByRole('textbox', {'name': 'Question name'}).type('Long answer question');
+
+        // Change type to "Long answer"
+        cy.findByRole('option', {'name': 'New question'}).changeQuestionType('Long answer');
+
+        // Set defaut value
+        cy.findByRole('region', {'name': 'Question details'}).within(() => {
+            cy.findByLabelText("Default value")
+                .awaitTinyMCE()
+                .type(default_value);
+        });
+
+        // Save and reload the form
+        cy.saveFormEditorAndReload();
+
+        // Act: Change back to short text
+        cy.findByRole('option', {'name': 'Long answer question'}).click('top');
+        cy.findByRole('option', {'name': 'Long answer question'}).changeQuestionType('Short answer');
+
+        // Assert: Check if default value has been converted
+        cy.findByRole('combobox', { name: 'Text' }).should('exist');
+        cy.findByRole('textbox', { name: 'Default value' }).should('have.value', default_value);
+    });
 });


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

- It fixes #22437

Fixes a JavaScript error that occurred when switching a form question type 
multiple times (e.g., Long answer → Short answer → Long answer).

## Root cause
When a Long answer question was loaded from database and TinyMCE was not 
yet initialized, the `extractDefaultValue` function returned an empty string 
instead of a proper value object, causing `convertDefaultValue` to fail 
when calling `getDatatype()` on it.

## Solution
Always return a valid `GlpiFormEditorConvertedExtractedDefaultValue` object 
from `extractDefaultValue`, falling back to the textarea value when TinyMCE 
is not initialized.