### PR TITLE
OAuth client session list and revocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The present file will list all changes made to the project; according to the
 ## [12.0.0] unreleased
 
 ### Added
+- Sessions tab for OAuth Clients to display non-expired sessions associated with the client and allow revoking them.
 
 ### Changed
 

--- a/src/Glpi/Controller/OAuth/AccessTokenController.php
+++ b/src/Glpi/Controller/OAuth/AccessTokenController.php
@@ -41,10 +41,10 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
-final class OAuthController extends AbstractController
+final class AccessTokenController extends AbstractController
 {
     #[Route(
-        "/OAuth/AccessToken/{access_token}/Revoke",
+        "/OAuth/AccessToken/Revoke/{access_token}",
         name: "oauth_revoke_access_token",
         requirements: [
             'access_token' => '\w+',

--- a/src/Glpi/Controller/OAuth/OAuthController.php
+++ b/src/Glpi/Controller/OAuth/OAuthController.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Controller\OAuth;
+
+use Glpi\Controller\AbstractController;
+use Glpi\Exception\Http\AccessDeniedHttpException;
+use Glpi\OAuth\AccessTokenRepository;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+final class OAuthController extends AbstractController
+{
+    #[Route(
+        "/OAuth/AccessToken/{access_token}/Revoke",
+        name: "oauth_revoke_access_token",
+        requirements: [
+            'access_token' => '\w+',
+        ],
+        methods: ['POST']
+    )]
+    public function revokeAccessToken(Request $request): Response
+    {
+        if (!\OAuthClient::canUpdate()) {
+            throw new AccessDeniedHttpException();
+        }
+        $repo = new AccessTokenRepository();
+        $repo->revokeAccessToken($request->attributes->getString('access_token'));
+        return new Response('', Response::HTTP_NO_CONTENT);
+    }
+}

--- a/src/OAuthClient.php
+++ b/src/OAuthClient.php
@@ -62,6 +62,9 @@ final class OAuthClient extends CommonDBTM
         return 'ti ti-key';
     }
 
+    /**
+     * @return array<string, string>
+     */
     public function defineTabs($options = [])
     {
         $tabs = parent::defineTabs($options);
@@ -70,6 +73,9 @@ final class OAuthClient extends CommonDBTM
         return $tabs;
     }
 
+    /**
+     * @return string[]
+     */
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
         return [
@@ -96,7 +102,7 @@ final class OAuthClient extends CommonDBTM
         return true;
     }
 
-    public function showSessions()
+    public function showSessions(): void
     {
         global $DB;
 

--- a/src/OAuthClient.php
+++ b/src/OAuthClient.php
@@ -141,7 +141,7 @@ final class OAuthClient extends CommonDBTM
                 'scopes'     => implode(', ', json_decode($token['scopes'], true) ?? []),
             ];
             if ($show_actions) {
-                $entry['actions'] = '<button type="button" name="revoke_oauth_token" class="btn btn-danger btn-sm">' . __('Revoke') . '</button>';
+                $entry['actions'] = '<button type="button" name="revoke_oauth_token" class="btn btn-danger btn-sm">' . __s('Revoke') . '</button>';
             }
             $entries[] = $entry;
         }
@@ -178,7 +178,7 @@ final class OAuthClient extends CommonDBTM
                                 const token_identifier = button.closest('tr').getAttribute('data-id');
                                 $.ajax({
                                     method: "POST",
-                                    url: "/OAuth/AccessToken/" + token_identifier + "/Revoke"
+                                    url: CFG_GLPI.root_doc + "/OAuth/AccessToken/Revoke/" + token_identifier
                                 }).then(() => {
                                     // Remove the row from the table
                                     const row = button.closest('tr');

--- a/src/OAuthClient.php
+++ b/src/OAuthClient.php
@@ -79,7 +79,7 @@ final class OAuthClient extends CommonDBTM
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
         return [
-            1 => _n('Session', 'Sessions', Session::getPluralNumber()),
+            1 => self::createTabEntry(text: _n('Session', 'Sessions', Session::getPluralNumber()), icon: 'ti ti-cloud-lock'),
         ];
     }
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Adds a tab in the OAuth client form to display current "sessions" information including the expiration, user and scopes in use, as well as allowing manual revocation.

Usually JWTs are stateless but GLPI stores access tokens and refresh tokens in the database which makes OAuth connections stateful in a way. The advantage of this is the ability to revoke access/refresh tokens which we were not taking advantage of yet.

<img width="961" height="185" alt="Selection_643" src="https://github.com/user-attachments/assets/234cdbf4-b8e1-42a0-82fc-0b845de3de2f" />