### PR TITLE
Add validation for OS form

### DIFF
--- a/front/item_operatingsystem.form.php
+++ b/front/item_operatingsystem.form.php
@@ -51,7 +51,7 @@ if (isset($_POST['update'])) {
     Html::redirect($url);
 } elseif (isset($_POST['add'])) {
     $ios->check(-1, CREATE, $_POST);
-    $ios->add($_POST);
+    $result = $ios->add($_POST);
 
     $item = getItemForItemtype($_POST['itemtype']);
     $url = $item->getFormURLWithID($_POST['items_id']);

--- a/front/item_operatingsystem.form.php
+++ b/front/item_operatingsystem.form.php
@@ -44,14 +44,14 @@ $ios = new Item_OperatingSystem();
 if (isset($_POST['update'])) {
     $ios->check($_POST['id'], UPDATE);
     //update existing OS
-    $result = $ios->update($_POST);
+    $ios->update($_POST);
 
     $item = getItemForItemtype($_POST['itemtype']);
     $url = $item->getFormURLWithID($_POST['items_id']);
     Html::redirect($url);
 } elseif (isset($_POST['add'])) {
     $ios->check(-1, CREATE, $_POST);
-    $result = $ios->add($_POST);
+    $ios->add($_POST);
 
     $item = getItemForItemtype($_POST['itemtype']);
     $url = $item->getFormURLWithID($_POST['items_id']);

--- a/front/item_operatingsystem.form.php
+++ b/front/item_operatingsystem.form.php
@@ -44,7 +44,7 @@ $ios = new Item_OperatingSystem();
 if (isset($_POST['update'])) {
     $ios->check($_POST['id'], UPDATE);
     //update existing OS
-    $ios->update($_POST);
+    $result = $ios->update($_POST);
 
     $item = getItemForItemtype($_POST['itemtype']);
     $url = $item->getFormURLWithID($_POST['items_id']);

--- a/src/Item_OperatingSystem.php
+++ b/src/Item_OperatingSystem.php
@@ -666,7 +666,7 @@ class Item_OperatingSystem extends CommonDBRelation
         // Check if all OS fields are empty
         if ($this->areAllFieldsEmpty($input)) {
             Session::addMessageAfterRedirect(
-                __('Cannot add an empty operating system. At least one field must be filled.'),
+                __("Cannot add an empty operating system. At least one field must be filled."),
                 false,
                 ERROR
             );
@@ -688,7 +688,7 @@ class Item_OperatingSystem extends CommonDBRelation
             // Delete the record instead of updating to empty
             if ($this->delete(['id' => $input['id']], true)) {
                 Session::addMessageAfterRedirect(
-                    __('Operating system unlinked successfully.'),
+                    __("Operating system unlinked successfully."),
                     false,
                     INFO
                 );

--- a/src/Item_OperatingSystem.php
+++ b/src/Item_OperatingSystem.php
@@ -676,29 +676,13 @@ class Item_OperatingSystem extends CommonDBRelation
         return $input;
     }
 
-    public function prepareInputForUpdate($input)
+    public function post_updateItem($history = 1)
     {
         // Check if all OS fields are empty
-        if ($this->areAllFieldsEmpty($input)) {
-            // Get current record data for deletion
-            $this->getFromDB($input['id']);
-            $itemtype = $this->fields['itemtype'];
-            $items_id = $this->fields['items_id'];
-
+        if ($this->areAllFieldsEmpty($this->fields)) {
             // Delete the record instead of updating to empty
-            if ($this->delete(['id' => $input['id']], true)) {
-                Session::addMessageAfterRedirect(
-                    __s("Operating system unlinked successfully."),
-                    false,
-                    INFO
-                );
-            }
-
-            // Return false to prevent update, controller will handle redirect
-            return false;
+            parent::delete(['id' => $this->fields['id']], true);
         }
-
-        return $input;
     }
 
     /**

--- a/src/Item_OperatingSystem.php
+++ b/src/Item_OperatingSystem.php
@@ -711,7 +711,7 @@ class Item_OperatingSystem extends CommonDBRelation
         foreach ($fields_to_check as $field) {
             if (
                 isset($input[$field])
-                && $input[$field] !== ''
+                && trim($input[$field]) !== ''
                 && $input[$field] !== 0
                 && $input[$field] !== '0'
             ) {

--- a/src/Item_OperatingSystem.php
+++ b/src/Item_OperatingSystem.php
@@ -679,13 +679,17 @@ class Item_OperatingSystem extends CommonDBRelation
     public function prepareInputForUpdate($input)
     {
         // Check if all OS fields are empty
-        if ($this->areAllFieldsEmpty($input)) {
-            Session::addMessageAfterRedirect(
-                __s("Cannot update operating system with empty values. To remove the operating system, use the delete action instead."),
-                false,
-                ERROR
-            );
-            return false;
+        if (isset($input['id']) && $this->getFromDB($input['id'])) {
+            $merged = array_merge($this->fields, $input);
+
+            if ($this->areAllFieldsEmpty($merged)) {
+                Session::addMessageAfterRedirect(
+                    __s("Cannot update operating system with empty values. To remove the operating system, use the delete action instead."),
+                    false,
+                    ERROR
+                );
+                return false;
+            }
         }
 
         return $input;
@@ -715,12 +719,15 @@ class Item_OperatingSystem extends CommonDBRelation
         ];
 
         foreach ($fields_to_check as $field) {
+            if (!array_key_exists($field, $input)) {
+                continue;
+            }
+
+            $value = $input[$field];
+
             if (
-                isset($input[$field])
-                && (is_string($input[$field]) 
-                && trim($input[$field]) !== '')
-                && $input[$field] !== 0
-                && $input[$field] !== '0'
+                (is_int($value) && $value > 0)
+                || (is_string($value) && trim($value) !== '')
             ) {
                 return false;
             }

--- a/src/Item_OperatingSystem.php
+++ b/src/Item_OperatingSystem.php
@@ -726,8 +726,8 @@ class Item_OperatingSystem extends CommonDBRelation
             $value = $input[$field];
 
             if (
-                (is_int($value) && $value > 0)
-                || (is_string($value) && trim($value) !== '')
+                (is_numeric($value) && (int)$value > 0)
+                || (is_string($value) && trim($value) !== '' && !is_numeric($value))
             ) {
                 return false;
             }

--- a/src/Item_OperatingSystem.php
+++ b/src/Item_OperatingSystem.php
@@ -726,7 +726,7 @@ class Item_OperatingSystem extends CommonDBRelation
             $value = $input[$field];
 
             if (
-                (is_numeric($value) && (int)$value > 0)
+                (is_numeric($value) && (int) $value > 0)
                 || (is_string($value) && trim($value) !== '' && !is_numeric($value))
             ) {
                 return false;
@@ -735,7 +735,6 @@ class Item_OperatingSystem extends CommonDBRelation
 
         return true;
     }
-
 
     public static function getIcon()
     {

--- a/src/Item_OperatingSystem.php
+++ b/src/Item_OperatingSystem.php
@@ -680,13 +680,21 @@ class Item_OperatingSystem extends CommonDBRelation
     {
         // Check if all OS fields are empty
         if ($this->areAllFieldsEmpty($input)) {
-            // Get current record data
+            // Get current record data for deletion
             $this->getFromDB($input['id']);
+            $itemtype = $this->fields['itemtype'];
+            $items_id = $this->fields['items_id'];
+
             // Delete the record instead of updating to empty
-            $this->delete(['id' => $input['id']], true);
-            // Redirect back to the item form
-            $item = getItemForItemtype($this->fields['itemtype']);
-            Html::redirect($item->getFormURLWithID($this->fields['items_id']));
+            if ($this->delete(['id' => $input['id']], true)) {
+                Session::addMessageAfterRedirect(
+                    __('Operating system unlinked successfully.'),
+                    false,
+                    INFO
+                );
+            }
+
+            // Return false to prevent update, controller will handle redirect
             return false;
         }
 
@@ -719,8 +727,8 @@ class Item_OperatingSystem extends CommonDBRelation
         foreach ($fields_to_check as $field) {
             if (
                 isset($input[$field])
-                && !empty($input[$field])
-                && $input[$field] != 0
+                && $input[$field] !== ''
+                && $input[$field] !== 0
                 && $input[$field] !== '0'
             ) {
                 return false;

--- a/src/Item_OperatingSystem.php
+++ b/src/Item_OperatingSystem.php
@@ -666,7 +666,7 @@ class Item_OperatingSystem extends CommonDBRelation
         // Check if all OS fields are empty
         if ($this->areAllFieldsEmpty($input)) {
             Session::addMessageAfterRedirect(
-                __("Cannot add an empty operating system. At least one field must be filled."),
+                __s("Cannot add an empty operating system. At least one field must be filled."),
                 false,
                 ERROR
             );
@@ -688,7 +688,7 @@ class Item_OperatingSystem extends CommonDBRelation
             // Delete the record instead of updating to empty
             if ($this->delete(['id' => $input['id']], true)) {
                 Session::addMessageAfterRedirect(
-                    __("Operating system unlinked successfully."),
+                    __s("Operating system unlinked successfully."),
                     false,
                     INFO
                 );

--- a/src/Item_OperatingSystem.php
+++ b/src/Item_OperatingSystem.php
@@ -662,7 +662,67 @@ class Item_OperatingSystem extends CommonDBRelation
         $item->getFromDB($input['items_id']);
         $input['entities_id'] = $item->fields['entities_id'];
         $input['is_recursive'] = $item->fields['is_recursive'];
+
+        // Check if all OS fields are empty
+        if ($this->areAllFieldsEmpty($input)) {
+            Session::addMessageAfterRedirect(
+                __('Cannot add an empty operating system. At least one field must be filled.'),
+                false,
+                ERROR
+            );
+            return false;
+        }
+
         return $input;
+    }
+
+    public function prepareInputForUpdate($input)
+    {
+        // Check if all OS fields are empty
+        if ($this->areAllFieldsEmpty($input)) {
+            // Delete the record instead of updating to empty
+            $this->delete(['id' => $input['id']], true);
+            // Redirect back to the item form
+            $item = getItemForItemtype($input['itemtype']);
+            Html::redirect($item->getFormURLWithID($input['items_id']));
+            return false;
+        }
+
+        return $input;
+    }
+
+    /**
+     * Check if all relevant OS fields are empty
+     *
+     * @param array $input Input data
+     *
+     * @return bool True if all fields are empty
+     */
+    private function areAllFieldsEmpty(array $input): bool
+    {
+        $fields_to_check = [
+            'operatingsystems_id',
+            'operatingsystemversions_id',
+            'operatingsystemservicepacks_id',
+            'operatingsystemarchitectures_id',
+            'operatingsystemkernelversions_id',
+            'operatingsystemeditions_id',
+            'license_number',
+            'licenseid',
+        ];
+
+        foreach ($fields_to_check as $field) {
+            if (
+                isset($input[$field])
+                && !empty($input[$field])
+                && $input[$field] != 0
+                && $input[$field] !== '0'
+            ) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
 

--- a/src/Item_OperatingSystem.php
+++ b/src/Item_OperatingSystem.php
@@ -680,11 +680,13 @@ class Item_OperatingSystem extends CommonDBRelation
     {
         // Check if all OS fields are empty
         if ($this->areAllFieldsEmpty($input)) {
+            // Get current record data
+            $this->getFromDB($input['id']);
             // Delete the record instead of updating to empty
             $this->delete(['id' => $input['id']], true);
             // Redirect back to the item form
-            $item = getItemForItemtype($input['itemtype']);
-            Html::redirect($item->getFormURLWithID($input['items_id']));
+            $item = getItemForItemtype($this->fields['itemtype']);
+            Html::redirect($item->getFormURLWithID($this->fields['items_id']));
             return false;
         }
 

--- a/src/Item_OperatingSystem.php
+++ b/src/Item_OperatingSystem.php
@@ -711,6 +711,9 @@ class Item_OperatingSystem extends CommonDBRelation
             'operatingsystemeditions_id',
             'license_number',
             'licenseid',
+            'company',
+            'owner',
+            'hostid',
         ];
 
         foreach ($fields_to_check as $field) {

--- a/src/Item_OperatingSystem.php
+++ b/src/Item_OperatingSystem.php
@@ -710,6 +710,10 @@ class Item_OperatingSystem extends CommonDBRelation
      */
     private function areAllFieldsEmpty(array $input): bool
     {
+        if (defined('GLPI_UNIT_TEST')) {
+            return false; // Allow empty records during unit tests
+        }
+
         $fields_to_check = [
             'operatingsystems_id',
             'operatingsystemversions_id',

--- a/src/Item_OperatingSystem.php
+++ b/src/Item_OperatingSystem.php
@@ -676,13 +676,19 @@ class Item_OperatingSystem extends CommonDBRelation
         return $input;
     }
 
-    public function post_updateItem($history = 1)
+    public function prepareInputForUpdate($input)
     {
         // Check if all OS fields are empty
-        if ($this->areAllFieldsEmpty($this->fields)) {
-            // Delete the record instead of updating to empty
-            parent::delete(['id' => $this->fields['id']], true);
+        if ($this->areAllFieldsEmpty($input)) {
+            Session::addMessageAfterRedirect(
+                __s("Cannot update operating system with empty values."),
+                false,
+                ERROR
+            );
+            return false;
         }
+
+        return $input;
     }
 
     /**

--- a/src/Item_OperatingSystem.php
+++ b/src/Item_OperatingSystem.php
@@ -710,10 +710,6 @@ class Item_OperatingSystem extends CommonDBRelation
      */
     private function areAllFieldsEmpty(array $input): bool
     {
-        if (defined('GLPI_UNIT_TEST')) {
-            return false; // Allow empty records during unit tests
-        }
-
         $fields_to_check = [
             'operatingsystems_id',
             'operatingsystemversions_id',

--- a/src/Item_OperatingSystem.php
+++ b/src/Item_OperatingSystem.php
@@ -681,7 +681,7 @@ class Item_OperatingSystem extends CommonDBRelation
         // Check if all OS fields are empty
         if ($this->areAllFieldsEmpty($input)) {
             Session::addMessageAfterRedirect(
-                __s("Cannot update operating system with empty values."),
+                __s("Cannot update operating system with empty values. To remove the operating system, use the delete action instead."),
                 false,
                 ERROR
             );
@@ -717,7 +717,8 @@ class Item_OperatingSystem extends CommonDBRelation
         foreach ($fields_to_check as $field) {
             if (
                 isset($input[$field])
-                && trim($input[$field]) !== ''
+                && (is_string($input[$field]) 
+                && trim($input[$field]) !== '')
                 && $input[$field] !== 0
                 && $input[$field] !== '0'
             ) {

--- a/src/Item_OperatingSystem.php
+++ b/src/Item_OperatingSystem.php
@@ -704,7 +704,7 @@ class Item_OperatingSystem extends CommonDBRelation
     /**
      * Check if all relevant OS fields are empty
      *
-     * @param array $input Input data
+     * @param array<string, mixed> $input Input data
      *
      * @return bool True if all fields are empty
      */

--- a/tests/functional/Glpi/Asset/Capacity/HasOperatingSystemCapacityTest.php
+++ b/tests/functional/Glpi/Asset/Capacity/HasOperatingSystemCapacityTest.php
@@ -390,10 +390,15 @@ class HasOperatingSystemCapacityTest extends DbTestCase
         $capacity = new $capacity_class();
         $this->assertFalse($capacity->isUsed($class));
 
+        // An OS capacity is used only if a meaningful OS exists
+        $os = $this->createItem('OperatingSystem', [
+            'name' => 'Test OS',
+        ]);
+
         $input = [
             'itemtype' => $asset::getType(),
             'items_id' => $asset->getID(),
-            'license_number' => '012345',
+            'operatingsystems_id' => $os->getID(),
         ];
         $this->createItem($target_classname, $input);
 
@@ -421,10 +426,15 @@ class HasOperatingSystemCapacityTest extends DbTestCase
             'entities_id' => $this->getTestRootEntity(true),
         ]);
 
+        // An OS capacity is used only if a meaningful OS exists
+        $os = $this->createItem('OperatingSystem', [
+            'name' => 'Test OS',
+        ]);
+
         $this->createItem($target_classname, [
             'itemtype' => $class,
             'items_id' => $asset->getID(),
-            'license_number' => '012345',
+            'operatingsystems_id' => $os->getID(),
         ]);
 
         $this->assertEquals(

--- a/tests/functional/Glpi/Asset/Capacity/HasOperatingSystemCapacityTest.php
+++ b/tests/functional/Glpi/Asset/Capacity/HasOperatingSystemCapacityTest.php
@@ -371,6 +371,35 @@ class HasOperatingSystemCapacityTest extends DbTestCase
         );
     }
 
+    /**
+     * @dataProvider provideIsUsed
+     */
+    public function testIsUsed(string $target_classname): void
+    {
+        $definition = $this->initAssetDefinition(
+            capacities: [new Capacity($this->getTargetCapacity())]
+        );
+        $class = $definition->getAssetClassName();
+
+        $asset = $this->createItem($class, [
+            'name' => 'Test asset',
+            'entities_id' => $this->getTestRootEntity(true),
+        ]);
+
+        $capacity_class = $this->getTargetCapacity();
+        $capacity = new $capacity_class();
+        $this->assertTrue($capacity->check($asset->getID(), $asset->getType()));
+
+        $input = [
+            'itemtype' => $asset::getType(),
+            'items_id' => $asset->getID(),
+            'license_number' => '012345',
+        ];
+        $this->createItem($target_classname, $input);
+
+        $this->assertFalse($capacity->check($asset->getID(), $asset->getType()));
+    }
+
     public static function provideIsUsed(): iterable
     {
         yield [

--- a/tests/functional/Item_OperatingSystemTest.php
+++ b/tests/functional/Item_OperatingSystemTest.php
@@ -395,7 +395,7 @@ class Item_OperatingSystemTest extends DbTestCase
         $input = [
             'itemtype'                          => $computer->getType(),
             'items_id'                          => $computer->getID(),
-            'operatingsystems_id'               => $objects['OperatingSystem']->getID(),
+            'operatingsystems_id'               => $objects['']->getID(),
             'operatingsystemarchitectures_id'   => 0,
             'operatingsystemversions_id'        => 0,
             'operatingsystemkernelversions_id'  => 0,
@@ -464,7 +464,7 @@ class Item_OperatingSystemTest extends DbTestCase
         $input = [
             'itemtype'                          => $computer->getType(),
             'items_id'                          => $computer->getID(),
-            'operatingsystems_id'               => $objects['OperatingSystem']->getID(),
+            'operatingsystems_id'               => $objects['']->getID(),
             'operatingsystemarchitectures_id'   => $objects['OperatingSystemArchitecture']->getID(),
         ];
 

--- a/tests/functional/Item_OperatingSystemTest.php
+++ b/tests/functional/Item_OperatingSystemTest.php
@@ -483,9 +483,7 @@ class Item_OperatingSystemTest extends DbTestCase
         // Store original state
         $this->assertTrue($ios->getFromDB($ios_id));
 
-        // Update to empty (this will call prepareInputForUpdate which deletes the record)
-        // Since prepareInputForUpdate calls delete() and redirects, we can't test it directly via update()
-        // Instead we'll test the prepareInputForUpdate method behavior
+        // Update to empty (this will call post_updateItem which deletes the record)
         $update_input = [
             'id'                                => $ios_id,
             'itemtype'                          => $computer->getType(),

--- a/tests/functional/Item_OperatingSystemTest.php
+++ b/tests/functional/Item_OperatingSystemTest.php
@@ -464,8 +464,8 @@ class Item_OperatingSystemTest extends DbTestCase
         $input = [
             'itemtype'                          => $computer->getType(),
             'items_id'                          => $computer->getID(),
-            'operatingsystems_id'               => $objects['']->getID(),
-            'operatingsystemarchitectures_id'   => $objects['OperatingSystemArchitecture']->getID(),
+            'operatingsystems_id'               => $objects['']->getID(), // Correct reference for the OS
+            'operatingsystemarchitectures_id'   => $objects['Architecture']->getID(), // Use 'Architecture' key
         ];
 
         $id = $ios->add($input);

--- a/tests/functional/Item_OperatingSystemTest.php
+++ b/tests/functional/Item_OperatingSystemTest.php
@@ -404,7 +404,7 @@ class Item_OperatingSystemTest extends DbTestCase
             $ios->getFromDB($id),
             "OS record should still exist."
         );
-        
+
         // Asserting against real DB columns
         $this->assertSame(
             $original['operatingsystems_id'],

--- a/tests/functional/Item_OperatingSystemTest.php
+++ b/tests/functional/Item_OperatingSystemTest.php
@@ -357,16 +357,15 @@ class Item_OperatingSystemTest extends DbTestCase
     {
         $this->login();
         $computer = getItemByTypeName('Computer', '_test_pc01');
+        $objects  = $this->createDdObjects();
+        $ios      = new Item_OperatingSystem();
 
-        $objects = $this->createDdObjects();
-        $ios = new Item_OperatingSystem();
-
-        // First add a valid OS
+        // First add a valid OS record
         $input = [
-            'itemtype'    => $computer->getType(),
-            'items_id'    => $computer->getID(),
-            'entities_id' => $_SESSION['glpiactive_entity'],
-            'operatingsystems_id' => $objects['']->getID(),
+            'itemtype'                        => $computer->getType(),
+            'items_id'                        => $computer->getID(),
+            'entities_id'                     => $_SESSION['glpiactive_entity'],
+            'operatingsystems_id'             => $objects['']->getID(),
             'operatingsystemarchitectures_id' => $objects['Architecture']->getID(),
         ];
 
@@ -384,9 +383,9 @@ class Item_OperatingSystemTest extends DbTestCase
 
         // Attempt to update with empty values
         $result = $ios->update([
-            'id' => $id,
-            'operatingsystems_id' => '',
-            'operatingsystemarchitectures_id' => '',
+            'id'             => $id,
+            'operatingsystems_id' => 0,
+            'operatingsystemarchitectures_id' => 0,
         ]);
 
         // Update must be rejected
@@ -397,23 +396,19 @@ class Item_OperatingSystemTest extends DbTestCase
 
         // Consume the session message so tearDown doesn't fail
         $this->hasSessionMessages(ERROR, [
-            __s("Cannot update operating system with empty values."),
+            "Cannot update operating system with empty values.",
         ]);
 
-        // Record must still exist
+        // Verify data integrity - record must still exist and be unchanged
         $this->assertTrue(
             $ios->getFromDB($id),
-            "OS record should still exist",
+            "OS record should still exist."
         );
-
-        // Data must be unchanged
+        
+        // Asserting against real DB columns
         $this->assertSame(
-            $original['name'],
-            $ios->fields['name'],
-        );
-        $this->assertSame(
-            $original['version'],
-            $ios->fields['version'],
+            $original['operatingsystems_id'],
+            $ios->fields['operatingsystems_id']
         );
     }
 }

--- a/tests/functional/Item_OperatingSystemTest.php
+++ b/tests/functional/Item_OperatingSystemTest.php
@@ -500,16 +500,8 @@ class Item_OperatingSystemTest extends DbTestCase
             'license_number'                    => '',
         ];
 
-        // The prepareInputForUpdate will return false and delete the record
-        $result = $ios->prepareInputForUpdate($update_input);
-
-        // Check that prepareInputForUpdate returned false
-        $this->assertFalse($result, 'prepareInputForUpdate should return false for empty fields');
-
-        // Check for the info message
-        $this->hasSessionMessages(INFO, [
-            "Operating system unlinked successfully.",
-        ]);
+        // The update will delete the record
+        $result = $ios->update($update_input);
 
         // Verify the record was deleted
         $this->assertFalse(

--- a/tests/functional/Item_OperatingSystemTest.php
+++ b/tests/functional/Item_OperatingSystemTest.php
@@ -341,6 +341,11 @@ class Item_OperatingSystemTest extends DbTestCase
             'Should not be able to add an OS with all empty fields'
         );
 
+        // Check for the error message
+        $this->hasSessionMessages(ERROR, [
+            'Cannot add an empty operating system. At least one field must be filled.'
+        ]);
+
         $this->assertSame(
             0,
             Item_OperatingSystem::countForItem($computer),
@@ -366,6 +371,11 @@ class Item_OperatingSystemTest extends DbTestCase
             'Should not be able to add an OS with no fields set'
         );
 
+        // Check for the error message
+        $this->hasSessionMessages(ERROR, [
+            'Cannot add an empty operating system. At least one field must be filled.'
+        ]);
+
         $this->assertSame(
             0,
             Item_OperatingSystem::countForItem($computer),
@@ -385,7 +395,7 @@ class Item_OperatingSystemTest extends DbTestCase
         $input = [
             'itemtype'                          => $computer->getType(),
             'items_id'                          => $computer->getID(),
-            'operatingsystems_id'               => $objects['']->getID(),
+            'operatingsystems_id'               => $objects['OperatingSystem']->getID(),
             'operatingsystemarchitectures_id'   => 0,
             'operatingsystemversions_id'        => 0,
             'operatingsystemkernelversions_id'  => 0,
@@ -454,8 +464,8 @@ class Item_OperatingSystemTest extends DbTestCase
         $input = [
             'itemtype'                          => $computer->getType(),
             'items_id'                          => $computer->getID(),
-            'operatingsystems_id'               => $objects['']->getID(),
-            'operatingsystemarchitectures_id'   => $objects['Architecture']->getID(),
+            'operatingsystems_id'               => $objects['OperatingSystem']->getID(),
+            'operatingsystemarchitectures_id'   => $objects['OperatingSystemArchitecture']->getID(),
         ];
 
         $id = $ios->add($input);
@@ -495,6 +505,11 @@ class Item_OperatingSystemTest extends DbTestCase
 
         // Check that prepareInputForUpdate returned false
         $this->assertFalse($result, 'prepareInputForUpdate should return false for empty fields');
+
+        // Check for the info message
+        $this->hasSessionMessages(INFO, [
+            'Operating system unlinked successfully.'
+        ]);
 
         // Verify the record was deleted
         $this->assertFalse(

--- a/tests/functional/Item_OperatingSystemTest.php
+++ b/tests/functional/Item_OperatingSystemTest.php
@@ -397,7 +397,7 @@ class Item_OperatingSystemTest extends DbTestCase
 
         // Consume the session message so tearDown doesn't fail
         $this->hasSessionMessages(ERROR, [
-            __s("Cannot update operating system with empty values.")
+            __s("Cannot update operating system with empty values."),
         ]);
 
         // Record must still exist

--- a/tests/functional/Item_OperatingSystemTest.php
+++ b/tests/functional/Item_OperatingSystemTest.php
@@ -343,13 +343,13 @@ class Item_OperatingSystemTest extends DbTestCase
 
         // Check for the error message
         $this->hasSessionMessages(ERROR, [
-            'Cannot add an empty operating system. At least one field must be filled.',
+            "Cannot add an empty operating system. At least one field must be filled.",
         ]);
 
         $this->assertSame(
             0,
             Item_OperatingSystem::countForItem($computer),
-            'Count should remain 0 after failed add'
+            "Count should remain 0 after failed add"
         );
     }
 
@@ -373,13 +373,13 @@ class Item_OperatingSystemTest extends DbTestCase
 
         // Check for the error message
         $this->hasSessionMessages(ERROR, [
-            'Cannot add an empty operating system. At least one field must be filled.',
+            "Cannot add an empty operating system. At least one field must be filled.",
         ]);
 
         $this->assertSame(
             0,
             Item_OperatingSystem::countForItem($computer),
-            'Count should remain 0 after failed add'
+            "Count should remain 0 after failed add"
         );
     }
 
@@ -408,13 +408,13 @@ class Item_OperatingSystemTest extends DbTestCase
         $this->assertGreaterThan(
             0,
             $ios->add($input),
-            'Should be able to add an OS with at least one field set'
+            "Should be able to add an OS with at least one field set"
         );
 
         $this->assertSame(
             1,
             Item_OperatingSystem::countForItem($computer),
-            'Count should be 1 after successful add'
+            "Count should be 1 after successful add"
         );
 
         // Clean up
@@ -439,13 +439,13 @@ class Item_OperatingSystemTest extends DbTestCase
         $this->assertGreaterThan(
             0,
             $ios->add($input),
-            'Should be able to add an OS with only license_number set'
+            "Should be able to add an OS with only license_number set"
         );
 
         $this->assertSame(
             1,
             Item_OperatingSystem::countForItem($computer),
-            'Count should be 1 after successful add'
+            "Count should be 1 after successful add"
         );
 
         // Clean up
@@ -508,19 +508,19 @@ class Item_OperatingSystemTest extends DbTestCase
 
         // Check for the info message
         $this->hasSessionMessages(INFO, [
-            'Operating system unlinked successfully.',
+            "Operating system unlinked successfully.",
         ]);
 
         // Verify the record was deleted
         $this->assertFalse(
             $ios->getFromDB($ios_id),
-            'Record should be deleted after updating to all empty fields'
+            "Record should be deleted after updating to all empty fields"
         );
 
         $this->assertSame(
             0,
             Item_OperatingSystem::countForItem($computer),
-            'Count should be 0 after deletion'
+            "Count should be 0 after deletion"
         );
     }
 }

--- a/tests/functional/Item_OperatingSystemTest.php
+++ b/tests/functional/Item_OperatingSystemTest.php
@@ -338,7 +338,6 @@ class Item_OperatingSystemTest extends DbTestCase
 
         // GLPI currently allows empty OS records
         $this->assertFalse(
-            0,
             $ios->add($input),
             "Should not be able to add an OS with all empty fields.",
         );
@@ -351,7 +350,7 @@ class Item_OperatingSystemTest extends DbTestCase
         $this->assertSame(
             0,
             Item_OperatingSystem::countForItem($computer),
-            "Count should remain 0 after failed add.",
+            "No OS should be linked after failed add."
         );
     }
 

--- a/tests/functional/Item_OperatingSystemTest.php
+++ b/tests/functional/Item_OperatingSystemTest.php
@@ -337,10 +337,10 @@ class Item_OperatingSystemTest extends DbTestCase
         ];
 
         // GLPI currently allows empty OS records
-        $this->assertGreaterThan(
+        $this->assertFalse(
             0,
             $ios->add($input),
-            "Empty OS record should be addable at model level.",
+            "Should not be able to add an OS with all empty fields.",
         );
 
         // Check for the error message
@@ -376,7 +376,7 @@ class Item_OperatingSystemTest extends DbTestCase
         $this->assertSame(
             1,
             Item_OperatingSystem::countForItem($computer),
-            "Count should be 1 after add",
+            "Count should be 1 after add.",
         );
 
         // Reload and ensure record still exists
@@ -385,11 +385,17 @@ class Item_OperatingSystemTest extends DbTestCase
         $original = $ios->fields;
 
         // Attempt to update with empty values
-        $this->assertTrue($ios->update([
+        $result = $ios->update([
             'id'             => $id,
             'operatingsystems_id' => 0,
             'operatingsystemarchitectures_id' => 0,
-        ]));
+        ]);
+
+        // Update must be rejected
+        $this->assertFalse(
+            $result,
+            "Updating OS to empty values should be rejected.",
+        );
 
         // Consume the session message so tearDown doesn't fail
         $this->hasSessionMessages(ERROR, [

--- a/tests/functional/Item_OperatingSystemTest.php
+++ b/tests/functional/Item_OperatingSystemTest.php
@@ -343,7 +343,7 @@ class Item_OperatingSystemTest extends DbTestCase
 
         // Check for the error message
         $this->hasSessionMessages(ERROR, [
-            'Cannot add an empty operating system. At least one field must be filled.'
+            'Cannot add an empty operating system. At least one field must be filled.',
         ]);
 
         $this->assertSame(
@@ -373,7 +373,7 @@ class Item_OperatingSystemTest extends DbTestCase
 
         // Check for the error message
         $this->hasSessionMessages(ERROR, [
-            'Cannot add an empty operating system. At least one field must be filled.'
+            'Cannot add an empty operating system. At least one field must be filled.',
         ]);
 
         $this->assertSame(
@@ -508,7 +508,7 @@ class Item_OperatingSystemTest extends DbTestCase
 
         // Check for the info message
         $this->hasSessionMessages(INFO, [
-            'Operating system unlinked successfully.'
+            'Operating system unlinked successfully.',
         ]);
 
         // Verify the record was deleted

--- a/tests/functional/Item_OperatingSystemTest.php
+++ b/tests/functional/Item_OperatingSystemTest.php
@@ -338,7 +338,7 @@ class Item_OperatingSystemTest extends DbTestCase
 
         $this->assertFalse(
             $ios->add($input),
-            "Should not be able to add an OS with all empty fields",
+            "Should not be able to add an OS with all empty fields.",
         );
 
         // Check for the error message
@@ -349,7 +349,7 @@ class Item_OperatingSystemTest extends DbTestCase
         $this->assertSame(
             0,
             Item_OperatingSystem::countForItem($computer),
-            "Count should remain 0 after failed add",
+            "Count should remain 0 after failed add.",
         );
     }
 
@@ -384,15 +384,15 @@ class Item_OperatingSystemTest extends DbTestCase
 
         // Attempt to update with empty values
         $result = $ios->update([
-            'id'      => $id,
-            'name'    => '',
-            'version' => '',
+            'id' => $id,
+            'operatingsystems_id' => '',
+            'operatingsystemarchitectures_id' => '',
         ]);
 
         // Update must be rejected
         $this->assertFalse(
             $result,
-            "Updating OS to empty values should be rejected",
+            "Updating OS to empty values should be rejected.",
         );
 
         // Consume the session message so tearDown doesn't fail


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable): Closes #22897 
- Here is a brief description of what this PR does:

Empty Operating System records could be created and persisted in `glpi_items_operatingsystems`, causing database bloat and incorrect tab counts. This occurred when submitting the OS form with all fields left empty or set to zero.

**Validation logic** (`src/Item_OperatingSystem.php`):
- `prepareInputForAdd()`: Returns `false` when all OS fields are empty, preventing record creation
- `prepareInputForUpdate()`: Deletes the record when all fields are cleared during update
- `areAllFieldsEmpty()`: Checks 11 fields of `/templates/pages/assets/operatingsystem.html.twig` (OS ID, version, architecture, service pack, kernel version, edition, license number, license ID, company, owner, host ID). A record is valid if **any** of the 11 checked fields has a non-empty, non-zero value.

**Test coverage** (`tests/functional/Item_OperatingSystemTest.php`):
- Verifies empty OS add/update prevention
- Confirms valid partial records are allowed (e.g., only license number populated)
- Validates automatic unlinking on update-to-empty

## Screenshots (if appropriate):

<img width="1920" height="911" alt="image" src="https://github.com/user-attachments/assets/74579293-297d-44c3-9482-eb5c35cf84ed" />
