### PR TITLE
Fix group search options for custom assets

### DIFF
--- a/src/Glpi/Asset/Asset.php
+++ b/src/Glpi/Asset/Asset.php
@@ -247,6 +247,8 @@ abstract class Asset extends CommonDBTM implements AssignableItemInterface, Stat
                     ],
                 ],
             ],
+            'forcegroupby'       => true,
+            'massiveaction'      => false,
             'datatype'           => 'dropdown',
         ];
 
@@ -302,6 +304,8 @@ abstract class Asset extends CommonDBTM implements AssignableItemInterface, Stat
                     ],
                 ],
             ],
+            'forcegroupby'       => true,
+            'massiveaction'      => false,
             'datatype'           => 'dropdown',
         ];
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

fixes #21919 

The Group search options for custom assets were missing the "forcegroupby" flag which causes duplicates in the search results for the web UI and presumably the legacy API. HLAPI was not affected by search options and didn't return duplicate results.

Other asset types also had massive actions for these fields disabled, probably because they cannot be set properly that way yet, so I added that here too.