### PR TITLE
Fix `ldap:synchronize_users` when using `--ldap-server-id` option

### DIFF
--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -2052,7 +2052,7 @@ TWIG, $twig_params);
                 ) {
                     // Only manage deleted user if ALL (because of entity visibility in delegated mode)
 
-                    if ($user['auths_id'] === $options['authldaps_id']) {
+                    if ($user['auths_id'] === (int) $options['authldaps_id']) {
                         if ((int) $user['is_deleted_ldap'] === 0) {
                             // If user is marked as coming from LDAP, but is not present in it anymore
                             User::manageDeletedUserInLdap($user['id']);


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.

## Description

While testing the `ldap:synchronize_users` command I noticed users without LDAP counterpart are not handled. I tracked the error down to the `if` changed in this PR. Reason for the int cast is the handling of the input.

https://github.com/glpi-project/glpi/blob/2e83e3b9af3075ab33593b2ee5beaf9380149f04/src/Glpi/Console/Ldap/SynchronizeUsersCommand.php#L245-L261
If the option `--ldap-server-id` is used, the `$servers_id` is an array of strings. The default loads the active servers from the database which results in an array of ints.

Later the check in
https://github.com/glpi-project/glpi/blob/2e83e3b9af3075ab33593b2ee5beaf9380149f04/src/AuthLDAP.php#L2055
fails because of the type safe comparison introduced with b5d9dbbd.

An alternative fix would be to change the array type in `SynchronizeUsersCommand.php`.

