### PR TITLE
fix savedsearch last_execution_time comparison

### DIFF
--- a/src/SavedSearch.php
+++ b/src/SavedSearch.php
@@ -1116,7 +1116,7 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
             ($force === true)
             || (($this->fields['do_count'] == self::COUNT_YES)
               || ($this->fields['do_count'] == self::COUNT_AUTO)
-              && ($this->getField('last_execution_time') != null)
+              && ($this->fields['last_execution_time'] !== null && $this->fields['last_execution_time'] !== '')
               && ($this->fields['last_execution_time'] <= $CFG_GLPI['max_time_for_count']))
         ) {
             $search = new Search();


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

fixes #22244

