### PR TITLE
fix double escape of itemtype in allasset searches

### DIFF
--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -4532,7 +4532,7 @@ final class SQLProvider implements SearchProviderInterface
                         // Use quoted value to prevent replacement of AllAssets in column identifiers
                         $tmpquery = str_replace(
                             $DB->quoteValue(AllAssets::getType()),
-                            $DB->quoteValue($DB->escape($ctype)),
+                            $DB->quoteValue($ctype),
                             $tmpquery
                         );
                     } else {// Ref table case


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

fixes #22290
Calls to `DBmysql::quoteValue` already escape the value as needed. This double escape was breaking AllAsset search joins like infocoms by using something like:
```sql
LEFT JOIN `glpi_infocoms` ON (`glpi_assets_assets`.`id` = `glpi_infocoms`.`items_id` AND `glpi_infocoms`.`itemtype` = 'Glpi\\\\CustomAsset\\\\CarAsset')
```
instead of
```sql
LEFT JOIN `glpi_infocoms` ON (`glpi_assets_assets`.`id` = `glpi_infocoms`.`items_id` AND `glpi_infocoms`.`itemtype` = 'Glpi\\CustomAsset\\CarAsset')
```