### PR TITLE
Enable dark mode in Swagger UI

### DIFF
--- a/src/Glpi/Api/HL/Controller/CoreController.php
+++ b/src/Glpi/Api/HL/Controller/CoreController.php
@@ -50,6 +50,7 @@ use Glpi\Http\Response;
 use Glpi\OAuth\Server;
 use Glpi\System\Status\StatusChecker;
 use Glpi\Toolbox\MarkdownRenderer;
+use Glpi\UI\ThemeManager;
 use Html;
 use JsonException;
 use League\OAuth2\Server\Exception\OAuthServerException;
@@ -159,7 +160,11 @@ final class CoreController extends AbstractController
     {
         global $CFG_GLPI;
 
-        $swagger_content = '<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><title>GLPI API Documentation</title>';
+        $swagger_content = '<!DOCTYPE html><html lang="en"';
+        if (ThemeManager::getInstance()->getCurrentTheme()->isDarkTheme()) {
+            $swagger_content .= ' class="dark-mode"';
+        }
+        $swagger_content .= '><head><meta charset="UTF-8"><title>GLPI API Documentation</title>';
         $swagger_content .= Html::script('/lib/swagger-ui.js');
         $swagger_content .= Html::css('/lib/swagger-ui.css');
         $favicon = Html::getPrefixedUrl('/pics/favicon.ico');


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Follows #22543 to enable the new dark mode feature in Swagger when the current GLPI theme is dark.