### PR TITLE
Fix - Prevent TypeError in mandatory field validation with array values

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -3026,7 +3026,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
 
                                 if (
                                     empty($input[$key])
-                                    || preg_match('/<p>([\s| ]+)?<\/p>/', $input[$key]) !== 0 //check for empty '<p></p>' in rich text
+                                    || (is_string($input[$key]) && preg_match('/<p>([\s| ]+)?<\/p>/', $input[$key]) !== 0) //check for empty '<p></p>' in rich text
                                     || ($input[$key] == 'NULL')
                                     || (is_array($input[$key])
                                     && ($input[$key] === [0 => "0"]))

--- a/tests/functional/TicketTest.php
+++ b/tests/functional/TicketTest.php
@@ -1036,7 +1036,7 @@ class TicketTest extends DbTestCase
         $this->assertFalse($tasktemplate->isNewItem());
 
         // 3 - create a ticket template with the task templates in predefined fields
-        $itiltemplate    = new \TicketTemplate();
+        $itiltemplate    = new TicketTemplate();
         $itiltemplate_id = $itiltemplate->add([
             'name' => 'my ticket template',
         ]);
@@ -9744,7 +9744,7 @@ HTML,
             'name' => 'Test template with mandatory field: ' . $mandatory_field,
         ]);
 
-        $search_option_id = match($mandatory_field) {
+        $search_option_id = match ($mandatory_field) {
             'content' => (new Ticket())->getSearchOptionIDByField('field', 'content', 'glpi_tickets'),
             '_users_id_requester' => 4,
             '_groups_id_requester' => 71,

--- a/tests/functional/TicketTest.php
+++ b/tests/functional/TicketTest.php
@@ -72,6 +72,8 @@ use Ticket;
 use Ticket_Contract;
 use Ticket_User;
 use TicketSatisfaction;
+use TicketTemplate;
+use TicketTemplateMandatoryField;
 use TicketValidation;
 use User;
 
@@ -9683,6 +9685,94 @@ HTML,
         } else {
             $this->assertFalse($result);
             $this->hasSessionMessages(ERROR, ['Mandatory fields are not filled. Please correct: Description']);
+        }
+    }
+
+    /**
+     * Test that validates the fix for TypeError when mandatory fields receive array input.
+     */
+    public static function mandatoryFieldsWithArrayInputProvider(): iterable
+    {
+        yield 'actor field with array value should not trigger TypeError' => [
+            'input' => [
+                Ticket::getTemplateFormFieldName() => 1,
+                'name' => 'Test ticket',
+                'content' => 'Valid content',
+                '_users_id_requester' => ['_actors_350' => 350],
+            ],
+            'mandatory_field' => '_users_id_requester',
+            'should_succeed' => true,
+        ];
+
+        yield 'content as empty paragraph with spaces should be rejected' => [
+            'input' => [
+                Ticket::getTemplateFormFieldName() => 1,
+                'name' => 'Test ticket',
+                'content' => '<p>   </p>',
+            ],
+            'mandatory_field' => 'content',
+            'should_succeed' => false,
+        ];
+
+        yield 'content as empty paragraph with nbsp should be rejected' => [
+            'input' => [
+                Ticket::getTemplateFormFieldName() => 1,
+                'name' => 'Test ticket',
+                'content' => '<p> </p>',
+            ],
+            'mandatory_field' => 'content',
+            'should_succeed' => false,
+        ];
+
+        yield 'content with actual text should succeed' => [
+            'input' => [
+                Ticket::getTemplateFormFieldName() => 1,
+                'name' => 'Test ticket',
+                'content' => '<p>Real content here</p>',
+            ],
+            'mandatory_field' => 'content',
+            'should_succeed' => true,
+        ];
+    }
+
+    #[DataProvider('mandatoryFieldsWithArrayInputProvider')]
+    public function testMandatoryFieldsWithArrayInput(array $input, string $mandatory_field, bool $should_succeed): void
+    {
+        $this->login();
+
+        $template = $this->createItem(TicketTemplate::class, [
+            'name' => 'Test template with mandatory field: ' . $mandatory_field,
+        ]);
+
+        $search_option_id = match($mandatory_field) {
+            'content' => (new Ticket())->getSearchOptionIDByField('field', 'content', 'glpi_tickets'),
+            '_users_id_requester' => 4,
+            '_groups_id_requester' => 71,
+            '_users_id_assign' => 5,
+            '_groups_id_assign' => 8,
+            '_users_id_observer' => 66,
+            default => 0,
+        };
+
+        $this->createItem(TicketTemplateMandatoryField::class, [
+            'tickettemplates_id' => $template->getID(),
+            'num' => $search_option_id,
+        ]);
+
+        $input[Ticket::getTemplateFormFieldName()] = $template->getID();
+
+        $ticket = new Ticket();
+        $result = $ticket->add($input);
+
+        if ($should_succeed) {
+            $this->assertGreaterThan(0, $result, 'Ticket creation should succeed');
+        } else {
+            $this->assertFalse($result, 'Ticket creation should fail due to mandatory field validation');
+            if ($mandatory_field === 'content') {
+                $this->hasSessionMessages(ERROR, ['Mandatory fields are not filled. Please correct: Description']);
+            } else {
+                $this->hasSessionMessages(ERROR, ['Mandatory fields are not filled']);
+            }
         }
     }
 


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !41777
- Here is a brief description of what this PR does

PR #22732 introduced preg_match to detect empty richtext paragraphs,
but didn't handle fields containing array values (e.g. actor fields).

**Client error:**
```php
Uncaught PHP Exception TypeError: "Safe\preg_match(): Argument #2 ($subject) must be of type string, array given, called in ./src/CommonITILObject.php on line 3028" at pcre.php line 613
  Backtrace :
  ...hecodingmachine/safe/generated/8.3/pcre.php:613 
  ./src/CommonITILObject.php:3028                    Safe\preg_match()
  ./src/Ticket.php:1527                              CommonITILObject->prepareInputForAdd()
  ./src/CommonDBTM.php:1339                          Ticket->prepareInputForAdd()
  ./front/ticket.form.php:79                         CommonDBTM->add()
  ...Glpi/Controller/LegacyFileLoadController.php:64 require()
  ./vendor/symfony/http-kernel/HttpKernel.php:181    Glpi\Controller\LegacyFileLoadController->__invoke()
  ./vendor/symfony/http-kernel/HttpKernel.php:76     Symfony\Component\HttpKernel\HttpKernel->handleRaw()
  ./vendor/symfony/http-kernel/Kernel.php:197        Symfony\Component\HttpKernel\HttpKernel->handle()
  ./public/index.php:71                              Symfony\Component\HttpKernel\Kernel->handle()
```
Input causing error: `$input['_users_id_requester'] = ['_actors_350' => 350]`

Changes:
- Add is_string() check before preg_match in mandatory validation
- Add tests for both array actor fields and richtext validation
- Preserve PR #22732 empty paragraph detection functionality"