### PR TITLE
fix(forms): Add attachment question for default incident and request forms

### DIFF
--- a/src/Glpi/Helpdesk/DefaultDataManager.php
+++ b/src/Glpi/Helpdesk/DefaultDataManager.php
@@ -48,6 +48,7 @@ use Glpi\Form\Destination\CommonITILField\SimpleValueConfig;
 use Glpi\Form\Destination\CommonITILField\TitleField;
 use Glpi\Form\Form;
 use Glpi\Form\Question;
+use Glpi\Form\QuestionType\QuestionTypeFile;
 use Glpi\Form\QuestionType\QuestionTypeItemDropdown;
 use Glpi\Form\QuestionType\QuestionTypeLongText;
 use Glpi\Form\QuestionType\QuestionTypeObserver;
@@ -315,6 +316,7 @@ final class DefaultDataManager
         $this->addQuestion($section, $this->getLocationQuestionData());
         $title_question = $this->addQuestion($section, $this->getTitleQuestionData());
         $description_question = $this->addQuestion($section, $this->getDescriptionQuestionData());
+        $this->addQuestion($section, $this->getAttachmentsQuestionData());
 
         // Find title and description question tags, needed to configure the created ticket
         $title_tag = $this->answer_tag_provider->getTagForQuestion(
@@ -375,6 +377,7 @@ final class DefaultDataManager
         $this->addQuestion($section, $this->getLocationQuestionData());
         $title_question = $this->addQuestion($section, $this->getTitleQuestionData());
         $description_question = $this->addQuestion($section, $this->getDescriptionQuestionData());
+        $this->addQuestion($section, $this->getAttachmentsQuestionData());
 
         // Find title and description question tags, needed to configure the created ticket
         $title_tag = $this->answer_tag_provider->getTagForQuestion(
@@ -537,6 +540,17 @@ final class DefaultDataManager
             'type' => QuestionTypeObserver::class,
             'name' => _n('Observer', 'Observers', Session::getPluralNumber()),
             'extra_data' => json_encode(['is_multiple_actors' => true]),
+        ];
+    }
+
+    /**
+     * @return array{'type': class-string, 'name': string}
+     */
+    private function getAttachmentsQuestionData(): array
+    {
+        return [
+            'type' => QuestionTypeFile::class,
+            'name' => __("Attachments"),
         ];
     }
 

--- a/tests/src/FormTesterTrait.php
+++ b/tests/src/FormTesterTrait.php
@@ -44,6 +44,7 @@ use Glpi\Form\Comment;
 use Glpi\Form\Condition\Type;
 use Glpi\Form\Destination\CommonITILField\SimpleValueConfig;
 use Glpi\Form\Destination\FormDestination;
+use Glpi\Form\EndUserInputNameProvider;
 use Glpi\Form\Export\Context\DatabaseMapper;
 use Glpi\Form\Form;
 use Glpi\Form\FormTranslation;
@@ -674,6 +675,7 @@ trait FormTesterTrait
     protected function sendFormAndGetAnswerSet(
         Form $form,
         array $answers = [],
+        array $files = [],
     ): AnswersSet {
         // The provider use a simplified answer format to be more readable.
         // Rewrite answers into expected format.
@@ -692,15 +694,17 @@ trait FormTesterTrait
         return $answers_handler->saveAnswers(
             $form,
             $formatted_answers,
-            getItemByTypeName(User::class, TU_USER, true)
+            getItemByTypeName(User::class, TU_USER, true),
+            $files
         );
     }
 
     protected function sendFormAndGetCreatedTicket(
         Form $form, // We assume $form has a single "Ticket" destination
         array $answers = [],
+        array $files = [],
     ): Ticket {
-        $answers = $this->sendFormAndGetAnswerSet($form, $answers);
+        $answers = $this->sendFormAndGetAnswerSet($form, $answers, $files);
 
         // Get created ticket
         $created_items = $answers->getCreatedItems();

--- a/tests/src/FormTesterTrait.php
+++ b/tests/src/FormTesterTrait.php
@@ -44,7 +44,6 @@ use Glpi\Form\Comment;
 use Glpi\Form\Condition\Type;
 use Glpi\Form\Destination\CommonITILField\SimpleValueConfig;
 use Glpi\Form\Destination\FormDestination;
-use Glpi\Form\EndUserInputNameProvider;
 use Glpi\Form\Export\Context\DatabaseMapper;
 use Glpi\Form\Form;
 use Glpi\Form\FormTranslation;


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes #22798

Since the integration of formcreator into the core, as well as the work done on the helpdesk interface, the default ticket creation form has been replaced by two native forms.
These two forms include all the questions that were asked in the old form, with the aim of having the same behavior (creating a ticket by defining certain fields).
However, in the old form it was possible to add attachments to the ticket created.
This option has not been carried over to the new forms.

This PR therefore adds a File type question to the two default forms to restore the previous behavior.

## Screenshots

### Old form
<img width="818" height="799" alt="image" src="https://github.com/user-attachments/assets/e655db4e-8cf0-40e8-bddb-fa5a907dd6d6" />

### New form
<img width="1005" height="1077" alt="image" src="https://github.com/user-attachments/assets/6e2c7f32-b16f-4d2c-9c4e-5833de95bb4c" />
