### PR TITLE
Fix empty rrule decoding and JS attribute issues in planning

### DIFF
--- a/ajax/planning.php
+++ b/ajax/planning.php
@@ -81,7 +81,7 @@ if ($_REQUEST["action"] == "get_externalevent_template") {
         $template = new PlanningExternalEventTemplate();
         $template->getFromDB($_POST[$key]);
 
-        // Decode rrule field on ly if not empty
+        // Decode rrule field only if not empty
         if (!empty($template->fields['rrule'])) {
             $template->fields['rrule'] = json_decode($template->fields['rrule'], true);
         }

--- a/ajax/planning.php
+++ b/ajax/planning.php
@@ -81,7 +81,10 @@ if ($_REQUEST["action"] == "get_externalevent_template") {
         $template = new PlanningExternalEventTemplate();
         $template->getFromDB($_POST[$key]);
 
-        $template->fields['rrule'] = json_decode($template->fields['rrule'], true);
+        // Decode rrule field on ly if not empty
+        if (!empty($template->fields['rrule'])) {
+            $template->fields['rrule'] = json_decode($template->fields['rrule'], true);
+        }
         header("Content-Type: application/json; charset=UTF-8");
         echo json_encode($template->fields, JSON_NUMERIC_CHECK);
         return;

--- a/templates/pages/assistance/planning/external_event.html.twig
+++ b/templates/pages/assistance/planning/external_event.html.twig
@@ -54,7 +54,7 @@
             {
                 entity: item.getEntityID(),
                 rand: rand,
-                onchange: 'template_update' ~ rand ~ '(this.value);'
+                on_change: 'template_update' ~ rand ~ '(this.value)'
             }|merge(field_options)
         ) }}
 
@@ -80,7 +80,7 @@
                     }
                     $("#dropdown_background{{ rand }}").trigger("setValue", data.background);
                     if (data.text.length > 0) {
-                        setRichTextEditorContent("text{$rand}", data.text);
+                        setRichTextEditorContent("text_{{ rand }}", data.text);
                     }
 
                     // set planification fields


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

- It fixes 40907

This worked correctly before the migration to Twig.
Since the switch, inconsistencies between PHP and Twig templates caused regressions (empty rrule handling and JS field mismatches).
This patch restores the expected behavior and prevents related errors.

