### PR TITLE
Fix tooltip display for cost comments

### DIFF
--- a/src/ContractCost.php
+++ b/src/ContractCost.php
@@ -363,7 +363,7 @@ TWIG, $twig_params);
             $name = sprintf(
                 __s('%1$s %2$s'),
                 htmlescape($name),
-                Html::showToolTip(htmlescape($data['comment']), ['display' => false])
+                !empty($data['comment']) ? Html::showToolTip(htmlescape($data['comment']), ['display' => false]) : ''
             );
             if (!isset($budget_cache[$data['budgets_id']])) {
                 $budget_cache[$data['budgets_id']] = Dropdown::getDropdownName(table: 'glpi_budgets', id: $data['budgets_id'], default: '');

--- a/src/ProjectCost.php
+++ b/src/ProjectCost.php
@@ -380,7 +380,7 @@ class ProjectCost extends CommonDBChild
                 printf(
                     __s('%1$s %2$s'),
                     htmlescape($name),
-                    Html::showToolTip(htmlescape($data['comment']), ['display' => false])
+                    !empty($data['comment']) ? Html::showToolTip(htmlescape($data['comment']), ['display' => false]) : ''
                 );
                 if ($canedit) {
                     $js = "function viewEditCost" . $project_id . "_" . $cost_id . "_$rand() {";


### PR DESCRIPTION
The tooltip for Project Costs is always shown for comments, even when the comment is empty:

https://github.com/eduardomozart/glpi/blob/72414484de398740ae298021d728b11bf24f756c/src/ProjectCost.php#L364-L380

The tooltip is displayed unconditionally, regardless of whether there's actually a comment or not. The same issue exists in src/ContractCost.php at line 365.

To fix this, the tooltip should only be rendered when $data['comment'] is not empty.

<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does

## Screenshots (if appropriate):


