### PR TITLE
Add a confirmation when regenerating direct access token

### DIFF
--- a/templates/pages/admin/form/access_control/direct_access.html.twig
+++ b/templates/pages/admin/form/access_control/direct_access.html.twig
@@ -106,6 +106,11 @@
         const preview = document.querySelector('[data-glpi-direct-access-refresh-url]');
 
         refresh_button.addEventListener('click', () => {
+            const message = __("Are you sure? Any users using the old link will no longer be able to access the form.");
+            if (!confirm(message)) {
+                return;
+            }
+
             // Quick copy of Toolbox::getRandomString()
             const keyspace = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
             let token = '';


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.

## Description

Requested by a partner, it informs the user that if he changed the direct access token then any link that he previously shared will no longer work.
