### PR TITLE
Remove <search> from vue component

### DIFF
--- a/js/src/vue/FuzzySearch/Modal.vue
+++ b/js/src/vue/FuzzySearch/Modal.vue
@@ -110,9 +110,7 @@
                         <i class="ti ti-alert-circle-filled fa-2x me-2"></i>
                         <p v-html="shortcut_message"></p>
                     </div>
-                    <search>
-                        <input type="text" class="form-control" name="fuzzysearch_modal_search_menu" :placeholder="placeholder" v-model="input_text">
-                    </search>
+                    <input type="text" class="form-control" name="fuzzysearch_modal_search_menu" :placeholder="placeholder" v-model="input_text">
                     <ul class="results list-group mt-2">
                         <li v-for="result in results" :key="result.index" class="list-group-item">
                             <a :href="result.original.url" v-html="result.string"></a>

--- a/js/src/vue/FuzzySearch/Modal.vue
+++ b/js/src/vue/FuzzySearch/Modal.vue
@@ -110,7 +110,9 @@
                         <i class="ti ti-alert-circle-filled fa-2x me-2"></i>
                         <p v-html="shortcut_message"></p>
                     </div>
-                    <input type="text" class="form-control" name="fuzzysearch_modal_search_menu" :placeholder="placeholder" v-model="input_text">
+                    <div role="search">
+                        <input type="text" class="form-control" name="fuzzysearch_modal_search_menu" :placeholder="placeholder" v-model="input_text">
+                    </div>
                     <ul class="results list-group mt-2">
                         <li v-for="result in results" :key="result.index" class="list-group-item">
                             <a :href="result.original.url" v-html="result.string"></a>


### PR DESCRIPTION
## Description

Fix a warning introduced by #22619:

<img width="762" height="64" alt="image" src="https://github.com/user-attachments/assets/7dee27c7-7206-4482-8058-434c23558c9d" />

Vue doesn't support using `<search>`, see https://github.com/vuejs/core/issues/9247.
