### PR TITLE
Feat(SNMPCredential): add IETF AES draft protocol

### DIFF
--- a/src/SNMPCredential.php
+++ b/src/SNMPCredential.php
@@ -195,6 +195,10 @@ class SNMPCredential extends CommonDBTM
                 return 'AES192C';
             case 5:
                 return 'AES256C';
+            case 6:
+                return 'CFB192-AES';
+            case 7:
+                return 'CFB256-AES';
             default:
                 return '';
         }

--- a/templates/components/form/snmpcredential.html.twig
+++ b/templates/components/form/snmpcredential.html.twig
@@ -99,7 +99,7 @@
    {{ fields.dropdownArrayField(
       'encryption',
       item.fields['encryption'],
-      {0: '-----', 1: 'DES', 2: 'AES128', 3: 'Triple-DES', 4: 'Cisco AES192', 5: 'Cisco AES256'},
+      {0: '-----', 1: 'DES', 2: 'AES128', 3: 'Triple-DES', 4: 'Cisco AES192', 5: 'Cisco AES256', 6: 'AES192 (ietf draft)', 7: 'AES256 (ietf draft)'},
       __('Encryption protocol for data'),
       {
          add_field_attribs: {

--- a/templates/components/form/snmpcredential.html.twig
+++ b/templates/components/form/snmpcredential.html.twig
@@ -99,7 +99,7 @@
    {{ fields.dropdownArrayField(
       'encryption',
       item.fields['encryption'],
-      {0: '-----', 1: 'DES', 2: 'AES128', 3: 'Triple-DES', 4: 'Cisco AES192', 5: 'Cisco AES256', 6: 'AES192 (ietf draft)', 7: 'AES256 (ietf draft)'},
+      {0: '-----', 1: 'DES', 2: 'AES128', 3: 'Triple-DES', 4: 'Cisco AES192', 5: 'Cisco AES256', 6: 'AES192 (IETF draft)', 7: 'AES256 (IETF draft)'},
       __('Encryption protocol for data'),
       {
          add_field_attribs: {


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !40784
- Here is a brief description of what this PR does


Since https://github.com/glpi-project/glpi/pull/20575, 

the **private protocols** (Cisco AES192 & AES256) have been added.

In the meantime, these protocols are still **being standardized by the IETF**.

The implementation is not yet finalized, but some vendors have already deployed them to anticipate the future standard.

Following recent testing (!40784), we can confirm that the agent works correctly with these two new protocols.

Therefore, it is relevant to **add them to the list of supported protocols for SNMP credentials**.


