### PR TITLE
[HLAPI] NetworkPort Instantiations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The present file will list all changes made to the project; according to the
 ## [11.0.5] unreleased
 
 ### Added
+- New schemas for network port instantiations in High-Level API v2.2.
 
 ### Changed
 - High-Level API performance improvements for both REST and GraphQL requests (3.3-10x performance uplift on average)

--- a/src/Glpi/Api/HL/Controller/AssetController.php
+++ b/src/Glpi/Api/HL/Controller/AssetController.php
@@ -62,6 +62,7 @@ use Glpi\SocketModel;
 use Group_Item;
 use GuzzleHttp\Psr7\Utils;
 use Infocom;
+use Item_DeviceNetworkCard;
 use Item_Rack;
 use Location;
 use Manufacturer;
@@ -69,6 +70,14 @@ use Monitor;
 use Network;
 use NetworkEquipment;
 use NetworkPort;
+use NetworkPortAggregate;
+use NetworkPortAlias;
+use NetworkPortDialup;
+use NetworkPortEthernet;
+use NetworkPortFiberchannel;
+use NetworkPortFiberchannelType;
+use NetworkPortLocal;
+use NetworkPortWifi;
 use OperatingSystem;
 use PassiveDCEquipment;
 use PassiveDCEquipmentModel;
@@ -87,6 +96,7 @@ use SoftwareCategory;
 use SoftwareVersion;
 use State;
 use User;
+use WifiNetwork;
 
 use function Safe\json_decode;
 use function Safe\json_encode;
@@ -356,6 +366,14 @@ final class AssetController extends AbstractController
                 'comment' => ['type' => Doc\Schema::TYPE_STRING],
                 'entity' => self::getDropdownTypeSchema(class: Entity::class, full_schema: 'Entity'),
                 'is_recursive' => ['type' => Doc\Schema::TYPE_BOOLEAN],
+                'instantiation_type' => [
+                    'type' => Doc\Schema::TYPE_STRING,
+                    'x-version-introduced' => '2.2.0',
+                    'enum' => [
+                        'NetworkPortEthernet', 'NetworkPortWifi', 'NetworkPortAggregate', 'NetworkPortAlias',
+                        'NetworkPortDialup', 'NetworkPortLocal', 'NetworkPortFiberchannel'
+                    ],
+                ],
                 'logical_number' => ['type' => Doc\Schema::TYPE_INTEGER],
                 'mac' => ['type' => Doc\Schema::TYPE_STRING],
                 'is_deleted' => ['type' => Doc\Schema::TYPE_BOOLEAN],
@@ -1422,6 +1440,187 @@ final class AssetController extends AbstractController
                 'itemtype' => ['type' => Doc\Schema::TYPE_STRING],
                 'items_id' => ['type' => Doc\Schema::TYPE_INTEGER, 'format' => Doc\Schema::FORMAT_INTEGER_INT64],
                 'network_port' => self::getDropdownTypeSchema(class: NetworkPort::class, full_schema: 'NetworkPort'),
