### PR TITLE
Improve update messages

### DIFF
--- a/src/Glpi/Helpdesk/DefaultDataManager.php
+++ b/src/Glpi/Helpdesk/DefaultDataManager.php
@@ -80,13 +80,14 @@ final class DefaultDataManager
         $this->tiles_manager = TilesManager::getInstance();
     }
 
-    public function initializeDataIfNeeded(): void
+    public function initializeDataIfNeeded(): bool
     {
         if ($this->dataHasBeenInitialized()) {
-            return;
+            return false;
         }
 
         $this->initializeData();
+        return true;
     }
 
     public function initializeData(): void

--- a/src/Glpi/OAuth/Server.php
+++ b/src/Glpi/OAuth/Server.php
@@ -217,11 +217,11 @@ final class Server
 
         return false;
     }
-    public static function generateKeys(): void
+    public static function generateKeys(): bool
     {
         if (self::checkKeys()) {
             // Keys are already generated
-            return;
+            return false;
         }
 
         // Partial data: unsure how to proceed, let the user review the files.
@@ -242,6 +242,7 @@ final class Server
         try {
             // Generate keys
             self::doGenerateKeys();
+            return true;
         } catch (Throwable $e) {
             // Make sure we don't save any partially generated data
             self::deleteKeys();

--- a/src/Glpi/Rules/RulesManager.php
+++ b/src/Glpi/Rules/RulesManager.php
@@ -47,11 +47,12 @@ final class RulesManager
     /**
      * Initialize rules for each collection that does not yet contains any rule.
      */
-    public static function initializeRules(): void
+    public static function initializeRules(): bool
     {
         global $CFG_GLPI;
 
         $rulecollections_types = $CFG_GLPI['rulecollections_types'];
+        $has_initialized_rules = false;
 
         foreach ($CFG_GLPI['dictionnary_types'] as $itemtype) {
             $rulecollection = RuleCollection::getClassByType($itemtype);
@@ -87,6 +88,7 @@ final class RulesManager
 
             if (countElementsInTable(Rule::getTable(), ['sub_type' => $ruleclass->getType()]) === 0) {
                 $ruleclass->initRules(false);
+                $has_initialized_rules = true;
             }
 
             // Mark collection as already initialized, to not reinitialize it on next update
@@ -97,5 +99,7 @@ final class RulesManager
                 ['initialized_rules_collections' => json_encode($initialized_collections)]
             );
         }
+
+        return $has_initialized_rules;
     }
 }

--- a/src/Update.php
+++ b/src/Update.php
@@ -289,17 +289,21 @@ class Update
         }
 
         // Create default forms
-        $progress_indicator?->setProgressBarMessage(__('Creating default forms…'));
+        $progress_indicator?->setProgressBarMessage(__('Creating default forms and helpdesk tiles if needed…'));
         $helpdesk_data_manager = new DefaultDataManager();
-        $helpdesk_data_manager->initializeDataIfNeeded();
+        $has_initialized_forms = $helpdesk_data_manager->initializeDataIfNeeded();
         $progress_indicator?->advance($init_form_weight);
-        $progress_indicator?->addMessage(MessageType::Success, __('Default forms created.'));
+        if ($has_initialized_forms) {
+            $progress_indicator?->addMessage(MessageType::Success, __('Default forms and helpdesk tiles created.'));
+        }
 
         // Initalize rules
-        $progress_indicator?->setProgressBarMessage(__('Initializing default rules…'));
-        RulesManager::initializeRules();
+        $progress_indicator?->setProgressBarMessage(__('Initializing default rules if needed…'));
+        $has_initialized_rules = RulesManager::initializeRules();
         $progress_indicator?->advance($init_rules_weight);
-        $progress_indicator?->addMessage(MessageType::Success, __('Default rules initialized.'));
+        if ($has_initialized_rules) {
+            $progress_indicator?->addMessage(MessageType::Success, __('Default rules initialized.'));
+        }
 
         $progress_indicator?->setProgressBarMessage(__('Checking the database structure…'));
         if (($myisam_count = $DB->getMyIsamTables()->count()) > 0) {
@@ -383,7 +387,7 @@ class Update
 
         $progress_indicator?->advance($post_update_weight);
 
-        $progress_indicator?->setProgressBarMessage(__('Generating security keys…'));
+        $progress_indicator?->setProgressBarMessage(__('Generating security keys if needed…'));
 
         //generate security key if missing, and update db
         $glpikey = new GLPIKey();
@@ -398,10 +402,12 @@ class Update
         }
 
         //generate keys, if needed
-        Server::generateKeys();
+        $has_generated_keys = Server::generateKeys();
 
         $progress_indicator?->advance($generate_keys_weight);
-        $progress_indicator?->addMessage(MessageType::Success, __('Security keys generated.'));
+        if ($has_generated_keys) {
+            $progress_indicator?->addMessage(MessageType::Success, __('Security keys generated.'));
+        }
 
         if (
             (Config::getConfigurationValue('core', 'plugins_execution_mode') ?? null) === Plugin::EXECUTION_MODE_SUSPENDED_BY_UPDATE


### PR DESCRIPTION
## Description

The update command always display that: 
* Default forms were created
* Default rules were created
* Security keys were generated

<img width="1337" height="349" alt="image" src="https://github.com/user-attachments/assets/da72984b-b4bc-451c-8726-c8a52ada3fd3" />

This is false as we only generate them if they are missing, so it might be miss-leading and it could confuse users.

These changes make it that the messages are only displayed if the related action was actually done:

<img width="1350" height="301" alt="image" src="https://github.com/user-attachments/assets/074f0083-a4fc-41d3-89dd-499afaa566e9" />

