### PR TITLE
Fix(Password): Fix 'token' URL

### DIFF
--- a/src/NotificationTargetUser.php
+++ b/src/NotificationTargetUser.php
@@ -170,12 +170,12 @@ class NotificationTargetUser extends NotificationTarget
                 $routes = [
                     'passwordforget' => [
                         'key'  => '##user.passwordforgeturl##',
-                        'path' => '/front/lostpassword.php'
+                        'path' => '/front/lostpassword.php',
                     ],
                     'passwordinit' => [
                         'key'  => '##user.passwordiniturl##',
-                        'path' => '/front/initpassword.php'
-                    ]
+                        'path' => '/front/initpassword.php',
+                    ],
                 ];
 
                 $this->data[$routes[$event]['key']] = urldecode(

--- a/src/NotificationTargetUser.php
+++ b/src/NotificationTargetUser.php
@@ -63,7 +63,7 @@ class NotificationTargetUser extends NotificationTarget
     #[Override]
     public function canNotificationContentBeDisclosed(string $event): bool
     {
-        if ($event === 'passwordforget') {
+        if ($event === 'passwordforget' || $event === 'passwordinit') {
             return false;
         }
 
@@ -161,19 +161,29 @@ class NotificationTargetUser extends NotificationTarget
                 );
                 break;
             case 'passwordforget':
+            case 'passwordinit':
                 $encrypted_token = $this->obj->fields['password_forget_token'];
                 $token = (new GLPIKey())->decrypt($encrypted_token);
 
-                $this->data['##user.token##']             = $token;
-                $this->data['##user.passwordforgeturl##'] = urldecode($this->getUrlBase()
-                . "/front/lostpassword.php?password_forget_token="
-                . $token);
-                break;
-            case 'passwordinit':
-                $this->data['##user.token##']           = $this->obj->getField("password_forget_token");
-                $this->data['##user.passwordiniturl##'] = urldecode($CFG_GLPI["url_base"]
-                . "/front/initpassword.php?password_forget_token="
-                . $this->obj->getField("password_forget_token"));
+                $this->data['##user.token##'] = $token;
+
+                $routes = [
+                    'passwordforget' => [
+                        'key'  => '##user.passwordforgeturl##',
+                        'path' => '/front/lostpassword.php'
+                    ],
+                    'passwordinit' => [
+                        'key'  => '##user.passwordiniturl##',
+                        'path' => '/front/initpassword.php'
+                    ]
+                ];
+
+                $this->data[$routes[$event]['key']] = urldecode(
+                    $this->getUrlBase()
+                    . $routes[$event]['path']
+                    . '?password_forget_token='
+                    . $token
+                );
                 break;
         }
 


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !41478

When the `initpassword` process is triggered (during user creation), the email containing the `password_forget_token` is not properly decrypted, unlike the `passwordforget` process.

This fix addresses this first issue.

Additionally, in the mail queue, the URL containing the token is displayed, unlike the URL used in the `passwordforget` process.

This pull request also fixes this issue.


## Screenshots (if appropriate):


