### PR TITLE
Fix(CI): directly show error log

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -362,13 +362,6 @@ jobs:
           name: playwright-report
           path: playwright-report/
           retention-days: 30
-      - name: "Upload GLPI logs"
-        if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v6
-        with:
-          name: glpi-playwright-logs
-          path: tests/e2e/glpi_files/_log
-          retention-days: 7
       - name: Publish test summary results
         if: ${{ !cancelled() }}
         run: npx github-actions-ctrf ctrf/ctrf-report.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -352,6 +352,8 @@ jobs:
           grep -v '\*\*\* Test logger' tests/e2e/glpi_files/_log/php-errors.log > /tmp/php-errors-filtered.log || true
           if [[ $(wc -l < /tmp/php-errors-filtered.log) -ge 1 ]]; then
             echo "PHP errors detected in log file"
+            echo "==============================="
+            cat /tmp/php-errors-filtered.log
             exit 1
           fi
       - uses: actions/upload-artifact@v6


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes #N/A

When this step fails, the message only states that there is an error, and you have to download a zip file with all the logs from the next step to find out what went wrong. I suggest displaying the error message directly.

<img width="930" height="159" alt="image" src="https://github.com/user-attachments/assets/cb6e7713-4dfd-4e76-bf7f-1b8cc20e558b" />

Exemple: https://github.com/glpi-project/glpi/actions/runs/21364208726/job/61491329780

## Screenshots (if appropriate):


