### PR TITLE
chore(Makefile): Add playwright linter to the global lint target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -291,7 +291,7 @@ phpcsfixer-fix: ## Fix php coding standards issues
 .PHONY: phpcsfixer-fix
 
 ## —— Linters ——————————————————————————————————————————————————————————————————
-lint: lint-php lint-scss lint-twig lint-js ## Run all linters
+lint: lint-php lint-scss lint-twig lint-js lint-playwright ## Run all linters
 .PHONY: lint
 
 lint-php: ## Run the php linter script


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.

## Description

This pull request makes a small update to the `Makefile` by adding `lint-playwright` to the list of commands run by the `lint` target. This ensures that Playwright-related linting is included when running the main linter command.