### PR TITLE
Fix(Forms): borders visibility

### DIFF
--- a/css/includes/_base.scss
+++ b/css/includes/_base.scss
@@ -567,6 +567,15 @@ body pre {
 
 .text-muted {
     color: var(--tblr-muted) !important;
+
+    thead,
+    tbody,
+    tfoot,
+    tr,
+    td,
+    th {
+        border-width: inherit; // Prevent removal of borders from reboot CSS
+    }
 }
 
 .input-group {


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !40823

In the form preview (before editing) If there is a question with an array, its inner borders are not visible, whereas they are visible in edit mode or in the form rendering.

## Screenshots (if appropriate):

Before:
<img width="1053" height="439" alt="image" src="https://github.com/user-attachments/assets/184e6d5f-c886-4260-a88b-6f8259afb2a9" />

After:
<img width="1053" height="439" alt="image" src="https://github.com/user-attachments/assets/19fc6c1c-89dc-43a7-9006-c73462af4d22" />

Edit mode:
<img width="1122" height="650" alt="image" src="https://github.com/user-attachments/assets/d7d764d8-8b7a-47ad-bc7a-d93ded5ad29f" />

Rendering:
<img width="1306" height="548" alt="image" src="https://github.com/user-attachments/assets/6a2cdd8e-e349-44d9-927b-961e952387f1" />

