### PR TITLE
[HLAPI] Infocom create, update, delete endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The present file will list all changes made to the project; according to the
 
 ### Added
 - New schemas for network port instantiations in High-Level API v2.2.
+- Endpoints for creating, updating and deleting Infocom (Financial and administrative information) for items in the High-Level API v2.2.
 
 ### Changed
 - High-Level API performance improvements for both REST and GraphQL requests (3.3-10x performance uplift on average)

--- a/src/Glpi/Api/HL/Controller/AssetController.php
+++ b/src/Glpi/Api/HL/Controller/AssetController.php
@@ -1667,6 +1667,32 @@ EOT,
         return $types_only ? array_keys($assets) : $assets;
     }
 
+    /**
+     * @param bool $types_only If true, only the type names are returned. If false, the type name => localized name pairs are returned.
+     * @return array<class-string<CommonDBTM>, string>
+     */
+    public static function getAssetInfocomTypes(bool $types_only = true): array
+    {
+        static $assets = null;
+
+        if ($assets === null) {
+            $assets = [];
+            $types = [
+                'Cartridge', 'CartridgeItem', 'Consumable', 'ConsumableItem',
+                'Computer', 'Monitor', 'NetworkEquipment',
+                'Peripheral', 'Phone', 'Printer', 'Software', 'SoftwareLicense',
+                'Certificate', 'Appliance', 'Rack', 'Enclosure', 'PDU', 'PassiveDCEquipment', 'Cable',
+            ];
+            /**
+             * @var class-string<CommonDBTM> $type
+             */
+            foreach ($types as $type) {
+                $assets[$type] = $type::getTypeName(1);
+            }
+        }
+        return $types_only ? array_keys($assets) : $assets;
+    }
+
     public static function getRackTypes(bool $schema_names_only = true): array
     {
         static $rack_types = null;
@@ -1788,7 +1814,7 @@ EOT,
     }
 
     #[Route(path: '/{itemtype}/{id}/Infocom', methods: ['GET'], requirements: [
-        'itemtype' => [self::class, 'getAssetTypes'],
+        'itemtype' => [self::class, 'getAssetInfocomTypes'],
         'id' => '\d+',
     ], middlewares: [ResultFormatterMiddleware::class])]
     #[RouteVersion(introduced: '2.0')]
@@ -1817,6 +1843,108 @@ EOT,
         }
         $results = reset($results);
         return $result->withBody(Utils::streamFor(json_encode($results)));
