### PR TITLE
Fix form export referencing deleted items

### DIFF
--- a/src/Glpi/Form/Destination/CommonITILField/AssociatedItemsField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/AssociatedItemsField.php
@@ -332,8 +332,13 @@ final class AssociatedItemsField extends AbstractConfigField implements Destinat
                     $requirement = DataRequirementSpecification::fromItem($item);
                     $requirements[] = $requirement;
                     $items[$itemtype][$i] = $requirement->name;
+                } else {
+                    // Remove deleted items from the export
+                    unset($items[$itemtype][$i]);
                 }
             }
+            // Re-index the array after removing elements
+            $items[$itemtype] = array_values($items[$itemtype]);
         }
 
         $config[AssociatedItemsFieldConfig::SPECIFIC_ASSOCIATED_ITEMS] = $items;

--- a/src/Glpi/Form/Destination/CommonITILField/EntityField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/EntityField.php
@@ -258,7 +258,8 @@ final class EntityField extends AbstractConfigField implements DestinationFieldC
         // Try to load entity
         $entity = Entity::getById($entity_id);
         if (!$entity) {
-            return $fallback;
+            $config[EntityFieldConfig::SPECIFIC_ENTITY_ID] = 0;
+            return new DynamicExportDataField($config, []);
         }
 
         // Insert entity name and requirement

--- a/src/Glpi/Form/Destination/CommonITILField/ITILActorField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ITILActorField.php
@@ -425,8 +425,13 @@ abstract class ITILActorField extends AbstractConfigField implements Destination
                     $requirement = DataRequirementSpecification::fromItem($item);
                     $requirements[] = $requirement;
                     $items[$itemtype][$i] = $requirement->name;
+                } else {
+                    // Remove deleted actors from the export
+                    unset($items[$itemtype][$i]);
                 }
             }
+            // Re-index the array after removing elements
+            $items[$itemtype] = array_values($items[$itemtype]);
         }
 
         $config[ITILActorFieldConfig::SPECIFIC_ITILACTORS_IDS] = $items;

--- a/src/Glpi/Form/Destination/CommonITILField/ITILCategoryField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ITILCategoryField.php
@@ -224,7 +224,8 @@ final class ITILCategoryField extends AbstractConfigField implements Destination
         // Try to load category
         $category = ITILCategory::getById($category_id);
         if (!$category) {
-            return $fallback;
+            $config[ITILCategoryFieldConfig::SPECIFIC_ITILCATEGORY_ID] = 0;
+            return new DynamicExportDataField($config, []);
         }
 
         // Insert category name and requirement

--- a/src/Glpi/Form/Destination/CommonITILField/LinkedITILObjectsField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/LinkedITILObjectsField.php
@@ -417,6 +417,9 @@ final class LinkedITILObjectsField extends AbstractConfigField implements Destin
                         $requirement = DataRequirementSpecification::fromItem($item);
                         $requirements[] = $requirement;
                         $strategy_config[LinkedITILObjectsFieldStrategyConfig::SPECIFIC_ITILOBJECT]['items_id'] = $requirement->name;
+                    } else {
+                        // Set to 0 if the linked object is deleted
+                        $strategy_config[LinkedITILObjectsFieldStrategyConfig::SPECIFIC_ITILOBJECT]['items_id'] = 0;
                     }
                 }
             }

--- a/src/Glpi/Form/Destination/CommonITILField/LocationField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/LocationField.php
@@ -230,7 +230,8 @@ final class LocationField extends AbstractConfigField implements DestinationFiel
         // Try to load location
         $location = Location::getById($location_id);
         if (!$location) {
-            return $fallback;
+            $config[LocationFieldConfig::SPECIFIC_LOCATION_ID] = 0;
+            return new DynamicExportDataField($config, []);
         }
 
         // Insert location name and requirement

--- a/src/Glpi/Form/Destination/CommonITILField/SLMField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/SLMField.php
@@ -176,7 +176,8 @@ abstract class SLMField extends AbstractConfigField implements DestinationFieldC
         // Try to load service level
         $slm = $this->getSLM()::getById($slm_id);
         if (!$slm) {
-            return $fallback;
+            $config[SLMFieldConfig::SLM_ID] = 0;
+            return new DynamicExportDataField($config, []);
         }
 
         // Insert service level name and requirement

--- a/src/Glpi/Form/Destination/CommonITILField/TemplateField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/TemplateField.php
@@ -203,7 +203,8 @@ final class TemplateField extends AbstractConfigField implements DestinationFiel
         $template_type = $itil_itemtype::getTemplateClass();
         $template = $template_type::getById($template_id);
         if (!$template) {
-            return $fallback;
+            $config[TemplateFieldConfig::TEMPLATE_ID] = 0;
+            return new DynamicExportDataField($config, []);
         }
 
         // Insert template name and requirement


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Forms destinations config might reference specific items like this:

<img width="567" height="148" alt="image" src="https://github.com/user-attachments/assets/8bfd96c4-6a7c-4de9-8fe3-e229ea1ee806" />

If "My category" is later deleted, the form export would keep its raw id in the generated JSON, leading to an error when importing the form later on.

With these changes, we remove references from deleted items in the exported JSON so they can be ignored when importing the form.

## References

Internal support ticket: !41624

