### PR TITLE
Ensure Entity::prepareInputForUpdate() sends false when no rights

### DIFF
--- a/.phpstan-baseline.missingType.iterableValue.php
+++ b/.phpstan-baseline.missingType.iterableValue.php
@@ -8012,18 +8012,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Enclosure.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Method Entity\\:\\:checkRightData\\(\\) has parameter \\$input with no value type specified in iterable type array\\.$#',
-	'identifier' => 'missingType.iterableValue',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Entity.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Method Entity\\:\\:checkRightData\\(\\) return type has no value type specified in iterable type array\\.$#',
-	'identifier' => 'missingType.iterableValue',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Entity.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method Entity\\:\\:cleanCloneInput\\(\\) has parameter \\$input with no value type specified in iterable type array\\.$#',
 	'identifier' => 'missingType.iterableValue',
 	'count' => 1,

--- a/.phpstan-baseline.missingType.iterableValue.php
+++ b/.phpstan-baseline.missingType.iterableValue.php
@@ -8012,13 +8012,13 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Enclosure.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Method Entity\\:\\:checkRightDatas\\(\\) has parameter \\$input with no value type specified in iterable type array\\.$#',
+	'message' => '#^Method Entity\\:\\:checkRightData\\(\\) has parameter \\$input with no value type specified in iterable type array\\.$#',
 	'identifier' => 'missingType.iterableValue',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Entity.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Method Entity\\:\\:checkRightDatas\\(\\) return type has no value type specified in iterable type array\\.$#',
+	'message' => '#^Method Entity\\:\\:checkRightData\\(\\) return type has no value type specified in iterable type array\\.$#',
 	'identifier' => 'missingType.iterableValue',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Entity.php',

--- a/src/Entity.php
+++ b/src/Entity.php
@@ -370,7 +370,7 @@ class Entity extends CommonTreeDropdown implements LinkableToTilesInterface, Pro
         // Add framework  / internal ones
         foreach ($input as $key => $val) {
             if ($key[0] === '_') {
-                $tmp[$key] = $input[$key];
+                $tmp[$key] = $val;
             }
         }
 

--- a/src/Entity.php
+++ b/src/Entity.php
@@ -337,17 +337,16 @@ class Entity extends CommonTreeDropdown implements LinkableToTilesInterface, Pro
     /**
      * Check right on each field before add / update
      *
-     * @param array $input
+     * @param array<string, mixed> $input
      *
-     * @return array (filtered input)
+     * @return false|array<string, mixed> (filtered input)
      **/
-    private function checkRightDatas($input): array
+    private function checkRightDatas(array $input): array|bool
     {
         $tmp = [];
 
-        if (isset($input['id'])) {
-            $tmp['id'] = $input['id'];
-        }
+        $existing_id = $input['id'] ?? null;
+        unset($input['id']);
 
         foreach (self::$field_right as $right => $fields) {
             if ($right === 'entity_helpdesk') {
@@ -375,6 +374,13 @@ class Entity extends CommonTreeDropdown implements LinkableToTilesInterface, Pro
             }
         }
 
+        if (!count($tmp)) {
+            return false;
+        }
+
+        if ($existing_id !== null) {
+            $tmp['id'] = $existing_id;
+        }
         return $tmp;
     }
 
@@ -457,8 +463,7 @@ class Entity extends CommonTreeDropdown implements LinkableToTilesInterface, Pro
 
         if (!Session::isCron()) { // Filter input for connected
             $input = $this->checkRightDatas($input);
-            if (count($input) === 1 && isset($input['id'])) {
-                // No fields to update
+            if ($input === false) {
                 return false;
             }
         }

--- a/src/Entity.php
+++ b/src/Entity.php
@@ -457,6 +457,10 @@ class Entity extends CommonTreeDropdown implements LinkableToTilesInterface, Pro
 
         if (!Session::isCron()) { // Filter input for connected
             $input = $this->checkRightDatas($input);
+            if (count($input) === 1 && isset($input['id'])) {
+                // No fields to update
+                return false;
+            }
         }
 
         $input = $this->handleCustomScenesInputValues($input);

--- a/src/Entity.php
+++ b/src/Entity.php
@@ -341,7 +341,7 @@ class Entity extends CommonTreeDropdown implements LinkableToTilesInterface, Pro
      *
      * @return false|array<string, mixed> (filtered input)
      **/
-    private function checkRightDatas(array $input): array|bool
+    private function checkRightData(array $input): array|bool
     {
         $tmp = [];
 
@@ -433,7 +433,7 @@ class Entity extends CommonTreeDropdown implements LinkableToTilesInterface, Pro
         }
 
         if (!Session::isCron()) { // Filter input for connected
-            $input = $this->checkRightDatas($input);
+            $input = $this->checkRightData($input);
         }
         return $input;
     }
@@ -462,7 +462,7 @@ class Entity extends CommonTreeDropdown implements LinkableToTilesInterface, Pro
         }
 
         if (!Session::isCron()) { // Filter input for connected
-            $input = $this->checkRightDatas($input);
+            $input = $this->checkRightData($input);
             if ($input === false) {
                 return false;
             }

--- a/src/Entity.php
+++ b/src/Entity.php
@@ -375,6 +375,11 @@ class Entity extends CommonTreeDropdown implements LinkableToTilesInterface, Pro
         }
 
         if (!count($tmp)) {
+            Session::addMessageAfterRedirect(
+                __s("You do not have rights for this entity."),
+                false,
+                ERROR
+            );
             return false;
         }
 

--- a/tests/functional/EntityTest.php
+++ b/tests/functional/EntityTest.php
@@ -178,7 +178,7 @@ class EntityTest extends DbTestCase
 
         //once logged, we have rights
         $this->login();
-        $this->assertSame($input, $entity->prepareInputForUpdate($input));
+        $this->assertEquals($input, $entity->prepareInputForUpdate($input));
     }
 
     /**

--- a/tests/functional/EntityTest.php
+++ b/tests/functional/EntityTest.php
@@ -175,6 +175,7 @@ class EntityTest extends DbTestCase
 
         //no login => no rights.
         $this->assertFalse($entity->prepareInputForUpdate($input));
+        $this->hasSessionMessages(ERROR, ['You do not have rights for this entity.']);
 
         //once logged, we have rights
         $this->login();

--- a/tests/functional/EntityTest.php
+++ b/tests/functional/EntityTest.php
@@ -137,7 +137,7 @@ class EntityTest extends DbTestCase
         );
     }
 
-    public function testPrepareInputForAdd()
+    public function testPrepareInputForAdd(): void
     {
         $this->login();
         $entity = new Entity();
@@ -163,6 +163,22 @@ class EntityTest extends DbTestCase
         $this->assertSame('entname', $prepared['completename']);
         $this->assertSame(1, $prepared['level']);
         $this->assertSame(0, $prepared['entities_id']);
+    }
+
+    public function testPrepareInputForUpdate(): void
+    {
+        $entity = new Entity();
+        $input = [
+            'id' => 1,
+            'agent_base_url' => 'http://anyurl',
+        ];
+
+        //no login => no rights.
+        $this->assertFalse($entity->prepareInputForUpdate($input));
+
+        //once logged, we have rights
+        $this->login();
+        $this->assertSame($input, $entity->prepareInputForUpdate($input));
     }
 
     /**


### PR DESCRIPTION
See added test. Previously, when rights were not OK, `prepareInputForUpdate()` was just returning an array with the id.