### PR TITLE
Fix(ITIL template): category as read-only

### DIFF
--- a/src/ITILTemplate.php
+++ b/src/ITILTemplate.php
@@ -148,7 +148,7 @@ abstract class ITILTemplate extends CommonDropdown
                     sprintf('`%s` is not an instance of `%s`.', $ttr_class, ITILTemplateReadonlyField::class)
                 );
             }
-            $this->readonly = $ttr->getReadonlyFields($ID);
+            $this->readonly = $ttr->getReadonlyFields($ID, true);
 
             // Force items_id if itemtype is defined
             if (


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !41400

The category was ignored as a read-only field.

## Screenshots (if appropriate):


