### PR TITLE
fix(forms): add translation support for dropdown options

### DIFF
--- a/src/Glpi/Form/QuestionType/QuestionTypeDropdown.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeDropdown.php
@@ -41,6 +41,7 @@ use Glpi\Form\Condition\ConditionHandler\MultipleChoiceFromValuesConditionHandle
 use Glpi\Form\Condition\ConditionHandler\SingleChoiceFromValuesConditionHandler;
 use Glpi\Form\Condition\ConditionValueTransformerInterface;
 use Glpi\Form\Condition\UsedAsCriteriaInterface;
+use Glpi\Form\FormTranslation;
 use Glpi\Form\Question;
 use InvalidArgumentException;
 use Override;
@@ -276,10 +277,18 @@ TWIG;
             fn($option) => $option['uuid'],
             array_filter($this->getValues($question), fn($option) => $option['checked'])
         );
+
+        $options = $this->getOptions($question);
+        $translated_options = [];
+        foreach ($options as $uuid => $option) {
+            $key = sprintf('%s-%s', self::TRANSLATION_KEY_OPTION, $uuid);
+            $translated_options[$uuid] = FormTranslation::translate($question, $key) ?? $option;
+        }
+
         return $twig->renderFromStringTemplate($template, [
             'question'       => $question,
             'label'          => $question->fields['name'],
-            'values'         => $this->getOptions($question),
+            'values'         => $translated_options,
             'checked_values' => $checked_values,
             'is_multiple'    => $this->isMultipleDropdown($question),
         ]);

--- a/tests/cypress/e2e/form/form_translation.cy.js
+++ b/tests/cypress/e2e/form/form_translation.cy.js
@@ -571,4 +571,80 @@ describe('Edit form translations', () => {
         // Check the translations for the question description
         cy.findByRole('note', { name: 'Question description' }).should('exist').contains('Ceci est une question avec une description');
     });
+
+    it('can translate options of a dropdown question', () => {
+        // Go to the form editor
+        cy.findByRole('tab', { name: 'Form' }).click();
+
+        // Add a dropdown question
+        cy.findByRole('button', { name: 'Add a question' }).click();
+        cy.findByRole('textbox', { name: 'Question name' }).type('Dropdown question');
+        cy.getDropdownByLabelText('Question type').selectDropdownValue('Dropdown');
+
+        // Add options to the question
+        cy.findAllByRole('textbox', { name: 'Selectable option' }).eq(-1).type('First option');
+        cy.findAllByRole('textbox', { name: 'Selectable option' }).eq(-1).type('Second option');
+        cy.findAllByRole('textbox', { name: 'Selectable option' }).eq(-1).type('Third option');
+
+        // Save the form
+        cy.findByRole('button', { name: 'Save' }).click();
+        cy.checkAndCloseAlert('Item successfully updated');
+
+        // Go to the form translations page
+        cy.findByRole('tab', { name: 'Form translations' }).click();
+
+        // Add a language translation
+        cy.findByRole('button', { name: 'Add language' }).click();
+        cy.getDropdownByLabelText('Select language to translate').selectDropdownValue('Français');
+        cy.findByRole('button', { name: 'Add' }).click();
+        cy.findByRole('dialog').should('have.attr', 'data-cy-shown', 'true');
+
+        // Add translations for options
+        cy.findByRole('table', { name: 'Form translations' }).as('formTranslationsTable');
+        cy.get('@formTranslationsTable').findAllByRole('row').as('formTranslationsRows');
+        cy.get('@formTranslationsRows').eq(-3).within(() => {
+            cy.findByRole('cell', { name: 'Translation name' }).contains('Dropdown Option');
+            cy.findByRole('cell', { name: 'Default value' }).contains('First option');
+            cy.findByRole('cell', { name: 'Translated value' }).findByRole('textbox', { name: 'Enter translation' })
+                .type('Première option');
+        });
+        cy.get('@formTranslationsRows').eq(-2).within(() => {
+            cy.findByRole('cell', { name: 'Translation name' }).contains('Dropdown Option');
+            cy.findByRole('cell', { name: 'Default value' }).contains('Second option');
+            cy.findByRole('cell', { name: 'Translated value' }).findByRole('textbox', { name: 'Enter translation' })
+                .type('Deuxième option');
+        });
+        cy.get('@formTranslationsRows').eq(-1).within(() => {
+            cy.findByRole('cell', { name: 'Translation name' }).contains('Dropdown Option');
+            cy.findByRole('cell', { name: 'Default value' }).contains('Third option');
+            cy.findByRole('cell', { name: 'Translated value' }).findByRole('textbox', { name: 'Enter translation' })
+                .type('Troisième option');
+        });
+
+        // Save the translations
+        cy.findByRole('button', { name: 'Save translation' }).click();
+        cy.checkAndCloseAlert('Item successfully updated');
+
+        // Go to the form preview
+        cy.get('@form_id').then((form_id) => {
+            cy.visit(`/Form/Render/${form_id}`);
+        });
+
+        // Check default translations in dropdown options
+        checkTranslations('Tests form translations', 'This form is used to test form translations');
+        cy.findByRole('heading', { name: 'Dropdown question' }).should('exist');
+        cy.getDropdownByLabelText('Dropdown question').hasDropdownValue('First option');
+        cy.getDropdownByLabelText('Dropdown question').hasDropdownValue('Second option');
+        cy.getDropdownByLabelText('Dropdown question').hasDropdownValue('Third option');
+
+        // Change the user language to French
+        changeUserLanguage('fr_FR');
+        cy.reload();
+
+        // Check the translations for the dropdown question
+        checkTranslations('Tests form translations', 'This form is used to test form translations');
+        cy.getDropdownByLabelText('Dropdown question').hasDropdownValue('Première option');
+        cy.getDropdownByLabelText('Dropdown question').hasDropdownValue('Deuxième option');
+        cy.getDropdownByLabelText('Dropdown question').hasDropdownValue('Troisième option');
+    });
 });


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

- It fixes !41187

Translation of options for questions of type `QuestionTypeDropdown`.
Currently, it is already possible to translate the options, but these translations are not taken into account.
This PR applies the translations.