### PR TITLE
Fix less/greater than condition on single choice value handler

### DIFF
--- a/src/Glpi/Form/Condition/Engine.php
+++ b/src/Glpi/Form/Condition/Engine.php
@@ -37,8 +37,10 @@ namespace Glpi\Form\Condition;
 use Glpi\Form\BlockInterface;
 use Glpi\Form\Comment;
 use Glpi\Form\Condition\ConditionHandler\ConditionHandlerInterface;
+use Glpi\Form\Condition\ConditionHandler\SingleChoiceFromValuesConditionHandler;
 use Glpi\Form\Form;
 use Glpi\Form\Question;
+use Glpi\Form\QuestionType\QuestionTypeSelectableExtraDataConfig;
 use Glpi\Form\Section;
 use LogicException;
 use Safe\Exceptions\JsonException;
@@ -427,10 +429,34 @@ final class Engine
             );
         }
 
+        // TODO: refactor on main branch so this can be done directly in the
+        // SingleChoiceFromValuesConditionHandler class by sending the question
+        // config to `applyValueOperator` as a 4th parameter.
+        // Can't be done on bugfix as it would be break classes implementing the
+        // interface.
+        if (
+            $condition_handler instanceof SingleChoiceFromValuesConditionHandler
+            && \in_array($operator, [
+                ValueOperator::LESS_THAN,
+                ValueOperator::LESS_THAN_OR_EQUALS,
+                ValueOperator::GREATER_THAN,
+                ValueOperator::GREATER_THAN_OR_EQUALS,
+            ], true)
+            && $config instanceof QuestionTypeSelectableExtraDataConfig
+        ) {
+            [$answer, $condition_value] = $this->mapSelectableValuesToRealValues(
+                $answer,
+                $condition->getValue(),
+                $config,
+            );
+        } else {
+            $condition_value = $condition->getValue();
+        }
+
         return $condition_handler->applyValueOperator(
             $answer,
             $condition->getValueOperator(),
-            $condition->getValue(),
+            $condition_value,
         );
     }
 
@@ -451,5 +477,28 @@ final class Engine
         }
 
         return false;
+    }
+
+    /**
+     * @return array{string, string}
+     */
+    private function mapSelectableValuesToRealValues(
+        mixed $answer,
+        mixed $condition_value,
+        QuestionTypeSelectableExtraDataConfig $config,
+    ): array {
+        $options = $config->getOptions();
+
+        if (is_array($answer)) {
+            $answer = array_pop($answer);
+        }
+        $answer = $options[$answer] ?? $answer;
+
+        if (is_array($condition_value)) {
+            $condition_value = array_pop($condition_value);
+        }
+        $condition_value = $options[$condition_value] ?? $condition_value;
+
+        return [$answer, $condition_value];
     }
 }

--- a/tests/functional/Glpi/Form/Condition/ConditionHandler/SingleChoiceFromValuesConditionHandlerTest.php
+++ b/tests/functional/Glpi/Form/Condition/ConditionHandler/SingleChoiceFromValuesConditionHandlerTest.php
@@ -57,9 +57,9 @@ final class SingleChoiceFromValuesConditionHandlerTest extends AbstractCondition
             "option_b" => "option B",
             "option_c" => "option C",
             "option_d" => "option D",
