### PR TITLE
Fix form import using unspecified template

### DIFF
--- a/src/Glpi/Form/Destination/CommonITILField/SLMField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/SLMField.php
@@ -193,7 +193,10 @@ abstract class SLMField extends AbstractConfigField implements DestinationFieldC
         DatabaseMapper $mapper,
     ): array {
         // Check if a service level is defined
-        if (!isset($config[SLMFieldConfig::SLM_ID])) {
+        if (
+            !isset($config[SLMFieldConfig::SLM_ID])
+            || $config[SLMFieldConfig::SLM_ID] == 0
+        ) {
             return parent::prepareDynamicConfigDataForImport(
                 $config,
                 $destination,

--- a/src/Glpi/Form/Destination/CommonITILField/TemplateField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/TemplateField.php
@@ -219,8 +219,11 @@ final class TemplateField extends AbstractConfigField implements DestinationFiel
         AbstractCommonITILFormDestination $destination,
         DatabaseMapper $mapper,
     ): array {
-        // Check if a template is defined
-        if (!isset($config[TemplateFieldConfig::TEMPLATE_ID])) {
+        // Check if a valid template is defined
+        if (
+            !isset($config[TemplateFieldConfig::TEMPLATE_ID])
+            || $config[TemplateFieldConfig::TEMPLATE_ID] == 0
+        ) {
             return parent::prepareDynamicConfigDataForImport(
                 $config,
                 $destination,

--- a/tests/fixtures/forms/form-with-empty-specific-sla.json
+++ b/tests/fixtures/forms/form-with-empty-specific-sla.json
@@ -1,0 +1,163 @@
+{
+    "version": 1,
+    "forms": [
+        {
+            "id": 12,
+            "uuid": "e7ee4c45-1157-4d4e-b222-f9e34e64d2ab",
+            "name": "Form using unspecified SLA",
+            "header": null,
+            "description": null,
+            "entity_name": "Root entity > _test_root_entity",
+            "is_recursive": true,
+            "is_active": false,
+            "submit_button_visibility_strategy": "always_visible",
+            "illustration": "",
+            "submit_button_conditions": [],
+            "sections": [
+                {
+                    "id": 19,
+                    "uuid": "dbabf67b-4ac2-46a5-b83a-ece12548dd1d",
+                    "name": "First section",
+                    "description": null,
+                    "rank": 0,
+                    "visibility_strategy": "always_visible",
+                    "conditions": []
+                }
+            ],
+            "comments": [],
+            "questions": [],
+            "policies": [
+                {
+                    "strategy": "Glpi\\Form\\AccessControl\\ControlType\\AllowList",
+                    "config": {
+                        "user_ids": [
+                            "all"
+                        ],
+                        "group_ids": [],
+                        "profile_ids": []
+                    },
+                    "is_active": true
+                }
+            ],
+            "destinations": [
+                {
+                    "id": 17,
+                    "itemtype": "Glpi\\Form\\Destination\\FormDestinationTicket",
+                    "name": "Ticket",
+                    "config": {
+                        "glpi-form-destination-commonitilfield-titlefield": {
+                            "value": "<span class=\"border-yellow border-start border-3 bg-dark-lt\" data-form-tag=\"true\" data-form-tag-value=\"12\" data-form-tag-provider=\"Glpi\\Form\\Tag\\FormTagProvider\">#Form name: Form using unspecified SLA<\/span>"
+                        },
+                        "glpi-form-destination-commonitilfield-contentfield_auto": "1",
+                        "glpi-form-destination-commonitilfield-itilfollowupfield": {
+                            "strategy": "no_followup"
+                        },
+                        "glpi-form-destination-commonitilfield-itiltaskfield": {
+                            "strategy": "no_task"
+                        },
+                        "glpi-form-destination-commonitilfield-validationfield": {
+                            "strategy_configs": [
+                                {
+                                    "strategy": "no_validation",
+                                    "specific_validationtemplates_ids": [],
+                                    "specific_question_ids": [],
+                                    "specific_actors": [],
+                                    "specific_validation_step_id": null
+                                }
+                            ]
+                        },
+                        "glpi-form-destination-commonitilfield-templatefield": {
+                            "strategy": "default_template"
+                        },
+                        "glpi-form-destination-commonitilfield-entityfield": {
+                            "strategy": "form_filler"
+                        },
+                        "glpi-form-destination-commonitilfield-requesttypefield": {
+                            "strategy": "last_valid_answer"
+                        },
+                        "glpi-form-destination-commonitilfield-itilcategoryfield": {
+                            "strategy": "last_valid_answer"
+                        },
+                        "glpi-form-destination-commonitilfield-statusfield": {
+                            "value": "default_status"
+                        },
+                        "glpi-form-destination-commonitilfield-requestsourcefield": {
+                            "strategy": "from_template"
+                        },
+                        "glpi-form-destination-commonitilfield-urgencyfield": {
+                            "strategy": "last_valid_answer"
+                        },
+                        "glpi-form-destination-commonitilfield-locationfield": {
+                            "strategy": "last_valid_answer"
+                        },
+                        "glpi-form-destination-commonitilfield-requesterfield": {
+                            "strategies": [
+                                "form_filler"
+                            ],
+                            "specific_itilactors_ids": null,
+                            "specific_question_ids": null
+                        },
+                        "glpi-form-destination-commonitilfield-observerfield": {
+                            "strategies": [
+                                "from_template"
+                            ],
+                            "specific_itilactors_ids": null,
+                            "specific_question_ids": null
+                        },
+                        "glpi-form-destination-commonitilfield-assigneefield": {
+                            "strategies": [
+                                "from_template"
+                            ],
+                            "specific_itilactors_ids": null,
+                            "specific_question_ids": null
+                        },
+                        "glpi-form-destination-commonitilfield-slattofield": {
+                            "strategy": "specific_value",
+                            "slm_id": "0"
+                        },
+                        "glpi-form-destination-commonitilfield-slattrfield": {
+                            "strategy": "specific_value",
+                            "slm_id": "0"
+                        },
+                        "glpi-form-destination-commonitilfield-olattofield": {
+                            "strategy": "specific_value",
+                            "slm_id": "0"
+                        },
+                        "glpi-form-destination-commonitilfield-olattrfield": {
+                            "strategy": "specific_value",
+                            "slm_id": "0"
+                        },
+                        "glpi-form-destination-commonitilfield-associateditemsfield": {
+                            "strategies": [
+                                "last_valid_answer"
+                            ],
+                            "specific_question_ids": null
+                        },
+                        "glpi-form-destination-commonitilfield-linkeditilobjectsfield": {
+                            "strategy_configs": [
+                                {
+                                    "strategy": null,
+                                    "linktype": "1",
+                                    "specific_destination_ids": [],
+                                    "specific_question_ids": [],
+                                    "specific_itilobject": []
+                                }
+                            ]
+                        }
+                    },
+                    "creation_strategy": "always_created",
+                    "conditions": []
+                }
+            ],
+            "translations": [],
+            "data_requirements": [
+                {
+                    "itemtype": "Entity",
+                    "name": "Root entity > _test_root_entity"
+                }
+            ],
+            "custom_types_requirements": [],
+            "plugin_requirements": []
+        }
+    ]
+}

--- a/tests/fixtures/forms/form-with-empty-specific-template.json
+++ b/tests/fixtures/forms/form-with-empty-specific-template.json
@@ -1,0 +1,178 @@
+{
+    "version": 1,
+    "forms": [
+        {
+            "id": 10,
+            "uuid": "46a37c52-25de-4303-8079-c15c81505413",
+            "name": "Form using unspecified template",
+            "header": null,
+            "description": null,
+            "entity_name": "Root entity > _test_root_entity",
+            "is_recursive": true,
+            "is_active": false,
+            "submit_button_visibility_strategy": "always_visible",
+            "illustration": "",
+            "submit_button_conditions": [],
+            "sections": [
+                {
+                    "id": 17,
+                    "uuid": "ed8b9d98-240a-4745-9aea-284324ac3662",
+                    "name": "First section",
+                    "description": null,
+                    "rank": 0,
+                    "visibility_strategy": "always_visible",
+                    "conditions": []
+                }
+            ],
+            "comments": [],
+            "questions": [
+                {
+                    "id": 97,
+                    "uuid": "fa59d22a-7151-456d-af15-2a27f392d260",
+                    "name": "Question 1",
+                    "type": "Glpi\\Form\\QuestionType\\QuestionTypeShortText",
+                    "is_mandatory": false,
+                    "vertical_rank": 0,
+                    "horizontal_rank": null,
+                    "description": "",
+                    "default_value": "",
+                    "extra_data": null,
+                    "section_id": 17,
+                    "visibility_strategy": "always_visible",
+                    "validation_strategy": "no_validation",
+                    "conditions": [],
+                    "validation_conditions": []
+                }
+            ],
+            "policies": [
+                {
+                    "strategy": "Glpi\\Form\\AccessControl\\ControlType\\AllowList",
+                    "config": {
+                        "user_ids": [
+                            "all"
+                        ],
+                        "group_ids": [],
+                        "profile_ids": []
+                    },
+                    "is_active": true
+                }
+            ],
+            "destinations": [
+                {
+                    "id": 15,
+                    "itemtype": "Glpi\\Form\\Destination\\FormDestinationTicket",
+                    "name": "Ticket",
+                    "config": {
+                        "glpi-form-destination-commonitilfield-titlefield": {
+                            "value": "<span class=\"border-yellow border-start border-3 bg-dark-lt\" data-form-tag=\"true\" data-form-tag-value=\"10\" data-form-tag-provider=\"Glpi\\Form\\Tag\\FormTagProvider\">#Form name: Form using unspecified template<\/span>"
+                        },
+                        "glpi-form-destination-commonitilfield-contentfield_auto": "1",
+                        "glpi-form-destination-commonitilfield-itilfollowupfield": {
+                            "strategy": "no_followup"
+                        },
+                        "glpi-form-destination-commonitilfield-itiltaskfield": {
+                            "strategy": "no_task"
+                        },
+                        "glpi-form-destination-commonitilfield-validationfield": {
+                            "strategy_configs": [
+                                {
+                                    "strategy": "no_validation",
+                                    "specific_validationtemplates_ids": [],
+                                    "specific_question_ids": [],
+                                    "specific_actors": [],
+                                    "specific_validation_step_id": null
+                                }
+                            ]
+                        },
+                        "glpi-form-destination-commonitilfield-templatefield": {
+                            "strategy": "specific_template",
+                            "template_id": "0"
+                        },
+                        "glpi-form-destination-commonitilfield-entityfield": {
+                            "strategy": "form_filler"
+                        },
+                        "glpi-form-destination-commonitilfield-requesttypefield": {
+                            "strategy": "last_valid_answer"
+                        },
+                        "glpi-form-destination-commonitilfield-itilcategoryfield": {
+                            "strategy": "last_valid_answer"
+                        },
+                        "glpi-form-destination-commonitilfield-statusfield": {
+                            "value": "default_status"
+                        },
+                        "glpi-form-destination-commonitilfield-requestsourcefield": {
+                            "strategy": "from_template"
+                        },
+                        "glpi-form-destination-commonitilfield-urgencyfield": {
+                            "strategy": "last_valid_answer"
+                        },
+                        "glpi-form-destination-commonitilfield-locationfield": {
+                            "strategy": "last_valid_answer"
+                        },
+                        "glpi-form-destination-commonitilfield-requesterfield": {
+                            "strategies": [
+                                "form_filler"
+                            ],
+                            "specific_itilactors_ids": null,
+                            "specific_question_ids": null
+                        },
+                        "glpi-form-destination-commonitilfield-observerfield": {
+                            "strategies": [
+                                "from_template"
+                            ],
+                            "specific_itilactors_ids": null,
+                            "specific_question_ids": null
+                        },
+                        "glpi-form-destination-commonitilfield-assigneefield": {
+                            "strategies": [
+                                "from_template"
+                            ],
+                            "specific_itilactors_ids": null,
+                            "specific_question_ids": null
+                        },
+                        "glpi-form-destination-commonitilfield-slattofield": {
+                            "strategy": "from_template"
+                        },
+                        "glpi-form-destination-commonitilfield-slattrfield": {
+                            "strategy": "from_template"
+                        },
+                        "glpi-form-destination-commonitilfield-olattofield": {
+                            "strategy": "from_template"
+                        },
+                        "glpi-form-destination-commonitilfield-olattrfield": {
+                            "strategy": "from_template"
+                        },
+                        "glpi-form-destination-commonitilfield-associateditemsfield": {
+                            "strategies": [
+                                "last_valid_answer"
+                            ],
+                            "specific_question_ids": null
+                        },
+                        "glpi-form-destination-commonitilfield-linkeditilobjectsfield": {
+                            "strategy_configs": [
+                                {
+                                    "strategy": null,
+                                    "linktype": "1",
+                                    "specific_destination_ids": [],
+                                    "specific_question_ids": [],
+                                    "specific_itilobject": []
+                                }
+                            ]
+                        }
+                    },
+                    "creation_strategy": "always_created",
+                    "conditions": []
+                }
+            ],
+            "translations": [],
+            "data_requirements": [
+                {
+                    "itemtype": "Entity",
+                    "name": "Root entity > _test_root_entity"
+                }
+            ],
+            "custom_types_requirements": [],
+            "plugin_requirements": []
+        }
+    ]
+}

--- a/tests/functional/Glpi/Form/Export/FormSerializerTest.php
+++ b/tests/functional/Glpi/Form/Export/FormSerializerTest.php
@@ -2381,6 +2381,7 @@ final class FormSerializerTest extends DbTestCase
         // once imported.
         return [
             ['file' => 'form-with-empty-specific-question-for-location.json'],
+            ['file' => 'form-with-empty-specific-template.json'],
         ];
     }
 

--- a/tests/functional/Glpi/Form/Export/FormSerializerTest.php
+++ b/tests/functional/Glpi/Form/Export/FormSerializerTest.php
@@ -2382,6 +2382,7 @@ final class FormSerializerTest extends DbTestCase
         return [
             ['file' => 'form-with-empty-specific-question-for-location.json'],
             ['file' => 'form-with-empty-specific-template.json'],
+            ['file' => 'form-with-empty-specific-sla.json'],
         ];
     }
 


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

A form configured like this would fail to be imported:

<img width="595" height="228" alt="image" src="https://github.com/user-attachments/assets/f70def72-f4a0-49ae-9c03-962a4e117a71" />

<img width="832" height="231" alt="image" src="https://github.com/user-attachments/assets/c3300c44-7d67-42db-8f33-a4f55b9a4f8b" />

## References

Internal support ticket: !41098


