### PR TITLE
fix entity column in rule list

### DIFF
--- a/src/RuleCollection.php
+++ b/src/RuleCollection.php
@@ -592,7 +592,7 @@ TWIG, $twig_params);
         }
         $columns['is_active'] = __('Active');
         if ($display_entities) {
-            $columns['entities_id'] = Entity::getTypeName(1);
+            $columns['entity'] = Entity::getTypeName(1);
         }
         $columns['rank'] = __('Position');
         $columns['sort'] = '';


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

fixes #22333

The entity column was given the wrong key so the entity names were not shown while the Position values were shifted to the left, under the Entity column header.
