### PR TITLE
Feat(Form\Category): Open class and add missing search option

### DIFF
--- a/src/Glpi/Form/Category.php
+++ b/src/Glpi/Form/Category.php
@@ -42,7 +42,7 @@ use Glpi\Form\ServiceCatalog\ServiceCatalogItemInterface;
 use Glpi\UI\IllustrationManager;
 use Override;
 
-final class Category extends CommonTreeDropdown implements ServiceCatalogCompositeInterface
+class Category extends CommonTreeDropdown implements ServiceCatalogCompositeInterface
 {
     public $can_be_translated = true;
 
@@ -105,7 +105,32 @@ final class Category extends CommonTreeDropdown implements ServiceCatalogComposi
             'datatype'          => 'text',
         ];
 
+        $options[] = [
+            'id'                => '4',
+            'table'             => $this->getTable(),
+            'field'             => 'illustration',
+            'name'              => __('Illustration'),
+            'datatype'          => 'text',
+            'massiveaction'      => false,
+            'nosearch'          => true,
+            'datatype'          => 'specific',
+        ];
+
         return $options;
+    }
+
+    public static function getSpecificValueToDisplay($field, $values, array $options = [])
+    {
+        if (!is_array($values)) {
+            $values = [$field => $values];
+        }
+
+        switch ($field) {
+            case 'illustration':
+                return (new IllustrationManager())->renderIcon($values[$field], 32);
+            break;
+        }
+        return parent::getSpecificValueToDisplay($field, $values, $options);
     }
 
     #[Override]

--- a/src/Glpi/Form/Category.php
+++ b/src/Glpi/Form/Category.php
@@ -127,7 +127,6 @@ class Category extends CommonTreeDropdown implements ServiceCatalogCompositeInte
         switch ($field) {
             case 'illustration':
                 return (new IllustrationManager())->renderIcon($values[$field], 32);
-                break;
         }
         return parent::getSpecificValueToDisplay($field, $values, $options);
     }

--- a/src/Glpi/Form/Category.php
+++ b/src/Glpi/Form/Category.php
@@ -128,7 +128,7 @@ class Category extends CommonTreeDropdown implements ServiceCatalogCompositeInte
         switch ($field) {
             case 'illustration':
                 return (new IllustrationManager())->renderIcon($values[$field], 32);
-            break;
+                break;
         }
         return parent::getSpecificValueToDisplay($field, $values, $options);
     }

--- a/src/Glpi/Form/Category.php
+++ b/src/Glpi/Form/Category.php
@@ -110,7 +110,6 @@ class Category extends CommonTreeDropdown implements ServiceCatalogCompositeInte
             'table'             => $this->getTable(),
             'field'             => 'illustration',
             'name'              => __('Illustration'),
-            'datatype'          => 'text',
             'massiveaction'      => false,
             'nosearch'          => true,
             'datatype'          => 'specific',


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)

- Removed the `final` keyword to allow class inheritance. (needed by https://github.com/pluginsGLPI/datainjection/pull/577)
- Added the missing `searchOption` to complete search configuration (`illustration`).
- Display illustrations in the search results table for better visual context.


<img width="1667" height="404" alt="image" src="https://github.com/user-attachments/assets/6c3e2ae6-c884-4af7-99a7-fd7c4f2be5d3" />


## Screenshots (if appropriate):


