### PR TITLE
[Fix] No wrap for long asset names in Impact Analysis

### DIFF
--- a/css/legacy/includes/_impact.scss
+++ b/css/legacy/includes/_impact.scss
@@ -535,14 +535,24 @@ i.fa-impact-manipulation {
 
 .impact-side-filter-itemtypes-item {
    cursor: pointer;
+   max-width: 100%; /* Ensure the container respects the sidebar width */
 
    span {
-      display: inline;
       margin-left: 4px;
+      /* Required for ellipsis in flexbox */
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      flex: 1;       /* Takes up remaining space */
+      min-width: 0;  /* Allows the item to shrink below its text content size */
    }
+
    h4 {
       margin-top: 0;
       margin-bottom: 0;
+      display: flex;
+      align-items: center;
+      width: 100%; /* Forces the flex container to fill the parent width */
    }
 }
 

--- a/src/Impact.php
+++ b/src/Impact.php
@@ -1051,7 +1051,7 @@ TWIG, $twig_params);
 
             echo '<div class="impact-side-filter-itemtypes-item">';
             echo '<h4><img class="impact-side-icon" src="' . htmlescape($icon) . '" title="' . htmlescape($itemtype::getTypeName()) . '" data-itemtype="' . htmlescape($itemtype) . '">';
-            echo "<span>" . htmlescape($itemtype::getTypeName()) . "</span></h4>";
+            echo "<span title=\"" . htmlescape($itemtype::getTypeName()) . "\">" . htmlescape($itemtype::getTypeName()) . "</span></h4>";
             echo '</div>'; // impact-side-filter-itemtypes-item
         }
         echo '</div>'; // impact-side-filter-itemtypes-items


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable): Closes #22713 
- Here is a brief description of what this PR does: add an ellipsis for long names on Impact Analysis sidebar. The full name is displayed on Tooltip.

## Screenshots (if appropriate):

<img width="863" height="470" alt="image" src="https://github.com/user-attachments/assets/3b95d3ac-6ed2-4b7f-a8e7-94b37ae81b94" />