+                'date_creation' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
+                'date_mod' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
+            ],
+        ];
+
+        $schemas['NetworkPortEthernet'] = [
+            'type' => Doc\Schema::TYPE_OBJECT,
+            'x-itemtype' => NetworkPortEthernet::class,
+            'x-version-introduced' => '2.2',
+            'properties' => [
+                'id' => [
+                    'type' => Doc\Schema::TYPE_INTEGER,
+                    'format' => Doc\Schema::FORMAT_INTEGER_INT64,
+                    'readOnly' => true,
+                ],
+                'network_port' => self::getDropdownTypeSchema(class: NetworkPort::class, full_schema: 'NetworkPort'),
+                'network_card' => self::getDropdownTypeSchema(class: Item_DeviceNetworkCard::class, full_schema: 'NetworkCardItem'),
+                'type' => [
+                    'type' => Doc\Schema::TYPE_STRING,
+                    'enum' => ['', 'T', 'SX', 'LX'],
+                    'description' => <<<EOT
+                        Type of Ethernet port.
+                        - '': Not specified
+                        - 'T': Twisted Pair (RJ-45)
+                        - 'SX': Multimode fiber
+                        - 'LX': Single mode fiber
+EOT,
+                ],
+                'speed' => [
+                    'type' => Doc\Schema::TYPE_INTEGER,
+                    'format' => Doc\Schema::FORMAT_INTEGER_INT32,
+                    'description' => 'Speed of the Ethernet port in Mbps',
+                    'default' => 10,
+                ],
+                'date_creation' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
+                'date_mod' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
+            ],
+        ];
+
+        $schemas['NetworkPortWifi'] = [
+            'type' => Doc\Schema::TYPE_OBJECT,
+            'x-itemtype' => NetworkPortWifi::class,
+            'x-version-introduced' => '2.2',
+            'properties' => [
+                'id' => [
+                    'type' => Doc\Schema::TYPE_INTEGER,
+                    'format' => Doc\Schema::FORMAT_INTEGER_INT64,
+                    'readOnly' => true,
+                ],
+                'network_port' => self::getDropdownTypeSchema(class: NetworkPort::class, full_schema: 'NetworkPort'),
+                'network_card' => self::getDropdownTypeSchema(class: Item_DeviceNetworkCard::class, full_schema: 'NetworkCardItem'),
+                'wifinetwork' => self::getDropdownTypeSchema(class: WifiNetwork::class, full_schema: 'WifiNetwork'),
+                'version' => [
+                    'type' => Doc\Schema::TYPE_STRING,
+                    'enum' => ['', 'a', 'b', 'a/b', 'a/b/g', 'a/b/g/n', 'a/b/g/n/y', 'ac', 'ax', 'be', 'bn'],
+                    'description' => <<<EOT
+                        Wi-Fi version.
+                        - '': Not specified
+                        - 'a': 802.11a
+                        - 'b': 802.11b
+                        - 'a/b': 802.11a/b
+                        - 'a/b/g': 802.11a/b/g
+                        - 'a/b/g/n': 802.11a/b/g/n
+                        - 'a/b/g/n/y': 802.11a/b/g/n/y
+                        - 'ac': 802.11ac (Wi-Fi 5)
+                        - 'ax': 802.11ax (Wi-Fi 6)
+                        - 'be': 802.11be (Wi-Fi 7)
+                        - 'bn': 802.11bn (Wi-Fi 8)
+EOT,
+                ],
+                'mode' => [
+                    'type' => Doc\Schema::TYPE_STRING,
+                    'enum' => ['', 'ad-hoc', 'managed', 'master', 'repeater', 'secondary', 'monitor', 'auto'],
+                    'description' => <<<EOT
+                        Wi-Fi mode.
+                        - '': Not specified
+                        - 'ad-hoc': Ad-Hoc mode
+                        - 'managed': Managed mode
+                        - 'master': Master mode
+                        - 'repeater': Repeater mode
+                        - 'secondary': Secondary mode
+                        - 'monitor': Monitor mode
+                        - 'auto': Automatic mode
+EOT,
+                ],
+                'date_creation' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
+                'date_mod' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
+            ],
+        ];
+
+        $schemas['NetworkPortAggregate'] = [
+            'type' => Doc\Schema::TYPE_OBJECT,
+            'x-itemtype' => NetworkPortAggregate::class,
+            'x-version-introduced' => '2.2',
+            'properties' => [
+                'id' => [
+                    'type' => Doc\Schema::TYPE_INTEGER,
+                    'format' => Doc\Schema::FORMAT_INTEGER_INT64,
+                    'readOnly' => true,
+                ],
+                'network_port' => self::getDropdownTypeSchema(class: NetworkPort::class, full_schema: 'NetworkPort'),
+                'network_port_list' => [
+                    'type' => Doc\Schema::TYPE_STRING,
+                    'x-field' => 'networkports_id_list',
+                    'description' => 'JSON-encoded array of Network Port IDs that are part of this aggregate port',
+                ],
+                //TODO add network_ports property that uses something like JSON_TABLE to properly join the related ports. May need changes to the search code to support it.
+                'date_creation' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
+                'date_mod' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
+            ],
+        ];
+
+        $schemas['NetworkPortAlias'] = [
+            'type' => Doc\Schema::TYPE_OBJECT,
+            'x-itemtype' => NetworkPortAlias::class,
+            'x-version-introduced' => '2.2',
+            'properties' => [
+                'id' => [
+                    'type' => Doc\Schema::TYPE_INTEGER,
+                    'format' => Doc\Schema::FORMAT_INTEGER_INT64,
+                    'readOnly' => true,
+                ],
+                'network_port' => self::getDropdownTypeSchema(class: NetworkPort::class, full_schema: 'NetworkPort'),
+                'aliased_network_port' => self::getDropdownTypeSchema(class: NetworkPort::class, field: 'networkports_id_alias', full_schema: 'NetworkPort'),
+                'date_creation' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
+                'date_mod' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
+            ],
+        ];
+
+        $schemas['NetworkPortDialup'] = [
+            'type' => Doc\Schema::TYPE_OBJECT,
+            'x-itemtype' => NetworkPortDialup::class,
+            'x-version-introduced' => '2.2',
+            'properties' => [
+                'id' => [
+                    'type' => Doc\Schema::TYPE_INTEGER,
+                    'format' => Doc\Schema::FORMAT_INTEGER_INT64,
+                    'readOnly' => true,
+                ],
+                'network_port' => self::getDropdownTypeSchema(class: NetworkPort::class, full_schema: 'NetworkPort'),
+                'date_creation' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
+                'date_mod' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
+            ],
+        ];
+
+        $schemas['NetworkPortLocal'] = [
+            'type' => Doc\Schema::TYPE_OBJECT,
+            'x-itemtype' => NetworkPortLocal::class,
+            'x-version-introduced' => '2.2',
+            'properties' => [
+                'id' => [
+                    'type' => Doc\Schema::TYPE_INTEGER,
+                    'format' => Doc\Schema::FORMAT_INTEGER_INT64,
+                    'readOnly' => true,
+                ],
+                'network_port' => self::getDropdownTypeSchema(class: NetworkPort::class, full_schema: 'NetworkPort'),
+                'date_creation' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
+                'date_mod' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
+            ],
+        ];
+
+        $schemas['NetworkPortFiberchannel'] = [
+            'type' => Doc\Schema::TYPE_OBJECT,
+            'x-itemtype' => NetworkPortFiberchannel::class,
+            'x-version-introduced' => '2.2',
+            'properties' => [
+                'id' => [
+                    'type' => Doc\Schema::TYPE_INTEGER,
+                    'format' => Doc\Schema::FORMAT_INTEGER_INT64,
+                    'readOnly' => true,
+                ],
+                'network_port' => self::getDropdownTypeSchema(class: NetworkPort::class, full_schema: 'NetworkPort'),
+                'network_card' => self::getDropdownTypeSchema(class: Item_DeviceNetworkCard::class, full_schema: 'NetworkCardItem'),
+                'type' => self::getDropdownTypeSchema(class: NetworkPortFiberchannelType::class, full_schema: 'NetworkPortFiberchannelType'),
+                'wwn' => ['type' => Doc\Schema::TYPE_STRING, 'maxLength' => 50],
+                'speed' => [
+                    'type' => Doc\Schema::TYPE_INTEGER,
+                    'format' => Doc\Schema::FORMAT_INTEGER_INT32,
+                    'description' => 'Speed of the Fiber Channel port in Mbps',
+                    'default' => 10,
+                ],
                 'date_creation' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
                 'date_mod' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
             ],

--- a/src/Glpi/Api/HL/Controller/AssetController.php
+++ b/src/Glpi/Api/HL/Controller/AssetController.php
@@ -382,7 +382,7 @@ final class AssetController extends AbstractController
                     'x-version-introduced' => '2.2.0',
                     'enum' => [
                         'NetworkPortEthernet', 'NetworkPortWifi', 'NetworkPortAggregate', 'NetworkPortAlias',
-                        'NetworkPortDialup', 'NetworkPortLocal', 'NetworkPortFiberchannel'
+                        'NetworkPortDialup', 'NetworkPortLocal', 'NetworkPortFiberchannel',
                     ],
                 ],
                 'logical_number' => ['type' => Doc\Schema::TYPE_INTEGER],
