### PR TITLE
Set testCanAddDocument as single thread

### DIFF
--- a/tests/functional/TicketTest.php
+++ b/tests/functional/TicketTest.php
@@ -9006,6 +9006,7 @@ HTML,
     }
 
     #[DataProvider('canAddDocumentProvider')]
+    #[\PHPUnit\Framework\Attributes\Group('single-thread')]
     public function testCanAddDocument(array $profilerights, bool $expected): void
     {
         global $DB;


### PR DESCRIPTION
This test seems flaky, idk why as it doesn't do anything special.

<img width="631" height="258" alt="image" src="https://github.com/user-attachments/assets/ddc444f5-2279-421d-a52a-88917b12a443" />

Hopefully it won't happens for more tests.
