### PR TITLE
Fix - Handle empty groups array in project search criteria

### DIFF
--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -734,49 +734,43 @@ final class SQLProvider implements SearchProviderInterface
                 if (!Session::haveRightsOr('project', [Project::READALL, Project::READMY])) {
                     // Can only see the tasks assigned to the user or one of his groups
                     $teamtable = 'glpi_projecttaskteams';
-                    $group_criteria = [];
+                    $user_criteria = [
+                        "$teamtable.itemtype" => User::class,
+                        "$teamtable.items_id" => Session::getLoginUserID(),
+                    ];
+                    $or_criteria = [$user_criteria];
                     if (count($_SESSION['glpigroups'])) {
                         $group_criteria = [
                             "$teamtable.itemtype" => Group::class,
                             "$teamtable.items_id" => $_SESSION['glpigroups'],
                         ];
+                        $or_criteria[] = $group_criteria;
                     }
-                    $user_criteria = [
-                        "$teamtable.itemtype" => User::class,
-                        "$teamtable.items_id" => Session::getLoginUserID(),
-                    ];
                     $criteria = [
                         "glpi_projects.is_template" => 0,
-                        'OR' => [
-                            $user_criteria,
-                        ],
+                        'OR' => $or_criteria,
                     ];
-                    if ($group_criteria !== []) {
-                        $criteria['OR'][] = $group_criteria;
-                    }
                 } elseif (Session::haveRight('project', Project::READMY)) {
                     // User must be the manager, in the manager group or in the project team
                     $teamtable = 'glpi_projectteams';
-                    $group_criteria = [];
+                    $user_criteria = [
+                        "$teamtable.itemtype" => User::class,
+                        "$teamtable.items_id" => Session::getLoginUserID(),
+                    ];
+                    $or_criteria = [
+                        $user_criteria,
+                        'glpi_projects.users_id' => Session::getLoginUserID(),
+                    ];
                     if (count($_SESSION['glpigroups'])) {
                         $group_criteria = [
                             "$teamtable.itemtype" => Group::class,
                             "$teamtable.items_id" => $_SESSION['glpigroups'],
                         ];
+                        $or_criteria[] = $group_criteria;
                     }
-                    $user_criteria = [
-                        "$teamtable.itemtype" => User::class,
-                        "$teamtable.items_id" => Session::getLoginUserID(),
-                    ];
                     $criteria = [
-                        'OR' => [
-                            $user_criteria,
-                            'glpi_projects.users_id' => Session::getLoginUserID(),
-                        ],
+                        'OR' => $or_criteria,
                     ];
-                    if ($group_criteria !== []) {
-                        $criteria['OR'][] = $group_criteria;
-                    }
                 }
                 break;
 
@@ -787,17 +781,20 @@ final class SQLProvider implements SearchProviderInterface
                         "$teamtable.itemtype" => User::class,
                         "$teamtable.items_id" => Session::getLoginUserID(),
                     ];
-                    $group_criteria = [
-                        "$teamtable.itemtype" => Group::class,
-                        "$teamtable.items_id" => $_SESSION['glpigroups'],
+                    $or_criteria = [
+                        "glpi_projects.users_id" => Session::getLoginUserID(),
+                        $user_criteria,
                     ];
+                    if (count($_SESSION['glpigroups'])) {
+                        $group_criteria = [
+                            "$teamtable.itemtype" => Group::class,
+                            "$teamtable.items_id" => $_SESSION['glpigroups'],
+                        ];
+                        $or_criteria[] = ["glpi_projects.groups_id" => $_SESSION['glpigroups']];
+                        $or_criteria[] = $group_criteria;
+                    }
                     $criteria = [
-                        "OR" => [
-                            "glpi_projects.users_id" => Session::getLoginUserID(),
-                            $user_criteria,
-                            "glpi_projects.groups_id" => $_SESSION['glpigroups'],
-                            $group_criteria,
-                        ],
+                        "OR" => $or_criteria,
                     ];
                 }
                 break;


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- Here is a brief description of what this PR does

Fixes "Empty IN are not allowed" error when users without group membership access the projects list.

