### PR TITLE
Fix helpdesk tickets list pagination

### DIFF
--- a/src/Glpi/Helpdesk/HomePageTabs.php
+++ b/src/Glpi/Helpdesk/HomePageTabs.php
@@ -201,6 +201,7 @@ final class HomePageTabs extends CommonGLPI
             'showmassiveactions' => false,
             'hide_controls'      => true,
             'as_map'             => false,
+            'usesession'         => 0, // false won't work here, need to be 0
             'push_history'       => false,
             'sort'               => [19],
             'order'              => ['DESC'],


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.

## Description

If a user use the map on the ticket search like so:

<img width="1406" height="645" alt="image" src="https://github.com/user-attachments/assets/60af4e79-1e6d-422e-9d7e-cc6566dc70d3" />

Then it will stays as "as_map = 1" in his session, which will mess with the tickets list on the homepage which don't support the map format.

Fixed by making sure the home page doesn't rely on stored session data.

## References

Internal support ticket: !40884


