### PR TITLE
[ci] add push flag so future release will be well published on docker/github

### DIFF
--- a/.github/workflows/docker_releases.yml
+++ b/.github/workflows/docker_releases.yml
@@ -15,4 +15,5 @@ jobs:
     # can use the inherit keyword to implicitly pass the secrets.
     secrets: inherit
     with:
-        glpi-version: "${{ github.event.release.tag_name }}"
+      push: true
+      glpi-version: "${{ github.event.release.tag_name }}"


### PR DESCRIPTION
The new builder https://github.com/glpi-project/docker-images/pull/250 now by default don't publish on docker to avoid any accidental push. (to be deployed on 10/bf 11/bg main)

Once it's merged, we should merge this one so the next GLPI will be published automatically on docker/github