### PR TITLE
doQuery never returns false

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -2078,12 +2078,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/install/migrations/update_9.5.x_to_10.0.0/domains.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Cannot call method fetch_all\\(\\) on bool\\|mysqli_result\\.$#',
-	'identifier' => 'method.nonObject',
-	'count' => 2,
-	'path' => __DIR__ . '/install/migrations/update_9.5.x_to_10.0.0/native_inventory.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method APIClient\\:\\:canCreate\\(\\) should return bool but returns bool\\|int\\.$#',
 	'identifier' => 'return.type',
 	'count' => 1,
@@ -3236,12 +3230,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/CommonDBTM.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$force of method CommonDBTM\\:\\:deleteFromDB\\(\\) expects bool, bool\\|int given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/CommonDBTM.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$integer of static method Toolbox\\:\\:cleanInteger\\(\\) expects string, int\\|string given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
@@ -3281,12 +3269,6 @@ $ignoreErrors[] = [
 	'message' => '#^Parameter \\#2 \\$items_id of static method Item_Devices\\:\\:cleanItemDeviceDBOnItemDelete\\(\\) expects int\\<1, max\\>, int given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
-	'path' => __DIR__ . '/src/CommonDBTM.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#2 \\$itemtype of static method Log\\:\\:history\\(\\) expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 2,
 	'path' => __DIR__ . '/src/CommonDBTM.php',
 ];
 $ignoreErrors[] = [
@@ -5012,30 +4994,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/DBConnection.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$result of method DBmysql\\:\\:numrows\\(\\) expects mysqli_result, bool\\|mysqli_result given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/DBConnection.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$result of method DBmysql\\:\\:numrows\\(\\) expects mysqli_result, mysqli_result\\|true given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 2,
-	'path' => __DIR__ . '/src/DBConnection.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$result of method DBmysql\\:\\:result\\(\\) expects mysqli_result, bool\\|mysqli_result given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/DBConnection.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$result of method DBmysql\\:\\:result\\(\\) expects mysqli_result, mysqli_result\\|true given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 2,
-	'path' => __DIR__ . '/src/DBConnection.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#2 \\$start of function mb_substr expects int, int\\<0, max\\>\\|false given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
@@ -5066,37 +5024,7 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/DBmysql.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Cannot call method fetch_array\\(\\) on bool\\|mysqli_result\\.$#',
-	'identifier' => 'method.nonObject',
-	'count' => 2,
-	'path' => __DIR__ . '/src/DBmysql.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Cannot call method fetch_assoc\\(\\) on bool\\|mysqli_result\\.$#',
-	'identifier' => 'method.nonObject',
-	'count' => 1,
-	'path' => __DIR__ . '/src/DBmysql.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Cannot call method fetch_assoc\\(\\) on mysqli_result\\|true\\.$#',
-	'identifier' => 'method.nonObject',
-	'count' => 1,
-	'path' => __DIR__ . '/src/DBmysql.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Cannot call method fetch_row\\(\\) on bool\\|mysqli_result\\.$#',
-	'identifier' => 'method.nonObject',
-	'count' => 1,
-	'path' => __DIR__ . '/src/DBmysql.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method DBmysql\\:\\:affectedRows\\(\\) should return int but returns int\\<\\-1, max\\>\\|string\\.$#',
-	'identifier' => 'return.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/DBmysql.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Method DBmysql\\:\\:doQueryOrDie\\(\\) should return mysqli_result but returns bool\\|mysqli_result\\.$#',
 	'identifier' => 'return.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/DBmysql.php',
@@ -5153,12 +5081,6 @@ $ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$result of method DBmysql\\:\\:fetchAssoc\\(\\) expects mysqli_result, mysqli_result\\|true given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
-	'path' => __DIR__ . '/src/DBmysql.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$result of method DBmysql\\:\\:fetchRow\\(\\) expects mysqli_result, bool\\|mysqli_result given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 2,
 	'path' => __DIR__ . '/src/DBmysql.php',
 ];
 $ignoreErrors[] = [
@@ -14366,12 +14288,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Search/Provider/SQLProvider.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$result of method DBmysql\\:\\:result\\(\\) expects mysqli_result, bool\\|mysqli_result given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Search/Provider/SQLProvider.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$separator of function explode expects non\\-empty\\-string, string given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
@@ -14770,12 +14686,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Cannot access offset \'innodb_page_size\' on array\\<string, float\\|int\\|string\\|null\\>\\|false\\|null\\.$#',
 	'identifier' => 'offsetAccess.nonOffsetAccessible',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/System/Requirement/DbConfiguration.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Cannot call method fetch_assoc\\(\\) on bool\\|mysqli_result\\.$#',
-	'identifier' => 'method.nonObject',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Glpi/System/Requirement/DbConfiguration.php',
 ];
