### PR TITLE
Fix #20837 add multiple group in charge of an asset main

### DIFF
--- a/src/RuleAsset.php
+++ b/src/RuleAsset.php
@@ -203,7 +203,8 @@ class RuleAsset extends Rule
         $actions['groups_id']['type']          = 'dropdown';
         $actions['groups_id']['table']         = 'glpi_groups';
         $actions['groups_id']['condition']     = ['is_itemgroup' => 1];
-        $actions['groups_id']['force_actions'] = ['assign', 'defaultfromuser', 'firstgroupfromuser'];
+        $actions['groups_id']['force_actions'] = ['assign', 'append', 'defaultfromuser', 'firstgroupfromuser'];
+        $actions['groups_id']['permitseveral'] = ['append'];
 
         $actions['users_id_tech']['table']      = 'glpi_users';
         $actions['users_id_tech']['type']       = 'dropdown_users';
@@ -213,6 +214,8 @@ class RuleAsset extends Rule
         $actions['groups_id_tech']['type']      = 'dropdown';
         $actions['groups_id_tech']['table']     = 'glpi_groups';
         $actions['groups_id_tech']['condition'] = ['is_assign' => 1];
+        $actions['groups_id_tech']['force_actions'] = ['assign', 'append'];
+        $actions['groups_id_tech']['permitseveral'] = ['append'];
 
         $actions['comment']['table']            = '';
         $actions['comment']['field']            = 'comment';
@@ -267,17 +270,19 @@ class RuleAsset extends Rule
                         break;
 
                     case "append":
-                        $actions = $this->getAllActions();
                         $value   = $action->fields["value"];
