### PR TITLE
Experiment with paratest support

### DIFF
--- a/.github/actions/test_tests-functional.sh
+++ b/.github/actions/test_tests-functional.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e -u -x -o pipefail
 
-vendor/bin/phpunit $@
+vendor/bin/phpunit --group "single-thread" $@

--- a/.github/actions/test_tests-functional_parallel.sh
+++ b/.github/actions/test_tests-functional_parallel.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e -u -x -o pipefail
+
+vendor/bin/paratest --exclude-group "single-thread" $@

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,10 +206,31 @@ jobs:
         run: |
           .github/actions/init_initialize-9.5-db.sh
           docker compose exec -T app .github/actions/test_update-from-9.5.sh
-      - name: "Functional tests"
+      - name: "Functional tests (phpunit)"
         if: "${{ success() || failure() }}"
         run: |
           docker compose exec -T app .github/actions/test_tests-functional.sh
+      - name: "Clone databases"
+        if: "${{ success() || failure() }}"
+        run: |
+          docker compose exec -T db bash -c '
+            if command -v mariadb &> /dev/null; then
+              DB_CLIENT="mariadb"
+              DB_DUMP="mariadb-dump"
+            else
+              DB_CLIENT="mysql"
+              DB_DUMP="mysqldump"
+            fi
+            for i in 2 3 4; do
+              $DB_CLIENT -u root -e "CREATE DATABASE glpi_$i CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
+              $DB_DUMP -u root --single-transaction glpi | $DB_CLIENT -u root glpi_$i
+              echo "Database glpi_$i created and populated"
+            done
+          '
+      - name: "Functional tests (paratest)"
+        if: "${{ success() || failure() }}"
+        run: |
+          docker compose exec -T app .github/actions/test_tests-functional_parallel.sh
       - name: "Cache tests"
         if: "${{ success() || failure() }}"
         run: |

