### PR TITLE
Improve html::timestampToRelativeStr() for single minute/hour

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -6251,8 +6251,14 @@ CSS;
                 if ($diff < 60) {
                     return __('Just now');
                 }
+                if ($diff < 120) {
+                    return  sprintf(__('%s minute ago'), floor($diff / 60));
+                }
                 if ($diff < 3600) {
                     return  sprintf(__('%s minutes ago'), floor($diff / 60));
+                }
+                if ($diff < 7200) {
+                    return  sprintf(__('%s hour ago'), floor($diff / 3600));
                 }
                 if ($diff < 86400) {
                     return  sprintf(__('%s hours ago'), floor($diff / 3600));

--- a/tests/functional/HtmlTest.php
+++ b/tests/functional/HtmlTest.php
@@ -986,7 +986,7 @@ SCSS,
 
         $this->assertEquals(
             <<<CSS
-            
+
             nav > ul {
               margin: 0;
               padding: 0;
@@ -1219,7 +1219,7 @@ SCSS,
         yield [
             'current' => '2025-01-01 12:00:00.000',
             'timestamp' => '2025-01-01 11:59:00.000',
-            'expected'  => '1 minutes ago',
+            'expected'  => '1 minute ago',
         ];
 
         yield [
@@ -1231,7 +1231,7 @@ SCSS,
         yield [
             'current' => '2025-01-01 23:59:59.000',
             'timestamp' => '2025-01-01 22:59:59.000',
-            'expected'  => '1 hours ago',
+            'expected'  => '1 hour ago',
         ];
 
         yield [


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

`1 minutes ago` -> `1 minute ago`
`1 hours ago` -> `1 hour ago`