### PR TITLE
Replace non-display uses of getField

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -2896,7 +2896,7 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Cannot call method getField\\(\\) on CommonDBTM\\|false\\.$#',
 	'identifier' => 'method.nonObject',
-	'count' => 2,
+	'count' => 1,
 	'path' => __DIR__ . '/src/CommonDBTM.php',
 ];
 $ignoreErrors[] = [
@@ -2912,7 +2912,7 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/CommonDBTM.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Cannot call method isField\\(\\) on CommonDBTM\\|false\\.$#',
+	'message' => '#^Cannot call method isDeleted\\(\\) on CommonDBTM\\|false\\.$#',
 	'identifier' => 'method.nonObject',
 	'count' => 1,
 	'path' => __DIR__ . '/src/CommonDBTM.php',
@@ -4184,12 +4184,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Computer.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Cannot call method getField\\(\\) on CommonDBTM\\|false\\.$#',
-	'identifier' => 'method.nonObject',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Computer.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Cannot call method getFromDB\\(\\) on CommonDBTM\\|false\\.$#',
 	'identifier' => 'method.nonObject',
 	'count' => 1,
@@ -4203,6 +4197,12 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	'message' => '#^Cannot call method getLink\\(\\) on Agent\\|null\\.$#',
+	'identifier' => 'method.nonObject',
+	'count' => 1,
+	'path' => __DIR__ . '/src/Computer.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Cannot call method isGlobal\\(\\) on CommonDBTM\\|false\\.$#',
 	'identifier' => 'method.nonObject',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Computer.php',
@@ -13988,8 +13988,8 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/ITILFollowup.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Cannot call method getForeignKeyField\\(\\) on CommonDBTM\\|false\\|null\\.$#',
-	'identifier' => 'method.nonObject',
+	'message' => '#^Cannot call static method getForeignKeyField\\(\\) on CommonDBTM\\|false\\|null\\.$#',
+	'identifier' => 'staticMethod.nonObject',
 	'count' => 1,
 	'path' => __DIR__ . '/src/ITILFollowup.php',
 ];
@@ -16220,12 +16220,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/NotificationTargetCommonITILObject.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Cannot call method getField\\(\\) on \\(T of CommonITILObject\\)\\|null\\.$#',
-	'identifier' => 'method.nonObject',
-	'count' => 1,
-	'path' => __DIR__ . '/src/NotificationTargetCommonITILObject.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Cannot call method getField\\(\\) on CommonDBTM\\|false\\.$#',
 	'identifier' => 'method.nonObject',
 	'count' => 2,
@@ -16252,7 +16246,7 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Cannot call method getID\\(\\) on \\(T of CommonITILObject\\)\\|null\\.$#',
 	'identifier' => 'method.nonObject',
-	'count' => 1,
+	'count' => 2,
 	'path' => __DIR__ . '/src/NotificationTargetCommonITILObject.php',
 ];
 $ignoreErrors[] = [
@@ -16606,19 +16600,19 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Cannot access property \\$fields on Project\\|null\\.$#',
 	'identifier' => 'property.nonObject',
-	'count' => 5,
+	'count' => 23,
 	'path' => __DIR__ . '/src/NotificationTargetProject.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Cannot call method getField\\(\\) on Project\\|null\\.$#',
 	'identifier' => 'method.nonObject',
-	'count' => 26,
+	'count' => 4,
 	'path' => __DIR__ . '/src/NotificationTargetProject.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Cannot call method getID\\(\\) on Project\\|null\\.$#',
 	'identifier' => 'method.nonObject',
-	'count' => 2,
+	'count' => 6,
 	'path' => __DIR__ . '/src/NotificationTargetProject.php',
 ];
 $ignoreErrors[] = [
@@ -16660,19 +16654,19 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Cannot access property \\$fields on ProjectTask\\|null\\.$#',
 	'identifier' => 'property.nonObject',
-	'count' => 6,
+	'count' => 26,
 	'path' => __DIR__ . '/src/NotificationTargetProjectTask.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Cannot call method getField\\(\\) on ProjectTask\\|null\\.$#',
 	'identifier' => 'method.nonObject',
-	'count' => 26,
+	'count' => 3,
 	'path' => __DIR__ . '/src/NotificationTargetProjectTask.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Cannot call method getID\\(\\) on ProjectTask\\|null\\.$#',
 	'identifier' => 'method.nonObject',
-	'count' => 1,
+	'count' => 4,
 	'path' => __DIR__ . '/src/NotificationTargetProjectTask.php',
 ];
 $ignoreErrors[] = [
@@ -16700,6 +16694,12 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/NotificationTargetReservation.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Cannot access property \\$fields on Reservation\\|null\\.$#',
+	'identifier' => 'property.nonObject',
+	'count' => 4,
+	'path' => __DIR__ . '/src/NotificationTargetReservation.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Cannot assign new offset to array\\<array\\<string, mixed\\>\\|string\\>\\|string\\.$#',
 	'identifier' => 'offsetAssign.dimType',
 	'count' => 1,
@@ -16708,7 +16708,13 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Cannot call method getField\\(\\) on Reservation\\|null\\.$#',
 	'identifier' => 'method.nonObject',
-	'count' => 6,
+	'count' => 1,
+	'path' => __DIR__ . '/src/NotificationTargetReservation.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Cannot call method getID\\(\\) on Reservation\\|null\\.$#',
+	'identifier' => 'method.nonObject',
+	'count' => 1,
 	'path' => __DIR__ . '/src/NotificationTargetReservation.php',
 ];
 $ignoreErrors[] = [
@@ -16730,8 +16736,8 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/NotificationTargetSavedSearch_Alert.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Cannot call method getField\\(\\) on SavedSearch_Alert\\|null\\.$#',
-	'identifier' => 'method.nonObject',
+	'message' => '#^Cannot access property \\$fields on SavedSearch_Alert\\|null\\.$#',
+	'identifier' => 'property.nonObject',
 	'count' => 1,
 	'path' => __DIR__ . '/src/NotificationTargetSavedSearch_Alert.php',
 ];
@@ -16760,7 +16766,7 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/NotificationTargetSoftwareLicense.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Cannot call method getField\\(\\) on Ticket\\|null\\.$#',
+	'message' => '#^Cannot call method getID\\(\\) on Ticket\\|null\\.$#',
 	'identifier' => 'method.nonObject',
 	'count' => 1,
 	'path' => __DIR__ . '/src/NotificationTargetTicket.php',
@@ -16774,7 +16780,7 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Cannot access property \\$fields on User\\|null\\.$#',
 	'identifier' => 'property.nonObject',
-	'count' => 2,
+	'count' => 3,
 	'path' => __DIR__ . '/src/NotificationTargetUser.php',
 ];
 $ignoreErrors[] = [
@@ -16786,7 +16792,7 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Cannot call method getField\\(\\) on User\\|null\\.$#',
 	'identifier' => 'method.nonObject',
-	'count' => 4,
+	'count' => 3,
 	'path' => __DIR__ . '/src/NotificationTargetUser.php',
 ];
 $ignoreErrors[] = [
@@ -16863,12 +16869,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$object of function get_class expects object, CommonGLPI\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/NotificationTemplate.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$object_or_class of function method_exists expects object\\|string, CommonGLPI\\|null given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/NotificationTemplate.php',
@@ -19094,6 +19094,12 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/SavedSearch.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Parameter \\#1 \\$itemtype of method Search\\:\\:prepareDatasForSearch\\(\\) expects class\\-string\\<CommonDBTM\\>, class\\-string given\\.$#',
+	'identifier' => 'argument.type',
+	'count' => 1,
+	'path' => __DIR__ . '/src/SavedSearch.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Offset \'savedsearches_id\' might not exist on array\\<string, mixed\\>\\|null\\.$#',
 	'identifier' => 'offsetAccess.notFound',
 	'count' => 1,
@@ -19538,8 +19544,8 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Telemetry.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Cannot call method getField\\(\\) on CommonDBTM\\|false\\.$#',
-	'identifier' => 'method.nonObject',
+	'message' => '#^Cannot access property \\$fields on CommonDBTM\\|false\\.$#',
+	'identifier' => 'property.nonObject',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Ticket.php',
 ];

