### PR TITLE
[ci] Improve docker build process

### DIFF
--- a/.github/workflows/docker_nightly.yml
+++ b/.github/workflows/docker_nightly.yml
@@ -1,0 +1,39 @@
+name: "Docker nightly images"
+
+on:
+  # Build Docker nightly images every day
+  schedule:
+    - cron: '0 0 * * *'
+  # Enable manual run
+  workflow_dispatch:
+
+jobs:
+  build-main:
+    name: "Build main branch"
+    if: ${{ github.repository == 'glpi-project/glpi' }}
+    uses: "glpi-project/docker-images/.github/workflows/glpi.yml@main"
+    secrets: inherit
+    with:
+      push: true
+      glpi-version: "main"
+      image-tag: "dev-nightly"
+
+  build-11:
+    name: "Build 11.0/bugfixes branch"
+    if: ${{ github.repository == 'glpi-project/glpi' }}
+    uses: "glpi-project/docker-images/.github/workflows/glpi.yml@main"
+    secrets: inherit
+    with:
+      push: true
+      glpi-version: "11.0/bugfixes"
+      image-tag: "11.0-nightly"
+
+  build-10:
+    name: "Build 10.0/bugfixes branch"
+    if: ${{ github.repository == 'glpi-project/glpi' }}
+    uses: "glpi-project/docker-images/.github/workflows/glpi.yml@main"
+    secrets: inherit
+    with:
+      push: true
+      glpi-version: "10.0/bugfixes"
+      image-tag: "10.0-nightly"

--- a/.github/workflows/docker_nightly.yml
+++ b/.github/workflows/docker_nightly.yml
@@ -37,3 +37,4 @@ jobs:
       push: true
       glpi-version: "10.0/bugfixes"
       image-tag: "10.0-nightly"
+      use-legacy-marketplace-path: true

--- a/.github/workflows/docker_releases.yml
+++ b/.github/workflows/docker_releases.yml
@@ -15,4 +15,5 @@ jobs:
     # can use the inherit keyword to implicitly pass the secrets.
     secrets: inherit
     with:
-        glpi-version: "${{ github.event.release.tag_name }}"
+      push: true
+      glpi-version: "${{ github.event.release.tag_name }}"

--- a/.github/workflows/docker_releases.yml
+++ b/.github/workflows/docker_releases.yml
@@ -6,7 +6,25 @@ on:
       - "published"
 
 jobs:
+  prepare:
+    name: "Prepare"
+    runs-on: "ubuntu-latest"
+    outputs:
+      use-legacy-marketplace-path: ${{ steps.detect.outputs.use_legacy }}
+    steps:
+      - name: "Detect v10.x release"
+        id: "detect"
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          MAJOR=$(echo "$TAG" | cut --delimiter='.' --fields=1)
+          if [[ "$MAJOR" = "10" ]]; then
+            echo "use_legacy=true" >> $GITHUB_OUTPUT
+          else
+            echo "use_legacy=false" >> $GITHUB_OUTPUT
+          fi
+
   trigger-docker-releases:
+    needs: [prepare]
     permissions:
       contents: "read"
     name: "Trigger Docker releases"
@@ -17,3 +35,4 @@ jobs:
     with:
       push: true
       glpi-version: "${{ github.event.release.tag_name }}"
+      use-legacy-marketplace-path: ${{ needs.prepare.outputs.use-legacy-marketplace-path == 'true' }}


### PR DESCRIPTION
The new builder https://github.com/glpi-project/docker-images/pull/250 now by default don't publish on docker to avoid any accidental push.

Once it's merged, we should merge this one so the next GLPI will be published automatically on docker/github

Nightly build is now managed here instead of inside [docker-images](https://github.com/glpi-project/docker-images)