### PR TITLE
fix(forms): Add required attribute to import file input and data-submit-once to form

### DIFF
--- a/templates/pages/admin/form/import/step1_index.html.twig
+++ b/templates/pages/admin/form/import/step1_index.html.twig
@@ -55,6 +55,7 @@
                     class="form-control"
                     type="file"
                     name="import_file"
+                    required
                 >
             </div>
         </div>

--- a/templates/pages/admin/form/import/step2_preview.html.twig
+++ b/templates/pages/admin/form/import/step2_preview.html.twig
@@ -42,6 +42,7 @@
     <form
         method="POST"
         action="{{ path('Form/Import/Execute') }}"
+        data-submit-once
     >
         <div class="card">
             <div class="card-header py-3 px-4">


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.

## Description

Add the `data-submit-once` attribute to the final form before importing the form in order to allow only one import and prevent the action from being executed multiple times by the user.
I also took the opportunity to add the `required` attribute to the input field in the first step of the form import process to ensure that a file has been provided before moving on to the next step.