### PR TITLE
Fix(Ticket): adding of inactive or deleted user

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -9359,8 +9359,6 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
             'observer',
         ];
 
-        $user_class = new User();
-
         foreach ($actor_types as $actor_type) {
             $actor_type_value = constant(CommonITILActor::class . '::' . strtoupper($actor_type));
 
@@ -9587,15 +9585,25 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
                     break; // As actor is found, do not continue to list existings
                 }
 
-                if ($found === false
-                    && $user_class->getFromDBByCrit([
-                        'id'         => $actor['items_id'],
-                        'is_active'  => 1,
-                        'is_deleted' => 0,
-                    ])
+                if (
+                    $actor['itemtype'] === User::class
+                    && $actor['items_id'] > 0
                 ) {
+                    $valid_users = iterator_to_array(
+                        User::getSqlSearchResult(
+                            false,
+                            'all',
+                            $this->fields['entities_id']
+                        )
+                    );
+
+                    if (isset($valid_users[$actor['items_id']])) {
+                        $added[] = $actor;
+                    }
+                } elseif ($found === false) {
                     $added[] = $actor;
                 }
+
             }
 
             // Add new actors

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -9359,6 +9359,8 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
             'observer',
         ];
 
+        $user_class = new User();
+
         foreach ($actor_types as $actor_type) {
             $actor_type_value = constant(CommonITILActor::class . '::' . strtoupper($actor_type));
 
@@ -9585,7 +9587,13 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
                     break; // As actor is found, do not continue to list existings
                 }
 
-                if ($found === false) {
+                if ($found === false
+                    && $user_class->getFromDBByCrit([
+                        'id'         => $actor['items_id'],
+                        'is_active'  => 1,
+                        'is_deleted' => 0,
+                    ])
+                ) {
                     $added[] = $actor;
                 }
             }

--- a/tests/functional/RuleTicketTest.php
+++ b/tests/functional/RuleTicketTest.php
@@ -945,11 +945,11 @@ class RuleTicketTest extends RuleCommonITILObjectTest
         );
 
         // Add user to ticket
-        $user = new \User();
-        $user_id = $user->add([
-            'name' => 'test',
-        ]);
-        $this->assertGreaterThan(0, $user_id);
+        $user_id = $this->createItem(\User::class, [
+            'name'        => 'test',
+            '_profiles_id' => getItemByTypeName('Profile', 'Self-Service', true),
+            '_entities_id' => 0,
+        ])->getID();
 
         $ticket->update([
             'id'                  => $ticket_id,

--- a/tests/functional/RuleTicketTest.php
+++ b/tests/functional/RuleTicketTest.php
@@ -661,15 +661,15 @@ class RuleTicketTest extends RuleCommonITILObjectTest
 
         // create users
         $user = new \User();
-        $manager_id = $user->add([
+        $manager_id = $this->createItem(\User::class, [
             'name' => 'test manager',
-        ]);
-        $this->assertGreaterThan(0, $manager_id);
-        $user_id = $user->add([
+            '_profiles_id' => getItemByTypeName('Profile', 'Observer', true),
+            '_entities_id' => 0,
+        ])->getID();
+        $user_id = $this->createItem(\User::class, [
             'name' => 'test user',
             'users_id_supervisor' => $manager_id,
-        ]);
-        $this->assertGreaterThan(0, $user_id);
+        ])->getID();
 
         // check manager
         $user->getFromDB($user_id);

--- a/tests/functional/TicketTest.php
+++ b/tests/functional/TicketTest.php
@@ -10164,13 +10164,10 @@ HTML,
         $this->login();
 
         // Disabled user as requester
-        $user_id = $this->createItem(
-            User::class,
-            [
-                'name' => $this->getUniqueString(),
-                'is_active' => 0,
-            ]
-        )->getID();
+        $user_id = $this->createItem(User::class, [
+            'name' => $this->getUniqueString(),
+            'is_active' => 0,
+        ])->getID();
 
         $ticket = $this->createItem(Ticket::class, [
             'name'        => 'Ticket for disabled user',
@@ -10182,13 +10179,10 @@ HTML,
         $this->checkActors($ticket, []);
 
         // Deleted user as requester
-        $user_id = $this->createItem(
-            User::class,
-            [
-                'name' => $this->getUniqueString(),
-                'is_deleted' => 1,
-            ]
-        );
+        $user_id = $this->createItem(User::class, [
+            'name' => $this->getUniqueString(),
+            'is_deleted' => 1,
+        ])->getID();
 
         $ticket = $this->createItem(Ticket::class, [
             'name'        => 'Ticket for deleted user',

--- a/tests/functional/TicketTest.php
+++ b/tests/functional/TicketTest.php
@@ -10159,4 +10159,37 @@ HTML,
             );
         }
     }
+    public function testUpdateActorsDisabledOrDeleted(): void
+    {
+        $this->login();
+        $user = new User();
+        $user->add([
+            'name' => $this->getUniqueString(),
+            'is_active' => 0,
+        ]);
+
+        $ticket = $this->createItem(Ticket::class, [
+            'name'        => 'Ticket for disabled user',
+            'content'     => 'test',
+            'entities_id' => $this->getTestRootEntity(true),
+            '_users_id_requester' => $user->getID(),
+        ]);
+
+        $this->checkActors($ticket, []);
+
+        $user->add([
+            'name' => $this->getUniqueString(),
+            'is_deleted' => 1,
+        ]);
+
+        $ticket = $this->createItem(Ticket::class, [
+            'name'        => 'Ticket for deleted user',
+            'content'     => 'test',
+            'entities_id' => $this->getTestRootEntity(true),
+            '_users_id_requester' => $user->getID(),
+        ]);
+
+        $this->checkActors($ticket, []);
+    }
+
 }

--- a/tests/functional/TicketTest.php
+++ b/tests/functional/TicketTest.php
@@ -10162,31 +10162,39 @@ HTML,
     public function testUpdateActorsDisabledOrDeleted(): void
     {
         $this->login();
-        $user = new User();
-        $user->add([
-            'name' => $this->getUniqueString(),
-            'is_active' => 0,
-        ]);
+
+        // Disabled user as requester
+        $user_id = $this->createItem(
+            User::class,
+            [
+                'name' => $this->getUniqueString(),
+                'is_active' => 0,
+            ]
+        )->getID();
 
         $ticket = $this->createItem(Ticket::class, [
             'name'        => 'Ticket for disabled user',
             'content'     => 'test',
             'entities_id' => $this->getTestRootEntity(true),
-            '_users_id_requester' => $user->getID(),
+            '_users_id_requester' => $user_id,
         ]);
 
         $this->checkActors($ticket, []);
 
-        $user->add([
-            'name' => $this->getUniqueString(),
-            'is_deleted' => 1,
-        ]);
+        // Deleted user as requester
+        $user_id = $this->createItem(
+            User::class,
+            [
+                'name' => $this->getUniqueString(),
+                'is_deleted' => 1,
+            ]
+        );
 
         $ticket = $this->createItem(Ticket::class, [
             'name'        => 'Ticket for deleted user',
             'content'     => 'test',
             'entities_id' => $this->getTestRootEntity(true),
-            '_users_id_requester' => $user->getID(),
+            '_users_id_requester' => $user_id,
         ]);
 
         $this->checkActors($ticket, []);


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !41701

On an ITIL object, it's possible to add an inactive or deleted user via rules, even though this isn't possible in the interface because it's filtered in the dropdowns. The check was only on the frontend; I suggest adding it to the backend as well.

## Screenshots (if appropriate):


