### PR TITLE
feat(form-translations): Add a button to copy default translation

### DIFF
--- a/css/includes/components/form/_item-translations.scss
+++ b/css/includes/components/form/_item-translations.scss
@@ -44,8 +44,12 @@
             padding: 0.5rem 0.75rem;
         }
 
-        td:not(:first-child) {
+        td:not(:first-child, :nth-child(3)) {
             width: 35%;
+        }
+
+        td:has(> .btn-actions) {
+            width: 0;
         }
     }
 

--- a/js/common.js
+++ b/js/common.js
@@ -1941,10 +1941,18 @@ document.addEventListener('hidden.bs.modal', (e) => {
 
 // Tinymce on click loading
 $(document).on('click', 'div[data-glpi-tinymce-init-on-demand-render]', function() {
-    const div = $(this);
-    const textarea_id = div.attr('data-glpi-tinymce-init-on-demand-render');
-    div.removeAttr('data-glpi-tinymce-init-on-demand-render');
-    const textarea = $("#" + textarea_id);
+    const $container = $(this);
+    const $textarea = $("#" + CSS.escape($container.attr('data-glpi-tinymce-init-on-demand-render')));
+    initTinyMCEOnDemand($textarea, $container);
+});
+
+/**
+ * Initialize TinyMCE editor on demand
+ * @param {string} textarea_id The ID of the textarea to initialize
+ * @param {HTMLElement} container The container element that triggered the initialization
+ */
+function initTinyMCEOnDemand($textarea, $container) {
+    $container.removeAttr('data-glpi-tinymce-init-on-demand-render');
 
     const loadingOverlay = $(`
         <div class="glpi-form-editor-loading-overlay position-absolute top-0 start-0 w-100 h-100 d-flex align-items-center justify-content-center bg-white bg-opacity-75">
@@ -1954,13 +1962,16 @@ $(document).on('click', 'div[data-glpi-tinymce-init-on-demand-render]', function
         </div>
     `);
 
-    textarea.show();
-    div.css('position', 'relative').append(loadingOverlay);
-    tinyMCE.init(tinymce_editor_configs[textarea_id]).then((editors) => {
+    $textarea.show();
+    $container.css('position', 'relative').append(loadingOverlay);
+    const promise = tinyMCE.init(tinymce_editor_configs[$textarea.attr('id')]);
+    promise.then((editors) => {
         editors[0].focus();
-        div.remove();
+        $container.remove();
     });
-});
+
+    return promise;
+}
 
 // Prevent Bootstrap dialog from blocking focusin
 // See: https://www.tiny.cloud/docs/tinymce/latest/bootstrap-cloud/#usingtinymceinabootstrapdialog

--- a/templates/components/datatable.html.twig
+++ b/templates/components/datatable.html.twig
@@ -231,6 +231,9 @@
                             {% if entry['id'] is defined %}
                                 data-id="{{ entry['id'] ?? "" }}"
                             {% endif %}
+                            {% if entry['row_aria_label'] is defined %}
+                                aria-label="{{ entry['row_aria_label'] }}"
+                            {% endif %}
                         >
                             {% if row_massiveactions %}
                                 <td style="width: 10px">

--- a/templates/pages/admin/form/form_translation.html.twig
+++ b/templates/pages/admin/form/form_translation.html.twig
@@ -85,6 +85,48 @@
     </div>
 {% endmacro %}
 
+{% macro getActions(handler) %}
+    <div class="btn-actions">
+        <a data-translation-action-copy-default-value="{{ handler.getKey() }}"
+            class="btn btn-action"
+            title="{{ __('Copy default value to translation') }}"
+            role="button"
+            aria-label="{{ __('Copy default value to translation') }}">
+            <i class="ti ti-arrow-big-right"></i>
+        </a>
+    </div>
+
+    <script>
+        $(function() {
+            $('[data-translation-action-copy-default-value="{{ handler.getKey() }}"]')
+                .on('click', (event) => {
+                    event.preventDefault();
+                    const row = $(event.currentTarget).closest('tr');
+                    const translationInput = row.find('td').eq(3).find('input, textarea').filter(':not([type="hidden"])').first();
+
+                    {% if handler.isRichText() %}
+                        if (translationInput.siblings('.tox-tinymce').length === 0) {
+                            initTinyMCEOnDemand(
+                                translationInput,
+                                $('[data-glpi-tinymce-init-on-demand-render="' + translationInput.attr('id') + '"]')
+                            ).then((editors) => {
+                                editors[0].setContent('{{ handler.getValue()|e('js') }}');
+                            });
+                        } else {
+                            const editorId = translationInput.attr('id');
+                            const editor = tinymce.get(editorId);
+                            if (editor) {
+                                editor.setContent('{{ handler.getValue()|e('js') }}');
+                            }
+                        }
+                    {% else %}
+                        translationInput.val('{{ handler.getValue()|e('js') }}');
+                    {% endif %}
+                });
+        });
+    </script>
+{% endmacro %}
+
 {% set entries = [] %}
 {% for handlers in form.listTranslationsHandlers() %}
     {% set group_entries = [] %}
@@ -104,13 +146,16 @@
             {% set group_entries = group_entries|merge([{
                 'type': '<span class="fw-medium">' ~ handler.getName() ~ '</span>',
                 'default': default_value,
+                'actions': _self.getActions(handler),
                 'translation': _self.getTranslationInput(
                     handler,
                     item_translation,
                     form_translation.getCldrLanguage().getPluralKey(1)
                 ),
+                'row_aria_label': __('Translation row for %s')|format(handler.getName()),
                 'type_aria_label': __('Translation name'),
                 'default_aria_label': __('Default value'),
+                'actions_aria_label': __('Translation actions'),
                 'translation_aria_label': __('Translated value')
             }]) %}
         {% endif %}
@@ -119,7 +164,7 @@
     {% if group_entries is not empty %}
         {% set entries = entries|merge([{
             'type': '<span data-glpi-form-translations-subtitle-row>' ~ handlers|first.getCategory() ~ '</span>',
-            'type_colspan': 3,
+            'type_colspan': 4,
             'type_aria_label': _n('Category', 'Categories', 1)
         }]) %}
         {% set entries = entries|merge(group_entries) %}
@@ -155,11 +200,13 @@
                     'columns': {
                         'type': '',
                         'default': __('Default (%s)')|format(call('Dropdown::getLanguageName', [config('language')])),
+                        'actions': __('Actions'),
                         'translation': call('Dropdown::getLanguageName', [form_translation.fields['language']]),
                     },
                     'formatters': {
                         'type': 'raw_html',
                         'default': 'raw_html',
+                        'actions': 'raw_html',
                         'translation': 'raw_html',
                     },
                     'entries': entries,

--- a/templates/pages/admin/form/form_translation.html.twig
+++ b/templates/pages/admin/form/form_translation.html.twig
@@ -108,7 +108,7 @@
                         if (translationInput.siblings('.tox-tinymce').length === 0) {
                             initTinyMCEOnDemand(
                                 translationInput,
-                                $('[data-glpi-tinymce-init-on-demand-render="' + translationInput.attr('id') + '"]')
+                                $('[data-glpi-tinymce-init-on-demand-render="' + CSS.escape(translationInput.attr('id')) + '"]')
                             ).then((editors) => {
                                 editors[0].setContent('{{ handler.getValue()|e('js') }}');
                             });

--- a/templates/pages/admin/form/form_translations.html.twig
+++ b/templates/pages/admin/form/form_translations.html.twig
@@ -39,6 +39,7 @@
             class="btn btn-primary"
             data-bs-toggle="modal"
             data-bs-target="#addLanguageModal"
+            aria-label="{{ __('Add language') }}"
         >
             <i class="ti ti-plus me-1"></i>
             {{ __('Add language') }}

--- a/tests/e2e/pages/FormTranslationPage.ts
+++ b/tests/e2e/pages/FormTranslationPage.ts
@@ -1,0 +1,91 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+import { expect, Locator, Page } from "@playwright/test";
+import { GlpiPage } from "./GlpiPage";
+
+export class FormTranslationPage extends GlpiPage
+{
+    public readonly add_language_button: Locator;
+    public readonly save_translation_button: Locator;
+
+    public constructor(page: Page)
+    {
+        super(page);
+
+        // Define locators
+        this.add_language_button = this.getButton("Add language");
+        this.save_translation_button = this.getButton("Save translation");
+    }
+
+    public async goto(id: number): Promise<void>
+    {
+        const tab = "Glpi\\Form\\FormTranslation$1";
+        await this.page.goto(`/front/form/form.form.php?id=${id}&forcetab=${tab}`);
+    }
+
+    public async openLanguage(language: string): Promise<void>
+    {
+        await this.page.getByRole('button', { name: 'Edit translation' })
+            .filter({ hasText: language })
+            .click();
+    }
+
+    public async addLanguage(language: string): Promise<void>
+    {
+        await this.add_language_button.click();
+        await this.doSetDropdownValue(
+            this.getDropdownByLabel('Select language to translate'),
+            language
+        );
+        await this.getButton('Add').click();
+    }
+
+    public async expectLanguageDropdownOpened(language: string): Promise<void>
+    {
+        const dropdown = this.page.getByRole('dialog', { name: `Form translations: ${language}` });
+        await expect(dropdown).toBeVisible();
+    }
+
+    /**
+     * The translation key is stored in an hidden input inside td inside the row
+     */
+    public async getTranslationRow(translation_name: string): Promise<Locator>
+    {
+        return this.page.getByRole('row', { name: `Translation row for ${translation_name}` });
+    }
+
+    public async saveTranslation(): Promise<void>
+    {
+        await this.save_translation_button.click();
+    }
+}

--- a/tests/e2e/specs/Form/form_translations.spec.ts
+++ b/tests/e2e/specs/Form/form_translations.spec.ts
@@ -1,0 +1,95 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+import { randomUUID } from "crypto";
+import { expect, test } from '../../fixtures/glpi_fixture';
+import { Profiles } from "../../utils/Profiles";
+import { getWorkerEntityId } from '../../utils/WorkerEntities';
+import { FormTranslationPage } from "../../pages/FormTranslationPage";
+
+test('Can copy default value to translation', async ({ page, profile, api }) => {
+    await profile.set(Profiles.SuperAdmin);
+    const form_translation = new FormTranslationPage(page);
+
+    // Create a form and go to its translation page
+    const uuid = randomUUID();
+    const form_id = await api.createItem('Glpi\\Form\\Form', {
+        name: `Form - ${uuid}`,
+        header: `Form description`,
+        entities_id: getWorkerEntityId(),
+    });
+    await form_translation.goto(form_id);
+
+    // Add a language
+    await form_translation.addLanguage('Français');
+    await form_translation.expectLanguageDropdownOpened('Français');
+
+    // Check we can copy default value to translation for "Form title"
+    const translationRow = await form_translation.getTranslationRow('Form title');
+    const copyDefaultValueButton = translationRow.getByRole('button', { name: 'Copy default value to translation' });
+    const translationInput = translationRow.getByRole('cell', { name: 'Translated value' }).getByRole('textbox');
+    await expect(copyDefaultValueButton).toBeVisible();
+    await expect(translationInput).toBeEmpty();
+
+    await copyDefaultValueButton.click();
+    await expect(translationInput).toHaveValue(`Form - ${uuid}`);
+
+    // Check we can copy default value to translation for "Form description"
+    const descriptionRow = await form_translation.getTranslationRow('Form description');
+    const copyDefaultValueButtonDesc = descriptionRow.getByRole('button', { name: 'Copy default value to translation' });
+    const translationInputDesc = descriptionRow.getByRole('cell', { name: 'Translated value' }).getByRole('textbox');
+    await expect(copyDefaultValueButtonDesc).toBeVisible();
+    await expect(translationInputDesc).toHaveText('Enter translation');
+
+    await copyDefaultValueButtonDesc.click();
+
+    // Ensure translationInputDesc has been replaced with a tinymce editor
+    await expect(translationInputDesc).toHaveCount(0);
+    const richText = await form_translation.getRichTextByLabel('Enter translation');
+    await expect(richText).toHaveText('Form description');
+
+    // Now test with already initialized tinymce
+    await richText.fill('');
+    await expect(richText).toBeEmpty();
+    await copyDefaultValueButtonDesc.click();
+    await expect(translationInputDesc).toHaveCount(0);
+    await expect(richText).toHaveText('Form description');
+
+    // Save the translation and open it again to ensure values are persisted
+    await form_translation.saveTranslation();
+    await form_translation.openLanguage('Français');
+    await form_translation.expectLanguageDropdownOpened('Français');
+
+    // Check values
+    await expect(translationInput).toHaveValue(`Form - ${uuid}`);
+    await expect(translationInputDesc).toHaveText('Form description');
+});


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Added an "actions" column to the form translation table, featuring a button that allows users to copy the default value into the translation field. This supports both plain text and rich text (TinyMCE) fields.

## Screenshots (if appropriate):

<img width="1156" height="489" alt="image" src="https://github.com/user-attachments/assets/6a6d21cb-43aa-436a-9cfc-7e086b53ca36" />
