### PR TITLE
[HLAPI] Preflight caching

### DIFF
--- a/src/Glpi/Api/HL/Controller/CoreController.php
+++ b/src/Glpi/Api/HL/Controller/CoreController.php
@@ -319,6 +319,8 @@ HTML;
                 $response_headers['Access-Control-Allow-Headers'][] = 'XDEBUG_TRIGGER';
             }
         }
+        // Cache preflight responses for 10 minutes
+        $response_headers['Access-Control-Max-Age'] = '600';
         return new JSONResponse(null, 204, $response_headers);
     }
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Does not affect most usages. In fact, it really only affects web frontends that utilize the HLAPI and therefore use CORS. When browsers send a request to the API, it makes a preflight/CORS request first. By default browsers typically cache these preflights for 5 seconds. This is a fairly small performance hit if using GraphQL to reduce the number of queries needed per page as there would only be a preflight for the GraphQL endpoint instead of one for each REST endpoint.

At least the way it works now, the HLAPI will try re-matching the request with all possible HTTP methods to see if there is a valid route match to determine which methods get returned in the `Allow` and `Access-Control-Allow-Methods` headers. Between this and the regular HTTP/HLAPI overhead these preflight requests were taking around 60ms.

Since the CORS data is unlikely to change for a given route, it make sense to tell browsers to cache it for longer. I chose 10 minutes.