### PR TITLE
add tooltip / better box dimensions for custom illustrations on helpdesk

### DIFF
--- a/css/helpdesk_home.scss
+++ b/css/helpdesk_home.scss
@@ -126,9 +126,16 @@ header {
         flex-direction: row;
         align-items: flex-end;
         z-index: 0;
+        overflow: hidden;
 
         svg {
             height: 393px;
+        }
+
+        img {
+            max-width: 100%;
+            max-height: 100%;
+            object-fit: contain;
         }
 
         // Hide for screens smaller than 1600px

--- a/templates/components/illustration/custom_icon.html.twig
+++ b/templates/components/illustration/custom_icon.html.twig
@@ -37,5 +37,4 @@
     width="{{ width }}"
     height="{{ height }}"
     class="align-self-start"
-    style="max-width: initial;"
 />

--- a/templates/pages/admin/helpdesk_home_config_for_entity.html.twig
+++ b/templates/pages/admin/helpdesk_home_config_for_entity.html.twig
@@ -133,6 +133,9 @@
                                 'onlyimages': true,
                             }
                         ]) %}
+                        <div class="form-text text-muted">
+                            {{ __("Recommended size: %s")|format("555x393px") }}
+                        </div>
                     </section>
 
                     {% if not is_root_entity %}

--- a/templates/pages/admin/helpdesk_home_config_for_entity.html.twig
+++ b/templates/pages/admin/helpdesk_home_config_for_entity.html.twig
@@ -134,7 +134,7 @@
                             }
                         ]) %}
                         <div class="form-text text-muted">
-                            {{ __("Recommended size: %s")|format("555x393px") }}
+                            {{ __("Recommended size: %s")|format("550x390px") }}
                         </div>
                     </section>
 


### PR DESCRIPTION
Proposal for #21887 

- add "tooltip" for user indication when uploading custom illustration
- better box sizing for default good ratio when illustration is displayed 