### PR TITLE
Fix(MetaSearch): fix first init of searchoption

### DIFF
--- a/src/Glpi/Search/Input/QueryBuilder.php
+++ b/src/Glpi/Search/Input/QueryBuilder.php
@@ -201,11 +201,11 @@ final class QueryBuilder implements SearchInputInterface
 
         // on first call, set default first field if not defined
         if (empty($request['field'])) {
-            $numericKeys = array_filter(
+            $numeric_keys = array_filter(
                 array_keys(SearchOption::getOptionsForItemtype($request['itemtype'])),
                 'is_numeric'
             );
-            $request['field'] = !empty($numericKeys) ? reset($numericKeys) : '';
+            $request['field'] = $numeric_keys !== [] ? reset($numeric_keys) : '';
         }
 
         $actions = SearchOption::getActionsFor($request["itemtype"], $request["field"]);

--- a/src/Glpi/Search/Input/QueryBuilder.php
+++ b/src/Glpi/Search/Input/QueryBuilder.php
@@ -199,6 +199,15 @@ final class QueryBuilder implements SearchInputInterface
             $request['meta'] = 0;
         }
 
+        // on first call, set default first field if not defined
+        if (empty($request['field'])) {
+            $numericKeys = array_filter(
+                array_keys(SearchOption::getOptionsForItemtype($request['itemtype'])),
+                'is_numeric'
+            );
+            $request['field'] = !empty($numericKeys) ? reset($numericKeys) : '';
+        }
+
         $actions = SearchOption::getActionsFor($request["itemtype"], $request["field"]);
 
         // is it a valid action for type ?


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !40909

When using **meta criteria (global rules)**, the initial initialization of operators is not correct for the criterion selected by default (the first one in the list, here `'name'`).

<img width="1663" height="296" alt="image" src="https://github.com/user-attachments/assets/2d01f94a-05d0-4f89-87c5-467cc9f246c8" />

However, if I change the criterion to another field (e.g., a **sub-entity**):

<img width="1663" height="296" alt="image" src="https://github.com/user-attachments/assets/132b5b9c-5ad3-4b22-a5b0-628c00ef7184" />

and then switch back to the first criterion (`name`), the operators are displayed correctly:

<img width="1667" height="344" alt="image" src="https://github.com/user-attachments/assets/42de6d7a-3ca6-4ef2-94fc-479801294620" />


In `criteria.html.twig`, the first call is executed via the following code, where the `field` value is empty on the initial load (which makes sense, as no user selection has occurred yet):

```twig
{% set value = criteria['field'] is defined ? criteria['field'] : '' %} {# empty on first initialization #}

{% set params = {
    itemtype: used_itemtype,
    _idor_token: idor_token(used_itemtype),
    field: value,
    searchtype: searchtype,
    value: p_value,
    num: num,
    p: p,
    mb: 'mb-0',
} %}
{{ call("Glpi\\Search\\Input\\QueryBuilder::displaySearchoption", [params]) }}
```

On the other hand, when the field is changed by the user, the following AJAX call is used:

```twig
{% do call('Ajax::updateItemOnSelectEvent', [
    field_id,
    spanid,
    config('root_doc') ~ "/ajax/search.php",
    params|merge({
        action: 'display_searchoption',
        field: '__VALUE__',
    })
]) %}
```

I therefore propose that, in case the value is empty, we use the **first numeric key from the list of search options**, since this corresponds to the **initial initialization** scenario. This works because the first numeric key matches the **first field selected by default** in the dropdown list.

## Screenshots (if appropriate):


