### PR TITLE
KB permissions modal

### DIFF
--- a/js/modules/Knowbase/ArticleController.js
+++ b/js/modules/Knowbase/ArticleController.js
@@ -30,7 +30,7 @@
  * ---------------------------------------------------------------------
  */
 
-/* global glpi_toast_error, glpi_confirm_danger */
+/* global glpi_toast_error, glpi_confirm_danger, glpi_ajax_dialog */
 
 import { post } from "/js/modules/Ajax.js";
 import { GlpiKnowbaseArticleSidePanelController } from "/js/modules/Knowbase/ArticleSidePanelController.js";
@@ -111,6 +111,9 @@ export class GlpiKnowbaseArticleController
             case 'DELETE_ARTICLE':
                 this.#deleteItem(params.id);
                 break;
+            case 'LOAD_MODAL':
+                this.#loadModal(params.id, params.key, params.title);
+                break;
         }
     }
 
@@ -166,5 +169,20 @@ export class GlpiKnowbaseArticleController
         const response = await post(`Knowbase/KnowbaseItem/${id}/Delete`, {});
         const body = await response.json();
         window.location.href = body.redirect;
+    }
+
+    /**
+     * Load content in a modal dialog
+     * @param {string} id - KnowbaseItem ID
+     * @param {string} key - Content key (e.g., 'permissions')
+     * @param {string} title - Modal title
+     */
+    #loadModal(id, key, title)
+    {
+        glpi_ajax_dialog({
+            url: `${CFG_GLPI.root_doc}/Knowbase/${id}/SidePanel/${key}`,
+            title: title || '',
+            dialogclass: 'modal-lg',
+        });
     }
 }

--- a/src/Glpi/Controller/Knowbase/SidePanelController.php
+++ b/src/Glpi/Controller/Knowbase/SidePanelController.php
@@ -38,6 +38,7 @@ use Glpi\Controller\AbstractController;
 use Glpi\Exception\Http\AccessDeniedHttpException;
 use Glpi\Exception\Http\BadRequestHttpException;
 use Glpi\Knowbase\SidePanel\CommentsRenderer;
+use Glpi\Knowbase\SidePanel\PermissionsRenderer;
 use Glpi\Knowbase\SidePanel\RendererInterface;
 use Glpi\Knowbase\SidePanel\RevisionsRenderer;
 use Glpi\Knowbase\SidePanel\ServiceCatalogRenderer;
@@ -84,6 +85,7 @@ final class SidePanelController extends AbstractController
             'comments'        => new CommentsRenderer(),
             'service-catalog' => new ServiceCatalogRenderer(),
             'revisions'       => new RevisionsRenderer(),
+            'permissions'     => new PermissionsRenderer(),
             default           => throw new BadRequestHttpException(),
         };
     }

