### PR TITLE
Fix modal buttons layout

### DIFF
--- a/templates/components/form/buttons.html.twig
+++ b/templates/components/form/buttons.html.twig
@@ -45,7 +45,7 @@
          {% if withtemplate > 0 or item.isNewID(id) %}
             {% if id <= 0 or withtemplate == 2 %}
                <button
-                  class="btn btn-primary me-2 {{ params['in_modal'] ? 'mt-2' : '' }}"
+                  class="btn btn-primary me-2 {{ params['in_modal']|default(false) ? 'mt-2' : '' }}"
                   type="submit"
                   name="add"
                   value="1"
@@ -56,7 +56,7 @@
                </button>
             {% else %}
                <button
-                  class="btn btn-primary me-2 {{ params['in_modal'] ? 'mt-2' : '' }}"
+                  class="btn btn-primary me-2 {{ params['in_modal']|default(false) ? 'mt-2' : '' }}"
                   type="submit"
                   name="update"
                   value="1"
@@ -73,7 +73,7 @@
 
             {% if canedit and item.can(id, constant('UPDATE')) %}
                <button
-                  class="btn btn-primary me-2 {{ params['in_modal'] ? 'mt-2' : '' }}"
+                  class="btn btn-primary me-2 {{ params['in_modal']|default(false) ? 'mt-2' : '' }}"
                   type="submit"
                   name="update"
                   value="1"
@@ -88,7 +88,7 @@
                {% if item.isDeleted() %}
                   {% if item.can(id, constant('DELETE')) %}
                      <button
-                        class="btn btn-outline-secondary me-2 {{ params['in_modal'] ? 'mt-2' : '' }}"
+                        class="btn btn-outline-secondary me-2 {{ params['in_modal']|default(false) ? 'mt-2' : '' }}"
                         type="submit"
                         name="restore"
                         value="1"

--- a/templates/components/form/buttons.html.twig
+++ b/templates/components/form/buttons.html.twig
@@ -34,18 +34,18 @@
 {% set candel       = params['candel'] ?? true %}
 {% set canedit      = params['canedit'] ?? true %}
 {% set id           = item.fields['id'] ?? -1 %}
+{% set in_modal     = params['in_modal']|default(_get._in_modal|default(false)) %}
 
 {% if item is defined %}
 
      {{ call_plugin_hook(constant('Glpi\\Plugin\\Hooks::POST_ITEM_FORM'), {'item': item, 'options': params}) }}
-
 
     {% if canedit or item.canEdit(item.fields['id']) %}
       <div class="form-button-separator card-body mx-n2 border-top d-flex flex-row-reverse align-items-start flex-wrap">
          {% if withtemplate > 0 or item.isNewID(id) %}
             {% if id <= 0 or withtemplate == 2 %}
                <button
-                  class="btn btn-primary me-2 {{ params['in_modal']|default(false) ? 'mt-2' : '' }}"
+                  class="btn btn-primary me-2 {{ in_modal ? 'mt-2' : '' }}"
                   type="submit"
                   name="add"
                   value="1"
@@ -56,7 +56,7 @@
                </button>
             {% else %}
                <button
-                  class="btn btn-primary me-2 {{ params['in_modal']|default(false) ? 'mt-2' : '' }}"
+                  class="btn btn-primary me-2 {{ in_modal ? 'mt-2' : '' }}"
                   type="submit"
                   name="update"
                   value="1"
@@ -73,7 +73,7 @@
 
             {% if canedit and item.can(id, constant('UPDATE')) %}
                <button
-                  class="btn btn-primary me-2 {{ params['in_modal']|default(false) ? 'mt-2' : '' }}"
+                  class="btn btn-primary me-2 {{ in_modal ? 'mt-2' : '' }}"
                   type="submit"
                   name="update"
                   value="1"
@@ -88,7 +88,7 @@
                {% if item.isDeleted() %}
                   {% if item.can(id, constant('DELETE')) %}
                      <button
-                        class="btn btn-outline-secondary me-2 {{ params['in_modal']|default(false) ? 'mt-2' : '' }}"
+                        class="btn btn-outline-secondary me-2 {{ in_modal ? 'mt-2' : '' }}"
                         type="submit"
                         name="restore"
                         value="1"

--- a/templates/components/form/buttons.html.twig
+++ b/templates/components/form/buttons.html.twig
@@ -45,7 +45,7 @@
          {% if withtemplate > 0 or item.isNewID(id) %}
             {% if id <= 0 or withtemplate == 2 %}
                <button
