### PR TITLE
Debounce Select2 AJAX calls

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -4873,7 +4873,6 @@ JAVASCRIPT
             placeholder: " . json_encode($placeholder) . ",
             allowClear: $allowclear,
             minimumInputLength: 0,
-            quietMillis: 100,
             dropdownAutoWidth: true,
             dropdownParent: $('#$field_id').closest('div.modal, div.dropdown-menu, body'),
             minimumResultsForSearch: " . $CFG_GLPI['ajax_limit_count'] . ",
@@ -4881,6 +4880,7 @@ JAVASCRIPT
                url: '$url',
                dataType: 'json',
                type: 'POST',
+               delay: 250,
                data: function (params) {
                   query = params;
                   return $.extend({}, params_$field_id, {


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

The `quietMillis` parameter has been replaced with `ajax.delay` since the v4 release (2015). When typing to filter Select2 AJAX dropdowns, it was spamming the server with requests on every keystroke even when typing fast.

https://forum.glpi-project.org/viewtopic.php?id=293781