### PR TITLE
fix(notification): fix missing attachments in notification emails

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -7998,7 +7998,10 @@ abstract class CommonITILObject extends CommonDBTM
         // documents associated to followups
         if (
             $bypass_rights ||
-            ITILFollowup::canView() ||
+            (
+                $user === null &&
+                ITILFollowup::canView()
+            ) ||
             (
                 $user !== null &&
                 $user->hasRightsOr($this->getType(), $can_view_itilobject[$this->getType()], $this->fields['entities_id']) &&
@@ -8039,7 +8042,10 @@ abstract class CommonITILObject extends CommonDBTM
         // documents associated to solutions
         if (
             $bypass_rights ||
-            ITILSolution::canView() ||
+            (
+                $user === null &&
+                ITILSolution::canView()
+            ) ||
             (
                 $user !== null &&
                 $user->hasRightsOr($this->getType(), $can_view_itilobject[$this->getType()], $this->fields['entities_id'])
@@ -8070,6 +8076,10 @@ abstract class CommonITILObject extends CommonDBTM
             (
                 $bypass_rights ||
                 (
+                    $user === null &&
+                    $validation_class::canView()
+                ) ||
+                (
                     $user !== null &&
                     $user->hasRightsOr($this->getType(), $can_view_itilobject[$this->getType()], $this->fields['entities_id'])
                 )
@@ -8095,7 +8105,10 @@ abstract class CommonITILObject extends CommonDBTM
         // documents associated to tasks
         if (
             $bypass_rights ||
-            $task_class::canView() ||
+            (
+                $user === null &&
+                $task_class::canView()
+            ) ||
             (
                 $user !== null &&
                 $user->hasRightsOr($this->getType(), $can_view_itilobject[$this->getType()], $this->fields['entities_id'])

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -7973,13 +7973,13 @@ abstract class CommonITILObject extends CommonDBTM
         $can_view_itilobject = [
             Ticket::class => [
                 Ticket::READALL, Ticket::READMY, UPDATE,
-                Ticket::READASSIGN, Ticket::READGROUP, Ticket::OWN, READ
+                Ticket::READASSIGN, Ticket::READGROUP, Ticket::OWN, READ,
             ],
             Change::class => [
-                Change::READALL, Change::READMY
+                Change::READALL, Change::READMY,
             ],
             Problem::class => [
-                Problem::READALL, Problem::READMY
+                Problem::READALL, Problem::READMY,
             ],
         ];
 

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -7998,10 +7998,7 @@ abstract class CommonITILObject extends CommonDBTM
         // documents associated to followups
         if (
             $bypass_rights ||
-            (
-                $user === null &&
-                ITILFollowup::canView()
-            ) ||
+            ITILFollowup::canView() ||
             (
                 $user !== null &&
                 $user->hasRightsOr($this->getType(), $can_view_itilobject[$this->getType()], $this->fields['entities_id']) &&
@@ -8042,10 +8039,7 @@ abstract class CommonITILObject extends CommonDBTM
         // documents associated to solutions
         if (
             $bypass_rights ||
-            (
-                $user === null &&
-                ITILSolution::canView()
-            ) ||
+            ITILSolution::canView() ||
             (
                 $user !== null &&
                 $user->hasRightsOr($this->getType(), $can_view_itilobject[$this->getType()], $this->fields['entities_id'])
@@ -8075,10 +8069,7 @@ abstract class CommonITILObject extends CommonDBTM
             class_exists($validation_class) &&
             (
                 $bypass_rights ||
-                (
-                    $user === null &&
-                    $validation_class::canView()
-                ) ||
+                $validation_class::canView() ||
                 (
                     $user !== null &&
                     $user->hasRightsOr($this->getType(), $can_view_itilobject[$this->getType()], $this->fields['entities_id'])
@@ -8105,10 +8096,7 @@ abstract class CommonITILObject extends CommonDBTM
         // documents associated to tasks
         if (
             $bypass_rights ||
-            (
-                $user === null &&
-                $task_class::canView()
-            ) ||
+            $task_class::canView() ||
             (
                 $user !== null &&
                 $user->hasRightsOr($this->getType(), $can_view_itilobject[$this->getType()], $this->fields['entities_id'])

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -8001,7 +8001,7 @@ abstract class CommonITILObject extends CommonDBTM
             ITILFollowup::canView() ||
             (
                 $user !== null &&
-                $user->hasRightsOr($this->getType(), $can_view_itilobject[$this->getType()], $this->fields['entities_id']) &&
+                $user->hasRightsOr(static::$rightname, $can_view_itilobject[$this->getType()], $this->fields['entities_id']) &&
                 $user->hasRight(ITILFollowup::$rightname, ITILFollowup::SEEPUBLIC, $this->fields['entities_id'])
             )
         ) {
@@ -8042,7 +8042,7 @@ abstract class CommonITILObject extends CommonDBTM
             ITILSolution::canView() ||
             (
                 $user !== null &&
-                $user->hasRightsOr($this->getType(), $can_view_itilobject[$this->getType()], $this->fields['entities_id'])
+                $user->hasRightsOr(static::$rightname, $can_view_itilobject[$this->getType()], $this->fields['entities_id'])
             )
         ) {
             // Run the subquery separately. It's better for huge databases
@@ -8072,7 +8072,16 @@ abstract class CommonITILObject extends CommonDBTM
                 $validation_class::canView() ||
                 (
                     $user !== null &&
-                    $user->hasRightsOr($this->getType(), $can_view_itilobject[$this->getType()], $this->fields['entities_id'])
+                    $user->hasRightsOr(static::$rightname, $can_view_itilobject[$this->getType()], $this->fields['entities_id']) &&
+                    $user->hasRightsOr(
+                        $validation_class::$rightname,
+                        array_merge(
+                            $validation_class::getCreateRights(),
+                            $validation_class::getValidateRights(),
+                            $validation_class::getPurgeRights()
+                        ),
+                        $this->fields['entities_id']
+                    )
                 )
             )
         ) {
@@ -8099,7 +8108,8 @@ abstract class CommonITILObject extends CommonDBTM
             $task_class::canView() ||
             (
                 $user !== null &&
-                $user->hasRightsOr($this->getType(), $can_view_itilobject[$this->getType()], $this->fields['entities_id'])
+                $user->hasRightsOr(static::$rightname, $can_view_itilobject[$this->getType()], $this->fields['entities_id']) &&
+                $user->hasRight($task_class::$rightname, $task_class::SEEPUBLIC, $this->fields['entities_id'])
             )
         ) {
             $tasks_crit = [

--- a/src/User.php
+++ b/src/User.php
@@ -7101,7 +7101,7 @@ HTML;
      * @param array   $rights Rights to check
      * @param integer $entities_id Entity to check
      *
-     * @return boolean|int
+     * @return bool
      **/
     public function hasRightsOr($module, $rights, $entities_id)
     {

--- a/src/User.php
+++ b/src/User.php
@@ -7098,7 +7098,7 @@ HTML;
      * User has at least one of the rights for given module.
      *
      * @param string  $module Module to check
-     * @param integer $right  Right to check
+     * @param array   $rights Rights to check
      * @param integer $entities_id Entity to check
      *
      * @return boolean|int

--- a/src/User.php
+++ b/src/User.php
@@ -7093,4 +7093,23 @@ HTML;
         }
         return false;
     }
+
+    /**
+     * User has at least one of the rights for given module.
+     *
+     * @param string  $module Module to check
+     * @param integer $right  Right to check
+     * @param integer $entities_id Entity to check
+     *
+     * @return boolean|int
+     **/
+    public function hasRightsOr($module, $rights, $entities_id)
+    {
+        foreach ($rights as $right) {
+            if ($this->hasRight($module, $right, $entities_id)) {
+                return true;
+            }
+        }
+        return false;
+    }
 }


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !41656
- Attachments were not attached to notifications when no session was active. For example, when a notification is sent via CLI. If permissions are not bypassed, permissions will be checked using the canView method, or if no session is active, this will return false. 