-                  class="btn btn-primary me-2"
+                  class="btn btn-primary me-2 {{ params['in_modal'] ? 'mt-2' : '' }}"
                   type="submit"
                   name="add"
                   value="1"
@@ -56,7 +56,7 @@
                </button>
             {% else %}
                <button
-                  class="btn btn-primary me-2"
+                  class="btn btn-primary me-2 {{ params['in_modal'] ? 'mt-2' : '' }}"
                   type="submit"
                   name="update"
                   value="1"
@@ -73,7 +73,7 @@
 
             {% if canedit and item.can(id, constant('UPDATE')) %}
                <button
-                  class="btn btn-primary me-2"
+                  class="btn btn-primary me-2 {{ params['in_modal'] ? 'mt-2' : '' }}"
                   type="submit"
                   name="update"
                   value="1"
@@ -88,7 +88,7 @@
                {% if item.isDeleted() %}
                   {% if item.can(id, constant('DELETE')) %}
                      <button
-                        class="btn btn-outline-secondary me-2"
+                        class="btn btn-outline-secondary me-2 {{ params['in_modal'] ? 'mt-2' : '' }}"
                         type="submit"
                         name="restore"
                         value="1"

--- a/templates/components/form/buttons.html.twig
+++ b/templates/components/form/buttons.html.twig
@@ -73,7 +73,7 @@
 
             {% if canedit and item.can(id, constant('UPDATE')) %}
                <button
-                  class="btn btn-primary me-2 {{ in_modal ? 'mt-2' : '' }}"
+                  class="btn btn-primary me-2"
                   type="submit"
                   name="update"
                   value="1"

--- a/templates/components/form/buttons.html.twig
+++ b/templates/components/form/buttons.html.twig
@@ -56,7 +56,7 @@
                </button>
             {% else %}
                <button
-                  class="btn btn-primary me-2 {{ in_modal ? 'mt-2' : '' }}"
+                  class="btn btn-primary me-2"
                   type="submit"
                   name="update"
                   value="1"

--- a/templates/components/form/buttons.html.twig
+++ b/templates/components/form/buttons.html.twig
@@ -88,7 +88,7 @@
                {% if item.isDeleted() %}
                   {% if item.can(id, constant('DELETE')) %}
                      <button
-                        class="btn btn-outline-secondary me-2 {{ in_modal ? 'mt-2' : '' }}"
+                        class="btn btn-outline-secondary me-2"
                         type="submit"
                         name="restore"
                         value="1"

--- a/templates/components/form/buttons.html.twig
+++ b/templates/components/form/buttons.html.twig
@@ -45,7 +45,7 @@
          {% if withtemplate > 0 or item.isNewID(id) %}
             {% if id <= 0 or withtemplate == 2 %}
                <button
-                  class="btn btn-primary me-2 {{ in_modal ? 'mt-2' : '' }}"
+                  class="btn btn-primary me-2"
                   type="submit"
                   name="add"
                   value="1"

--- a/templates/components/form/buttons.html.twig
+++ b/templates/components/form/buttons.html.twig
@@ -41,7 +41,7 @@
      {{ call_plugin_hook(constant('Glpi\\Plugin\\Hooks::POST_ITEM_FORM'), {'item': item, 'options': params}) }}
 
     {% if canedit or item.canEdit(item.fields['id']) %}
-      <div class="form-button-separator card-body mx-n2 border-top d-flex flex-row-reverse align-items-start flex-wrap">
+      <div class="form-button-separator card-body mx-n2 border-top d-flex flex-row-reverse align-items-start flex-wrap  {{ in_modal ? 'p-2' : '' }}">
          {% if withtemplate > 0 or item.isNewID(id) %}
             {% if id <= 0 or withtemplate == 2 %}
                <button


### PR DESCRIPTION
Updated button classes to conditionally apply margin-top based on params.

<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does:

Add a margin-top for action buttons on modals. Tested in:

- Creating a new external event on Planning (/front/planning.php)
- Creating a new Plug in PDU (/front/pdu.form.php).

## Screenshots (if appropriate):

Before:

<img width="738" height="507" alt="image" src="https://github.com/user-attachments/assets/4b77e85e-dfe7-40ea-b439-588f380092cb" />

After:

<img width="741" height="500" alt="image" src="https://github.com/user-attachments/assets/824fb07e-5b66-4efd-9e82-358aed742e50" />

