### PR TITLE
Separate cache instances when testing with multiple threads

### DIFF
--- a/src/Glpi/Kernel/Kernel.php
+++ b/src/Glpi/Kernel/Kernel.php
@@ -90,8 +90,14 @@ final class Kernel extends BaseKernel
      */
     public static function getCacheRootDir(): string
     {
+        $suffix = "";
+        $test_token = getenv('TEST_TOKEN');
+        if ($test_token !== false && $test_token !== '') {
+            $suffix = '-' . $test_token;
+        }
+
         // FIXME: Inject it as a DI parameter when corresponding services will be instanciated from the DI system.
-        return GLPI_CACHE_DIR . '/' . GLPI_FILES_VERSION . '-' . Environment::get()->value;
+        return GLPI_CACHE_DIR . '/' . GLPI_FILES_VERSION . '-' . Environment::get()->value . $suffix;
     }
 
     #[Override()]


### PR DESCRIPTION
## Description

The newly merged paratest support seems to be a bit flaky.
Looking at our code, one possible issue is that we clear the cache in between each tests.

Using a separate cache for each runner should hopefully help with that.

