### PR TITLE
Fix Safe\preg_match(): Argument #2 ($subject) must be of type string, null given

### DIFF
--- a/src/RuleMailCollectorCollection.php
+++ b/src/RuleMailCollectorCollection.php
@@ -129,7 +129,7 @@ class RuleMailCollectorCollection extends RuleCollection
         }
 
         if (in_array('known_domain', $fields, true)) {
-            if (isset($input['from']) && $input['from'] !== null && preg_match("/@(.*)/", $input['from'], $results)) {
+            if (!empty($input['from']) && preg_match("/@(.*)/", $input['from'], $results)) {
                 if (Entity::getEntityIDByDomain($results[1]) !== -1) {
                     $input['KNOWN_DOMAIN'] = 1;
                 } else {

--- a/src/RuleMailCollectorCollection.php
+++ b/src/RuleMailCollectorCollection.php
@@ -129,7 +129,7 @@ class RuleMailCollectorCollection extends RuleCollection
         }
 
         if (in_array('known_domain', $fields, true)) {
-            if (!empty($input['from']) && preg_match("/@(.*)/", $input['from'], $results)) {
+            if (preg_match("/@(.*)/", $input['from'] ?? '', $results)) {
                 if (Entity::getEntityIDByDomain($results[1]) !== -1) {
                     $input['KNOWN_DOMAIN'] = 1;
                 } else {

--- a/src/RuleMailCollectorCollection.php
+++ b/src/RuleMailCollectorCollection.php
@@ -129,7 +129,7 @@ class RuleMailCollectorCollection extends RuleCollection
         }
 
         if (in_array('known_domain', $fields, true)) {
-            if (preg_match("/@(.*)/", $input['from'], $results)) {
+            if (isset($input['from']) && $input['from'] !== null && preg_match("/@(.*)/", $input['from'], $results)) {
                 if (Entity::getEntityIDByDomain($results[1]) !== -1) {
                     $input['KNOWN_DOMAIN'] = 1;
                 } else {


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !41647
- Here is a brief description of what this PR does
Fix this error :
```
glpi.ERROR:   *** Caught TypeError: Safe\preg_match(): Argument #2 ($subject) must be of type string, null given, called in ./src/RuleMailCollectorCollection.php on line 132
Backtrace :   ...hecodingmachine/safe/generated/8.3/pcre.php:613   ./src/RuleMailCollectorCollection.php:132          Safe\preg_match()   ./src/RuleCollection.php:1693                     
RuleMailCollectorCollection->prepareInputDataForProcess()   ./src/RuleCollection.php:1526                      
RuleCollection->prepareInputDataForProcessWithPlugins()   ./src/MailCollector.php:1173                       R
uleCollection->processAllRules()   ./src/MailCollector.php:697                        
MailCollector->buildTicket()   ...temType/Form/MailCollectorFormController.php:56 MailCollector->collect()   ./vendor/symfony/http-kernel/HttpKernel.php:181    
Glpi\Controller\ItemType\Form\MailCollectorFormController->__invoke()   ./vendor/symfony/http-kernel/HttpKernel.php:76     
Symfony\Component\HttpKernel\HttpKernel->handleRaw()   ./vendor/symfony/http-kernel/Kernel.php:197        
Symfony\Component\HttpKernel\HttpKernel->handle()   ./public/index.php:70                              
Symfony\Component\HttpKernel\Kernel->handle() 
```

## Screenshots (if appropriate):


