### PR TITLE
FIX / Display item ID in logs for single item massive actions

### DIFF
--- a/src/MassiveAction.php
+++ b/src/MassiveAction.php
@@ -1381,9 +1381,10 @@ class MassiveAction
                     } else {
                         // For multiple items, use the generic count message
                         $message = sprintf(
-                            __('%1$s deletes %2$d items by massive action'),
+                            __('%1$s deletes %2$d items by massive action: %3$s'),
                             $_SESSION["glpiname"],
-                            $deleted_count
+                            $deleted_count,
+                            implode(', ', $deleted_ids)
                         );
                         Event::log(
                             0,

--- a/src/MassiveAction.php
+++ b/src/MassiveAction.php
@@ -1362,12 +1362,28 @@ class MassiveAction
 
                 // Log event for successful delete actions (grouped)
                 if ($deleted_count > 0) {
+                    if ($deleted_count === 1 && count($ids) === 1) {
+                        // For single item, include the ID in the log message
+                        $message = sprintf(
+                            __('%1$s deletes item %2$s (ID: %3$d) by massive action'),
+                            $_SESSION["glpiname"],
+                            $item->getType(),
+                            $ids[0]
+                        );
+                    } else {
+                        // For multiple items, use the generic count message
+                        $message = sprintf(
+                            __('%1$s deletes %2$d items by massive action'),
+                            $_SESSION["glpiname"],
+                            $deleted_count
+                        );
+                    }
                     Event::log(
                         0,
                         strtolower($item->getType()),
                         4,
                         "massiveaction",
-                        sprintf(__('%1$s deletes %2$d items by massive action'), $_SESSION["glpiname"], $deleted_count)
+                        $message
                     );
                 }
                 break;
@@ -1388,15 +1404,30 @@ class MassiveAction
                         $ma->addMessage($item->getErrorMessage(ERROR_RIGHT));
                     }
                 }
-
                 // Log event for successful restore actions (grouped)
                 if ($restored_count > 0) {
+                    if ($restored_count === 1 && count($ids) === 1) {
+                        // For single item, include the ID in the log message
+                        $message = sprintf(
+                            __('%1$s restores item %2$s (ID: %3$d) by massive action'),
+                            $_SESSION["glpiname"],
+                            $item->getType(),
+                            $ids[0]
+                        );
+                    } else {
+                        // For multiple items, use the generic count message
+                        $message = sprintf(
+                            __('%1$s restores %2$d items by massive action'),
+                            $_SESSION["glpiname"],
+                            $restored_count
+                        );
+                    }
                     Event::log(
                         0,
                         strtolower($item->getType()),
                         4,
                         "massiveaction",
-                        sprintf(__('%1$s restores %2$d items by massive action'), $_SESSION["glpiname"], $restored_count)
+                        $message
                     );
                 }
                 break;
@@ -1456,17 +1487,36 @@ class MassiveAction
 
                 // Log event for successful purge actions (grouped)
                 if ($purged_count > 0) {
-                    $is_force_purge = $action === 'purge';
-                    $purge_message = $is_force_purge
-                        ? sprintf(__('%1$s purges %2$d items by massive action'), $_SESSION["glpiname"], $purged_count)
-                        : sprintf(__('%1$s deletes %2$d items by massive action'), $_SESSION["glpiname"], $purged_count);
+                    if ($purged_count === 1 && count($ids) === 1) {
+                        // For single item, include the ID in the log message
+                        $is_force_purge = $action === 'purge';
+                        $message = $is_force_purge
+                            ? sprintf(
+                                __('%1$s purges item %2$s (ID: %3$d) by massive action'),
+                                $_SESSION["glpiname"],
+                                $item->getType(),
+                                $ids[0]
+                            )
+                            : sprintf(
+                                __('%1$s deletes item %2$s (ID: %3$d) by massive action'),
+                                $_SESSION["glpiname"],
+                                $item->getType(),
+                                $ids[0]
+                            );
+                    } else {
+                        // For multiple items, use the generic count message
+                        $is_force_purge = $action === 'purge';
+                        $message = $is_force_purge
+                            ? sprintf(__('%1$s purges %2$d items by massive action'), $_SESSION["glpiname"], $purged_count)
+                            : sprintf(__('%1$s deletes %2$d items by massive action'), $_SESSION["glpiname"], $purged_count);
+                    }
 
                     Event::log(
                         0,
                         strtolower($item->getType()),
                         4,
                         "massiveaction",
-                        $purge_message
+                        $message
                     );
                 }
                 break;

