### PR TITLE
fix(form-translations): Use more specific selectors

### DIFF
--- a/templates/pages/admin/form/form_translation.html.twig
+++ b/templates/pages/admin/form/form_translation.html.twig
@@ -86,8 +86,10 @@
 {% endmacro %}
 
 {% macro getActions(handler) %}
+    {% set rand = random() %}
+
     <div class="btn-actions">
-        <a data-translation-action-copy-default-value="{{ handler.getKey() }}"
+        <a data-translation-action-copy-default-value="{{ rand }}"
             class="btn btn-action"
             title="{{ __('Copy default value to translation') }}"
             role="button"
@@ -98,11 +100,11 @@
 
     <script>
         $(function() {
-            $('[data-translation-action-copy-default-value="{{ handler.getKey() }}"]')
+            $('[data-translation-action-copy-default-value="{{ rand }}"]')
                 .on('click', (event) => {
                     event.preventDefault();
                     const row = $(event.currentTarget).closest('tr');
-                    const translationInput = row.find('td').eq(3).find('input, textarea').filter(':not([type="hidden"])').first();
+                    const translationInput = row.find('> td').eq(3).find('input, textarea').filter(':not([type="hidden"])').first();
 
                     {% if handler.isRichText() %}
                         if (translationInput.siblings('.tox-tinymce').length === 0) {


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

This pull request updates the translation form template to use a random value as the selector for the copy default value action, instead of relying on the handler key. This helps ensure unique selectors when multiple translation rows are present. Additionally, the jQuery selector for finding the translation input is made more specific.

**Improvements to translation action handling:**

* Changed the `data-translation-action-copy-default-value` attribute in the action button to use a random value instead of `handler.getKey()`, ensuring uniqueness for each row.
* Updated the JavaScript selector to use the new random value and made the search for input elements in the translation row more specific by using `row.find('> td')`.