### PR TITLE
fix #22558 - Event::log() threshold not respected

### DIFF
--- a/src/Glpi/Event.php
+++ b/src/Glpi/Event.php
@@ -109,10 +109,10 @@ class Event extends CommonDBTM
      * $level is above or equal to setting from configuration.
      *
      * @param string|int $items_id
-     * @param string $type
-     * @param int $level
-     * @param string $service
-     * @param string $event
+     * @param string     $type
+     * @param int        $level @see \CommonDBTM::getLogDefaultLevel() documentation
+     * @param string     $service
+     * @param string     $event
      *
      * @return void
      */

--- a/src/Glpi/Event.php
+++ b/src/Glpi/Event.php
@@ -120,7 +120,7 @@ class Event extends CommonDBTM
     {
         global $CFG_GLPI, $DB;
 
-        if ($level >= $CFG_GLPI["event_loglevel"]) {
+        if ($CFG_GLPI["event_loglevel"] < $level) {
             return;
         }
 

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -410,13 +410,11 @@ class Toolbox
     /**
      * Generate a Backtrace
      *
-     * @param string $log  Log file name (default php-errors) if false, return the string
+     * @param string $log  Log file name (default php-errors) no file loggin if falsy
      * @param string $hide Call to hide (but display script/line)
      * @param array  $skip Calls to not display at all
      *
-     * @return string
-     *
-     * @since 0.85
+     * @return string backtrace or script filename ($_SERVER["SCRIPT_FILENAME"])
      **/
     public static function backtrace($log = 'php-errors', $hide = '', array $skip = [])
     {
@@ -539,14 +537,12 @@ class Toolbox
     /**
      * Switch error mode for GLPI
      *
-     * @param int|null $mode       From Session::*_MODE
+     * @param Session::*_MODE|null $mode
      * @param bool|null $removed_param No longer used (Used to be $debug_sql)
      * @param bool|null $removed_param_2 No longer used (Used to be $debug_vars)
      * @param bool|null $log_in_files
      *
      * @return void
-     *
-     * @since 0.84
      **/
     public static function setDebugMode($mode = null, $removed_param = null, $removed_param_2 = null, $log_in_files = null)
     {

--- a/tests/functional/EventTest.php
+++ b/tests/functional/EventTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace tests\units;
+
+use Glpi\Event;
+use Glpi\Tests\DbTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+class EventTest extends DbTestCase
+{
+    #[DataProvider('eventLogLevelThresholdDataProvider')]
+    public function testEventLogThreshold(int $level, int $threshold, bool $should_be_logged_in_file): void
+    {
+        // --- arrange
+        global $CFG_GLPI;
+
+        $CFG_GLPI["use_log_in_files"] = 1; // ensure file logging is enabled
+        $CFG_GLPI["event_loglevel"] = $threshold;
+        $log_file = GLPI_LOG_DIR . "/event.log"; // event.log is hardcoded \Glpi\Event::log()
+        $log_service = $this->getUniqueString();
+        file_put_contents($log_file, ""); // empty log file for easier debugging
+
+        // --- act
+        Event::log(0, self::class, $level, $log_service, 'event');
+
+        // --- assert
+        $expected_count = $level <= $threshold ? 1 : 0;
+        $this->assertEquals(
+            $expected_count,
+            countElementsInTable(
+                Event::getTable(),
+                ['service' => $log_service, 'level' => $level]
+            )
+        );
+
+        $should_be_logged_in_file
+            ? $this->assertStringContainsString(
+            "[$log_service]",
+            file_get_contents($log_file),
+            implode(' ', ['service' => $log_service, 'level' => $level, 'should be logged in file' => $should_be_logged_in_file])
+        )
+            : $this->assertStringNotContainsString(
+            "[$log_service]",
+            file_get_contents($log_file),
+            implode(' ', ['service' => $log_service, 'level' => $level, 'should be logged in file' => $should_be_logged_in_file])
+        );
+    }
+
+    public static function eventLogLevelThresholdDataProvider(): iterable
+    {
+        foreach (range(1, 5) as $threshold) {
+            foreach (range(1, 5) as $level) {
+                yield "level=$level, threshold=$threshold" => [
+                    'level' => $level,
+                    'threshold' => $threshold,
+                    'should_be_logged_in_file'
+                    => ($level <= $threshold) // should be logged if level is equal or more critical than threshold (notice glpi level are inverted compared to PSR)
+                        && $level <= 3 // no logging for level higher than 3
+                    ,
+                ];
+            }
+        }
+    }
+}

--- a/tests/functional/EventTest.php
+++ b/tests/functional/EventTest.php
@@ -1,5 +1,37 @@
 <?php
 
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
 namespace tests\units;
 
 use Glpi\Event;
@@ -35,15 +67,15 @@ class EventTest extends DbTestCase
 
         $should_be_logged_in_file
             ? $this->assertStringContainsString(
-            "[$log_service]",
-            file_get_contents($log_file),
-            implode(' ', ['service' => $log_service, 'level' => $level, 'should be logged in file' => $should_be_logged_in_file])
-        )
+                "[$log_service]",
+                file_get_contents($log_file),
+                implode(' ', ['service' => $log_service, 'level' => $level, 'should be logged in file' => $should_be_logged_in_file])
+            )
             : $this->assertStringNotContainsString(
-            "[$log_service]",
-            file_get_contents($log_file),
-            implode(' ', ['service' => $log_service, 'level' => $level, 'should be logged in file' => $should_be_logged_in_file])
-        );
+                "[$log_service]",
+                file_get_contents($log_file),
+                implode(' ', ['service' => $log_service, 'level' => $level, 'should be logged in file' => $should_be_logged_in_file])
+            );
     }
 
     public static function eventLogLevelThresholdDataProvider(): iterable


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

when setting event log level to x, lower level (=more critical) are logged but not error of the limit level.
e.g. if set to 3, errors at level 1 & 2 are logged, but not level 3.



