### PR TITLE
Fix(GroupSearch): first init of searchoption

### DIFF
--- a/templates/components/search/query_builder/criteria.html.twig
+++ b/templates/components/search/query_builder/criteria.html.twig
@@ -87,7 +87,7 @@
          </div>
 
          {% set field_id = ("dropdown_criteria" ~ prefix ~ "[" ~ num ~ "][field]" ~ rand) %}
-         {% set spanid = ("SearchSpan" ~ normalized_itemtype ~ prefix ~ num) %}
+         {% set spanid = ("SearchSpan" ~ normalized_itemtype ~ prefix|replace({'[': '_', ']': '_'}) ~ num) %}
          <div class="col-auto">
             <div class="row g-1" id="{{ spanid }}">
                {% set used_itemtype = itemtype == 'AllAssets' ? 'Computer' : itemtype %}


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !41773

When adding a group to the search criteria, the search type dropdown was not updated according to the value of the dropdown field.

_Looks like https://github.com/glpi-project/glpi/pull/22575 but different_

## Screenshots (if appropriate):

<img width="700" height="322" alt="image" src="https://github.com/user-attachments/assets/029f03ac-acb2-4de7-a774-2f80c2f989da" />