--- a/src/Glpi/Knowbase/SidePanel/PermissionsRenderer.php
+++ b/src/Glpi/Knowbase/SidePanel/PermissionsRenderer.php
@@ -1,0 +1,231 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Knowbase\SidePanel;
+
+use Dropdown;
+use Entity;
+use Entity_KnowbaseItem;
+use Group;
+use Group_KnowbaseItem;
+use Html;
+use KnowbaseItem;
+use KnowbaseItem_Profile;
+use KnowbaseItem_User;
+use Override;
+use Profile;
+use Session;
+use User;
+
+final class PermissionsRenderer implements RendererInterface
+{
+    #[Override]
+    public function canView(KnowbaseItem $item): bool
+    {
+        return $item->can($item->getID(), READ);
+    }
+
+    #[Override]
+    public function getTemplate(): string
+    {
+        return "pages/tools/kb/modal/permissions.html.twig";
+    }
+
+    #[Override]
+    public function getParams(KnowbaseItem $item): array
+    {
+        $id = $item->getID();
+        $can_edit = $item->canEdit($id);
+        $rand = mt_rand();
+
+        $entries = $this->buildEntries($item);
+
+        $visiblity_dropdown_params = [
+            'type'  => '__VALUE__',
+            'right' => 'knowbaseitem_public',
+        ];
+        if (isset($item->fields['entities_id'])) {
+            $visiblity_dropdown_params['entity'] = $item->fields['entities_id'];
+        }
+        if (isset($item->fields['is_recursive'])) {
+            $visiblity_dropdown_params['is_recursive'] = $item->fields['is_recursive'];
+        }
+
+        $massive_action_params = [
+            'num_displayed' => count($entries),
+            'container' => 'mass' . KnowbaseItem::class . $rand,
+            'specific_actions' => ['delete' => _x('button', 'Delete permanently')],
+        ];
+        if ($item->fields['users_id'] !== Session::getLoginUserID()) {
+            $massive_action_params['confirm'] = __('Caution! You are not the author of this item. Deleting targets can result in loss of access.');
+        }
+
+        return [
+            'id' => $id,
+            'rand' => $rand,
+            'can_edit' => $can_edit,
+            'entries' => $entries,
+            'visiblity_dropdown_params' => $visiblity_dropdown_params,
+            'massive_action_params' => $massive_action_params,
+        ];
+    }
+
+    /**
+     * Build entries array for the permissions datatable
+     *
+     * @param KnowbaseItem $item
+     * @return array<int, array{itemtype: string, id: int, type: string, recipient: string}>
+     */
+    private function buildEntries(KnowbaseItem $item): array
+    {
+        $id = $item->getID();
+        $entries = [];
+
+        $users = KnowbaseItem_User::getUsers($id);
+        foreach ($users as $val) {
+            foreach ($val as $data) {
+                $entries[] = [
+                    'itemtype' => 'KnowbaseItem_User',
+                    'id' => $data['id'],
+                    'type' => User::getTypeName(1),
+                    'recipient' => htmlescape(getUserName($data['users_id'])),
+                ];
+            }
+        }
+
+        $groups = Group_KnowbaseItem::getGroups($id);
+        foreach ($groups as $val) {
+            foreach ($val as $data) {
+                $name = Dropdown::getDropdownName('glpi_groups', $data['groups_id']);
+                $tooltip = Dropdown::getDropdownComments('glpi_groups', (int) $data['groups_id']);
+                $recipient = sprintf(
+                    __s('%1$s %2$s'),
+                    htmlescape($name),
+                    Html::showToolTip($tooltip, ['display' => false])
+                );
+                if ($data['entities_id'] !== null) {
+                    $recipient = sprintf(
+                        __s('%1$s / %2$s'),
+                        $recipient,
+                        htmlescape(
+                            Dropdown::getDropdownName(
+                                'glpi_entities',
+                                $data['entities_id']
+                            )
+                        )
+                    );
+                    if ($data['is_recursive']) {
+                        $recipient = sprintf(
+                            __s('%1$s %2$s'),
+                            $recipient,
+                            "<span class='fw-bold'>(" . __s('R') . ")</span>"
+                        );
+                    }
+                }
+                $entries[] = [
+                    'itemtype' => 'Group_KnowbaseItem',
+                    'id' => $data['id'],
+                    'type' => Group::getTypeName(1),
+                    'recipient' => $recipient,
+                ];
+            }
+        }
+
+        $entities = Entity_KnowbaseItem::getEntities($id);
+        foreach ($entities as $val) {
+            foreach ($val as $data) {
+                $name = Dropdown::getDropdownName('glpi_entities', $data['entities_id']);
+                $tooltip = Dropdown::getDropdownComments('glpi_entities', (int) $data['entities_id']);
+                $recipient = sprintf(
+                    __s('%1$s %2$s'),
+                    htmlescape($name),
+                    Html::showToolTip($tooltip, ['display' => false])
+                );
+                if ($data['is_recursive']) {
+                    $recipient = sprintf(
+                        __s('%1$s %2$s'),
+                        $recipient,
+                        "<span class='fw-bold'>(" . __s('R') . ")</span>"
+                    );
+                }
+                $entries[] = [
+                    'itemtype' => 'Entity_KnowbaseItem',
+                    'id' => $data['id'],
+                    'type' => Entity::getTypeName(1),
+                    'recipient' => $recipient,
+                ];
+            }
+        }
+
+        $profiles = KnowbaseItem_Profile::getProfiles($id);
+        foreach ($profiles as $val) {
+            foreach ($val as $data) {
+                $name = Dropdown::getDropdownName('glpi_profiles', $data['profiles_id']);
+                $tooltip = Dropdown::getDropdownComments('glpi_profiles', (int) $data['profiles_id']);
+                $recipient = sprintf(
+                    __s('%1$s %2$s'),
+                    htmlescape($name),
+                    Html::showToolTip($tooltip, ['display' => false])
+                );
+                if ($data['entities_id'] !== null) {
+                    $recipient = sprintf(
+                        __s('%1$s / %2$s'),
+                        $recipient,
+                        htmlescape(
+                            Dropdown::getDropdownName(
+                                'glpi_entities',
+                                $data['entities_id']
+                            )
+                        )
+                    );
+                    if ($data['is_recursive']) {
+                        $recipient = sprintf(
+                            __s('%1$s %2$s'),
+                            $recipient,
+                            "<span class='fw-bold'>(" . __s('R') . ")</span>"
+                        );
+                    }
+                }
+                $entries[] = [
+                    'itemtype' => 'KnowbaseItem_Profile',
+                    'id' => $data['id'],
+                    'type' => Profile::getTypeName(1),
+                    'recipient' => $recipient,
+                ];
+            }
+        }
+
+        return $entries;
+    }
+}

