### PR TITLE
dispose monaco editors when deleting webhook header

### DIFF
--- a/templates/pages/setup/webhook/webhook_headers.html.twig
+++ b/templates/pages/setup/webhook/webhook_headers.html.twig
@@ -104,7 +104,14 @@
               $('div.custom-header-fields').on('click', 'button[name="add_header"]', () => {
                   add_custom_header('', '');
               }).on('click', 'button[name="remove_header"]', (e) => {
-                  $(e.target).closest('.custom-header-field-pair').remove();
+                  const header_pair = $(e.target).closest('.custom-header-field-pair');
+                  header_pair.find('.header_value').each((i, editor_dom) => {
+                      const editor = window.monaco.editor.getEditors().find((ed) => ed._domElement === editor_dom);
+                      if (editor) {
+                          editor.dispose();
+                      }
+                  });
+                  header_pair.remove();
               });
 
               // Add formdata handler to inject the custom header values from the monaco editors


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

fixes #22497 (issue in comment. original report not a bug)

The webhook headers form was pulling the header names and values from the monaco editors but the button to remove a header was only deleting the elements in the DOM.  The actual editors still existed and held the information of the deleted elements. This prevented you from actually deleting a custom header.