### PR TITLE
fix(widget): legend color not adapting to light/dark mode

### DIFF
--- a/src/Glpi/Dashboard/Widget.php
+++ b/src/Glpi/Dashboard/Widget.php
@@ -1279,8 +1279,11 @@ HTML;
 
         if ($p['legend']) {
             $options['legend'] = [
-                'show' => true,
-                'left' => 'left',
+                'show'      => true,
+                'left'      => 'left',
+                'textStyle' => [
+                    'color' => $fg_color,
+                ],
             ];
         }
 
@@ -1643,8 +1646,11 @@ HTML;
 
         if ($p['legend']) {
             $options['legend'] = [
-                'show' => true,
-                'left' => 'left',
+                'show'      => true,
+                'left'      => 'left',
+                'textStyle' => [
+                    'color' => $fg_color,
+                ],
             ];
         }
 


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !41249
- The color of the widget legend did not match the active theme.
It remained black in both light and dark modes, making it difficult to read in dark mode.

## Screenshots (if appropriate):

Before:
<img width="1428" height="1187" alt="image" src="https://github.com/user-attachments/assets/1977dd6e-1e77-4dcf-a0c7-597fea55a90b" />

After:
<img width="1428" height="1187" alt="image" src="https://github.com/user-attachments/assets/1c7a5e45-9fe0-4703-924b-fa56e6bbc99e" />


