### PR TITLE
Move "Add several ports" checkbox to NetworkPort form

### DIFF
--- a/src/NetworkPort.php
+++ b/src/NetworkPort.php
@@ -699,11 +699,6 @@ class NetworkPort extends CommonDBChild
             );
             echo "</div>";
 
-            echo "<div class='col-auto m-2'>";
-            echo "<label for='several'>" . __s('Add several ports') . "</label>";
-            echo "&nbsp;<input type='checkbox' name='several' id='several' value='1'></td>";
-            echo "</div>";
-
             echo "<div class='col-auto'>";
             echo "<button type='submit' name='add' value='1' class='btn btn-primary ms-1'>";
             echo "<i class='ti ti-link'></i>" . _sx('button', 'Add');

--- a/templates/pages/assets/networkport/form.html.twig
+++ b/templates/pages/assets/networkport/form.html.twig
@@ -43,25 +43,61 @@
     {% set type_value = call('NetworkPort::displayRecursiveItems', [recursive_items, 'Link', false]) %}
     {{ fields.htmlField('', type_value, type_label) }}
 
-    {% if not params.several %}
-        {{ fields.numberField('logical_number', item.fields['logical_number'], _n('Port number', 'Port number', 1)) }}
-    {% else %}
-        {% set logical_num_field %}
-            <div class="d-flex">
-                {{ fields.numberField('from_logical_number', 0, null, {
-                    no_label: true,
-                    mb: ''
-                }) }}
-                <span class="mx-1 mt-2 text-nowrap">--></span>
-                {{ fields.numberField('to_logical_number', 0, null, {
-                    no_label: true,
-                    mb: ''
-                }) }}
-            </div>
-        {% endset %}
-        {{ fields.htmlField('', logical_num_field, _n('Port number', 'Port number', 1)) }}
-        <input type="hidden" name="several" value="yes">
+    {% if item.isNewID(item.getID()) %}
+        {{ fields.sliderField('_add_several', 0, __('Add several ports')) }}
+        <script>
+            (function() {
+                const checkbox = $('input[type="checkbox"][name="_add_several"]');
+                if (checkbox.length && !checkbox.data('handler-bound')) {
+                    checkbox.data('handler-bound', true);
+                    checkbox.on('change', function(e) {
+                        const chkbox = $(this);
+                        const form = chkbox.closest('form');
+                        
+                        if (chkbox.prop('checked')) {
+                            form.find('.single-port-field').addClass('d-none');
+                            form.find('.multiple-port-fields').removeClass('d-none');
+                            form.find('.network-name-section').addClass('d-none');
+                            form.find('.network-name-section input, .network-name-section select, .network-name-section textarea').prop('disabled', true);
+                            form.find('input[name="several"]').prop('disabled', false);
+                        } else {
+                            form.find('.single-port-field').removeClass('d-none');
+                            form.find('.multiple-port-fields').addClass('d-none');
+                            form.find('.network-name-section').removeClass('d-none');
+                            form.find('.network-name-section input, .network-name-section select, .network-name-section textarea').prop('disabled', false);
+                            form.find('input[name="several"]').prop('disabled', true);
+                        }
+                    });
+                }
+            })();
+        </script>
+        {{ fields.nullField() }}
     {% endif %}
+
+    {{ fields.numberField('logical_number', item.fields['logical_number'], _n('Port number', 'Port number', 1), {
+        'add_field_class': 'single-port-field'
+    }) }}
+    
+    {% set logical_num_field %}
+        <div class="d-flex">
+            {{ fields.numberField('from_logical_number', 0, null, {
+                no_label: true,
+                mb: '',
+                field_class: 'flex-grow-1'
+            }) }}
+            <span class="mx-1 mt-2 text-nowrap">--></span>
+            {{ fields.numberField('to_logical_number', 0, null, {
+                no_label: true,
+                mb: '',
+                field_class: 'flex-grow-1'
+            }) }}
+        </div>
+    {% endset %}
+    {{ fields.htmlField('', logical_num_field, _n('Port number', 'Port number', 1), {
+        'add_field_class': 'multiple-port-fields d-none',
+        'wrapper_class': ''
+    }) }}
+    <input type="hidden" name="several" value="yes" disabled>
     {{ fields.textField('name', item.fields['name'], __('Name')) }}
     {{ fields.textField('ifalias', item.fields['ifalias'], __('Alias')) }}
 
@@ -90,7 +126,7 @@
         {{ call([instantiation, 'showInstantiationForm'], [item, params, recursive_items]) }}
     {% endif %}
 
-    {% if not params.several %}
+    <div class="network-name-section">
         {{ call('NetworkName::showFormForNetworkPort', [item.getID()]) }}
-    {% endif %}
+    </div>
 {% endblock %}

--- a/templates/pages/assets/networkport/form.html.twig
+++ b/templates/pages/assets/networkport/form.html.twig
@@ -53,7 +53,7 @@
                     checkbox.on('change', function(e) {
                         const chkbox = $(this);
                         const form = chkbox.closest('form');
-                        
+
                         if (chkbox.prop('checked')) {
                             form.find('.single-port-field').addClass('d-none');
                             form.find('.multiple-port-fields').removeClass('d-none');
@@ -77,7 +77,7 @@
     {{ fields.numberField('logical_number', item.fields['logical_number'], _n('Port number', 'Port number', 1), {
         'add_field_class': 'single-port-field'
     }) }}
-    
+
     {% set logical_num_field %}
         <div class="d-flex">
             {{ fields.numberField('from_logical_number', 0, null, {


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does: Relocates "Add several ports" checkbox from `NetworkPort::showPorts()` to NetworkPort form.

Currently, the "Add Several Ports" checkbox is displayed in the NetworkEquipment ports list when adding ports from a network equipment (/front/networkequipment.form.php). This checkbox should be moved to the NetworkPort form itself (`/front/networkport.form.php`) with similar behavior to the "Add Several Sockets" checkbox.

## Changes

1. **src/NetworkPort.php**:
    - Remove the "Add Several Ports" checkbox from the `showPorts` method
 
2. **templates/pages/assets/networkport/form.html.twig**:
    - Add a slider field for "Add several ports" checkbox at the beginning of the form
    - Add JavaScript to toggle the port number field display similar to socket form

## Screenshots (if appropriate):

![2026-01-2919-43-00-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/03149537-0c05-40ab-b0e3-c1d1c47ec5ae)

