### PR TITLE
Fix approval widget on dashboard shared to self service users

### DIFF
--- a/src/Glpi/Dashboard/Provider.php
+++ b/src/Glpi/Dashboard/Provider.php
@@ -371,15 +371,17 @@ class Provider
                     $where[] = TicketValidation::getTargetCriteriaForUser(Session::getLoginUserID());
                 }
 
-                $query_criteria = array_merge_recursive($query_criteria, [
-                    'LEFT JOIN' => [
-                        'glpi_ticketvalidations' => [
-                            'ON' => [
-                                'glpi_ticketvalidations' => 'tickets_id',
-                                $table                   => 'id',
-                            ],
+                // Join glpi_ticketvalidations table if not already done
+                if (!isset($query_criteria['LEFT JOIN']['glpi_ticketvalidations'])) {
+                    $query_criteria['LEFT JOIN']['glpi_ticketvalidations'] = [
+                        'ON' => [
+                            'glpi_ticketvalidations' => 'tickets_id',
+                            $table                   => 'id',
                         ],
-                    ],
+                    ];
+                }
+
+                $query_criteria = array_merge_recursive($query_criteria, [
                     'WHERE' => $where,
                 ]);
                 break;

--- a/tests/functional/Glpi/Dashboard/ProviderTest.php
+++ b/tests/functional/Glpi/Dashboard/ProviderTest.php
@@ -41,6 +41,7 @@ use Glpi\Tests\DbTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Reminder;
 use Reminder_User;
+use TicketValidation;
 use User;
 
 /* Test for inc/dashboard/provider.class.php */
@@ -923,5 +924,26 @@ class ProviderTest extends DbTestCase
             $results = Provider::getArticleListReminder();
             $this->assertEquals($expected, $results['number']);
         }
+    }
+
+    /**
+     * Regression test to make sure this widget does not crash when loaded as
+     * a self service user with validation rights enabled.
+     */
+    public function testTicketsWaitingForApprovalSelfService(): void
+    {
+        // Arrange: allow self service users to validate tickets
+        $this->addRightToProfile(
+            "Self-service",
+            TicketValidation::$rightname,
+            TicketValidation::VALIDATEREQUEST | TicketValidation::VALIDATEINCIDENT
+        );
+
+        // Act: get waiting_validation widget content
+        $this->login('post-only');
+        $params = Provider::nbTicketsGeneric('waiting_validation');
+
+        // Assert: just make sure this was executed without errors
+        $this->assertNotEmpty($params);
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

The "tickets awaiting your approval" dashboard widget would fail for self service users with the right to validate tickets:

<img width="589" height="822" alt="image" src="https://github.com/user-attachments/assets/712d8543-bd40-4164-9bc1-87232b4a6374" />

This was because a table was joined two times, leading to an array criteria with an invalid format.

## References

Internal support ticket: !41109