@@ -21806,12 +21716,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Toolbox.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Cannot call method fetch_assoc\\(\\) on bool\\|mysqli_result\\.$#',
-	'identifier' => 'method.nonObject',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Toolbox.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method Toolbox\\:\\:addslashes_deep\\(\\) should return array\\<string\\>\\|string but returns array\\<array\\<string\\>\\|string\\>\\|string\\.$#',
 	'identifier' => 'return.type',
 	'count' => 1,
@@ -22058,21 +21962,9 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Unmanaged.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Cannot call method fetch_assoc\\(\\) on bool\\|mysqli_result\\.$#',
-	'identifier' => 'method.nonObject',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Update.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Offset \'target_version\' might not exist on array\\{0\\?\\: string, source_version\\?\\: non\\-falsy\\-string, 1\\?\\: non\\-falsy\\-string, target_version\\?\\: non\\-falsy\\-string, 2\\?\\: non\\-falsy\\-string\\}\\.$#',
 	'identifier' => 'offsetAccess.notFound',
 	'count' => 4,
-	'path' => __DIR__ . '/src/Update.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#2 \\$string of function explode expects string, float\\|int\\|string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
 	'path' => __DIR__ . '/src/Update.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -5018,18 +5018,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/DBmysql.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Cannot access offset \'version\\(\\)\' on array\\|false\\|null\\.$#',
-	'identifier' => 'offsetAccess.nonOffsetAccessible',
-	'count' => 1,
-	'path' => __DIR__ . '/src/DBmysql.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Method DBmysql\\:\\:affectedRows\\(\\) should return int but returns int\\<\\-1, max\\>\\|string\\.$#',
-	'identifier' => 'return.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/DBmysql.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method DBmysql\\:\\:fetchArray\\(\\) should return array\\<string\\>\\|null but returns array\\|object\\|false\\|null\\.$#',
 	'identifier' => 'return.type',
 	'count' => 1,
@@ -5043,12 +5031,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	'message' => '#^Method DBmysql\\:\\:fetchObject\\(\\) should return object\\|null but returns array\\|object\\|false\\|null\\.$#',
-	'identifier' => 'return.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/DBmysql.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Method DBmysql\\:\\:numrows\\(\\) should return int but returns int\\<0, max\\>\\|string\\.$#',
 	'identifier' => 'return.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/DBmysql.php',
@@ -5068,30 +5050,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Offset \'table\' might not exist on array\\{0\\?\\: string, 1\\?\\: non\\-falsy\\-string, 2\\?\\: string, 3\\?\\: string, 4\\?\\: non\\-empty\\-string, table\\?\\: non\\-empty\\-string, 5\\?\\: non\\-empty\\-string, 6\\?\\: non\\-empty\\-string\\}\\.$#',
 	'identifier' => 'offsetAccess.notFound',
-	'count' => 1,
-	'path' => __DIR__ . '/src/DBmysql.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Offset 0 might not exist on array\\|null\\.$#',
-	'identifier' => 'offsetAccess.notFound',
-	'count' => 1,
-	'path' => __DIR__ . '/src/DBmysql.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$result of method DBmysql\\:\\:fetchAssoc\\(\\) expects mysqli_result, mysqli_result\\|true given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/DBmysql.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$result of method DBmysql\\:\\:numrows\\(\\) expects mysqli_result, mysqli_result\\|true given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/DBmysql.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#2 \\$length of function Safe\\\\fread expects int\\<1, max\\>, int\\<0, max\\> given\\.$#',
-	'identifier' => 'argument.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/DBmysql.php',
 ];

