### PR TITLE
[HLAPI] Add active profile rights to session schema

### DIFF
--- a/.phpstan-baseline.missingType.iterableValue.php
+++ b/.phpstan-baseline.missingType.iterableValue.php
@@ -10346,36 +10346,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Api/HL/GraphQL.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Method Glpi\\\\Api\\\\HL\\\\GraphQLGenerator\\:\\:convertRESTPropertyToGraphQLType\\(\\) has parameter \\$property with no value type specified in iterable type array\\.$#',
-	'identifier' => 'missingType.iterableValue',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/GraphQLGenerator.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Method Glpi\\\\Api\\\\HL\\\\GraphQLGenerator\\:\\:convertRESTSchemaToGraphQLSchema\\(\\) has parameter \\$schema with no value type specified in iterable type array\\.$#',
-	'identifier' => 'missingType.iterableValue',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/GraphQLGenerator.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Method Glpi\\\\Api\\\\HL\\\\GraphQLGenerator\\:\\:getTypesForSchema\\(\\) has parameter \\$schema with no value type specified in iterable type array\\.$#',
-	'identifier' => 'missingType.iterableValue',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/GraphQLGenerator.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Method Glpi\\\\Api\\\\HL\\\\GraphQLGenerator\\:\\:getTypesForSchema\\(\\) return type has no value type specified in iterable type array\\.$#',
-	'identifier' => 'missingType.iterableValue',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/GraphQLGenerator.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Property Glpi\\\\Api\\\\HL\\\\GraphQLGenerator\\:\\:\\$types type has no value type specified in iterable type array\\.$#',
-	'identifier' => 'missingType.iterableValue',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/GraphQLGenerator.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method Glpi\\\\Api\\\\HL\\\\Middleware\\\\MiddlewareInput\\:\\:__construct\\(\\) has parameter \\$client with no value type specified in iterable type array\\.$#',
 	'identifier' => 'missingType.iterableValue',
 	'count' => 1,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The present file will list all changes made to the project; according to the
 - Endpoints for creating, updating and deleting Infocom (Financial and administrative information) for items in the High-Level API v2.2.
 - New endpoints/schema for notes in High-Level API v2.2.
 - New EventLog schema, endpoints, and webhook support in the High-Level API v2.2.
+- `active_profile.rights` property for the `Session` schema in High-Level API v2.2 to indicate the rights of the user's current profile.
 
 ### Changed
 - High-Level API performance improvements for both REST and GraphQL requests (3.3-10x performance uplift on average)

--- a/src/Glpi/Api/HL/Controller/CoreController.php
+++ b/src/Glpi/Api/HL/Controller/CoreController.php
@@ -54,6 +54,8 @@ use Glpi\Toolbox\MarkdownRenderer;
 use Html;
 use JsonException;
 use League\OAuth2\Server\Exception\OAuthServerException;
+use Profile;
+use ProfileRight;
 use Session;
 use Throwable;
 use Transfer;
