### PR TITLE
Optimize custom object boot

### DIFF
--- a/src/Glpi/Asset/AssetDefinition.php
+++ b/src/Glpi/Asset/AssetDefinition.php
@@ -63,6 +63,7 @@ final class AssetDefinition extends AbstractDefinition
 {
     use AssetImage;
 
+    /** @var Capacity[] */
     private ?array $decoded_capacities_cache = null;
 
     public static function getSectorizedDetails(): array

--- a/src/Glpi/Asset/AssetDefinition.php
+++ b/src/Glpi/Asset/AssetDefinition.php
@@ -407,6 +407,12 @@ TWIG, $twig_params);
         }
     }
 
+    public function post_getFromDB()
+    {
+        parent::post_getFromDB();
+        $this->decoded_capacities_cache = null;
+    }
+
     public function cleanDBonPurge()
     {
         $capacities = $this->getDecodedCapacitiesField();

--- a/src/Glpi/Asset/AssetDefinition.php
+++ b/src/Glpi/Asset/AssetDefinition.php
@@ -63,6 +63,8 @@ final class AssetDefinition extends AbstractDefinition
 {
     use AssetImage;
 
+    private ?array $decoded_capacities_cache = null;
+
     public static function getSectorizedDetails(): array
     {
         return ['config', self::class];
@@ -637,7 +639,10 @@ TWIG, $twig_params);
      */
     private function getDecodedCapacitiesField(): array
     {
-        return $this->decodeCapacities($this->fields['capacities']);
+        if ($this->decoded_capacities_cache === null) {
+            $this->decoded_capacities_cache = $this->decodeCapacities($this->fields['capacities']);
+        }
+        return $this->decoded_capacities_cache;
     }
 
     /**


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Custom objects boot process does not scale well. With 6 custom assets with all capacities enabled, it takes 20ms for `AssetDefinitionManager::bootDefinitions` with the time mainly taken to bootstrap capacities.

This PR memoizes the decoded capacity field to skip redundant capacity array validation happening for every known capacity (28 so far) for every asset definition, which reduces the execution time to 5ms. Removing the component capacity from all of them brings it down to 3ms.
This should let it scale a little better with a lot of custom assets.