### PR TITLE
Fix(DCroom): blueprint not visible

### DIFF
--- a/templates/pages/management/dcroom_racks.html.twig
+++ b/templates/pages/management/dcroom_racks.html.twig
@@ -117,7 +117,7 @@
         </div>
         {% if blueprint_url is not empty %}
             <div class="blueprint"
-                 style="background-image: url('{{ blueprint_url }}') no-repeat top left/100% 100%; height: {{ grid_h }}px"></div>
+                 style="background: url('{{ blueprint_url }}') no-repeat top left/100% 100%; height: {{ grid_h }}px"></div>
         {% endif %}
     </div>
 </div>


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !41376

The image was not displayed.

## Screenshots (if appropriate):

After:
<img width="698" height="707" alt="image" src="https://github.com/user-attachments/assets/fd9a630d-5dc2-4f05-8d4b-ea70f137b797" />

