### PR TITLE
Hide requester/observer ticket widgets without READMY right

### DIFF
--- a/src/Central.php
+++ b/src/Central.php
@@ -219,14 +219,6 @@ class Central extends CommonGLPI
                     'itemtype'  => Ticket::class,
                     'status'    => 'survey',
                 ];
-                $lists[] = [
-                    'itemtype'  => Ticket::class,
-                    'status'    => 'requestbyself',
-                ];
-                $lists[] = [
-                    'itemtype'  => Ticket::class,
-                    'status'    => 'observed',
-                ];
             }
             $lists[] = [
                 'itemtype'  => Ticket::class,
@@ -236,6 +228,16 @@ class Central extends CommonGLPI
                 'itemtype'  => Ticket::class,
                 'status'    => 'solution.rejected',
             ];
+            if ($showmyticket) {
+                $lists[] = [
+                    'itemtype'  => Ticket::class,
+                    'status'    => 'requestbyself',
+                ];
+                $lists[] = [
+                    'itemtype'  => Ticket::class,
+                    'status'    => 'observed',
+                ];
+            }
             $lists[] = [
                 'itemtype'  => Ticket::class,
                 'status'    => 'process',

--- a/src/Central.php
+++ b/src/Central.php
@@ -207,26 +207,18 @@ class Central extends CommonGLPI
         }
 
         if ($showticket) {
-            if (Ticket::isAllowedStatus(Ticket::SOLVED, Ticket::CLOSED)) {
+            if ($showmyticket) {
+                if (Ticket::isAllowedStatus(Ticket::SOLVED, Ticket::CLOSED)) {
+                    $lists[] = [
+                        'itemtype'  => Ticket::class,
+                        'status'    => 'toapprove',
+                    ];
+                }
+
                 $lists[] = [
                     'itemtype'  => Ticket::class,
-                    'status'    => 'toapprove',
+                    'status'    => 'survey',
                 ];
-            }
-
-            $lists[] = [
-                'itemtype'  => Ticket::class,
-                'status'    => 'survey',
-            ];
-            $lists[] = [
-                'itemtype'  => Ticket::class,
-                'status'    => 'validation.rejected',
-            ];
-            $lists[] = [
-                'itemtype'  => Ticket::class,
-                'status'    => 'solution.rejected',
-            ];
-            if ($showmyticket) {
                 $lists[] = [
                     'itemtype'  => Ticket::class,
                     'status'    => 'requestbyself',
@@ -236,6 +228,14 @@ class Central extends CommonGLPI
                     'status'    => 'observed',
                 ];
             }
+            $lists[] = [
+                'itemtype'  => Ticket::class,
+                'status'    => 'validation.rejected',
+            ];
+            $lists[] = [
+                'itemtype'  => Ticket::class,
+                'status'    => 'solution.rejected',
+            ];
             $lists[] = [
                 'itemtype'  => Ticket::class,
                 'status'    => 'process',

--- a/src/Central.php
+++ b/src/Central.php
@@ -188,6 +188,11 @@ class Central extends CommonGLPI
             [Ticket::READMY, Ticket::READALL, Ticket::READASSIGN]
         );
 
+        $showmyticket = Session::haveRightsOr(
+            "ticket",
+            [Ticket::READMY, Ticket::READALL]
+        );
+
         $showproblem = Session::haveRightsOr('problem', [Problem::READALL, Problem::READMY]);
 
         $showchanges = Session::haveRightsOr('change', [Change::READALL, Change::READMY]);
@@ -221,14 +226,16 @@ class Central extends CommonGLPI
                 'itemtype'  => Ticket::class,
                 'status'    => 'solution.rejected',
             ];
-            $lists[] = [
-                'itemtype'  => Ticket::class,
-                'status'    => 'requestbyself',
-            ];
-            $lists[] = [
-                'itemtype'  => Ticket::class,
-                'status'    => 'observed',
-            ];
+            if ($showmyticket) {
+                $lists[] = [
+                    'itemtype'  => Ticket::class,
+                    'status'    => 'requestbyself',
+                ];
+                $lists[] = [
+                    'itemtype'  => Ticket::class,
+                    'status'    => 'observed',
+                ];
+            }
             $lists[] = [
                 'itemtype'  => Ticket::class,
                 'status'    => 'process',


### PR DESCRIPTION
Fixes #22122

Add permission check for 'requestbyself' and 'observed' widgets in Central dashboard.

These widgets display tickets where the user is requester or observer, which requires READMY right. Previously, users with only READASSIGN right could see these widgets but got "Missing READ right" error when clicking tickets.