--- a/composer.json
+++ b/composer.json
@@ -107,6 +107,7 @@
     },
     "require-dev": {
         "ext-xml": "*",
+        "brianium/paratest": "^7.8",
         "friendsofphp/php-cs-fixer": "^3.86",
         "friendsoftwig/twigcs": "^6.5",
         "glpi-project/phpstan-glpi": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "51e26447f6418ca6eccbe51ab465e43a",
+    "content-hash": "5a1d21b8b321bddb8422cdf29909deeb",
     "packages": [
         {
             "name": "altcha-org/altcha",
@@ -10263,6 +10263,99 @@
             "time": "2024-08-03T19:31:26+00:00"
         },
         {
+            "name": "brianium/paratest",
+            "version": "v7.8.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paratestphp/paratest.git",
+                "reference": "9b324c8fc319cf9728b581c7a90e1c8f6361c5e5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paratestphp/paratest/zipball/9b324c8fc319cf9728b581c7a90e1c8f6361c5e5",
+                "reference": "9b324c8fc319cf9728b581c7a90e1c8f6361c5e5",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-pcre": "*",
+                "ext-reflection": "*",
+                "ext-simplexml": "*",
+                "fidry/cpu-core-counter": "^1.3.0",
+                "jean85/pretty-package-versions": "^2.1.1",
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
+                "phpunit/php-code-coverage": "^11.0.12",
+                "phpunit/php-file-iterator": "^5.1.0",
+                "phpunit/php-timer": "^7.0.1",
+                "phpunit/phpunit": "^11.5.46",
+                "sebastian/environment": "^7.2.1",
+                "symfony/console": "^6.4.22 || ^7.3.4 || ^8.0.3",
+                "symfony/process": "^6.4.20 || ^7.3.4 || ^8.0.3"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^12.0.0",
+                "ext-pcov": "*",
+                "ext-posix": "*",
+                "phpstan/phpstan": "^2.1.33",
+                "phpstan/phpstan-deprecation-rules": "^2.0.3",
+                "phpstan/phpstan-phpunit": "^2.0.11",
+                "phpstan/phpstan-strict-rules": "^2.0.7",
+                "squizlabs/php_codesniffer": "^3.13.5",
+                "symfony/filesystem": "^6.4.13 || ^7.3.2 || ^8.0.1"
+            },
+            "bin": [
+                "bin/paratest",
+                "bin/paratest_for_phpstorm"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "ParaTest\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Brian Scaturro",
+                    "email": "scaturrob@gmail.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Filippo Tessarotto",
+                    "email": "zoeslam@gmail.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Parallel testing for PHP",
+            "homepage": "https://github.com/paratestphp/paratest",
+            "keywords": [
+                "concurrent",
+                "parallel",
+                "phpunit",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/paratestphp/paratest/issues",
+                "source": "https://github.com/paratestphp/paratest/tree/v7.8.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/Slamdunk",
+                    "type": "github"
+                },
+                {
+                    "url": "https://paypal.me/filippotessarotto",
+                    "type": "paypal"
+                }
+            ],
+            "time": "2026-01-08T08:02:38+00:00"
+        },
+        {
             "name": "clue/ndjson-react",
             "version": "v1.3.0",
             "source": {
@@ -11030,6 +11123,66 @@
                 "source": "https://github.com/glpi-project/tools"
             },
             "time": "2025-10-14T10:26:06+00:00"
+        },
+        {
+            "name": "jean85/pretty-package-versions",
+            "version": "2.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Jean85/pretty-package-versions.git",
+                "reference": "4d7aa5dab42e2a76d99559706022885de0e18e1a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Jean85/pretty-package-versions/zipball/4d7aa5dab42e2a76d99559706022885de0e18e1a",
+                "reference": "4d7aa5dab42e2a76d99559706022885de0e18e1a",
+                "shasum": ""
+            },
+            "require": {
+                "composer-runtime-api": "^2.1.0",
+                "php": "^7.4|^8.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.2",
+                "jean85/composer-provided-replaced-stub-package": "^1.0",
+                "phpstan/phpstan": "^2.0",
+                "phpunit/phpunit": "^7.5|^8.5|^9.6",
+                "rector/rector": "^2.0",
+                "vimeo/psalm": "^4.3 || ^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Jean85\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alessandro Lai",
+                    "email": "alessandro.lai85@gmail.com"
+                }
+            ],
+            "description": "A library to get pretty versions strings of installed dependencies",
+            "keywords": [
+                "composer",
+                "package",
+                "release",
+                "versions"
+            ],
+            "support": {
+                "issues": "https://github.com/Jean85/pretty-package-versions/issues",
+                "source": "https://github.com/Jean85/pretty-package-versions/tree/2.1.1"
+            },
+            "time": "2025-03-19T14:43:43+00:00"
         },
         {
             "name": "kelunik/certificate",
@@ -14868,5 +15021,5 @@
     "platform-overrides": {
         "php": "8.2.99"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/src/DBmysql.php
+++ b/src/DBmysql.php
@@ -235,6 +235,16 @@ class DBmysql
      */
     public function __construct($choice = null)
     {
+        // Handle separate DB instances per worker for unit tests (when enabled)
+        // First runner will use the existing `glpi` database
+        // Second runner will use `glpi_2`
+        // Third runner will use `glpi_3`
+        // And so on...
+        $test_token = getenv('TEST_TOKEN');
+        if ($test_token !== false && $test_token !== '' && $test_token > 1) {
+            $this->dbdefault = $this->dbdefault . '_' . $test_token;
+        }
+
         $this->connect($choice);
     }
 

--- a/tests/functional/Glpi/Api/HL/Controller/AdministrationControllerTest.php
+++ b/tests/functional/Glpi/Api/HL/Controller/AdministrationControllerTest.php
@@ -39,6 +39,7 @@ use Glpi\Event;
 use Glpi\Http\Request;
 use Glpi\Tests\HLAPITestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 class AdministrationControllerTest extends HLAPITestCase
 {
@@ -304,6 +305,7 @@ class AdministrationControllerTest extends HLAPITestCase
         ]);
     }
 