@@ -1467,7 +1467,7 @@ final class AssetController extends AbstractController
                     'readOnly' => true,
                 ],
                 'network_port' => self::getDropdownTypeSchema(class: NetworkPort::class, full_schema: 'NetworkPort'),
-                'network_card' => self::getDropdownTypeSchema(class: Item_DeviceNetworkCard::class, full_schema: 'NetworkCardItem'),
+                'network_card' => self::getDropdownTypeSchema(class: Item_DeviceNetworkCard::class, name_field: 'serial', full_schema: 'NetworkCardItem'),
                 'type' => [
                     'type' => Doc\Schema::TYPE_STRING,
                     'enum' => ['', 'T', 'SX', 'LX'],
@@ -1501,7 +1501,7 @@ EOT,
                     'readOnly' => true,
                 ],
                 'network_port' => self::getDropdownTypeSchema(class: NetworkPort::class, full_schema: 'NetworkPort'),
-                'network_card' => self::getDropdownTypeSchema(class: Item_DeviceNetworkCard::class, full_schema: 'NetworkCardItem'),
+                'network_card' => self::getDropdownTypeSchema(class: Item_DeviceNetworkCard::class, name_field: 'serial', full_schema: 'NetworkCardItem'),
                 'wifinetwork' => self::getDropdownTypeSchema(class: WifiNetwork::class, full_schema: 'WifiNetwork'),
                 'version' => [
                     'type' => Doc\Schema::TYPE_STRING,
@@ -1623,7 +1623,7 @@ EOT,
                     'readOnly' => true,
                 ],
                 'network_port' => self::getDropdownTypeSchema(class: NetworkPort::class, full_schema: 'NetworkPort'),
