### PR TITLE
Restore form document behavior from formcreator

### DIFF
--- a/src/Glpi/Form/Form.php
+++ b/src/Glpi/Form/Form.php
@@ -40,6 +40,7 @@ use Change_Item;
 use CommonDBTM;
 use CommonGLPI;
 use CronTask;
+use Document_Item;
 use Entity;
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\QuerySubQuery;
@@ -163,6 +164,7 @@ final class Form extends CommonDBTM implements
         $this->addStandardTab(FormAccessControl::class, $tabs, $options);
         $this->addStandardTab(FormDestination::class, $tabs, $options);
         $this->addStandardTab(FormTranslation::class, $tabs, $options);
+        $this->addStandardTab(Document_Item::class, $tabs, $options);
         $this->addStandardTab(Log::class, $tabs, $options);
         $tabs['no_all_tab'] = true;
         return $tabs;

--- a/tests/functional/Glpi/Form/FormTest.php
+++ b/tests/functional/Glpi/Form/FormTest.php
@@ -652,6 +652,7 @@ class FormTest extends DbTestCase
                 'Access controls 1',
                 'Destinations 1',
                 'Form translations',
+                'Documents',
             ],
         ];
         yield 'Form with default destination and 1 answers' => [
@@ -664,6 +665,7 @@ class FormTest extends DbTestCase
                 'Access controls 1',
                 'Destinations 1',
                 'Form translations',
+                'Documents',
             ],
         ];
         yield 'Form with default destination and 5 answers' => [
@@ -676,6 +678,7 @@ class FormTest extends DbTestCase
                 'Access controls 1',
                 'Destinations 1',
                 'Form translations',
+                'Documents',
             ],
         ];
     }
@@ -696,6 +699,7 @@ class FormTest extends DbTestCase
                 'Access controls 1',
                 'Destinations 4',
                 'Form translations',
+                'Documents',
             ],
         ];
         yield 'Form with multiple tickets destinations and 1 answers' => [
@@ -708,6 +712,7 @@ class FormTest extends DbTestCase
                 'Access controls 1',
                 'Destinations 4',
                 'Form translations',
+                'Documents',
             ],
         ];
         yield 'Form with multiple tickets destinations and 5 answers' => [
@@ -720,6 +725,7 @@ class FormTest extends DbTestCase
                 'Access controls 1',
                 'Destinations 4',
                 'Form translations',
+                'Documents',
             ],
         ];
     }
@@ -740,6 +746,7 @@ class FormTest extends DbTestCase
                 'Access controls 1',
                 'Destinations 4',
                 'Form translations',
+                'Documents',
             ],
         ];
         yield 'Form with multiple changes destinations and 1 answers' => [
@@ -753,6 +760,7 @@ class FormTest extends DbTestCase
                 'Access controls 1',
                 'Destinations 4',
                 'Form translations',
+                'Documents',
             ],
         ];
         yield 'Form with multiple changes destinations and 5 answers' => [
@@ -766,6 +774,7 @@ class FormTest extends DbTestCase
                 'Access controls 1',
                 'Destinations 4',
                 'Form translations',
+                'Documents',
             ],
         ];
     }
@@ -786,6 +795,7 @@ class FormTest extends DbTestCase
                 'Access controls 1',
                 'Destinations 4',
                 'Form translations',
+                'Documents',
             ],
         ];
         yield 'Form with multiple problems destinations and 1 answers' => [
@@ -799,6 +809,7 @@ class FormTest extends DbTestCase
                 'Access controls 1',
                 'Destinations 4',
                 'Form translations',
+                'Documents',
             ],
         ];
         yield 'Form with multiple problems destinations and 5 answers' => [
@@ -812,6 +823,7 @@ class FormTest extends DbTestCase
                 'Access controls 1',
                 'Destinations 4',
                 'Form translations',
+                'Documents',
             ],
         ];
     }

--- a/tests/src/DbTestCase.php
+++ b/tests/src/DbTestCase.php
@@ -47,6 +47,7 @@ use Glpi\Asset\CapacityConfig;
 use Glpi\Dropdown\DropdownDefinition;
 use Profile;
 use ProfileRight;
+use Ramsey\Uuid\Uuid;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use ReflectionClass;
@@ -744,6 +745,31 @@ class DbTestCase extends GLPITestCase
         ]);
         $this->updateItem(ProfileRight::class, $profile_right->fields['id'], [
             'rights' => $profile_right->fields['rights'] & ~$value,
+        ]);
+    }
+
+    protected function addDocumentToItem(
+        string $name,
+        string $content,
+        CommonDBTM $item,
+    ): Document {
+        $this->login();
+
+        $prefix = uniqid(more_entropy: true);
+        file_put_contents(GLPI_TMP_DIR . '/' . "$prefix" . $name, $content);
+        return $this->createItem(Document::class, [
+            'documentcategories_id' => 0,
+            '_filename'             => ["$prefix" . $name],
+            '_prefix_filename'      => [$prefix],
+            '_tag_filename'         => [Uuid::uuid4()],
+            'itemtype'              => $item::class,
+            'items_id'              => $item->getID(),
+        ], [
+            '_filename',
+            '_prefix_filename',
+            '_tag_filename',
+            'itemtype',
+            'items_id',
         ]);
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Add a "document" tab on forms:

<img width="1060" height="598" alt="image" src="https://github.com/user-attachments/assets/9535b919-7c14-4f26-9dbe-7e026e6822aa" />

Documents that are linked to this tab will be visible for any users that can see the form.

This was a feature used on formcreator (for example, you could add download link to the document in the form description).

## References

Internal support ticket: !41105


