### PR TITLE
Fix(Inventory): add missing osname value from inventory process

### DIFF
--- a/src/Glpi/Inventory/MainAsset/MainAsset.php
+++ b/src/Glpi/Inventory/MainAsset/MainAsset.php
@@ -529,6 +529,12 @@ abstract class MainAsset extends InventoryAsset
             $input['oscomment'] = $val->comment;
         }
 
+        // retrieve OS name from raw data because operating system are not handled yet
+        $input['osname'] = $this->raw_data->content->operatingsystem?->full_name
+            ?? $this->raw_data->content->operatingsystem?->name
+            ?? '';
+
+
         // * entity rules
         $input['entities_id'] = $this->entities_id;
 

--- a/src/Glpi/Inventory/MainAsset/MainAsset.php
+++ b/src/Glpi/Inventory/MainAsset/MainAsset.php
@@ -530,8 +530,8 @@ abstract class MainAsset extends InventoryAsset
         }
 
         // retrieve OS name from raw data because operating system are not handled yet
-        $input['osname'] =
-            $this->raw_data->content->operatingsystem->full_name
+        $input['osname']
+            = $this->raw_data->content->operatingsystem->full_name
             ?? $this->raw_data->content->operatingsystem->name
             ?? '';
 

--- a/src/Glpi/Inventory/MainAsset/MainAsset.php
+++ b/src/Glpi/Inventory/MainAsset/MainAsset.php
@@ -530,8 +530,9 @@ abstract class MainAsset extends InventoryAsset
         }
 
         // retrieve OS name from raw data because operating system are not handled yet
-        $input['osname'] = $this->raw_data->content->operatingsystem?->full_name
-            ?? $this->raw_data->content->operatingsystem?->name
+        $input['osname'] =
+            $this->raw_data->content->operatingsystem->full_name
+            ?? $this->raw_data->content->operatingsystem->name
             ?? '';
 
 

--- a/tests/functional/RuleDefineItemtypeCollectionTest.php
+++ b/tests/functional/RuleDefineItemtypeCollectionTest.php
@@ -77,6 +77,7 @@ class RuleDefineItemtypeCollectionTest extends InventoryTestCase
             'computertypes_id'       => 'Laptop',
             'contact'                => 'trasher/root',
             '_inventory_users'       => ['trasher', 'root'],
+            'osname'                 => 'Fedora 31 (Workstation Edition)',
             'entities_id'            => 0,
         ]);
 

--- a/tests/functional/RuleImportAssetCollectionTest.php
+++ b/tests/functional/RuleImportAssetCollectionTest.php
@@ -77,6 +77,7 @@ class RuleImportAssetCollectionTest extends InventoryTestCase
             'computertypes_id'       => 'Laptop',
             'contact'                => 'trasher/root',
             '_inventory_users'       => ['trasher', 'root'],
+            'osname'                 => 'Fedora 31 (Workstation Edition)',
             'entities_id'            => 0,
         ]);
 

--- a/tests/functional/RuleMatchedLogTest.php
+++ b/tests/functional/RuleMatchedLogTest.php
@@ -121,7 +121,7 @@ class RuleMatchedLogTest extends DbTestCase
         ));
         $input = $rulematchedlog->fields['input'];
         $this->assertNotEmpty($input);
-        $this->assertEquals('{"_auto":1,"deviceid":"bar","autoupdatesystems_id":"GLPI Native Inventory","last_inventory_update":"' . $date_add . '","manufacturer":"HP","memory":64,"model":"LaserJet Pro MFP M428fdw","name":"Imprimante HP LaserJet Pro MFP M428fdw","serial":"ABC123456","type":"Printer","uptime":"7 days, 12:34:56.78","ip":["192.168.1.100"],"mac":"01:23:45:67:89:ab","description":"Imprimante HP LaserJet Pro MFP M428fdw","sysdescr":"Imprimante HP LaserJet Pro MFP M428fdw","printertypes_id":"Printer","manufacturers_id":"HP","have_ethernet":1,"memory_size":128,"itemtype":"Printer","entities_id":"0"}', $input);
+        $this->assertEquals('{"_auto":1,"deviceid":"bar","autoupdatesystems_id":"GLPI Native Inventory","last_inventory_update":"' . $date_add . '","manufacturer":"HP","memory":64,"model":"LaserJet Pro MFP M428fdw","name":"Imprimante HP LaserJet Pro MFP M428fdw","serial":"ABC123456","type":"Printer","uptime":"7 days, 12:34:56.78","ip":["192.168.1.100"],"mac":"01:23:45:67:89:ab","description":"Imprimante HP LaserJet Pro MFP M428fdw","sysdescr":"Imprimante HP LaserJet Pro MFP M428fdw","printertypes_id":"Printer","manufacturers_id":"HP","have_ethernet":1,"memory_size":128,"itemtype":"Printer","osname":"","entities_id":"0"}', $input);
 
         // Update test
         $xmlupdate = '<?xml version="1.0" encoding="UTF-8" ?>

--- a/tests/functional/RuleMatchedLogTest.php
+++ b/tests/functional/RuleMatchedLogTest.php
@@ -174,6 +174,6 @@ class RuleMatchedLogTest extends DbTestCase
         $update_result = reset($result);
         $input = $update_result['input'];
         $this->assertNotEmpty($input);
-        $this->assertEquals('{"_auto":1,"deviceid":"bar","autoupdatesystems_id":"GLPI Native Inventory","last_inventory_update":"' . $date_update . '","manufacturer":"HP","memory":64,"model":"LaserJet Pro MFP M428fdw V2","name":"Imprimante HP LaserJet Pro MFP M428fdw V2","serial":"ABC123456","type":"Printer","uptime":"7 days, 12:34:56.78","ip":["192.168.1.100"],"mac":"01:23:45:67:89:ab","description":"Imprimante HP LaserJet Pro MFP M428fdw V2","sysdescr":"Imprimante HP LaserJet Pro MFP M428fdw V2","printertypes_id":"Printer","manufacturers_id":"HP","have_ethernet":1,"memory_size":128,"itemtype":"Printer","entities_id":"0"}', $input);
+        $this->assertEquals('{"_auto":1,"deviceid":"bar","autoupdatesystems_id":"GLPI Native Inventory","last_inventory_update":"' . $date_update . '","manufacturer":"HP","memory":64,"model":"LaserJet Pro MFP M428fdw V2","name":"Imprimante HP LaserJet Pro MFP M428fdw V2","serial":"ABC123456","type":"Printer","uptime":"7 days, 12:34:56.78","ip":["192.168.1.100"],"mac":"01:23:45:67:89:ab","description":"Imprimante HP LaserJet Pro MFP M428fdw V2","sysdescr":"Imprimante HP LaserJet Pro MFP M428fdw V2","printertypes_id":"Printer","manufacturers_id":"HP","have_ethernet":1,"memory_size":128,"itemtype":"Printer","osname":"","entities_id":"0"}', $input);
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !41380

Fix the issue where the `osname` criterion, defined in `RuleImportAsset` and used by `RuleDefineItemtype`, is never populated by the inventory when the rules are executed.


## Screenshots (if appropriate):