+    #[Group('single-thread')]
     public function testGetMyPicture()
     {
         $this->login();
@@ -336,6 +338,7 @@ class AdministrationControllerTest extends HLAPITestCase
         });
     }
 
+    #[Group('single-thread')]
     public function testGetUserPictureByID()
     {
         $this->login();
@@ -361,6 +364,7 @@ class AdministrationControllerTest extends HLAPITestCase
         });
     }
 
+    #[Group('single-thread')]
     public function testGetUserPictureByUsername()
     {
         $this->login();

--- a/tests/functional/Glpi/Form/Export/FormSerializerTest.php
+++ b/tests/functional/Glpi/Form/Export/FormSerializerTest.php
@@ -119,6 +119,7 @@ use ITILCategory;
 use Location;
 use Monitor;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Ramsey\Uuid\Uuid;
 use Session;
 
@@ -1573,6 +1574,7 @@ final class FormSerializerTest extends DbTestCase
         $this->assertEquals(0, (new QuestionTypeItem())->getDefaultValueItemId($question));
     }
 
+    #[Group('single-thread')]
     public function testExportAndImportWithCustomIcon(): void
     {
         // Arrange: create a form with a custom icon

--- a/tests/functional/Glpi/Form/Migration/FormMigrationTest.php
+++ b/tests/functional/Glpi/Form/Migration/FormMigrationTest.php
@@ -109,10 +109,14 @@ final class FormMigrationTest extends DbTestCase
         global $DB;
 
         parent::setUpBeforeClass();
+
+        // Clean up data in case execution was stopped before tearDownAfterClass
+        // could run.
         $tables = $DB->listTables('glpi\_plugin\_formcreator\_%');
         foreach ($tables as $table) {
             $DB->dropTable($table['TABLE_NAME']);
         }
+
         $queries = $DB->getQueriesFromFile(sprintf('%s/tests/glpi-formcreator-migration-data.sql', GLPI_ROOT));
         foreach ($queries as $query) {
             $DB->doQuery($query);

--- a/tests/functional/Glpi/Form/Migration/TargetsMigrationTest.php
+++ b/tests/functional/Glpi/Form/Migration/TargetsMigrationTest.php
@@ -124,6 +124,13 @@ final class TargetsMigrationTest extends DbTestCase
 
         parent::setUpBeforeClass();
 
+        // Clean up data in case execution was stopped before tearDownAfterClass
+        // could run.
+        $tables = $DB->listTables('glpi\_plugin\_formcreator\_%');
+        foreach ($tables as $table) {
+            $DB->dropTable($table['TABLE_NAME']);
+        }
+
         $queries = $DB->getQueriesFromFile(sprintf('%s/tests/glpi-formcreator-migration-data.sql', GLPI_ROOT));
         foreach ($queries as $query) {
             $DB->doQuery($query);

--- a/tests/functional/Glpi/Inventory/Assets/AntivirusTest.php
+++ b/tests/functional/Glpi/Inventory/Assets/AntivirusTest.php
@@ -38,7 +38,9 @@ use Glpi\Inventory\Asset\Antivirus;
 use Glpi\Inventory\Converter;
 use Glpi\Tests\AbstractInventoryAsset;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('single-thread')]
 class AntivirusTest extends AbstractInventoryAsset
 {
     public static function assetProvider(): array

--- a/tests/functional/Glpi/Inventory/Assets/BatteryTest.php
+++ b/tests/functional/Glpi/Inventory/Assets/BatteryTest.php
@@ -38,7 +38,9 @@ use Glpi\Inventory\Asset\Battery;
 use Glpi\Inventory\Converter;
 use Glpi\Tests\AbstractInventoryAsset;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('single-thread')]
 class BatteryTest extends AbstractInventoryAsset
 {
     public static function assetProvider(): array

--- a/tests/functional/Glpi/Inventory/Assets/BiosTest.php
+++ b/tests/functional/Glpi/Inventory/Assets/BiosTest.php
@@ -38,7 +38,9 @@ use Glpi\Inventory\Asset\Bios;
 use Glpi\Inventory\Converter;
 use Glpi\Tests\AbstractInventoryAsset;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('single-thread')]
 class BiosTest extends AbstractInventoryAsset
 {
     public static function assetProvider(): array

--- a/tests/functional/Glpi/Inventory/Assets/CameraTest.php
+++ b/tests/functional/Glpi/Inventory/Assets/CameraTest.php
@@ -38,7 +38,9 @@ use Glpi\Inventory\Asset\Camera;
 use Glpi\Inventory\Converter;
 use Glpi\Tests\AbstractInventoryAsset;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('single-thread')]
 class CameraTest extends AbstractInventoryAsset
 {
     public static function assetProvider(): array

--- a/tests/functional/Glpi/Inventory/Assets/CartridgeTest.php
+++ b/tests/functional/Glpi/Inventory/Assets/CartridgeTest.php
@@ -38,7 +38,9 @@ use Glpi\Inventory\Asset\Cartridge;
 use Glpi\Inventory\Converter;
 use Glpi\Tests\AbstractInventoryAsset;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('single-thread')]
 class CartridgeTest extends AbstractInventoryAsset
 {
     public static function assetProvider(): array

--- a/tests/functional/Glpi/Inventory/Assets/ComputerTest.php
+++ b/tests/functional/Glpi/Inventory/Assets/ComputerTest.php
@@ -41,7 +41,9 @@ use Glpi\Inventory\Inventory;
 use Glpi\Inventory\Request;
 use Glpi\Tests\AbstractInventoryAsset;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('single-thread')]
 class ComputerTest extends AbstractInventoryAsset
 {
     public const INV_FIXTURES = GLPI_ROOT . '/vendor/glpi-project/inventory_format/examples/';

--- a/tests/functional/Glpi/Inventory/Assets/ControllerTest.php
+++ b/tests/functional/Glpi/Inventory/Assets/ControllerTest.php
@@ -38,7 +38,9 @@ use Glpi\Inventory\Asset\Controller;
 use Glpi\Inventory\Converter;
 use Glpi\Tests\AbstractInventoryAsset;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('single-thread')]
 class ControllerTest extends AbstractInventoryAsset
 {
     public static function assetProvider(): array

--- a/tests/functional/Glpi/Inventory/Assets/DeviceTest.php
+++ b/tests/functional/Glpi/Inventory/Assets/DeviceTest.php
@@ -35,7 +35,9 @@
 namespace tests\units\Glpi\Inventory\Asset;
 
 use Glpi\Tests\AbstractInventoryAsset;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('single-thread')]
 class DeviceTest extends AbstractInventoryAsset
 {
     public static function assetProvider(): array

--- a/tests/functional/Glpi/Inventory/Assets/DriveTest.php
+++ b/tests/functional/Glpi/Inventory/Assets/DriveTest.php
@@ -39,7 +39,9 @@ use Glpi\Inventory\Conf;
 use Glpi\Inventory\Converter;
 use Glpi\Tests\AbstractInventoryAsset;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('single-thread')]
 class DriveTest extends AbstractInventoryAsset
 {
     public static function assetProvider(): array

--- a/tests/functional/Glpi/Inventory/Assets/EnvironmentTest.php
+++ b/tests/functional/Glpi/Inventory/Assets/EnvironmentTest.php
@@ -41,7 +41,9 @@ use Glpi\Inventory\Conf;
 use Glpi\Inventory\Converter;
 use Glpi\Tests\AbstractInventoryAsset;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('single-thread')]
 class EnvironmentTest extends AbstractInventoryAsset
 {
     public static function assetProvider(): array

--- a/tests/functional/Glpi/Inventory/Assets/FirmwareTest.php
+++ b/tests/functional/Glpi/Inventory/Assets/FirmwareTest.php
@@ -38,7 +38,9 @@ use Glpi\Inventory\Asset\Firmware;
 use Glpi\Inventory\Converter;
 use Glpi\Tests\AbstractInventoryAsset;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('single-thread')]
 class FirmwareTest extends AbstractInventoryAsset
 {
     public static function assetProvider(): array

--- a/tests/functional/Glpi/Inventory/Assets/GraphicCardTest.php
+++ b/tests/functional/Glpi/Inventory/Assets/GraphicCardTest.php
@@ -38,7 +38,9 @@ use Glpi\Inventory\Asset\GraphicCard;
 use Glpi\Inventory\Converter;
 use Glpi\Tests\AbstractInventoryAsset;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('single-thread')]
 class GraphicCardTest extends AbstractInventoryAsset
 {
     public static function assetProvider(): array

--- a/tests/functional/Glpi/Inventory/Assets/MemoryTest.php
+++ b/tests/functional/Glpi/Inventory/Assets/MemoryTest.php
@@ -38,7 +38,9 @@ use Glpi\Inventory\Asset\Memory;
 use Glpi\Inventory\Converter;
 use Glpi\Tests\AbstractInventoryAsset;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('single-thread')]
 class MemoryTest extends AbstractInventoryAsset
 {
     public static function assetProvider(): array

--- a/tests/functional/Glpi/Inventory/Assets/MonitorTest.php
+++ b/tests/functional/Glpi/Inventory/Assets/MonitorTest.php
@@ -39,7 +39,9 @@ use Glpi\Inventory\Conf;
 use Glpi\Inventory\Converter;
 use Glpi\Tests\AbstractInventoryAsset;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('single-thread')]
 class MonitorTest extends AbstractInventoryAsset
 {
     public static function assetProvider(): array

--- a/tests/functional/Glpi/Inventory/Assets/NetworkCardTest.php
+++ b/tests/functional/Glpi/Inventory/Assets/NetworkCardTest.php
@@ -39,7 +39,9 @@ use Glpi\Inventory\Conf;
 use Glpi\Inventory\Converter;
 use Glpi\Tests\AbstractInventoryAsset;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('single-thread')]
 class NetworkCardTest extends AbstractInventoryAsset
 {
     public static function assetProvider(): array

--- a/tests/functional/Glpi/Inventory/Assets/NetworkEquipmentTest.php
+++ b/tests/functional/Glpi/Inventory/Assets/NetworkEquipmentTest.php
@@ -39,7 +39,9 @@ use Glpi\Inventory\Converter;
 use Glpi\Inventory\Inventory;
 use Glpi\Tests\AbstractInventoryAsset;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('single-thread')]
 class NetworkEquipmentTest extends AbstractInventoryAsset
 {
     public const INV_FIXTURES = GLPI_ROOT . '/vendor/glpi-project/inventory_format/examples/';

--- a/tests/functional/Glpi/Inventory/Assets/NetworkEquipmentUpdateTest.php
+++ b/tests/functional/Glpi/Inventory/Assets/NetworkEquipmentUpdateTest.php
@@ -46,8 +46,10 @@ use NetworkPort_NetworkPort;
 use NetworkPort_Vlan;
 use NetworkPortAggregate;
 use NetworkPortType;
+use PHPUnit\Framework\Attributes\Group;
 use Unmanaged;
 
+#[Group('single-thread')]
 class NetworkEquipmentUpdateTest extends InventoryTestCase
 {
     public function testAddNetworkEquipment()

--- a/tests/functional/Glpi/Inventory/Assets/NetworkPortTest.php
+++ b/tests/functional/Glpi/Inventory/Assets/NetworkPortTest.php
@@ -41,7 +41,9 @@ use Glpi\Inventory\Converter;
 use Glpi\Inventory\Inventory;
 use Glpi\Tests\AbstractInventoryAsset;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('single-thread')]
 class NetworkPortTest extends AbstractInventoryAsset
 {
     public static function assetProvider(): array

--- a/tests/functional/Glpi/Inventory/Assets/OperatingSystemTest.php
+++ b/tests/functional/Glpi/Inventory/Assets/OperatingSystemTest.php
@@ -38,11 +38,13 @@ use Glpi\Inventory\Conf;
 use Glpi\Inventory\Converter;
 use Glpi\Tests\AbstractInventoryAsset;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Rule;
 use RuleDictionnaryOperatingSystem;
 use RuleDictionnaryOperatingSystemEdition;
 use RuleDictionnaryOperatingSystemVersion;
 
+#[Group('single-thread')]
 class OperatingSystemTest extends AbstractInventoryAsset
 {
     public static function assetProvider(): array

--- a/tests/functional/Glpi/Inventory/Assets/PeripheralTest.php
+++ b/tests/functional/Glpi/Inventory/Assets/PeripheralTest.php
@@ -39,7 +39,9 @@ use Glpi\Inventory\Conf;
 use Glpi\Inventory\Converter;
 use Glpi\Tests\AbstractInventoryAsset;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('single-thread')]
 class PeripheralTest extends AbstractInventoryAsset
 {
     public static function assetProvider(): array

--- a/tests/functional/Glpi/Inventory/Assets/PowerSupplyTest.php
+++ b/tests/functional/Glpi/Inventory/Assets/PowerSupplyTest.php
@@ -38,7 +38,9 @@ use Glpi\Inventory\Asset\PowerSupply;
 use Glpi\Inventory\Converter;
 use Glpi\Tests\AbstractInventoryAsset;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('single-thread')]
 class PowerSupplyTest extends AbstractInventoryAsset
 {
     public static function assetProvider(): array

--- a/tests/functional/Glpi/Inventory/Assets/PrinterTest.php
+++ b/tests/functional/Glpi/Inventory/Assets/PrinterTest.php
@@ -40,7 +40,9 @@ use Glpi\Inventory\Converter;
 use Glpi\Inventory\Inventory;
 use Glpi\Tests\AbstractInventoryAsset;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('single-thread')]
 class PrinterTest extends AbstractInventoryAsset
 {
     public const INV_FIXTURES = GLPI_ROOT . '/vendor/glpi-project/inventory_format/examples/';

--- a/tests/functional/Glpi/Inventory/Assets/ProcessTest.php
+++ b/tests/functional/Glpi/Inventory/Assets/ProcessTest.php
@@ -40,7 +40,9 @@ use Glpi\Inventory\Conf;
 use Glpi\Inventory\Converter;
 use Glpi\Tests\AbstractInventoryAsset;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('single-thread')]
 class ProcessTest extends AbstractInventoryAsset
 {
     public static function assetProvider(): array

--- a/tests/functional/Glpi/Inventory/Assets/ProcessorTest.php
+++ b/tests/functional/Glpi/Inventory/Assets/ProcessorTest.php
@@ -38,7 +38,9 @@ use Glpi\Inventory\Asset\Processor;
 use Glpi\Inventory\Converter;
 use Glpi\Tests\AbstractInventoryAsset;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('single-thread')]
 class ProcessorTest extends AbstractInventoryAsset
 {
     public static function assetProvider(): array

--- a/tests/functional/Glpi/Inventory/Assets/RemoteManagementTest.php
+++ b/tests/functional/Glpi/Inventory/Assets/RemoteManagementTest.php
@@ -38,7 +38,9 @@ use Glpi\Inventory\Asset\RemoteManagement;
 use Glpi\Inventory\Converter;
 use Glpi\Tests\AbstractInventoryAsset;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('single-thread')]
 class RemoteManagementTest extends AbstractInventoryAsset
 {
     public static function assetProvider(): array

--- a/tests/functional/Glpi/Inventory/Assets/SensorTest.php
+++ b/tests/functional/Glpi/Inventory/Assets/SensorTest.php
@@ -38,7 +38,9 @@ use Glpi\Inventory\Asset\Sensor;
 use Glpi\Inventory\Converter;
 use Glpi\Tests\AbstractInventoryAsset;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('single-thread')]
 class SensorTest extends AbstractInventoryAsset
 {
     public static function assetProvider(): array

--- a/tests/functional/Glpi/Inventory/Assets/SoftwareTest.php
+++ b/tests/functional/Glpi/Inventory/Assets/SoftwareTest.php
@@ -37,8 +37,10 @@ namespace tests\units\Glpi\Inventory\Asset;
 use Glpi\Inventory\Converter;
 use Glpi\Tests\AbstractInventoryAsset;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use SoftwareVersion;
 
+#[Group('single-thread')]
 class SoftwareTest extends AbstractInventoryAsset
 {
     public static function assetProvider(): array

--- a/tests/functional/Glpi/Inventory/Assets/SoundCardTest.php
+++ b/tests/functional/Glpi/Inventory/Assets/SoundCardTest.php
@@ -38,7 +38,9 @@ use Glpi\Inventory\Asset\SoundCard;
 use Glpi\Inventory\Converter;
 use Glpi\Tests\AbstractInventoryAsset;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('single-thread')]
 class SoundCardTest extends AbstractInventoryAsset
 {
     public static function assetProvider(): array

--- a/tests/functional/Glpi/Inventory/Assets/UnmanagedTest.php
+++ b/tests/functional/Glpi/Inventory/Assets/UnmanagedTest.php
@@ -39,7 +39,9 @@ use Glpi\Inventory\Converter;
 use Glpi\Tests\AbstractInventoryAsset;
 use Lockedfield;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('single-thread')]
 class UnmanagedTest extends AbstractInventoryAsset
 {
     public static function assetProvider(): array

--- a/tests/functional/Glpi/Inventory/Assets/VirtualMachineTest.php
+++ b/tests/functional/Glpi/Inventory/Assets/VirtualMachineTest.php
@@ -39,7 +39,9 @@ use Glpi\Inventory\Conf;
 use Glpi\Inventory\Converter;
 use Glpi\Tests\AbstractInventoryAsset;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('single-thread')]
 class VirtualMachineTest extends AbstractInventoryAsset
 {
     public static function assetProvider(): array

--- a/tests/functional/Glpi/Inventory/Assets/VolumeTest.php
+++ b/tests/functional/Glpi/Inventory/Assets/VolumeTest.php
@@ -39,7 +39,9 @@ use Glpi\Inventory\Conf;
 use Glpi\Inventory\Converter;
 use Glpi\Tests\AbstractInventoryAsset;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('single-thread')]
 class VolumeTest extends AbstractInventoryAsset
 {
     public static function assetProvider(): array

--- a/tests/functional/Glpi/Inventory/ConfTest.php
+++ b/tests/functional/Glpi/Inventory/ConfTest.php
@@ -37,8 +37,10 @@ namespace tests\units\Glpi\Inventory;
 use Glpi\Inventory\Conf;
 use Glpi\Tests\GLPITestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Psr\Log\LogLevel;
 
+#[Group('single-thread')]
 class ConfTest extends GLPITestCase
 {
     public function testKnownInventoryExtensions()

--- a/tests/functional/Glpi/Inventory/GenericAssetInventoryTest.php
+++ b/tests/functional/Glpi/Inventory/GenericAssetInventoryTest.php
@@ -43,7 +43,9 @@ use Glpi\Asset\Capacity\HasVolumesCapacity;
 use Glpi\Asset\Capacity\IsInventoriableCapacity;
 use Glpi\Inventory\Request;
 use Glpi\Tests\InventoryTestCase;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('single-thread')]
 class GenericAssetInventoryTest extends InventoryTestCase
 {
     /**

--- a/tests/functional/Glpi/Inventory/GenericNetworkAssetInventoryTest.php
+++ b/tests/functional/Glpi/Inventory/GenericNetworkAssetInventoryTest.php
@@ -44,7 +44,9 @@ use Glpi\Inventory\MainAsset\GenericNetworkAsset;
 use Glpi\Inventory\Request;
 use Glpi\Tests\InventoryTestCase;
 use NetworkEquipment;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('single-thread')]
 class GenericNetworkAssetInventoryTest extends InventoryTestCase
 {
     /**

--- a/tests/functional/Glpi/Inventory/GenericPrinterAssetInventoryTest.php
+++ b/tests/functional/Glpi/Inventory/GenericPrinterAssetInventoryTest.php
@@ -42,7 +42,9 @@ use Glpi\Asset\CapacityConfig;
 use Glpi\Inventory\MainAsset\GenericPrinterAsset;
 use Glpi\Inventory\Request;
 use Glpi\Tests\InventoryTestCase;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('single-thread')]
 class GenericPrinterAssetInventoryTest extends InventoryTestCase
 {
     /**

--- a/tests/functional/Glpi/Inventory/InventoryOptionsTest.php
+++ b/tests/functional/Glpi/Inventory/InventoryOptionsTest.php
@@ -37,7 +37,9 @@ namespace tests\units\Glpi\Inventory;
 use Glpi\Asset\Asset_PeripheralAsset;
 use Glpi\Inventory\Conf;
 use Glpi\Tests\InventoryTestCase;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('single-thread')]
 class InventoryOptionsTest extends InventoryTestCase
 {
     private string $json_computer = <<<JSON

--- a/tests/functional/Glpi/Inventory/InventoryTest.php
+++ b/tests/functional/Glpi/Inventory/InventoryTest.php
@@ -47,10 +47,12 @@ use OperatingSystemArchitecture;
 use OperatingSystemServicePack;
 use OperatingSystemVersion;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use RuleImportAsset;
 use UserEmail;
 use wapmorgan\UnifiedArchive\UnifiedArchive;
 
+#[Group('single-thread')]
 class InventoryTest extends InventoryTestCase
 {
     private function checkComputer1($computers_id)

--- a/tests/functional/Glpi/Inventory/RequestTest.php
+++ b/tests/functional/Glpi/Inventory/RequestTest.php
@@ -37,7 +37,9 @@ namespace tests\units\Glpi\Inventory;
 use Glpi\Inventory\Request;
 use Glpi\Tests\GLPITestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('single-thread')]
 class RequestTest extends GLPITestCase
 {
     public function testConstructor()

--- a/tests/functional/MigrationTest.php
+++ b/tests/functional/MigrationTest.php
@@ -44,6 +44,7 @@ use Glpi\Tests\DbTestCase;
 use LogicException;
 use Migration;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 class MigrationTest extends DbTestCase
 {
@@ -274,6 +275,7 @@ class MigrationTest extends DbTestCase
         ], $migration->getMockedQueries());
     }
 
+    #[Group('single-thread')]
     public function testBackupNonExistantTables()
     {
         $migration = $this->getMigrationMock(db_options: [

--- a/tests/functional/PendingReasonTest.php
+++ b/tests/functional/PendingReasonTest.php
@@ -49,6 +49,7 @@ use NotificationTemplateTranslation;
 use PendingReason;
 use PendingReason_Item;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Problem;
 use ProblemTask;
 use SolutionTemplate;
@@ -1539,6 +1540,7 @@ class PendingReasonTest extends DbTestCase
         $this->assertFalse($pending_item, 'PendingReason_Item should be deleted when status is changed by a rule');
     }
 
+    #[Group('single-thread')]
     public function testPendingReasonWarningMessage(): void
     {
         $this->login();


### PR DESCRIPTION
## Description

Trying paratest again, with some specific tests excluded (maybe they can be included later if properly analyzed to understand why they don't play well with multi threading).

It seems good, tests times are almost halved and I don't see any flakiness for now.

Before:
<img width="641" height="46" alt="image" src="https://github.com/user-attachments/assets/cdba80ef-3245-468d-8b8a-507663010827" />

After:
<img width="647" height="113" alt="image" src="https://github.com/user-attachments/assets/4944b3b8-0311-4ea2-b58f-f3560536cc32" />

Note that the main complexity comes from the necessity to have one dedicated database per runner.
With a single database, there is almost no gain due to table locking.



