### PR TITLE
fix: prevent duplicated queued webhooks

### DIFF
--- a/src/QueuedWebhook.php
+++ b/src/QueuedWebhook.php
@@ -155,6 +155,7 @@ class QueuedWebhook extends CommonDBChild
         }
         $input['sent_try'] = 0;
 
+        // Prevent duplicate queued webhooks for the same webhook and the same item/event.
         $webhook_fields = ['webhooks_id', 'itemtype', 'items_id', 'event', 'url', 'send_time'];
         $criteria = array_intersect_key($input, array_flip($webhook_fields));
         if ($criteria !== []) {

--- a/src/QueuedWebhook.php
+++ b/src/QueuedWebhook.php
@@ -155,6 +155,24 @@ class QueuedWebhook extends CommonDBChild
         }
         $input['sent_try'] = 0;
 
+        $webhook_fields = ['webhooks_id', 'itemtype', 'items_id', 'event', 'url', 'send_time'];
+        $criteria = array_intersect_key($input, array_flip($webhook_fields));
+        if ($criteria !== []) {
+            $criteria['is_deleted'] = 0;
+            $criteria['sent_time'] = null;
+
+            $iterator = $DB->request([
+                'SELECT' => ['id'],
+                'FROM'   => $this->getTable(),
+                'WHERE'  => $criteria,
+                'LIMIT'  => 1,
+            ]);
+
+            if ($iterator->count() > 0) {
+                return [];
+            }
+        }
+
         return $input;
     }
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

Prevent duplicate queued webhooks for the same webhook and the same item/event.

Example case:

* when adding a solution to a ticket with `set_solution_tech`
* this triggers the update event twice within nearly the same second
* without this PR, two webhooks would be queued for the same ticket update event
