### PR TITLE
Upgrade `rector/rector` to `^2.3`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -117,7 +117,7 @@
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-deprecation-rules": "^2.0",
         "phpunit/phpunit": "^11.5",
-        "rector/rector": "^2.1",
+        "rector/rector": "^2.3",
         "sebastian/comparator": "^6.3",
         "shipmonk/composer-dependency-analyser": "^1.8",
         "symfony/browser-kit": "^6.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5a1d21b8b321bddb8422cdf29909deeb",
+    "content-hash": "e657cbb167ddee7793b25866f62f3e74",
     "packages": [
         {
             "name": "altcha-org/altcha",
@@ -3333,25 +3333,25 @@
         },
         {
             "name": "nette/schema",
-            "version": "v1.3.2",
+            "version": "v1.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/schema.git",
-                "reference": "da801d52f0354f70a638673c4a0f04e16529431d"
+                "reference": "2befc2f42d7c715fd9d95efc31b1081e5d765004"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/schema/zipball/da801d52f0354f70a638673c4a0f04e16529431d",
-                "reference": "da801d52f0354f70a638673c4a0f04e16529431d",
+                "url": "https://api.github.com/repos/nette/schema/zipball/2befc2f42d7c715fd9d95efc31b1081e5d765004",
+                "reference": "2befc2f42d7c715fd9d95efc31b1081e5d765004",
                 "shasum": ""
             },
             "require": {
                 "nette/utils": "^4.0",
-                "php": "8.1 - 8.4"
+                "php": "8.1 - 8.5"
             },
             "require-dev": {
                 "nette/tester": "^2.5.2",
-                "phpstan/phpstan-nette": "^1.0",
+                "phpstan/phpstan-nette": "^2.0@stable",
                 "tracy/tracy": "^2.8"
             },
             "type": "library",
@@ -3361,6 +3361,9 @@
                 }
             },
             "autoload": {
+                "psr-4": {
+                    "Nette\\": "src"
+                },
                 "classmap": [
                     "src/"
                 ]
@@ -3389,26 +3392,26 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/schema/issues",
-                "source": "https://github.com/nette/schema/tree/v1.3.2"
+                "source": "https://github.com/nette/schema/tree/v1.3.3"
             },
-            "time": "2024-10-06T23:10:23+00:00"
+            "time": "2025-10-30T22:57:59+00:00"
         },
         {
             "name": "nette/utils",
-            "version": "v4.0.8",
+            "version": "v4.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/utils.git",
-                "reference": "c930ca4e3cf4f17dcfb03037703679d2396d2ede"
+                "reference": "c99059c0315591f1a0db7ad6002000288ab8dc72"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/utils/zipball/c930ca4e3cf4f17dcfb03037703679d2396d2ede",
-                "reference": "c930ca4e3cf4f17dcfb03037703679d2396d2ede",
+                "url": "https://api.github.com/repos/nette/utils/zipball/c99059c0315591f1a0db7ad6002000288ab8dc72",
+                "reference": "c99059c0315591f1a0db7ad6002000288ab8dc72",
                 "shasum": ""
             },
             "require": {
-                "php": "8.0 - 8.5"
+                "php": "8.2 - 8.5"
             },
             "conflict": {
                 "nette/finder": "<3",
@@ -3431,7 +3434,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-master": "4.1-dev"
                 }
             },
             "autoload": {
@@ -3478,9 +3481,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/utils/issues",
-                "source": "https://github.com/nette/utils/tree/v4.0.8"
+                "source": "https://github.com/nette/utils/tree/v4.1.1"
             },
-            "time": "2025-08-06T21:43:34+00:00"
+            "time": "2025-12-22T12:14:32+00:00"
         },
         {
             "name": "paragonie/sodium_compat",
@@ -3909,16 +3912,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "2.3.0",
+            "version": "2.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "1e0cd5370df5dd2e556a36b9c62f62e555870495"
+                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/1e0cd5370df5dd2e556a36b9c62f62e555870495",
-                "reference": "1e0cd5370df5dd2e556a36b9c62f62e555870495",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/a004701b11273a26cd7955a61d67a7f1e525a45a",
+                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a",
                 "shasum": ""
             },
             "require": {
@@ -3950,9 +3953,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.0"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.2"
             },
