### PR TITLE
Fix: gray out readonly fields

### DIFF
--- a/css/legacy/includes/_inputs.scss
+++ b/css/legacy/includes/_inputs.scss
@@ -122,3 +122,8 @@ input.submit,
    border-color: #d63939 !important;
    background-color: rgba(255, 0, 0, 0.1) !important;
 }
+.form-control[readonly] {
+   opacity: 0.7;
+   background-color: rgba(var(--tblr-body-color-rgb), 0.1);
+   cursor: not-allowed;
+}


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !41400

Read-only fields were not distinguished from editable fields.

## Screenshots (if appropriate):

Before:
<img width="470" height="682" alt="image" src="https://github.com/user-attachments/assets/7d6033d8-076b-4281-afff-c5fdc825e2c9" />

After:

Auror:
<img width="470" height="682" alt="image" src="https://github.com/user-attachments/assets/1bfde1a7-1b94-4317-92bb-22635f5435b8" />

Dark Auror:
<img width="470" height="682" alt="image" src="https://github.com/user-attachments/assets/3cb33af6-3c77-4f91-b329-8db7b322664f" />


