### PR TITLE
fix: use friendly name for User objects in QuestionTypeItem

### DIFF
--- a/src/Glpi/Form/QuestionType/QuestionTypeItem.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeItem.php
@@ -408,7 +408,7 @@ class QuestionTypeItem extends AbstractQuestionType implements
         }
 
         // If the object is a user, use getFriendlyName()
-        if ($item instanceof \User) {
+        if ($item instanceof User) {
             return $item->getFriendlyName();
         }
 

--- a/src/Glpi/Form/QuestionType/QuestionTypeItem.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeItem.php
@@ -407,6 +407,11 @@ class QuestionTypeItem extends AbstractQuestionType implements
             return '';
         }
 
+        // If the object is a user, use getFriendlyName()
+        if ($item instanceof \User) {
+            return $item->getFriendlyName();
+        }
+
         return $item->fields['name'];
     }
 


### PR DESCRIPTION
## Summary
This PR improves how User objects are displayed within `QuestionTypeItem`. It adds a specific check to use the `getFriendlyName()` method when the item is a `User` instance, rather than defaulting to the raw `name` field.

## Related Issue
Fixes #22856

## Solution
- Added a check `if ($item instanceof \User)`.
- Implemented `getFriendlyName()` for User objects to ensure the proper display name (e.g., Firstname Lastname) is returned.
- Retained the fallback to `$item->fields['name']` for non-user objects.

## Technical Details
Modified `src/Glpi/Form/QuestionType/QuestionTypeItem.php` to handle the `\User` class specifically before returning the label.