### PR TITLE
[HLAPI] Optimize path matching

### DIFF
--- a/src/Glpi/Api/HL/Router.php
+++ b/src/Glpi/Api/HL/Router.php
@@ -498,7 +498,7 @@ EOT;
         $api_version = self::normalizeAPIVersion($request->getHeaderLine('GLPI-API-Version') ?: static::API_VERSION);
         // Filter routes by the requested API version and method
         $routes = array_filter($routes, static function ($route) use ($request, $api_version) {
-            if ($route->matchesAPIVersion($api_version) && in_array($request->getMethod(), $route->getRouteMethods(), true)) {
+            if (in_array($request->getMethod(), $route->getRouteMethods(), true) && $route->matchesAPIVersion($api_version)) {
                 // Verify the request uri path matches the compiled path
                 return (bool) preg_match('#^' . $route->getCompiledPath() . '$#i', $request->getUri()->getPath());
             }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

12ms -> 4ms for matching.

Route version matching is more expensive than checking the HTTP method. We are at 1012 routes in HLAPI v2.1 and there will be a lot more added with v2.2. By doing the method matching first we can cut the number of routes needing to have their versions checked by a lot.