### PR TITLE
Improve visual grouping of AJAX dropdowns in software installation forms

### DIFF
--- a/css/includes/components/_select2.scss
+++ b/css/includes/components/_select2.scss
@@ -247,6 +247,24 @@
             }
         }
     }
+
+    // Fix for select2 inside AJAX span wrappers within input-group
+    // The AJAX span breaks Bootstrap's direct child selector
+    .input-group > span > & {
+        flex-grow: 1;
+        flex-basis: content;
+        .select2-selection {
+            border-top-left-radius: 0;
+            border-bottom-left-radius: 0;
+        }
+    }
+
+    .input-group:has(span > &) > & {
+        .select2-selection {
+            border-top-right-radius: 0 !important;
+            border-bottom-right-radius: 0 !important;
+        }
+    }
 }
 
 // fix z-index issue for select2 dropdown container with a boostrap modal

--- a/css/includes/components/_select2.scss
+++ b/css/includes/components/_select2.scss
@@ -253,6 +253,7 @@
     .input-group > span > & {
         flex-grow: 1;
         flex-basis: content;
+
         .select2-selection {
             border-top-left-radius: 0;
             border-bottom-left-radius: 0;

--- a/src/Software.php
+++ b/src/Software.php
@@ -670,7 +670,7 @@ class Software extends CommonDBTM implements TreeBrowseInterface, AssignableItem
 
         // Start the input group wrapper
         echo "<div class='input-group'>";
-        
+
         $rand = Dropdown::show('Software', ['condition' => ['WHERE' => $where]]);
 
         $paramsselsoft = [

--- a/src/Software.php
+++ b/src/Software.php
@@ -667,6 +667,10 @@ class Software extends CommonDBTM implements TreeBrowseInterface, AssignableItem
             $entity_restrict,
             true
         );
+
+        // Start the input group wrapper
+        echo "<div class='input-group'>";
+        
         $rand = Dropdown::show('Software', ['condition' => ['WHERE' => $where]]);
 
         $paramsselsoft = [
@@ -682,6 +686,9 @@ class Software extends CommonDBTM implements TreeBrowseInterface, AssignableItem
         );
 
         echo "<span id='show_" . htmlescape($myname . $rand) . "'>&nbsp;</span>\n";
+
+        // Close the input group wrapper
+        echo "</div>";
 
         return $rand;
     }
@@ -725,6 +732,10 @@ class Software extends CommonDBTM implements TreeBrowseInterface, AssignableItem
             $softwares_id          = $data["id"];
             $values[$softwares_id] = $data["name"];
         }
+
+        // Start the input group wrapper
+        echo "<div class='input-group'>";
+
         $rand = Dropdown::showFromArray('softwares_id', $values, ['display_emptychoice' => true]);
 
         $paramsselsoft = ['softwares_id'    => '__VALUE__',
@@ -740,6 +751,9 @@ class Software extends CommonDBTM implements TreeBrowseInterface, AssignableItem
         );
 
         echo "<span id='show_" . htmlescape($myname . $rand) . "'>&nbsp;</span>\n";
+
+        // Close the input group wrapper
+        echo "</div>";
 
         return $rand;
     }


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does:

This PR improves the visual appearance of cascading dropdown menus in the software installation interface by properly grouping them using Bootstrap's input-group component with appropriate border-radius handling.

## Screenshots (if appropriate):

### Before

The dropdowns in "Install a Software" and "Add a licence" sections appeared as separate, disconnected elements with visible gaps between them, making the relationship between the primary dropdown (software selection) and the secondary AJAX-loaded dropdown (version/license selection) unclear.

<img width="343" height="314" alt="2026-01-29 21_08_37-Preferences" src="https://github.com/user-attachments/assets/1cc70f88-be7c-427b-bf71-a9739053b553" />

### After

The dropdowns now appear as a cohesive, visually connected group:

<img width="337" height="307" alt="2026-01-29 21_19_20-Preferences" src="https://github.com/user-attachments/assets/6f6ab6a5-b90e-4a7c-a51e-fef55ca537ff" />
