### PR TITLE
Prevent errors on helpdesk form submission when entity is empty

### DIFF
--- a/src/Glpi/Form/Destination/CommonITILField/EntityFieldStrategy.php
+++ b/src/Glpi/Form/Destination/CommonITILField/EntityFieldStrategy.php
@@ -121,7 +121,9 @@ enum EntityFieldStrategy: string
             $answers_set->getAnswersByType(
                 QuestionTypeItem::class
             ),
-            fn($answer) => $answer->getRawAnswer()['itemtype'] === Entity::getType()
+            fn($answer) =>
+                $answer->getRawAnswer()['itemtype'] === Entity::getType()
+                && $answer->getRawAnswer()['items_id'] > -1
         );
 
         if (count($valid_answers) == 0) {

--- a/src/Glpi/Form/Destination/CommonITILField/EntityFieldStrategy.php
+++ b/src/Glpi/Form/Destination/CommonITILField/EntityFieldStrategy.php
@@ -121,8 +121,8 @@ enum EntityFieldStrategy: string
             $answers_set->getAnswersByType(
                 QuestionTypeItem::class
             ),
-            fn($answer) =>
-                $answer->getRawAnswer()['itemtype'] === Entity::getType()
+            fn($answer)
+                => $answer->getRawAnswer()['itemtype'] === Entity::getType()
                 && $answer->getRawAnswer()['items_id'] > -1
         );
 

--- a/tests/functional/Glpi/Form/Destination/CommonITILField/EntityFieldTest.php
+++ b/tests/functional/Glpi/Form/Destination/CommonITILField/EntityFieldTest.php
@@ -255,6 +255,26 @@ final class EntityFieldTest extends AbstractDestinationFieldTest
         );
     }
 
+    public function testEntityFromLastValidAnswerWithEmptyAnswer()
+    {
+        $form = $this->createAndGetFormWithMultipleEntityAndRequesterQuestions();
+
+        // No answers, fallback to current entity
+        $this->sendFormAndAssertTicketEntity(
+            form: $form,
+            config: new EntityFieldConfig(
+                EntityFieldStrategy::LAST_VALID_ANSWER
+            ),
+            answers: [
+                'Entity 1' => [
+                    'itemtype' => Entity::class,
+                    'items_id' => -1,
+                ],
+            ],
+            expected_entity_id: $this->getTestRootEntity(only_id: true)
+        );
+    }
+
     #[Override]
     public static function provideConvertFieldConfigFromFormCreator(): iterable
     {


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

The default value of an empty entity question (`-1`) was not taken into account correctly by the `Last valid answer` strategy.

<img width="470" height="204" alt="image" src="https://github.com/user-attachments/assets/fc19d6c4-a714-4860-b368-d41b09e83359" />

