### PR TITLE
fix(user): handle mouseleave to close user info card popover

### DIFF
--- a/templates/components/itilobject/actors/field.html.twig
+++ b/templates/components/itilobject/actors/field.html.twig
@@ -345,7 +345,7 @@
 
             setTimeout(() => {
                 // Find the trigger element and hide its popover
-                const popover_element = $('[data-glpi-popover-source][aria-describedby="' + popover.attr('id') + '"]');
+                const popover_element = $('[data-glpi-popover-source][aria-describedby="' + CSS.escape(popover.attr('id')) + '"]');
                 if (popover_element.length > 0) {
                     const popover_instance = bootstrap.Popover.getInstance(popover_element[0]);
                     popover_instance.hide();

--- a/templates/components/itilobject/actors/field.html.twig
+++ b/templates/components/itilobject/actors/field.html.twig
@@ -336,24 +336,20 @@
             }
         });
 
-        // when the mouse leave the user card in the popover, close it
-        $(document).on('mouseleave', '.user-info-card', () => {
-            setTimeout(() => {
-                $('.popover').popover('hide');
-            }, 300);
-        });
+        // when the mouse leave the info card in the popover, close it
+        $(document).on('mouseleave', '.user-info-card, .group-info-card, .supplier-info-card', (e) => {
+            const popover = $(e.target).closest('.popover');
+            if (popover.length === 0) {
+                return;
+            }
 
-        // when the mouse leave the group card in the popover, close it
-        $(document).on('mouseleave', '.group-info-card', () => {
             setTimeout(() => {
-                $('.popover').popover('hide');
-            }, 300);
-        });
-
-        // when the mouse leave the supplier card in the popover, close it
-        $(document).on('mouseleave', '.supplier-info-card', () => {
-            setTimeout(() => {
-                $('.popover').popover('hide');
+                // Find the trigger element and hide its popover
+                const popover_element = $('[data-glpi-popover-source][aria-describedby="' + popover.attr('id') + '"]');
+                if (popover_element.length > 0) {
+                    const popover_instance = bootstrap.Popover.getInstance(popover_element[0]);
+                    popover_instance.hide();
+                }
             }, 300);
         });
 


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !41539
- The user profile remained displayed after hovering over it and required refreshing the page to disappear, obstructing the visibility of the ticket.

## Screenshots (if appropriate):

<img width="289" height="92" alt="image" src="https://github.com/user-attachments/assets/f1a9c8db-b463-4879-8a9b-012c28872c4c" />


