### PR TITLE
Delete KB comments

### DIFF
--- a/js/glpi_dialog.js
+++ b/js/glpi_dialog.js
@@ -326,6 +326,74 @@ var glpi_close_all_dialogs = function() {
     $('.modal.show').modal('hide').remove();
 };
 
+
+/**
+ * Create a danger confirmation dialog with Tabler styling
+ *
+ * @param {Object} options - options
+ * @param {string} options.title - string to display as the modal title
+ * @param {string} options.message - html string to display as the modal message
+ * @param {string} options.id - id attribute of the modal
+ * @param {string} options.confirm_label - change "confirm" button label
+ * @param {string} options.cancel_label - change "cancel" button label
+ * @returns {Promise<boolean>} - resolves to true if confirmed, false if cancelled
+ */
+var glpi_confirm_danger = function({
+    title         = __('Are you sure?'),
+    message       = "",
+    id            = `modal_${Math.random().toString(36).substring(7)}`,
+    confirm_label = _x('button', 'Confirm'),
+    cancel_label  = _x('button', 'Cancel'),
+} = {}) {
+    return new Promise((resolve) => {
+        // remove old modal
+        glpi_close_all_dialogs();
+
+        const confirm_btn_id = `${id}_confirm`;
+        const cancel_btn_id = `${id}_cancel`;
+
+        // Create a modal with tabler classes
+        const modal_html = `
+            <div class="modal modal-blur fade" id="${_.escape(id)}" tabindex="-1" role="dialog" aria-hidden="true">
+                <div class="modal-dialog modal-sm modal-dialog-centered" role="document">
+                    <div class="modal-content">
+                        <div class="modal-body">
+                            <div class="modal-title">${title}</div>
+                            <div>${message}</div>
+                        </div>
+                        <div class="modal-footer">
+                            <button type="button" id="${_.escape(cancel_btn_id)}" class="btn btn-link link-secondary me-auto" data-bs-dismiss="modal">${cancel_label}</button>
+                            <button type="button" id="${_.escape(confirm_btn_id)}" class="btn btn-danger" data-bs-dismiss="modal">${confirm_label}</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        `;
+        $('body').append(modal_html);
+
+        let confirmed = false;
+        $(`#${CSS.escape(confirm_btn_id)}`).on('click', () => {
+            confirmed = true;
+        });
+
+        const modal_el = document.getElementById(id);
+        const modal = new bootstrap.Modal(modal_el, {});
+
+        modal_el.addEventListener('hidden.bs.modal', () => {
+            // Defensive cleanup code, won't be needed most of the time
+            if ($('div.modal.show').length === 0) {
+                $('div.modal-backdrop').remove();
+            }
+
+            $(`#${CSS.escape(id)}`).remove();
+            resolve(confirmed);
+        });
+
+        modal.show();
+    });
+};
+
+
 var toast_id = 0;
 
 /**

--- a/js/modules/Knowbase/ArticleController.js
+++ b/js/modules/Knowbase/ArticleController.js
@@ -130,7 +130,7 @@ export class GlpiKnowbaseArticleController
     {
         const value = toggle.checked;
         try {
-            await post(`Knowbase/KnowbaseItem/${id}/ToggleField`, {
+            await post(`Knowbase/${id}/ToggleField`, {
                 field: field,
                 value: value,
             });

--- a/js/modules/Knowbase/CommentsPanelController.js
+++ b/js/modules/Knowbase/CommentsPanelController.js
@@ -140,7 +140,7 @@ export class GlpiKnowbaseCommentsPanelController
         data.append('content', textarea.value);
 
         const base_url = CFG_GLPI.root_doc;
-        const url = `${base_url}/Knowbase/Comment/${comment_id}/Update`;
+        const url = `${base_url}/Knowbase/UpdateComment/${comment_id}`;
         const response = await fetch(url, {
             method: "POST",
             body: data,
@@ -185,7 +185,7 @@ export class GlpiKnowbaseCommentsPanelController
 
         // Delete comment on the backend
         const base_url = CFG_GLPI.root_doc;
-        const url = `${base_url}/Knowbase/Comment/${comment_id}/Delete`;
+        const url = `${base_url}/Knowbase/DeleteComment/${comment_id}`;
         const response = await fetch(url, {
             method: "POST",
             headers: {

--- a/src/Glpi/Controller/Knowbase/AddCommentController.php
+++ b/src/Glpi/Controller/Knowbase/AddCommentController.php
@@ -89,6 +89,7 @@ final class AddCommentController extends AbstractController
             'date_creation' => $comment->fields['date_creation'],
             'comment'       => $comment->fields['comment'],
             'can_edit'      => true,
+            'can_delete'    => true,
         ]);
     }
 }

--- a/src/Glpi/Controller/Knowbase/DeleteCommentController.php
+++ b/src/Glpi/Controller/Knowbase/DeleteCommentController.php
@@ -46,8 +46,8 @@ use Symfony\Component\Routing\Attribute\Route;
 final class DeleteCommentController extends AbstractController
 {
     #[Route(
-        "/Knowbase/Comment/{id}/Delete",
-        name: "knowbase_comment_delete",
+        "/Knowbase/DeleteComment/{id}",
+        name: "knowbase_delete_comment",
         methods: ["POST"],
         requirements: [
             'id' => '\d+',

--- a/src/Glpi/Controller/Knowbase/SidePanelController.php
+++ b/src/Glpi/Controller/Knowbase/SidePanelController.php
@@ -43,11 +43,11 @@ use KnowbaseItem;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
-final class ArticleSidePanelController extends AbstractController
+final class SidePanelController extends AbstractController
 {
     #[Route(
         "/Knowbase/{id}/SidePanel/{key}",
-        name: "knowbase_article_side_panel",
+        name: "knowbase_side_panel",
         requirements: [
             'id' => '\d+',
         ]

--- a/src/Glpi/Controller/Knowbase/ToggleFieldController.php
+++ b/src/Glpi/Controller/Knowbase/ToggleFieldController.php
@@ -51,7 +51,7 @@ final class ToggleFieldController extends AbstractController
     private const ALLOWED_FIELDS = ['is_faq'];
 
     #[Route(
-        "/Knowbase/KnowbaseItem/{id}/ToggleField",
+        "/Knowbase/{id}/ToggleField",
         name: "knowbase_toggle_field",
         requirements: [
             'id' => '\d+',

--- a/src/Glpi/Controller/Knowbase/UpdateCommentController.php
+++ b/src/Glpi/Controller/Knowbase/UpdateCommentController.php
@@ -48,8 +48,8 @@ final class UpdateCommentController extends AbstractController
     use CrudControllerTrait;
 
     #[Route(
-        "/Knowbase/Comment/{id}/Update",
-        name: "knowbase_comment_update",
+        "/Knowbase/UpdateComment/{id}",
+        name: "knowbase_update_comment",
         methods: ["POST"],
         requirements: [
             'id' => '\d+',

--- a/src/KnowbaseItem_Comment.php
+++ b/src/KnowbaseItem_Comment.php
@@ -99,7 +99,15 @@ class KnowbaseItem_Comment extends CommonDBTM
 
     public function canDeleteItem(): bool
     {
-        return $this->canUpdateItem();
+        if (!$this->canComment()) {
+            return false;
+        }
+
+        // Users can delete their own comments and admins can delete all comments
+        return
+            Session::getLoginUserID() === $this->fields['users_id']
+            || Session::haveRight(KnowbaseItem::$rightname, KnowbaseItem::KNOWBASEADMIN)
+        ;
     }
 
     public function canPurgeItem(): bool

--- a/templates/pages/tools/kb/sidepanel/comment.html.twig
+++ b/templates/pages/tools/kb/sidepanel/comment.html.twig
@@ -54,7 +54,7 @@
                         {{ date_creation|relative_datetime }}
                     </span>
                 </div>
-                {% set has_actions = can_edit %}
+                {% set has_actions = can_edit or can_delete %}
                 {% if has_actions %}
                     <div class="dropdown ms-2">
                         <button
@@ -70,9 +70,27 @@
                         <ul class="dropdown-menu dropdown-menu-end">
                             {% if can_edit %}
                                 <li>
-                                    <button type="button" class="dropdown-item" data-glpi-comment-edit>
+                                    <button
+                                        type="button"
+                                        class="dropdown-item"
+                                        data-glpi-comment-edit
+                                        aria-label="{{ __('Edit comment') }}"
+                                    >
                                         <i class="ti ti-edit me-2"></i>
                                         <span>{{ __('Edit comment') }}</span>
+                                    </button>
+                                </li>
+                            {% endif %}
+                            {% if can_delete %}
+                                <li>
+                                    <button
+                                        type="button"
+                                        class="dropdown-item text-danger"
+                                        data-glpi-comment-delete
+                                        aria-label="{{ __('Delete comment') }}"
+                                    >
+                                        <i class="ti ti-trash me-2"></i>
+                                        <span>{{ __('Delete comment') }}</span>
                                     </button>
                                 </li>
                             {% endif %}

--- a/templates/pages/tools/kb/sidepanel/comments.html.twig
+++ b/templates/pages/tools/kb/sidepanel/comments.html.twig
@@ -46,6 +46,7 @@
                 date_creation: comment.date_creation,
                 comment: comment.comment,
                 can_edit: comment.can_edit ?? false,
+                can_delete: comment.can_delete ?? false,
             }, with_context = false) }}
         {% endfor %}
     </div>

--- a/tests/e2e/pages/GlpiPage.ts
+++ b/tests/e2e/pages/GlpiPage.ts
@@ -379,6 +379,16 @@ export class GlpiPage
         ;
     }
 
+    public getDialog(text: string): Locator
+    {
+        return this.page.getByRole('dialog')
+            .filter({
+                visible: true,
+                hasText: text,
+            })
+        ;
+    }
+
     public getEntityFromTree(name: string): Locator
     {
         return this.page.getByRole('gridcell', {


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Allow users to delete KB comments.

<img width="234" height="159" alt="image" src="https://github.com/user-attachments/assets/63b0ff46-0fbe-4fb3-ab57-eb904699523d" />

There is a confirmation modal:

<img width="441" height="255" alt="image" src="https://github.com/user-attachments/assets/ed12cb85-90a6-45aa-84c5-7dafb8056311" />

For this modal, I've made a re-usable method in glpi_dialog.js as it is a case we often encounter and the existing methods didn't provide a good enough option.