-                'network_card' => self::getDropdownTypeSchema(class: Item_DeviceNetworkCard::class, full_schema: 'NetworkCardItem'),
+                'network_card' => self::getDropdownTypeSchema(class: Item_DeviceNetworkCard::class, name_field: 'serial', full_schema: 'NetworkCardItem'),
                 'type' => self::getDropdownTypeSchema(class: NetworkPortFiberchannelType::class, full_schema: 'NetworkPortFiberchannelType'),
                 'wwn' => ['type' => Doc\Schema::TYPE_STRING, 'maxLength' => 50],
                 'speed' => [

--- a/src/Glpi/Api/HL/Controller/AssetController.php
+++ b/src/Glpi/Api/HL/Controller/AssetController.php
@@ -366,6 +366,17 @@ final class AssetController extends AbstractController
                 'comment' => ['type' => Doc\Schema::TYPE_STRING],
                 'entity' => self::getDropdownTypeSchema(class: Entity::class, full_schema: 'Entity'),
                 'is_recursive' => ['type' => Doc\Schema::TYPE_BOOLEAN],
+                'itemtype' => [
+                    'type' => Doc\Schema::TYPE_STRING,
+                    'x-version-introduced' => '2.2.0',
+                    'readOnly' => true,
+                ],
+                'items_id' => [
+                    'type' => Doc\Schema::TYPE_INTEGER,
+                    'format' => Doc\Schema::FORMAT_INTEGER_INT64,
+                    'x-version-introduced' => '2.2.0',
+                    'readOnly' => true,
+                ],
                 'instantiation_type' => [
                     'type' => Doc\Schema::TYPE_STRING,
                     'x-version-introduced' => '2.2.0',

--- a/src/Glpi/Api/HL/Controller/DropdownController.php
+++ b/src/Glpi/Api/HL/Controller/DropdownController.php
@@ -49,7 +49,9 @@ use Glpi\Http\Request;
 use Glpi\Http\Response;
 use Location;
 use Manufacturer;
+use NetworkPortFiberchannelType;
 use State;
+use WifiNetwork;
 
 #[Route(path: '/Dropdowns', priority: 1, tags: ['Dropdowns'])]
 #[Doc\Route(
@@ -227,6 +229,45 @@ final class DropdownController extends AbstractController
             ],
         ];
 