--- a/src/MassiveAction.php
+++ b/src/MassiveAction.php
@@ -1345,11 +1345,13 @@ class MassiveAction
         switch ($action) {
             case 'delete':
                 $deleted_count = 0;
+                $deleted_ids = [];
                 foreach ($ids as $id) {
                     if ($item->can($id, DELETE)) {
                         if ($item->delete(["id" => $id])) {
                             $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
                             $deleted_count++;
+                            $deleted_ids[] = $id;
                         } else {
                             $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
                             $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));
@@ -1362,13 +1364,19 @@ class MassiveAction
 
                 // Log event for successful delete actions (grouped)
                 if ($deleted_count > 0) {
-                    if ($deleted_count === 1 && count($ids) === 1) {
-                        // For single item, include the ID in the log message
+                    if ($deleted_count === 1 && count($deleted_ids) === 1) {
+                        // For single item, show ID in element column and simplified message
                         $message = sprintf(
-                            __('%1$s deletes item %2$s (ID: %3$d) by massive action'),
+                            __('%1$s deletes item %2$s by massive action'),
                             $_SESSION["glpiname"],
-                            $item->getType(),
-                            $ids[0]
+                            $item->getType()
+                        );
+                        Event::log(
+                            $deleted_ids[0],
+                            strtolower($item->getType()),
+                            4,
+                            "massiveaction",
+                            $message
                         );
                     } else {
                         // For multiple items, use the generic count message
@@ -1377,24 +1385,26 @@ class MassiveAction
                             $_SESSION["glpiname"],
                             $deleted_count
                         );
+                        Event::log(
+                            0,
+                            strtolower($item->getType()),
+                            4,
+                            "massiveaction",
+                            $message
+                        );
                     }
-                    Event::log(
-                        0,
-                        strtolower($item->getType()),
-                        4,
-                        "massiveaction",
-                        $message
-                    );
                 }
                 break;
 
             case 'restore':
                 $restored_count = 0;
+                $restored_ids = [];
                 foreach ($ids as $id) {
                     if ($item->can($id, DELETE)) {
                         if ($item->restore(["id" => $id])) {
                             $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
                             $restored_count++;
+                            $restored_ids[] = $id;
                         } else {
                             $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
                             $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));
@@ -1406,13 +1416,19 @@ class MassiveAction
                 }
                 // Log event for successful restore actions (grouped)
                 if ($restored_count > 0) {
-                    if ($restored_count === 1 && count($ids) === 1) {
-                        // For single item, include the ID in the log message
+                    if ($restored_count === 1 && count($restored_ids) === 1) {
+                        // For single item, show ID in element column and simplified message
                         $message = sprintf(
-                            __('%1$s restores item %2$s (ID: %3$d) by massive action'),
+                            __('%1$s restores item %2$s by massive action'),
                             $_SESSION["glpiname"],
-                            $item->getType(),
-                            $ids[0]
+                            $item->getType()
+                        );
+                        Event::log(
+                            $restored_ids[0],
+                            strtolower($item->getType()),
+                            4,
+                            "massiveaction",
+                            $message
                         );
                     } else {
                         // For multiple items, use the generic count message
@@ -1421,14 +1437,14 @@ class MassiveAction
                             $_SESSION["glpiname"],
                             $restored_count
                         );
+                        Event::log(
+                            0,
+                            strtolower($item->getType()),
+                            4,
+                            "massiveaction",
+                            $message
+                        );
                     }
-                    Event::log(
-                        0,
-                        strtolower($item->getType()),
-                        4,
-                        "massiveaction",
-                        $message
-                    );
                 }
                 break;
 
@@ -1436,6 +1452,7 @@ class MassiveAction
             case 'purge_but_item_linked':
             case 'purge':
                 $purged_count = 0;
+                $purged_ids = [];
                 foreach ($ids as $id) {
                     if ($item->can($id, PURGE)) {
                         $force = true;
@@ -1475,6 +1492,7 @@ class MassiveAction
                         if ($item->delete($delete_array, $force)) {
                             $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
                             $purged_count++;
+                            $purged_ids[] = $id;
                         } else {
                             $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
                             $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));
@@ -1487,37 +1505,41 @@ class MassiveAction
 
                 // Log event for successful purge actions (grouped)
                 if ($purged_count > 0) {
-                    if ($purged_count === 1 && count($ids) === 1) {
-                        // For single item, include the ID in the log message
+                    if ($purged_count === 1 && count($purged_ids) === 1) {
+                        // For single item, show ID in element column and simplified message
                         $is_force_purge = $action === 'purge';
                         $message = $is_force_purge
                             ? sprintf(
-                                __('%1$s purges item %2$s (ID: %3$d) by massive action'),
+                                __('%1$s purges item %2$s by massive action'),
                                 $_SESSION["glpiname"],
-                                $item->getType(),
-                                $ids[0]
+                                $item->getType()
                             )
                             : sprintf(
-                                __('%1$s deletes item %2$s (ID: %3$d) by massive action'),
+                                __('%1$s deletes item %2$s by massive action'),
                                 $_SESSION["glpiname"],
-                                $item->getType(),
-                                $ids[0]
+                                $item->getType()
                             );
+                        Event::log(
+                            $purged_ids[0],
+                            strtolower($item->getType()),
+                            4,
+                            "massiveaction",
+                            $message
+                        );
                     } else {
                         // For multiple items, use the generic count message
                         $is_force_purge = $action === 'purge';
                         $message = $is_force_purge
                             ? sprintf(__('%1$s purges %2$d items by massive action'), $_SESSION["glpiname"], $purged_count)
                             : sprintf(__('%1$s deletes %2$d items by massive action'), $_SESSION["glpiname"], $purged_count);
+                        Event::log(
+                            0,
+                            strtolower($item->getType()),
+                            4,
+                            "massiveaction",
+                            $message
+                        );
                     }
-
-                    Event::log(
-                        0,
-                        strtolower($item->getType()),
-                        4,
-                        "massiveaction",
-                        $message
-                    );
                 }
                 break;
 

--- a/src/MassiveAction.php
+++ b/src/MassiveAction.php
@@ -1363,7 +1363,7 @@ class MassiveAction
                 }
 
                 // Log event for successful delete actions (grouped)
-                self::logMassiveActionEvent($item, 'deletes', $deleted_count, $deleted_ids);
+                self::logMassiveActionEvent($item, 'deletes', $deleted_ids);
                 break;
 
             case 'restore':
@@ -1385,7 +1385,7 @@ class MassiveAction
                     }
                 }
                 // Log event for successful restore actions (grouped)
-                self::logMassiveActionEvent($item, 'restores', $restored_count, $restored_ids);
+                self::logMassiveActionEvent($item, 'restores', $restored_ids);
                 break;
 
             case 'purge_item_but_devices':
@@ -1446,7 +1446,7 @@ class MassiveAction
                 // Log event for successful purge actions (grouped)
                 $is_force_purge = $action === 'purge';
                 $action_verb = $is_force_purge ? 'purges' : 'deletes';
-                self::logMassiveActionEvent($item, $action_verb, $purged_count, $purged_ids);
+                self::logMassiveActionEvent($item, $action_verb, $purged_ids);
                 break;
 
             case 'update':
@@ -1855,17 +1855,17 @@ class MassiveAction
      *
      * @param CommonDBTM $item         Item instance
      * @param string     $action_verb  Action verb (deletes, restores, purges)
-     * @param int        $count        Number of items processed
      * @param int[]      $ids          Array of item IDs processed
      * @return void
      */
-    private static function logMassiveActionEvent(CommonDBTM $item, string $action_verb, int $count, array $ids): void
+    private static function logMassiveActionEvent(CommonDBTM $item, string $action_verb, array $ids): void
     {
+        $count = count($ids);
         if ($count <= 0) {
             return;
         }
 
-        if ($count === 1 && count($ids) === 1) {
+        if ($count === 1) {
             // For single item, show ID in element column and simplified message
             $message = sprintf(
                 __('%1$s %2$s item %3$s by massive action'),

--- a/src/MassiveAction.php
+++ b/src/MassiveAction.php
@@ -1349,7 +1349,6 @@ class MassiveAction
                     if ($item->can($id, DELETE)) {
                         if ($item->delete(["id" => $id])) {
                             $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
-                            $deleted_count++;
                             $deleted_ids[] = $id;
                         } else {
                             $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
@@ -1371,7 +1370,6 @@ class MassiveAction
                     if ($item->can($id, DELETE)) {
                         if ($item->restore(["id" => $id])) {
                             $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
-                            $restored_count++;
                             $restored_ids[] = $id;
                         } else {
                             $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
@@ -1428,7 +1426,6 @@ class MassiveAction
                         }
                         if ($item->delete($delete_array, $force)) {
                             $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
-                            $purged_count++;
                             $purged_ids[] = $id;
                         } else {
                             $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);

--- a/src/MassiveAction.php
+++ b/src/MassiveAction.php
@@ -1344,7 +1344,6 @@ class MassiveAction
 
         switch ($action) {
             case 'delete':
-                $deleted_count = 0;
                 $deleted_ids = [];
                 foreach ($ids as $id) {
                     if ($item->can($id, DELETE)) {
@@ -1367,7 +1366,6 @@ class MassiveAction
                 break;
 
             case 'restore':
-                $restored_count = 0;
                 $restored_ids = [];
                 foreach ($ids as $id) {
                     if ($item->can($id, DELETE)) {
@@ -1391,7 +1389,6 @@ class MassiveAction
             case 'purge_item_but_devices':
             case 'purge_but_item_linked':
             case 'purge':
-                $purged_count = 0;
                 $purged_ids = [];
                 foreach ($ids as $id) {
                     if ($item->can($id, PURGE)) {

--- a/src/MassiveAction.php
+++ b/src/MassiveAction.php
@@ -1856,7 +1856,7 @@ class MassiveAction
      * @param CommonDBTM $item         Item instance
      * @param string     $action_verb  Action verb (deletes, restores, purges)
      * @param int        $count        Number of items processed
-     * @param array      $ids          Array of item IDs processed
+     * @param int[]      $ids          Array of item IDs processed
      * @return void
      */
     private static function logMassiveActionEvent(CommonDBTM $item, string $action_verb, int $count, array $ids): void

--- a/tests/functional/MassiveActionTest.php
+++ b/tests/functional/MassiveActionTest.php
@@ -1077,7 +1077,7 @@ class MassiveActionTest extends DbTestCase
                 'itemtype' => 'Computer',
                 'action' => 'delete',
                 'item_names' => ['Single Computer for Delete'],
-                'expected_message_pattern' => '/deletes 1 items by massive action/',
+                'expected_message_pattern' => '/deletes item Computer \(ID: \d+\) by massive action/',
                 'setup_callback' => null,
             ],
         ];

--- a/tests/functional/MassiveActionTest.php
+++ b/tests/functional/MassiveActionTest.php
@@ -1077,7 +1077,7 @@ class MassiveActionTest extends DbTestCase
                 'itemtype' => 'Computer',
                 'action' => 'delete',
                 'item_names' => ['Single Computer for Delete'],
-                'expected_message_pattern' => '/deletes item Computer \(ID: \d+\) by massive action/',
+                'expected_message_pattern' => '/deletes item Computer by massive action/',
                 'setup_callback' => null,
             ],
         ];


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !40347
- When a single item is processed by mass actions, the item ID did not appear in the log entry


