### PR TITLE
Disable unsanitization of DB data for new GLPI instances

### DIFF
--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -413,6 +413,7 @@ $empty_data_builder = new class {
             'timezone' => '0',
             'glpi_11_form_migration' => 0,
             'glpi_11_assets_migration' => 0,
+            'must_unsanitize_db_data' => 0,
         ];
 
         $tables['glpi_configs'] = [];

--- a/install/migrations/update_11.0.3_to_11.0.5/configs.php
+++ b/install/migrations/update_11.0.3_to_11.0.5/configs.php
@@ -36,10 +36,15 @@
  * @var DBmysql $DB
  * @var Migration $migration
  */
-$migration->addConfig(['found_new_version' => ''], 'core');
-$migration->removeConfig(['founded_new_version']);
+$migration->addConfig(
+    [
+        'found_new_version'         => '',
+        'proxy_exclusions'          => exportArrayToDB([]),
+        'must_unsanitize_db_data'   => 1,
+    ]
+);
 
-$migration->addConfig(['proxy_exclusions' => exportArrayToDB([])]);
+$migration->removeConfig(['founded_new_version']);
 
 $migration->addPostQuery(
     $DB->buildUpdate(

--- a/resources/Rules/RuleDictionnaryOperatingSystem.xml
+++ b/resources/Rules/RuleDictionnaryOperatingSystem.xml
@@ -11,16 +11,16 @@
         <comment>/(SUSE|SunOS|Red Hat|CentOS|Ubuntu|Debian|Fedora|AlmaLinux|Oracle|Amazon Linux)(?:\D+|)([\d.]*) ?(?:\(?([\w ]+)\)?)?/
 
             Example :
-            Ubuntu 22.04.1 LTS -&amp;#62; #0 = Ubuntu
-            SUSE Linux Enterprise Server 11 (x86_64)  -&amp;#62;#0 = SUSE
-            SunOS -&amp;#62; #0 = SunOS
-            Red Hat Enterprise Linux Server release 7.9 (Maipo) -&amp;#62; #0 = Red Hat
-            Oracle Linux Server release 7.3 -&amp;#62; #0 = Oracle
-            Fedora release 36 (Thirty Six) -&amp;#62; #0 = Fedora
-            Debian GNU/Linux 9.5 (stretch) -&amp;#62; #0 = Debian
-            CentOS Stream release 8 -&amp;#62; #0 = CentOS
-            AlmaLinux 9.0 (Emerald Puma) -&amp;#62; #0 = AlmaLinux
-            Amazon Linux 2023 -&amp;#62; #0 = Amazon Linux</comment>
+            Ubuntu 22.04.1 LTS -&#62; #0 = Ubuntu
+            SUSE Linux Enterprise Server 11 (x86_64)  -&#62;#0 = SUSE
+            SunOS -&#62; #0 = SunOS
+            Red Hat Enterprise Linux Server release 7.9 (Maipo) -&#62; #0 = Red Hat
+            Oracle Linux Server release 7.3 -&#62; #0 = Oracle
+            Fedora release 36 (Thirty Six) -&#62; #0 = Fedora
+            Debian GNU/Linux 9.5 (stretch) -&#62; #0 = Debian
+            CentOS Stream release 8 -&#62; #0 = CentOS
+            AlmaLinux 9.0 (Emerald Puma) -&#62; #0 = AlmaLinux
+            Amazon Linux 2023 -&#62; #0 = Amazon Linux</comment>
         <is_recursive>1</is_recursive>
         <uuid>clean_linux_os_name</uuid>
         <condition>0</condition>
@@ -44,16 +44,16 @@
         <description></description>
         <match>AND</match>
         <is_active>0</is_active>
-        <comment>/(Microsoft)(?&amp;#62;\(R\)|&#xAE;)? (Windows) (XP|\d\.\d|\d{1,4}|Vista)(&#x2122;)? ?(.*)/
+        <comment>/(Microsoft)(?&#62;\(R\)|&#xAE;)? (Windows) (XP|\d\.\d|\d{1,4}|Vista)(&#x2122;)? ?(.*)/
 
             Example :
-            Microsoft Windows XP Professionnel -&amp;#62; #1 : Windows
-            Microsoft Windows 7 Enterprise  -&amp;#62; #1 : Windows
-            Microsoft&#xAE; Windows Vista Professionnel  -&amp;#62; #1 : Windows
-            Microsoft Windows XP &#xC9;dition familiale  -&amp;#62; #1 : Windows
-            Microsoft Windows 10 Entreprise  -&amp;#62; #1 : Windows
-            Microsoft Windows 10 Professionnel  -&amp;#62; #1 : Windows
-            Microsoft Windows 11 Professionnel  -&amp;#62; #1 : Windows</comment>
+            Microsoft Windows XP Professionnel -&#62; #1 : Windows
+            Microsoft Windows 7 Enterprise  -&#62; #1 : Windows
+            Microsoft&#xAE; Windows Vista Professionnel  -&#62; #1 : Windows
+            Microsoft Windows XP &#xC9;dition familiale  -&#62; #1 : Windows
+            Microsoft Windows 10 Entreprise  -&#62; #1 : Windows
+            Microsoft Windows 10 Professionnel  -&#62; #1 : Windows
+            Microsoft Windows 11 Professionnel  -&#62; #1 : Windows</comment>
         <is_recursive>1</is_recursive>
         <uuid>clean_windows_os_name</uuid>
         <condition>0</condition>
@@ -61,7 +61,7 @@
         <rulecriteria>
             <criteria>name</criteria>
             <condition>6</condition>
-            <pattern>/(Microsoft)(?&amp;#62;\(R\)|&#xAE;)? (Windows) (XP|\d\.\d|\d{1,4}|Vista)(&#x2122;)? ?(.*)/</pattern>
+            <pattern>/(Microsoft)(?&#62;\(R\)|&#xAE;)? (Windows) (XP|\d\.\d|\d{1,4}|Vista)(&#x2122;)? ?(.*)/</pattern>
         </rulecriteria>
         <ruleaction>
             <action_type>append_regex_result</action_type>
@@ -77,13 +77,13 @@
         <description></description>
         <match>AND</match>
         <is_active>0</is_active>
-        <comment>/(Microsoft)(?&amp;#62;\(R\)|&#xAE;)? (?:(Hyper-V|Windows)(?:\(R\))?) ((?:Server|))(?:\(R\)|&#xAE;)? (\d{4}(?: R2)?)(?:[,\s]++)?([^\s]*)(?: Edition(?: x64)?)?$/
+        <comment>/(Microsoft)(?&#62;\(R\)|&#xAE;)? (?:(Hyper-V|Windows)(?:\(R\))?) ((?:Server|))(?:\(R\)|&#xAE;)? (\d{4}(?: R2)?)(?:[,\s]++)?([^\s]*)(?: Edition(?: x64)?)?$/
 
             Example :
-            Microsoft Windows Server 2012 R2 Datacenter -&amp;#62; #1 #2 : Windows Server
-            Microsoft(R) Windows(R) Server 2003, Standard Edition x64 -&amp;#62; #1 #2 : Windows Server
-            Microsoft Hyper-V Server 2012 R2 -&amp;#62; #1 #2 : Hyper-V Server
-            Microsoft&#xAE; Windows Server&#xAE; 2008 Standard -&amp;#62; #1 #2 : Windows Server</comment>
+            Microsoft Windows Server 2012 R2 Datacenter -&#62; #1 #2 : Windows Server
+            Microsoft(R) Windows(R) Server 2003, Standard Edition x64 -&#62; #1 #2 : Windows Server
+            Microsoft Hyper-V Server 2012 R2 -&#62; #1 #2 : Hyper-V Server
+            Microsoft&#xAE; Windows Server&#xAE; 2008 Standard -&#62; #1 #2 : Windows Server</comment>
         <is_recursive>1</is_recursive>
         <uuid>clean_windows_server_os_name</uuid>
         <condition>0</condition>
@@ -91,7 +91,7 @@
         <rulecriteria>
             <criteria>name</criteria>
             <condition>6</condition>
-            <pattern>/(Microsoft)(?&amp;#62;\(R\)|&#xAE;)? (?:(Hyper-V|Windows)(?:\(R\))?) ((?:Server|))(?:\(R\)|&#xAE;)? (\d{4}(?: R2)?)(?:[,\s]++)?([^\s]*)(?: Edition(?: x64)?)?$/</pattern>
+            <pattern>/(Microsoft)(?&#62;\(R\)|&#xAE;)? (?:(Hyper-V|Windows)(?:\(R\))?) ((?:Server|))(?:\(R\)|&#xAE;)? (\d{4}(?: R2)?)(?:[,\s]++)?([^\s]*)(?: Edition(?: x64)?)?$/</pattern>
         </rulecriteria>
         <ruleaction>
             <action_type>append_regex_result</action_type>

--- a/resources/Rules/RuleDictionnaryOperatingSystemEdition.xml
+++ b/resources/Rules/RuleDictionnaryOperatingSystemEdition.xml
@@ -11,16 +11,16 @@
         <comment>/(SUSE|SunOS|Red Hat|CentOS|Ubuntu|Debian|Fedora|AlmaLinux|Oracle)(?:\D+|)([\d.]+) ?(?:\(?([\w ]+)\)?)?/
 
         Example :
-        Ubuntu 22.04.1 LTS -&amp;#62; #2 = LTS
-        SUSE Linux Enterprise Server 11 (x86_64) -&amp;#62; #2 = x86_64
-        Red Hat Enterprise Linux Server release 7.9 (Maipo) -&amp;#62; #2 = Maipo
-        Red Hat Enterprise Linux Server release 6.10 (Santiago) -&amp;#62; #2 = Santiago
-        Fedora release 36 (Thirty Six) -&amp;#62; #2 = Thirty Six
-        Debian GNU/Linux 9.5 (stretch) -&amp;#62; #2 = stretch
-        Debian GNU/Linux 8.9 (jessie) -&amp;#62; #2 = jessie
-        CentOS Linux release 7.2.1511 (Core) -&amp;#62; #2 = Core
-        AlmaLinux 9.0 (Emerald Puma) -&amp;#62; #2 = Emerald Puma
-        AlmaLinux 8.6 (Sky Tiger) -&amp;#62; #2 = Sky Tiger</comment>
+        Ubuntu 22.04.1 LTS -&#62; #2 = LTS
+        SUSE Linux Enterprise Server 11 (x86_64) -&#62; #2 = x86_64
+        Red Hat Enterprise Linux Server release 7.9 (Maipo) -&#62; #2 = Maipo
+        Red Hat Enterprise Linux Server release 6.10 (Santiago) -&#62; #2 = Santiago
+        Fedora release 36 (Thirty Six) -&#62; #2 = Thirty Six
+        Debian GNU/Linux 9.5 (stretch) -&#62; #2 = stretch
+        Debian GNU/Linux 8.9 (jessie) -&#62; #2 = jessie
+        CentOS Linux release 7.2.1511 (Core) -&#62; #2 = Core
+        AlmaLinux 9.0 (Emerald Puma) -&#62; #2 = Emerald Puma
+        AlmaLinux 8.6 (Sky Tiger) -&#62; #2 = Sky Tiger</comment>
         <is_recursive>1</is_recursive>
         <uuid>clean_linux_os_edition</uuid>
         <condition>0</condition>
@@ -44,16 +44,16 @@
         <description></description>
         <match>AND</match>
         <is_active>0</is_active>
-        <comment>/(Microsoft)(?&amp;#62;\(R\)|&#xAE;)? (Windows) (XP|\d\.\d|\d{1,4}|Vista)(&#x2122;)? ?(.*)/
+        <comment>/(Microsoft)(?&#62;\(R\)|&#xAE;)? (Windows) (XP|\d\.\d|\d{1,4}|Vista)(&#x2122;)? ?(.*)/
 
         Example :
-        Microsoft Windows XP Professionnel -&amp;#62; #4 : Professionnel
-        Microsoft Windows 7 Enterprise  -&amp;#62; #4 : Enterprise
-        Microsoft&#xAE; Windows Vista Professionnel  -&amp;#62; #4 : Professionnel
-        Microsoft Windows XP &#xC9;dition familiale  -&amp;#62; #4 : &#xC9;dition familiale
-        Microsoft Windows 10 Entreprise  -&amp;#62; #4 : Entreprise
-        Microsoft Windows 10 Professionnel  -&amp;#62; #4 : Professionnel
-        Microsoft Windows 11 Professionnel  -&amp;#62; #4 : Professionnel</comment>
+        Microsoft Windows XP Professionnel -&#62; #4 : Professionnel
+        Microsoft Windows 7 Enterprise  -&#62; #4 : Enterprise
+        Microsoft&#xAE; Windows Vista Professionnel  -&#62; #4 : Professionnel
+        Microsoft Windows XP &#xC9;dition familiale  -&#62; #4 : &#xC9;dition familiale
+        Microsoft Windows 10 Entreprise  -&#62; #4 : Entreprise
+        Microsoft Windows 10 Professionnel  -&#62; #4 : Professionnel
+        Microsoft Windows 11 Professionnel  -&#62; #4 : Professionnel</comment>
         <is_recursive>1</is_recursive>
         <uuid>clean_windows_os_edition</uuid>
         <condition>0</condition>
@@ -61,7 +61,7 @@
         <rulecriteria>
             <criteria>os_name</criteria>
             <condition>6</condition>
-            <pattern>/(Microsoft)(?&amp;#62;\(R\)|&#xAE;)? (Windows) (XP|\d\.\d|\d{1,4}|Vista)(&#x2122;)? ?(.*)/</pattern>
+            <pattern>/(Microsoft)(?&#62;\(R\)|&#xAE;)? (Windows) (XP|\d\.\d|\d{1,4}|Vista)(&#x2122;)? ?(.*)/</pattern>
         </rulecriteria>
         <ruleaction>
             <action_type>append_regex_result</action_type>
@@ -77,13 +77,13 @@
         <description></description>
         <match>AND</match>
         <is_active>0</is_active>
-        <comment>/(Microsoft)(?&amp;#62;\(R\)|&#xAE;)? (?:(Hyper-V|Windows)(?:\(R\))?) ((?:Server|))(?:\(R\)|&#xAE;)? (\d{4}(?: R2)?)(?:[,\s]++)?([^\s]*)(?: Edition(?: x64)?)?$/
+        <comment>/(Microsoft)(?&#62;\(R\)|&#xAE;)? (?:(Hyper-V|Windows)(?:\(R\))?) ((?:Server|))(?:\(R\)|&#xAE;)? (\d{4}(?: R2)?)(?:[,\s]++)?([^\s]*)(?: Edition(?: x64)?)?$/
 
         Example :
-        Microsoft Windows Server 2012 R2 Datacenter -&amp;#62; #4 : Datacenter
-        Microsoft(R) Windows(R) Server 2003, Standard Edition x64 -&amp;#62; #4 : Standard
-        Microsoft Hyper-V Server 2012 R2 -&amp;#62; #4 :
-        Microsoft&#xAE; Windows Server&#xAE; 2008 Standard -&amp;#62; #4: Standard</comment>
+        Microsoft Windows Server 2012 R2 Datacenter -&#62; #4 : Datacenter
+        Microsoft(R) Windows(R) Server 2003, Standard Edition x64 -&#62; #4 : Standard
+        Microsoft Hyper-V Server 2012 R2 -&#62; #4 :
+        Microsoft&#xAE; Windows Server&#xAE; 2008 Standard -&#62; #4: Standard</comment>
         <is_recursive>1</is_recursive>
         <uuid>clean_windows_server_os_edition</uuid>
         <condition>0</condition>
@@ -91,7 +91,7 @@
         <rulecriteria>
             <criteria>os_name</criteria>
             <condition>6</condition>
-            <pattern>/(Microsoft)(?&amp;#62;\(R\)|&#xAE;)? (?:(Hyper-V|Windows)(?:\(R\))?) ((?:Server|))(?:\(R\)|&#xAE;)? (\d{4}(?: R2)?)(?:[,\s]++)?([^\s]*)(?: Edition(?: x64)?)?$/</pattern>
+            <pattern>/(Microsoft)(?&#62;\(R\)|&#xAE;)? (?:(Hyper-V|Windows)(?:\(R\))?) ((?:Server|))(?:\(R\)|&#xAE;)? (\d{4}(?: R2)?)(?:[,\s]++)?([^\s]*)(?: Edition(?: x64)?)?$/</pattern>
         </rulecriteria>
         <ruleaction>
             <action_type>append_regex_result</action_type>

--- a/resources/Rules/RuleDictionnaryOperatingSystemVersion.xml
+++ b/resources/Rules/RuleDictionnaryOperatingSystemVersion.xml
@@ -11,15 +11,15 @@
         <comment>/(SUSE|SunOS|Red Hat|CentOS|Ubuntu|Debian|Fedora|AlmaLinux|Oracle)(?:\D+|)([\d.]+) ?(?:\(?([\w ]+)\)?)?/
 
             Example :
-            Ubuntu 22.04.1 LTS -&amp;#62; #1 = 22.04.1
-            SUSE Linux Enterprise Server 11 (x86_64) -&amp;#62; #1 =  11
-            SunOS 5.10 -&amp;#62; #1 = 5.10
-            Red Hat Enterprise Linux Server release 7.9 (Maipo) -&amp;#62; #1 = 7.9
-            Oracle Linux Server release 7.3 -&amp;#62; #1 = 7.3
-            Fedora release 36 (Thirty Six) -&amp;#62; #1 =  36
-            Debian GNU/Linux 9.5 (stretch) -&amp;#62; #1 = 9.5
-            CentOS release 6.9 (Final) -&amp;#62; #1 = 6.9
-            AlmaLinux 9.0 (Emerald Puma) -&amp;#62; #1 = 9.0</comment>
+            Ubuntu 22.04.1 LTS -&#62; #1 = 22.04.1
+            SUSE Linux Enterprise Server 11 (x86_64) -&#62; #1 =  11
+            SunOS 5.10 -&#62; #1 = 5.10
+            Red Hat Enterprise Linux Server release 7.9 (Maipo) -&#62; #1 = 7.9
+            Oracle Linux Server release 7.3 -&#62; #1 = 7.3
+            Fedora release 36 (Thirty Six) -&#62; #1 =  36
+            Debian GNU/Linux 9.5 (stretch) -&#62; #1 = 9.5
+            CentOS release 6.9 (Final) -&#62; #1 = 6.9
+            AlmaLinux 9.0 (Emerald Puma) -&#62; #1 = 9.0</comment>
         <is_recursive>1</is_recursive>
         <uuid>clean_linux_os_version</uuid>
         <condition>0</condition>
@@ -43,16 +43,16 @@
         <description></description>
         <match>AND</match>
         <is_active>0</is_active>
-        <comment>/(Microsoft)(?&amp;#62;\(R\)|&#xAE;)? (Windows) (XP|\d\.\d|\d{1,4}|Vista)(&#x2122;)? ?(.*)/
+        <comment>/(Microsoft)(?&#62;\(R\)|&#xAE;)? (Windows) (XP|\d\.\d|\d{1,4}|Vista)(&#x2122;)? ?(.*)/
 
             Example :
-            Microsoft Windows XP Professionnel -&amp;#62; #2 : XP
-            Microsoft Windows 7 Enterprise  -&amp;#62; #2 : 7
-            Microsoft&#xAE; Windows Vista Professionnel  -&amp;#62; #2 : Vista
-            Microsoft Windows XP &#xC9;dition familiale  -&amp;#62; #2 : XP
-            Microsoft Windows 10 Entreprise  -&amp;#62; #2 : 10
-            Microsoft Windows 10 Professionnel  -&amp;#62; #2 : 10
-            Microsoft Windows 11 Professionnel  -&amp;#62; #2 : 11</comment>
+            Microsoft Windows XP Professionnel -&#62; #2 : XP
+            Microsoft Windows 7 Enterprise  -&#62; #2 : 7
+            Microsoft&#xAE; Windows Vista Professionnel  -&#62; #2 : Vista
+            Microsoft Windows XP &#xC9;dition familiale  -&#62; #2 : XP
+            Microsoft Windows 10 Entreprise  -&#62; #2 : 10
+            Microsoft Windows 10 Professionnel  -&#62; #2 : 10
+            Microsoft Windows 11 Professionnel  -&#62; #2 : 11</comment>
         <is_recursive>1</is_recursive>
         <uuid>clean_windows_os_version</uuid>
         <condition>0</condition>
@@ -60,7 +60,7 @@
         <rulecriteria>
             <criteria>os_name</criteria>
             <condition>6</condition>
-            <pattern>/(Microsoft)(?&amp;#62;\(R\)|&#xAE;)? (Windows) (XP|\d\.\d|\d{1,4}|Vista)(&#x2122;)? ?(.*)/</pattern>
+            <pattern>/(Microsoft)(?&#62;\(R\)|&#xAE;)? (Windows) (XP|\d\.\d|\d{1,4}|Vista)(&#x2122;)? ?(.*)/</pattern>
         </rulecriteria>
         <ruleaction>
             <action_type>append_regex_result</action_type>
@@ -76,13 +76,13 @@
         <description></description>
         <match>AND</match>
         <is_active>0</is_active>
-        <comment>/(Microsoft)(?&amp;#62;\(R\)|&#xAE;)? (?:(Hyper-V|Windows)(?:\(R\))?) ((?:Server|))(?:\(R\)|&#xAE;)? (\d{4}(?: R2)?)(?:[,\s]++)?([^\s]*)(?: Edition(?: x64)?)?$/
+        <comment>/(Microsoft)(?&#62;\(R\)|&#xAE;)? (?:(Hyper-V|Windows)(?:\(R\))?) ((?:Server|))(?:\(R\)|&#xAE;)? (\d{4}(?: R2)?)(?:[,\s]++)?([^\s]*)(?: Edition(?: x64)?)?$/
 
             Example :
-            Microsoft Windows Server 2012 R2 Datacenter -&amp;#62; #3 : 2012 R2
-            Microsoft(R) Windows(R) Server 2003, Standard Edition x64 -&amp;#62; #3 : 2003
-            Microsoft Hyper-V Server 2012 R2 -&amp;#62; #3 : 2012 R2
-            Microsoft&#xAE; Windows Server&#xAE; 2008 Standard -&amp;#62; #3 : 2008</comment>
+            Microsoft Windows Server 2012 R2 Datacenter -&#62; #3 : 2012 R2
+            Microsoft(R) Windows(R) Server 2003, Standard Edition x64 -&#62; #3 : 2003
+            Microsoft Hyper-V Server 2012 R2 -&#62; #3 : 2012 R2
+            Microsoft&#xAE; Windows Server&#xAE; 2008 Standard -&#62; #3 : 2008</comment>
         <is_recursive>1</is_recursive>
         <uuid>clean_windows_server_os_version</uuid>
         <condition>0</condition>
@@ -90,7 +90,7 @@
         <rulecriteria>
             <criteria>os_name</criteria>
             <condition>6</condition>
-            <pattern>/(Microsoft)(?&amp;#62;\(R\)|&#xAE;)? (?:(Hyper-V|Windows)(?:\(R\))?) ((?:Server|))(?:\(R\)|&#xAE;)? (\d{4}(?: R2)?)(?:[,\s]++)?([^\s]*)(?: Edition(?: x64)?)?$/</pattern>
+            <pattern>/(Microsoft)(?&#62;\(R\)|&#xAE;)? (?:(Hyper-V|Windows)(?:\(R\))?) ((?:Server|))(?:\(R\)|&#xAE;)? (\d{4}(?: R2)?)(?:[,\s]++)?([^\s]*)(?: Edition(?: x64)?)?$/</pattern>
         </rulecriteria>
         <ruleaction>
             <action_type>append_regex_result</action_type>

--- a/src/DBmysql.php
+++ b/src/DBmysql.php
@@ -222,6 +222,11 @@ class DBmysql
     private int $transaction_level = 0;
 
     /**
+     * Indicates whether the data fetched from DB must be unsanitized.
+     */
+    private bool $must_unsanitize_data = false;
+
+    /**
      * Constructor / Connect to the MySQL Database
      *
      * @param int $choice host number (default NULL)
@@ -2216,11 +2221,20 @@ class DBmysql
         return $config_flags;
     }
 
+    public function setMustUnsanitizeData(bool $must_unsanitize_data): void
+    {
+        $this->must_unsanitize_data = $must_unsanitize_data;
+    }
+
     /**
      * Decode HTML special chars on fetch operation result.
      */
     private function decodeFetchResult(array|object|false|null $values): array|object|false|null
     {
+        if ($this->must_unsanitize_data === false) {
+            return $values;
+        }
+
         if ($values === null || $values === false) {
             // No more results or error on fetch operation.
             return $values;

--- a/tests/functional/DBTest.php
+++ b/tests/functional/DBTest.php
@@ -885,7 +885,12 @@ SQL,
         $mysqli_result->method($mysqli_method)->willReturn($row);
 
         $instance = new \DB();
+
+        $instance->setMustUnsanitizeData(true);
         $this->assertEquals($expected, $instance->{$method}($mysqli_result));
+
+        $instance->setMustUnsanitizeData(false);
+        $this->assertEquals($row, $instance->{$method}($mysqli_result));
     }
 
     public static function dataDrop()

--- a/tests/functional/DBmysqlIteratorTest.php
+++ b/tests/functional/DBmysqlIteratorTest.php
@@ -1793,9 +1793,15 @@ class DBmysqlIteratorTest extends DbTestCase
         $db->method('doQuery')->willReturn($mysqli_result);
         $db->method('numrows')->willReturn(1);
 
+        // Check result with active unsanitization
+        $db->setMustUnsanitizeData(true);
         $iterator = $db->request(['FROM' => 'glpi_mocks']);
-
         $this->assertEquals($result, $iterator->current());
+
+        // Check result with deactivated unsanitization
+        $db->setMustUnsanitizeData(false);
+        $iterator = $db->request(['FROM' => 'glpi_mocks']);
+        $this->assertEquals($db_data, $iterator->current());
     }
 
     public function testRawFKeyCondition()

--- a/tests/functional/Glpi/Console/Diagnostic/CheckHtmlEncodingCommandTest.php
+++ b/tests/functional/Glpi/Console/Diagnostic/CheckHtmlEncodingCommandTest.php
@@ -157,6 +157,8 @@ class CheckHtmlEncodingCommandTest extends DbTestCase
     {
         global $DB;
 
+        $DB->setMustUnsanitizeData(true); // The tested command has been made to correct autosanitized data
+
         $checker = new CheckHtmlEncodingCommand();
 
         // Create and load item

--- a/tests/functional/Glpi/Form/Migration/FormMigrationTest.php
+++ b/tests/functional/Glpi/Form/Migration/FormMigrationTest.php
@@ -143,6 +143,15 @@ final class FormMigrationTest extends DbTestCase
         parent::tearDownAfterClass();
     }
 
+    public function setUp(): void
+    {
+        global $DB;
+
+        parent::setUp();
+
+        $DB->setMustUnsanitizeData(true); // plugin data has been autosanitized
+    }
+
     private static function getSectionIDFromFormName($form_name, $section_name)
     {
         $section = new Section();

--- a/tests/src/DbTestCase.php
+++ b/tests/src/DbTestCase.php
@@ -83,6 +83,8 @@ class DbTestCase extends GLPITestCase
         $in_transaction = $this->callPrivateMethod($DB, 'isInTransaction');
         $this->assertFalse($in_transaction);
 
+        $DB->setMustUnsanitizeData(false); // Be sure to switch back to disabled unsanitization.
+
         parent::tearDown();
     }
 

--- a/tests/web/APIRestTest.php
+++ b/tests/web/APIRestTest.php
@@ -3048,59 +3048,6 @@ class APIRestTest extends TestCase
         }
     }
 
-    /**
-     * Data provider for testReturnSanitizedContentUnit
-     *
-     * @return array
-     */
-    public static function testReturnSanitizedContentUnitProvider(): array
-    {
-        return [
-            [null, true],
-            ["", false],
-            ["true", true],
-            ["false", false],
-            ["on", true],
-            ["off", false],
-            ["1", true],
-            ["0", false],
-            ["yes", true],
-            ["no", false],
-            ["asfbhueshf", false],
-        ];
-    }
-
-    /**
-     * Functional test to ensure returned content is not sanitized.
-     *
-            $expected_output,
-     * @return void
-     */
-    public function testContentEncoding(): void
-    {
-        // Get computer with encoded comment
-        $computers_id = getItemByTypeName(
-            "Computer",
-            "_test_pc_with_encoded_comment",
-            true
-        );
-
-        // Request params
-        $url = "/Computer/$computers_id";
-        $method = "GET";
-        $headers = ['Session-Token' => $this->session_token];
-
-        $data = $this->query(
-            $url,
-            [
-                'headers' => $headers,
-                'verb'    => $method,
-            ],
-            200
-        );
-        $this->assertEquals("<>", $data['comment']);
-    }
-
     public function test_ActorUpdate()
     {
         $headers = ['Session-Token' => $this->session_token];


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

The database of GLPI instance created with a GLPI 11.0+ version will never contain sanitize data. Therefore, there is no reason to automatically unsanitize data.

My proposal is to add a flag in the `glpi_configs` database to indicates whether the data must be unsanitized, and to set this flag to `false` for any new GLPI installation.

This will add an extra DB query, but IMHO it is safer to have a dedicated query executed right after the DB connection init to be sure that the correct behaviour is applied ASAP.

To prevent the requirement of this extra query, we could use the same mechanism as for other BD flags (e.g. `use_utf8mb4`), but there are two problems with that:
1. using flags in configuration files has caused support requests in the past, because a few people manipulates config files manually and erase flags values;
2. other flags values can be easilly computed based on the DB structure, the current one is pretty impossible to recompute without a complex logic that would have to parse almost the whole database data until it finds sanitized data.

I decided to target GLPI 11.0.5, but maybe this is preferable to do it in GLPI 12.0.