-            "time": "2025-08-30T15:50:23+00:00"
+            "time": "2026-01-25T14:56:51+00:00"
         },
         {
             "name": "psr/cache",
@@ -12714,21 +12717,21 @@
         },
         {
             "name": "rector/rector",
-            "version": "2.1.7",
+            "version": "2.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "c34cc07c4698f007a20dc5c99ff820089ae413ce"
+                "reference": "9afc1bb43571b25629f353c61a9315b5ef31383a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/c34cc07c4698f007a20dc5c99ff820089ae413ce",
-                "reference": "c34cc07c4698f007a20dc5c99ff820089ae413ce",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/9afc1bb43571b25629f353c61a9315b5ef31383a",
+                "reference": "9afc1bb43571b25629f353c61a9315b5ef31383a",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4|^8.0",
-                "phpstan/phpstan": "^2.1.18"
+                "phpstan/phpstan": "^2.1.33"
             },
             "conflict": {
                 "rector/rector-doctrine": "*",
@@ -12762,7 +12765,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/2.1.7"
+                "source": "https://github.com/rectorphp/rector/tree/2.3.1"
             },
             "funding": [
                 {
@@ -12770,7 +12773,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-09-10T11:13:58+00:00"
+            "time": "2026-01-13T15:13:58+00:00"
         },
         {
             "name": "revolt/event-loop",
@@ -15021,5 +15024,5 @@
     "platform-overrides": {
         "php": "8.2.99"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/front/logout.php
+++ b/front/logout.php
@@ -43,7 +43,7 @@ global $CFG_GLPI;
 
 if (
     $CFG_GLPI["ssovariables_id"] > 0
-    && strlen($CFG_GLPI['ssologout_url']) > 0
+    && (string) $CFG_GLPI['ssologout_url'] !== ''
 ) {
     Session::cleanOnLogout();
     Html::redirect($CFG_GLPI["ssologout_url"]);
@@ -69,9 +69,9 @@ if (
 $toADD = "";
 
 // Redirect management
-if (isset($_POST['redirect']) && (strlen($_POST['redirect']) > 0)) {
+if (isset($_POST['redirect']) && ((string) $_POST['redirect'] !== '')) {
     $toADD = "?redirect=" . rawurlencode($_POST['redirect']);
-} elseif (isset($_GET['redirect']) && (strlen($_GET['redirect']) > 0)) {
+} elseif (isset($_GET['redirect']) && ((string) $_GET['redirect'] !== '')) {
     $toADD = "?redirect=" . rawurlencode($_GET['redirect']);
 }
 

--- a/src/Ajax.php
+++ b/src/Ajax.php
@@ -697,14 +697,14 @@ JS;
         // Old scheme
         if (
             isset($options["update_item"])
-            && (is_array($options["update_item"]) || (strlen($options["update_item"]) > 0))
+            && (is_array($options["update_item"]) || ((string) $options["update_item"] !== ''))
         ) {
             $field     = "update_item";
         }
         // New scheme
         if (
             isset($options["toupdate"])
-            && (is_array($options["toupdate"]) || (strlen($options["toupdate"]) > 0))
+            && (is_array($options["toupdate"]) || ((string) $options["toupdate"] !== ''))
         ) {
             $field     = "toupdate";
         }

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -3533,7 +3533,7 @@ class CommonDBTM extends CommonGLPI
 
         if ($this->isField('states_id') && $this->getType() != 'State') {
             $name = Dropdown::getDropdownName('glpi_states', $this->fields['states_id']);
-            if (strlen($name) > 0) {
+            if ((string) $name !== '') {
                 $toadd[] = [
                     'name'  => __s('Status'),
                     'value' => htmlescape($name),
@@ -3543,7 +3543,7 @@ class CommonDBTM extends CommonGLPI
 
         if ($this->isField('locations_id') && $this->getType() != 'Location') {
             $name = Dropdown::getDropdownName("glpi_locations", $this->fields['locations_id']);
-            if (strlen($name) > 0) {
+            if ((string) $name !== '') {
                 $toadd[] = [
                     'name'  => htmlescape(Location::getTypeName(1)),
                     'value' => htmlescape($name),
@@ -3553,7 +3553,7 @@ class CommonDBTM extends CommonGLPI
 
         if ($this->isField('users_id')) {
             $name = getUserName($this->fields['users_id']);
-            if (strlen($name) > 0) {
+            if ((string) $name !== '') {
                 $toadd[] = [
                     'name'  => htmlescape(User::getTypeName(1)),
                     'value' => htmlescape($name),
@@ -3568,7 +3568,7 @@ class CommonDBTM extends CommonGLPI
             }
             foreach ($groups as $group) {
                 $name = Dropdown::getDropdownName("glpi_groups", $group);
-                if (strlen($name) > 0) {
+                if ((string) $name !== '') {
                     $toadd[] = [
                         'name'  => htmlescape(Group::getTypeName(1)),
                         'value' => htmlescape($name),
@@ -3579,7 +3579,7 @@ class CommonDBTM extends CommonGLPI
 
         if ($this->isField('users_id_tech')) {
             $name = getUserName($this->fields['users_id_tech']);
-            if (strlen($name) > 0) {
+            if ((string) $name !== '') {
                 $toadd[] = [
                     'name'  => htmlescape(__('Technician in charge')),
                     'value' => htmlescape($name),

--- a/src/CommonDCModelDropdown.php
+++ b/src/CommonDCModelDropdown.php
@@ -205,7 +205,7 @@ abstract class CommonDCModelDropdown extends CommonDropdown
         switch ($field) {
             case 'picture_front':
             case 'picture_rear':
-                if (isset($values['name']) && strlen($values['name']) > 0 && isset($options['html']) && $options['html']) {
+                if (isset($values['name']) && (string) $values['name'] !== '' && isset($options['html']) && $options['html']) {
                     return Html::image(Toolbox::getPictureUrl($values[$field]), [
                         'alt'   => $options['searchopt']['name'],
                         'style' => 'max-height: 60px;',

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -514,7 +514,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
                         } elseif (
                             $actor_obj instanceof User
                             && $existing_actor['items_id'] == 0
-                            && strlen($existing_actor['alternative_email']) > 0
+                            && (string) $existing_actor['alternative_email'] !== ''
                         ) {
                             // direct mail actor
                             $fn_add_actor($existing_actor['itemtype'], $existing_actor['items_id'], $existing_actor + [
@@ -7924,7 +7924,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
                 $log->post_getFromDB();
 
                 $content = $log_row['change'];
-                if (strlen($log_row['field']) > 0) {
+                if ((string) $log_row['field'] !== '') {
                     $content = sprintf(__s("%s: %s"), htmlescape($log_row['field']), $content);
                 }
                 $content = "<i class='ti ti-history me-1' title='" . __s("Log entry") . "' data-bs-toggle='tooltip'></i>" . $content;

--- a/src/DBmysql.php
+++ b/src/DBmysql.php
@@ -2041,7 +2041,7 @@ class DBmysql
         $output = "";
 
         for ($i = 0; $i < $linecount; $i++) {
-            if (($i != ($linecount - 1)) || (strlen($lines[$i]) > 0)) {
+            if (($i != ($linecount - 1)) || ($lines[$i] !== '')) {
                 if (isset($lines[$i][0])) {
                     if ($lines[$i][0] != "#" && !str_starts_with($lines[$i], "--")) {
                         $output .= $lines[$i] . "\n";

--- a/src/DbUtils.php
+++ b/src/DbUtils.php
@@ -1701,10 +1701,10 @@ final class DbUtils
             $id_visible = $_SESSION["glpiis_ids_visible"];
         }
 
-        if (strlen($realname ?? '') > 0) {
-            $formatted = $realname;
+        if ((string) $realname !== '') {
+            $formatted = (string) $realname;
 
-            if (strlen($firstname ?? '') > 0) {
+            if ((string) ($firstname ?? '') !== '') {
                 if ($order == User::FIRSTNAME_BEFORE) {
                     $formatted = $firstname . " " . $formatted;
                 } else {
@@ -2072,7 +2072,7 @@ final class DbUtils
                 $a = explode("=>", $item);
 
                 if (
-                    (strlen($a[0]) > 0)
+                    ($a[0] !== '')
                     && isset($a[1])
                 ) {
                     $tab[urldecode($a[0])] = urldecode($a[1]);

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -3721,7 +3721,7 @@ HTML;
                                         $data[$key]
                                     );
                                 }
-                                if ((strlen($withoutput) > 0) && ($withoutput != '&nbsp;')) {
+                                if (((string) $withoutput !== '') && ($withoutput != '&nbsp;')) {
                                     $outputval = sprintf(__('%1$s - %2$s'), $outputval, $withoutput);
                                 }
                             }
@@ -3829,7 +3829,7 @@ HTML;
             $where["$table.is_template"] = 0;
         }
 
-        if (isset($post['searchText']) && (strlen($post['searchText']) > 0)) {
+        if (isset($post['searchText']) && ((string) $post['searchText'] !== '')) {
             $search = Search::makeTextSearchValue($post['searchText']);
             $where['OR'] = [
                 "$table.name"        => ['LIKE', $search],
@@ -4026,7 +4026,7 @@ HTML;
             $where[] = State::getDisplayConditionForAssistance();
         }
 
-        if (isset($_POST['searchText']) && (strlen($post['searchText']) > 0)) {
+        if (isset($_POST['searchText']) && ((string) $post['searchText'] !== '')) {
             $search = ['LIKE', Search::makeTextSearchValue($post['searchText'])];
             $orwhere = $item->isField('name') ? [
                 'name'   => $search,
@@ -4997,7 +4997,7 @@ HTML;
                     'title'             => sprintf(__('%1$s - %2$s'), $text, $user['name']),
                     'itemtype'          => "User",
                     'items_id'          => $ID,
-                    'use_notification'  => strlen($user['default_email'] ?? "") > 0 ? 1 : 0,
+                    'use_notification'  => (string) ($user['default_email'] ?? "") !== '' ? 1 : 0,
                     'default_email'     => $user['default_email'],
                     'alternative_email' => '',
                 ];
@@ -5071,7 +5071,7 @@ HTML;
                         $children['items_id']          = $children['id'];
                         $children['id']                = "Supplier_" . $children['id'];
                         $children['itemtype']          = "Supplier";
-                        $children['use_notification']  = strlen($supplier_obj->fields['email'] ?? '') > 0 ? 1 : 0;
+                        $children['use_notification']  = (string) ($supplier_obj->fields['email'] ?? '') !== '' ? 1 : 0;
                         $children['default_email']     = $supplier_obj->fields['email'];
                         $children['alternative_email'] = '';
                     }

--- a/src/Glpi/Api/APIRest.php
+++ b/src/Glpi/Api/APIRest.php
@@ -501,7 +501,7 @@ class APIRest extends API
 
         // now how about PUT/POST bodies? These override what we got from GET
         $body = trim($this->getHttpBody());
-        if (strlen($body) > 0 && $this->verb == "GET") {
+        if ($body !== '' && $this->verb == "GET") {
             // GET method requires an empty body
             $this->returnError(
                 "GET Request should not have json payload (http body)",

--- a/src/Glpi/Controller/IndexController.php
+++ b/src/Glpi/Controller/IndexController.php
@@ -131,7 +131,7 @@ final class IndexController extends AbstractController
                 'emptylabel'          => __('Default (from user profile)'),
                 'width'               => '100%',
             ]),
-            'right_panel'         => strlen($CFG_GLPI['text_login']) > 0
+            'right_panel'         => (string) $CFG_GLPI['text_login'] !== ''
                 || count($PLUGIN_HOOKS[Hooks::DISPLAY_LOGIN] ?? []) > 0
                 || $CFG_GLPI["use_public_faq"],
             'auth_dropdown_login' => Auth::dropdownLogin(false, $rand),

--- a/src/Glpi/Dashboard/Grid.php
+++ b/src/Glpi/Dashboard/Grid.php
@@ -1528,7 +1528,7 @@ HTML;
         global $CFG_GLPI;
         $new_key = "";
         $target = Toolbox::cleanTarget($_REQUEST['_target'] ?? $_SERVER['REQUEST_URI'] ?? "");
-        if (isset($_SESSION['last_dashboards']) && strlen($target) > 0) {
+        if (isset($_SESSION['last_dashboards']) && $target !== '') {
             $target = preg_replace('/^' . preg_quote($CFG_GLPI['root_doc'], '/') . '/', '', $target);
             if (!isset($_SESSION['last_dashboards'][$target])) {
                 return "";
@@ -1566,7 +1566,7 @@ HTML;
 
         if (!$strict) {
             $restored = $grid->restoreLastDashboard();
-            if (strlen($restored) > 0) {
+            if ($restored !== '') {
                 return $restored;
             }
         }

--- a/src/Glpi/Features/PlanningEvent.php
+++ b/src/Glpi/Features/PlanningEvent.php
@@ -616,7 +616,7 @@ trait PlanningEvent
                     : $CFG_GLPI["url_base"]
                     . static::getFormURLWithID($data['id'], false);
 
-                    $is_rrule = isset($data['rrule']) && strlen($data['rrule']) > 0;
+                    $is_rrule = isset($data['rrule']) && (string) $data['rrule'] !== '';
 
                     $events[$key] = [
                         'color'            => $options['color'],

--- a/src/Glpi/Marketplace/Api/Plugins.php
+++ b/src/Glpi/Marketplace/Api/Plugins.php
@@ -257,7 +257,7 @@ class Plugins
             $plugins_colct = self::$plugins;
         }
 
-        if (strlen($tag_filter) > 0) {
+        if ($tag_filter !== '') {
             $tagged_plugins = array_column($this->getPluginsForTag($tag_filter), 'key');
             if ($this->last_error !== null) {
                 $this->is_list_truncated = true;
@@ -265,7 +265,7 @@ class Plugins
             $plugins_colct  = array_intersect_key($plugins_colct, array_flip($tagged_plugins));
         }
 
-        if (strlen($string_filter) > 0) {
+        if ($string_filter !== '') {
             $plugins_colct = array_filter($plugins_colct, fn($plugin) => str_contains(strtolower(json_encode($plugin)), strtolower($string_filter)));
         }
 

--- a/src/Glpi/Marketplace/Controller.php
+++ b/src/Glpi/Marketplace/Controller.php
@@ -512,7 +512,7 @@ class Controller extends CommonGLPI
         } else {
             $url = $api_plugin['installation_url'] ?? '';
         }
-        return strlen($url) > 0;
+        return (string) $url !== '';
     }
 
     /**

--- a/src/Glpi/Search/Output/Spreadsheet.php
+++ b/src/Glpi/Search/Output/Spreadsheet.php
@@ -229,7 +229,7 @@ abstract class Spreadsheet extends ExportSearchOutput
                         $this->getTitle($newdata)
                     );
                 } else {
-                    if (strlen($criteria['value']) > 0) {
+                    if ((string) $criteria['value'] !== '') {
                         if (isset($criteria['link'])) {
                             $titlecontain = " " . $criteria['link'] . " ";
                         }
@@ -369,7 +369,7 @@ abstract class Spreadsheet extends ExportSearchOutput
                 }
 
                 $titlecontain2 = '';
-                if (strlen($metacriteria['value']) > 0) {
+                if ((string) $metacriteria['value'] !== '') {
                     if (isset($metacriteria['link'])) {
                         $titlecontain2 = sprintf(
                             __('%1$s %2$s'),

--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -4777,7 +4777,7 @@ final class SQLProvider implements SearchProviderInterface
                 }
             } elseif (
                 isset($criterion['value'])
-                && strlen($criterion['value']) > 0
+                && (string) $criterion['value'] !== ''
             ) { // view and all search
                 $LINK       = " OR ";
                 $NOT        = false;
@@ -5065,7 +5065,7 @@ final class SQLProvider implements SearchProviderInterface
                 foreach ($data['search']['metacriteria'] as $metacriteria) {
                     if (
                         isset($metacriteria['itemtype']) && !empty($metacriteria['itemtype'])
-                        && isset($metacriteria['value']) && (strlen($metacriteria['value']) > 0)
+                        && isset($metacriteria['value']) && ((string) $metacriteria['value'] !== '')
                     ) {
                         if (!isset($already_printed[$metacriteria['itemtype'] . $metacriteria['field']])) {
                             $m_searchopt = SearchOption::getOptionsForItemtype($metacriteria['itemtype']);
@@ -5603,7 +5603,7 @@ final class SQLProvider implements SearchProviderInterface
                         for ($k = 0; $k < $data[$ID]['count']; $k++) {
                             if (
                                 isset($data[$ID][$k]['name'])
-                                && strlen(trim($data[$ID][$k]['name'])) > 0
+                                && trim($data[$ID][$k]['name']) !== ''
                                 && !in_array(
                                     $data[$ID][$k]['name'] . "-" . $data[$ID][$k]['entities_id'],
                                     $added
@@ -5648,7 +5648,7 @@ final class SQLProvider implements SearchProviderInterface
                         $added         = [];
                         $count_display = 0;
                         for ($k = 0; $k < $data[$ID]['count']; $k++) {
-                            $completename = isset($data[$ID][$k]['name']) && (strlen(trim($data[$ID][$k]['name'])) > 0)
+                            $completename = isset($data[$ID][$k]['name']) && (trim($data[$ID][$k]['name']) !== '')
                                 ? (new SanitizedStringsDecoder())->decodeHtmlSpecialCharsInCompletename($data[$ID][$k]['name'])
                                 : null;
                             if (
@@ -6532,7 +6532,7 @@ final class SQLProvider implements SearchProviderInterface
                     $out           = '';
                     $count_display = 0;
                     for ($k = 0; $k < $data[$ID]['count']; $k++) {
-                        if (strlen(trim((string) $data[$ID][$k]['name'])) > 0) {
+                        if (trim((string) $data[$ID][$k]['name']) !== '') {
                             if ($count_display) {
                                 $out .= $separate;
                             }
@@ -6666,7 +6666,7 @@ final class SQLProvider implements SearchProviderInterface
                     $out           = "";
                     $count_display = 0;
                     for ($k = 0; $k < $data[$ID]['count']; $k++) {
-                        if (strlen(trim((string) $data[$ID][$k]['name'])) > 0) {
+                        if (trim((string) $data[$ID][$k]['name']) !== '') {
                             if ($count_display) {
                                 $out .= $separate;
                             }
@@ -6688,7 +6688,7 @@ final class SQLProvider implements SearchProviderInterface
                     $out           = "";
                     $count_display = 0;
                     for ($k = 0; $k < $data[$ID]['count']; $k++) {
-                        if (strlen(trim((string) $data[$ID][$k]['name'])) > 0) {
+                        if (trim((string) $data[$ID][$k]['name']) !== '') {
                             if ($count_display) {
                                 $out .= $separate;
                             }
@@ -6710,7 +6710,7 @@ final class SQLProvider implements SearchProviderInterface
                     $out           = "";
                     $count_display = 0;
                     for ($k = 0; $k < $data[$ID]['count']; $k++) {
-                        if (strlen(trim((string) $data[$ID][$k]['name'])) > 0) {
+                        if (trim((string) $data[$ID][$k]['name']) !== '') {
                             if ($count_display) {
                                 $out .= $separate;
                             }

--- a/src/Glpi/Search/SearchEngine.php
+++ b/src/Glpi/Search/SearchEngine.php
@@ -478,7 +478,7 @@ final class SearchEngine
 
                         if (
                             isset($criterion['value'])
-                            && (strlen($criterion['value']) > 0)
+                            && ((string) $criterion['value'] !== '')
                         ) {
                             $data['search']['no_search'] = false;
                         }

--- a/src/Html.php
+++ b/src/Html.php
@@ -1272,7 +1272,7 @@ TWIG,
             ],
         ];
 
-        if ($can_read_dashboard && strlen($default_asset_dashboard) > 0) {
+        if ($can_read_dashboard && $default_asset_dashboard !== '') {
             $menu['assets']['default_dashboard'] = '/front/dashboard_assets.php';
         }
 
@@ -1287,7 +1287,7 @@ TWIG,
             ],
         ];
 
-        if ($can_read_dashboard && strlen($default_asset_helpdesk) > 0) {
+        if ($can_read_dashboard && $default_asset_helpdesk !== '') {
             $menu['helpdesk']['default_dashboard'] = '/front/dashboard_helpdesk.php';
         }
 
@@ -6299,7 +6299,7 @@ JS);
         // retrieve menu
         foreach ($_SESSION['glpimenu'] as $firstlvl) {
             if (isset($firstlvl['default'])) {
-                if (strlen($firstlvl['title']) > 0) {
+                if ((string) $firstlvl['title'] !== '') {
                     $fuzzy_entries[] = [
                         'url'   => self::getPrefixedUrl($firstlvl['default']),
                         'title' => $firstlvl['title'],
@@ -6308,7 +6308,7 @@ JS);
             }
 
             if (isset($firstlvl['default_dashboard'])) {
-                if (strlen($firstlvl['title']) > 0) {
+                if ((string) $firstlvl['title'] !== '') {
                     $fuzzy_entries[] = [
                         'url'   => self::getPrefixedUrl($firstlvl['default_dashboard']),
                         'title' => $firstlvl['title'] . " > " . __('Dashboard'),
@@ -6318,7 +6318,7 @@ JS);
 
             if (isset($firstlvl['content'])) {
                 foreach ($firstlvl['content'] as $menu) {
-                    if (isset($menu['title']) && strlen($menu['title']) > 0) {
+                    if (isset($menu['title']) && (string) $menu['title'] !== '') {
                         $fuzzy_entries[] = [
                             'url'   => self::getPrefixedUrl($menu['page']),
                             'title' => $firstlvl['title'] . " > " . $menu['title'],
@@ -6326,7 +6326,7 @@ JS);
 
                         if (isset($menu['options'])) {
                             foreach ($menu['options'] as $submenu) {
-                                if (isset($submenu['title']) && strlen($submenu['title']) > 0) {
+                                if (isset($submenu['title']) && (string) $submenu['title'] !== '') {
                                     $fuzzy_entries[] = [
                                         'url'   => self::getPrefixedUrl($submenu['page']),
                                         'title' => $firstlvl['title'] . " > "

--- a/src/Item_Devices.php
+++ b/src/Item_Devices.php
@@ -1531,7 +1531,7 @@ class Item_Devices extends CommonDBRelation implements StateInterface
             $specificities['label'] = $attributs['long name'];
             $specificities['protected'] = isset($attributs['protected']) && $attributs['protected'];
 
-            if (isset($attributs['tooltip']) && strlen($attributs['tooltip']) > 0) {
+            if (isset($attributs['tooltip']) && (string) $attributs['tooltip'] !== '') {
                 $tooltip = $attributs['tooltip'];
             } else {
                 $tooltip = null;

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -1146,7 +1146,7 @@ TWIG, $twig_params);
                 break;
 
             case 'search':
-                if (strlen($params["contains"]) > 0) {
+                if ((string) $params["contains"] !== '') {
                     $search = $params["contains"];
                     $search_wilcard = self::computeBooleanFullTextSearch($search);
 

--- a/src/Notification.php
+++ b/src/Notification.php
@@ -594,7 +594,7 @@ class Notification extends CommonDBTM implements FilterableInterface
         global $CFG_GLPI;
 
         $signature = trim(Entity::getUsedConfig('mailing_signature', $entity, '', ''));
-        if (strlen($signature) > 0) {
+        if ($signature !== '') {
             return $signature;
         }
 

--- a/src/NotificationTarget.php
+++ b/src/NotificationTarget.php
@@ -1377,7 +1377,7 @@ class NotificationTarget extends CommonDBChild
         global $CFG_GLPI;
 
         $url_base = trim(Entity::getUsedConfig('url_base', $this->getEntity(), '', ''));
-        if (strlen($url_base) > 0) {
+        if ($url_base !== '') {
             return $url_base;
         }
 

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -1689,7 +1689,7 @@ class Ticket extends CommonITILObject implements DefaultSearchRequestInterface
             isset($this->input["_followup"])
             && is_array($this->input["_followup"])
             && isset($this->input["_followup"]['content'])
-            && (strlen($this->input["_followup"]['content']) > 0)
+            && ((string) $this->input["_followup"]['content'] !== '')
         ) {
             $fup  = new ITILFollowup();
             $type = "new";

--- a/src/UploadHandler.php
+++ b/src/UploadHandler.php
@@ -409,7 +409,7 @@ class UploadHandler
     protected function is_valid_file_object($file_name)
     {
         $file_path = $this->get_upload_path($file_name);
-        if (strlen($file_name) > 0 && $file_name[0] !== '.' && is_file($file_path)) {
+        if ((string) $file_name !== '' && $file_name[0] !== '.' && is_file($file_path)) {
             return true;
         }
         return false;
@@ -1832,7 +1832,7 @@ class UploadHandler
         $response = [];
         foreach ($file_names as $file_name) {
             $file_path = $this->get_upload_path($file_name);
-            $success = strlen($file_name) > 0 && $file_name[0] !== '.' && is_file($file_path) && \unlink($file_path); //@phpstan-ignore theCodingMachineSafe.function
+            $success = (string) $file_name !== '' && $file_name[0] !== '.' && is_file($file_path) && \unlink($file_path); //@phpstan-ignore theCodingMachineSafe.function
             if ($success) {
                 foreach ($this->options['image_versions'] as $version => $options) {
                     if (!empty($version)) {

--- a/src/User.php
+++ b/src/User.php
@@ -1000,7 +1000,7 @@ class User extends CommonDBTM implements TreeBrowseInterface
     public function pre_addInDB()
     {
         // Hash user_dn if set
-        if (isset($this->input['user_dn']) && is_string($this->input['user_dn']) && strlen($this->input['user_dn']) > 0) {
+        if (isset($this->input['user_dn']) && is_string($this->input['user_dn']) && $this->input['user_dn'] !== '') {
             $this->input['user_dn_hash'] = md5($this->input['user_dn']);
         }
     }
@@ -3022,7 +3022,7 @@ HTML;
         // Hash user_dn if is updated
         if (in_array('user_dn', $this->updates)) {
             $this->updates[] = 'user_dn_hash';
-            $this->fields['user_dn_hash'] = is_string($this->input['user_dn']) && strlen($this->input['user_dn']) > 0
+            $this->fields['user_dn_hash'] = is_string($this->input['user_dn']) && $this->input['user_dn'] !== ''
                 ? md5($this->input['user_dn'])
                 : null;
         }
@@ -4122,7 +4122,7 @@ HTML;
         }
 
         if (!$count) {
-            if (strlen((string) $search) > 0) {
+            if ((string) $search !== '') {
                 $txt_search = Search::makeTextSearchValue($search);
 
                 $firstname_field = self::getTableField('firstname');
@@ -4458,7 +4458,7 @@ HTML;
             $icons .= '</div>';
         }
 
-        if (strlen($icons) > 0) {
+        if ($icons !== '') {
             $output = "<div class='btn-group btn-group-sm " . ($p['width'] == "100%" ? "w-100" : "") . "' role='group'>{$output} {$icons}</div>";
         }
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Rector uses PHPStan methods marked as internal. These are not subject to any backward compatibility promises and were recently changed, making the 2.1 version or Rector not compatible with the latest version of PHPStan (see error below).

It is therefore mandatory to upgrade Rector if we want to get latest PHPStan version.

```
 [ERROR] Could not process "front/item_devicemotherboard.form.php" file, due to:                                        
         "Call to undefined method PHPStan\PhpDocParser\Ast\PhpDoc\TemplateTagValueNode::__set_state()". On line: 52   
```