### PR TITLE
Add comment variable to asset content templates objects

### DIFF
--- a/src/Glpi/ContentTemplates/Parameters/AssetParameters.php
+++ b/src/Glpi/ContentTemplates/Parameters/AssetParameters.php
@@ -70,6 +70,7 @@ class AssetParameters extends AbstractParameters
             new AttributeParameter("name", __('Name')),
             new AttributeParameter("itemtype", __('Itemtype')),
             new AttributeParameter("serial", __('Serial number')),
+            new AttributeParameter("comment", __('Comments')),
             new ObjectParameter(new EntityParameters()),
         ];
     }
@@ -83,6 +84,7 @@ class AssetParameters extends AbstractParameters
             'name'     => $fields['name'],
             'itemtype' => $asset->getType(),
             'serial'   => $fields['serial'],
+            'comment'  => $fields['comment'],
         ];
 
         // Add asset's entity

--- a/tests/functional/Glpi/ContentTemplates/Parameters/AssetParametersTest.php
+++ b/tests/functional/Glpi/ContentTemplates/Parameters/AssetParametersTest.php
@@ -47,6 +47,7 @@ class AssetParametersTest extends AbstractParametersTest
             'name'        => 'pc_testGetValues',
             'serial'      => 'abcd1234',
             'entities_id' => $test_entity_id,
+            'comment'     => 'This is a test computer.',
         ]);
 
         $parameters = new AssetParameters();
@@ -62,6 +63,7 @@ class AssetParametersTest extends AbstractParametersTest
                     'name'         => '_test_child_2',
                     'completename' => 'Root entity > _test_root_entity > _test_child_2',
                 ],
+                'comment'     => 'This is a test computer.',
             ],
             $values
         );


### PR DESCRIPTION
Please, in AssetParameters.php, add the following lines::
`new AttributeParameter("comment", __('Comments')),`
`'comment'  => $fields['comment'],`

For comment to be one more TWIG **variable available** for templates:
{{ asset.comment }}


