### PR TITLE
Add span elements around messages in Link

### DIFF
--- a/src/Link.php
+++ b/src/Link.php
@@ -563,13 +563,13 @@ class Link extends CommonDBTM
                     {% if show_add %}
                         <a class="btn btn-primary ms-1" href="{{ 'ManualLink'|itemtype_form_path ~ '?itemtype=' ~ item.getType() ~ '&items_id=' ~ item.fields[item.getIndexName()] }}">
                             <i class="ti ti-link"></i>
-                            {{ add_msg }}
+                            <span>{{ add_msg }}</span>
                         </a>
                     {% endif %}
                     {% if show_configure %}
                         <a class="btn btn-primary ms-1" href="{{ 'Link'|itemtype_search_path }}">
                             <i class="ti ti-settings"></i>
-                            {{ configure_msg }}
+                            <span>{{ configure_msg }}</span>
                         </a>
                     {% endif %}
                 </div>

--- a/src/NetworkPort.php
+++ b/src/NetworkPort.php
@@ -706,7 +706,7 @@ class NetworkPort extends CommonDBChild
 
             echo "<div class='col-auto'>";
             echo "<button type='submit' name='add' value='1' class='btn btn-primary ms-1'>";
-            echo "<i class='ti ti-link'></i>" . _sx('button', 'Add');
+            echo "<i class='ti ti-link'></i><span>" . _sx('button', 'Add') . "</span>";
             echo "</button>";
             echo "</div>";
 

--- a/templates/components/tab/addlink_block.html.twig
+++ b/templates/components/tab/addlink_block.html.twig
@@ -57,6 +57,6 @@
 {% if button_icon is not empty %}
         <i class="{{ button_icon }}"></i>
 {% endif %}
-        {{ button_label }}
+        <span>{{ button_label }}</span>
     </a>
 </div>


### PR DESCRIPTION
Wrap add_msg and configure_msg in span elements for better styling.

<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does: Similar to #22924 

Demo in /front/computer.form.php?id=1 ("Links" tab)

## Screenshots (if appropriate):

<img width="345" height="65" alt="image" src="https://github.com/user-attachments/assets/68aade29-ffd6-40b3-a662-95efaaa269d8" />