Error : 
```php
An unexpected error occurred
[Return to previous page](http://localhost/glpi/front/central.php)
An exception has been thrown during the rendering of a template ("Empty IN are not allowed") in "pages/generic_list.html.twig" at line 37.
In ./templates/pages/generic_list.html.twig(37)
#0 ./vendor/twig/twig/src/Template.php(358): Twig\Template->yield()
#1 ./vendor/twig/twig/src/Template.php(373): Twig\Template->display()
#2 ./vendor/twig/twig/src/TemplateWrapper.php(51): Twig\Template->render()
#3 ./src/Glpi/Application/View/TemplateRenderer.php(170): Twig\TemplateWrapper->render()
#4 ./src/Glpi/Controller/AbstractController.php(68): Glpi\Application\View\TemplateRenderer->render()
#5 ./src/Glpi/Controller/GenericListController.php(51): Glpi\Controller\AbstractController->render()
#6 ./vendor/symfony/http-kernel/HttpKernel.php(181): Glpi\Controller\GenericListController->__invoke()
#7 ./vendor/symfony/http-kernel/HttpKernel.php(76): Symfony\Component\HttpKernel\HttpKernel->handleRaw()
#8 ./vendor/symfony/http-kernel/Kernel.php(197): Symfony\Component\HttpKernel\HttpKernel->handle()
#9 ./public/index.php(71): Symfony\Component\HttpKernel\Kernel->handle()
#10 {main}

Previous: Empty IN are not allowed
In ./src/DBmysqlIterator.php(613)
#0 ./src/DBmysqlIterator.php(579): DBmysqlIterator->analyseCriterion()
#1 ./src/DBmysqlIterator.php(567): DBmysqlIterator->analyseCrit()
#2 ./src/DBmysqlIterator.php(310): DBmysqlIterator->analyseCrit()
#3 ./src/Search.php(622): DBmysqlIterator->buildQuery()
#4 ./src/Glpi/Search/Provider/SQLProvider.php(4252): Search::addDefaultWhere()
#5 ./src/Glpi/Search/SearchEngine.php(673): Glpi\Search\Provider\SQLProvider::constructSQL()
#6 ./src/Glpi/Search/SearchEngine.php(689): Glpi\Search\SearchEngine::getData()
#7 ./src/Glpi/Search/SearchEngine.php(646): Glpi\Search\SearchEngine::showOutput()
#8 [internal function]: Glpi\Search\SearchEngine::show()
#9 ./src/Glpi/Application/View/Extension/PhpExtension.php(105): call_user_func_array()
#10 ./files/_cache/11.0.6-dev-00000000-development/templates/31/315031d9b942d18a6454a36bf209d523.php(55): Glpi\Application\View\Extension\PhpExtension->call()
#11 ./vendor/twig/twig/src/Template.php(402): __TwigTemplate_51da712e5a10bc2f866a5d97f544c825->doDisplay()
#12 ./vendor/twig/twig/src/Template.php(358): Twig\Template->yield()
#13 ./vendor/twig/twig/src/Template.php(373): Twig\Template->display()
#14 ./vendor/twig/twig/src/TemplateWrapper.php(51): Twig\Template->render()
#15 ./src/Glpi/Application/View/TemplateRenderer.php(170): Twig\TemplateWrapper->render()
#16 ./src/Glpi/Controller/AbstractController.php(68): Glpi\Application\View\TemplateRenderer->render()
#17 ./src/Glpi/Controller/GenericListController.php(51): Glpi\Controller\AbstractController->render()
#18 ./vendor/symfony/http-kernel/HttpKernel.php(181): Glpi\Controller\GenericListController->__invoke()
#19 ./vendor/symfony/http-kernel/HttpKernel.php(76): Symfony\Component\HttpKernel\HttpKernel->handleRaw()
#20 ./vendor/symfony/http-kernel/Kernel.php(197): Symfony\Component\HttpKernel\HttpKernel->handle()
#21 ./public/index.php(71): Symfony\Component\HttpKernel\Kernel->handle()
#22 {main}
```

The issue occurred in `SQLProvider::getDefaultWhereCriteria()` where `$_SESSION['glpigroups']` was used directly in SQL IN clauses without checking if the array was empty.

**Changes:**
- Check if user belongs to groups before adding group-based criteria for Project and ProjectTask search filters
- Build OR criteria dynamically to avoid empty IN clauses