### PR TITLE
Fix(Ticket_Contract): fix 'purge' action from listed item

### DIFF
--- a/src/Ticket_Contract.php
+++ b/src/Ticket_Contract.php
@@ -168,8 +168,7 @@ TWIG, $twig_params);
                     continue;
                 }
                 $entry = [
-                    'itemtype' => self::class,
-                    'id' => $data['id'],
+                    'id' => $data['linkid'],
                     'name' => $item->getLink(),
                     'num' => $item->fields['num'],
                     'begin_date' => $item->fields['begin_date'],
@@ -186,6 +185,11 @@ TWIG, $twig_params);
                 $entry['end_date'] = Infocom::getWarrantyExpir($item->fields['begin_date'], $item->fields['duration'], 0, true);
                 $entries[] = $entry;
             }
+        }
+
+        foreach ($entries as &$entry) {
+            $entry['itemtype'] = self::class;
+            $entry['id'] = $entry['linkid'] ?? $entry['id'];
         }
 
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !40842

The `displayTabContentForItem` function handles the display of tickets linked to contracts and contracts linked to tickets, depending on the current view.

When tickets linked to a contract are displayed, the `itemtype` (used for massive actions) was correctly set.

However, when contracts linked to a ticket are displayed, the `itemtype` was set to **"Ticket"**, as the data entries are processed by the `Ticket::getDatatableEntries` function.

The code has been updated to explicitly enforce the correct `itemtype` and the ID (to prevent right error) of the relation table, following the same approach used in **ITIL_Project** to adjust the `itemtype`  see L226.


 
## Screenshots (if appropriate):


