### PR TITLE
fix rack item and pdu forms in modal

### DIFF
--- a/front/item_rack.form.php
+++ b/front/item_rack.form.php
@@ -89,7 +89,7 @@ if ($ajax) {
     if ($id > 0 && !$item->getFromDB($params['id'])) {
         throw new NotFoundHttpException();
     }
-    $item->showForm($id, $params);
+    $item->showForm($id, $params + ['no_header' => true]);
 } else {
     $menus = ["assets", "rack"];
     Item_Rack::displayFullPageForItem($params['id'] ?? 0, $menus, $params);

--- a/front/pdu_rack.form.php
+++ b/front/pdu_rack.form.php
@@ -75,7 +75,7 @@ $_SESSION['glpilisturl'][PDU_Rack::getType()] = $rack->getSearchURL();
 $ajax = isset($_REQUEST['ajax']);
 
 if ($ajax) {
-    $pra->display($params);
+    $pra->showForm($params['id'] ?? 0, $params + ['no_header' => true]);
 } else {
     $menus = ["assets", "rack"];
     PDU_Rack::displayFullPageForItem((int) ($_GET['id'] ?? 0), $menus, $params);

--- a/src/Item_Rack.php
+++ b/src/Item_Rack.php
@@ -533,7 +533,7 @@ class Item_Rack extends CommonDBRelation
         echo "<div class='center'>";
 
         $this->initForm($ID, $options);
-        $this->showFormHeader();
+        $this->showFormHeader($options);
 
         $rack = new Rack();
         $rack->getFromDB($this->fields['racks_id']);

--- a/src/PDU_Rack.php
+++ b/src/PDU_Rack.php
@@ -232,7 +232,7 @@ class PDU_Rack extends CommonDBRelation
         echo "<div class='center'>";
 
         $this->initForm($ID, $options);
-        $this->showFormHeader();
+        $this->showFormHeader($options);
 
         $rack = new Rack();
         $rack->getFromDB($this->fields['racks_id']);


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

fixes #22070

Change from displaying full tabs content for the PDU_Rack in modal to just showing the main form.
Cleans UI by hiding the header in both the Item_Rack and PDU_Rack forms in the modal (the ribbon in the header was showing in the wrong location anyways).