### PR TITLE
fix processor frequency search option computation

### DIFF
--- a/src/DeviceProcessor.php
+++ b/src/DeviceProcessor.php
@@ -302,9 +302,9 @@ class DeviceProcessor extends CommonDevice
             'width'              => 100,
             'massiveaction'      => false,
             'joinparams'         => $main_joinparams,
-            'computation'        => QueryFunction::sum('TABLE.frequency') . ' * ' . QueryFunction::count(
+            'computation'        => QueryFunction::sum('TABLE.frequency') . ' / ' . QueryFunction::count(
                 expression: 'TABLE.id',
-            ) . ' / ' . QueryFunction::count(new QueryExpression('*')),
+            ),
             'nometa'             => true, // cannot GROUP_CONCAT a SUM
         ];
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

fixes #22509

Seems like an issue with copy/paste from other search options when migrating raw SQL to QueryFunction calls. This PR restores the computation to what it is in GLPI 10.
