### PR TITLE
Allow custom devcontainers

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -3,3 +3,7 @@
 The docker devcontainers are meant to be used by VSCode or in a Github Codespaces environment.
 
 See the main `README.md` file in the `../.docker` folder.
+
+If you need to customize the values from `devcontainer.json`, you can copy it to a subfolder of `.devcontainer`.  
+Code will then ask you which file to use when starting the devcontainer.  
+I suggest the `custom` folder as it is already git-ignored but you can use any name.  

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ phpstan.neon
 /phpunit/files/
 /phpunit/config
 /.dump/
+.devcontainer/custom


### PR DESCRIPTION
## Description

The `devcontainer.json` contains things like a list of extensions that some users might want to customize (for example, use a different PHP extension).  

There is no support for partial overriding (like docker do with `-override.json` files), the only solution is to copy the file to a subfolder (code will ask you which file to use when it detect multiples, see https://github.com/microsoft/vscode-remote-release/issues/10091).

