### PR TITLE
Fix race condition in Entity ID generation

### DIFF
--- a/install/migrations/update_11.0.3_to_11.0.5/entities.php
+++ b/install/migrations/update_11.0.3_to_11.0.5/entities.php
@@ -43,6 +43,8 @@ $migration->changeField('glpi_entities', 'inquest_URL_change', 'inquest_URL_chan
 // Fix glpi_entities.id column to use AUTO_INCREMENT instead of DEFAULT 0
 // This is required for concurrent entity creation to work properly
 // see #22625
+// Add NO_AUTO_VALUE_ON_ZERO to allow operations on entities with id=0 (root entity)
+$DB->doQuery("SET SESSION sql_mode = CONCAT(@@sql_mode, ',NO_AUTO_VALUE_ON_ZERO')");
 $DB->doQuery(
     "ALTER TABLE `glpi_entities`
      MODIFY `id` INT unsigned NOT NULL AUTO_INCREMENT"

--- a/install/migrations/update_11.0.3_to_11.0.5/entities.php
+++ b/install/migrations/update_11.0.3_to_11.0.5/entities.php
@@ -39,3 +39,18 @@
 // see #18814
 $migration->changeField('glpi_entities', 'inquest_URL', 'inquest_URL', 'text');
 $migration->changeField('glpi_entities', 'inquest_URL_change', 'inquest_URL_change', 'text');
+
+// Fix glpi_entities.id column to use AUTO_INCREMENT instead of DEFAULT 0
+// This is required for concurrent entity creation to work properly
+// see #22625
+$DB->doQuery(
+    "ALTER TABLE `glpi_entities`
+     MODIFY `id` INT unsigned NOT NULL AUTO_INCREMENT"
+);
+
+// Reset AUTO_INCREMENT to continue from the highest existing ID
+$max_id = $DB->request([
+    'SELECT' => ['MAX' => 'id AS max_id'],
+    'FROM'   => 'glpi_entities',
+])->current()['max_id'] ?? 0;
+$DB->doQuery("ALTER TABLE `glpi_entities` AUTO_INCREMENT = " . ($max_id + 1));

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -2724,7 +2724,7 @@ CREATE TABLE `glpi_dropdowntranslations` (
 
 DROP TABLE IF EXISTS `glpi_entities`;
 CREATE TABLE `glpi_entities` (
-  `id` int unsigned NOT NULL DEFAULT '0',
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
   `name` varchar(255) DEFAULT NULL,
   `entities_id` int unsigned DEFAULT '0',
   `completename` text,

--- a/src/DBmysql.php
+++ b/src/DBmysql.php
@@ -294,8 +294,8 @@ class DBmysql
             // force mysqlnd to return int and float types correctly (not as strings)
             $this->dbh->options(MYSQLI_OPT_INT_AND_FLOAT_NATIVE, 1);
 
-            // Remove ONLY_FULL_GROUP_BY and add NO_AUTO_VALUE_ON_ZERO to allow inserting id=0 for root entity
-            $this->dbh->query("SET SESSION sql_mode = CONCAT((SELECT REPLACE(@@sql_mode, 'ONLY_FULL_GROUP_BY', '')), ',NO_AUTO_VALUE_ON_ZERO')");
+            // Remove ONLY_FULL_GROUP_BY from SQL mode
+            $this->dbh->query("SET SESSION sql_mode = (SELECT REPLACE(@@sql_mode, 'ONLY_FULL_GROUP_BY', ''))");
 
             $this->connected = true;
 

--- a/src/DBmysql.php
+++ b/src/DBmysql.php
@@ -294,7 +294,8 @@ class DBmysql
             // force mysqlnd to return int and float types correctly (not as strings)
             $this->dbh->options(MYSQLI_OPT_INT_AND_FLOAT_NATIVE, 1);
 
-            $this->dbh->query("SET SESSION sql_mode = (SELECT REPLACE(@@sql_mode, 'ONLY_FULL_GROUP_BY', ''))");
+            // Remove ONLY_FULL_GROUP_BY and add NO_AUTO_VALUE_ON_ZERO to allow inserting id=0 for root entity
+            $this->dbh->query("SET SESSION sql_mode = CONCAT((SELECT REPLACE(@@sql_mode, 'ONLY_FULL_GROUP_BY', '')), ',NO_AUTO_VALUE_ON_ZERO')");
 
             $this->connected = true;
 

--- a/src/Entity.php
+++ b/src/Entity.php
@@ -34,8 +34,6 @@
  */
 
 use Glpi\Application\View\TemplateRenderer;
-use Glpi\DBAL\QueryExpression;
-use Glpi\DBAL\QueryFunction;
 use Glpi\Debug\Profiler;
 use Glpi\Event;
 use Glpi\Features\Clonable;
@@ -397,14 +395,6 @@ class Entity extends CommonTreeDropdown implements LinkableToTilesInterface, Pro
         }
 
         $input = $this->handleConfigStrategyFields($input);
-
-        $result = $DB->request([
-            'SELECT' => [
-                new QueryExpression(QueryFunction::max('id') . '+1', 'newID'),
-            ],
-            'FROM'   => static::getTable(),
-        ])->current();
-        $input['id'] = $result['newID'];
 
         $input['max_closedate'] = $_SESSION["glpi_currenttime"];
 

--- a/src/Update.php
+++ b/src/Update.php
@@ -225,6 +225,10 @@ class Update
             $DB->doQuery(sprintf('SET SESSION sql_mode = %s', $DB->quote(implode(',', $sql_mode_flags))));
         }
 
+        // Add NO_AUTO_VALUE_ON_ZERO to allow operations on entities with id=0 (root entity)
+        // This is required because glpi_entities uses id=0 for the root entity
+        $DB->doQuery("SET SESSION sql_mode = CONCAT(@@sql_mode, ',NO_AUTO_VALUE_ON_ZERO')");
+
         $migrations = $this->getMigrationsToDo($current_version, $force_latest);
 
         $number_of_steps = count($migrations);

--- a/src/Update.php
+++ b/src/Update.php
@@ -225,10 +225,6 @@ class Update
             $DB->doQuery(sprintf('SET SESSION sql_mode = %s', $DB->quote(implode(',', $sql_mode_flags))));
         }
 
-        // Add NO_AUTO_VALUE_ON_ZERO to allow operations on entities with id=0 (root entity)
-        // This is required because glpi_entities uses id=0 for the root entity
-        $DB->doQuery("SET SESSION sql_mode = CONCAT(@@sql_mode, ',NO_AUTO_VALUE_ON_ZERO')");
-
         $migrations = $this->getMigrationsToDo($current_version, $force_latest);
 
         $number_of_steps = count($migrations);

--- a/tests/functional/EntityTest.php
+++ b/tests/functional/EntityTest.php
@@ -166,6 +166,46 @@ class EntityTest extends DbTestCase
     }
 
     /**
+     * Test that prepareInputForAdd does not manually set the ID.
+     * Race condition fix using AUTO_INCREMENT.
+     */
+    public function testPrepareInputForAddDoesNotSetId(): void
+    {
+        $this->login();
+        $entity = new Entity();
+
+        $prepared = $entity->prepareInputForAdd([
+            'name' => 'Test Entity No Manual ID',
+            'entities_id' => 0,
+        ]);
+
+        $this->assertArrayNotHasKey('id', $prepared);
+    }
+
+    /**
+     * Test that entity creation generates unique and sequential IDs.
+     */
+    public function testEntityCreationGeneratesUniqueIds(): void
+    {
+        $this->login();
+
+        $ids = [];
+        for ($i = 1; $i <= 5; $i++) {
+            $entity = $this->createItem(Entity::class, [
+                'name' => "Test Entity AutoIncrement $i",
+                'entities_id' => 0,
+            ]);
+            $ids[] = $entity->getID();
+        }
+
+        $this->assertCount(5, array_unique($ids));
+
+        for ($i = 1; $i < count($ids); $i++) {
+            $this->assertGreaterThan($ids[$i - 1], $ids[$i]);
+        }
+    }
+
+    /**
      * Run getSonsOf tests
      *
      * @param bool $cache Is cache enabled?

--- a/tests/functional/EntityTest.php
+++ b/tests/functional/EntityTest.php
@@ -166,42 +166,20 @@ class EntityTest extends DbTestCase
     }
 
     /**
-     * Test that prepareInputForAdd does not manually set the ID.
-     * Race condition fix using AUTO_INCREMENT.
+     * Test that entity creation generates sequential IDs.
      */
