### PR TITLE
fix(transfer): prevent duplicate software version entries during item transfer

### DIFF
--- a/src/Transfer.php
+++ b/src/Transfer.php
@@ -1715,15 +1715,29 @@ final class Transfer extends CommonDBTM
                     ($newversID > 0)
                     && ($newversID != $data['softwareversions_id'])
                 ) {
-                    $DB->update(
-                        'glpi_items_softwareversions',
-                        [
-                            'softwareversions_id' => $newversID,
+                    $soft_version_existing = $DB->request([
+                        'SELECT' => 'id',
+                        'FROM'   => Item_SoftwareVersion::getTable(),
+                        'WHERE'  => [
+                            'itemtype'             => $itemtype,
+                            'items_id'             => $ID,
+                            'softwareversions_id'  => $newversID,
                         ],
-                        [
-                            'id' => $data['id'],
-                        ]
-                    );
+                    ])->current();
+
+                    if ($soft_version_existing) {
+                        $DB->delete(Item_SoftwareVersion::getTable(), ['id' => $data['id']]);
+                    } else {
+                        $DB->update(
+                            Item_SoftwareVersion::getTable(),
+                            [
+                                'softwareversions_id' => $newversID,
+                            ],
+                            [
+                                'id' => $data['id'],
+                            ]
+                        );
+                    }
                 }
             } else { // Do not keep
                 // Delete inst software for item

--- a/tests/functional/TransferTest.php
+++ b/tests/functional/TransferTest.php
@@ -1184,7 +1184,7 @@ class TransferTest extends DbTestCase
             ], [
                 'name' => 'TestSoftware',
                 'entities_id' => $dest_entity,
-            ]
+            ],
         ]);
 
         [$softversion_1, $softversion_2] = $this->createItems(SoftwareVersion::class, [


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !41481
- An SQL error occurs when transferring a computer from one entity to another when it has software with an identical version present in both the source entity and the target entity.

```
[2026-01-15 16:30:44] glpi.ERROR:   *** Caught RuntimeException: MySQL query error: Duplicate entry 'Computer-14-35' for key 'unicity' (1062) in SQL query "UPDATE `glpi_items_softwareversions` SET `softwareversions_id` = '35' WHERE `id` = '22'".
  Backtrace :
  ./src/DBmysql.php:404                              
  ./src/DBmysql.php:1481                             DBmysql->doQuery()
  ./src/Transfer.php:1718                            DBmysql->update()
  ./src/Transfer.php:1275                            Transfer->transferItemSoftwares()
  ./src/Transfer.php:250                             Transfer->transferItem()
  ./front/transfer.action.php:51                     Transfer->moveItems()
  ...Glpi/Controller/LegacyFileLoadController.php:64 require()
  ./vendor/symfony/http-kernel/HttpKernel.php:181    Glpi\Controller\LegacyFileLoadController->__invoke()
  ./vendor/symfony/http-kernel/HttpKernel.php:76     Symfony\Component\HttpKernel\HttpKernel->handleRaw()
  ./vendor/symfony/http-kernel/Kernel.php:197        Symfony\Component\HttpKernel\HttpKernel->handle()
  ./public/index.php:71                              Symfony\Component\HttpKernel\Kernel->handle()
```

### Steps to reproduce

**In the source entity**
1. Create a software.
2. Assign **two versions with the same name** to this software.
3. Create a computer.
4. Assign the **two versions of the same software** to the computer.

**In the target entity**
1. Create a software.
2. Assign **one version with the same name** as the versions created in the source entity.

When transferring the computer to the target entity, an **SQL error** occurs.