@@ -67,40 +69,85 @@ final class CoreController extends AbstractController
 {
     public static function getRawKnownSchemas(): array
     {
-        return [
-            'Session' => [
-                'x-version-introduced' => '2.0',
-                'type' => Doc\Schema::TYPE_OBJECT,
-                'properties' => [
-                    'current_time' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
-                    'user_id' => ['type' => Doc\Schema::TYPE_INTEGER],
-                    'use_mode' => ['type' => Doc\Schema::TYPE_INTEGER],
-                    'friendly_name' => ['type' => Doc\Schema::TYPE_STRING],
-                    'name' => ['type' => Doc\Schema::TYPE_STRING],
-                    'real_name' => ['type' => Doc\Schema::TYPE_STRING],
-                    'first_name' => ['type' => Doc\Schema::TYPE_STRING],
-                    'default_entity' => ['type' => Doc\Schema::TYPE_INTEGER],
-                    'profiles' => ['type' => Doc\Schema::TYPE_ARRAY, 'items' => ['type' => Doc\Schema::TYPE_INTEGER]],
-                    'active_entities' => ['type' => Doc\Schema::TYPE_ARRAY, 'items' => ['type' => Doc\Schema::TYPE_INTEGER]],
-                    'active_profile' => [
-                        'type' => Doc\Schema::TYPE_OBJECT,
-                        'properties' => [
-                            'id' => ['type' => Doc\Schema::TYPE_INTEGER],
-                            'name' => ['type' => Doc\Schema::TYPE_STRING],
-                            'interface' => ['type' => Doc\Schema::TYPE_STRING],
-                        ],
-                    ],
-                    'active_entity' => [
-                        'type' => Doc\Schema::TYPE_OBJECT,
-                        'properties' => [
-                            'id' => ['type' => Doc\Schema::TYPE_INTEGER],
-                            'short_name' => ['type' => Doc\Schema::TYPE_STRING],
-                            'complete_name' => ['type' => Doc\Schema::TYPE_STRING],
-                            'recursive' => ['type' => Doc\Schema::TYPE_INTEGER],
+        $session_schema = [
+            'x-version-introduced' => '2.0',
+            'type' => Doc\Schema::TYPE_OBJECT,
+            'properties' => [
+                'current_time' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
+                'user_id' => ['type' => Doc\Schema::TYPE_INTEGER],
+                'use_mode' => ['type' => Doc\Schema::TYPE_INTEGER],
+                'friendly_name' => ['type' => Doc\Schema::TYPE_STRING],
+                'name' => ['type' => Doc\Schema::TYPE_STRING],
+                'real_name' => ['type' => Doc\Schema::TYPE_STRING],
+                'first_name' => ['type' => Doc\Schema::TYPE_STRING],
+                'default_entity' => ['type' => Doc\Schema::TYPE_INTEGER],
+                'profiles' => ['type' => Doc\Schema::TYPE_ARRAY, 'items' => ['type' => Doc\Schema::TYPE_INTEGER]],
+                'active_entities' => ['type' => Doc\Schema::TYPE_ARRAY, 'items' => ['type' => Doc\Schema::TYPE_INTEGER]],
+                'active_profile' => [
+                    'type' => Doc\Schema::TYPE_OBJECT,
+                    'properties' => [
+                        'id' => ['type' => Doc\Schema::TYPE_INTEGER],
+                        'name' => ['type' => Doc\Schema::TYPE_STRING],
+                        'interface' => ['type' => Doc\Schema::TYPE_STRING],
+                        'rights' => [
+                            'type' => Doc\Schema::TYPE_OBJECT,
+                            'x-version-introduced' => '2.2',
+                            'description' => 'Rights associated with the active profile. Each right value is an integer with the individual bitwise flags combined by OR depending on the specific right.',
+                            'properties' => [
+                                // Filled dynamically below
+                            ],
                         ],
                     ],
                 ],
+                'active_entity' => [
+                    'type' => Doc\Schema::TYPE_OBJECT,
+                    'properties' => [
+                        'id' => ['type' => Doc\Schema::TYPE_INTEGER],
+                        'short_name' => ['type' => Doc\Schema::TYPE_STRING],
+                        'complete_name' => ['type' => Doc\Schema::TYPE_STRING],
+                        'recursive' => ['type' => Doc\Schema::TYPE_INTEGER],
+                    ],
+                ],
             ],
+        ];
+        $all_right_names = array_keys(ProfileRight::getAllPossibleRights());
+        $rights_info = [];
+        foreach (Profile::getRightsForForm() as $forms) {
+            foreach ($forms as $groups) {
+                foreach ($groups as $rights) {
+                    foreach ($rights as $right) {
+                        if (!array_key_exists($right['field'], $rights_info)) {
+                            $rights_info[$right['field']] = $right;
+                        }
+                    }
+                }
+            }
+        }
+
+        foreach ($all_right_names as $right_name) {
+            $right_prop = [
+                'type' => Doc\Schema::TYPE_INTEGER,
+            ];
+            if (array_key_exists($right_name, $rights_info)) {
+                $right_prop['description'] = $rights_info[$right_name]['label'] . ' rights. Possible values:';
+                $rights = $rights_info[$right_name]['rights'];
+                ksort($rights);
+                foreach ($rights as $right_bit => $right_label) {
+                    if (is_array($right_label)) {
+                        $right_label = $right_label['short'];
+                    }
+                    $right_prop['description'] .= "\n- " . $right_bit . ': ' . $right_label;
+                    $right_prop['enum'][] = $right_bit;
+                }
+
+                $right_prop['x-label'] = $rights_info[$right_name]['label'];
+                $right_prop['x-right-scope'] = $rights_info[$right_name]['scope'];
+            }
+            $session_schema['properties']['active_profile']['properties']['rights']['properties'][$right_name] = $right_prop;
+        }
+
+        return [
+            'Session' => $session_schema,
             'EntityTransferRecord' => [
                 'x-version-introduced' => '2.0',
                 'type' => Doc\Schema::TYPE_OBJECT,
@@ -393,6 +440,18 @@ HTML;
             'name' => $active_profile['name'],
             'interface' => $active_profile['interface'],
         ];
+
+        if (version_compare($this->getAPIVersion($request), '2.2', '>=')) {
+            $all_right_names = array_keys(ProfileRight::getAllPossibleRights());
+            foreach ($active_profile as $key => $value) {
+                if (in_array($key, $all_right_names, true)) {
+                    $session['active_profile']['rights'][$key] = (int) $value;
+                } else {
+                    $session['active_profile']['rights'][$key] = 0;
+                }
+            }
+        }
+
         $session['active_entity'] = [
             'id' => $_SESSION['glpiactive_entity'],
             'short_name' => $_SESSION['glpiactive_entity_shortname'],

--- a/src/Glpi/Api/HL/OpenAPIGenerator.php
+++ b/src/Glpi/Api/HL/OpenAPIGenerator.php
@@ -97,7 +97,10 @@ final class OpenAPIGenerator
 
     private function getPublicVendorExtensions(): array
     {
-        return ['x-full-schema', 'x-introduced', 'x-deprecated', 'x-removed', 'x-itemtype', 'x-supports-mentions'];
+        return [
+            'writeOnly', 'readOnly', 'x-full-schema', 'x-introduced', 'x-deprecated', 'x-removed', 'x-itemtype',
+            'x-supports-mentions', 'x-label', 'x-right-scope',
+        ];
     }
 
     private function cleanVendorExtensions(array $schema, ?string $parent_key = null, ?array $parent_schema = null): array

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -48,8 +48,9 @@ use Glpi\Toolbox\ArrayNormalizer;
 
 /**
  * Profile class
- * @phpstan-type RightDefinition array{rights: array{}, label: string, field: string, scope: string}
- **/
+ *
+ * @phpstan-type RightDefinition array{rights: array<int, string|array{short: string, long: string}>, label: string, field: string, scope: string}
+ */
 class Profile extends CommonDBTM implements LinkableToTilesInterface
 {
     /** @use Clonable<static> */


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] This change requires a documentation update.

## Description

For HLAPI v2.2.

Adds a new `active_profile.rights` property to the `Session` schema which shows all of the rights for the user's current profile.

This allows client applications/scripts to know if the connected user will have the permissions expected to improve error handling or change the available options.

The new property is an object with each possible right as a child property with its info generated dynamically when available. For plugin rights, plugins will need to use the relevant plugin hook to modify this schema to add information for its own rights but they should at least show up as long as at least one profile has a value for it in the DB.

<img width="1333" height="755" alt="Selection_638" src="https://github.com/user-attachments/assets/da289fd2-49eb-4820-9195-b2836a8ab1db" />

New extension properties:
- `x-label` The label a client may display for the property.
- `x-right-scope` Only applies to right properties. Indicates if the right applies only to the connected entities (most rights are this) or if it is a global permission (config, entity, log, etc).