### PR TITLE
Enhance reservation log messages

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -19906,17 +19906,11 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Cannot call method getFromDB\\(\\) on CommonDBTM\\|false\\.$#',
 	'identifier' => 'method.nonObject',
-	'count' => 3,
+	'count' => 2,
 	'path' => __DIR__ . '/src/Reservation.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Cannot call method getIcon\\(\\) on CommonDBTM\\|false\\.$#',
-	'identifier' => 'method.nonObject',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Reservation.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Cannot call method getLink\\(\\) on CommonDBTM\\|false\\.$#',
 	'identifier' => 'method.nonObject',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Reservation.php',

--- a/front/reservation.form.php
+++ b/front/reservation.form.php
@@ -95,6 +95,10 @@ if (isset($_POST["update"])) {
     $_POST['begin']   = $_POST['resa']["begin"];
     $_POST['end']     = $_POST['resa']["end"];
     if ($rr->update($_POST)) {
+        $rri = new ReservationItem();
+        $rri->getFromDB($_POST['_item']);
+        $item = getItemForItemtype($rri->fields["itemtype"]);
+        $item->getFromDB($rri->fields["items_id"]);
         Event::log(
             $_POST["id"],
             "reservation",
@@ -102,9 +106,11 @@ if (isset($_POST["update"])) {
             "inventory",
             //TRANS: %s is the user login
             sprintf(
-                __('%1$s updates the reservation for item %2$s'),
+                __('%1$s updates reservation %2$s for %3$s %4$s'),
                 $_SESSION["glpiname"],
-                $_POST['_item']
+                $_POST['id'],
+                $item::getTypeName(1),
+                $item->getNameID(['forceid' => true])
             )
         );
     }
@@ -114,6 +120,10 @@ if (isset($_POST["update"])) {
 
     $reservationitems_id = key($_POST["items"]);
     if ($rr->delete($_POST, true)) {
+        $rri = new ReservationItem();
+        $rri->getFromDB($reservationitems_id);
+        $item = getItemForItemtype($rri->fields["itemtype"]);
+        $item->getFromDB($rri->fields["items_id"]);
         Event::log(
             $_POST["id"],
             "reservation",
@@ -121,9 +131,11 @@ if (isset($_POST["update"])) {
             "inventory",
             //TRANS: %s is the user login
             sprintf(
-                __('%1$s purges the reservation for item %2$s'),
+                __('%1$s purges reservation %2$s for %3$s %4$s'),
                 $_SESSION["glpiname"],
-                $reservationitems_id
+                $_POST['id'],
+                $item::getTypeName(1),
+                $item->getNameID(['forceid' => true])
             )
         );
     }

--- a/front/reservation.form.php
+++ b/front/reservation.form.php
@@ -98,21 +98,22 @@ if (isset($_POST["update"])) {
         $rri = new ReservationItem();
         $rri->getFromDB($_POST['_item']);
         $item = getItemForItemtype($rri->fields["itemtype"]);
-        $item->getFromDB($rri->fields["items_id"]);
-        Event::log(
-            $_POST["id"],
-            "reservation",
-            4,
-            "inventory",
-            //TRANS: %s is the user login
-            sprintf(
-                __('%1$s updates reservation %2$s for %3$s %4$s'),
-                $_SESSION["glpiname"],
-                $_POST['id'],
-                $item::getTypeName(1),
-                $item->getNameID(['forceid' => true])
-            )
-        );
+        if ($item && $item->getFromDB($rri->fields["items_id"])) {
+            Event::log(
+                $_POST["id"],
+                "reservation",
+                4,
+                "inventory",
+                //TRANS: %s is the user login
+                sprintf(
+                    __('%1$s updates reservation %2$s for %3$s %4$s'),
+                    $_SESSION["glpiname"],
+                    $_POST['id'],
+                    $item::getTypeName(1),
+                    $item->getNameID(['forceid' => true])
+                )
+            );
+        }
     }
     $fn_redirect_back();
 } elseif (isset($_POST["purge"])) {
@@ -123,21 +124,22 @@ if (isset($_POST["update"])) {
         $rri = new ReservationItem();
         $rri->getFromDB($reservationitems_id);
         $item = getItemForItemtype($rri->fields["itemtype"]);
-        $item->getFromDB($rri->fields["items_id"]);
-        Event::log(
-            $_POST["id"],
-            "reservation",
-            4,
-            "inventory",
-            //TRANS: %s is the user login
-            sprintf(
-                __('%1$s purges reservation %2$s for %3$s %4$s'),
-                $_SESSION["glpiname"],
-                $_POST['id'],
-                $item::getTypeName(1),
-                $item->getNameID(['forceid' => true])
-            )
-        );
+        if ($item && $item->getFromDB($rri->fields["items_id"])) {
+            Event::log(
+                $_POST["id"],
+                "reservation",
+                4,
+                "inventory",
+                //TRANS: %s is the user login
+                sprintf(
+                    __('%1$s purges reservation %2$s for %3$s %4$s'),
+                    $_SESSION["glpiname"],
+                    $_POST['id'],
+                    $item::getTypeName(1),
+                    $item->getNameID(['forceid' => true])
+                )
+            );
+        }
     }
 
     [$begin_year, $begin_month] = explode("-", $rr->fields["begin"]);

--- a/src/Reservation.php
+++ b/src/Reservation.php
@@ -222,24 +222,24 @@ class Reservation extends CommonDBChild
                 }
 
                 if ($newID = $rr->add($reservation_input)) {
+                    $rri = new ReservationItem();
+                    $rri->getFromDB($reservationitems_id);
+                    $item = getItemForItemtype($rri->fields["itemtype"]);
+                    $item->getFromDB($rri->fields["items_id"]);
+
                     Event::log(
                         $newID,
                         "reservation",
                         4,
                         "inventory",
                         sprintf(
-                            __s('%1$s adds the reservation %2$s for item %3$s'),
+                            __s('%1$s adds reservation %2$s for %3$s %4$s'),
                             $_SESSION["glpiname"],
                             $newID,
-                            $reservationitems_id
+                            $item::getTypeName(1),
+                            $item->getNameID(['forceid' => true])
                         )
                     );
-
-                    $rri = new ReservationItem();
-                    $rri->getFromDB($reservationitems_id);
-                    $item = getItemForItemtype($rri->fields["itemtype"]);
-                    $item->getFromDB($rri->fields["items_id"]);
-
                     Session::addMessageAfterRedirect(
                         sprintf(
                             __s('Reservation added for item %s at %s'),

--- a/src/Reservation.php
+++ b/src/Reservation.php
@@ -225,28 +225,28 @@ class Reservation extends CommonDBChild
                     $rri = new ReservationItem();
                     $rri->getFromDB($reservationitems_id);
                     $item = getItemForItemtype($rri->fields["itemtype"]);
-                    $item->getFromDB($rri->fields["items_id"]);
-
-                    Event::log(
-                        $newID,
-                        "reservation",
-                        4,
-                        "inventory",
-                        sprintf(
-                            __s('%1$s adds reservation %2$s for %3$s %4$s'),
-                            $_SESSION["glpiname"],
+                    if ($item && $item->getFromDB($rri->fields["items_id"])) {
+                        Event::log(
                             $newID,
-                            $item::getTypeName(1),
-                            $item->getNameID(['forceid' => true])
-                        )
-                    );
-                    Session::addMessageAfterRedirect(
-                        sprintf(
-                            __s('Reservation added for item %s at %s'),
-                            $item->getLink(),
-                            htmlescape(Html::convDateTime($reservation_input['begin']))
-                        )
-                    );
+                            "reservation",
+                            4,
+                            "inventory",
+                            sprintf(
+                                __s('%1$s adds reservation %2$s for %3$s %4$s'),
+                                $_SESSION["glpiname"],
+                                $newID,
+                                $item::getTypeName(1),
+                                $item->getNameID(['forceid' => true])
+                            )
+                        );
+                        Session::addMessageAfterRedirect(
+                            sprintf(
+                                __s('Reservation added for item %s at %s'),
+                                $item->getLink(),
+                                htmlescape(Html::convDateTime($reservation_input['begin']))
+                            )
+                        );
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Improves the messages for reservation logging.
While working on #22511, I noticed the messages were not very helpful.
"glpi adds the reservation 6 for item 1" - No clue what item 1 is
"glpi purges the reservation for item 1" - No clue what item 1 is or what reservation ID was deleted

New messages:
"glpi adds the reservation 8 for Computers Bulk 0002 (4)"
"glpi updates the reservation 8 for Computer Bulk 0002 (4)"
"glpi purges the reservation 8 for Computer Bulk 0002 (4)"