### PR TITLE
Add action to lock old closed issues/PRs

### DIFF
--- a/.github/workflows/lock_closed.yaml
+++ b/.github/workflows/lock_closed.yaml
@@ -28,3 +28,5 @@ jobs:
           pr-comment: >
             This PR has been is closed and has been automatically locked.
             Please open a new issue with all requested information for related bugs.
+          exclude-issue-created-before: '2025-01-01T00:00:00Z'
+          exclude-pr-created-before: '2025-01-01T00:00:00Z'

--- a/.github/workflows/lock_closed.yaml
+++ b/.github/workflows/lock_closed.yaml
@@ -1,0 +1,30 @@
+name: 'Lock closed threads'
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+  discussions: write
+
+concurrency:
+  group: lock-threads
+
+jobs:
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v6
+        with:
+          process-only: 'issues,prs'
+          issue-inactive-days: '100'
+          pr-inactive-days: '100'
+          issue-comment: >
+            This issue is closed and has been automatically locked.
+            Please open a new issue with all requested information for related bugs.
+          pr-comment: >
+            This PR has been is closed and has been automatically locked.
+            Please open a new issue with all requested information for related bugs.


### PR DESCRIPTION
See https://github.com/dessant/lock-threads.

Opened for discussion; inactive delays are arbitrary (defaults is 365 days which is a bit too long).