### PR TITLE
fix: Improve link detection for duplicate image tags

### DIFF
--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -2584,10 +2584,18 @@ class Toolbox
                             // Avoids creating a link within a link, when the image is already in an <a> tag
                             $add_link_tmp = $add_link;
                             if ($add_link) {
-                                // Try to detect any unclosed `<a>` tag that preced the `<img>` tag
-                                $pattern = '/<a[^>]*>((?!<\/a>).)*<img[^>]*' . preg_quote($image['tag'], '/') . '/s';
-                                if (preg_match($pattern, $content_text)) {
-                                    $add_link_tmp = false;
+                                // Find the position of this specific image occurrence in content_text
+                                $img_pos = strpos($content_text, (string) $match_img);
+                                if ($img_pos !== false) {
+                                    // Extract content before this image
+                                    $content_before = substr($content_text, 0, $img_pos);
+                                    // Count opening and closing <a> tags
+                                    $open_count = preg_match_all('/<a[^>]*>/i', $content_before);
+                                    $close_count = preg_match_all('/<\/a>/i', $content_before);
+                                    // If there are more opening tags than closing tags, we're inside a link
+                                    if ($open_count > $close_count) {
+                                        $add_link_tmp = false;
+                                    }
                                 }
                             }
                             // replace image

--- a/tests/functional/ToolboxTest.php
+++ b/tests/functional/ToolboxTest.php
@@ -881,6 +881,17 @@ HTML;
             $expected_result4,
             \Toolbox::convertTagToImage($content_text4, $item, $docs_data)
         );
+
+        $content_text5 = <<<HTML
+            <a href="http://example.org/" target="_blank"><img id="{$img_1_tag}" width="10" height="10" data-upload_id="1"><img id="{$img_1_tag}" width="10" height="10" data-upload_id="2"></a>
+        HTML;
+        $expected_result5 = <<<HTML
+            <a href="http://example.org/" target="_blank"><img alt="{$img_1_tag}" width="10" src="{$image_1_src}" /><img alt="{$img_1_tag}" width="10" src="{$image_1_src}" /></a>
+        HTML;
+        $this->assertEquals(
+            $expected_result5,
+            \Toolbox::convertTagToImage($content_text5, $item, $docs_data)
+        );
     }
 
     public static function shortenNumbers()

--- a/tests/functional/ToolboxTest.php
+++ b/tests/functional/ToolboxTest.php
@@ -870,6 +870,17 @@ HTML;
             $expected_result3,
             \Toolbox::convertTagToImage($content_text3, $item, $docs_data)
         );
+
+        $content_text4 = <<<HTML
+            <img id="{$img_1_tag}" width="10" height="10" data-upload_id="1"><img id="{$img_1_tag}" width="10" height="10" data-upload_id="2">
+        HTML;
+        $expected_result4 = <<<HTML
+            <a href="{$image_1_src}" target="_blank" ><img alt="{$img_1_tag}" width="10" src="{$image_1_src}" /></a><a href="{$image_1_src}" target="_blank" ><img alt="{$img_1_tag}" width="10" src="{$image_1_src}" /></a>
+        HTML;
+        $this->assertEquals(
+            $expected_result4,
+            \Toolbox::convertTagToImage($content_text4, $item, $docs_data)
+        );
     }
 
     public static function shortenNumbers()


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

When multiple images share the same tag but have different attributes (e.g., data-upload_id), the regex used to detect if an image is already inside a link was incorrectly matching the tag in previously processed images instead of checking the current image's context.

This caused the second occurrence to incorrectly be considered as already wrapped in a link, preventing proper link wrapping.

**Solution**: Replace regex-based detection with a tag counting approach that counts opening <a> and closing </a> tags before each specific image occurrence to determine if it's inside an unclosed link.