### PR TITLE
Test performance without auto-decode

### DIFF
--- a/src/DBmysql.php
+++ b/src/DBmysql.php
@@ -2221,32 +2221,33 @@ class DBmysql
      */
     private function decodeFetchResult(array|object|false|null $values): array|object|false|null
     {
-        if ($values === null || $values === false) {
-            // No more results or error on fetch operation.
-            return $values;
-        }
-
-        foreach ($values as $key => $value) {
-            if (!is_string($value)) {
-                continue;
-            }
-
-            $decoder = new SanitizedStringsDecoder();
-
-            if ($key === 'completename') {
-                $value = $decoder->decodeHtmlSpecialCharsInCompletename($value);
-            } else {
-                $value = $decoder->decodeHtmlSpecialChars($value);
-            }
-
-            if (is_object($values)) {
-                $values->{$key} = $value;
-            } else {
-                $values[$key] = $value;
-            }
-        }
-
         return $values;
+//        if ($values === null || $values === false) {
+//            // No more results or error on fetch operation.
+//            return $values;
+//        }
+//
+//        foreach ($values as $key => $value) {
+//            if (!is_string($value)) {
+//                continue;
+//            }
+//
+//            $decoder = new SanitizedStringsDecoder();
+//
+//            if ($key === 'completename') {
+//                $value = $decoder->decodeHtmlSpecialCharsInCompletename($value);
+//            } else {
+//                $value = $decoder->decodeHtmlSpecialChars($value);
+//            }
+//
+//            if (is_object($values)) {
+//                $values->{$key} = $value;
+//            } else {
+//                $values[$key] = $value;
+//            }
+//        }
+//
+//        return $values;
     }
 
     /**

--- a/tests/functional/DBTest.php
+++ b/tests/functional/DBTest.php
@@ -808,85 +808,85 @@ SQL,
         );
     }
 
-    public static function fetchResultProvider(): iterable
-    {
-        foreach (['fetchArray', 'fetchRow', 'fetchAssoc', 'fetchObject'] as $method) {
-            // No more results => null.
-            yield [
-                'method'   => $method,
-                'row'      => null,
-                'expected' => null,
-            ];
-
-            // Fetch failed => false.
-            yield [
-                'method'   => $method,
-                'row'      => false,
-                'expected' => false,
-            ];
-
-            // Data produced by GLPI <= 10.0 XSS cleaning process.
-            yield [
-                'method'   => $method,
-                'row'      => [
-                    'id'      => 10,
-                    'content' => '&lt;strong&gt;string&lt;/strong&gt;',
-                    'extra'   => null,
-                ],
-                'expected' => [
-                    'id'      => 10,
-                    'content' => '<strong>string</strong>',
-                    'extra'   => null,
-                ],
-            ];
-
-            // Data produced by GLPI 10.0 XSS cleaning process.
-            yield [
-                'method'   => $method,
-                'row'      => [
-                    'id'      => 10,
-                    'content' => '&#60;p&#62;HTML containing a code snippet&#60;/p&#62;&#60;pre&#62;&#38;lt;a href=&#38;quot;/test&#38;quot;&#38;gt;link&#38;lt;/a&#38;gt;&#60;/pre&#62;',
-                    'extra'   => null,
-                ],
-                'expected' => [
-                    'id'      => 10,
-                    'content' => '<p>HTML containing a code snippet</p><pre>&lt;a href=&quot;/test&quot;&gt;link&lt;/a&gt;</pre>',
-                    'extra'   => null,
-                ],
-            ];
-
-            // Data produced by GLPI 11.0.
-            yield [
-                'method'   => $method,
-                'row'      => [
-                    'id'      => 10,
-                    'content' => '<p>HTML containing a code snippet</p><pre>&lt;a href=&quot;/test&quot;&gt;link&lt;/a&gt;</pre>',
-                    'extra'   => null,
-                ],
-                'expected' => [
-                    'id'      => 10,
-                    'content' => '<p>HTML containing a code snippet</p><pre>&lt;a href=&quot;/test&quot;&gt;link&lt;/a&gt;</pre>',
-                    'extra'   => null,
-                ],
-            ];
-        }
-    }
-
-    #[DataProvider('fetchResultProvider')]
-    public function testDecodeFetchResult(string $method, mixed $row, mixed $expected)
-    {
-        if ($method === 'fetchObject') {
-            $row = is_array($row) ? (object) $row : $row;
-            $expected = is_array($expected) ? (object) $expected : $expected;
-        }
-
-        $mysqli_result = $this->createMock(\mysqli_result::class);
-        $mysqli_method = strtolower(preg_replace('/[A-Z]/', '_$0', $method)); // e.g. fetchArray -> fetch_array
-        $mysqli_result->method($mysqli_method)->willReturn($row);
-
-        $instance = new \DB();
-        $this->assertEquals($expected, $instance->{$method}($mysqli_result));
-    }
+//    public static function fetchResultProvider(): iterable
+//    {
+//        foreach (['fetchArray', 'fetchRow', 'fetchAssoc', 'fetchObject'] as $method) {
+//            // No more results => null.
+//            yield [
+//                'method'   => $method,
+//                'row'      => null,
+//                'expected' => null,
+//            ];
+//
+//            // Fetch failed => false.
+//            yield [
+//                'method'   => $method,
+//                'row'      => false,
+//                'expected' => false,
+//            ];
+//
+//            // Data produced by GLPI <= 10.0 XSS cleaning process.
+//            yield [
+//                'method'   => $method,
+//                'row'      => [
+//                    'id'      => 10,
+//                    'content' => '&lt;strong&gt;string&lt;/strong&gt;',
+//                    'extra'   => null,
+//                ],
+//                'expected' => [
+//                    'id'      => 10,
+//                    'content' => '<strong>string</strong>',
+//                    'extra'   => null,
+//                ],
+//            ];
+//
+//            // Data produced by GLPI 10.0 XSS cleaning process.
+//            yield [
+//                'method'   => $method,
+//                'row'      => [
+//                    'id'      => 10,
+//                    'content' => '&#60;p&#62;HTML containing a code snippet&#60;/p&#62;&#60;pre&#62;&#38;lt;a href=&#38;quot;/test&#38;quot;&#38;gt;link&#38;lt;/a&#38;gt;&#60;/pre&#62;',
+//                    'extra'   => null,
+//                ],
+//                'expected' => [
+//                    'id'      => 10,
+//                    'content' => '<p>HTML containing a code snippet</p><pre>&lt;a href=&quot;/test&quot;&gt;link&lt;/a&gt;</pre>',
+//                    'extra'   => null,
+//                ],
+//            ];
+//
+//            // Data produced by GLPI 11.0.
+//            yield [
+//                'method'   => $method,
+//                'row'      => [
+//                    'id'      => 10,
+//                    'content' => '<p>HTML containing a code snippet</p><pre>&lt;a href=&quot;/test&quot;&gt;link&lt;/a&gt;</pre>',
+//                    'extra'   => null,
+//                ],
+//                'expected' => [
+//                    'id'      => 10,
+//                    'content' => '<p>HTML containing a code snippet</p><pre>&lt;a href=&quot;/test&quot;&gt;link&lt;/a&gt;</pre>',
+//                    'extra'   => null,
+//                ],
+//            ];
+//        }
+//    }
+//
+//    #[DataProvider('fetchResultProvider')]
+//    public function testDecodeFetchResult(string $method, mixed $row, mixed $expected)
+//    {
+//        if ($method === 'fetchObject') {
+//            $row = is_array($row) ? (object) $row : $row;
+//            $expected = is_array($expected) ? (object) $expected : $expected;
+//        }
+//
+//        $mysqli_result = $this->createMock(\mysqli_result::class);
+//        $mysqli_method = strtolower(preg_replace('/[A-Z]/', '_$0', $method)); // e.g. fetchArray -> fetch_array
+//        $mysqli_result->method($mysqli_method)->willReturn($row);
+//
+//        $instance = new \DB();
+//        $this->assertEquals($expected, $instance->{$method}($mysqli_result));
+//    }
 
     public static function dataDrop()
     {


### PR DESCRIPTION
Just testing unit test execution time with automatic decoding skipped for DB results.