--- a/src/Glpi/Knowbase/SidePanel/PermissionsRenderer.php
+++ b/src/Glpi/Knowbase/SidePanel/PermissionsRenderer.php
@@ -73,7 +73,8 @@ final class PermissionsRenderer implements RendererInterface
 
         $visiblity_dropdown_params = [
             'type'  => '__VALUE__',
-            'right' => 'knowbaseitem_public',
+            'right' => ($item->getField('is_faq') ? 'faq' : 'knowbase'),
+            'allusers' => 1,
         ];
         if (isset($item->fields['entities_id'])) {
             $visiblity_dropdown_params['entity'] = $item->fields['entities_id'];

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -1027,6 +1027,16 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria, S
                 ]),
             );
         }
+        $actions[] = new EditorAction(
+            label: _n('Target', 'Targets', Session::getPluralNumber()),
+            icon: "ti ti-eye",
+            type: EditorActionType::LOAD_MODAL,
+            params: [
+                'id' => $this->fields['id'],
+                'key' => 'permissions',
+                'title' => _n('Target', 'Targets', Session::getPluralNumber()),
+            ],
+        );
         $out = TemplateRenderer::getInstance()->render('pages/tools/kb/article.html.twig', [
             'views' => $this->fields['view'],
             'answer' => $this->getAnswer(),

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -236,19 +236,10 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria, S
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
         if (!$withtemplate) {
-            $nb = 0;
             switch ($item::class) {
                 case self::class:
                     $ong[1] = self::createTabEntry(self::getTypeName(1));
                     if ($item->canUpdateItem()) {
-                        if ($_SESSION['glpishow_count_on_tabs']) {
-                            $nb = $item->countVisibilities();
-                        }
-                        $ong[2] = self::createTabEntry(
-                            _n('Target', 'Targets', Session::getPluralNumber()),
-                            $nb,
-                            $item::class
-                        );
                         $ong[3] = self::createTabEntry(__('Edit'), 0, $item::class, 'ti ti-pencil');
                     }
                     return $ong;
@@ -265,9 +256,6 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria, S
         switch ($tabnum) {
             case 1:
                 return (bool) $item->showFull(['edit_mode' => true]);
-
-            case 2:
-                return $item->showVisibility();
 
             case 3:
                 return $item->showForm($item->getID());

--- a/templates/pages/tools/kb/modal/permissions.html.twig
+++ b/templates/pages/tools/kb/modal/permissions.html.twig
@@ -1,0 +1,78 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2026 Teclib' and contributors.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+{% import "components/form/fields_macros.html.twig" as fields %}
+
+{% if can_edit %}
+    <div class="mb-3">
+        <form method="post" action="{{ 'KnowbaseItem'|itemtype_form_path }}">
+            <input type="hidden" name="knowbaseitems_id" value="{{ id }}">
+            {{ fields.csrfField() }}
+            <div class="d-flex flex-wrap">
+                {{ fields.dropdownItemTypes('_type', '', __('Add a target'), {
+                    types: ['Entity', 'Group', 'Profile', 'User'],
+                    rand: rand,
+                    inline_add_field_html: true,
+                    add_field_html: "<span id='visibility" ~ rand ~ "'></span>",
+                }) }}
+            </div>
+            <script>
+                $('#dropdown__type{{ rand }}').on('change', (e) => {
+                    $('#visibility{{ rand }}').load(
+                        `${CFG_GLPI.root_doc}/ajax/visibility.php`,
+                        {
+                            ...{{ visiblity_dropdown_params|json_encode|raw }},
+                            type: e.target.value,
+                        }
+                    );
+                });
+            </script>
+        </form>
+    </div>
+{% endif %}
+
+{{ include('components/datatable.html.twig', {
+    is_tab: true,
+    nofilter: true,
+    nosort: true,
+    columns: {
+        'type': _n('Type', 'Types', 1),
+        'recipient': _n('Recipient', 'Recipients', 1),
+    },
+    formatters: {
+        'recipient': 'raw_html',
+    },
+    entries: entries,
+    total_number: entries|length,
+    showmassiveactions: can_edit,
+    massiveactionparams: massive_action_params,
+}) }}

--- a/templates/pages/tools/kb/modal/permissions.html.twig
+++ b/templates/pages/tools/kb/modal/permissions.html.twig
@@ -37,13 +37,14 @@
         <form method="post" action="{{ 'KnowbaseItem'|itemtype_form_path }}">
             <input type="hidden" name="knowbaseitems_id" value="{{ id }}">
             {{ fields.csrfField() }}
-            <div class="d-flex flex-wrap">
-                {{ fields.dropdownItemTypes('_type', '', __('Add a target'), {
-                    types: ['Entity', 'Group', 'Profile', 'User'],
-                    rand: rand,
-                    inline_add_field_html: true,
-                    add_field_html: "<span id='visibility" ~ rand ~ "'></span>",
-                }) }}
+            <div class="d-flex flex-column gap-2">
+                <div class="d-flex align-items-center gap-2">
+                    {{ fields.dropdownItemTypes('_type', '', __('Add a target'), {
+                        types: ['Entity', 'Group', 'Profile', 'User'],
+                        rand: rand,
+                    }) }}
+                </div>
+                <div id="visibility{{ rand }}"></div>
             </div>
             <script>
                 $('#dropdown__type{{ rand }}').on('change', (e) => {


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

-Proposal for https://github.com/glpi-project/roadmap/issues/37
- Here is a brief description of what this PR does :

Move the "Targets" (permissions) tab content to a modal accessible from the KB article actions menu (3 dots).                                                                               
                                                                                                                                                                                              
  ## Changes                                                                                                                                                                                  
                                                                                                                                                                                              
  - Add `LOAD_MODAL` action type in `EditorActionType` enum                                                                                                                                   
  - Add `PermissionsRenderer` to load permissions data (users, groups, entities, profiles)                                                                                                    
  - Add `permissions.html.twig` modal template with datatable and add form                                                                                                                    
  - Add E2E test validating modal opening                                                                                                                                                     
                                                                                                                                                                                              
  ## Technical note: why `glpi_ajax_dialog` vs Bootstrap modal (cf https://github.com/glpi-project/glpi/pull/22750)

We use `glpi_ajax_dialog` instead of a pre-rendered Bootstrap modal (`data-bs-toggle`) because od the dynamic content : Permissions are article-specific and can change; pre-rendering would be wasteful.

## Screenshots : 
<img width="899" height="422" alt="image" src="https://github.com/user-attachments/assets/2239fa4c-d78e-46bf-9143-c2c3fae1827a" />



