### PR TITLE
Fix (Forms) - Prevent TinyMCE toolbar clipping when switching between editors

### DIFF
--- a/css/includes/components/_content-editable-inputs.scss
+++ b/css/includes/components/_content-editable-inputs.scss
@@ -92,6 +92,7 @@ $inline-input-padding: 2px 4px;
         // on width)
         opacity: 0;
         height: 0 !important;
+        overflow: hidden;
         transition: height 0.25s ease !important;
         padding: 0 !important;
     }
@@ -112,6 +113,7 @@ form:not(.disable-focus) {
         .tox-editor-header {
             opacity: unset;
             height: 48px !important; // Need to set a fixed height for transition
+            overflow: visible;
             transition: height 0.25s ease !important;
             margin-top: 1rem !important;
             padding: 4px !important;

--- a/css/includes/components/form/_form-editor.scss
+++ b/css/includes/components/form/_form-editor.scss
@@ -229,7 +229,8 @@
         }
 
         // Hide tinymce toolbar on inactive questions
-        .tox-editor-header {
+        // But allow it to show when simulate-focus is present (during focus transition)
+        .content-editable-tinymce:not(.simulate-focus) .tox-editor-header {
             display: none !important;
         }
     }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !40824
- Here is a brief description of what this PR does

Fixes an intermittent display issue where the TinyMCE toolbar in form question descriptions would be partially visible or clipped when switching focus directly from one editor to another.

### Root cause
The `.tox-editor-header` had `display: none !important` applied when the question didn't have `data-glpi-form-editor-active-question` attribute. Due to async timing (`setTimeout` in `#setActiveItem`), the `.simulate-focus` class was added before the active attribute, causing a brief state where the toolbar was hidden.

### Solution
Updated CSS selector to allow toolbar display when `.simulate-focus` is present, regardless of the active question state.

### Affected browsers
Chrome, Edge

## Screenshots (if appropriate):

<img width="1145" height="233" alt="image" src="https://github.com/user-attachments/assets/3a27bc23-b38c-42a0-8556-1d610a9fa19b" />
