### PR TITLE
fix(dashboard): access control for get_dashboard_filters action

### DIFF
--- a/ajax/dashboard.php
+++ b/ajax/dashboard.php
@@ -249,7 +249,7 @@ switch ($_REQUEST['action']) {
         $grid->displayFilterForm($_REQUEST);
         break;
     case 'get_dashboard_filters':
-        if (!Session::haveRight('dashboard', READ)) {
+        if (!$dashboard->canViewCurrent()) {
             throw new AccessDeniedHttpException();
         }
 

--- a/js/modules/Dashboard/Dashboard.js
+++ b/js/modules/Dashboard/Dashboard.js
@@ -1177,6 +1177,7 @@ class GLPIDashboard {
             data: {
                 "action": "get_dashboard_filters",
                 "filters": filters,
+                "dashboard": this.current_name,
             }
         }).then((html) => {
             $(this.filters_selector).html(html);


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !41109
- Dashboards shared with a Self-Service profile trigger an error in the access-errors.log file when accessing dashboard filters.

```
[2026-01-14 10:19:45] User ID: `2` tried to execute an invalid request on `/ajax/dashboard.php?action=get_dashboard_filters`.

  Backtrace :
  ./ajax/dashboard.php:253                           
  ...Glpi/Controller/LegacyFileLoadController.php:64 require()
  ./vendor/symfony/http-kernel/HttpKernel.php:181    Glpi\Controller\LegacyFileLoadController->__invoke()
  ./vendor/symfony/http-kernel/HttpKernel.php:76     Symfony\Component\HttpKernel\HttpKernel->handleRaw()
  ./vendor/symfony/http-kernel/Kernel.php:197        Symfony\Component\HttpKernel\HttpKernel->handle()
  ./public/index.php:71                              Symfony\Component\HttpKernel\Kernel->handle()
```


