### PR TITLE
fix: warning undefined array key thrown on an itilobject creation/update

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -8396,8 +8396,9 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
      * @return ITILTemplate|null
      *
      * @since 11.0.2
+     * @TODO Make this method private in GLPI 12.
      */
-    public function getITILTemplateFromInput(array $input = [], ?CommonITILObject $existing_object = null): ?ITILTemplate
+    public function getITILTemplateFromInput(array $input = [], $existing_object = null): ?ITILTemplate
     {
         if (!$existing_object) {
             $existing_object = $this;


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description
This PR is an improvement of #21970 (closed now)

Users had complain about the warning in the logs (i.e: #22420, https://github.com/pluginsGLPI/tag/issues/302)

This was due to `CommonITILObject::enforceReadonlyFields` being called before the object was loaded resulting in an empty fields array.

For example in `ticket.form.php`  for an update, it's call before the `ticket->update()` action. 
Instead of manually loading from the database on each x.form.php (ITILObject related form) I prefer do an empty check in the method itself (having fields empty in that case is an ok case as we want to block update on fields before they are applied)

## How to reproduce
1. Change the `Category` from a ticket
2. Check the logs, you should get this warning

<img width="1095" height="270" alt="image" src="https://github.com/user-attachments/assets/5edeabb6-0793-46c1-b2f6-6923762df4fa" />


