### PR TITLE
[HLAPI] Fix 0 as RSQL filter value

### DIFF
--- a/src/Glpi/Api/HL/RSQL/Lexer.php
+++ b/src/Glpi/Api/HL/RSQL/Lexer.php
@@ -159,7 +159,7 @@ final class Lexer
                 $fn_validate_pos();
                 $in_value = true;
                 $char = mb_substr($query, $pos, 1, 'UTF-8');
-                if (empty($char)) {
+                if ($char === '') {
                     $tokens[] = [self::T_UNSPECIFIED_VALUE, ''];
                     break;
                 }

--- a/tests/functional/Glpi/Api/HL/RSQL/LexerTest.php
+++ b/tests/functional/Glpi/Api/HL/RSQL/LexerTest.php
@@ -134,6 +134,10 @@ class LexerTest extends GLPITestCase
                 'name==テスト',
                 [[5, 'name'], [6, '=='], [7, 'テスト']],
             ],
+            [
+                'is_deleted==0',
+                [[5, 'is_deleted'], [6, '=='], [7, '0']],
+            ],
         ];
     }
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

An RSQL filter with a value of 0 was being treated as a missing value because of using `empty()`.
