### PR TITLE
FIX / Manage deleted users during sync

### DIFF
--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -2196,10 +2196,9 @@ class AuthLDAP extends CommonDBTM
                         ];
                     }
                 } elseif (
-                    ($values['mode'] == self::ACTION_ALL)
+                    in_array($values['mode'], [self::ACTION_ALL, self::ACTION_SYNCHRONIZE])
                         && !$limitexceeded
                 ) {
-                    // Only manage deleted user if ALL (because of entity visibility in delegated mode)
 
                     if ($user['auths_id'] == $options['authldaps_id']) {
                         if (!$userfound && $user['is_deleted_ldap'] == 0) {

--- a/src/Console/Ldap/SynchronizeUsersCommand.php
+++ b/src/Console/Ldap/SynchronizeUsersCommand.php
@@ -85,7 +85,7 @@ class SynchronizeUsersCommand extends AbstractCommand
             'only-update-existing',
             'u',
             InputOption::VALUE_NONE,
-            __('Only update existing users (will not handle deleted users)')
+            __('Only update existing users')
         );
 
         $this->addOption(


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !41312

- Previously, deleted LDAP users were only handled when running a full synchronization (`ACTION_ALL`).
In real usage, most customers mainly use:

`bin/console ldap:synchronize_users --only-update-existing`

which corresponds to `ACTION_SYNCHRONIZE`.

As a result, LDAP user deletions were not processed in most cases.

This fix allows deleted users to be managed for both `ACTION_ALL` and `ACTION_SYNCHRONIZE`, ensuring consistent behavior with common synchronization workflows.
