### PR TITLE
Feat(SNMPCredential): add IETF AES draft protocol

### DIFF
--- a/src/SNMPCredential.php
+++ b/src/SNMPCredential.php
@@ -193,6 +193,10 @@ class SNMPCredential extends CommonDBTM
                 return 'AES192C';
             case 5:
                 return 'AES256C';
+            case 6:
+                return 'CFB192-AES';
+            case 7:
+                return 'CFB256-AES';
             default:
                 return '';
         }

--- a/templates/components/form/snmpcredential.html.twig
+++ b/templates/components/form/snmpcredential.html.twig
@@ -72,7 +72,7 @@
    {{ fields.dropdownArrayField(
       'authentication',
       item.fields['authentication'],
-      {0: '-----', 1: 'MD5', 2: 'SHA', 3: 'SHA224', 4: 'SHA256', 5: 'SHA384', 6: 'SHA512'},
+      {0: '-----', 1: 'DES', 2: 'AES128', 3: 'Triple-DES', 4: 'Cisco AES192', 5: 'Cisco AES256', 6: 'AES192 (IETF draft)', 7: 'AES256 (IETF draft)'},
       __('Encryption protocol for authentication '),
       {
          add_field_attribs: {

--- a/templates/components/form/snmpcredential.html.twig
+++ b/templates/components/form/snmpcredential.html.twig
@@ -72,7 +72,7 @@
    {{ fields.dropdownArrayField(
       'authentication',
       item.fields['authentication'],
-      {0: '-----', 1: 'DES', 2: 'AES128', 3: 'Triple-DES', 4: 'Cisco AES192', 5: 'Cisco AES256', 6: 'AES192 (IETF draft)', 7: 'AES256 (IETF draft)'},
+      {0: '-----', 1: 'MD5', 2: 'SHA', 3: 'SHA224', 4: 'SHA256', 5: 'SHA384', 6: 'SHA512'},
       __('Encryption protocol for authentication '),
       {
          add_field_attribs: {
@@ -99,7 +99,7 @@
    {{ fields.dropdownArrayField(
       'encryption',
       item.fields['encryption'],
-      {0: '-----', 1: 'DES', 2: 'AES128', 3: 'Triple-DES', 4: 'Cisco AES192', 5: 'Cisco AES256'},
+      {0: '-----', 1: 'DES', 2: 'AES128', 3: 'Triple-DES', 4: 'Cisco AES192', 5: 'Cisco AES256', 6: 'AES192 (IETF draft)', 7: 'AES256 (IETF draft)'},
       __('Encryption protocol for data'),
       {
          add_field_attribs: {


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Same as https://github.com/glpi-project/glpi/pull/22661

but for GLPI 10

> Since https://github.com/glpi-project/glpi/pull/20575, 
> 
> the **private protocols** (Cisco AES192 & AES256) have been added.
> 
> In the meantime, these protocols are still **being standardized by the IETF**.
> 
> The implementation is not yet finalized, but some vendors have already deployed them to anticipate the future > standard.
> 
> Following recent testing (!40784), we can confirm that the agent works correctly with these two new protocols.
> 
> Therefore, it is relevant to **add them to the list of supported protocols for SNMP credentials**.

## Screenshots (if appropriate):


