### PR TITLE
fix(collector): skip blacklisted documents during mail collection

### DIFF
--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -5602,6 +5602,17 @@ class CommonDBTM extends CommonGLPI
                     $doc->update($input2);
                 }
             } else {
+                // Only block blacklisted documents when importing via mail collector
+                if (isset($input['_auto_import']) && $input['_auto_import']) {
+                    $blacklisted_doc = new Document();
+                    if ($blacklisted_doc->getFromDBbyContent($entities_id, $filename)) {
+                        if ($blacklisted_doc->fields['is_blacklisted']) {
+                            // Document is blacklisted, skip attachment
+                            continue;
+                        }
+                    }
+                }
+
                 if ($this instanceof Ticket || (isset($input['_job']) && $input['_job'] instanceof Ticket)) {
                     if (isset($input['_job']) && $input['_job'] instanceof Ticket) {
                         $ticket_id = $input['_job']->getID();

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -5603,7 +5603,7 @@ class CommonDBTM extends CommonGLPI
                 }
             } else {
                 // Only block blacklisted documents when importing via mail collector
-                if (isset($input['_auto_import']) && $input['_auto_import']) {
+                if ($input['_auto_import'] ?? false) {
                     $blacklisted_doc = new Document();
                     if ($blacklisted_doc->getFromDBbyContent($entities_id, $filename)) {
                         if ($blacklisted_doc->fields['is_blacklisted']) {

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -5573,6 +5573,17 @@ class CommonDBTM extends CommonGLPI
                 $is_recursive = 1;
             }
 
+            // Check if document is blacklisted when importing via mail collector
+            if ($input['_auto_import'] ?? false) {
+                $blacklisted_doc = new Document();
+                if ($blacklisted_doc->getFromDBbyContent($entities_id, $filename)) {
+                    if ($blacklisted_doc->fields['is_blacklisted']) {
+                        // Document is blacklisted, skip attachment
+                        continue;
+                    }
+                }
+            }
+
             // Check for duplicate and availability (e.g. file deleted in _files)
             if ($doc->getDuplicateOf($entities_id, $filename)) {
                 $docID = $doc->fields["id"];
@@ -5602,17 +5613,6 @@ class CommonDBTM extends CommonGLPI
                     $doc->update($input2);
                 }
             } else {
-                // Only block blacklisted documents when importing via mail collector
-                if ($input['_auto_import'] ?? false) {
-                    $blacklisted_doc = new Document();
-                    if ($blacklisted_doc->getFromDBbyContent($entities_id, $filename)) {
-                        if ($blacklisted_doc->fields['is_blacklisted']) {
-                            // Document is blacklisted, skip attachment
-                            continue;
-                        }
-                    }
-                }
-
                 if ($this instanceof Ticket || (isset($input['_job']) && $input['_job'] instanceof Ticket)) {
                     if (isset($input['_job']) && $input['_job'] instanceof Ticket) {
                         $ticket_id = $input['_job']->getID();

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -5576,11 +5576,12 @@ class CommonDBTM extends CommonGLPI
             // Check if document is blacklisted when importing via mail collector
             if ($input['_auto_import'] ?? false) {
                 $blacklisted_doc = new Document();
-                if ($blacklisted_doc->getFromDBbyContent($entities_id, $filename)) {
-                    if ($blacklisted_doc->fields['is_blacklisted']) {
-                        // Document is blacklisted, skip attachment
-                        continue;
-                    }
+                if (
+                    $blacklisted_doc->getFromDBbyContent($entities_id, $filename)
+                    && $blacklisted_doc->fields['is_blacklisted']
+                ) {
+                    // Document is blacklisted, skip attachment
+                    continue;
                 }
             }
 

--- a/src/MailCollector.php
+++ b/src/MailCollector.php
@@ -1642,21 +1642,6 @@ class MailCollector extends CommonDBTM
 
             $contents = $this->getDecodedContent($part);
             if (file_put_contents($path . $filename, $contents)) {
-                // Check if the document is blacklisted
-                $document = new Document();
-                if ($document->getFromDBbyContent(0, $path . $filename)) {
-                    if ($document->fields['is_blacklisted']) {
-                        // Remove the temporary file and skip this attachment
-                        unlink($path . $filename);
-                        $this->addtobody .= "\n\n" . sprintf(
-                            __('%1$s: %2$s'),
-                            __('Blacklisted attached file'),
-                            $filename
-                        );
-                        return;
-                    }
-                }
-
                 $this->files[$filename] = $filename;
 
                 // If embeded image, we add a tag

--- a/src/MailCollector.php
+++ b/src/MailCollector.php
@@ -1642,6 +1642,21 @@ class MailCollector extends CommonDBTM
 
             $contents = $this->getDecodedContent($part);
             if (file_put_contents($path . $filename, $contents)) {
+                // Check if the document is blacklisted
+                $document = new Document();
+                if ($document->getFromDBbyContent(0, $path . $filename)) {
+                    if ($document->fields['is_blacklisted']) {
+                        // Remove the temporary file and skip this attachment
+                        unlink($path . $filename);
+                        $this->addtobody .= "\n\n" . sprintf(
+                            __('%1$s: %2$s'),
+                            __('Blacklisted attached file'),
+                            $filename
+                        );
+                        return;
+                    }
+                }
+
                 $this->files[$filename] = $filename;
 
                 // If embeded image, we add a tag

--- a/tests/imap/MailCollectorTest.php
+++ b/tests/imap/MailCollectorTest.php
@@ -1594,7 +1594,7 @@ PLAINTEXT,
             ]
         );
 
-        // Verify documents are& attached when manually uploaded
+        // Verify documents are attached when manually uploaded
         $doc_items_manual = getAllDataFromTable(\Document_Item::getTable(), [
             'itemtype' => Ticket::getType(),
             'items_id' => $ticket->getID(),

--- a/tests/imap/MailCollectorTest.php
+++ b/tests/imap/MailCollectorTest.php
@@ -1557,7 +1557,7 @@ PLAINTEXT,
         );
 
         // Test 1: Auto-import (mail collector) should be blocked
-        copy($png_file, GLPI_TMP_DIR . '/foo.png');
+        \Safe\copy($png_file, GLPI_TMP_DIR . '/foo.png');
 
         $ticket = $this->createItem(
             Ticket::class,
@@ -1581,7 +1581,7 @@ PLAINTEXT,
         // Test 2: Manual upload should work (not blocked)
         $png_file_manual = GLPI_ROOT . '/tests/fixtures/uploads/bar.png';
 
-        copy($png_file_manual, GLPI_TMP_DIR . '/bar.png');
+        \Safe\copy($png_file_manual, GLPI_TMP_DIR . '/bar.png');
 
         $ticket = $this->createItem(
             Ticket::class,
@@ -1602,7 +1602,7 @@ PLAINTEXT,
         $this->assertCount(1, $doc_items_manual, 'Documents should be attached when manually uploaded');
 
         // Cleanup temporary copies only
-        @unlink(GLPI_TMP_DIR . '/foo.png');
-        @unlink(GLPI_TMP_DIR . '/bar.png');
+        \Safe\unlink(GLPI_TMP_DIR . '/foo.png');
+        \Safe\unlink(GLPI_TMP_DIR . '/bar.png');
     }
 }


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !41834
The “Blacklisted for import” option prevents a document from being associated with a ticket when it is imported via an email collector.

Previously, when this option was set to “Yes,” the document was still associated with the ticket, regardless of whether it was imported via a collector or not.

This correction now ensures that documents marked as blacklisted are no longer added to tickets when imported via a collector.


