### PR TITLE
fix(calendarSegment): SLA escalation date incorrect with calendar

### DIFF
--- a/phpunit/functional/CalendarSegmentTest.php
+++ b/phpunit/functional/CalendarSegmentTest.php
@@ -195,8 +195,7 @@ class CalendarSegmentTest extends DbTestCase
     }
 
     /**
-     * Test the addDelayInDay method with various scenarios
-     * This tests complex calendars with multiple disconnected segments per day
+     * Test the addDelayInDay method
      *
      * @dataProvider addDelayInDayProvider
      *

--- a/phpunit/functional/CalendarSegmentTest.php
+++ b/phpunit/functional/CalendarSegmentTest.php
@@ -47,23 +47,10 @@ class CalendarSegmentTest extends DbTestCase
      */
     protected function addDelayInDayProvider(): iterable
     {
-        // Create a calendar with segments on different days
-        // Monday (day 1): 09:00-18:00 (9h continuous)
-        // Tuesday (day 2): 08:00-12:00 and 14:00-18:00 (8h split)
-        $calendar = $this->createItem(\Calendar::class, [
-            'name' => 'Test Calendar with multiple days',
-        ]);
-        $this->createItems(CalendarSegment::class, [
-            ['calendars_id' => $calendar->getID(), 'day' => 1, 'begin' => '09:00:00', 'end' => '18:00:00'],
-            ['calendars_id' => $calendar->getID(), 'day' => 2, 'begin' => '08:00:00', 'end' => '12:00:00'],
-            ['calendars_id' => $calendar->getID(), 'day' => 2, 'begin' => '14:00:00', 'end' => '18:00:00'],
-        ]);
-
         // POSITIVE DELAY TESTS
 
         // Test 1: Simple positive delay within a single segment
         yield [
-            'calendar_id' => $calendar->getID(),
             'day' => 1,
             'begin_time' => '10:00:00',
             'delay' => 2 * HOUR_TIMESTAMP,
@@ -73,7 +60,6 @@ class CalendarSegmentTest extends DbTestCase
 
         // Test 2: Positive delay from start to end of segment
         yield [
-            'calendar_id' => $calendar->getID(),
             'day' => 1,
             'begin_time' => '09:00:00',
             'delay' => 9 * HOUR_TIMESTAMP,
@@ -83,7 +69,6 @@ class CalendarSegmentTest extends DbTestCase
 
         // Test 3: Positive delay spanning two segments on same day
         yield [
-            'calendar_id' => $calendar->getID(),
             'day' => 2,
             'begin_time' => '10:00:00',
             'delay' => 5 * HOUR_TIMESTAMP,
@@ -93,7 +78,6 @@ class CalendarSegmentTest extends DbTestCase
 
         // Test 4: Positive delay starting before segment
         yield [
-            'calendar_id' => $calendar->getID(),
             'day' => 2,
             'begin_time' => '07:00:00',
             'delay' => 3 * HOUR_TIMESTAMP,
@@ -103,7 +87,6 @@ class CalendarSegmentTest extends DbTestCase
 
         // Test 5: Positive delay starting in gap between segments
         yield [
-            'calendar_id' => $calendar->getID(),
             'day' => 2,
             'begin_time' => '13:00:00',
             'delay' => 2 * HOUR_TIMESTAMP,
@@ -113,7 +96,6 @@ class CalendarSegmentTest extends DbTestCase
 
         // Test 6: Positive delay exceeding available time
         yield [
-            'calendar_id' => $calendar->getID(),
             'day' => 1,
             'begin_time' => '17:00:00',
             'delay' => 3 * HOUR_TIMESTAMP,
@@ -125,7 +107,6 @@ class CalendarSegmentTest extends DbTestCase
 
         // Test 7: Simple negative delay within a single segment
         yield [
-            'calendar_id' => $calendar->getID(),
             'day' => 1,
             'begin_time' => '15:00:00',
             'delay' => 2 * HOUR_TIMESTAMP,
@@ -135,7 +116,6 @@ class CalendarSegmentTest extends DbTestCase
 
         // Test 8: Negative delay from end to start of segment
         yield [
-            'calendar_id' => $calendar->getID(),
             'day' => 1,
             'begin_time' => '18:00:00',
             'delay' => 9 * HOUR_TIMESTAMP,
@@ -145,7 +125,6 @@ class CalendarSegmentTest extends DbTestCase
 
         // Test 9: Negative delay spanning two segments
         yield [
-            'calendar_id' => $calendar->getID(),
             'day' => 2,
             'begin_time' => '17:00:00',
             'delay' => 5 * HOUR_TIMESTAMP,
@@ -155,7 +134,6 @@ class CalendarSegmentTest extends DbTestCase
 
         // Test 10: Negative delay starting after segment
         yield [
-            'calendar_id' => $calendar->getID(),
             'day' => 1,
             'begin_time' => '19:00:00',
             'delay' => 3 * HOUR_TIMESTAMP,
@@ -165,7 +143,6 @@ class CalendarSegmentTest extends DbTestCase
 
         // Test 11: Negative delay starting in gap between segments
         yield [
-            'calendar_id' => $calendar->getID(),
             'day' => 2,
             'begin_time' => '13:00:00',
             'delay' => 2 * HOUR_TIMESTAMP,
@@ -175,7 +152,6 @@ class CalendarSegmentTest extends DbTestCase
 
         // Test 12: Negative delay exceeding available time
         yield [
-            'calendar_id' => $calendar->getID(),
             'day' => 2,
             'begin_time' => '10:00:00',
             'delay' => 3 * HOUR_TIMESTAMP,
@@ -185,7 +161,6 @@ class CalendarSegmentTest extends DbTestCase
 
         // Test 13: Zero delay
         yield [
-            'calendar_id' => $calendar->getID(),
             'day' => 1,
             'begin_time' => '12:00:00',
             'delay' => 0,
@@ -199,7 +174,6 @@ class CalendarSegmentTest extends DbTestCase
      *
      * @dataProvider addDelayInDayProvider
      *
-     * @param integer      $calendar_id      Calendar ID
      * @param integer      $day              Day number (1|2)
      * @param string       $begin_time       Starting time (HH:MM:SS)
      * @param integer      $delay            Delay in seconds
@@ -209,15 +183,26 @@ class CalendarSegmentTest extends DbTestCase
      * @return void
      */
     public function testAddDelayInDay(
-        int $calendar_id,
         int $day,
         string $begin_time,
         int $delay,
         bool $negative_delay,
         $expected
     ): void {
+        // Create a calendar with segments on different days
+        // Monday (day 1): 09:00-18:00 (9h continuous)
+        // Tuesday (day 2): 08:00-12:00 and 14:00-18:00 (8h split)
+        $calendar = $this->createItem(\Calendar::class, [
+            'name' => 'Test Calendar',
+        ]);
+        $this->createItems(CalendarSegment::class, [
+            ['calendars_id' => $calendar->getID(), 'day' => 1, 'begin' => '09:00:00', 'end' => '18:00:00'],
+            ['calendars_id' => $calendar->getID(), 'day' => 2, 'begin' => '08:00:00', 'end' => '12:00:00'],
+            ['calendars_id' => $calendar->getID(), 'day' => 2, 'begin' => '14:00:00', 'end' => '18:00:00'],
+        ]);
+
         $result = CalendarSegment::addDelayInDay(
-            $calendar_id,
+            $calendar->getID(),
             $day,
             $begin_time,
             $delay,

--- a/phpunit/functional/CalendarSegmentTest.php
+++ b/phpunit/functional/CalendarSegmentTest.php
@@ -1,0 +1,233 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units;
+
+use CalendarSegment;
+use DbTestCase;
+
+class CalendarSegmentTest extends DbTestCase
+{
+    /**
+     * Data provider for testAddDelayInDay function
+     * Tests various scenarios with positive and negative delays, single and multiple segments
+     *
+     * @return iterable
+     */
+    protected function addDelayInDayProvider(): iterable
+    {
+        // Create a calendar with segments on different days
+        // Monday (day 1): 09:00-18:00 (9h continuous)
+        // Tuesday (day 2): 08:00-12:00 and 14:00-18:00 (8h split)
+        $calendar = $this->createItem(\Calendar::class, [
+            'name' => 'Test Calendar with multiple days',
+        ]);
+        $this->createItems(CalendarSegment::class, [
+            ['calendars_id' => $calendar->getID(), 'day' => 1, 'begin' => '09:00:00', 'end' => '18:00:00'],
+            ['calendars_id' => $calendar->getID(), 'day' => 2, 'begin' => '08:00:00', 'end' => '12:00:00'],
+            ['calendars_id' => $calendar->getID(), 'day' => 2, 'begin' => '14:00:00', 'end' => '18:00:00'],
+        ]);
+
+        // POSITIVE DELAY TESTS
+
+        // Test 1: Simple positive delay within a single segment
+        yield [
+            'calendar_id' => $calendar->getID(),
+            'day' => 1,
+            'begin_time' => '10:00:00',
+            'delay' => 2 * HOUR_TIMESTAMP,
+            'negative_delay' => false,
+            'expected' => '12:00:00',
+        ];
+
+        // Test 2: Positive delay from start to end of segment
+        yield [
+            'calendar_id' => $calendar->getID(),
+            'day' => 1,
+            'begin_time' => '09:00:00',
+            'delay' => 9 * HOUR_TIMESTAMP,
+            'negative_delay' => false,
+            'expected' => '18:00:00',
+        ];
+
+        // Test 3: Positive delay spanning two segments on same day
+        yield [
+            'calendar_id' => $calendar->getID(),
+            'day' => 2,
+            'begin_time' => '10:00:00',
+            'delay' => 5 * HOUR_TIMESTAMP,
+            'negative_delay' => false,
+            'expected' => '17:00:00',
+        ];
+
+        // Test 4: Positive delay starting before segment
+        yield [
+            'calendar_id' => $calendar->getID(),
+            'day' => 2,
+            'begin_time' => '07:00:00',
+            'delay' => 3 * HOUR_TIMESTAMP,
+            'negative_delay' => false,
+            'expected' => '11:00:00',
+        ];
+
+        // Test 5: Positive delay starting in gap between segments
+        yield [
+            'calendar_id' => $calendar->getID(),
+            'day' => 2,
+            'begin_time' => '13:00:00',
+            'delay' => 2 * HOUR_TIMESTAMP,
+            'negative_delay' => false,
+            'expected' => '16:00:00',
+        ];
+
+        // Test 6: Positive delay exceeding available time
+        yield [
+            'calendar_id' => $calendar->getID(),
+            'day' => 1,
+            'begin_time' => '17:00:00',
+            'delay' => 3 * HOUR_TIMESTAMP,
+            'negative_delay' => false,
+            'expected' => false,
+        ];
+
+        // NEGATIVE DELAY TESTS
+
+        // Test 7: Simple negative delay within a single segment
+        yield [
+            'calendar_id' => $calendar->getID(),
+            'day' => 1,
+            'begin_time' => '15:00:00',
+            'delay' => 2 * HOUR_TIMESTAMP,
+            'negative_delay' => true,
+            'expected' => '13:00:00',
+        ];
+
+        // Test 8: Negative delay from end to start of segment
+        yield [
+            'calendar_id' => $calendar->getID(),
+            'day' => 1,
+            'begin_time' => '18:00:00',
+            'delay' => 9 * HOUR_TIMESTAMP,
+            'negative_delay' => true,
+            'expected' => '09:00:00',
+        ];
+
+        // Test 9: Negative delay spanning two segments
+        yield [
+            'calendar_id' => $calendar->getID(),
+            'day' => 2,
+            'begin_time' => '17:00:00',
+            'delay' => 5 * HOUR_TIMESTAMP,
+            'negative_delay' => true,
+            'expected' => '10:00:00',
+        ];
+
+        // Test 10: Negative delay starting after segment
+        yield [
+            'calendar_id' => $calendar->getID(),
+            'day' => 1,
+            'begin_time' => '19:00:00',
+            'delay' => 3 * HOUR_TIMESTAMP,
+            'negative_delay' => true,
+            'expected' => '15:00:00',
+        ];
+
+        // Test 11: Negative delay starting in gap between segments
+        yield [
+            'calendar_id' => $calendar->getID(),
+            'day' => 2,
+            'begin_time' => '13:00:00',
+            'delay' => 2 * HOUR_TIMESTAMP,
+            'negative_delay' => true,
+            'expected' => '10:00:00',
+        ];
+
+        // Test 12: Negative delay exceeding available time
+        yield [
+            'calendar_id' => $calendar->getID(),
+            'day' => 2,
+            'begin_time' => '10:00:00',
+            'delay' => 3 * HOUR_TIMESTAMP,
+            'negative_delay' => true,
+            'expected' => false,
+        ];
+
+        // Test 13: Zero delay
+        yield [
+            'calendar_id' => $calendar->getID(),
+            'day' => 1,
+            'begin_time' => '12:00:00',
+            'delay' => 0,
+            'negative_delay' => false,
+            'expected' => '12:00:00',
+        ];
+    }
+
+    /**
+     * Test the addDelayInDay method with various scenarios
+     * This tests complex calendars with multiple disconnected segments per day
+     *
+     * @dataProvider addDelayInDayProvider
+     *
+     * @param integer      $calendar_id      Calendar ID
+     * @param integer      $day              Day number (1|2)
+     * @param string       $begin_time       Starting time (HH:MM:SS)
+     * @param integer      $delay            Delay in seconds
+     * @param boolean      $negative_delay   Whether to subtract time instead of adding
+     * @param string|false $expected         Expected result time (HH:MM:SS) or false
+     *
+     * @return void
+     */
+    public function testAddDelayInDay(
+        int $calendar_id,
+        int $day,
+        string $begin_time,
+        int $delay,
+        bool $negative_delay,
+        $expected
+    ): void {
+        $result = CalendarSegment::addDelayInDay(
+            $calendar_id,
+            $day,
+            $begin_time,
+            $delay,
+            $negative_delay
+        );
+
+        $this->assertEquals(
+            $expected,
+            $result
+        );
+    }
+}

--- a/phpunit/functional/CalendarSegmentTest.php
+++ b/phpunit/functional/CalendarSegmentTest.php
@@ -45,7 +45,7 @@ class CalendarSegmentTest extends DbTestCase
      *
      * @return iterable
      */
-    protected function addDelayInDayProvider(): iterable
+    public function addDelayInDayProvider(): iterable
     {
         // POSITIVE DELAY TESTS
 

--- a/src/CalendarSegment.php
+++ b/src/CalendarSegment.php
@@ -203,26 +203,8 @@ class CalendarSegment extends CommonDBChild
         $delay,
         bool $negative_delay = false
     ) {
-        // TODO: unit test this method with complex calendars using multiple
-        // disconnected segments per day
         /** @var \DBmysql $DB */
         global $DB;
-
-        // Common SELECT for both modes
-        $SELECT = [
-            new \QueryExpression(
-                sprintf(
-                    "TIMEDIFF(
-                        %s,
-                        GREATEST(%s, %s)
-                    ) AS %s",
-                    $DB->quoteName('end'),
-                    $DB->quoteName('begin'),
-                    $DB->quoteValue($begin_time),
-                    $DB->quoteName('TDIFF')
-                ),
-            ),
-        ];
 
         // Common WHERE for both modes
         $WHERE = [
@@ -230,8 +212,21 @@ class CalendarSegment extends CommonDBChild
             'day'          => $day,
         ];
 
+        // Build SELECT clauses based on delay direction
+        $SELECT = [];
+        
         // Add specific SELECT and WHERE clauses
         if (!$negative_delay) {
+            // For positive delay: calculate time from begin_time to end of segment
+            $SELECT[] = new \QueryExpression(
+                sprintf(
+                    "TIMEDIFF(%s, GREATEST(%s, %s)) AS %s",
+                    $DB->quoteName('end'),
+                    $DB->quoteName('begin'),
+                    $DB->quoteValue($begin_time),
+                    $DB->quoteName('TDIFF')
+                )
+            );
             $SELECT[] = new \QueryExpression(
                 sprintf("GREATEST(%s, %s) AS %s", ...[
                     $DB->quoteName('begin'),
@@ -247,6 +242,17 @@ class CalendarSegment extends CommonDBChild
             // return no results but using 23:59:59 get us the correct behavior).
             $adjusted_time_for_comparaison_in_negative_delay_mode = $begin_time == "00:00:00" ? "23:59:59" : $begin_time;
 
+            // For negative delay: calculate time from begin of segment to begin_time
+            // This gives us the available time to go backwards in this segment
+            $SELECT[] = new \QueryExpression(
+                sprintf(
+                    "TIMEDIFF(LEAST(%s, %s), %s) AS %s",
+                    $DB->quoteName('end'),
+                    $DB->quoteValue($adjusted_time_for_comparaison_in_negative_delay_mode),
+                    $DB->quoteName('begin'),
+                    $DB->quoteName('TDIFF')
+                )
+            );
             $SELECT[] = new \QueryExpression(
                 sprintf(
                     "LEAST(%s, %s) AS %s",

--- a/src/CalendarSegment.php
+++ b/src/CalendarSegment.php
@@ -214,7 +214,7 @@ class CalendarSegment extends CommonDBChild
 
         // Build SELECT clauses based on delay direction
         $SELECT = [];
-        
+
         // Add specific SELECT and WHERE clauses
         if (!$negative_delay) {
             // For positive delay: calculate time from begin_time to end of segment


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !40374
- When an SLA has an escalation level that must be executed before the end of the SLA, and a calendar with multiple segments is associated with it, the calculation of the escalation level execution date is incorrect.

The execution time was systematically set to 00:00, instead of following the schedule defined by the calendar.

**Example**

- Calendar: Monday to Friday, from 08:00 to 18:00
- SLA (TTO): 4 hours duration
- Escalation level: triggered 1 hour before the SLA deadline

**Case 1 — Ticket created on Monday at 10:00**

SLA deadline: Monday at 14:00
Escalation execution: Monday at 13:00
✅ Expected and correct behavior

**Case 2 — Ticket created on Monday at 17:00**

Remaining time on Monday: 1 hour (until 18:00)
Remaining time carried over to Tuesday: 3 hours
Expected SLA deadline: Tuesday at 11:00
Expected escalation execution: Tuesday at 10:00

❌ The escalation level is executed on Tuesday at 00:00, instead of 10:00


