### PR TITLE
fix(forms/condition-engine): Extend the visibility of the parent section to its child elements

### DIFF
--- a/src/Glpi/Form/Condition/Engine.php
+++ b/src/Glpi/Form/Condition/Engine.php
@@ -34,6 +34,7 @@
 
 namespace Glpi\Form\Condition;
 
+use Glpi\Form\BlockInterface;
 use Glpi\Form\Comment;
 use Glpi\Form\Condition\ConditionHandler\ConditionHandlerInterface;
 use Glpi\Form\Form;
@@ -196,6 +197,14 @@ final class Engine
     private function evaluateItemVisibility(ConditionableVisibilityInterface $item): bool
     {
         $strategy = $item->getConfiguredVisibilityStrategy();
+
+        // Before evaluating conditions, check parent visibility for BlockInterface items
+        if ($item instanceof BlockInterface) {
+            $parent_visible = $this->visibility_cache[$item->getSection()->getUUID()] ?? true;
+            if (!$parent_visible) {
+                return false;
+            }
+        }
 
         // Strategy ALWAYS_VISIBLE means always visible
         if ($strategy === VisibilityStrategy::ALWAYS_VISIBLE) {


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

This pull request improves the visibility logic for form blocks in the condition engine and adds new functional tests to ensure correct behavior when parent sections are hidden. The main focus is to ensure that child blocks (like comments and questions) are only visible if their parent section is visible.