### PR TITLE
Update altcha JS lib

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
                 "@tabler/core": "^1.4.0",
                 "@tabler/icons-webfont": "^3.34.1",
                 "@typescript-eslint/parser": "^8.49.0",
-                "altcha": "^2.1.0",
+                "altcha": "^2.3.0",
                 "animate.css": "^4.1.1",
                 "cropperjs": "^2.0.1",
                 "cytoscape": "^3.32.2",
@@ -5923,9 +5923,9 @@
             }
         },
         "node_modules/altcha": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/altcha/-/altcha-2.1.0.tgz",
-            "integrity": "sha512-V+Ug4Qr9oLR2WcDSgtzmwOzHGqoencaJoyRmUb1hqZ6Y91B3Xe8vHQ0Q3RwoKuBOYHX9yTYccJvaWHEp8+4UIQ==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/altcha/-/altcha-2.3.0.tgz",
+            "integrity": "sha512-vl8I0dQvSQB7/Mx09XuWZ1+LdSP7vEda6OLbg9kUQ2ZO2LT7MzgUyLK7Iips+GAV6c0ntVcS1XWOqhEPpwbDhQ==",
             "license": "MIT",
             "dependencies": {
                 "@altcha/crypto": "^0.0.1"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
         "@tabler/core": "^1.4.0",
         "@tabler/icons-webfont": "^3.34.1",
         "@typescript-eslint/parser": "^8.49.0",
-        "altcha": "^2.1.0",
+        "altcha": "^2.3.0",
         "animate.css": "^4.1.1",
         "cropperjs": "^2.0.1",
         "cytoscape": "^3.32.2",


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

fixes #22457

The only noted breaking change from 2.1 to 2.3 are plugins being split into a separate package but we don't seem to use any. The CVE is disputed but was still marked by `npm audit` and as far as I can tell it only affected the obfuscation plugin for altcha, not altcha itself. Since the PHP library for altcha was updated in #22376, this is more to ensure compatibility is maintained.