### PR TITLE
Reduce the entity selector ajax response size

### DIFF
--- a/ajax/entitytreesons.php
+++ b/ajax/entitytreesons.php
@@ -40,5 +40,5 @@ global $CFG_GLPI, $GLPI_CACHE;
 header("Content-Type: application/json; charset=UTF-8");
 Html::header_nocache();
 
-echo json_encode(Entity::getEntitySelectorTree());
+echo json_encode(Entity::getEntitySelectorTree((int) ($_GET['rand'] ?? 0)));
 return;

--- a/templates/layout/parts/profile_selector.html.twig
+++ b/templates/layout/parts/profile_selector.html.twig
@@ -100,6 +100,24 @@
                 <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}" />
             </form>
 
+            <form
+                id="ch_ent_o_{{ rand }}"
+                method="POST"
+                action="{{ path('/Session/ChangeEntity') }}"
+            >
+                <input type="hidden" name="is_recursive" value="0">
+                <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}" />
+            </form>
+
+            <form
+                id="ch_ent_r_{{ rand }}"
+                method="POST"
+                action="{{ path('/Session/ChangeEntity') }}"
+            >
+                <input type="hidden" name="is_recursive" value="1">
+                <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}" />
+            </form>
+
             <div class="input-group">
                 <input type="text" class="form-control" name="entsearchtext" id="entsearchtext{{ rand }}"
                         placeholder="{{ __('Search entity') }}" autocomplete="off">
@@ -189,7 +207,7 @@
 
                 // load data by ajax
                 source: {
-                    url:  '{{ path("/ajax/entitytreesons.php") }}',
+                    url:  '{{ path("/ajax/entitytreesons.php?rand=" ~ rand) }}',
                     cache: false
                 },
 

--- a/templates/layout/parts/profile_selector_form.html.twig
+++ b/templates/layout/parts/profile_selector_form.html.twig
@@ -31,30 +31,30 @@
  #}
 
 <div class="d-flex align-items-center">
-    <form method="POST" action="{{ path('/Session/ChangeEntity') }}">
-        <button class="btn btn-link p-0 bg-transparent {{ is_recursive ? 'fw-bold' : '' }}">
-            {{ name }}
-        </button>
-        <input type="hidden" name="id" value="{{ id }}">
-        <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token }}">
-    </form>
+    <button
+        type="submit"
+        form="ch_ent_o_{{ rand }}"
+        name="id"
+        value="{{ id }}"
+        class="btn btn-link p-0 bg-transparent {{ is_recursive ? 'fw-bold' : '' }}">
+        {{ name }}
+    </button>
 
     {% if is_recursive %}
-        <form method="POST" action="{{ path('/Session/ChangeEntity') }}">
-            <button
-                class="btn btn-outline-secondary p-0 ms-1"
-                aria-label="{{ __('Select %1s entity with all its sub entities')|format(name) }}"
-            >
-                <i
-                    class="ti ti-chevrons-down"
-                    data-bs-toggle="tooltip"
-                    data-bs-placement="right"
-                    title="{{ __('Select %1s entity with all its sub entities')|format(name) }}"
-                ></i>
-            </button>
-            <input type="hidden" name="id" value="{{ id }}">
-            <input type="hidden" name="is_recursive" value="1">
-            <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token }}">
-        </form>
+        <button
+            type="submit"
+            form="ch_ent_r_{{ rand }}"
+            name="id"
+            value="{{ id }}"
+            class="btn btn-outline-secondary p-0 ms-1"
+            aria-label="{{ __('Select %1s entity with all its sub entities')|format(name) }}"
+        >
+            <i
+                class="ti ti-chevrons-down"
+                data-bs-toggle="tooltip"
+                data-bs-placement="right"
+                title="{{ __('Select %1s entity with all its sub entities')|format(name) }}"
+            ></i>
+        </button>
     {% endif %}
 </div>


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Partially fixes !41719.

The purpose of this PR is to drastically reduce the entity selector AJAX response size by:
 - using common `<form>` tags, including `_glpi_csrf_token` and `is_recursive` inputs, to not repeat them for each entity;
 - compact spaces to prevent sending too many extra spacing chars.

The response size could also be reduced by replacing the `class` attributes by dedicated CSS rules with precise CSS selectors, but I cannot afford enough time to this subject for the moment.

Another solution would be to use the `renderTitle` callback to remove the `title` from the response and generate it directly on client side. The response size would be really small, but I cannot tell if the title computation would be done for all nodes at once (with a risk of freezing the browser for some seconds), or would be done only when the corresponding node is visible in the virtual DOM viewport.