### PR TITLE
Allow classes to define client side actions

### DIFF
--- a/src/Glpi/Actions/ClientSideAction.php
+++ b/src/Glpi/Actions/ClientSideAction.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Actions;
+
+final readonly class ClientSideAction
+{
+    public function __construct(
+        private string $key,
+        private string $icon,
+        private string $label,
+    ) {}
+
+    public function getKey(): string
+    {
+        return $this->key;
+    }
+
+    public function getIcon(): string
+    {
+        return $this->icon;
+    }
+
+    public function getLabel(): string
+    {
+        return $this->label;
+    }
+}

--- a/src/Glpi/Actions/ClientSideActionList.php
+++ b/src/Glpi/Actions/ClientSideActionList.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Actions;
+
+final class ClientSideActionList
+{
+    /** @var ClientSideAction[] */
+    private array $actions = [];
+
+    public function add(ClientSideAction $action): void
+    {
+        $this->actions[] = $action;
+    }
+
+    /**
+     * Format the actions into the standard format used by massive actions.
+     * @return array<string, string>
+     */
+    public function toFormattedArray(): array
+    {
+        $formatted_actions = [];
+
+        foreach ($this->actions as $action) {
+            $formatted_actions["client:" . $action->getKey()] = sprintf(
+                '<i class="%s"></i>%s',
+                htmlescape($action->getIcon()),
+                htmlescape($action->getLabel()),
+            );
+        }
+
+        return $formatted_actions;
+    }
+}

--- a/src/Glpi/Actions/HasClientSideActionsInterface.php
+++ b/src/Glpi/Actions/HasClientSideActionsInterface.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Actions;
+
+interface HasClientSideActionsInterface
+{
+    public function getClientSideActions(): ClientSideActionList;
+}

--- a/src/MassiveAction.php
+++ b/src/MassiveAction.php
@@ -33,6 +33,7 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Actions\HasClientSideActionsInterface;
 use Glpi\Asset\CustomFieldDefinition;
 use Glpi\Features\Clonable;
 use Glpi\Plugin\Hooks;
@@ -238,6 +239,18 @@ class MassiveAction
                                     $this->getCheckItem($POST),
                                     $items_id
                                 );
+
+                                if (
+                                    isset($item)
+                                    && $item instanceof HasClientSideActionsInterface
+                                ) {
+                                    $client_actions = $item
+                                        ->getClientSideActions()
+                                        ->toFormattedArray()
+                                    ;
+                                    $actions = [...$actions, ...$client_actions];
+                                }
+
                                 $POST['actions'] = array_merge($actions, $POST['actions']);
                                 foreach ($actions as $action => $label) {
                                     $POST['action_filter'][$action][] = $itemtype;

--- a/src/MassiveAction.php
+++ b/src/MassiveAction.php
@@ -241,7 +241,8 @@ class MassiveAction
                                 );
 
                                 if (
-                                    isset($item)
+                                    !isAPI()
+                                    && isset($item)
                                     && $item instanceof HasClientSideActionsInterface
                                 ) {
                                     $client_actions = $item

--- a/templates/components/form/single-action.html.twig
+++ b/templates/components/form/single-action.html.twig
@@ -77,6 +77,12 @@ $(function () {
       $('.moreactions + .dropdown-menu').hide();
 
       var current_action = $(this).data('action');
+      if (current_action.startsWith('client:')) {
+         const action_name = current_action.replace('client:', '');
+         const event = new Event(action_name);
+         document.dispatchEvent(event);
+         return;
+      }
 
       glpi_ajax_dialog({
          url: `${CFG_GLPI.root_doc}/ajax/dropdownMassiveAction.php`,


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works -> no features to test yet

## Description

Classes can now implement a `HasClientSideActionsInterface` interface like this:

```php
#[Override]
 public function getClientSideActions(): ClientSideActionList
  {
      $list = new ClientSideActionList();
      $list->add(new ClientSideAction(
          key: "do_something",
          icon: "ti ti-send",
          label: "My action",
      ));
      return $list;
  }
```

In this example, this will add the "My action" entry to the single action dropdown:
Which will display this:

<img width="276" height="256" alt="image" src="https://github.com/user-attachments/assets/432bc50d-5e80-4d5d-9643-d9f21a5cd9b2" />

This action does nothing by default.
You can then listen to the event (using the value defined as the `key`) to execute client side code as needed:

```js
document.addEventListener('do_something', () => {
    console.log("Doing something");
});
```

This will be needed for the upcoming KB rework as we need to execute some client side logic using the action dropdown.

