### PR TITLE
Fix warning with samlSSO login

### DIFF
--- a/src/Auth.php
+++ b/src/Auth.php
@@ -1572,12 +1572,12 @@ class Auth extends CommonGLPI
 
         // Redirect to Command Central if not post-only
         if (Session::getCurrentInterface() === "helpdesk") {
-            if ($_SESSION['glpiactiveprofile']['create_ticket_on_login']) {
+            if (isset($_SESSION['glpiactiveprofile']['create_ticket_on_login']) && $_SESSION['glpiactiveprofile']['create_ticket_on_login']) {
                 Html::redirect($CFG_GLPI['root_doc'] . "/ServiceCatalog");
             }
             Html::redirect($CFG_GLPI['root_doc'] . "/Helpdesk");
         } else {
-            if ($_SESSION['glpiactiveprofile']['create_ticket_on_login']) {
+            if (isset($_SESSION['glpiactiveprofile']['create_ticket_on_login']) && $_SESSION['glpiactiveprofile']['create_ticket_on_login']) {
                 Html::redirect(Ticket::getFormURL());
             }
             Html::redirect($CFG_GLPI['root_doc'] . "/front/central.php");


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does

The following Warning is thrown during samlSSO plugin login:

```
glpi.WARNING:   *** Warning: Undefined array key "glpiactiveprofile" at Auth.php line 1579
  Backtrace :
  ./src/Auth.php:1579                                
  ./src/Glpi/Controller/IndexController.php:71       Auth::redirectIfAuthenticated()
  ./vendor/symfony/http-kernel/HttpKernel.php:181    Glpi\Controller\IndexController->__invoke()
  ./vendor/symfony/http-kernel/HttpKernel.php:76     Symfony\Component\HttpKernel\HttpKernel->handleRaw()
  ./vendor/symfony/http-kernel/Kernel.php:197        Symfony\Component\HttpKernel\HttpKernel->handle()
  ./public/index.php:70                              Symfony\Component\HttpKernel\Kernel->handle()
glpi.WARNING:   *** Warning: Trying to access array offset on null at Auth.php line 1579
  Backtrace :
  ./src/Auth.php:1579                                
  ./src/Glpi/Controller/IndexController.php:71       Auth::redirectIfAuthenticated()
  ./vendor/symfony/http-kernel/HttpKernel.php:181    Glpi\Controller\IndexController->__invoke()
  ./vendor/symfony/http-kernel/HttpKernel.php:76     Symfony\Component\HttpKernel\HttpKernel->handleRaw()
  ./vendor/symfony/http-kernel/Kernel.php:197        Symfony\Component\HttpKernel\HttpKernel->handle()
  ./public/index.php:70                              Symfony\Component\HttpKernel\Kernel->handle()
```

## Screenshots (if appropriate):


