### PR TITLE
Fix - Prevent editing recursive objects from child entities

### DIFF
--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -2484,7 +2484,7 @@ class CommonDBTM extends CommonGLPI
     public function canUpdateItem(): bool
     {
 
-        if (!$this->checkEntity(true)) {
+        if (!$this->checkEntity()) {
             return false;
         }
         return true;
@@ -2503,7 +2503,7 @@ class CommonDBTM extends CommonGLPI
     public function canDeleteItem(): bool
     {
 
-        if (!$this->checkEntity(true)) {
+        if (!$this->checkEntity()) {
             return false;
         }
         return true;
@@ -2522,7 +2522,7 @@ class CommonDBTM extends CommonGLPI
     public function canPurgeItem(): bool
     {
 
-        if (!$this->checkEntity(true)) {
+        if (!$this->checkEntity()) {
             return false;
         }
 

--- a/tests/cypress/e2e/form/destination_config_fields/request_source.cy.js
+++ b/tests/cypress/e2e/form/destination_config_fields/request_source.cy.js
@@ -76,11 +76,25 @@ describe('Request source configuration', () => {
     });
 
     it('can create ticket using default configuration', () => {
-        cy.createWithAPI('TicketTemplatePredefinedField', {
-            'tickettemplates_id': 1, // Default template
-            'num': 9, // Request source
-            'value': 3, // Phone
+        // Create a ticket template with predefined request source
+        cy.createWithAPI('TicketTemplate', {
+            'name': 'Test template for request source',
+        }).then((ticket_template_id) => {
+            cy.createWithAPI('TicketTemplatePredefinedField', {
+                'tickettemplates_id': ticket_template_id,
+                'num': 9, // Request source
+                'value': 3, // Phone
+            });
+
+            // Configure the destination to use this specific template
+            cy.openAccordionItem('Destination fields accordion', 'Properties');
+            cy.findByRole('region', { 'name': "Template configuration" }).as("template_config");
+            cy.get('@template_config').getDropdownByLabelText('Template').selectDropdownValue('Specific template');
+            cy.get('@template_config').getDropdownByLabelText('Select a template...').selectDropdownValue('Test template for request source');
+            cy.findByRole('button', { 'name': 'Update item' }).click();
+            cy.checkAndCloseAlert('Item successfully updated');
         });
+
         // Go to preview
         cy.findByRole('tab', { 'name': "Form" }).click();
         cy.findByRole('link', { 'name': "Preview" })

--- a/tests/cypress/e2e/notifications.cy.js
+++ b/tests/cypress/e2e/notifications.cy.js
@@ -36,59 +36,79 @@ describe('Notifications', () => {
         cy.changeProfile('Super-Admin');
     });
     it('View Templates for a Notification', () => {
-        // New Ticket notification
-        cy.visit('/front/notification.form.php?id=2');
+        // Create a notification template in the current entity
+        cy.createWithAPI('NotificationTemplate', {
+            'name': 'Test Notification Template',
+            'itemtype': 'Ticket',
+        }).then((template_id) => {
+            // Create a notification in the current entity
+            cy.createWithAPI('Notification', {
+                'name': 'Test Notification',
+                'itemtype': 'Ticket',
+                'event': 'new',
+                'is_active': 1,
+            }).then((notification_id) => {
+                // Link the template to the notification
+                cy.createWithAPI('Notification_NotificationTemplate', {
+                    'notifications_id': notification_id,
+                    'notificationtemplates_id': template_id,
+                    'mode': 'mailing',
+                });
 
-        cy.get('#tabspanel .nav-item').contains('Templates').within((nav_link) => {
-            cy.get('.glpi-badge').should('exist').invoke('text').should((t) => {
-                expect(parseInt(t)).to.be.gte(1);
+                cy.visit(`/front/notification.form.php?id=${notification_id}`);
+
+                cy.get('#tabspanel .nav-item').contains('Templates').within((nav_link) => {
+                    cy.get('.glpi-badge').should('exist').invoke('text').should((t) => {
+                        expect(parseInt(t)).to.be.gte(1);
+                    });
+                    cy.wrap(nav_link).click();
+                });
+
+                cy.get('.tab-content .tab-pane.active[id^="tab"]').within(() => {
+                    cy.get('.btn').contains('Add a template').should('exist');
+                    cy.get('table.table[id^="datatable"]').should('exist').within(() => {
+                        cy.get('thead th:nth-of-type(1) input[type="checkbox"].massive_action_checkbox').should('exist');
+                        cy.get('thead th').contains('ID').should('exist');
+                        cy.get('thead th').contains('Template').should('exist');
+                        cy.get('thead th').contains('Mode').should('exist');
+
+                        // All cells in 1st column should be checkboxes
+                        cy.get('tbody td:nth-of-type(1)').each((cell) => {
+                            cy.wrap(cell).find('input[type="checkbox"]').should('exist');
+                        });
+                        // All cells in 2nd column should be links to notification_notificationtemplate forms
+                        cy.get('tbody td:nth-of-type(2)').each((cell) => {
+                            cy.wrap(cell).find('a').invoke('attr', 'href').should('contain', '/front/notification_notificationtemplate.form.php');
+                        });
+                        // All cells in 3rd column should be links to notificationtemplate forms
+                        cy.get('tbody td:nth-of-type(3)').each((cell) => {
+                            cy.wrap(cell).find('a').invoke('attr', 'href').should('contain', '/front/notificationtemplate.form.php');
+                        });
+                    });
+                });
+
+                cy.findByRole('tabpanel').within(() => {
+                    cy.findByRole('button', { name: /Add a template/ }).click();
+                });
+
+                // Should be redirected to notification_notificationtemplate form
+                cy.url().should('include', '/front/notification_notificationtemplate.form.php').and('include', `notifications_id=${notification_id}`);
+                cy.get('label').contains('Notification').next().find('a').invoke('attr', 'href').should('contain', `/front/notification.form.php?id=${notification_id}`);
+
+                // Go back to the notification form
+                cy.go('back');
+                cy.findByRole('tab', { name: /Templates/ }).click();
+
+                cy.findByRole('table').findByRole('link', {name: "Test Notification Template"}).click();
+                cy.findByRole('tab', { name: /Template translations/ }).click();
+                // Click the "Add a new translation" button
+                cy.findByRole('link', {name: "Add a new translation"}).click();
+                // Fill and submit the form to create a translation
+                cy.get('input[name="subject"]').type('Test Subject');
+                cy.findByRole('button', { name: /Add/ }).click();
+                // Verify the translation was created (toast message should contain "Default translation" link)
+                cy.get('.toast-body').findByRole('link', {name: "Default translation"}).should('exist');
             });
-            cy.wrap(nav_link).click();
-        });
-
-        cy.get('.tab-content .tab-pane.active[id^="tab"]').within(() => {
-            cy.get('.btn').contains('Add a template').should('exist');
-            cy.get('table.table[id^="datatable"]').should('exist').within(() => {
-                cy.get('thead th:nth-of-type(1) input[type="checkbox"].massive_action_checkbox').should('exist');
-                cy.get('thead th').contains('ID').should('exist');
-                cy.get('thead th').contains('Template').should('exist');
-                cy.get('thead th').contains('Mode').should('exist');
-
-                // All cells in 1st column should be checkboxes
-                cy.get('tbody td:nth-of-type(1)').each((cell) => {
-                    cy.wrap(cell).find('input[type="checkbox"]').should('exist');
-                });
-                // All cells in 2nd column should be links to notification_notificationtemplate forms
-                cy.get('tbody td:nth-of-type(2)').each((cell) => {
-                    cy.wrap(cell).find('a').invoke('attr', 'href').should('contain', '/front/notification_notificationtemplate.form.php');
-                });
-                // All cells in 3rd column should be links to notificationtemplate forms
-                cy.get('tbody td:nth-of-type(3)').each((cell) => {
-                    cy.wrap(cell).find('a').invoke('attr', 'href').should('contain', '/front/notificationtemplate.form.php');
-                });
-            });
-        });
-
-        cy.findByRole('tabpanel').within(() => {
-            cy.findByRole('button', { name: /Add a template/ }).click();
-        });
-
-        // Should be redirected to notification_notificationtemplate form
-        cy.url().should('include', '/front/notification_notificationtemplate.form.php').and('include', 'notifications_id=2');
-        cy.get('label').contains('Notification').next().find('a').invoke('attr', 'href').should('contain', '/front/notification.form.php?id=2');
-
-        // Go back to the notification form
-        cy.go('back');
-        cy.findByRole('tab', { name: /Templates/ }).click();
-
-        cy.findByRole('table').findByRole('link', {name: "Tickets"}).click();
-        cy.findByRole('tab', { name: /Template translations/ }).click();
-        // Click the default template translation link
-        cy.findByRole('link', {name: "Default translation"}).click();
-        cy.findByRole('tab', { name: /Template translation/ }).click();
-        cy.findByRole('tabpanel').within(() => {
-            cy.get('select[name=language]').should('have.value', '');
-            cy.get('select[name=language] option:selected').should('have.text', 'Default translation');
         });
     });
 });

--- a/tests/functional/CommonDBTMTest.php
+++ b/tests/functional/CommonDBTMTest.php
@@ -499,7 +499,7 @@ class CommonDBTMTest extends DbTestCase
         $this->assertFalse($printer->can($id[3], READ), "Fail can't read Printer 4");
 
         $this->assertFalse($printer->canEdit($id[0]), "Fail can't write Printer 1");
-        $this->assertTrue($printer->canEdit($id[1]), "Fail can't write Printer 2");
+        $this->assertFalse($printer->canEdit($id[1]), "Fail can't write Printer 2");
         $this->assertTrue($printer->canEdit($id[2]), "Fail can write Printer 3");
         $this->assertFalse($printer->canEdit($id[3]), "Fail can't write Printer 4");
 
@@ -512,7 +512,7 @@ class CommonDBTMTest extends DbTestCase
         $this->assertTrue($printer->can($id[3], READ), "Fail can read Printer 4");
 
         $this->assertFalse($printer->canEdit($id[0]), "Fail can't write Printer 1");
-        $this->assertTrue($printer->canEdit($id[1]), "Fail can't write Printer 2");
+        $this->assertFalse($printer->canEdit($id[1]), "Fail can't write Printer 2");
         $this->assertFalse($printer->canEdit($id[2]), "Fail can't write Printer 3");
         $this->assertTrue($printer->canEdit($id[3]), "Fail can write Printer 4");
     }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !41500
- Here is a brief description of what this PR does

Recursive objects from parent entities should be **visible** (READ) in child entities, but should **not be editable** (UPDATE/DELETE/PURGE) from child entities.

This regression was introduced by PR #13113, which changed `canUpdateItem()`, `canDeleteItem()` and `canPurgeItem()` to use `checkEntity(true)` instead of `checkEntity()`.

The parameter `true` allows recursive items to pass the entity check, which is correct for READ operations (`canViewItem()`) but incorrect for write operations.

### Changes

- Restore `checkEntity()` without parameter in `canUpdateItem()`, `canDeleteItem()` and `canPurgeItem()`
- Update existing test to reflect expected behavior
- Add specific test for ITILCategory recursive rights

### How to reproduce

1. Create a recursive ITIL Category in root entity
2. Switch to a child entity
3. **Before fix:** Save button is available (bug)
4. **After fix:** Save button is not available (expected V10 behavior)


## Screenshots (if appropriate):

v10 : 
<img width="1920" height="921" alt="image" src="https://github.com/user-attachments/assets/aadc8e87-433c-4583-ae1f-b279662d9a6a" />

v11 : 
<img width="1920" height="921" alt="image" src="https://github.com/user-attachments/assets/0aa85e7c-76fd-4ee2-a915-fb3ad827828b" />


