### PR TITLE
Fix CSS memory limit

### DIFF
--- a/front/css.php
+++ b/front/css.php
@@ -43,8 +43,8 @@ use function Safe\preg_match;
 if (preg_match('~^css/glpi(\.scss)?$~', $_GET['file'] ?? '') === 1) {
     // Ensure to have enough memory to not reach memory limit.
     $max_memory = Html::MAIN_SCSS_COMPILATION_REQUIRED_MEMORY;
-    if (Toolbox::getMemoryLimit() < ($max_memory * 1024 * 1024)) {
-        Toolbox::safeIniSet('memory_limit', sprintf('%dM', $max_memory));
+    if (Toolbox::getMemoryLimit() < $max_memory) {
+        Toolbox::safeIniSet('memory_limit', $max_memory);
     }
 }
 

--- a/src/Glpi/Console/Build/CompileScssCommand.php
+++ b/src/Glpi/Console/Build/CompileScssCommand.php
@@ -106,8 +106,8 @@ class CompileScssCommand extends Command
 
         // Ensure to have enough memory to not reach memory limit.
         $max_memory = Html::MAIN_SCSS_COMPILATION_REQUIRED_MEMORY;
-        if (Toolbox::getMemoryLimit() < ($max_memory * 1024 * 1024)) {
-            Toolbox::safeIniSet('memory_limit', sprintf('%dM', $max_memory));
+        if (Toolbox::getMemoryLimit() < $max_memory) {
+            Toolbox::safeIniSet('memory_limit', $max_memory);
         }
     }
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Fix memory limit setting when the current memory limit is less than required for CSS compilation (192MB). Due to the constant already being specified in bytes, GLPI was asking for 1048576x more memory than needed in some cases.
201TB of RAM? In this economy?