### PR TITLE
Fix date input overriding additional_attributes

### DIFF
--- a/templates/components/form/basic_inputs_macros.html.twig
+++ b/templates/components/form/basic_inputs_macros.html.twig
@@ -277,7 +277,7 @@
         {{ _self.input(name, value, options|merge({
             'type': 'text',
             'id': options.id ~ '_input',
-            'additional_attributes': {'data-input': ''},
+            'additional_attributes': (options.additional_attributes ?? {})|merge({'data-input': ''}),
             'input_addclass': options.input_addclass ~ final_expiration_class,
             'clearable': false
         })) }}


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

The date input override additional_attributes beacause twig merge is not recursive

## Screenshots (if appropriate):