+        $schemas['WifiNetwork'] = [
+            'type' => Doc\Schema::TYPE_OBJECT,
+            'x-itemtype' => WifiNetwork::class,
+            'x-version-introduced' => '2.2',
+            'properties' => [
+                'id' => [
+                    'type' => Doc\Schema::TYPE_INTEGER,
+                    'format' => Doc\Schema::FORMAT_INTEGER_INT64,
+                    'readOnly' => true,
+                ],
+                'entity' => self::getDropdownTypeSchema(class: Entity::class, full_schema: 'Entity'),
+                'is_recursive' => ['type' => Doc\Schema::TYPE_BOOLEAN],
+                'name' => ['type' => Doc\Schema::TYPE_STRING, 'maxLength' => 255],
+                'essid' => ['type' => Doc\Schema::TYPE_STRING, 'maxLength' => 255],
+                'mode' => ['type' => Doc\Schema::TYPE_STRING, 'maxLength' => 255],
+                'comment' => ['type' => Doc\Schema::TYPE_STRING],
+                'date_creation' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
+                'date_mod' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
+            ],
+        ];
+
+        $schemas['NetworkPortFiberchannelType'] = [
+            'x-version-introduced' => '2.2',
+            'type' => Doc\Schema::TYPE_OBJECT,
+            'x-itemtype' => NetworkPortFiberchannelType::class,
+            'description' => NetworkPortFiberchannelType::getTypeName(1),
+            'properties' => [
+                'id' => [
+                    'type' => Doc\Schema::TYPE_INTEGER,
+                    'format' => Doc\Schema::FORMAT_INTEGER_INT64,
+                    'readOnly' => true,
+                ],
+                'name' => ['type' => Doc\Schema::TYPE_STRING],
+                'comment' => ['type' => Doc\Schema::TYPE_STRING],
+                'date_creation' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
+                'date_mod' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
+            ],
+        ];
+
         return $schemas;
     }
 
@@ -244,6 +285,8 @@ final class DropdownController extends AbstractController
                 'State' => State::getTypeName(1),
                 'Manufacturer' => Manufacturer::getTypeName(1),
                 'Calendar' => Calendar::getTypeName(1),
+                'WifiNetwork' => WifiNetwork::getTypeName(1),
+                'NetworkPortFiberchannelType' => NetworkPortFiberchannelType::getTypeName(1),
             ];
         }
         return $types_only ? array_keys($dropdowns) : $dropdowns;

--- a/src/Glpi/Api/HL/Router.php
+++ b/src/Glpi/Api/HL/Router.php
@@ -90,7 +90,7 @@ use function Safe\preg_match;
 class Router
 {
     /** @var string */
-    public const API_VERSION = '2.1.0';
+    public const API_VERSION = '2.2.0';
 
     /**
      * @var AbstractController[]
@@ -169,6 +169,11 @@ EOT;
                 'api_version' => '2',
                 'version' => '2.1.0',
                 'endpoint' => $CFG_GLPI['url_base'] . '/api.php/v2.1',
+            ],
+            [
+                'api_version' => '2',
+                'version' => '2.2.0',
+                'endpoint' => $CFG_GLPI['url_base'] . '/api.php/v2.2',
             ],
         ];
     }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

For HLAPI v.2.2.
Adds new schemas for network port instantiation information.
No endpoints added in this PR for instantiations, and in fact they are missing for network ports too.
Both network ports and the instantiations remain visible through GraphQL.

A non-blocking note was added for aggregate ports to eventually try adding a property that can read the JSON list `networkports_id_list` and join on its IDs for better graph support and to be more user friendly. The existing string property would remain but be deprecated (or removed if implemented before v2.2 is released).