--- a/install/migrations/update_9.5.x_to_10.0.0/native_inventory.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/native_inventory.php
@@ -525,7 +525,9 @@ if (!$DB->tableExists('glpi_printerlogs')) {
                 $DB->quoteName('date')
             )
         );
-        $to_preserve_result = $DB->doQuery($to_preserve_sql->getValue())->fetch_all(MYSQLI_ASSOC);
+        /** @var mysqli_result $request */
+        $request = $DB->doQuery($to_preserve_sql->getValue());
+        $to_preserve_result = $request->fetch_all(MYSQLI_ASSOC);
         if (!empty($to_preserve_result)) { // If there is no entries to preserve, it means that table is empty, and nothing has to be deleted
             $DB->delete(
                 'glpi_printerlogs',
@@ -605,7 +607,9 @@ if (!$DB->tableExists('glpi_networkportmetrics')) {
                 $DB->quoteName('date')
             )
         );
-        $to_preserve_result = $DB->doQuery($to_preserve_sql->getValue())->fetch_all(MYSQLI_ASSOC);
+        /** @var mysqli_result $request */
+        $request = $DB->doQuery($to_preserve_sql->getValue());
+        $to_preserve_result = $request->fetch_all(MYSQLI_ASSOC);
         if (!empty($to_preserve_result)) { // If there is no entries to preserve, it means that table is empty, and nothing has to be deleted
             $DB->delete(
                 'glpi_networkportmetrics',

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -2131,7 +2131,7 @@ class CommonDBTM extends CommonGLPI
             || ($this->useDeletedToLockIfDynamic()
               && !$this->isDynamic())
         ) {
-            $force = 1;
+            $force = true;
         }
 
         // Store input in the object to be available in all sub-method / hook
@@ -2203,7 +2203,7 @@ class CommonDBTM extends CommonGLPI
 
                         Log::history(
                             $this->fields["id"],
-                            $this->getType(),
+                            static::class,
                             $changes,
                             0,
                             $logaction
@@ -2364,7 +2364,7 @@ class CommonDBTM extends CommonGLPI
                 ) {
                     $logaction = Log::HISTORY_UNLOCK_ITEM;
                 }
-                Log::history($this->input["id"], $this->getType(), $changes, 0, $logaction);
+                Log::history($this->input["id"], static::class, $changes, 0, $logaction);
             }
 
             $this->post_restoreItem();

--- a/src/DBConnection.php
+++ b/src/DBConnection.php
@@ -586,6 +586,7 @@ class DBConnection extends CommonGLPI
                 $data['source'][strtolower($var_name)] = $var_value;
             }
 
