### PR TITLE
Fix tiles translations preview

### DIFF
--- a/src/Glpi/Helpdesk/Tile/ExternalPageTile.php
+++ b/src/Glpi/Helpdesk/Tile/ExternalPageTile.php
@@ -35,6 +35,7 @@
 namespace Glpi\Helpdesk\Tile;
 
 use CommonDBTM;
+use Glpi\Helpdesk\HelpdeskTranslation;
 use Glpi\ItemTranslation\Context\ProvideTranslationsInterface;
 use Glpi\ItemTranslation\Context\TranslationHandler;
 use Glpi\Session\SessionInfo;
@@ -75,13 +76,19 @@ final class ExternalPageTile extends CommonDBTM implements TileInterface, Provid
     #[Override]
     public function getTitle(): string
     {
-        return $this->fields['title'] ?? "";
+        return HelpdeskTranslation::translate(
+            $this,
+            self::TRANSLATION_KEY_TITLE
+        ) ?? '';
     }
 
     #[Override]
     public function getDescription(): string
     {
-        return $this->fields['description'] ?? "";
+        return HelpdeskTranslation::translate(
+            $this,
+            self::TRANSLATION_KEY_DESCRIPTION
+        ) ?? '';
     }
 
     #[Override]
@@ -130,22 +137,22 @@ final class ExternalPageTile extends CommonDBTM implements TileInterface, Provid
         $handlers = [];
         $key = sprintf('%s_%d', self::getType(), $this->getID());
         $category_name = sprintf('%s: %s', $this->getLabel(), $this->fields['title'] ?? NOT_AVAILABLE);
-        if (!empty($this->getTitle())) {
+        if (!empty($this->fields['title'])) {
             $handlers[$key][] = new TranslationHandler(
                 item: $this,
                 key: self::TRANSLATION_KEY_TITLE,
                 name: __('Title'),
-                value: $this->getTitle(),
+                value: $this->fields['title'],
                 is_rich_text: false,
                 category: $category_name
             );
         }
-        if (!empty($this->getDescription())) {
+        if (!empty($this->fields['description'])) {
             $handlers[$key][] = new TranslationHandler(
                 item: $this,
                 key: self::TRANSLATION_KEY_DESCRIPTION,
                 name: __('Description'),
-                value: $this->getDescription(),
+                value: $this->fields['description'],
                 is_rich_text: true,
                 category: $category_name
             );

--- a/src/Glpi/Helpdesk/Tile/GlpiPageTile.php
+++ b/src/Glpi/Helpdesk/Tile/GlpiPageTile.php
@@ -100,13 +100,19 @@ final class GlpiPageTile extends CommonDBTM implements TileInterface, ProvideTra
     #[Override]
     public function getTitle(): string
     {
-        return $this->fields['title'] ?? "";
+        return HelpdeskTranslation::translate(
+            $this,
+            self::TRANSLATION_KEY_TITLE
+        ) ?? '';
     }
 
     #[Override]
     public function getDescription(): string
     {
-        return $this->fields['description'] ?? "";
+        return HelpdeskTranslation::translate(
+            $this,
+            self::TRANSLATION_KEY_DESCRIPTION
+        ) ?? '';
     }
 
     #[Override]
@@ -234,22 +240,22 @@ final class GlpiPageTile extends CommonDBTM implements TileInterface, ProvideTra
         $handlers = [];
         $key = sprintf('%s_%d', self::getType(), $this->getID());
         $category_name = sprintf('%s: %s', $this->getLabel(), $this->fields['title'] ?? NOT_AVAILABLE);
-        if (!empty($this->getTitle())) {
+        if (!empty($this->fields['title'])) {
             $handlers[$key][] = new TranslationHandler(
                 item: $this,
                 key: self::TRANSLATION_KEY_TITLE,
                 name: __('Title'),
-                value: $this->getTitle(),
+                value: $this->fields['title'],
                 is_rich_text: false,
                 category: $category_name
             );
         }
-        if (!empty($this->getDescription())) {
+        if (!empty($this->fields['description'])) {
             $handlers[$key][] = new TranslationHandler(
                 item: $this,
                 key: self::TRANSLATION_KEY_DESCRIPTION,
                 name: __('Description'),
-                value: $this->getDescription(),
+                value: $this->fields['description'],
                 is_rich_text: true,
                 category: $category_name
             );

--- a/templates/pages/admin/external_page_tile_config_fields.html.twig
+++ b/templates/pages/admin/external_page_tile_config_fields.html.twig
@@ -32,7 +32,7 @@
 
 {% import 'components/form/fields_macros.html.twig' as fields %}
 
-{{ fields.textField('title', tile.getTitle(), __('Title'), {
+{{ fields.textField('title', tile.fields['title']|default(''), __('Title'), {
     full_width: true,
     is_horizontal: false,
     maxlength: 255,
@@ -40,7 +40,7 @@
 
 {{ fields.textareaField(
     'description',
-    tile.getDescription(),
+    tile.fields['description']|default(''),
     __('Description'), {
         full_width: true,
         is_horizontal: false,

--- a/templates/pages/admin/glpi_page_tile_config_fields.html.twig
+++ b/templates/pages/admin/glpi_page_tile_config_fields.html.twig
@@ -32,7 +32,7 @@
 
 {% import 'components/form/fields_macros.html.twig' as fields %}
 
-{{ fields.textField('title', tile.getTitle(), __('Title'), {
+{{ fields.textField('title', tile.fields['title']|default(''), __('Title'), {
     full_width: true,
     is_horizontal: false,
     maxlength: 255,
@@ -40,7 +40,7 @@
 
 {{ fields.textareaField(
     'description',
-    tile.getDescription(),
+    tile.fields['description']|default(''),
     __('Description'), {
         full_width: true,
         is_horizontal: false,

--- a/templates/pages/helpdesk/index.html.twig
+++ b/templates/pages/helpdesk/index.html.twig
@@ -108,10 +108,6 @@
 
                 <div class="row">
                     {% for tile in tiles %}
-                        {# Check if the tile provides translations #}
-                        {# Actually, only FormTile does not provide translations because its title and description are already translated in the form itself #}
-                        {% set is_tile_provide_translations = tile is instanceof('Glpi\\ItemTranslation\\Context\\ProvideTranslationsInterface') %}
-
                         <div class="col-12 col-sm-6 col-md-4 d-flex">
                             <a
                                 class="card mx-1 my-2 flex-grow-1"
@@ -124,19 +120,10 @@
                                         </div>
                                         <div class="ms-4">
                                             <h2 class="card-title mb-2 text-break">
-                                                {% if is_tile_provide_translations %}
-                                                    {{ translate_helpdesk_item_key(tile, constant('TRANSLATION_KEY_TITLE', tile)) }}
-                                                {% else %}
-                                                    {{ tile.getTitle() }}
-                                                {% endif %}
+                                                {{ tile.getTitle() }}
                                             </h2>
                                             <div class="text-secondary remove-last-tinymce-margin">
-                                                {# If the tile provides translations, use the translation handler to get the description #}
-                                                {% if is_tile_provide_translations %}
-                                                    {{ translate_helpdesk_item_key(tile, constant('TRANSLATION_KEY_DESCRIPTION', tile))|safe_html }}
-                                                {% else %}
-                                                    {{ tile.getDescription()|safe_html }}
-                                                {% endif %}
+                                                {{ tile.getDescription()|safe_html }}
                                             </div>
                                         </div>
                                     </div>


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.

## Description

The `getTitle()` and `getDescription()` method for tiles were not returning translated values.

I've updated them and replaced call that expect raw values by direct access to the fields properties.

## References

Internal support ticket: !41259