-                        if (
-                            isset($actions[$action->fields["field"]]["appendtoarray"])
-                            && isset($actions[$action->fields["field"]]["appendtoarrayfield"])
-                        ) {
-                            $value = $actions[$action->fields["field"]]["appendtoarray"];
-                            $value[$actions[$action->fields["field"]]["appendtoarrayfield"]]
-                            = $action->fields["value"];
+                        switch ($action->fields["field"]) {
+                            case 'groups_id':
+                            case 'groups_id_tech':
+                                $input_field_name = '_' . $action->fields["field"];
+                                if (!array_key_exists($input_field_name, $output)) {
+                                    $output[$input_field_name] = $input[$input_field_name] ?? [];
+                                }
+
+                                $output[$input_field_name][] = $value;
+                                break;
+                                // do not use 'default'
                         }
-                        $output[$actions[$action->fields["field"]]["appendto"]][] = $value;
                         break;
 
                     case "regex_result":

--- a/tests/functional/Glpi/Features/AssignableItemTest.php
+++ b/tests/functional/Glpi/Features/AssignableItemTest.php
@@ -36,14 +36,16 @@ namespace tests\units\Glpi\Features;
 
 use Glpi\DBAL\QueryExpression;
 use Glpi\Features\AssignableItem;
-use Glpi\Features\AssignableItemInterface;
 use Glpi\Tests\DbTestCase;
+use Glpi\Tests\Glpi\Asset\ProviderTrait;
 use Group;
 use Group_Item;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 class AssignableItemTest extends DbTestCase
 {
+    use ProviderTrait;
+
     public static function itemtypeProvider(): iterable
     {
         global $CFG_GLPI;
@@ -51,24 +53,6 @@ class AssignableItemTest extends DbTestCase
         foreach ($CFG_GLPI['assignable_types'] as $itemtype) {
             yield $itemtype => [
                 'class' => $itemtype,
-            ];
-        }
-    }
-
-    /**
-     * @return iterable<array{class: class-string<AssignableItemInterface>, field: "groups_id"|"groups_id_tech"}>
-     */
-    public static function itemtypeAndGroupFieldProvider(): iterable
-    {
-        foreach (self::itemtypeProvider() as $itemtype) {
-            yield [
-                'item_type' => $itemtype['class'],
-                'field' => 'groups_id',
-            ];
-
-            yield [
-                'item_type' => $itemtype['class'],
-                'field' => 'groups_id_tech',
             ];
         }
     }
@@ -155,46 +139,47 @@ class AssignableItemTest extends DbTestCase
      * - update the asset to associate with another group (without first group in input)
      * -> only last group is associated
     */
-    #[DataProvider('itemtypeAndGroupFieldProvider')]
-    public function testAssignGroupRemovePreviousData(string $item_type, string $field): void
+    #[DataProvider('assignableAssetsItemtypeProvider')]
+    public function testAssignGroupRemovePreviousData(string $class): void
     {
         // --- arrange - create 2 groups
         $this->login();
-        $group_type = match ($field) {
-            'groups_id_tech' => Group_Item::GROUP_TYPE_TECH,
-            'groups_id' => Group_Item::GROUP_TYPE_NORMAL,
-        };
 
-        $group_1 = $this->createItem(Group::class, $this->getMinimalCreationInput(Group::class));
-        $group_2 = $this->createItem(Group::class, $this->getMinimalCreationInput(Group::class));
+        $tested_fields = ['groups_id_tech', 'groups_id'];
 
-        $asset = $this->createItem(
-            $item_type,
-            [
-                $field => [$group_1->getID()],
-            ] + $this->getMinimalCreationInput($item_type),
-            ['name'] // name for Item_DeviceSimcard at least
-        );
+        foreach ($tested_fields as $field) {
+            $group_1 = $this->createItem(Group::class, $this->getMinimalCreationInput(Group::class));
+            $group_2 = $this->createItem(Group::class, $this->getMinimalCreationInput(Group::class));
 
-        // --- act - update asset
-        $this->updateItem(
-            $item_type,
-            $asset->getID(),
-            [$field => [$group_2->getID()]] + $this->getMinimalCreationInput($item_type),
-            ['name'] // name for Item_DeviceSimcard at least
-        );
+            $asset = $this->createItem(
+                $class,
+                [
+                    $field => [$group_1->getID()],
+                ] + $this->getMinimalCreationInput($class),
+                ['name'] // name for Item_DeviceSimcard at least
+            );
 
-        // --- assert - check that the asset has the tech groups assigned
-        $this->assertEquals(
-            1,
-            countElementsInTable(
-                Group_Item::getTable(),
-                [   'groups_id'  =>  [$group_2->getID()],
-                    'items_id'   => $asset->getID(),
-                    'itemtype'   => $asset::class,
-                ]
-            )
-        );
+            // --- act - update asset
+            $this->updateItem(
+                $class,
+                $asset->getID(),
+                [$field => [$group_2->getID()]] + $this->getMinimalCreationInput($class),
+                ['name'] // name for Item_DeviceSimcard at least
+            );
+
+            // --- assert - check that the asset has the tech groups assigned
+            $this->assertEquals(
+                1,
+                countElementsInTable(
+                    Group_Item::getTable(),
+                    [
+                        'groups_id' => [$group_2->getID()],
+                        'items_id' => $asset->getID(),
+                        'itemtype' => $asset::class,
+                    ]
+                )
+            );
+        }
     }
 
     /**

--- a/tests/functional/Glpi/Features/AssignableItemTest.php
+++ b/tests/functional/Glpi/Features/AssignableItemTest.php
@@ -138,7 +138,10 @@ class AssignableItemTest extends DbTestCase
      * - create an asset associated with a group
      * - update the asset to associate with another group (without first group in input)
      * -> only last group is associated
-    */
+     *
+     *  Notice behavior is not always the same, for ticket, previous group is preserved.
+     * @see \tests\units\TicketTest::testAssignGroup()
+     */
     #[DataProvider('assignableAssetsItemtypeProvider')]
     public function testAssignGroupRemovePreviousData(string $class): void
     {
@@ -146,10 +149,10 @@ class AssignableItemTest extends DbTestCase
         $this->login();
 
         $tested_fields = ['groups_id_tech', 'groups_id'];
+        $group_1 = $this->createItem(Group::class, $this->getMinimalCreationInput(Group::class));
+        $group_2 = $this->createItem(Group::class, $this->getMinimalCreationInput(Group::class));
 
         foreach ($tested_fields as $field) {
-            $group_1 = $this->createItem(Group::class, $this->getMinimalCreationInput(Group::class));
-            $group_2 = $this->createItem(Group::class, $this->getMinimalCreationInput(Group::class));
 
             $asset = $this->createItem(
                 $class,

--- a/tests/functional/Glpi/Features/AssignableItemTest.php
+++ b/tests/functional/Glpi/Features/AssignableItemTest.php
@@ -159,7 +159,6 @@ class AssignableItemTest extends DbTestCase
                 [
                     $field => [$group_1->getID()],
                 ] + $this->getMinimalCreationInput($class),
-                ['name'] // name for Item_DeviceSimcard at least
             );
 
             // --- act - update asset
@@ -167,7 +166,6 @@ class AssignableItemTest extends DbTestCase
                 $class,
                 $asset->getID(),
                 [$field => [$group_2->getID()]] + $this->getMinimalCreationInput($class),
-                ['name'] // name for Item_DeviceSimcard at least
             );
 
             // --- assert - check that the asset has the tech groups assigned

--- a/tests/functional/Glpi/Features/AssignableItemTest.php
+++ b/tests/functional/Glpi/Features/AssignableItemTest.php
@@ -145,15 +145,17 @@ class AssignableItemTest extends DbTestCase
     #[DataProvider('assignableAssetsItemtypeProvider')]
     public function testAssignGroupRemovePreviousData(string $class): void
     {
-        // --- arrange - create 2 groups
         $this->login();
 
-        $tested_fields = ['groups_id_tech', 'groups_id'];
+        // --- arrange - create 2 groups
         $group_1 = $this->createItem(Group::class, $this->getMinimalCreationInput(Group::class));
         $group_2 = $this->createItem(Group::class, $this->getMinimalCreationInput(Group::class));
 
+        $tested_fields = ['groups_id_tech', 'groups_id'];
+
         foreach ($tested_fields as $field) {
 
+            // --- arrange - create item
             $asset = $this->createItem(
                 $class,
                 [

--- a/tests/functional/RuleAssetTest.php
+++ b/tests/functional/RuleAssetTest.php
@@ -37,6 +37,10 @@ namespace tests\units;
 use Computer;
 use Generator;
 use Glpi\Tests\DbTestCase;
+use Glpi\Tests\Glpi\Asset\ProviderTrait;
+use Glpi\Tests\RuleBuilder;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestWith;
 use Rule;
 use RuleAction;
 use RuleCriteria;
@@ -44,6 +48,8 @@ use SingletonRuleList;
 
 class RuleAssetTest extends DbTestCase
 {
+    use ProviderTrait;
+
     protected function testCriteriaProvider(): Generator
     {
         // Test case 1 for last_inventory_update -> Precise date
@@ -636,6 +642,403 @@ class RuleAssetTest extends DbTestCase
         $this->assertTrue($update);
         $this->assertTrue($computer_em->getFromDB($computer_id));
         $this->assertEquals($locations_id, $computer_em->getField('locations_id'));
+    }
+
+    /**
+     * Assign groups & tech group to asset on creation
+     */
+    #[DataProvider('assignableAssetsItemtypeProvider')]
+    public function testAddGroupOnAdd(string $class): void
+    {
+        $this->login();
+        $entities_id = $this->getTestRootEntity(true);
+        // fields to test + associated group type
+        $tested_fields = [
+            'groups_id_tech' => \Group_Item::GROUP_TYPE_TECH,
+            'groups_id' => \Group_Item::GROUP_TYPE_NORMAL,
+        ];
+
+        foreach ($tested_fields as $field => $type) {
+
+            // --- arrange - create 2 groups + create rule to associate a Computer with created groups
+            $rule_group_1 = $this->createItem(\Group::class, $this->getMinimalCreationInput(\Group::class));
+            $rule_group_2 = $this->createItem(\Group::class, $this->getMinimalCreationInput(\Group::class));
+            $rule_builder = new RuleBuilder(__FUNCTION__, \RuleAsset::class);
+            $rule_builder->setEntity($entities_id);
+            $rule_builder->addCriteria('entities_id', Rule::PATTERN_IS, $entities_id);
+            $rule_builder->addAction('append', $field, $rule_group_1->getID());
+            $rule_builder->addAction('append', $field, $rule_group_2->getID());
+            $rule_builder->setCondtion(\RuleAsset::ONADD);
+            $this->createRule($rule_builder);
+
+            // --- act - create a Computer
+            $asset = $this->createItem($class, ['entities_id' => $entities_id] + $this->getMinimalCreationInput($class));
+
+            // --- assert - check that the asset has the groups added
+            $associations = (new \Group_Item())->find([
+                'items_id' => $asset->getID(),
+                'itemtype' => $asset::class,
+                'type' => $type,
+            ]);
+            $fetched_group_ids = array_column($associations, 'groups_id');
+
+            $this->assertEqualsCanonicalizing([$rule_group_1->getID(), $rule_group_2->getID()], $fetched_group_ids, 'Unexpected Asset associated groups with ' . $class . ' ' . $field);
+        }
+    }
+
+    /**
+     * Assign groups & tech group to asset on creation
+     */
+    #[TestWith(['groups_id_tech'])]
+    #[TestWith(['groups_id'])]
+    public function xtestAddGroupOnAddWithInput(string $field): void // @todo sup le x
+    {
+        $this->login();
+        $group_type = match ($field) {
+            'groups_id_tech' => \Group_Item::GROUP_TYPE_TECH,
+            'groups_id' => \Group_Item::GROUP_TYPE_NORMAL,
+        };
+
+        // --- arrange - create groups + rule to associate a Computer with created groups
+        $rule_group_1 = $this->createItem(\Group::class, $this->getMinimalCreationInput(\Group::class));
+        $rule_group_2 = $this->createItem(\Group::class, $this->getMinimalCreationInput(\Group::class));
+        $input_group = $this->createItem(\Group::class, $this->getMinimalCreationInput(\Group::class));
+        $rule_builder = new RuleBuilder(__FUNCTION__, \RuleAsset::class);
+        $rule_builder->setEntity(0);
+        $rule_builder->addCriteria('entities_id', Rule::PATTERN_IS, '0');
+        $rule_builder->addAction('append', $field, $rule_group_1->getID());
+        $rule_builder->addAction('append', $field, $rule_group_2->getID());
+        $rule_builder->setCondtion(\RuleAsset::ONADD);
+        $this->createRule($rule_builder);
+
+        // --- act - create a Computer
+        $computer = $this->createItem(
+            Computer::class,
+            [
+                'name' => 'Computer',
+                'entities_id' => 0,
+                $field => [$input_group->getID()],
+            ],
+            [
+                $field,
+            ]
+        );
+
+        // --- assert - check that the computer has the groups added
+        $associations = (new \Group_Item())->find([
+            'items_id' => $computer->getID(),
+            'itemtype' => $computer::class,
+            'type' => $group_type,
+        ]);
+        $fetched_group_ids = array_column($associations, 'groups_id');
+
+        $this->assertEqualsCanonicalizing([$input_group->getID(), $rule_group_1->getID(), $rule_group_2->getID()], $fetched_group_ids, 'Unexpected Asset associated groups');
+    }
+
+    /**
+     * Assign groups on update
+     *
+     * Notice group set on creation is lost after the update.
+     * - this is because of \Glpi\Features\AssignableItem::updateGroupFields() implementation that remove previous groups
+     * - important : behavior is not the same for Tickets (@todo ajouter ref au tests + ajouter ref à ici dans la ref)
+     */
+    #[TestWith(['groups_id_tech'])]
+    #[TestWith(['groups_id'])]
+    public function testAddGroupOnUpdate(string $field): void
+    {
+        $auth = $this->login();
+        $group_type = match ($field) {
+            'groups_id_tech' => \Group_Item::GROUP_TYPE_TECH,
+            'groups_id' => \Group_Item::GROUP_TYPE_NORMAL,
+        };
+
+        // --- arrange - create 2 groups + create rule to associate a Computer with created groups
+        $entity_id = $auth->user->fields['entities_id'];
+        $asset_name_to_trigger_rule = $this->getUniqueString();
+        $input_group = $this->createItem(\Group::class, $this->getMinimalCreationInput(\Group::class));
+        $group_for_rule = $this->createItem(\Group::class, $this->getMinimalCreationInput(\Group::class));
+        $rule_builder = new RuleBuilder(__FUNCTION__, \RuleAsset::class);
+        $rule_builder->setEntity($entity_id);
+        $rule_builder->addCriteria('name', Rule::PATTERN_IS, $asset_name_to_trigger_rule);
+        $rule_builder->addAction('append', $field, $group_for_rule->getID());
+        $rule_builder->setCondtion(\RuleAsset::ONUPDATE);
+        $this->createRule($rule_builder);
+
+        $computer = $this->createItem(Computer::class, [
+            'name'        => $this->getUniqueString(),
+            'entities_id' => $entity_id,
+            $field        => [$input_group->getID()],
+        ]);
+
+        // --- act - update the Computer : triggers rule to append $group_for_rule to Asset ownership groups
+        $this->updateItem(Computer::class, $computer->getID(), ['name' => $asset_name_to_trigger_rule]);
+
+        // --- assert - check that the computer has the tech groups assigned and previous group is removed
+        $associations = (new \Group_Item())->find([
+            'items_id' => $computer->getID(),
+            'itemtype' => $computer::class,
+            'type' => $group_type,
+        ]);
+        $fetched_group_ids = array_column($associations, 'groups_id');
+        $this->assertEqualsCanonicalizing([$group_for_rule->getID()], $fetched_group_ids, 'Unexpected Asset associated tech groups');
+    }
+
+    /**
+     * Adding groups also adds the input groups
+     *
+     * action : append
+     * field: groups_id_tech
+     */
+    #[TestWith(['groups_id_tech'])]
+    #[TestWith(['groups_id'])]
+    public function testAddGroupOnUpdateWithInput(string $field): void
+    {
+        $auth = $this->login();
+        $group_type = match ($field) {
+            'groups_id_tech' => \Group_Item::GROUP_TYPE_TECH,
+            'groups_id' => \Group_Item::GROUP_TYPE_NORMAL,
+        };
+        // --- arrange - create 2 groups + create rule to associate a Computer with created groups
+        $entity_id = $auth->user->fields['entities_id'];
+        $asset_name_to_trigger_rule = $this->getUniqueString();
+        $group_for_form = $this->createItem(\Group::class, $this->getMinimalCreationInput(\Group::class));
+        $group_for_rule = $this->createItem(\Group::class, $this->getMinimalCreationInput(\Group::class));
+        $rule_builder = new RuleBuilder(__FUNCTION__, \RuleAsset::class);
+        $rule_builder->setEntity($entity_id);
+        $rule_builder->addCriteria('name', Rule::PATTERN_IS, $asset_name_to_trigger_rule);
+        $rule_builder->addAction('append', $field, $group_for_rule->getID());
+        $rule_builder->setCondtion(\RuleAsset::ONUPDATE);
+        $this->createRule($rule_builder);
+
+        $computer = $this->createItem(
+            Computer::class,
+            [
+                'name' => $this->getUniqueString(),
+                'entities_id' => $entity_id,
+            ]
+        );
+
+        $this->updateItem(
+            Computer::class,
+            $computer->getID(),
+            [
+                'name' => $asset_name_to_trigger_rule,
+                $field   => [$group_for_form->getID()],
+            ],
+            [
+                $field, // one group is also added by rule
+            ]
+        );
+
+        // assert - check that the computer has both the tech groups added (input + rule)
+        $associations = (new \Group_Item())->find([
+            'items_id' => $computer->getID(),
+            'itemtype' => $computer::getType(),
+            'type' => $group_type,
+        ]);
+        $fetched_group_ids = array_column($associations, 'groups_id');
+        $this->assertEqualsCanonicalizing([$group_for_form->getID(), $group_for_rule->getID()], $fetched_group_ids, 'Unexpected Asset associated owner groups');
+    }
+
+    // --- groups_id & groups_tech_id assign actions
+
+    /**
+     * Assign groups & tech group to asset on creation
+     */
+    #[TestWith(['groups_id_tech'])]
+    #[TestWith(['groups_id'])]
+    public function testAssignGroupOnAdd(string $field): void
+    {
+        $this->login();
+        $group_type = match ($field) {
+            'groups_id_tech' => \Group_Item::GROUP_TYPE_TECH,
+            'groups_id' => \Group_Item::GROUP_TYPE_NORMAL,
+        };
+
+        // --- arrange - create 1 group + rule to associate an asset with created group
+        $rule_group_1 = $this->createItem(\Group::class, $this->getMinimalCreationInput(\Group::class));
+
+        $rule_builder = new RuleBuilder(__FUNCTION__, \RuleAsset::class);
+        $rule_builder->setEntity(0);
+        $rule_builder->addCriteria('entities_id', Rule::PATTERN_IS, '0');
+        $rule_builder->addAction('assign', $field, $rule_group_1->getID());
+        $rule_builder->setCondtion(\RuleAsset::ONADD);
+        $this->createRule($rule_builder);
+
+        // --- act - create a Computer
+        $computer = $this->createItem(
+            Computer::class,
+            ['entities_id' => 0]
+            + $this->getMinimalCreationInput(Computer::class) // @todo utiliser getMinimal partout
+        );
+
+        // --- assert - check that the computer has the assigned group
+        $associations = (new \Group_Item())->find(
+            [
+                'items_id' => $computer->getID(),
+                'itemtype' => $computer::class,
+                'type' => $group_type,
+            ]
+        );
+        $fetched_group_ids = array_column($associations, 'groups_id');
+
+        $this->assertEqualsCanonicalizing([$rule_group_1->getID()], $fetched_group_ids, 'Unexpected Asset associated groups');
+    }
+
+    /**
+     * Assign groups & tech group to asset on creation with input
+     *
+     * Group passed in input is ignored, the rule assigned group is recorded
+     * // @todo mettre un commentaire sur les autres tests
+     */
+    #[TestWith(['groups_id_tech'])]
+    #[TestWith(['groups_id'])]
+    public function testAssignGroupOnAddWithInput(string $field): void
+    {
+        $this->login();
+        $group_type = match ($field) {
+            'groups_id_tech' => \Group_Item::GROUP_TYPE_TECH,
+            'groups_id' => \Group_Item::GROUP_TYPE_NORMAL,
+        };
+
+        // --- arrange - create groups + rule to associate a Computer with created groups
+        $rule_group = $this->createItem(\Group::class, $this->getMinimalCreationInput(\Group::class));
+        $input_group = $this->createItem(\Group::class, $this->getMinimalCreationInput(\Group::class));
+
+        $rule_builder = new RuleBuilder(__FUNCTION__, \RuleAsset::class);
+        $rule_builder->setEntity(0);
+        $rule_builder->addCriteria('entities_id', Rule::PATTERN_IS, '0');
+        $rule_builder->addAction('assign', $field, $rule_group->getID());
+        $rule_builder->setCondtion(\RuleAsset::ONADD);
+        $this->createRule($rule_builder);
+
+        // --- act - create a Computer
+        $computer = $this->createItem(
+            Computer::class,
+            [
+                'name' => 'Computer',
+                'entities_id' => 0,
+                $field => [$input_group->getID()],
+            ],
+            [
+                $field, // another group is added by rule
+            ]
+        );
+
+        // --- assert - check that the computer has the groups assigned
+        $associations = (new \Group_Item())->find([
+            'items_id' => $computer->getID(),
+            'itemtype' => $computer::class,
+            'type' => $group_type,
+        ]);
+        $fetched_group_ids = array_column($associations, 'groups_id');
+
+        $this->assertEqualsCanonicalizing([$rule_group->getID()], $fetched_group_ids, 'Unexpected Asset associated groups');
+    }
+
+    /**
+     * Assign groups on update
+     *
+     * Group previously associated is removed, rule assigned group is recorded
+     *
+     * Notice group set on creation is lost after the update.
+     * - this is because of \Glpi\Features\AssignableItem::updateGroupFields() implementation that remove previous groups
+     * - important : behavior is not the same for Tickets (@todo ajouter ref au tests + ajouter ref à ici dans la ref)
+     */
+    #[TestWith(['groups_id_tech'])]
+    #[TestWith(['groups_id'])]
+    public function testAssignGroupOnUpdate(string $field): void
+    {
+        // --- arrange - create 2 groups + an asset + rule to associate a Computer with created groups
+        $auth = $this->login();
+        $group_type = match ($field) {
+            'groups_id_tech' => \Group_Item::GROUP_TYPE_TECH,
+            'groups_id' => \Group_Item::GROUP_TYPE_NORMAL,
+        };
+        $entity_id = $auth->user->fields['entities_id'];
+        $asset_name_to_trigger_rule = $this->getUniqueString();
+
+        $input_group = $this->createItem(\Group::class, $this->getMinimalCreationInput(\Group::class));
+        $group_for_rule = $this->createItem(\Group::class, $this->getMinimalCreationInput(\Group::class));
+
+        $rule_builder = new RuleBuilder(__FUNCTION__, \RuleAsset::class);
+        $rule_builder->setEntity($entity_id);
+        $rule_builder->addCriteria('name', Rule::PATTERN_IS, $asset_name_to_trigger_rule);
+        $rule_builder->addAction('assign', $field, $group_for_rule->getID());
+        $rule_builder->setCondtion(\RuleAsset::ONUPDATE);
+        $this->createRule($rule_builder);
+
+        $computer = $this->createItem(Computer::class, [
+            'name'        => $this->getUniqueString(),
+            'entities_id' => $entity_id,
+            $field        => [$input_group->getID()],
+        ]);
+
+        // --- act - update the Computer : triggers rule to append $group_for_rule to Asset ownership groups
+        $this->updateItem(Computer::class, $computer->getID(), ['name' => $asset_name_to_trigger_rule]);
+
+        // --- assert - check that the computer has the tech groups assigned and previous group is removed
+        $associations = (new \Group_Item())->find([
+            'items_id' => $computer->getID(),
+            'itemtype' => $computer::class,
+            'type' => $group_type,
+        ]);
+        $fetched_group_ids = array_column($associations, 'groups_id');
+        $this->assertEqualsCanonicalizing([$group_for_rule->getID()], $fetched_group_ids, 'Unexpected Asset associated tech groups');
+    }
+
+    /**
+     * Assigning groups on update with input
+     */
+    #[TestWith(['groups_id_tech'])]
+    #[TestWith(['groups_id'])]
+    public function testAssignGroupOnUpdateWithInput(string $field): void
+    {
+        $auth = $this->login();
+        $group_type = match ($field) {
+            'groups_id_tech' => \Group_Item::GROUP_TYPE_TECH,
+            'groups_id' => \Group_Item::GROUP_TYPE_NORMAL,
+        };
+        // --- arrange - create 2 groups + create rule to associate a Computer with created groups
+        $entity_id = $auth->user->fields['entities_id'];
+        $asset_name_to_trigger_rule = $this->getUniqueString();
+        $group_for_form = $this->createItem(\Group::class, $this->getMinimalCreationInput(\Group::class));
+        $group_for_rule = $this->createItem(\Group::class, $this->getMinimalCreationInput(\Group::class));
+        $rule_builder = new RuleBuilder(__FUNCTION__, \RuleAsset::class);
+        $rule_builder->setEntity($entity_id);
+        $rule_builder->addCriteria('name', Rule::PATTERN_IS, $asset_name_to_trigger_rule);
+        $rule_builder->addAction('assign', $field, $group_for_rule->getID());
+        $rule_builder->setCondtion(\RuleAsset::ONUPDATE);
+        $this->createRule($rule_builder);
+
+        $computer = $this->createItem(
+            Computer::class,
+            [
+                'name' => $this->getUniqueString(),
+                'entities_id' => $entity_id,
+            ]
+        );
+
+        $this->updateItem(
+            Computer::class,
+            $computer->getID(),
+            [
+                'name' => $asset_name_to_trigger_rule,
+                $field   => [$group_for_form->getID()],
+            ],
+            [
+                $field, // one group is also assigned by rule
+            ]
+        );
+
+        // assert - check that the computer has both the tech groups assigned (input + rule)
+        $associations = (new \Group_Item())->find([
+            'items_id' => $computer->getID(),
+            'itemtype' => $computer::getType(),
+            'type' => $group_type,
+        ]);
+        $fetched_group_ids = array_column($associations, 'groups_id');
+        $this->assertEqualsCanonicalizing([$group_for_rule->getID()], $fetched_group_ids, 'Unexpected Asset associated owner groups');
     }
 
     public function testGroupUserAssignFromDefaultUser()

--- a/tests/functional/RuleAssetTest.php
+++ b/tests/functional/RuleAssetTest.php
@@ -691,7 +691,7 @@ class RuleAssetTest extends DbTestCase
      */
     #[TestWith(['groups_id_tech'])]
     #[TestWith(['groups_id'])]
-    public function xtestAddGroupOnAddWithInput(string $field): void // @todo sup le x
+    public function testAddGroupOnAddWithInput(string $field): void
     {
         $this->login();
         $group_type = match ($field) {
@@ -740,7 +740,8 @@ class RuleAssetTest extends DbTestCase
      *
      * Notice group set on creation is lost after the update.
      * - this is because of \Glpi\Features\AssignableItem::updateGroupFields() implementation that remove previous groups
-     * - important : behavior is not the same for Tickets (@todo ajouter ref au tests + ajouter ref à ici dans la ref)
+     * - important : behavior is not the same for Tickets (
+     * @see \tests\units\TicketTest::testAssignGroup()
      */
     #[TestWith(['groups_id_tech'])]
     #[TestWith(['groups_id'])]

--- a/tests/functional/TicketTest.php
+++ b/tests/functional/TicketTest.php
@@ -4622,6 +4622,8 @@ HTML,
      * - create a ticket associated with a group
      * - update the ticket to associate with another group (without first group in input)
      * -> both groups are associated
+     *
+     * Notice behavior is not always the same, @see \tests\units\Glpi\Features\AssignableItemTest::testAssignGroupRemovePreviousData()
      */
     public function testAssignGroup(): void
     {

--- a/tests/src/Glpi/Asset/ProviderTrait.php
+++ b/tests/src/Glpi/Asset/ProviderTrait.php
@@ -1,5 +1,37 @@
 <?php
 
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
 namespace Glpi\Tests\Glpi\Asset;
 
 trait ProviderTrait
@@ -12,6 +44,7 @@ trait ProviderTrait
         global $CFG_GLPI;
         $assignable_assets_itemtypes = array_intersect($CFG_GLPI['assignable_types'], $CFG_GLPI['asset_types']);
 
+        dump($assignable_assets_itemtypes);
         foreach ($assignable_assets_itemtypes as $itemtype) {
             yield $itemtype => [
                 'class' => $itemtype,

--- a/tests/src/Glpi/Asset/ProviderTrait.php
+++ b/tests/src/Glpi/Asset/ProviderTrait.php
@@ -37,9 +37,9 @@ namespace Glpi\Tests\Glpi\Asset;
 trait ProviderTrait
 {
     /**
-     * @return \Generator Item type that are both assets and assignable
+     * @return iterable Item type that are both assets and assignable
      */
-    public static function assignableAssetsItemtypeProvider(): \Generator
+    public static function assignableAssetsItemtypeProvider(): iterable
     {
         global $CFG_GLPI;
         $assignable_assets_itemtypes = array_intersect($CFG_GLPI['assignable_types'], $CFG_GLPI['asset_types']);

--- a/tests/src/Glpi/Asset/ProviderTrait.php
+++ b/tests/src/Glpi/Asset/ProviderTrait.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Glpi\Tests\Glpi\Asset;
+
+trait ProviderTrait
+{
+    /**
+     * @return \Generator Item type that are both assets and assignable
+     */
+    public static function assignableAssetsItemtypeProvider(): \Generator
+    {
+        global $CFG_GLPI;
+        $assignable_assets_itemtypes = array_intersect($CFG_GLPI['assignable_types'], $CFG_GLPI['asset_types']);
+
+        foreach ($assignable_assets_itemtypes as $itemtype) {
+            yield $itemtype => [
+                'class' => $itemtype,
+            ];
+        }
+    }
+}

--- a/tests/src/Glpi/Asset/ProviderTrait.php
+++ b/tests/src/Glpi/Asset/ProviderTrait.php
@@ -44,7 +44,6 @@ trait ProviderTrait
         global $CFG_GLPI;
         $assignable_assets_itemtypes = array_intersect($CFG_GLPI['assignable_types'], $CFG_GLPI['asset_types']);
 
-        dump($assignable_assets_itemtypes);
         foreach ($assignable_assets_itemtypes as $itemtype) {
             yield $itemtype => [
                 'class' => $itemtype,


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] This change requires a documentation update.

## Description

- It fixes #20837
- Asset rules : add _append_/_add_ actions for _group_ and _group\_in\_charge_ (several permitted)

Replacement for #21668