+            /** @var mysqli_result $result */
             $result = $db_main->doQuery($db_main->getBinaryLogStatusQuery());
             if ($result && $db_main->numrows($result)) {
                 foreach (['File', 'Position'] as $var_name) {
@@ -616,6 +617,7 @@ class DBConnection extends CommonGLPI
                     $data['replica'][$num][strtolower($var_name)] = $var_value;
                 }
 
+                /** @var mysqli_result $result */
                 $result = $db_replica->doQuery($db_replica->getReplicaStatusQuery());
                 if ($result && $db_replica->numrows($result)) {
                     $replica_vars = $db_replica->getReplicaStatusVars();
@@ -645,8 +647,8 @@ class DBConnection extends CommonGLPI
     {
 
         if ($DBconnection->connected) {
-            $result = $DBconnection->doQuery("SELECT UNIX_TIMESTAMP(MAX(`date_mod`)) AS max_date
-                                         FROM `glpi_logs`");
+            /** @var mysqli_result $result */
+            $result = $DBconnection->doQuery("SELECT UNIX_TIMESTAMP(MAX(`date_mod`)) AS max_date FROM `glpi_logs`");
             if ($DBconnection->numrows($result) > 0) {
                 return $DBconnection->result($result, 0, "max_date");
             }

--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -79,6 +79,7 @@ use KnowbaseItem;
 use KnowbaseItem_Profile;
 use KnowbaseItem_User;
 use Link;
+use mysqli_result;
 use Notification;
 use OLA;
 use Override;
@@ -4982,6 +4983,7 @@ final class SQLProvider implements SearchProviderInterface
                     $data['data']['totalcount'] = $DBread->numrows($result);
                 } else {
                     foreach ($data['sql']['count'] as $sqlcount) {
+                        /** @var mysqli_result $result_num */
                         $result_num = $DBread->doQuery($sqlcount);
                         $data['data']['totalcount'] += $DBread->result($result_num, 0, 0);
                     }

--- a/src/Glpi/System/Requirement/DbConfiguration.php
+++ b/src/Glpi/System/Requirement/DbConfiguration.php
@@ -36,6 +36,7 @@
 namespace Glpi\System\Requirement;
 
 use DBmysql;
+use mysqli_result;
 
 /**
  * @since 10.0.0
@@ -62,11 +63,8 @@ class DbConfiguration extends AbstractRequirement
     {
         $query = 'SELECT @@GLOBAL.' . $this->db->quoteName('innodb_page_size as innodb_page_size');
 
-        if (($db_config_res = $this->db->doQuery($query)) === false) {
-            $this->validated = false;
-            $this->validation_messages[] = __('Unable to validate database configuration variables.');
-        }
-
+        /** @var mysqli_result $db_config_res */
+        $db_config_res = $this->db->doQuery($query);
         $db_config = $db_config_res->fetch_assoc();
 
         $incompatibilities = [];

--- a/src/ProfileRight.php
+++ b/src/ProfileRight.php
@@ -70,17 +70,15 @@ class ProfileRight extends CommonDBChild
 
         $input = $new_item->prepareInputForClone($input);
 
-        $result = $DB->updateOrInsert(static::getTable(), $input, [
+        $DB->updateOrInsert(static::getTable(), $input, [
             'name' => $input['name'],
             'profiles_id' => $input['profiles_id'],
         ]);
-        if ($result !== false) {
-            $new_item->getFromDBByCrit([
-                'name' => $input['name'],
-                'profiles_id' => $input['profiles_id'],
-            ]);
-            $new_item->post_clone($this, $history);
-        }
+        $new_item->getFromDBByCrit([
+            'name' => $input['name'],
+            'profiles_id' => $input['profiles_id'],
+        ]);
+        $new_item->post_clone($this, $history);
 
         return $new_item->fields['id'];
     }

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -2228,9 +2228,11 @@ class Toolbox
             // Enable NO_AUTO_VALUE_ON_ZERO for glpi_entities insertion (needed for id=0 root entity)
             $original_sql_mode = null;
             if ($table === 'glpi_entities') {
-                $original_sql_mode = $database->doQuery(
+                /** @var mysqli_result $request */
+                $request = $database->doQuery(
                     sprintf('SELECT @@sql_mode as %s', $database->quoteName('sql_mode'))
-                )->fetch_assoc()['sql_mode'] ?? '';
+                );
+                $original_sql_mode = $request->fetch_assoc()['sql_mode'] ?? '';
                 $new_sql_mode = $original_sql_mode !== ''
                     ? $original_sql_mode . ',NO_AUTO_VALUE_ON_ZERO'
                     : 'NO_AUTO_VALUE_ON_ZERO';

--- a/src/Update.php
+++ b/src/Update.php
@@ -208,7 +208,9 @@ class Update
             // e.g. with `NO_ZERO_DATE` flag `ALTER TABLE` operations fails when a row contains a `0000-00-00 00:00:00` datetime value.
             // Unitary removal of these flags is not pôssible as MySQL 8.0 triggers warning if
             // `STRICT_{ALL|TRANS}_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO` are not used all together.
-            $sql_mode = $DB->doQuery(sprintf('SELECT @@sql_mode as %s', $DB->quoteName('sql_mode')))->fetch_assoc()['sql_mode'] ?? '';
+            /** @var mysqli_result $request */
+            $request = $DB->doQuery(sprintf('SELECT @@sql_mode as %s', $DB->quoteName('sql_mode')));
+            $sql_mode = (string) ($request->fetch_assoc()['sql_mode'] ?? '');
             $sql_mode_flags = array_filter(
                 explode(',', $sql_mode),
                 fn(string $flag) => !in_array(


### PR DESCRIPTION
Since v11, doQuery can return either a `mysqli_result` for `SELECT` queries, or `true` for all other. 
The `false` case throws an exception; and therefore is never returned.

I've fixed also a few other phpstan issues in `DBmysql` class.