### PR TITLE
Fix missing pointer events after config change

### DIFF
--- a/js/modules/Helpdesk/HelpdeskConfigController.js
+++ b/js/modules/Helpdesk/HelpdeskConfigController.js
@@ -184,6 +184,7 @@ export class GlpiHelpdeskConfigController
 
             // Refresh content and confirm success
             this.#getTilesContainerDiv().innerHTML = await response.text();
+            this.#enablePointerEvents();
             glpi_toast_info(__("Configuration updated successfully."));
         } catch (e) {
             glpi_toast_error(__('An unexpected error occurred'));
@@ -267,6 +268,7 @@ export class GlpiHelpdeskConfigController
             glpi_toast_info(__("Configuration updated successfully."));
 
             this.#getTilesContainerDiv().innerHTML = await response.text();
+            this.#enablePointerEvents();
             bootstrap.Offcanvas.getInstance('#tile-form-offcanvas').hide();
         } catch (e) {
             glpi_toast_error(__('An unexpected error occurred'));
@@ -353,6 +355,7 @@ export class GlpiHelpdeskConfigController
             glpi_toast_info(__("Configuration updated successfully."));
 
             this.#getTilesContainerDiv().innerHTML = await response.text();
+            this.#enablePointerEvents();
             bootstrap.Offcanvas.getInstance('#tile-form-offcanvas').hide();
         } catch (e) {
             glpi_toast_error(__('An unexpected error occurred'));
@@ -432,6 +435,7 @@ export class GlpiHelpdeskConfigController
             glpi_toast_info(__("Configuration updated successfully."));
 
             this.#getTilesContainerDiv().innerHTML = await response.text();
+            this.#enablePointerEvents();
             bootstrap.Offcanvas.getInstance('#tile-form-offcanvas').hide();
         } catch (e) {
             glpi_toast_error(__('An unexpected error occurred'));


### PR DESCRIPTION
## Description

Followup to some anti flakiness measures from https://github.com/glpi-project/glpi/pull/22601, I missed that the twig template is reloaded after each actions so we need to remove the specific pointer event class again.


