### PR TITLE
missing Html::back() after linking user to a group

### DIFF
--- a/front/group_user.form.php
+++ b/front/group_user.form.php
@@ -61,14 +61,6 @@ if (isset($_POST["add"])) {
             );
         }
     } catch (ItemLinkException $e) {
-        Event::log(
-            $_POST["groups_id"],
-            "groups",
-            2,
-            "setup",
-            //TRANS: %s is the user login
-            sprintf(__('%s failed to add a user to a group'), $_SESSION["glpiname"])
-        );
     } finally {
         Html::back();
     }

--- a/front/group_user.form.php
+++ b/front/group_user.form.php
@@ -50,20 +50,22 @@ $group_user = new Group_User();
 if (isset($_POST["add"])) {
     try {
         $group_user->check(-1, CREATE, $_POST);
-        if ($group_user->add($_POST)) {
-            Event::log(
-                $_POST["groups_id"],
-                "groups",
-                4,
-                "setup",
-                //TRANS: %s is the user login
-                sprintf(__('%s adds a user to a group'), $_SESSION["glpiname"])
-            );
-        }
     } catch (ItemLinkException $e) {
-    } finally {
         Html::back();
     }
+
+    if ($group_user->add($_POST)) {
+        Event::log(
+            $_POST["groups_id"],
+            "groups",
+            4,
+            "setup",
+            //TRANS: %s is the user login
+            sprintf(__('%s adds a user to a group'), $_SESSION["glpiname"])
+        );
+    }
+
+    Html::back();
 }
 
 throw new BadRequestHttpException();

--- a/front/group_user.form.php
+++ b/front/group_user.form.php
@@ -61,6 +61,15 @@ if (isset($_POST["add"])) {
             );
         }
     } catch (ItemLinkException $e) {
+        Event::log(
+            $_POST["groups_id"],
+            "groups",
+            2,
+            "setup",
+            //TRANS: %s is the user login
+            sprintf(__('%s failed to add a user to a group'), $_SESSION["glpiname"])
+        );
+    } finally {
         Html::back();
     }
 }


### PR DESCRIPTION
group tab on user edit page.

<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

missing Html::back() after linking user to a group

Display :
<img width="1724" height="593" alt="Capture d’écran du 2026-01-22 10-38-33" src="https://github.com/user-attachments/assets/0c710d8c-c9a8-436b-8e20-866d411a1d36" />
But linking is done correctly.

