### PR TITLE
Worker mode and early hints

### DIFF
--- a/public/worker.php
+++ b/public/worker.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * FrankenPHP Worker Mode entry point.
+ *
+ * This script is designed to run GLPI in FrankenPHP's persistent worker mode,
+ * keeping the Symfony kernel booted across requests for better performance.
+ *
+ * @see https://frankenphp.dev/docs/worker/
+ */
+
+use Glpi\Application\ResourcesChecker;
+use Glpi\Kernel\Kernel;
+use Symfony\Component\HttpFoundation\Request;
+
+// Version check must be first
+if (version_compare(PHP_VERSION, '8.2.0', '<') || version_compare(PHP_VERSION, '8.5.999', '>')) {
+    exit('PHP version must be between 8.2 and 8.5.');
+}
+
+// Check resources before Kernel instantiation
+require_once dirname(__DIR__) . '/src/Glpi/Application/ResourcesChecker.php';
+(new ResourcesChecker(dirname(__DIR__)))->checkResources();
+
+require_once dirname(__DIR__) . '/vendor/autoload.php';
+
+// Boot kernel once, outside the worker loop
+$kernel = new Kernel();
+$kernel->boot();
+
+// Track requests for periodic kernel refresh
+$requestCount = 0;
+$maxRequests = (int) ($_SERVER['GLPI_WORKER_MAX_REQUESTS'] ?? 500);
+
+// Request handler callback
+$handleRequest = static function () use (&$kernel, &$requestCount, $maxRequests): void {
+    $request = Request::createFromGlobals();
+
+    try {
+        $response = $kernel->handle($request);
+
+        $kernel->sendResponse($request, $response);
+
+        $kernel->terminate($request, $response);
+    } finally {
+        // Periodic kernel refresh to prevent memory leaks
+        if (++$requestCount >= $maxRequests) {
+            $kernel->shutdown();
+            $kernel = new Kernel();
+            $kernel->boot();
+            $requestCount = 0;
+        }
+
+        // Perform garbage collection periodically
+        if ($requestCount % 50 === 0) {
+            gc_collect_cycles();
+        }
+    }
+};
+
+// Worker loop - handles requests persistently
+while (frankenphp_handle_request($handleRequest)) {}

--- a/public/worker.php
+++ b/public/worker.php
@@ -91,4 +91,5 @@ $handleRequest = static function () use (&$kernel, &$requestCount, $maxRequests)
 };
 
 // Worker loop - handles requests persistently
-while (frankenphp_handle_request($handleRequest)) {}
+while (frankenphp_handle_request($handleRequest)) {
+}

--- a/src/Html.php
+++ b/src/Html.php
@@ -655,6 +655,7 @@ TWIG,
             'is_anonymous_page'  => false,
             'css_files'          => [],
             'js_files'           => [],
+            'js_modules'         => [],
             'custom_header_tags' => [],
         ];
 
@@ -827,8 +828,8 @@ TWIG,
         // Send HTTP/2 103 Early Hints for critical assets (FrankenPHP/compatible servers)
         self::sendEarlyHints(
             $tpl_vars['css_files'],
-            $tpl_vars['js_files'] ?? [],
-            $tpl_vars['js_modules'] ?? []
+            $tpl_vars['js_files'],
+            $tpl_vars['js_modules']
         );
 
         if ($display) {
@@ -1672,9 +1673,9 @@ TWIG,
      * Only effective with FrankenPHP or servers supporting headers_send().
      * Falls back gracefully on traditional setups (Apache/nginx with php-fpm/mod_php).
      *
-     * @param array $css_files  CSS files array with 'path' key
-     * @param array $js_files   JS files array with 'path' key
-     * @param array $js_modules JS modules array with 'path' key
+     * @param array<array{path: string, options?: array<string, mixed>}> $css_files  CSS files array with 'path' key
+     * @param array<array{path: string, options?: array<string, mixed>}> $js_files   JS files array with 'path' key
+     * @param array<array{path: string, options?: array<string, mixed>}> $js_modules JS modules array with 'path' key
      */
     public static function sendEarlyHints(array $css_files, array $js_files = [], array $js_modules = []): void
     {
@@ -1711,7 +1712,7 @@ TWIG,
         }
 
         // Send 103 Early Hints response
-        headers_send(103); // @phpstan-ignore function.notFound (early-hint-specific function)
+        headers_send(103);
     }
 
     /**

--- a/src/Html.php
+++ b/src/Html.php
@@ -35,6 +35,7 @@
 
 use donatj\UserAgent\UserAgentParser;
 use Glpi\Application\Environment;
+use Glpi\Application\View\Extension\FrontEndAssetsExtension;
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\Asset\AssetDefinition;
 use Glpi\Asset\AssetDefinitionManager;
@@ -1683,7 +1684,7 @@ TWIG,
         }
 
         // Use the same path transformation as Twig templates
-        $assets = new \Glpi\Application\View\Extension\FrontEndAssetsExtension();
+        $assets = new FrontEndAssetsExtension();
 
         foreach ($css_files as $css) {
             $path = $css['path'] ?? '';


### PR DESCRIPTION
I wanted to try [frankenphp](https://frankenphp.dev) features, so:

- a custom worker script to be launched in persist mode. There is a package for symfony, see [doc](https://frankenphp.dev/fr/docs/worker/#runtime-symfony), I'll test later.
- early hints headers to indicate to the webservers that static assets can be loaded before waiting PHP to finish its computing part.

Currently, I launch the thing locally with frankenphp installed directly on the system:
`frankenphp php-server -r public/ --worker public/worker.php -l :8080 -v`

It's probably possible to launch it with docker, but their official image seems to lack mysqli extension.


At this point, it works ! It probably needs more work, test and obviously benchmarks (I didn't find a significant change on this point)

<details>

<summary>
**Edit benchmark:**
</summary>
scenario: index.php (login page) with TLS enabled, all debug disabled and following command:
`ab -n 500 -c 50 $URL 2>&1` (very quick setup)
maybe not representative of real GLPI usage (my sentiment on browsing GLPI, it's not evident), I'm not fully convinced how to make a real test (maybe with HLAPI)

## 📊 Final Benchmark Results (Debug Mode Disabled)

| Metric | FrankenPHP (HTTPS) | nginx + php-fpm (HTTPS) | Winner |
|--------|---------------------|------------------------|--------|
| **Requests/sec** | 110.49 | 67.28 | FrankenPHP 🏆 |
| **Time per request (mean)** | 453 ms | 743 ms | FrankenPHP 🏆 |
| **Total time for 500 requests** | 4.5 sec | 7.4 sec | FrankenPHP 🏆 |
| **Transfer rate** | 5.1 MB/sec | 3.1 MB/sec | FrankenPHP 🏆 |
| **Median response** | 431 ms | 699 ms | FrankenPHP 🏆 |
| **99th percentile** | 578 ms | 954 ms | FrankenPHP 🏆 |

### 📈 Performance Improvement

| Metric | FrankenPHP | nginx | Difference |
|--------|------------|-------|------------|
| Requests/sec | 110.49 | 67.28 | **+64%** |
| Latency (mean) | 453 ms | 743 ms | **-39%** |
| 99th percentile | 578 ms | 954 ms | **-39%** |

### 🎯 Conclusion

**FrankenPHP with worker mode is ~1.64x faster than nginx+php-fpm** with:
- Both using HTTPS/TLS 1.3
- Debug mode disabled
- FrankenPHP using 8 workers

</details>