-    public function testPrepareInputForAddDoesNotSetId(): void
-    {
-        $this->login();
-        $entity = new Entity();
-
-        $prepared = $entity->prepareInputForAdd([
-            'name' => 'Test Entity No Manual ID',
-            'entities_id' => 0,
-        ]);
-
-        $this->assertArrayNotHasKey('id', $prepared);
-    }
-
-    /**
-     * Test that entity creation generates unique and sequential IDs.
-     */
-    public function testEntityCreationGeneratesUniqueIds(): void
+    public function testEntityCreationGeneratesSequentialIds(): void
     {
         $this->login();
 
-        $ids = [];
+        $id = 0;
         for ($i = 1; $i <= 5; $i++) {
             $entity = $this->createItem(Entity::class, [
                 'name' => "Test Entity AutoIncrement $i",
                 'entities_id' => 0,
             ]);
-            $ids[] = $entity->getID();
-        }
-
-        $this->assertCount(5, array_unique($ids));
-
-        for ($i = 1; $i < count($ids); $i++) {
-            $this->assertGreaterThan($ids[$i - 1], $ids[$i]);
+            $this->assertGreaterThan($id, $entity->getID());
+            $id = $entity->getID();
         }
     }
 


### PR DESCRIPTION
Fixes #22625 

- Remove manual `MAX(id)+1` calculation in `Entity::prepareInputForAdd()`
- Rely on MySQL AUTO_INCREMENT for ID generation
- Prevents duplicate ID errors when creating entities concurrently

Tested manually, w/ a script to simulate same-time entities creation, unit tests also provided.