+    }
+
+    #[Route(path: '/{itemtype}/{id}/Infocom', methods: ['POST'], requirements: [
+        'itemtype' => [self::class, 'getAssetInfocomTypes'],
+        'id' => '\d+',
+    ])]
+    #[RouteVersion(introduced: '2.2')]
+    #[Doc\CreateRoute(
+        schema_name: 'Infocom',
+        description: 'Create the financial and administration information for a specific asset'
+    )]
+    public function createItemInfocom(Request $request): Response
+    {
+        $request->setParameter('itemtype', $request->getAttribute('itemtype'));
+        $request->setParameter('items_id', $request->getAttribute('id'));
+        $management_controller = new ManagementController();
+        $infocom_schema = $management_controller->getKnownSchema('Infocom', $this->getAPIVersion($request));
+        unset($infocom_schema['properties']['itemtype']['readOnly']);
+        unset($infocom_schema['properties']['items_id']['readOnly']);
+        return ResourceAccessor::createBySchema(
+            $infocom_schema,
+            $request->getParameters(),
+            [self::class, 'getItemInfocom'],
+            [
+                'mapped' => [
+                    'itemtype' => $request->getAttribute('itemtype'),
+                    'id' => $request->getAttribute('id'),
+                ],
+                'id' => 'noop',
+            ]
+        );
+    }
+
+    #[Route(path: '/{itemtype}/{id}/Infocom', methods: ['PATCH'], requirements: [
+        'itemtype' => [self::class, 'getAssetInfocomTypes'],
+        'id' => '\d+',
+    ])]
+    #[RouteVersion(introduced: '2.2')]
+    #[Doc\UpdateRoute(
+        schema_name: 'Infocom',
+        description: 'Update the financial and administration information for a specific asset'
+    )]
+    public function updateItemInfocom(Request $request): Response
+    {
+        global $DB;
+
+        $request->setParameter('itemtype', $request->getAttribute('itemtype'));
+        $request->setParameter('items_id', $request->getAttribute('id'));
+        $it = $DB->request([
+            'SELECT' => ['id'],
+            'FROM'   => 'glpi_infocoms',
+            'WHERE'  => [
+                'itemtype' => $request->getAttribute('itemtype'),
+                'items_id' => $request->getAttribute('id'),
+            ],
+        ]);
+        if (!count($it)) {
+            return self::getNotFoundErrorResponse();
+        }
+        $infocom_id = $it->current()['id'];
+        $request->setAttribute('id', $infocom_id);
+        $management_controller = new ManagementController();
+        return ResourceAccessor::updateBySchema(
+            $management_controller->getKnownSchema('Infocom', $this->getAPIVersion($request)),
+            $request->getAttributes(),
+            $request->getParameters()
+        );
+    }
+
+    #[Route(path: '/{itemtype}/{id}/Infocom', methods: ['DELETE'], requirements: [
+        'itemtype' => [self::class, 'getAssetInfocomTypes'],
+        'id' => '\d+',
+    ])]
+    #[RouteVersion(introduced: '2.2')]
+    #[Doc\DeleteRoute(
+        schema_name: 'Infocom',
+        description: 'Delete the financial and administration information for a specific asset',
+    )]
+    public function deleteItemInfocom(Request $request): Response
+    {
+        global $DB;
+        $request->setParameter('itemtype', $request->getAttribute('itemtype'));
+        $request->setParameter('items_id', $request->getAttribute('id'));
+        $it = $DB->request([
+            'SELECT' => ['id'],
+            'FROM'   => 'glpi_infocoms',
+            'WHERE'  => [
+                'itemtype' => $request->getAttribute('itemtype'),
+                'items_id' => $request->getAttribute('id'),
+            ],
+        ]);
+        if (!count($it)) {
+            return self::getNotFoundErrorResponse();
+        }
+        $infocom_id = $it->current()['id'];
+        $request->setAttribute('id', $infocom_id);
+        $management_controller = new ManagementController();
+        return ResourceAccessor::deleteBySchema(
+            $management_controller->getKnownSchema('Infocom', $this->getAPIVersion($request)),
+            $request->getAttributes(),
+            $request->getParameters()
+        );
     }
 
     #[Route(path: '/{itemtype}', methods: ['POST'], requirements: [

--- a/tests/functional/Glpi/Api/HL/Controller/AssetControllerTest.php
+++ b/tests/functional/Glpi/Api/HL/Controller/AssetControllerTest.php
@@ -35,6 +35,7 @@
 namespace tests\units\Glpi\Api\HL\Controller;
 
 use Computer;
+use Glpi\Api\HL\Controller\AssetController;
 use Glpi\Api\HL\Middleware\InternalAuthMiddleware;
 use Glpi\Asset\Asset;
 use Glpi\Features\AssignableItemInterface;
@@ -638,5 +639,30 @@ class AssetControllerTest extends HLAPITestCase
                     $this->assertEquals('_test_group_2', $content['group'][1]['name']);
                 });
         });
+    }
+
+    public function testCRUDInfocom()
+    {
+        $this->login();
+        $infocom_types = AssetController::getAssetInfocomTypes(true);
+        foreach ($infocom_types as $itemtype) {
+            $create_input = [];
+            if ($itemtype === 'Cartridge') {
+                $create_input['cartridgeitems_id'] = getItemByTypeName('CartridgeItem', '_test_cartridgeitem01', true);
+            } elseif ($itemtype === 'Consumable') {
+                $create_input['consumableitems_id'] = getItemByTypeName('ConsumableItem', '_test_consumableitem01', true);
+            } else {
+                $create_input['name'] = __FUNCTION__;
+                $create_input['entities_id'] = $this->getTestRootEntity(true);
+            }
+            $item = $this->createItem($itemtype, $create_input);
+            $this->api->autoTestCRUD('/Assets/' . $itemtype . '/' . $item->getID() . '/Infocom', [
+                'date_buy' => '2026-01-14',
+            ], [
+                'date_buy' => '2026-01-15',
+            ], [
+                'new_location_singleton' => true,
+            ]);
+        }
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

For HLAPI v2.2.
Add missing endpoints to create, update and delete infocom data for assets.
The only regression is the removal of an endpoint to get infocoms for Unmanaged assets which was never valid as Unmanaged is not in the `infocom_types` array.