--- a/ajax/commonitilsatisfaction.php
+++ b/ajax/commonitilsatisfaction.php
@@ -49,13 +49,13 @@ if (isset($_POST['inquest_config' . $config_suffix], $_POST['entities_id'])) {
         if (!$ent->canViewItem()) {
             throw new AccessDeniedHttpException();
         }
-        $inquest_delay             = $ent->getfield('inquest_delay' . $config_suffix);
-        $inquest_rate              = $ent->getfield('inquest_rate' . $config_suffix);
-        $inquest_duration          = $ent->getfield('inquest_duration' . $config_suffix);
-        $inquest_max_rate          = $ent->getfield('inquest_max_rate' . $config_suffix);
-        $inquest_default_rate      = $ent->getfield('inquest_default_rate' . $config_suffix);
-        $inquest_mandatory_comment = $ent->getfield('inquest_mandatory_comment' . $config_suffix);
-        $max_closedate             = $ent->getfield('max_closedate' . $config_suffix);
+        $inquest_delay             = $ent->fields['inquest_delay' . $config_suffix];
+        $inquest_rate              = $ent->fields['inquest_rate' . $config_suffix];
+        $inquest_duration          = $ent->fields['inquest_duration' . $config_suffix];
+        $inquest_max_rate          = $ent->fields['inquest_max_rate' . $config_suffix];
+        $inquest_default_rate      = $ent->fields['inquest_default_rate' . $config_suffix];
+        $inquest_mandatory_comment = $ent->fields['inquest_mandatory_comment' . $config_suffix];
+        $max_closedate             = $ent->fields['max_closedate' . $config_suffix];
     } else {
         $inquest_delay             = -1;
         $inquest_rate              = -1;

--- a/ajax/dropdownTicketCategories.php
+++ b/ajax/dropdownTicketCategories.php
@@ -50,14 +50,14 @@ if ($_POST["type"]) {
     switch ($_POST['type']) {
         case Ticket::INCIDENT_TYPE:
             $condition['is_incident'] = 1;
-            if ($currentcateg->getField('is_incident') == 1) {
+            if ($currentcateg->fields['is_incident'] == 1) {
                 $opt['value'] = $_POST['value'];
             }
             break;
 
         case Ticket::DEMAND_TYPE:
             $condition['is_request'] = 1;
-            if ($currentcateg->getField('is_request') == 1) {
+            if ($currentcateg->fields['is_request'] == 1) {
                 $opt['value'] = $_POST['value'];
             }
             break;

--- a/front/changesatisfaction.form.php
+++ b/front/changesatisfaction.form.php
@@ -45,7 +45,7 @@ if (isset($_POST["update"])) {
     $inquest->update($_POST);
 
     Event::log(
-        $inquest->getField('changes_id'),
+        $inquest->fields['changes_id'],
         "change",
         4,
         "tracking",

--- a/front/commonitiltask.form.php
+++ b/front/commonitiltask.form.php
@@ -60,8 +60,6 @@ $track = $task::getItilObjectItemInstance();
 $itemtype = $track::class;
 $fk       = $track::getForeignKeyField();
 
-$track->getFromDB($task->getField($fk));
-
 $redirect = null;
 $handled = false;
 
@@ -70,60 +68,60 @@ if (isset($_POST["add"])) {
     $task->add($_POST);
 
     Event::log(
-        $task->getField($fk),
+        $task->fields[$fk],
         strtolower($itemtype),
         4,
         "tracking",
         //TRANS: %s is the user login
         sprintf(__('%s adds a task'), $_SESSION["glpiname"])
     );
-    $redirect = $itemtype::getFormURLWithID($task->getField($fk));
+    $redirect = $itemtype::getFormURLWithID($task->fields[$fk]);
     $handled = true;
 } elseif (isset($_POST["purge"])) {
     $task->check($_POST['id'], PURGE);
     $task->delete($_POST, true);
 
     Event::log(
-        $task->getField($fk),
+        $task->fields[$fk],
         strtolower($itemtype),
         4,
         "tracking",
         //TRANS: %s is the user login
         sprintf(__('%s purges a task'), $_SESSION["glpiname"])
     );
-    Html::redirect($itemtype::getFormURLWithID($task->getField($fk)));
+    Html::redirect($itemtype::getFormURLWithID($task->fields[$fk]));
 } elseif (isset($_POST["update"])) {
     $task->check($_POST["id"], UPDATE);
     $task->update($_POST);
 
     Event::log(
-        $task->getField($fk),
+        $task->fields[$fk],
         strtolower($itemtype),
         4,
         "tracking",
         //TRANS: %s is the user login
         sprintf(__('%s updates a task'), $_SESSION["glpiname"])
     );
-    $redirect = $itemtype::getFormURLWithID($task->getField($fk));
+    $redirect = $itemtype::getFormURLWithID($task->fields[$fk]);
     $handled = true;
 } elseif (isset($_POST["unplan"])) {
     $task->check($_POST["id"], UPDATE);
     $task->unplan();
 
     Event::log(
-        $task->getField($fk),
+        $task->fields[$fk],
         strtolower($itemtype),
         4,
         "tracking",
         //TRANS: %s is the user login
         sprintf(__('%s unplans a task'), $_SESSION["glpiname"])
     );
-    $redirect = $itemtype::getFormURLWithID($task->getField($fk));
+    $redirect = $itemtype::getFormURLWithID($task->fields[$fk]);
     $handled = true;
 }
 
 if ($handled) {
-    if ($track->can($task->getField($fk), READ)) {
+    if ($track->can($task->fields[$fk], READ)) {
         $toadd = '';
         // Copy followup to KB redirect to KB
         if (isset($_POST['_task_to_kb']) && $_POST['_task_to_kb']) {

--- a/front/commonitilvalidation.form.php
+++ b/front/commonitilvalidation.form.php
@@ -81,7 +81,7 @@ if (isset($_POST["add"])) {
             $_POST['items_id_target'] = $target;
             $validation->add($_POST);
             Event::log(
-                $validation->getField($fk),
+                $validation->fields[$fk],
                 strtolower($itemtype),
                 4,
                 "tracking",
@@ -95,7 +95,7 @@ if (isset($_POST["add"])) {
     $validation->check($_POST['id'], UPDATE);
     $validation->update($_POST);
     Event::log(
-        $validation->getField($fk),
+        $validation->fields[$fk],
         strtolower($itemtype),
         4,
         "tracking",
@@ -108,7 +108,7 @@ if (isset($_POST["add"])) {
     $validation->delete($_POST, true);
 
     Event::log(
-        $validation->getField($fk),
+        $validation->fields[$fk],
         strtolower($itemtype),
         4,
         "tracking",

--- a/front/itilfollowup.form.php
+++ b/front/itilfollowup.form.php
@@ -58,14 +58,14 @@ if (isset($_POST["add"])) {
     $fup->add($_POST);
 
     Event::log(
-        $fup->getField('items_id'),
+        $fup->fields['items_id'],
         strtolower($_POST['itemtype']),
         4,
         "tracking",
         //TRANS: %s is the user login
         sprintf(__('%s adds a followup'), $_SESSION["glpiname"])
     );
-    $redirect = $track->getFormURLWithID($fup->getField('items_id'));
+    $redirect = $track->getFormURLWithID($fup->fields['items_id']);
     $handled = true;
 } elseif (
     (
@@ -79,7 +79,7 @@ if (isset($_POST["add"])) {
         $fup->add($_POST);
 
         Event::log(
-            $fup->getField('items_id'),
+            $fup->fields['items_id'],
             strtolower($_POST['itemtype']),
             4,
             "tracking",
@@ -92,28 +92,28 @@ if (isset($_POST["add"])) {
     $fup->update($_POST);
 
     Event::log(
-        $fup->getField('items_id'),
+        $fup->fields['items_id'],
         strtolower($_POST['itemtype']),
         4,
         "tracking",
         //TRANS: %s is the user login
         sprintf(__('%s updates a followup'), $_SESSION["glpiname"])
     );
-    $redirect = $track->getFormURLWithID($fup->getField('items_id'));
+    $redirect = $track->getFormURLWithID($fup->fields['items_id']);
     $handled = true;
 } elseif (isset($_POST["purge"])) {
     $fup->check($_POST['id'], PURGE);
     $fup->delete($_POST, true);
 
     Event::log(
-        $fup->getField('items_id'),
+        $fup->fields['items_id'],
         strtolower($_POST['itemtype']),
         4,
         "tracking",
         //TRANS: %s is the user login
         sprintf(__('%s purges a followup'), $_SESSION["glpiname"])
     );
-    $redirect = $track->getFormURLWithID($fup->getField('items_id'));
+    $redirect = $track->getFormURLWithID($fup->fields['items_id']);
 }
 
 if ($handled) {

--- a/front/knowbaseitem.php
+++ b/front/knowbaseitem.php
@@ -56,7 +56,7 @@ if (
 ) {
     if (in_array($_GET["item_itemtype"], $CFG_GLPI['kb_types']) && $item = getItemForItemtype($_GET["item_itemtype"])) {
         if ($item->can($_GET["item_items_id"], READ)) {
-            $_GET["contains"] = $item->getField('name');
+            $_GET["contains"] = $item->fields['name'];
         }
     }
 }

--- a/front/ticketsatisfaction.form.php
+++ b/front/ticketsatisfaction.form.php
@@ -45,7 +45,7 @@ if (isset($_POST["update"])) {
     $inquest->update($_POST);
 
     Event::log(
-        $inquest->getField('tickets_id'),
+        $inquest->fields['tickets_id'],
         "ticket",
         4,
         "tracking",

--- a/src/AuthMail.php
+++ b/src/AuthMail.php
@@ -234,7 +234,7 @@ class AuthMail extends CommonDBTM
      */
     public function showFormTestMail()
     {
-        $ID = $this->getField('id');
+        $ID = $this->getID();
 
         if ($this->getFromDB($ID)) {
             $twig_params = [
@@ -374,7 +374,7 @@ TWIG, $twig_params);
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
         /** @var CommonDBTM $item */
-        if (!$withtemplate && $item->can($item->getField('id'), READ)) {
+        if (!$withtemplate && $item->can($item->getID(), READ)) {
             $ong = [];
             $ong[1] = self::createTabEntry(_x('button', 'Test'), icon: 'ti ti-stethoscope');
 

--- a/src/CalendarSegment.php
+++ b/src/CalendarSegment.php
@@ -371,7 +371,7 @@ class CalendarSegment extends CommonDBChild
     {
         global $DB;
 
-        $ID = $calendar->getField('id');
+        $ID = $calendar->getID();
         if (!$calendar->can($ID, READ)) {
             return;
         }

--- a/src/Calendar_Holiday.php
+++ b/src/Calendar_Holiday.php
@@ -68,7 +68,7 @@ class Calendar_Holiday extends CommonDBRelation
     {
         global $DB;
 
-        $ID = $calendar->getField('id');
+        $ID = $calendar->getID();
         if (!$calendar->can($ID, READ)) {
             return false;
         }

--- a/src/Cartridge.php
+++ b/src/Cartridge.php
@@ -141,8 +141,8 @@ class Cartridge extends CommonDBRelation
             $printer = new Printer();
             if (
                 $printer->getFromDB($this->fields['printers_id'])
-                && (($this->fields['pages'] > $printer->getField('last_pages_counter'))
-                    || ($this->oldvalues['pages'] == $printer->getField('last_pages_counter')))
+                && (($this->fields['pages'] > $printer->fields['last_pages_counter'])
+                    || ($this->oldvalues['pages'] == $printer->fields['last_pages_counter']))
             ) {
                 $printer->update([
                     'id' => $printer->getID(),
@@ -326,7 +326,7 @@ class Cartridge extends CommonDBRelation
         if ($this->getFromDB($ID)) {
             $printer = new Printer();
             $toadd   = [];
-            if ($printer->getFromDB($this->getField("printers_id"))) {
+            if ($printer->getFromDB($this->fields["printers_id"])) {
                 $toadd['pages'] = $printer->fields['last_pages_counter'];
             }
 
@@ -350,7 +350,7 @@ class Cartridge extends CommonDBRelation
                     __('Uninstalling a cartridge'),
                 ];
                 Log::history(
-                    $this->getField("printers_id"),
+                    $this->fields["printers_id"],
                     'Printer',
                     $changes,
                     0,
@@ -746,7 +746,7 @@ TWIG, ['counts' => $counts, 'highlight' => $highlight]);
     {
         global $DB;
 
-        $tID = $cartitem->getField('id');
+        $tID = $cartitem->getID();
         if (!$cartitem->can($tID, READ)) {
             return false;
         }
@@ -941,7 +941,7 @@ TWIG, ['counts' => $counts, 'highlight' => $highlight]);
     public static function showAddForm(CartridgeItem $cartitem)
     {
 
-        $ID = $cartitem->getField('id');
+        $ID = $cartitem->getID();
         if (!$cartitem->can($ID, UPDATE)) {
             return false;
         }
@@ -992,7 +992,7 @@ TWIG, $twig_params);
     {
         global $DB;
 
-        $instID = $printer->getField('id');
+        $instID = $printer->getID();
         if (!self::canView()) {
             return false;
         }
@@ -1231,10 +1231,10 @@ TWIG, ['printer_id' => $printer->getID()]);
             return false;
         }
 
-        $printer->check($this->getField('printers_id'), UPDATE);
+        $printer->check($this->fields['printers_id'], UPDATE);
 
         $cartitem = new CartridgeItem();
-        $cartitem->getFromDB($this->getField('cartridgeitems_id'));
+        $cartitem->getFromDB($this->fields['cartridgeitems_id']);
 
         TemplateRenderer::getInstance()->display('pages/assets/cartridge.html.twig', [
             'item' => $this,
@@ -1277,7 +1277,7 @@ TWIG, ['printer_id' => $printer->getID()]);
      */
     public static function countForCartridgeItem(CartridgeItem $item)
     {
-        return countElementsInTable(['glpi_cartridges'], ['glpi_cartridges.cartridgeitems_id' => $item->getField('id')]);
+        return countElementsInTable(['glpi_cartridges'], ['glpi_cartridges.cartridgeitems_id' => $item->getID()]);
     }
 
     /**
@@ -1287,7 +1287,7 @@ TWIG, ['printer_id' => $printer->getID()]);
      */
     public static function countForPrinter(Printer $item)
     {
-        return countElementsInTable(['glpi_cartridges'], ['glpi_cartridges.printers_id' => $item->getField('id')]);
+        return countElementsInTable(['glpi_cartridges'], ['glpi_cartridges.printers_id' => $item->getID()]);
     }
 
     public static function displayTabContentForItem(CommonGLPI $item, $tabnum = 1, $withtemplate = 0)

--- a/src/Certificate_Item.php
+++ b/src/Certificate_Item.php
@@ -69,8 +69,9 @@ class Certificate_Item extends CommonDBRelation
     public static function cleanForItem(CommonDBTM $item)
     {
         $temp = new self();
-        $temp->deleteByCriteria(['itemtype' => $item::class,
-            'items_id' => $item->getField('id'),
+        $temp->deleteByCriteria([
+            'itemtype' => $item::class,
+            'items_id' => $item->getID(),
         ]);
     }
 
@@ -304,7 +305,7 @@ class Certificate_Item extends CommonDBRelation
     public static function showForItem(CommonDBTM $item, $withtemplate = 0)
     {
 
-        $ID = $item->getField('id');
+        $ID = $item->getID();
 
         if (
             $item->isNewID($ID)

--- a/src/Change_Problem.php
+++ b/src/Change_Problem.php
@@ -108,7 +108,7 @@ class Change_Problem extends CommonITILObject_CommonITILObject
     {
         global $DB;
 
-        $ID = $problem->getField('id');
+        $ID = $problem->getID();
         if (!$problem->can($ID, READ)) {
             return;
         }
@@ -200,7 +200,7 @@ class Change_Problem extends CommonITILObject_CommonITILObject
     {
         global $DB;
 
-        $ID = $change->getField('id');
+        $ID = $change->getID();
         if (!$change->can($ID, READ)) {
             return;
         }

--- a/src/Change_Ticket.php
+++ b/src/Change_Ticket.php
@@ -212,7 +212,7 @@ class Change_Ticket extends CommonITILObject_CommonITILObject
     {
         global $DB;
 
-        $ID = $change->getField('id');
+        $ID = $change->getID();
         if (!$change->can($ID, READ)) {
             return;
         }
@@ -313,7 +313,7 @@ class Change_Ticket extends CommonITILObject_CommonITILObject
     {
         global $DB;
 
-        $ID = $ticket->getField('id');
+        $ID = $ticket->getID();
         if (!$ticket->can($ID, READ)) {
             return;
         }

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -1785,7 +1785,7 @@ class CommonDBTM extends CommonGLPI
                             if (
                                 Infocom::canApplyOn($this)
                                 && in_array('states_id', $this->updates)
-                                && ($this->getField('is_template') != NOT_AVAILABLE)
+                                && !$this->isTemplate()
                             ) {
                                 //Check if we have to automatically fill dates
                                 Infocom::manageDateOnStatusChange($this, false);
@@ -4472,7 +4472,7 @@ class CommonDBTM extends CommonGLPI
                 }
             }
             // Add information on item in trashbin
-            if ($item->isField('is_deleted') && $item->getField('is_deleted')) {
+            if ($item->isDeleted()) {
                 $double_text = sprintf(__s('%1$s - %2$s'), $double_text, __s('Item in the trashbin'));
             }
 
@@ -5698,7 +5698,7 @@ class CommonDBTM extends CommonGLPI
             $title = __s('You can define an autofill template');
         } elseif ($this->isTemplate()) {
             if ($value === null) {
-                $value = $this->getField($field);
+                $value = $this->fields[$field];
             }
             $len = Toolbox::strlen($value);
             if (

--- a/src/CommonITILTask.php
+++ b/src/CommonITILTask.php
@@ -270,7 +270,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
     public function canReadITILItem()
     {
         $item = static::getItilObjectItemInstance();
-        if (!$item->can($this->getField($item->getForeignKeyField()), READ)) {
+        if (!$item->can($this->fields[$item::getForeignKeyField()], READ)) {
             return false;
         }
         return true;
@@ -286,7 +286,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
     public function canUpdateITILItem()
     {
         $item = static::getItilObjectItemInstance();
-        if (!$item->can($this->getField($item->getForeignKeyField()), UPDATE)) {
+        if (!$item->can($this->fields[$item::getForeignKeyField()], UPDATE)) {
             return false;
         }
         return true;
@@ -401,7 +401,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
             $this->fields['id'],
         ];
         Log::history(
-            $this->getField($item::getForeignKeyField()),
+            $this->fields[$item::getForeignKeyField()],
             $item::class,
             $changes,
             static::class,
@@ -610,7 +610,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
             if (!$proceed) {
                 if (
                     isset($this->input['_status'])
-                    && $this->input['_status'] != $item->getField('status')
+                    && $this->input['_status'] != $item->fields['status']
                 ) {
                     $proceed = true;
                 }
@@ -648,7 +648,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
                 $this->fields['id'],
             ];
             Log::history(
-                $this->getField($item->getForeignKeyField()),
+                $this->fields[$item->getForeignKeyField()],
                 $item::class,
                 $changes,
                 static::class,
@@ -849,7 +849,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
             $this->fields['id'],
         ];
         Log::history(
-            $this->getField($this->input["_job"]->getForeignKeyField()),
+            $this->fields[$this->input["_job"]->getForeignKeyField()],
             $this->input["_job"]->getTYpe(),
             $changes,
             static::class,

--- a/src/CommonTreeDropdown.php
+++ b/src/CommonTreeDropdown.php
@@ -265,8 +265,8 @@ abstract class CommonTreeDropdown extends CommonDropdown
             $currentNode = clone $this;
 
             if ($currentNode->getFromDB($ID)) {
-                $currentNodeCompleteName = $currentNode->getField("completename");
-                $nextNodeLevel           = ($currentNode->getField("level") + 1);
+                $currentNodeCompleteName = $currentNode->fields['completename'];
+                $nextNodeLevel           = ($currentNode->fields['level'] + 1);
             } else {
                 $nextNodeLevel = 1;
             }

--- a/src/Computer.php
+++ b/src/Computer.php
@@ -259,7 +259,7 @@ class Computer extends CommonDBTM implements AssignableItemInterface, DCBreadcru
                 foreach ($items_result as $data) {
                     $tID = $data['items_id_peripheral'];
                     $item->getFromDB($tID);
-                    if (!$item->getField('is_global')) {
+                    if (!$item->isGlobal()) {
                         $item_input = $changes;
                         $item_input['id'] = $item->getID();
                         //propage is_dynamic value if needed to prevent locked fields

--- a/src/Consumable.php
+++ b/src/Consumable.php
@@ -583,7 +583,7 @@ class Consumable extends CommonDBChild
         global $DB;
 
         $itemtype = $user::class;
-        $items_id = $user->getField('id');
+        $items_id = $user->getID();
 
         $start       = (int) ($_GET["start"] ?? 0);
         $sort        = $_GET["sort"] ?? "";
@@ -842,7 +842,7 @@ class Consumable extends CommonDBChild
      **/
     public static function countForConsumableItem(ConsumableItem $item)
     {
-        return countElementsInTable(['glpi_consumables'], ['glpi_consumables.consumableitems_id' => $item->getField('id')]);
+        return countElementsInTable(['glpi_consumables'], ['glpi_consumables.consumableitems_id' => $item->getID()]);
     }
 
     /**
@@ -854,7 +854,7 @@ class Consumable extends CommonDBChild
     {
         return countElementsInTable(['glpi_consumables'], [
             'glpi_consumables.itemtype' => 'User',
-            'glpi_consumables.items_id' => $item->getField('id'),
+            'glpi_consumables.items_id' => $item->getID(),
             'NOT' => ['glpi_consumables.date_out' => 'NULL'],
         ]);
     }

--- a/src/Document_Item.php
+++ b/src/Document_Item.php
@@ -494,9 +494,7 @@ TWIG, $twig_params);
      **/
     public static function showForItem(CommonDBTM $item, $withtemplate = 0): bool
     {
-        $ID = $item->getField('id');
-
-        if ($item->isNewID($ID)) {
+        if ($item->isNewItem()) {
             return false;
         }
 

--- a/src/Domain_Item.php
+++ b/src/Domain_Item.php
@@ -59,8 +59,9 @@ class Domain_Item extends CommonDBRelation
     {
         $temp = new self();
         $temp->deleteByCriteria(
-            ['itemtype' => $item::class,
-                'items_id' => $item->getField('id'),
+            [
+                'itemtype' => $item::class,
+                'items_id' => $item->getID(),
             ]
         );
     }
@@ -475,9 +476,7 @@ TWIG, $twig_params);
     {
         global $DB;
 
-        $ID = $item->getField('id');
-
-        if ($item->isNewID($ID) || !Session::haveRight('domain', READ)) {
+        if ($item->isNewItem() || !Session::haveRight('domain', READ)) {
             return false;
         }
 

--- a/src/Entity.php
+++ b/src/Entity.php
@@ -302,7 +302,7 @@ class Entity extends CommonTreeDropdown implements LinkableToTilesInterface, Pro
     public function canCreateItem(): bool
     {
         // Check the parent
-        return Session::haveRecursiveAccessToEntity($this->getField('entities_id'));
+        return Session::haveRecursiveAccessToEntity($this->fields['entities_id']);
     }
 
     public static function canUpdate(): bool
@@ -314,13 +314,13 @@ class Entity extends CommonTreeDropdown implements LinkableToTilesInterface, Pro
     public function canUpdateItem(): bool
     {
         // Check the current entity
-        return Session::haveAccessToEntity($this->getField('id'));
+        return Session::haveAccessToEntity($this->getID());
     }
 
     public function canViewItem(): bool
     {
         // Check the current entity
-        return Session::haveAccessToEntity($this->getField('id'));
+        return Session::haveAccessToEntity($this->getID());
     }
 
     public static function isNewID($ID): bool
@@ -1700,7 +1700,7 @@ class Entity extends CommonTreeDropdown implements LinkableToTilesInterface, Pro
         // root entity first
         $ent = new self();
         if ($ent->getFromDB(0)) {  // always exists
-            $val = $ent->getField($field);
+            $val = $ent->fields[$field];
             if ($val > 0) {
                 $entities[0] = $val;
             }
@@ -1736,8 +1736,7 @@ class Entity extends CommonTreeDropdown implements LinkableToTilesInterface, Pro
 
     public static function showStandardOptions(Entity $entity): bool
     {
-        $ID = $entity->getField('id');
-        if (!$entity->can($ID, READ)) {
+        if (!$entity->can($entity->getID(), READ)) {
             return false;
         }
         TemplateRenderer::getInstance()->display('pages/admin/entity/address.html.twig', [
@@ -1751,8 +1750,7 @@ class Entity extends CommonTreeDropdown implements LinkableToTilesInterface, Pro
 
     public static function showAdvancedOptions(Entity $entity): bool
     {
-        $ID          = $entity->getField('id');
-        if (!$entity->can($ID, READ)) {
+        if (!$entity->can($entity->getID(), READ)) {
             return false;
         }
         TemplateRenderer::getInstance()->display('pages/admin/entity/advanced.html.twig', [
@@ -1767,7 +1765,7 @@ class Entity extends CommonTreeDropdown implements LinkableToTilesInterface, Pro
 
     public static function showInventoryOptions(Entity $entity): bool
     {
-        $ID = $entity->getField('id');
+        $ID = $entity->getID();
         if (!$entity->can($ID, READ)) {
             return false;
         }
@@ -1856,7 +1854,7 @@ class Entity extends CommonTreeDropdown implements LinkableToTilesInterface, Pro
     public static function showNotificationOptions(Entity $entity): bool
     {
 
-        $ID = $entity->getField('id');
+        $ID = $entity->getID();
         if (
             !$entity->can($ID, READ)
             || !Notification::canView()
@@ -1901,7 +1899,7 @@ class Entity extends CommonTreeDropdown implements LinkableToTilesInterface, Pro
             'approval_reminder_repeat_interval' => $entity->getInheritedValueBadge('approval_reminder_repeat_interval'),
         ];
         if ($entity->fields['delay_send_emails'] == self::CONFIG_PARENT) {
-            $tid = self::getUsedConfig('delay_send_emails', $entity->getField('entities_id'));
+            $tid = self::getUsedConfig('delay_send_emails', $entity->fields['entities_id']);
             $inheritance_labels['delay_send_emails'] = self::inheritedValue(
                 $entity->getValueToDisplay('delay_send_emails', $tid, ['html' => true]),
                 false,
@@ -1909,7 +1907,7 @@ class Entity extends CommonTreeDropdown implements LinkableToTilesInterface, Pro
             );
         }
         if ($entity->fields['is_notif_enable_default'] == self::CONFIG_PARENT) {
-            $tid = self::getUsedConfig('is_notif_enable_default', $entity->getField('entities_id'));
+            $tid = self::getUsedConfig('is_notif_enable_default', $entity->fields['entities_id']);
             $inheritance_labels['is_notif_enable_default'] = self::inheritedValue(
                 self::getSpecificValueToDisplay('is_notif_enable_default', $tid),
                 false,
@@ -1943,7 +1941,7 @@ class Entity extends CommonTreeDropdown implements LinkableToTilesInterface, Pro
 
     public static function showUiCustomizationOptions(Entity $entity): bool
     {
-        $ID = $entity->getField('id');
+        $ID = $entity->getID();
         if (!$entity->can($ID, READ) || !Session::haveRight(Config::$rightname, UPDATE)) {
             return false;
         }
@@ -1990,7 +1988,7 @@ class Entity extends CommonTreeDropdown implements LinkableToTilesInterface, Pro
 
     public static function showSecurityOptions(Entity $entity): bool
     {
-        $ID = $entity->getField('id');
+        $ID = $entity->getID();
         if (!$entity->can($ID, READ)) {
             return false;
         }
@@ -2111,7 +2109,7 @@ class Entity extends CommonTreeDropdown implements LinkableToTilesInterface, Pro
 
         if (
             $entity->getFromDB($entities_id)
-            && ($entity->getField('authldaps_id') > 0)
+            && ($entity->fields['authldaps_id'] > 0)
         ) {
             return true;
         }
@@ -2127,7 +2125,7 @@ class Entity extends CommonTreeDropdown implements LinkableToTilesInterface, Pro
 
     public static function showHelpdeskOptions(Entity $entity): bool
     {
-        $ID = $entity->getField('id');
+        $ID = $entity->getID();
         if (
             !$entity->can($ID, READ)
             || !Session::haveRightsOr(

--- a/src/Glpi/Asset/Asset_PeripheralAsset.php
+++ b/src/Glpi/Asset/Asset_PeripheralAsset.php
@@ -120,7 +120,7 @@ final class Asset_PeripheralAsset extends CommonDBRelation
             $updates = [];
 
             if (
-                $asset->fields['locations_id'] !== $peripheral->getField('locations_id')
+                $asset->fields['locations_id'] !== $peripheral->fields['locations_id']
                 && Entity::getUsedConfig('is_location_autoupdate', $asset->getEntityID())
             ) {
                 $updates['locations_id'] = $asset->fields['locations_id'];
@@ -131,9 +131,9 @@ final class Asset_PeripheralAsset extends CommonDBRelation
             }
             if (
                 (Entity::getUsedConfig('is_user_autoupdate', $asset->getEntityID())
-                && ($asset->fields['users_id'] !== $peripheral->getField('users_id')))
+                && ($asset->fields['users_id'] !== $peripheral->fields['users_id']))
                 || (Entity::getUsedConfig('is_group_autoupdate', $asset->getEntityID())
-                 && ($asset->fields['groups_id'] !== $peripheral->getField('groups_id')))
+                 && ($asset->fields['groups_id'] !== $peripheral->fields['groups_id']))
             ) {
                 if (Entity::getUsedConfig('is_user_autoupdate', $asset->getEntityID())) {
                     $updates['users_id'] = $asset->fields['users_id'];

--- a/src/Glpi/Controller/Knowbase/KnowbaseItemController.php
+++ b/src/Glpi/Controller/Knowbase/KnowbaseItemController.php
@@ -190,7 +190,7 @@ final class KnowbaseItemController extends AbstractController
         if (empty($contains)) {
             if (in_array($itemtype, $CFG_GLPI['kb_types'], true) && $item = getItemForItemtype($itemtype)) {
                 if ($item->can($items_id, READ)) {
-                    $contains = $item->getField('name');
+                    $contains = $item->fields['name'];
                 }
             }
         }

--- a/src/Glpi/Socket.php
+++ b/src/Glpi/Socket.php
@@ -788,7 +788,7 @@ class Socket extends CommonDBChild
     {
         global $DB;
 
-        $ID       = $item->getField('id');
+        $ID       = $item->getID();
         $item->check($ID, READ);
         $canedit  = $item->canEdit($ID);
 

--- a/src/Group.php
+++ b/src/Group.php
@@ -136,16 +136,16 @@ class Group extends CommonTreeDropdown
                     }
                     $ong[4] = self::createTabEntry(__('Child groups'), $nb, $item::class);
 
-                    if ($item->getField('is_itemgroup')) {
+                    if ($item->fields['is_itemgroup']) {
                         $count = countElementsInTable(Group_Item::getTable(), ['groups_id' => $item->getID(), 'type' => Group_Item::GROUP_TYPE_NORMAL]);
                         $ong[1] = self::createTabEntry(__('Used items'), $count, $item::class, 'ti ti-package');
                     }
-                    if ($item->getField('is_assign')) {
+                    if ($item->fields['is_assign']) {
                         $count = countElementsInTable(Group_Item::getTable(), ['groups_id' => $item->getID(), 'type' => Group_Item::GROUP_TYPE_TECH]);
                         $ong[2] = self::createTabEntry(__('Managed items'), $count, $item::class, 'ti ti-package');
                     }
                     if (
-                        $item->getField('is_usergroup')
+                        $item->fields['is_usergroup']
                         && self::canUpdate()
                         && Session::haveRight("user", User::UPDATEAUTHENT)
                         && AuthLDAP::useAuthLdap()
@@ -755,7 +755,7 @@ class Group extends CommonTreeDropdown
             }
 
             $assignees = [];
-            if ($grps = $item->getField($tech ? 'groups_id_tech' : 'groups_id')) {
+            if ($grps = $item->fields[$tech ? 'groups_id_tech' : 'groups_id']) {
                 foreach ($grps as $grp) {
                     if (!isset($group_links[$grp]) && $group->getFromDB($grp)) {
                         $group_links[$grp] = $group->getLink(['comments' => true]);
@@ -763,7 +763,7 @@ class Group extends CommonTreeDropdown
                     $assignees[] = $group_links[$grp] ?? '';
                 }
             }
-            if ($usr = $item->getField($tech ? 'users_id_tech' : 'users_id')) {
+            if ($usr = $item->fields[$tech ? 'users_id_tech' : 'users_id']) {
                 if (!isset($user_links[$usr]) && $tuser->getFromDB($usr)) {
                     $user_links[$usr] = $tuser->getLink(['comments' => true]);
                 }

--- a/src/IPAddress.php
+++ b/src/IPAddress.php
@@ -169,8 +169,8 @@ class IPAddress extends CommonDBChild
             if ($input['itemtype'] == 'NetworkName') {
                 $name = new NetworkName();
                 if ($name->getFromDB($input['items_id'])) {
-                    if ($port = getItemForItemtype($name->getField('itemtype'))) {
-                        if ($port->getFromDB($name->getField('items_id'))) {
+                    if ($port = getItemForItemtype($name->fields['itemtype'])) {
+                        if ($port->getFromDB($name->fields['items_id'])) {
                             if (isset($port->fields['itemtype']) && isset($port->fields['items_id'])) {
                                 $input['mainitemtype'] = $port->fields['itemtype'];
                                 $input['mainitems_id'] = $port->fields['items_id'];
@@ -367,7 +367,7 @@ class IPAddress extends CommonDBChild
         if (
             ($item instanceof CommonDBTM)
             && $item->getID()
-            && $item->can($item->getField('id'), READ)
+            && $item->can($item->getID(), READ)
         ) {
             $nb = 0;
             if ($_SESSION['glpishow_count_on_tabs']) {

--- a/src/ITILFollowup.php
+++ b/src/ITILFollowup.php
@@ -91,7 +91,7 @@ class ITILFollowup extends CommonDBChild
             $itemtype = $this->getItilObjectItemType();
             $item     = getItemForItemtype($itemtype);
         }
-        if (!$item->can($this->getField($item->getForeignKeyField()), READ)) {
+        if (!$item->can($this->fields[$item::getForeignKeyField()], READ)) {
             return false;
         }
         return true;
@@ -148,7 +148,7 @@ class ITILFollowup extends CommonDBChild
         } else {
             $itilobject = getItemForItemtype($this->fields['itemtype']);
         }
-        if (!$itilobject->can($this->getField('items_id'), READ)) {
+        if (!$itilobject->can($this->fields['items_id'], READ)) {
             return false;
         }
         if (Session::haveRight(self::$rightname, self::SEEPRIVATE)) {
@@ -190,7 +190,7 @@ class ITILFollowup extends CommonDBChild
         }
 
         if (
-            !$itilobject->can($this->getField('items_id'), READ)
+            !$itilobject->can($this->fields['items_id'], READ)
             // No validation for closed tickets
             || in_array($itilobject->fields['status'], $itilobject->getClosedStatusArray())
             && !$itilobject->canReopen()
@@ -208,7 +208,7 @@ class ITILFollowup extends CommonDBChild
         } else {
             $itilobject = getItemForItemtype($this->fields['itemtype']);
         }
-        if (!$itilobject->can($this->getField('items_id'), READ)) {
+        if (!$itilobject->can($this->fields['items_id'], READ)) {
             return false;
         }
 
@@ -235,7 +235,7 @@ class ITILFollowup extends CommonDBChild
         } else {
             $itilobject = getItemForItemtype($this->fields['itemtype']);
         }
-        if (!$itilobject instanceof CommonITILObject || !$itilobject->can($this->getField('items_id'), READ)) {
+        if (!$itilobject instanceof CommonITILObject || !$itilobject->can($this->fields['items_id'], READ)) {
             return false;
         }
 
@@ -295,7 +295,7 @@ class ITILFollowup extends CommonDBChild
             $this->fields['id'],
         ];
         Log::history(
-            $this->getField('items_id'),
+            $this->fields['items_id'],
             get_class($parentitem),
             $changes,
             static::class,
@@ -360,7 +360,7 @@ class ITILFollowup extends CommonDBChild
             $this->fields['id'],
         ];
         Log::history(
-            $this->getField(self::$items_id),
+            $this->fields[self::$items_id],
             $this->fields['itemtype'],
             $changes,
             static::class,
@@ -586,7 +586,7 @@ class ITILFollowup extends CommonDBChild
             $this->fields['id'],
         ];
         Log::history(
-            $this->getField('items_id'),
+            $this->fields['items_id'],
             $this->fields['itemtype'],
             $changes,
             static::class,

--- a/src/Infocom.php
+++ b/src/Infocom.php
@@ -204,7 +204,7 @@ class Infocom extends CommonDBChild
         return countElementsInTable(
             'glpi_infocoms',
             [
-                'suppliers_id' => $item->getField('id'),
+                'suppliers_id' => $item->getID(),
                 'NOT' => ['itemtype' => ['ConsumableItem', 'CartridgeItem', 'Software']],
             ] + getEntitiesRestrictCriteria('glpi_infocoms', '', $_SESSION['glpiactiveentities'])
         );
@@ -1389,7 +1389,7 @@ HTML;
             return;
         }
 
-        $dev_ID   = $item->getField('id');
+        $dev_ID   = $item->getID();
         $ic       = new self();
 
         if (in_array($item::class, self::getExcludedTypes())) {

--- a/src/Item_Environment.php
+++ b/src/Item_Environment.php
@@ -101,7 +101,7 @@ final class Item_Environment extends CommonDBChild
         global $DB;
 
         $itemtype = $item::class;
-        $items_id = $item->getField('id');
+        $items_id = $item->getID();
 
         $start       = intval($_GET["start"] ?? 0);
         $sort        = $_GET["sort"] ?? "";

--- a/src/Item_Process.php
+++ b/src/Item_Process.php
@@ -100,7 +100,7 @@ class Item_Process extends CommonDBChild
         global $DB;
 
         $itemtype = $item::class;
-        $items_id = $item->getField('id');
+        $items_id = $item->getID();
 
         $start       = intval($_GET["start"] ?? 0);
         $sort        = $_GET["sort"] ?? "";

--- a/src/Item_SoftwareLicense.php
+++ b/src/Item_SoftwareLicense.php
@@ -180,9 +180,9 @@ class Item_SoftwareLicense extends CommonDBRelation
                             $number += SoftwareLicense_User::countForLicense($license_id);
 
                             if (
-                                $license->getField('number') != -1
-                                && $number >= $license->getField('number')
-                                && !$license->getField('allow_overquota')
+                                $license->fields['number'] != -1
+                                && $number >= $license->fields['number']
+                                && !$license->fields['allow_overquota']
                             ) {
                                 $can_add_user = false;
                                 break;
@@ -317,9 +317,9 @@ class Item_SoftwareLicense extends CommonDBRelation
                         if ($input['itemtype'] == User::class) {
                             $item_licence = new SoftwareLicense_User();
                             if (
-                                $license->getField('number') != -1
-                                && $number >= $license->getField('number')
-                                && !$license->getField('allow_overquota')
+                                $license->fields['number'] != -1
+                                && $number >= $license->fields['number']
+                                && !$license->fields['allow_overquota']
                             ) {
                                 $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                                 $ma->addMessage(sprintf(__s('Maximum number of items reached for license "%s".'), htmlescape($license->getName())));
@@ -519,7 +519,7 @@ class Item_SoftwareLicense extends CommonDBRelation
     {
         global $DB;
 
-        $softwarelicense_id = $license->getField('id');
+        $softwarelicense_id = $license->getID();
         $license_table = SoftwareLicense::getTable();
         $item_license_table = self::getTable(self::class);
 
@@ -632,8 +632,8 @@ class Item_SoftwareLicense extends CommonDBRelation
         //and over-quota is not allowed, do not allow to add more assets
         if (
             $canedit
-            && ($license->getField('number') == -1 || $number < $license->getField('number')
-            || $license->getField('allow_overquota'))
+            && ($license->fields['number'] == -1 || $number < $license->fields['number']
+            || $license->fields['allow_overquota'])
         ) {
             echo "<form method='post' action='" . htmlescape(Item_SoftwareLicense::getFormURL()) . "'>";
             echo "<input type='hidden' name='softwarelicenses_id' value='$searchID'>";

--- a/src/Item_SoftwareVersion.php
+++ b/src/Item_SoftwareVersion.php
@@ -119,12 +119,8 @@ class Item_SoftwareVersion extends CommonDBRelation
             || (!isset($input['is_deleted_item']) && $item->maybeDeleted())
         ) {
             if ($item->getFromDB($input['items_id'])) {
-                if ($item->maybeTemplate()) {
-                    $input['is_template_item'] = $item->getField('is_template');
-                }
-                if ($item->maybeDeleted()) {
-                    $input['is_deleted_item']  = $item->getField('is_deleted');
-                }
+                $input['is_template_item'] = $item->isTemplate();
+                $input['is_deleted_item']  = $item->isDeleted();
             } else {
                 return false;
             }
@@ -259,8 +255,8 @@ class Item_SoftwareVersion extends CommonDBRelation
             return $DB->update(
                 static::getTable(),
                 [
-                    'is_template_item'  => $item->maybeTemplate() ? $item->getField('is_template') : 0,
-                    'is_deleted_item'   => $item->maybeDeleted() ? $item->getField('is_deleted') : 0,
+                    'is_template_item'  => $item->isTemplate(),
+                    'is_deleted_item'   => $item->isDeleted(),
                 ],
                 [
                     'items_id' => $items_id,
@@ -427,7 +423,7 @@ class Item_SoftwareVersion extends CommonDBRelation
      **/
     public static function showForSoftware(Software $software)
     {
-        self::showInstallations($software->getField('id'), 'softwares_id');
+        self::showInstallations($software->getID(), 'softwares_id');
     }
 
     /**
@@ -439,7 +435,7 @@ class Item_SoftwareVersion extends CommonDBRelation
      **/
     public static function showForVersion(SoftwareVersion $version)
     {
-        self::showInstallations($version->getField('id'), 'id');
+        self::showInstallations($version->getID(), 'id');
     }
 
     /**
@@ -836,7 +832,7 @@ class Item_SoftwareVersion extends CommonDBRelation
     {
         global $DB;
 
-        $softwareversions_id = $version->getField('id');
+        $softwareversions_id = $version->getID();
 
         if (!Software::canView() || !$softwareversions_id) {
             return;
@@ -935,7 +931,7 @@ class Item_SoftwareVersion extends CommonDBRelation
                 ],
             ],
             'WHERE'     => [
-                "{$selftable}.items_id" => $item->getField('id'),
+                "{$selftable}.items_id" => $item->getID(),
                 "{$selftable}.itemtype" => $item::class,
             ] + getEntitiesRestrictCriteria('glpi_softwares', '', '', true),
             'ORDER'     => ['softname', 'version'],

--- a/src/Itil_Project.php
+++ b/src/Itil_Project.php
@@ -127,7 +127,7 @@ class Itil_Project extends CommonDBRelation
     {
         global $DB, $CFG_GLPI;
 
-        $ID = $project->getField('id');
+        $ID = $project->getID();
         if (!$project->can($ID, READ)) {
             return false;
         }

--- a/src/Knowbase.php
+++ b/src/Knowbase.php
@@ -95,7 +95,7 @@ class Knowbase extends CommonGLPI
         if (isset($_GET["itemtype"], $_GET["items_id"]) && !isset($_GET["contains"])) {
             if (in_array($_GET["item_itemtype"], $CFG_GLPI['kb_types'], true) && $item = getItemForItemtype($_GET["itemtype"])) {
                 if ($item->can($_GET["item_items_id"], READ)) {
-                    $_GET["contains"] = $item->getField('name');
+                    $_GET["contains"] = $item->fields['name'];
                 }
             }
         }

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -2289,7 +2289,7 @@ TWIG, $twig_params);
     protected function getShowVisibilityDropdownParams()
     {
         $params = parent::getShowVisibilityDropdownParams();
-        $params['right'] = ($this->getField('is_faq') ? 'faq' : 'knowbase');
+        $params['right'] = $this->fields['is_faq'] ? 'faq' : 'knowbase';
         $params['allusers'] = 1;
         return $params;
     }

--- a/src/LevelAgreement.php
+++ b/src/LevelAgreement.php
@@ -156,7 +156,7 @@ abstract class LevelAgreement extends CommonDBChild
             $this->check($ID, READ);
         } else {
             // Create item
-            $options[static::$items_id] = $slm->getField('id');
+            $options[static::$items_id] = $slm->getID();
 
             // force itemtype of parent
             static::$itemtype = get_class($slm);
@@ -498,7 +498,7 @@ TWIG, $twig_params);
                     if ($_SESSION['glpishow_count_on_tabs']) {
                         $nb = countElementsInTable(
                             self::getTable(),
-                            ['slms_id' => $item->getField('id')]
+                            ['slms_id' => $item->getID()]
                         );
                     }
                     return self::createTabEntry(static::getTypeName($nb), $nb, $item::class);

--- a/src/LevelAgreementLevel.php
+++ b/src/LevelAgreementLevel.php
@@ -437,7 +437,7 @@ abstract class LevelAgreementLevel extends RuleTicket
     {
         global $DB;
 
-        $ID = $la->getField('id');
+        $ID = $la->getID();
         if (!$la->can($ID, READ)) {
             return;
         }

--- a/src/NetworkAlias.php
+++ b/src/NetworkAlias.php
@@ -81,7 +81,7 @@ class NetworkAlias extends FQDNLabel
 
         $lastItem = $recursiveItems[count($recursiveItems) - 1];
 
-        $options['entities_id'] = $lastItem->getField('entities_id');
+        $options['entities_id'] = $lastItem->fields['entities_id'];
         $this->showFormHeader($options);
 
         echo "<tr class='tab_bg_1'><td>";
@@ -472,7 +472,7 @@ class NetworkAlias extends FQDNLabel
         if (
             ($item instanceof CommonDBTM)
             && $item->getID()
-            && $item->can($item->getField('id'), READ)
+            && $item->can($item->getID(), READ)
         ) {
             $nb = 0;
             if ($_SESSION['glpishow_count_on_tabs']) {

--- a/src/NetworkName.php
+++ b/src/NetworkName.php
@@ -98,7 +98,7 @@ class NetworkName extends FQDNLabel
         $recursiveItems = $this->recursivelyGetItems();
         if (count($recursiveItems) !== 0) {
             $lastItem               = $recursiveItems[count($recursiveItems) - 1];
-            $options['entities_id'] = $lastItem->getField('entities_id');
+            $options['entities_id'] = $lastItem->fields['entities_id'];
         }
 
         $recursive_items_type_data = _n('Associated element', 'Associated elements', Session::getPluralNumber());
@@ -883,7 +883,7 @@ TWIG, $twig_params);
         if (
             ($item instanceof CommonDBTM)
             && $item->getID()
-            && $item->can($item->getField('id'), READ)
+            && $item->can($item->getID(), READ)
         ) {
             $nb = 0;
             if ($_SESSION['glpishow_count_on_tabs']) {

--- a/src/NetworkPort.php
+++ b/src/NetworkPort.php
@@ -608,7 +608,7 @@ class NetworkPort extends CommonDBChild
         global $CFG_GLPI, $DB;
 
         $itemtype = $item::class;
-        $items_id = $item->getField('id');
+        $items_id = $item->getID();
 
         $netport = new self();
         $netport_table = $netport->getTable();
@@ -1370,7 +1370,7 @@ class NetworkPort extends CommonDBChild
         $recursiveItems = $this->recursivelyGetItems();
         if (count($recursiveItems) > 0) {
             $lastItem             = $recursiveItems[count($recursiveItems) - 1];
-            $options['entities_id'] = $lastItem->getField('entities_id');
+            $options['entities_id'] = $lastItem->fields['entities_id'];
         } else {
             $options['entities_id'] = $_SESSION['glpiactive_entity'];
         }
@@ -1754,7 +1754,7 @@ class NetworkPort extends CommonDBChild
         if ($item::class === self::class) {
             $nbAlias = countElementsInTable(
                 'glpi_networkportaliases',
-                ['networkports_id_alias' => $item->getField('id')]
+                ['networkports_id_alias' => $item->getID()]
             );
             if ($nbAlias > 0) {
                 $aliases = self::createTabEntry(NetworkPortAlias::getTypeName(Session::getPluralNumber()), $nbAlias, $item::class);
@@ -1763,7 +1763,7 @@ class NetworkPort extends CommonDBChild
             }
             $nbAggregates = countElementsInTable(
                 'glpi_networkportaggregates',
-                ['networkports_id_list'   => ['LIKE', '%"' . $item->getField('id') . '"%']]
+                ['networkports_id_list'   => ['LIKE', '%"' . $item->getID() . '"%']]
             );
             if ($nbAggregates > 0) {
                 $aggregates = self::createTabEntry(
@@ -1792,7 +1792,7 @@ class NetworkPort extends CommonDBChild
             'glpi_networkports',
             [
                 'itemtype'   => $item::class,
-                'items_id'   => $item->getField('id'),
+                'items_id'   => $item->getID(),
                 'is_deleted' => 0,
             ]
         );

--- a/src/NetworkPortAlias.php
+++ b/src/NetworkPortAlias.php
@@ -59,7 +59,7 @@ class NetworkPortAlias extends NetworkPortInstantiation
         ) {
             $networkPort = new NetworkPort();
             if ($networkPort->getFromDB($input['networkports_id_alias'])) {
-                $input['mac']            = $networkPort->getField('mac');
+                $input['mac']            = $networkPort->fields['mac'];
             }
         }
 

--- a/src/NetworkPortMetrics.php
+++ b/src/NetworkPortMetrics.php
@@ -55,7 +55,7 @@ class NetworkPortMetrics extends CommonDBChild
         $array_ret = [];
 
         if ($item::class === NetworkPort::class) {
-            $cnt = countElementsInTable([static::getTable()], [static::$items_id => $item->getField('id')]);
+            $cnt = countElementsInTable([static::getTable()], [static::$items_id => $item->getID()]);
             $array_ret[] = self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $cnt, $item::class);
         }
         return $array_ret;

--- a/src/NotificationEventMailing.php
+++ b/src/NotificationEventMailing.php
@@ -400,13 +400,13 @@ class NotificationEventMailing extends NotificationEventAbstract
 
                 self::attachDocuments($mail, $documents_to_attach);
 
-                $recipient = $current->getField('recipient');
+                $recipient = $current->fields['recipient'];
                 if (defined('GLPI_FORCE_MAIL')) {
                     Toolbox::deprecated('Usage of the `GLPI_FORCE_MAIL` constant is deprecated. Please use a mail catcher service instead.');
                     //force recipient to configured email address
                     $recipient = GLPI_FORCE_MAIL;
                     //add original email address to message body
-                    $text = sprintf(__('Original email address was %1$s'), $current->getField('recipient'));
+                    $text = sprintf(__('Original email address was %1$s'), $current->fields['recipient']);
                     $mail->text($mail->getTextBody() . "\n" . $text);
                     if ($is_html) {
                         $mail->html($mail->getHtmlBody() . "<br/>" . htmlescape($text));

--- a/src/NotificationTarget.php
+++ b/src/NotificationTarget.php
@@ -393,8 +393,8 @@ class NotificationTarget extends CommonDBChild
     protected function computeFriendlyName()
     {
 
-        return $this->notification_targets_labels[$this->getField("type")]
-                                              [$this->getField("items_id")] ?? '';
+        return $this->notification_targets_labels[$this->fields["type"]]
+                                              [$this->fields["items_id"]] ?? '';
     }
 
     /**
@@ -481,7 +481,7 @@ class NotificationTarget extends CommonDBChild
             return false;
         }
 
-        if ($notification->getField('itemtype') != '') {
+        if ($notification->fields['itemtype'] != '') {
             $notifications_id = $notification->fields['id'];
             $canedit = $notification->can($notifications_id, UPDATE);
 
@@ -659,12 +659,12 @@ class NotificationTarget extends CommonDBChild
             $user = new User();
             if (
                 !$user->getFromDB($data['users_id'])
-                || ($user->getField('is_deleted') == 1)
-                || ($user->getField('is_active') == 0)
-                || (!is_null($user->getField('begin_date'))
-                  && ($user->getField('begin_date') > $_SESSION["glpi_currenttime"]))
-                || (!is_null($user->getField('end_date'))
-                  && ($user->getField('end_date') < $_SESSION["glpi_currenttime"]))
+                || ($user->isDeleted())
+                || (!$user->isActive())
+                || (!is_null($user->fields['begin_date'])
+                  && ($user->fields['begin_date'] > $_SESSION["glpi_currenttime"]))
+                || (!is_null($user->fields['end_date'])
+                  && ($user->fields['end_date'] < $_SESSION["glpi_currenttime"]))
             ) {
                 // unknown, deleted or disabled user
                 return;
@@ -694,9 +694,9 @@ class NotificationTarget extends CommonDBChild
             if (empty($username)) {
                 $username = formatUserName(
                     0,
-                    $user->getField('name'),
-                    $user->getField('realname'),
-                    $user->getField('firstname'),
+                    $user->fields['name'],
+                    $user->fields['realname'],
+                    $user->fields['firstname'],
                     force_config: true
                 );
             }
@@ -841,11 +841,11 @@ class NotificationTarget extends CommonDBChild
         $user = new User();
         if (
             $this->obj->isField('users_id')
-            && $user->getFromDB($this->obj->getField('users_id'))
+            && $user->getFromDB($this->obj->fields['users_id'])
         ) {
             $this->addToRecipientsList([
-                'language' => $user->getField('language'),
-                'users_id' => $user->getField('id'),
+                'language' => $user->fields['language'],
+                'users_id' => $user->getID(),
             ]);
         }
     }
@@ -1243,7 +1243,7 @@ class NotificationTarget extends CommonDBChild
                 return;
             }
 
-            $id[] = $this->obj->getField($field);
+            $id[] = $this->obj->fields[$field];
         } elseif ($this->target_object !== []) {
             foreach ($this->target_object as $target) {
                 if (!$target instanceof CommonDBTM) {
@@ -1903,8 +1903,8 @@ class NotificationTarget extends CommonDBChild
 
             $target = self::getInstanceByType(
                 $itemtype,
-                $item->getField('event'),
-                ['entities_id' => $item->getField('entities_id')]
+                $item->fields['event'],
+                ['entities_id' => $item->fields['entities_id']]
             );
             if ($target) {
                 return $target->showForNotification($item);

--- a/src/NotificationTargetChange.php
+++ b/src/NotificationTargetChange.php
@@ -85,7 +85,7 @@ class NotificationTargetChange extends NotificationTargetCommonITILObject
         $data['##change.urlvalidation##']
                      = $this->formatURL(
                          $options['additionnaloption']['usertype'],
-                         "change_" . $item->getField("id") . '_Change$main',
+                         "change_" . $item->getID() . '_Change$main',
                          $anchor
                      );
         $data['##change.globalvalidation##']
@@ -97,13 +97,9 @@ class NotificationTargetChange extends NotificationTargetCommonITILObject
         $data['##change.backoutplancontent##'] = $item->getField("backoutplancontent");
         $data['##change.checklistcontent##']   = $item->getField("checklistcontent");
 
-        // $data["##problem.impacts##"]  = $item->getField('impactcontent');
-        // $data["##problem.causes##"]   = $item->getField('causecontent');
-        // $data["##problem.symptoms##"] = $item->getField('symptomcontent');
-
         // Complex mode
         if (!$simple) {
-            $restrict = ['changes_id' => $item->getField('id')];
+            $restrict = ['changes_id' => $item->getID()];
             $tickets  = getAllDataFromTable('glpi_changes_tickets', $restrict);
 
             $data['tickets'] = [];

--- a/src/NotificationTargetCommonITILObject.php
+++ b/src/NotificationTargetCommonITILObject.php
@@ -111,7 +111,7 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
             $perso_tag = 'GLPI';
         }
 
-        return sprintf("[$perso_tag #%07d] ", $this->obj->getField('id'));
+        return sprintf("[$perso_tag #%07d] ", $this->obj->getID());
     }
 
     #[Override]
@@ -1230,20 +1230,19 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
         $data["##$objettype.title##"]        = $item->getField('name');
         $data["##$objettype.content##"]      = $item->getField('content');
         $data["##$objettype.description##"]  = $item->getField('content');
-        $data["##$objettype.id##"]           = sprintf("%07d", $item->getField("id"));
+        $data["##$objettype.id##"]           = sprintf("%07d", $item->getID());
 
         $data["##$objettype.url##"]
                         = $this->formatURL(
                             $options['additionnaloption']['usertype'],
-                            $objettype . "_" . $item->getField("id")
+                            $objettype . "_" . $item->getID()
                         );
 
         $tab = '$1';
         $data["##$objettype.urlapprove##"]
                            = $this->formatURL(
                                $options['additionnaloption']['usertype'],
-                               $objettype . "_" . $item->getField("id") . "_"
-                               . $item::class . $tab
+                               $objettype . "_" . $item->getID() . "_" . $item::class . $tab
                            );
 
         $entity = new Entity();
@@ -1267,24 +1266,24 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
         }
 
         $data["##$objettype.storestatus##"]  = $item->getField('status');
-        $data["##$objettype.status##"]       = $item->getStatus($item->getField('status'));
+        $data["##$objettype.status##"]       = $item->getStatus($item->fields['status']);
 
-        $data["##$objettype.urgency##"]      = $item->getUrgencyName($item->getField('urgency'));
-        $data["##$objettype.impact##"]       = $item->getImpactName($item->getField('impact'));
-        $data["##$objettype.priority##"]     = $item->getPriorityName($item->getField('priority'));
-        $data["##$objettype.time##"]         = $item->getActionTime($item->getField('actiontime'));
+        $data["##$objettype.urgency##"]      = $item->getUrgencyName($item->fields['urgency']);
+        $data["##$objettype.impact##"]       = $item->getImpactName($item->fields['impact']);
+        $data["##$objettype.priority##"]     = $item->getPriorityName($item->fields['priority']);
+        $data["##$objettype.time##"]         = $item->getActionTime($item->fields['actiontime']);
 
-        $data["##$objettype.creationdate##"] = Html::convDateTime($item->getField('date'));
-        $data["##$objettype.closedate##"]    = Html::convDateTime($item->getField('closedate'));
-        $data["##$objettype.solvedate##"]    = Html::convDateTime($item->getField('solvedate'));
-        $data["##$objettype.duedate##"]      = Html::convDateTime($item->getField('time_to_resolve'));
+        $data["##$objettype.creationdate##"] = Html::convDateTime($item->fields['date']);
+        $data["##$objettype.closedate##"]    = Html::convDateTime($item->fields['closedate']);
+        $data["##$objettype.solvedate##"]    = Html::convDateTime($item->fields['solvedate']);
+        $data["##$objettype.duedate##"]      = Html::convDateTime($item->fields['time_to_resolve']);
 
         $data["##$objettype.category##"] = '';
-        if ($item->getField('itilcategories_id')) {
+        if ($item->fields['itilcategories_id']) {
             $data["##$objettype.category##"]
                               = Dropdown::getDropdownName(
                                   'glpi_itilcategories',
-                                  $item->getField('itilcategories_id')
+                                  $item->fields['itilcategories_id']
                               );
         }
         $data['actors']                = [];
@@ -1343,16 +1342,16 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
         }
 
         $data["##$objettype.openbyuser##"] = '';
-        if ($item->getField('users_id_recipient')) {
+        if ($item->fields['users_id_recipient']) {
             $user_tmp = new User();
-            $user_tmp->getFromDB($item->getField('users_id_recipient'));
+            $user_tmp->getFromDB($item->fields['users_id_recipient']);
             $data["##$objettype.openbyuser##"] = $user_tmp->getName();
         }
 
         $data["##$objettype.lastupdater##"] = '';
-        if ($item->getField('users_id_lastupdater')) {
+        if ($item->fields['users_id_lastupdater']) {
             $user_tmp = new User();
-            $user_tmp->getFromDB($item->getField('users_id_lastupdater'));
+            $user_tmp->getFromDB($item->fields['users_id_lastupdater']);
             $data["##$objettype.lastupdater##"] = $user_tmp->getName();
         }
 
@@ -1460,14 +1459,14 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
 
         if ($solution) {
             $data["##$objettype.solution.type##"] = '';
-            if ($itilsolution->getField('solutiontypes_id')) {
+            if ($itilsolution->fields['solutiontypes_id']) {
                 $data["##$objettype.solution.type##"] = Dropdown::getDropdownName(
                     'glpi_solutiontypes',
-                    $itilsolution->getField('solutiontypes_id')
+                    $itilsolution->fields['solutiontypes_id']
                 );
             }
 
-            $data["##$objettype.solution.author##"] = getUserName($itilsolution->getField('users_id'));
+            $data["##$objettype.solution.author##"] = getUserName($itilsolution->fields['users_id']);
             $data["##$objettype.solution.description##"] = $itilsolution->getField('content');
         }
 
@@ -1496,9 +1495,9 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
                     'LIMIT'  => 1,
                 ])
             ) {
-                $data["##$objettype.reminder.bumpcounter##"]   = $pending_reason_item->getField('bump_count');
-                $data["##$objettype.reminder.bumpremaining##"] = $pending_reason_item->getField('followups_before_resolution') - $pending_reason_item->getField('bump_count');
-                $data["##$objettype.reminder.bumptotal##"]     = $pending_reason_item->getField('followups_before_resolution');
+                $data["##$objettype.reminder.bumpcounter##"]   = (int) $pending_reason_item->fields['bump_count'];
+                $data["##$objettype.reminder.bumpremaining##"] = (int) $pending_reason_item->fields['followups_before_resolution'] - $pending_reason_item->fields['bump_count'];
+                $data["##$objettype.reminder.bumptotal##"]     = (int) $pending_reason_item->fields['followups_before_resolution'];
                 $data["##$objettype.reminder.deadline##"]      = $pending_reason_item->getAutoResolvedate();
                 $data["##$objettype.reminder.text##"]          = $followup_template instanceof ITILFollowupTemplate ? $followup_template->getRenderedContent($item) : '';
                 $data["##$objettype.reminder.name##"]          = $pending_reason->getField('name');
@@ -1507,7 +1506,7 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
 
         // Complex mode
         if (!$simple) {
-            $linked = CommonITILObject_CommonITILObject::getAllLinkedTo($item::class, $item->getField('id'));
+            $linked = CommonITILObject_CommonITILObject::getAllLinkedTo($item::class, $item->getID());
             $data['linkedtickets'] = [];
             $data['linkedchanges'] = [];
             $data['linkedproblems'] = [];
@@ -1547,7 +1546,7 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
 
             $show_private = $options['additionnaloption']['show_private'] ?? false;
             $followup_restrict = [];
-            $followup_restrict['items_id'] = $item->getField('id');
+            $followup_restrict['items_id'] = $item->getID();
             if (!$show_private) {
                 $followup_restrict['is_private'] = 0;
             }
@@ -1701,7 +1700,7 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
             $data["##$objettype.urldocument##"]
                         = $this->formatURL(
                             $options['additionnaloption']['usertype'],
-                            $objettype . "_" . $item->getField("id") . '_Document_Item$1'
+                            $objettype . "_" . $item->getID() . '_Document_Item$1'
                         );
 
             $data["##$objettype.numberofdocuments##"]
@@ -1709,7 +1708,7 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
 
             //costs infos
             $costtype = $item::class . 'Cost';
-            $costs    = $costtype::getCostsSummary($costtype, $item->getField("id"));
+            $costs    = $costtype::getCostsSummary($costtype, $item->getID());
 
             $data["##$objettype.costfixed##"]    = $costs['costfixed'];
             $data["##$objettype.costmaterial##"] = $costs['costmaterial'];
@@ -1719,7 +1718,7 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
             $costs          = getAllDataFromTable(
                 getTableForItemType($costtype),
                 [
-                    'WHERE'  => [$item->getForeignKeyField() => $item->getField('id')],
+                    'WHERE'  => [$item->getForeignKeyField() => $item->getID()],
                     'ORDER'  => ['begin_date DESC', 'id ASC'],
                 ]
             );
@@ -1750,7 +1749,7 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
 
             //Task infos
             $taskobj = $item->getTaskClassInstance();
-            $restrict = [$item->getForeignKeyField() => $item->getField('id')];
+            $restrict = [$item->getForeignKeyField() => $item->getID()];
             if (
                 $taskobj->maybePrivate()
                 && (!isset($options['additionnaloption']['show_private'])
@@ -1864,11 +1863,11 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
                 $data['##satisfaction.satisfaction##'] = '';
                 $data['##satisfaction.description##'] = '';
 
-                if ($inquest->getFromDB($item->getField('id'))) {
+                if ($inquest->getFromDB($item->getID())) {
                     // internal inquest
                     if ($inquest->fields['type'] == 1) {
                         $user_type = $options['additionnaloption']['usertype'];
-                        $redirect = "{$objettype}_" . $item->getField("id") . '_' . $item::class . '$3';
+                        $redirect = "{$objettype}_" . $item->getID() . '_' . $item::class . '$3';
                         $data["##{$objettype}.urlsatisfaction##"] = $this->formatURL($user_type, $redirect);
                     } elseif ($inquest->fields['type'] == 2) { // external inquest
                         $data["##{$objettype}.urlsatisfaction##"] = Entity::generateLinkSatisfaction($item);
@@ -1966,16 +1965,16 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
                 $data[sprintf('##%s.town##', $key_prefix)]       = $actor->getField('town');
                 $data[sprintf('##%s.state##', $key_prefix)]      = $actor->getField('state');
                 $data[sprintf('##%s.country##', $key_prefix)]    = $actor->getField('country');
-                if ($actor->getField('suppliertypes_id')) {
+                if ($actor->fields['suppliertypes_id']) {
                     $data[sprintf('##%s.type##', $key_prefix)]
                                = Dropdown::getDropdownName(
                                    'glpi_suppliertypes',
-                                   $actor->getField('suppliertypes_id')
+                                   $actor->fields['suppliertypes_id']
                                );
                     $data[sprintf('##%s.suppliertype##', $key_prefix)]
                                = Dropdown::getDropdownName(
                                    'glpi_suppliertypes',
-                                   $actor->getField('suppliertypes_id')
+                                   $actor->fields['suppliertypes_id']
                                );
                 }
                 break;

--- a/src/NotificationTargetObjectLock.php
+++ b/src/NotificationTargetObjectLock.php
@@ -85,7 +85,7 @@ class NotificationTargetObjectLock extends NotificationTarget
 
         $user = new User();
         if ($user->getFromDB($this->obj->fields['users_id'])) {
-            $this->addToRecipientsList(['language' => $user->getField('language'),
+            $this->addToRecipientsList(['language' => $user->fields['language'],
                 'users_id' => $user->getID(),
             ]);
         }

--- a/src/NotificationTargetPlanningRecall.php
+++ b/src/NotificationTargetPlanningRecall.php
@@ -209,31 +209,31 @@ class NotificationTargetPlanningRecall extends NotificationTarget
         $this->data['##recall.item.private##'] = '';
         if ($target_object->isField('is_private')) {
             $this->data['##recall.item.private##']
-                     = Dropdown::getYesNo($target_object->getField('is_private'));
+                     = Dropdown::getYesNo($target_object->isPrivate());
         }
 
         $this->data['##recall.item.date_mod##'] = '';
         if ($target_object->isField('date_mod')) {
             $this->data['##recall.item.date_mod##']
-                     = Html::convDateTime($target_object->getField('date_mod'));
+                     = Html::convDateTime($target_object->fields['date_mod']);
         }
 
         $this->data['##recall.item.user##'] = '';
         $user_tmp                            = new User();
-        if ($user_tmp->getFromDB($target_object->getField('users_id'))) {
+        if ($user_tmp->getFromDB($target_object->fields['users_id'])) {
             $this->data['##recall.item.user##'] = $user_tmp->getName();
         }
 
         $this->data['##recall.planning.state##'] = '';
         if ($target_object->isField('state')) {
             $this->data['##recall.planning.state##']
-                     = Planning::getState($target_object->getField('state'));
+                     = Planning::getState($target_object->fields['state']);
         }
 
         $this->data['##recall.planning.begin##']
-                  = Html::convDateTime($target_object->getField('begin'));
+                  = Html::convDateTime($target_object->fields['begin']);
         $this->data['##recall.planning.end##']
-                  = Html::convDateTime($target_object->getField('end'));
+                  = Html::convDateTime($target_object->fields['end']);
 
         $this->getTags();
         foreach ($this->tag_descriptions[NotificationTarget::TAG_LANGUAGE] as $tag => $values) {
@@ -274,8 +274,8 @@ class NotificationTargetPlanningRecall extends NotificationTarget
     {
         if ($this->obj) {
             if (
-                ($item = getItemForItemtype($this->obj->getField('itemtype')))
-                && $item->getFromDB($this->obj->getField('items_id'))
+                ($item = getItemForItemtype($this->obj->fields['itemtype']))
+                && $item->getFromDB($this->obj->fields['items_id'])
             ) {
                 $this->target_object[] = $item;
             }

--- a/src/NotificationTargetProblem.php
+++ b/src/NotificationTargetProblem.php
@@ -68,7 +68,7 @@ class NotificationTargetProblem extends NotificationTargetCommonITILObject
 
         // Complex mode
         if (!$simple) {
-            $restrict = ['problems_id' => $item->getField('id')];
+            $restrict = ['problems_id' => $item->getID()];
             $tickets  = getAllDataFromTable('glpi_problems_tickets', $restrict);
 
             $data['tickets'] = [];

--- a/src/NotificationTargetProject.php
+++ b/src/NotificationTargetProject.php
@@ -156,8 +156,9 @@ class NotificationTargetProject extends NotificationTarget
         $user = new User();
         foreach ($iterator as $data) {
             if ($user->getFromDB($data['items_id'])) {
-                $this->addToRecipientsList(['language' => $user->getField('language'),
-                    'users_id' => $user->getField('id'),
+                $this->addToRecipientsList([
+                    'language' => $user->fields['language'],
+                    'users_id' => $user->getID(),
                 ]);
             }
         }
@@ -262,7 +263,7 @@ class NotificationTargetProject extends NotificationTarget
         $this->data['##project.url##']
             = $this->formatURL(
                 $options['additionnaloption']['usertype'],
-                "Project_" . $item->getField("id")
+                "Project_" . $item->getID()
             );
         $this->data["##project.name##"]
             = $item->getField('name');
@@ -273,21 +274,21 @@ class NotificationTargetProject extends NotificationTarget
         $this->data["##project.comments##"]
             = $item->getField('comment');
         $this->data["##project.creationdate##"]
-            = Html::convDateTime($item->getField('date'));
+            = Html::convDateTime($item->fields['date']);
         $this->data["##project.lastupdatedate##"]
-            = Html::convDateTime($item->getField('date_mod'));
+            = Html::convDateTime($item->fields['date_mod']);
         $this->data["##project.priority##"]
-            = CommonITILObject::getPriorityName($item->getField('priority'));
+            = CommonITILObject::getPriorityName($item->fields['priority']);
         $this->data["##project.percent##"]
-            = Dropdown::getValueWithUnit($item->getField('percent_done'), "%");
+            = Dropdown::getValueWithUnit($item->fields['percent_done'], "%");
         $this->data["##project.planstartdate##"]
-            = Html::convDateTime($item->getField('plan_start_date'));
+            = Html::convDateTime($item->fields['plan_start_date']);
         $this->data["##project.planenddate##"]
-            = Html::convDateTime($item->getField('plan_end_date'));
+            = Html::convDateTime($item->fields['plan_end_date']);
         $this->data["##project.realstartdate##"]
-            = Html::convDateTime($item->getField('real_start_date'));
+            = Html::convDateTime($item->fields['real_start_date']);
         $this->data["##project.realenddate##"]
-            = Html::convDateTime($item->getField('real_end_date'));
+            = Html::convDateTime($item->fields['real_end_date']);
 
         $this->data["##project.plannedduration##"]
             = Html::timestampToString(
@@ -309,49 +310,49 @@ class NotificationTargetProject extends NotificationTarget
         }
 
         $this->data["##project.father##"] = '';
-        if ($item->getField('projects_id')) {
+        if ($item->fields['projects_id']) {
             $this->data["##project.father##"]
                               = Dropdown::getDropdownName(
                                   'glpi_projects',
-                                  $item->getField('projects_id')
+                                  $item->fields['projects_id']
                               );
         }
 
         $this->data["##project.state##"] = '';
-        if ($item->getField('projectstates_id')) {
+        if ($item->fields['projectstates_id']) {
             $this->data["##project.state##"]
                               = Dropdown::getDropdownName(
                                   'glpi_projectstates',
-                                  $item->getField('projectstates_id')
+                                  $item->fields['projectstates_id']
                               );
         }
 
         $this->data["##project.type##"] = '';
-        if ($item->getField('projecttypes_id')) {
+        if ($item->fields['projecttypes_id']) {
             $this->data["##project.type##"]
                               = Dropdown::getDropdownName(
                                   'glpi_projecttypes',
-                                  $item->getField('projecttypes_id')
+                                  $item->fields['projecttypes_id']
                               );
         }
 
         $this->data["##project.manager##"] = '';
-        if ($item->getField('users_id')) {
+        if ($item->fields['users_id']) {
             $user_tmp = new User();
-            $user_tmp->getFromDB($item->getField('users_id'));
+            $user_tmp->getFromDB($item->fields['users_id']);
             $this->data["##project.manager##"] = $user_tmp->getName();
         }
 
         $this->data["##project.managergroup##"] = '';
-        if ($item->getField('groups_id')) {
+        if ($item->fields['groups_id']) {
             $this->data["##project.managergroup##"]
                               = Dropdown::getDropdownName(
                                   'glpi_groups',
-                                  $item->getField('groups_id')
+                                  $item->fields['groups_id']
                               );
         }
         // Team infos
-        $restrict = ['projects_id' => $item->getField('id')];
+        $restrict = ['projects_id' => $item->getID()];
         $items    = getAllDataFromTable('glpi_projectteams', $restrict);
 
         $this->data['teammembers'] = [];
@@ -468,7 +469,7 @@ class NotificationTargetProject extends NotificationTarget
 
             $lc_itemtype = strtolower($itemtype);
             $restrict = [
-                'projects_id' => $item->getField('id'),
+                'projects_id' => $item->getID(),
                 'itemtype'    => $itemtype,
             ];
             $link_items = getAllDataFromTable(Itil_Project::getTable(), $restrict);
@@ -544,7 +545,7 @@ class NotificationTargetProject extends NotificationTarget
         $this->data["##project.urldocument##"]
                      = $this->formatURL(
                          $options['additionnaloption']['usertype'],
-                         "Project_" . $item->getField("id") . '_Document_Item$1'
+                         "Project_" . $item->getID() . '_Document_Item$1'
                      );
 
         $this->data["##project.numberofdocuments##"] = (string) count($this->data['documents']);

--- a/src/NotificationTargetProjectTask.php
+++ b/src/NotificationTargetProjectTask.php
@@ -131,8 +131,9 @@ class NotificationTargetProjectTask extends NotificationTarget
         $user = new User();
         foreach ($iterator as $data) {
             if ($user->getFromDB($data['items_id'])) {
-                $this->addToRecipientsList(['language' => $user->getField('language'),
-                    'users_id' => $user->getField('id'),
+                $this->addToRecipientsList([
+                    'language' => $user->fields['language'],
+                    'users_id' => $user->getID(),
                 ]);
             }
         }
@@ -263,47 +264,47 @@ class NotificationTargetProjectTask extends NotificationTarget
         $this->data['##projecttask.url##']
                   = $this->formatURL(
                       $options['additionnaloption']['usertype'],
-                      "ProjectTask_" . $item->getField("id")
+                      "ProjectTask_" . $item->getID()
                   );
         $this->data["##projecttask.name##"]
                   = $item->getField('name');
         $this->data["##projecttask.project##"]
-                  = Dropdown::getDropdownName('glpi_projects', $item->getField('projects_id'));
+                  = Dropdown::getDropdownName('glpi_projects', $item->fields['projects_id']);
         $this->data["##projecttask.projecturl##"]
                   = $this->formatURL(
                       $options['additionnaloption']['usertype'],
-                      "Project_" . $item->getField("projects_id")
+                      "Project_" . $item->fields["projects_id"]
                   );
         $this->data["##projecttask.description##"]
                   = $item->getField('content');
         $this->data["##projecttask.comments##"]
                   = $item->getField('comment');
         $this->data["##projecttask.creationdate##"]
-                  = Html::convDateTime($item->getField('date_creation'));
+                  = Html::convDateTime($item->fields['date_creation']);
         $this->data["##projecttask.lastupdatedate##"]
-                  = Html::convDateTime($item->getField('date_mod'));
+                  = Html::convDateTime($item->fields['date_mod']);
         $this->data["##projecttask.percent##"]
-                  = Dropdown::getValueWithUnit($item->getField('percent_done'), "%");
+                  = Dropdown::getValueWithUnit($item->fields['percent_done'], "%");
         $this->data["##projecttask.planstartdate##"]
-                  = Html::convDateTime($item->getField('plan_start_date'));
+                  = Html::convDateTime($item->fields['plan_start_date']);
         $this->data["##projecttask.planenddate##"]
-                  = Html::convDateTime($item->getField('plan_end_date'));
+                  = Html::convDateTime($item->fields['plan_end_date']);
         $this->data["##projecttask.realstartdate##"]
-                  = Html::convDateTime($item->getField('real_start_date'));
+                  = Html::convDateTime($item->fields['real_start_date']);
         $this->data["##projecttask.realenddate##"]
-                  = Html::convDateTime($item->getField('real_end_date'));
+                  = Html::convDateTime($item->fields['real_end_date']);
 
         $this->data["##projecttask.plannedduration##"]
-                  = Html::timestampToString($item->getField('planned_duration'), false);
+                  = Html::timestampToString($item->fields['planned_duration'], false);
         $this->data["##projecttask.effectiveduration##"]
-                  = Html::timestampToString($item->getField('effective_duration'), false);
+                  = Html::timestampToString($item->fields['effective_duration'], false);
         $ticket_duration
                   = ProjectTask_Ticket::getTicketsTotalActionTime($item->getID());
         $this->data["##projecttask.ticketsduration##"]
                   = Html::timestampToString($ticket_duration, false);
         $this->data["##projecttask.totalduration##"]
                   = Html::timestampToString(
-                      $ticket_duration + $item->getField('effective_duration'),
+                      $ticket_duration + $item->fields['effective_duration'],
                       false
                   );
 
@@ -316,41 +317,41 @@ class NotificationTargetProjectTask extends NotificationTarget
         }
 
         $this->data["##projecttask.father##"] = '';
-        if ($item->getField('projecttasks_id')) {
+        if ($item->fields['projecttasks_id']) {
             $this->data["##projecttask.father##"]
                               = Dropdown::getDropdownName(
                                   'glpi_projecttasks',
-                                  $item->getField('projecttasks_id')
+                                  $item->fields['projecttasks_id']
                               );
         }
 
         $this->data["##projecttask.state##"] = '';
-        if ($item->getField('projectstates_id')) {
+        if ($item->fields['projectstates_id']) {
             $this->data["##projecttask.state##"]
                               = Dropdown::getDropdownName(
                                   'glpi_projectstates',
-                                  $item->getField('projectstates_id')
+                                  $item->fields['projectstates_id']
                               );
         }
 
         $this->data["##projecttask.type##"] = '';
-        if ($item->getField('projecttasktypes_id')) {
+        if ($item->fields['projecttasktypes_id']) {
             $this->data["##projecttask.type##"]
                               = Dropdown::getDropdownName(
                                   'glpi_projecttasktypes',
-                                  $item->getField('projecttasktypes_id')
+                                  $item->fields['projecttasktypes_id']
                               );
         }
 
         $this->data["##projecttask.createbyuser##"] = '';
-        if ($item->getField('users_id')) {
+        if ($item->fields['users_id']) {
             $user_tmp = new User();
-            $user_tmp->getFromDB($item->getField('users_id'));
+            $user_tmp->getFromDB($item->fields['users_id']);
             $this->data["##projecttask.createbyuser##"] = $user_tmp->getName();
         }
 
         // Team infos
-        $restrict = ['projecttasks_id' => $item->getField('id')];
+        $restrict = ['projecttasks_id' => $item->getID()];
         $items    = getAllDataFromTable('glpi_projecttaskteams', $restrict);
 
         $this->data['teammembers'] = [];
@@ -512,7 +513,7 @@ class NotificationTargetProjectTask extends NotificationTarget
         $this->data["##projecttask.urldocument##"]
                      = $this->formatURL(
                          $options['additionnaloption']['usertype'],
-                         "ProjectTask_" . $item->getField("id") . '_Document_Item$1'
+                         "ProjectTask_" . $item->getID() . '_Document_Item$1'
                      );
 
         $this->data["##projecttask.numberofdocuments##"] = (string) count($this->data['documents']);

--- a/src/NotificationTargetReservation.php
+++ b/src/NotificationTargetReservation.php
@@ -78,19 +78,19 @@ class NotificationTargetReservation extends NotificationTarget
         if ($event != 'alert') {
             $this->data['##reservation.user##']   = "";
             $user_tmp                              = new User();
-            if ($user_tmp->getFromDB($this->obj->getField('users_id'))) {
+            if ($user_tmp->getFromDB($this->obj->fields['users_id'])) {
                 $this->data['##reservation.user##'] = $user_tmp->getName();
             }
-            $this->data['##reservation.begin##']   = Html::convDateTime($this->obj->getField('begin'));
-            $this->data['##reservation.end##']     = Html::convDateTime($this->obj->getField('end'));
+            $this->data['##reservation.begin##']   = Html::convDateTime($this->obj->fields['begin']);
+            $this->data['##reservation.end##']     = Html::convDateTime($this->obj->fields['end']);
             $this->data['##reservation.comment##'] = $this->obj->getField('comment');
 
             $reservationitem = new ReservationItem();
-            $reservationitem->getFromDB($this->obj->getField('reservationitems_id'));
-            $itemtype        = $reservationitem->getField('itemtype');
+            $reservationitem->getFromDB($this->obj->fields['reservationitems_id']);
+            $itemtype        = $reservationitem->fields['itemtype'];
 
             if ($item = getItemForItemtype($itemtype)) {
-                $item->getFromDB($reservationitem->getField('items_id'));
+                $item->getFromDB($reservationitem->fields['items_id']);
                 $this->data["##reservation.note##"]
                                  = $reservationitem->getField('comment');
                 $this->data['##reservation.itemtype##']
@@ -100,27 +100,27 @@ class NotificationTargetReservation extends NotificationTarget
                 $this->data['##reservation.item.entity##']
                                  = Dropdown::getDropdownName(
                                      'glpi_entities',
-                                     $item->getField('entities_id')
+                                     $item->fields['entities_id']
                                  );
 
                 if ($item->isField('users_id_tech')) {
                     $this->data['##reservation.item.tech##']
                                 = Dropdown::getDropdownName(
                                     'glpi_users',
-                                    $item->getField('users_id_tech')
+                                    $item->fields['users_id_tech']
                                 );
                 }
 
                 $this->data['##reservation.itemurl##']
                                  = $this->formatURL(
                                      $options['additionnaloption']['usertype'],
-                                     $itemtype . "_" . $item->getField('id')
+                                     $itemtype . "_" . $item->getID()
                                  );
 
                 $this->data['##reservation.url##']
                                  = $this->formatURL(
                                      $options['additionnaloption']['usertype'],
-                                     "Reservation_" . $this->obj->getField('id')
+                                     "Reservation_" . $this->obj->getID()
                                  );
             }
         } else {
@@ -220,14 +220,14 @@ class NotificationTargetReservation extends NotificationTarget
         if ($this->obj) {
             $ri = new ReservationItem();
 
-            if ($ri->getFromDB($this->obj->getField('reservationitems_id'))) {
-                $itemtype = $ri->getField('itemtype');
+            if ($ri->getFromDB($this->obj->fields['reservationitems_id'])) {
+                $itemtype = $ri->fields['itemtype'];
 
                 if (
                     ($itemtype != NOT_AVAILABLE) && ($itemtype != '')
                     && ($item = getItemForItemtype($itemtype))
                 ) {
-                    $item->getFromDB($ri->getField('items_id'));
+                    $item->getFromDB($ri->fields['items_id']);
                     $this->target_object[] = $item;
                 }
             }

--- a/src/NotificationTargetSavedSearch_Alert.php
+++ b/src/NotificationTargetSavedSearch_Alert.php
@@ -138,13 +138,13 @@ class NotificationTargetSavedSearch_Alert extends NotificationTarget
                         $usertype = self::GLPI_USER;
                         $user = new User();
                         $savedsearch = new SavedSearch();
-                        $savedsearch->getFromDB($this->obj->getField('savedsearches_id'));
-                        $user->getFromDB($savedsearch->getField('users_id'));
+                        $savedsearch->getFromDB($this->obj->fields['savedsearches_id']);
+                        $user->getFromDB($savedsearch->fields['users_id']);
                         // Send to user without any check on profile / entity
                         // Do not set users_id
                         $data = ['name'     => $user->getName(),
                             'email'    => $user->getDefaultEmail(),
-                            'language' => $user->getField('language'),
+                            'language' => $user->fields['language'],
                             'users_id' => $user->getID(),
                             'usertype' => $usertype,
                         ];

--- a/src/NotificationTargetTicket.php
+++ b/src/NotificationTargetTicket.php
@@ -69,7 +69,7 @@ class NotificationTargetTicket extends NotificationTargetCommonITILObject
             if (empty($perso_tag)) {
                 $perso_tag = 'GLPI';
             }
-            return sprintf("[$perso_tag #%07d] ", $this->obj->getField('id'));
+            return sprintf("[$perso_tag #%07d] ", $this->obj->getID());
         }
         return parent::getSubjectPrefix();
     }
@@ -167,15 +167,15 @@ class NotificationTargetTicket extends NotificationTargetCommonITILObject
         $data['##ticket.urlvalidation##']
                         = $this->formatURL(
                             $options['additionnaloption']['usertype'],
-                            "ticket_" . $item->getField("id") . '_Ticket$main',
+                            "ticket_" . $item->getID() . '_Ticket$main',
                             $anchor
                         );
         $data['##ticket.globalvalidation##']
-                        = TicketValidation::getStatus($item->getField('global_validation'));
+                        = TicketValidation::getStatus($item->fields['global_validation']);
         $data['##ticket.type##']
-                        = Ticket::getTicketTypeName($item->getField('type'));
+                        = Ticket::getTicketTypeName($item->fields['type']);
         $data['##ticket.requesttype##'] = '';
-        if ($requesttype_id = $item->getField('requesttypes_id')) {
+        if ($requesttype_id = $item->fields['requesttypes_id']) {
             $data['##ticket.requesttype##'] = Dropdown::getDropdownName('glpi_requesttypes', $requesttype_id);
         }
 
@@ -203,81 +203,60 @@ class NotificationTargetTicket extends NotificationTargetCommonITILObject
         }
 
         $data['##ticket.sla_tto##'] = '';
-        if ($item->getField('slas_id_tto')) {
+        if ($item->fields['slas_id_tto']) {
             $data['##ticket.sla_tto##'] = Dropdown::getDropdownName(
                 'glpi_slas',
-                $item->getField('slas_id_tto')
+                $item->fields['slas_id_tto']
             );
         }
         $data['##ticket.sla_ttr##'] = '';
-        if ($item->getField('slas_id_ttr')) {
+        if ($item->fields['slas_id_ttr']) {
             $data['##ticket.sla_ttr##'] = Dropdown::getDropdownName(
                 'glpi_slas',
-                $item->getField('slas_id_ttr')
+                $item->fields['slas_id_ttr']
             );
         }
         $data['##ticket.sla##'] = $data['##ticket.sla_ttr##'];
 
         $data['##ticket.ola_tto##'] = '';
-        if ($item->getField('olas_id_tto')) {
+        if ($item->fields['olas_id_tto']) {
             $data['##ticket.ola_tto##'] = Dropdown::getDropdownName(
                 'glpi_olas',
-                $item->getField('olas_id_tto')
+                $item->fields['olas_id_tto']
             );
         }
         $data['##ticket.ola_ttr##'] = '';
-        if ($item->getField('olas_id_ttr')) {
+        if ($item->fields['olas_id_ttr']) {
             $data['##ticket.ola_ttr##'] = Dropdown::getDropdownName(
                 'glpi_olas',
-                $item->getField('olas_id_ttr')
+                $item->fields['olas_id_ttr']
             );
         }
 
         $data['##ticket.location##'] = '';
-        if ($item->getField('locations_id')) {
+        if ($item->fields['locations_id']) {
             $data['##ticket.location##'] = Dropdown::getDropdownName(
                 'glpi_locations',
-                $item->getField('locations_id')
+                $item->fields['locations_id']
             );
             $locations = new Location();
-            $locations->getFromDB($item->getField('locations_id'));
-            if ($locations->getField('comment')) {
+            if ($locations->getFromDB($item->fields['locations_id'])) {
                 $data['##ticket.location.comment##'] = $locations->getField('comment');
-            }
-            if ($locations->getField('room')) {
                 $data['##ticket.location.room##'] = $locations->getField('room');
-            }
-            if ($locations->getField('building')) {
                 $data['##ticket.location.building##'] = $locations->getField('building');
-            }
-            if ($locations->getField('latitude')) {
                 $data['##ticket.location.latitude##'] = $locations->getField('latitude');
-            }
-            if ($locations->getField('longitude')) {
                 $data['##ticket.location.longitude##'] = $locations->getField('longitude');
-            }
-            if ($locations->getField('altitude')) {
                 $data['##ticket.location.altitude##'] = $locations->getField('altitude');
-            }
-            if ($locations->getField('address')) {
                 $data['##ticket.location.address##'] = $locations->getField('address');
-            }
-            if ($locations->getField('postcode')) {
                 $data['##ticket.location.postcode##'] = $locations->getField('postcode');
-            }
-            if ($locations->getField('town')) {
                 $data['##ticket.location.town##'] = $locations->getField('town');
-            }
-            if ($locations->getField('state')) {
                 $data['##ticket.location.state##'] = $locations->getField('state');
-            }
-            if ($locations->getField('country')) {
                 $data['##ticket.location.country##'] = $locations->getField('country');
             }
         }
 
         // is ticket deleted
-        $data['##ticket.isdeleted##'] = Dropdown::getYesNo($item->getField('is_deleted'));
+        $data['##ticket.isdeleted##'] = Dropdown::getYesNo($item->isDeleted());
 
         //Tags associated with the object linked to the ticket
         $data['##ticket.itemtype##']                 = '';
@@ -303,7 +282,7 @@ class NotificationTargetTicket extends NotificationTargetCommonITILObject
         $data['##ticket.item.model##']               = '';
 
         $item_ticket = new Item_Ticket();
-        $items = $item_ticket->find(['tickets_id' => $item->getField('id')]);
+        $items = $item_ticket->find(['tickets_id' => $item->getID()]);
         $data['items'] = [];
         if (count($items)) {
             foreach ($items as $val) {
@@ -344,42 +323,21 @@ class NotificationTargetTicket extends NotificationTargetCommonITILObject
                     //Object location
                     if ($hardware->isField('locations_id')) {
                         $tmp['##ticket.item.location##'] = '';
-                        if ($h_locations_id = $hardware->getField('locations_id')) {
+                        if ($h_locations_id = $hardware->fields['locations_id']) {
                             $tmp['##ticket.item.location##'] = Dropdown::getDropdownName('glpi_locations', $h_locations_id);
                         }
                         $locations = new Location();
-                        $locations->getFromDB($h_locations_id);
-                        if ($hardware->getField('comment')) {
+                        if ($locations->getFromDB($h_locations_id)) {
                             $data['##ticket.item.locationcomment##'] = $locations->getField('comment');
-                        }
-                        if ($hardware->getField('room')) {
                             $data['##ticket.item.locationroom##'] = $locations->getField('room');
-                        }
-                        if ($hardware->getField('building')) {
                             $data['##ticket.item.locationbuilding##'] = $locations->getField('building');
-                        }
-                        if ($hardware->getField('latitude')) {
                             $data['##ticket.item.locationlatitude##'] = $locations->getField('latitude');
-                        }
-                        if ($hardware->getField('longitude')) {
                             $data['##ticket.item.locationlongitude##'] = $locations->getField('longitude');
-                        }
-                        if ($hardware->getField('altitude')) {
                             $data['##ticket.item.locationaltitude##'] = $locations->getField('altitude');
-                        }
-                        if ($hardware->getField('address')) {
                             $data['##ticket.item.locationaddress##'] = $locations->getField('address');
-                        }
-                        if ($hardware->getField('postcode')) {
                             $data['##ticket.item.locationpostcode##'] = $locations->getField('postcode');
-                        }
-                        if ($hardware->getField('town')) {
                             $data['##ticket.item.locationtown##'] = $locations->getField('town');
-                        }
-                        if ($hardware->getField('state')) {
                             $data['##ticket.item.locationstate##'] = $locations->getField('state');
-                        }
-                        if ($hardware->getField('country')) {
                             $data['##ticket.item.locationcountry##'] = $locations->getField('country');
                         }
                     }
@@ -388,7 +346,7 @@ class NotificationTargetTicket extends NotificationTargetCommonITILObject
                     if ($hardware->isField('users_id')) {
                         $tmp['##ticket.item.user##'] = '';
                         $user_tmp = new User();
-                        if ($user_tmp->getFromDB($hardware->getField('users_id'))) {
+                        if ($user_tmp->getFromDB($hardware->fields['users_id'])) {
                             $tmp['##ticket.item.user##'] = $user_tmp->getName();
                         }
                     }
@@ -396,7 +354,7 @@ class NotificationTargetTicket extends NotificationTargetCommonITILObject
                     //Object group
                     if ($hardware->isField('groups_id')) {
                         $tmp['##ticket.item.group##'] = '';
-                        if ($h_group_id = $hardware->getField('groups_id')) {
+                        if ($h_group_id = $hardware->fields['groups_id']) {
                             $tmp['##ticket.item.group##'] = Dropdown::getDropdownName('glpi_groups', $h_group_id);
                         }
                     }
@@ -406,7 +364,7 @@ class NotificationTargetTicket extends NotificationTargetCommonITILObject
 
                     if ($hardware->isField($modelfield)) {
                         $tmp['##ticket.item.model##'] = '';
-                        if ($h_model_id = $hardware->getField($modelfield)) {
+                        if ($h_model_id = $hardware->fields[$modelfield]) {
                             $tmp['##ticket.item.model##'] = Dropdown::getDropdownName($modeltable, $h_model_id);
                         }
                     }
@@ -420,7 +378,7 @@ class NotificationTargetTicket extends NotificationTargetCommonITILObject
 
         // Get followups, log, validation
         if (!$simple) {
-            $restrict          = ['tickets_id' => $item->getField('id')];
+            $restrict          = ['tickets_id' => $item->getID()];
             $problems          = getAllDataFromTable('glpi_problems_tickets', $restrict);
             $data['problems'] = [];
             if (count($problems)) {
@@ -432,7 +390,7 @@ class NotificationTargetTicket extends NotificationTargetCommonITILObject
                         $tmp['##problem.id##']
                                  = $row['problems_id'];
                         $tmp['##problem.date##']
-                                 = $problem->getField('date');
+                                 = Html::convDateTime($problem->fields['date']);
                         $tmp['##problem.title##']
                                  = $problem->getField('name');
                         $tmp['##problem.url##']
@@ -461,7 +419,7 @@ class NotificationTargetTicket extends NotificationTargetCommonITILObject
                         $tmp['##change.id##']
                                  = $row['changes_id'];
                         $tmp['##change.date##']
-                                 = $change->getField('date');
+                                 = Html::convDateTime($change->fields['date']);
                         $tmp['##change.title##']
                                  = $change->getField('name');
                         $tmp['##change.url##']
@@ -482,7 +440,7 @@ class NotificationTargetTicket extends NotificationTargetCommonITILObject
             // Approbation of solution
             $solution_restrict = [
                 'itemtype' => Ticket::class,
-                'items_id' => $item->getField('id'),
+                'items_id' => $item->getID(),
             ];
             $replysolved = getAllDataFromTable(
                 'glpi_itilfollowups',
@@ -497,7 +455,7 @@ class NotificationTargetTicket extends NotificationTargetCommonITILObject
             $data['##ticket.solution.approval.author##']      = $current ? getUserName($current['users_id']) : '';
 
             //Validation infos
-            $restrict = ['tickets_id' => $item->getField('id')];
+            $restrict = ['tickets_id' => $item->getID()];
 
             if (isset($options['validation_id']) && $options['validation_id']) {
                 $restrict['glpi_ticketvalidations.id'] = $options['validation_id'];

--- a/src/NotificationTargetUser.php
+++ b/src/NotificationTargetUser.php
@@ -113,7 +113,7 @@ class NotificationTargetUser extends NotificationTarget
                         // Do not set users_id
                         $data = ['name'     => $this->obj->getName(),
                             'email'    => $this->obj->getDefaultEmail(),
-                            'language' => $this->obj->getField('language'),
+                            'language' => $this->obj->fields['language'],
                             'usertype' => $usertype,
                         ];
                         $this->addToRecipientsList($data);

--- a/src/NotificationTemplate.php
+++ b/src/NotificationTemplate.php
@@ -606,7 +606,7 @@ class NotificationTemplate extends CommonDBTM
         $iterator = $DB->request([
             'FROM'   => 'glpi_notificationtemplatetranslations',
             'WHERE'  => [
-                'notificationtemplates_id' => $this->getField('id'),
+                'notificationtemplates_id' => $this->getID(),
                 'language'                 => [$language, ''],
             ],
             'ORDER'  => 'language DESC',
@@ -649,9 +649,7 @@ class NotificationTemplate extends CommonDBTM
         $mailing_options['subject']      = $template_data['subject'];
         $mailing_options['content_html'] = $template_data['content_html'];
         $mailing_options['content_text'] = $template_data['content_text'];
-        $mailing_options['items_id']     = method_exists($target->obj, "getField")
-         ? $target->obj->getField('id')
-         : 0;
+        $mailing_options['items_id']     = $target->obj instanceof CommonDBTM ? $target->obj->getID() : 0;
         if (property_exists($target->obj, 'documents') && isset($target->obj->documents)) {
             $mailing_options['documents'] = $target->obj->documents;
         }

--- a/src/NotificationTemplateTranslation.php
+++ b/src/NotificationTemplateTranslation.php
@@ -79,8 +79,8 @@ class NotificationTemplateTranslation extends CommonDBChild
     {
         global $CFG_GLPI;
 
-        if ($this->getField('language') !== '') {
-            return $CFG_GLPI['languages'][$this->getField('language')][0];
+        if ($this->fields['language'] !== '') {
+            return $CFG_GLPI['languages'][$this->fields['language']][0];
         }
         return __('Default translation');
     }
@@ -105,7 +105,7 @@ class NotificationTemplateTranslation extends CommonDBChild
         $notificationtemplates_id = $options['notificationtemplates_id'] ?? -1;
 
         if ($this->getFromDB($ID)) {
-            $notificationtemplates_id = $this->getField('notificationtemplates_id');
+            $notificationtemplates_id = $this->fields['notificationtemplates_id'];
         }
         $template = new NotificationTemplate();
         $template->getFromDB($notificationtemplates_id);
@@ -113,7 +113,7 @@ class NotificationTemplateTranslation extends CommonDBChild
         $used_languages = self::getAllUsedLanguages($notificationtemplates_id);
         // Remove current language
         if (!$this->isNewItem()) {
-            $used_languages = array_diff($used_languages, [$this->getField('language')]);
+            $used_languages = array_diff($used_languages, [$this->fields['language']]);
         }
 
         TemplateRenderer::getInstance()->display('pages/setup/notification/translation.html.twig', [
@@ -134,7 +134,7 @@ class NotificationTemplateTranslation extends CommonDBChild
     {
         global $CFG_GLPI, $DB;
 
-        $nID     = $template->getField('id');
+        $nID     = $template->getID();
         $canedit = Config::canUpdate();
 
         if ($canedit) {

--- a/src/PrinterLog.php
+++ b/src/PrinterLog.php
@@ -67,7 +67,7 @@ class PrinterLog extends CommonDBChild
 
         /** @var Printer|Asset $item */
         if (in_array($item::class, $CFG_GLPI['printer_types'])) {
-            $cnt = countElementsInTable([static::getTable()], [static::$items_id => $item->getField('id')]);
+            $cnt = countElementsInTable([static::getTable()], [static::$items_id => $item->getID()]);
             $array_ret[] = self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $cnt, $item::class);
         }
         return $array_ret;

--- a/src/Problem_Ticket.php
+++ b/src/Problem_Ticket.php
@@ -195,7 +195,7 @@ class Problem_Ticket extends CommonITILObject_CommonITILObject
      **/
     public static function showForProblem(Problem $problem)
     {
-        $ID = $problem->getField('id');
+        $ID = $problem->getID();
 
         if (!static::canView() || !$problem->can($ID, READ)) {
             return;
@@ -271,7 +271,7 @@ class Problem_Ticket extends CommonITILObject_CommonITILObject
     public static function showForTicket(Ticket $ticket)
     {
 
-        $ID = $ticket->getField('id');
+        $ID = $ticket->getID();
 
         if (!static::canView() || !$ticket->can($ID, READ)) {
             return;

--- a/src/Profile_User.php
+++ b/src/Profile_User.php
@@ -125,7 +125,7 @@ class Profile_User extends CommonDBRelation
      */
     public static function showForUser(User $user)
     {
-        $ID = $user->getField('id');
+        $ID = $user->getID();
         if (!$user->can($ID, READ)) {
             return;
         }
@@ -245,7 +245,7 @@ class Profile_User extends CommonDBRelation
     {
         global $DB;
 
-        $ID = $entity->getField('id');
+        $ID = $entity->getID();
         if (!$entity->can($ID, READ)) {
             return;
         }
@@ -657,7 +657,7 @@ TWIG, $avatar_params) . $username;
         if ($default_first) {
             $user = new User();
             if ($user->getFromDB((int) $user_ID)) {
-                $ent = $user->getField('entities_id');
+                $ent = $user->fields['entities_id'];
                 if (in_array($ent, $entities)) {
                     array_unshift($entities, $ent);
                 }

--- a/src/ProjectTask_Ticket.php
+++ b/src/ProjectTask_Ticket.php
@@ -157,7 +157,7 @@ class ProjectTask_Ticket extends CommonDBRelation
      **/
     public static function showForProjectTask(ProjectTask $projecttask)
     {
-        $ID = $projecttask->getField('id');
+        $ID = $projecttask->getID();
         if (!$projecttask->can($ID, READ)) {
             return false;
         }
@@ -240,7 +240,7 @@ class ProjectTask_Ticket extends CommonDBRelation
     {
         global $CFG_GLPI, $DB;
 
-        $ID = $ticket->getField('id');
+        $ID = $ticket->getID();
         if (!$ticket->can($ID, READ)) {
             return false;
         }

--- a/src/QueuedNotification.php
+++ b/src/QueuedNotification.php
@@ -516,7 +516,7 @@ class QueuedNotification extends CommonDBTM
     public function sendById($ID)
     {
         if ($this->getFromDB($ID)) {
-            $mode = $this->getField('mode');
+            $mode = $this->fields['mode'];
             $eventclass = 'NotificationEvent' . ucfirst($mode);
             $conf = Notification_NotificationTemplate::getMode($mode);
             if ($conf['from'] !== 'core') {

--- a/src/Reservation.php
+++ b/src/Reservation.php
@@ -795,7 +795,7 @@ class Reservation extends CommonDBChild
             // Set item if not set
             if (
                 (!isset($options['item']) || (count($options['item']) === 0))
-                && ($itemid = $resa->getField('reservationitems_id'))
+                && ($itemid = $resa->fields['reservationitems_id'])
             ) {
                 $options['item'][$itemid] = $itemid;
             }

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -3017,7 +3017,7 @@ TWIG, ['label' => $this->getTitle()]);
             $this->showForm(0, [
                 'no_header' => true,
                 'short'     => true,
-                'entities_id' => $item->getField('id'),
+                'entities_id' => $item->getID(),
                 'params' => [
                     'formfooter' => false,
                 ],
@@ -3027,7 +3027,7 @@ TWIG, ['label' => $this->getTitle()]);
         // Get all rules and actions
         $crit = [
             'field' => getForeignKeyFieldForTable($item->getTable()),
-            'value' => $item->getField('id'),
+            'value' => $item->getID(),
         ];
 
         $rules = $this->getRulesForCriteria($crit);
@@ -3171,7 +3171,7 @@ TWIG, ['label' => $this->getTitle()]);
                     $valfield => $item->input['_replace_by'],
                 ],
                 [
-                    $valfield   => $item->getField('id'),
+                    $valfield   => $item->getID(),
                     $fieldfield => ['LIKE', $field],
                 ]
             );
@@ -3180,7 +3180,7 @@ TWIG, ['label' => $this->getTitle()]);
                 'SELECT' => [$fieldid],
                 'FROM'   => $table,
                 'WHERE'  => [
-                    $valfield   => $item->getField('id'),
+                    $valfield   => $item->getID(),
                     $fieldfield => ['LIKE', $field],
                 ],
             ]);

--- a/src/RuleMailCollector.php
+++ b/src/RuleMailCollector.php
@@ -270,7 +270,7 @@ class RuleMailCollector extends Rule
                                                 $user = new User();
                                                 $user->getFromDB($params['_users_id_requester']);
 
-                                                $tmpid = $user->getField('entities_id');
+                                                $tmpid = $user->fields['entities_id'];
 
                                                 // Retrieve all the entities (pref could be set on a child)
                                                 $entities

--- a/src/RuleMatchedLog.php
+++ b/src/RuleMatchedLog.php
@@ -73,7 +73,7 @@ class RuleMatchedLog extends CommonDBTM
             self::getTable(),
             [
                 'itemtype' => $item::class,
-                'items_id' => $item->getField('id'),
+                'items_id' => $item->getID(),
             ]
         );
     }

--- a/src/SavedSearch.php
+++ b/src/SavedSearch.php
@@ -1041,7 +1041,7 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
         $cron_status = 0;
 
         if ($CFG_GLPI['show_count_on_tabs'] != -1) {
-            $lastdate = new DateTime($task->getField('lastrun'));
+            $lastdate = new DateTime($task->fields['lastrun']);
             $lastdate->sub(new DateInterval('P7D'));
 
             $iterator = $DB->request(['FROM'   => self::getTable(),
@@ -1135,16 +1135,16 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
             $search = new Search();
             //Do the same as self::getParameters() but getFromDB is useless
             $query_tab = [];
-            parse_str($this->getField('query'), $query_tab);
+            parse_str($this->fields['query'], $query_tab);
 
-            $params = class_exists($this->getField('itemtype')) ? $query_tab : null;
+            $params = class_exists($this->fields['itemtype']) ? $query_tab : null;
 
             if (!$params) {
                 throw new RuntimeException('Saved search #' . $this->getID() . ' seems to be broken!');
             } else {
                 $params['silent_validation'] = true;
                 $data                   = $search->prepareDatasForSearch(
-                    $this->getField('itemtype'),
+                    $this->fields['itemtype'],
                     $params
                 );
                 // force saved search ID to indicate to Search to save execution time

--- a/src/SavedSearch_Alert.php
+++ b/src/SavedSearch_Alert.php
@@ -172,7 +172,7 @@ class SavedSearch_Alert extends CommonDBChild
             'FROM'   => Notification::getTable(),
             'WHERE'  => [
                 'itemtype'  => static::class,
-                'event'     => 'alert' . ($search->getField('is_private') ? '' : '_' . $search->getID()),
+                'event'     => 'alert' . ($search->isPrivate() ? '' : ('_' . $search->getID())),
             ],
         ]);
 
@@ -425,7 +425,8 @@ class SavedSearch_Alert extends CommonDBChild
                     self::restoreContext($context);
 
                     if ($notify) {
-                        $event = 'alert' . ($savedsearch->getField('is_private') ? '' : '_' . $savedsearch->getID());
+                        // 'alert' = private saved search, 'alert_ID' = public saved search
+                        $event = 'alert' . ($savedsearch->isPrivate() ? '' : ('_' . $savedsearch->getID()));
                         $savedsearch_alert = new self();
                         $savedsearch_alert->getFromDB($row['id']);
                         $data['savedsearch'] = $savedsearch;

--- a/src/Session.php
+++ b/src/Session.php
@@ -2006,7 +2006,7 @@ class Session
 
         // Cannot impersonate inactive user
         $user = new User();
-        if (!$user->getFromDB($user_id) || !$user->getField('is_active')) {
+        if (!$user->getFromDB($user_id) || !$user->isActive()) {
             $message = __("The user is not active.");
             return false;
         }

--- a/src/Software.php
+++ b/src/Software.php
@@ -927,7 +927,7 @@ class Software extends CommonDBTM implements TreeBrowseInterface, AssignableItem
     {
         global $DB;
 
-        $ID   = $this->getField('id');
+        $ID   = $this->getID();
         $this->check($ID, UPDATE);
 
         $iterator = $DB->request([
@@ -1011,7 +1011,7 @@ class Software extends CommonDBTM implements TreeBrowseInterface, AssignableItem
     {
         global $DB;
 
-        $ID = $this->getField('id');
+        $ID = $this->getID();
 
         $item = array_keys($item);
 
@@ -1079,7 +1079,7 @@ class Software extends CommonDBTM implements TreeBrowseInterface, AssignableItem
                         'glpi_softwareversions',
                         [
                             'softwares_id' => $ID,
-                            'entities_id'  => $this->getField('entities_id'),
+                            'entities_id'  => $this->fields['entities_id'],
                         ],
                         [
                             'id' => $from['id'],

--- a/src/SoftwareLicense.php
+++ b/src/SoftwareLicense.php
@@ -989,7 +989,7 @@ class SoftwareLicense extends CommonTreeDropdown implements AssignableItemInterf
     {
         global $DB;
 
-        $softwares_id  = $software->getField('id');
+        $softwares_id  = $software->getID();
         $license       = new self();
 
         if (!$software->can($softwares_id, READ)) {

--- a/src/SoftwareLicense_User.php
+++ b/src/SoftwareLicense_User.php
@@ -73,14 +73,14 @@ class SoftwareLicense_User extends CommonDBRelation
 
         // Check quota if not unlimited (-1) and over-quota not allowed
         if (
-            $license->getField('number') != -1
-            && !$license->getField('allow_overquota')
+            $license->fields['number'] != -1
+            && !$license->fields['allow_overquota']
         ) {
             // Count current assignments (users + items)
             $count = self::countForLicense($softwarelicenses_id);
             $count += Item_SoftwareLicense::countForLicense($softwarelicenses_id);
 
-            if ($count >= $license->getField('number')) {
+            if ($count >= $license->fields['number']) {
                 Session::addMessageAfterRedirect(
                     __s('Maximum number of items reached for this license.'),
                     false,

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -1305,7 +1305,7 @@ class Ticket extends CommonITILObject implements DefaultSearchRequestInterface
             $sla->setTicketCalendar($calendars_id);
             $sla->addLevelToDo($this, $slalevels_id);
         }
-        SlaLevel_Ticket::replayForTicket($this->getID(), $sla->getField('type'));
+        SlaLevel_Ticket::replayForTicket($this->getID(), $sla->fields['type']);
     }
 
     /**
@@ -1335,7 +1335,7 @@ class Ticket extends CommonITILObject implements DefaultSearchRequestInterface
             $ola->setTicketCalendar($calendars_id);
             $ola->addLevelToDo($this, $olalevels_id);
         }
-        OlaLevel_Ticket::replayForTicket($this->getID(), $ola->getField('type'));
+        OlaLevel_Ticket::replayForTicket($this->getID(), $ola->fields['type']);
     }
 
 
@@ -3387,7 +3387,7 @@ JAVASCRIPT;
             ],
             'WHERE'     => [
                 'glpi_items_tickets.itemtype' => get_class($item),
-                'glpi_items_tickets.items_id' => $item->getField('id'),
+                'glpi_items_tickets.items_id' => $item->getID(),
                 'OR'                          => [
                     'glpi_ticketcosts.cost_time'     => ['>', 0],
                     'glpi_ticketcosts.cost_fixed'    => ['>', 0],
@@ -3572,15 +3572,15 @@ JAVASCRIPT;
             if (isset($options['_projecttasks_id'])) {
                 $pt = new ProjectTask();
                 if ($pt->getFromDB($options['_projecttasks_id'])) {
-                    $options['name'] = $pt->getField('name');
-                    $options['content'] = $pt->getField('content');
+                    $options['name'] = $pt->fields['name'];
+                    $options['content'] = $pt->fields['content'];
                 }
             }
             // Override default values from followup if needed
             if (isset($options['_promoted_fup_id']) && !$options['_skip_promoted_fields']) {
                 $fup = new ITILFollowup();
                 if ($fup->getFromDB($options['_promoted_fup_id'])) {
-                    $options['content'] = $fup->getField('content');
+                    $options['content'] = $fup->fields['content'];
                     $options['_users_id_requester'] = $fup->fields['users_id'];
                     // FIXME Use new format
                     $options['_link'] = [
@@ -3589,10 +3589,10 @@ JAVASCRIPT;
                     ];
 
                     // Set entity from parent
-                    $parent_itemtype = $fup->getField('itemtype');
+                    $parent_itemtype = $fup->fields['itemtype'];
                     $parent = getItemForItemtype($parent_itemtype);
-                    if ($parent->getFromDB($fup->getField('items_id'))) {
-                        $options['entities_id'] = $parent->getField('entities_id');
+                    if ($parent->getFromDB($fup->fields['items_id'])) {
+                        $options['entities_id'] = $parent->fields['entities_id'];
                     }
                 }
                 //Allow overriding the default values
@@ -3602,7 +3602,7 @@ JAVASCRIPT;
             if (isset($options['_promoted_task_id']) && !$options['_skip_promoted_fields']) {
                 $tickettask = new TicketTask();
                 if ($tickettask->getFromDB($options['_promoted_task_id'])) {
-                    $options['content'] = $tickettask->getField('content');
+                    $options['content'] = $tickettask->fields['content'];
                     $options['_users_id_requester'] = $tickettask->fields['users_id'];
                     $options['_users_id_assign'] = $tickettask->fields['users_id_tech'];
                     $options['_groups_id_assign'] = $tickettask->fields['groups_id_tech'];
@@ -3614,8 +3614,8 @@ JAVASCRIPT;
 
                     // Set entity from parent
                     $parent = new Ticket();
-                    if ($parent->getFromDB($tickettask->getField('tickets_id'))) {
-                        $options['entities_id'] = $parent->getField('entities_id');
+                    if ($parent->getFromDB($tickettask->fields['tickets_id'])) {
+                        $options['entities_id'] = $parent->fields['entities_id'];
                     }
                 }
                 //Allow overriding the default values
@@ -5531,7 +5531,7 @@ JAVASCRIPT;
         Html::showDatesTimelineGraph([
             'title'   => _n('Date', 'Dates', Session::getPluralNumber()),
             'dates'   => $dates,
-            'add_now' => $this->getField('closedate') == "",
+            'add_now' => $this->fields['closedate'] == "",
         ]);
     }
 

--- a/src/Ticket_Contract.php
+++ b/src/Ticket_Contract.php
@@ -95,7 +95,7 @@ class Ticket_Contract extends CommonDBRelation
         /** @var class-string<Ticket|Contract> $linked_itemtype */
         $twig_params['linked_itemtype'] = $linked_itemtype;
 
-        $ID = $item->getField('id');
+        $ID = $item->getID();
         $twig_params['id'] = $ID;
 
         if (!static::canView() || !$item->can($ID, READ)) {

--- a/src/Transfer.php
+++ b/src/Transfer.php
@@ -1852,14 +1852,14 @@ final class Transfer extends CommonDBTM
         $license                  = new SoftwareLicense();
 
         if ($item_softwarelicense->getFromDB($ID)) {
-            if ($license->getFromDB($item_softwarelicense->getField('softwarelicenses_id'))) {
+            if ($license->getFromDB($item_softwarelicense->fields['softwarelicenses_id'])) {
                 //// Update current : decrement number by 1 if valid
-                if ($license->getField('number') > 1) {
+                if ($license->fields['number'] > 1) {
                     $license->update([
                         'id'     => $license->getID(),
-                        'number' => ($license->getField('number') - 1),
+                        'number' => ($license->fields['number'] - 1),
                     ]);
-                } elseif ($license->getField('number') == 1) {
+                } elseif ($license->fields['number'] == 1) {
                     // Drop license
                     $license->delete(['id' => $license->getID()]);
                 }
@@ -3010,7 +3010,7 @@ final class Transfer extends CommonDBTM
                                     'WHERE'  => [
                                         'is_global'    => 1,
                                         'entities_id'  => $this->to,
-                                        'name'         => $link_item->getField('name'),
+                                        'name'         => $link_item->fields['name'],
                                     ],
                                 ]);
 

--- a/src/User.php
+++ b/src/User.php
@@ -1251,7 +1251,7 @@ class User extends CommonDBTM implements TreeBrowseInterface
                     if (
                         isset($input[$input_key])
                         && !str_starts_with($input_key, '_') // virtual field
-                        && $input[$input_key] != $this->getField($input_key)
+                        && $input[$input_key] != $this->fields[$input_key]
                     ) {
                         $ignored_fields[] = $input_key;
                     }
@@ -1275,7 +1275,7 @@ class User extends CommonDBTM implements TreeBrowseInterface
         if (
             isset($input["authtype"])
             && $input["authtype"] != Auth::DB_GLPI
-            && $input["authtype"] != $this->getField('authtype')
+            && $input["authtype"] != $this->fields['authtype']
         ) {
             $input["password"] = "";
         }
@@ -4646,7 +4646,7 @@ HTML;
     {
         global $CFG_GLPI, $DB;
 
-        $ID = $this->getField('id');
+        $ID = $this->getID();
 
         $start       = intval($_GET["start"] ?? 0);
 

--- a/tests/functional/Item_SoftwareVersionTest.php
+++ b/tests/functional/Item_SoftwareVersionTest.php
@@ -113,8 +113,8 @@ class Item_SoftwareVersionTest extends DbTestCase
             'items_id'              => $computer1->getID(),
             'itemtype'              => 'Computer',
             'name'                  => 'A name',
-            'is_template_item'      => $computer1->getField('is_template'),
-            'is_deleted_item'       => $computer1->getField('is_deleted'),
+            'is_template_item'      => $computer1->isTemplate(),
+            'is_deleted_item'       => $computer1->isDeleted(),
             'entities_id'           => getItemByTypeName('Entity', '_test_root_entity', true),
             'is_recursive'          => 0,
         ];
@@ -151,8 +151,8 @@ class Item_SoftwareVersionTest extends DbTestCase
             'items_id'              => $computer1->getID(),
             'itemtype'              => 'Computer',
             'name'                  => 'Another name',
-            'is_template_item'      => $computer1->getField('is_template'),
-            'is_deleted_item'       => $computer1->getField('is_deleted'),
+            'is_template_item'      => $computer1->isTemplate(),
+            'is_deleted_item'       => $computer1->isDeleted(),
         ];
 
         $this->assertSame($expected, $ins->prepareInputForUpdate($input));


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

`CommonDBTM::getField` is not meant to be used except for values that will displayed to the user. Maybe due to its name making it look like a simple getter, there are a lot of cases where the result of the function is used for SQL queries and other backend logic.