### PR TITLE
Fix: Notification template cache shared between users

### DIFF
--- a/src/NotificationTarget.php
+++ b/src/NotificationTarget.php
@@ -1395,6 +1395,10 @@ class NotificationTarget extends CommonDBChild
         // Store current user info for plugins to access during ITEM_GET_DATA hook
         if (isset($options['additionnaloption']['users_id'])) {
             $this->recipient_data['users_id'] = $options['additionnaloption']['users_id'];
+            $this->recipient_data = [
+                'itemtype' => User::class,
+                'items_id' => $options['additionnaloption']['users_id'],
+            ];
         }
 
         $this->addDataForTemplate($event, $options);
@@ -1403,6 +1407,7 @@ class NotificationTarget extends CommonDBChild
         $this->data += $this->getGlobalTagsData();
 
         Plugin::doHook(Hooks::ITEM_GET_DATA, $this);
+        $this->recipient_data = [];
 
         return $this->data;
     }

--- a/src/NotificationTarget.php
+++ b/src/NotificationTarget.php
@@ -1392,6 +1392,11 @@ class NotificationTarget extends CommonDBChild
     {
         $this->data = [];
 
+        // Store current user info for plugins to access during ITEM_GET_DATA hook
+        if (isset($options['additionnaloption']['users_id'])) {
+            $this->recipient_data['users_id'] = $options['additionnaloption']['users_id'];
+        }
+
         $this->addDataForTemplate($event, $options);
 
         // Add global tags data, use `+` operator to preserve overriden values

--- a/src/NotificationTarget.php
+++ b/src/NotificationTarget.php
@@ -1394,7 +1394,6 @@ class NotificationTarget extends CommonDBChild
 
         // Store current user info for plugins to access during ITEM_GET_DATA hook
         if (isset($options['additionnaloption']['users_id'])) {
-            $this->recipient_data['users_id'] = $options['additionnaloption']['users_id'];
             $this->recipient_data = [
                 'itemtype' => User::class,
                 'items_id' => $options['additionnaloption']['users_id'],


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !41131

Fixes an issue where notification template caching was shared between users of the same type and language, preventing plugins from generating user-specific data (like unique tokens or URLs) for each recipient.

Rework of https://github.com/glpi-project/glpi/pull/22104

Needed for https://github.com/glpi-network/approvalbymail/pull/44

## Screenshots (if appropriate):