-            "1" => 1,
-            "2" => 2,
-            "3" => 3,
+            "fsefes-1" => 1,
+            "zzdzdd-2" => 2,
+            "abcdef-3" => 3,
         ];
 
         yield from self::getCasesForTypeAndConfig(
@@ -122,24 +122,24 @@ final class SingleChoiceFromValuesConditionHandlerTest extends AbstractCondition
         yield "Less than check - case 1 for $type" => [
             'question_type'       => $type,
             'condition_operator'  => ValueOperator::LESS_THAN,
-            'condition_value'     => "2",
-            'submitted_answer'    => "1",
+            'condition_value'     => "zzdzdd-2", // Fake UUID for the "2" value
+            'submitted_answer'    => "fsefes-1", // Fake UUID for the "1" value
             'expected_result'     => true,
             'question_extra_data' => $extra_data,
         ];
         yield "Less than check - case 2 for $type" => [
             'question_type'       => $type,
             'condition_operator'  => ValueOperator::LESS_THAN,
-            'condition_value'     => "2",
-            'submitted_answer'    => "2",
+            'condition_value'     => "zzdzdd-2", // Fake UUID for the "2" value
+            'submitted_answer'    => "zzdzdd-2", // Fake UUID for the "2" value
             'expected_result'     => false,
             'question_extra_data' => $extra_data,
         ];
         yield "Less than check - case 3 for $type" => [
             'question_type'       => $type,
             'condition_operator'  => ValueOperator::LESS_THAN,
-            'condition_value'     => "2",
-            'submitted_answer'    => "3",
+            'condition_value'     => "zzdzdd-2", // Fake UUID for the "2" value
+            'submitted_answer'    => "abcdef-3", // Fake UUID for the "3" value
             'expected_result'     => false,
             'question_extra_data' => $extra_data,
         ];
@@ -148,24 +148,24 @@ final class SingleChoiceFromValuesConditionHandlerTest extends AbstractCondition
         yield "Less than or equals check - case 1 for $type" => [
             'question_type'       => $type,
             'condition_operator'  => ValueOperator::LESS_THAN_OR_EQUALS,
-            'condition_value'     => "2",
-            'submitted_answer'    => "1",
+            'condition_value'     => "zzdzdd-2",  // Fake UUID for the "2" value
+            'submitted_answer'    => "fsefes-1",  // Fake UUID for the "1" value
             'expected_result'     => true,
             'question_extra_data' => $extra_data,
         ];
         yield "Less than or equals check - case 2 for $type" => [
             'question_type'       => $type,
             'condition_operator'  => ValueOperator::LESS_THAN_OR_EQUALS,
-            'condition_value'     => "2",
-            'submitted_answer'    => "2",
+            'condition_value'     => "zzdzdd-2", // Fake UUID for the "2" value
+            'submitted_answer'    => "zzdzdd-2", // Fake UUID for the "2" value
             'expected_result'     => true,
             'question_extra_data' => $extra_data,
         ];
         yield "Less than or equals check - case 3 for $type" => [
             'question_type'       => $type,
             'condition_operator'  => ValueOperator::LESS_THAN_OR_EQUALS,
-            'condition_value'     => "2",
-            'submitted_answer'    => "3",
+            'condition_value'     => "zzdzdd-2", // Fake UUID for the "2" value
+            'submitted_answer'    => "abcdef-3", // Fake UUID for the "3" value
             'expected_result'     => false,
             'question_extra_data' => $extra_data,
         ];
@@ -174,24 +174,24 @@ final class SingleChoiceFromValuesConditionHandlerTest extends AbstractCondition
         yield "Greater than check - case 1 for $type" => [
             'question_type'       => $type,
             'condition_operator'  => ValueOperator::GREATER_THAN,
-            'condition_value'     => "2",
-            'submitted_answer'    => "1",
+            'condition_value'     => "zzdzdd-2", // Fake UUID for the "2" value
+            'submitted_answer'    => "fsefes-1", // Fake UUID for the "1" value
             'expected_result'     => false,
             'question_extra_data' => $extra_data,
         ];
         yield "Greater than check - case 2 for $type" => [
             'question_type'       => $type,
             'condition_operator'  => ValueOperator::GREATER_THAN,
-            'condition_value'     => "2",
-            'submitted_answer'    => "2",
+            'condition_value'     => "zzdzdd-2", // Fake UUID for the "2" value
+            'submitted_answer'    => "zzdzdd-2", // Fake UUID for the "2" value
             'expected_result'     => false,
             'question_extra_data' => $extra_data,
         ];
         yield "Greater than check - case 3 for $type" => [
             'question_type'       => $type,
             'condition_operator'  => ValueOperator::GREATER_THAN,
-            'condition_value'     => "2",
-            'submitted_answer'    => "3",
+            'condition_value'     => "zzdzdd-2", // Fake UUID for the "2" value
+            'submitted_answer'    => "abcdef-3", // Fake UUID for the "3" value
             'expected_result'     => true,
             'question_extra_data' => $extra_data,
         ];
@@ -200,24 +200,24 @@ final class SingleChoiceFromValuesConditionHandlerTest extends AbstractCondition
         yield "Greater than or equals check - case 1 for $type" => [
             'question_type'       => $type,
             'condition_operator'  => ValueOperator::GREATER_THAN_OR_EQUALS,
-            'condition_value'     => "2",
-            'submitted_answer'    => "1",
+            'condition_value'     => "zzdzdd-2", // Fake UUID for the "2" value
+            'submitted_answer'    => "fsefes-1", // Fake UUID for the "1" value
             'expected_result'     => false,
             'question_extra_data' => $extra_data,
         ];
         yield "Greater than or equals check - case 2 for $type" => [
             'question_type'       => $type,
             'condition_operator'  => ValueOperator::GREATER_THAN_OR_EQUALS,
-            'condition_value'     => "2",
-            'submitted_answer'    => "2",
+            'condition_value'     => "zzdzdd-2", // Fake UUID for the "2" value
+            'submitted_answer'    => "zzdzdd-2", // Fake UUID for the "2" value
             'expected_result'     => true,
             'question_extra_data' => $extra_data,
         ];
         yield "Greater than or equals check - case 3 for $type" => [
             'question_type'       => $type,
             'condition_operator'  => ValueOperator::GREATER_THAN_OR_EQUALS,
-            'condition_value'     => "2",
-            'submitted_answer'    => "3",
+            'condition_value'     => "zzdzdd-2", // Fake UUID for the "2" value
+            'submitted_answer'    => "abcdef-3", // Fake UUID for the "3" value
             'expected_result'     => true,
             'question_extra_data' => $extra_data,
         ];


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Conditions like one:

<img width="1671" height="705" alt="image" src="https://github.com/user-attachments/assets/591fd679-bca0-4465-8947-5ce58c7e5f31" />

Would not work as expected due to the less/greater than comparison being using on the value key (some kind of uuid, see image below to better understand why) instead of the value itself.

<img width="1217" height="134" alt="image" src="https://github.com/user-attachments/assets/183ee945-3a56-46a0-965a-95d7c090decf" />

Fixed by getting the proper values before triggering the comparison.

## References:

Internal support ticket: !41238
