### PR TITLE
Disable form when cloning

### DIFF
--- a/src/Glpi/Form/Clone/FormCloneHelper.php
+++ b/src/Glpi/Form/Clone/FormCloneHelper.php
@@ -100,6 +100,9 @@ final class FormCloneHelper
         // Reset counters
         $input['usage_count'] = 0;
 
+        // Disable the form
+        $input['is_active'] = false;
+
         // Disable default data creation
         $input['_init_sections'] = false;
         $input['_init_destinations'] = false;

--- a/tests/functional/Glpi/Form/Clone/FormCloneHelperTest.php
+++ b/tests/functional/Glpi/Form/Clone/FormCloneHelperTest.php
@@ -107,7 +107,6 @@ use Glpi\Form\Tag\CommentTitleTagProvider;
 use Glpi\Form\Tag\FormTagProvider;
 use Glpi\Form\Tag\QuestionTagProvider;
 use Glpi\Form\Tag\SectionTagProvider;
-use Glpi\Form\Tag\Tag;
 use Glpi\Tests\DbTestCase;
 use Glpi\Tests\FormBuilder;
 use Glpi\Tests\FormTesterTrait;
@@ -154,7 +153,7 @@ final class FormCloneHelperTest extends DbTestCase
 
         // Assert: the form should be cloned succesfully
         $this->assertTrue((bool) $clone->fields['is_recursive']);
-        $this->assertTrue((bool) $clone->fields['is_active']);
+        $this->assertFalse((bool) $clone->fields['is_active']);
         $this->assertTrue((bool) $clone->fields['is_deleted']);
         $this->assertTrue((bool) $clone->fields['is_draft']);
         $this->assertTrue((bool) $clone->fields['is_pinned']);


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Internal request, it make sense to disable a form when it is cloned as the administrator will usually need to edit it before it is production ready.

