### PR TITLE
Downgrade playwright to 1.56.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -80,7 +80,7 @@
                 "@babel/preset-env": "^7.28.5",
                 "@eslint/eslintrc": "^3.3.3",
                 "@eslint/js": "^9.39.2",
-                "@playwright/test": "^1.57.0",
+                "@playwright/test": "^1.56.1",
                 "@testing-library/cypress": "^10.1.0",
                 "@testing-library/jest-dom": "^6.9.1",
                 "@types/node": "^24.10.4",
@@ -4342,13 +4342,13 @@
             }
         },
         "node_modules/@playwright/test": {
-            "version": "1.57.0",
-            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.57.0.tgz",
-            "integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
+            "version": "1.56.1",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.56.1.tgz",
+            "integrity": "sha512-vSMYtL/zOcFpvJCW71Q/OEGQb7KYBPAdKh35WNSkaZA75JlAO8ED8UN6GUNTm3drWomcbcqRPFqQbLae8yBTdg==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "playwright": "1.57.0"
+                "playwright": "1.56.1"
             },
             "bin": {
                 "playwright": "cli.js"
@@ -13878,13 +13878,13 @@
             }
         },
         "node_modules/playwright": {
-            "version": "1.57.0",
-            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
-            "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
+            "version": "1.56.1",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.1.tgz",
+            "integrity": "sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "playwright-core": "1.57.0"
+                "playwright-core": "1.56.1"
             },
             "bin": {
                 "playwright": "cli.js"
@@ -13897,9 +13897,9 @@
             }
         },
         "node_modules/playwright-core": {
-            "version": "1.57.0",
-            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
-            "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
+            "version": "1.56.1",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.1.tgz",
+            "integrity": "sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
         "@babel/preset-env": "^7.28.5",
         "@eslint/eslintrc": "^3.3.3",
         "@eslint/js": "^9.39.2",
-        "@playwright/test": "^1.57.0",
+        "@playwright/test": "^1.56.1",
         "@testing-library/cypress": "^10.1.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@types/node": "^24.10.4",


### PR DESCRIPTION
## Description

Tests that uses drag and drop are broken on main, probably due to an issue in the chromium version used by playwright 1.57.0.

I've opened an issue here: https://github.com/microsoft/playwright/issues/38796

In the meantime we can downgrade to 1.56.1 which works fine.
