### PR TITLE
ui(rule): hide inventory rules menu items when user lacks view rights

### DIFF
--- a/templates/pages/admin/rules/index.html.twig
+++ b/templates/pages/admin/rules/index.html.twig
@@ -48,6 +48,7 @@
                 <span>{{ __('Agent sends an inventory file') }}</span>
             </li>
 
+            {% if call('RuleDefineItemtype::canView') %}
             <li class="step">
                 <a class="btn flex-column" href="{{ 'RuleDefineItemtype'|itemtype_search_path }}">
                     <div class="d-flex align-items-center">
@@ -59,7 +60,9 @@
                     </div>
                 </a>
             </li>
+            {% endif %}
 
+            {% if call('RuleImportEntity::canView') %}
             <li class="step">
                 <a class="btn flex-column" href="{{ 'RuleImportEntity'|itemtype_search_path }}">
                     <div class="d-flex align-items-center">
@@ -71,7 +74,9 @@
                     </div>
                 </a>
             </li>
+            {% endif %}
 
+            {% if call('RuleLocation::canView') %}
             <li class="step">
                 <a class="btn flex-column" href="{{ 'RuleLocation'|itemtype_search_path }}">
                     <div class="d-flex align-items-center">
@@ -83,7 +88,9 @@
                     </div>
                 </a>
             </li>
+            {% endif %}
 
+            {% if call('RuleImportAsset::canView') %}
             <li class="step">
                 <a class="btn flex-column" href="{{ 'RuleImportAsset'|itemtype_search_path }}">
                     <div class="d-flex align-items-center">
@@ -95,7 +102,9 @@
                     </div>
                 </a>
             </li>
+            {% endif %}
 
+            {% if call('RuleDictionnaryDropdownCollection::canView') %}
             <li class="step">
                 <a class="btn flex-column" href="{{ path('/front/dictionnary.php') }}">
                     <div class="d-flex align-items-center">
@@ -107,7 +116,9 @@
                     </div>
                 </a>
             </li>
+            {% endif %}
 
+            {% if call('RuleAsset::canView') %}
             <li class="step">
                 <a class="btn flex-column" href="{{ 'RuleAsset'|itemtype_search_path }}">
                     <div class="d-flex align-items-center">
@@ -119,6 +130,7 @@
                     </div>
                 </a>
             </li>
+            {% endif %}
 
             <li class="end">
                 <i class="ti ti-circle-check me-1 fa-2x"></i>

--- a/templates/pages/admin/rules/index.html.twig
+++ b/templates/pages/admin/rules/index.html.twig
@@ -30,9 +30,9 @@
  # ---------------------------------------------------------------------
  #}
 
-{% macro rule_step(itemtype, title, description, url = null) %}
+{% macro rule_step(itemtype, title, description, can_view, url = null) %}
     <li class="step">
-        {% if call(itemtype ~ '::canView') %}
+        {% if can_view %}
             <a class="btn flex-column" href="{{ url ?? (itemtype|itemtype_search_path) }}">
                 <div class="d-flex align-items-center">
                     <i class="{{ itemtype|itemtype_icon }}"></i>
@@ -43,7 +43,7 @@
                 </div>
             </a>
         {% else %}
-            <div class="btn flex-column disabled">
+            <div class="btn flex-column opacity-70" style="cursor: not-allowed;">
                 <div class="d-flex align-items-center">
                     <i class="{{ itemtype|itemtype_icon }}"></i>
                     <span>{{ title }}</span>
@@ -77,38 +77,44 @@
             {{ _self.rule_step(
                 'RuleDefineItemtype',
                 __('Transform itemtypes'),
-                __("Override the asset to another custom definition (like Servers)")
+                __("Override the asset to another custom definition (like Servers)"),
+                call('RuleDefineItemtype::canView')
             ) }}
 
             {{ _self.rule_step(
                 'RuleImportEntity',
                 __('Rules for assigning an item to an entity'),
-                __("Set an entity with some criteria (by its tag for example)")
+                __("Set an entity with some criteria (by its tag for example)"),
+                call('RuleImportEntity::canView')
             ) }}
 
             {{ _self.rule_step(
                 'RuleLocation',
                 __('Location rules'),
-                __("Apply a location by checking common criteria")
+                __("Apply a location by checking common criteria"),
+                call('RuleLocation::canView')
             ) }}
 
             {{ _self.rule_step(
                 'RuleImportAsset',
                 __("Rules for import and link equipments"),
-                __("Match data with an existing asset, create a new asset, or deny the import")
+                __("Match data with an existing asset, create a new asset, or deny the import"),
+                call('RuleImportAsset::canView')
             ) }}
 
             {{ _self.rule_step(
                 'RuleDictionnaryDropdownCollection',
                 _n('Dictionary', 'Dictionaries', get_plural_number()),
                 __("Normalize sub-data (like softwares, OS and models)"),
+                call('RuleDictionnaryDropdownCollection::canView') or call('RuleDictionnarySoftware::canView') or call('RuleDictionnaryPrinter::canView'),
                 path('/front/dictionnary.php')
             ) }}
 
             {{ _self.rule_step(
                 'RuleAsset',
                 __("Business rules for assets"),
-                __("Alter asset fields based on their data")
+                __("Alter asset fields based on their data"),
+                call('RuleAsset::canView')
             ) }}
 
             <li class="end">

--- a/templates/pages/admin/rules/index.html.twig
+++ b/templates/pages/admin/rules/index.html.twig
@@ -30,6 +30,32 @@
  # ---------------------------------------------------------------------
  #}
 
+{% macro rule_step(itemtype, title, description, url = null) %}
+    <li class="step">
+        {% if call(itemtype ~ '::canView') %}
+            <a class="btn flex-column" href="{{ url ?? (itemtype|itemtype_search_path) }}">
+                <div class="d-flex align-items-center">
+                    <i class="{{ itemtype|itemtype_icon }}"></i>
+                    <span>{{ title }}</span>
+                </div>
+                <div class="text-muted">
+                    {{ description }}
+                </div>
+            </a>
+        {% else %}
+            <div class="btn flex-column disabled">
+                <div class="d-flex align-items-center">
+                    <i class="{{ itemtype|itemtype_icon }}"></i>
+                    <span>{{ title }}</span>
+                </div>
+                <div class="text-muted">
+                    {{ description }}
+                </div>
+            </div>
+        {% endif %}
+    </li>
+{% endmacro %}
+
 {{ include('pages/admin/rules/backup_header.html.twig') }}
 
 <div class="row">
@@ -48,89 +74,42 @@
                 <span>{{ __('Agent sends an inventory file') }}</span>
             </li>
 
-            {% if call('RuleDefineItemtype::canView') %}
-            <li class="step">
-                <a class="btn flex-column" href="{{ 'RuleDefineItemtype'|itemtype_search_path }}">
-                    <div class="d-flex align-items-center">
-                        <i class="{{ 'RuleDefineItemtype'|itemtype_icon }}"></i>
-                        <span>{{ __('Transform itemtypes') }}</span>
-                    </div>
-                    <div class="text-muted">
-                        {{ __("Override the asset to another custom definition (like Servers)") }}
-                    </div>
-                </a>
-            </li>
-            {% endif %}
+            {{ _self.rule_step(
+                'RuleDefineItemtype',
+                __('Transform itemtypes'),
+                __("Override the asset to another custom definition (like Servers)")
+            ) }}
 
-            {% if call('RuleImportEntity::canView') %}
-            <li class="step">
-                <a class="btn flex-column" href="{{ 'RuleImportEntity'|itemtype_search_path }}">
-                    <div class="d-flex align-items-center">
-                        <i class="{{ 'RuleImportEntity'|itemtype_icon }}"></i>
-                        <span>{{ __('Rules for assigning an item to an entity') }}</span>
-                    </div>
-                    <div class="text-muted">
-                        {{ __("Set an entity with some criteria (by its tag for example)") }}
-                    </div>
-                </a>
-            </li>
-            {% endif %}
+            {{ _self.rule_step(
+                'RuleImportEntity',
+                __('Rules for assigning an item to an entity'),
+                __("Set an entity with some criteria (by its tag for example)")
+            ) }}
 
-            {% if call('RuleLocation::canView') %}
-            <li class="step">
-                <a class="btn flex-column" href="{{ 'RuleLocation'|itemtype_search_path }}">
-                    <div class="d-flex align-items-center">
-                        <i class="{{ 'RuleLocation'|itemtype_icon }}"></i>
-                        <span>{{ __('Location rules') }}</span>
-                    </div>
-                    <div class="text-muted">
-                        {{ __("Apply a location by checking common criteria") }}
-                    </div>
-                </a>
-            </li>
-            {% endif %}
+            {{ _self.rule_step(
+                'RuleLocation',
+                __('Location rules'),
+                __("Apply a location by checking common criteria")
+            ) }}
 
-            {% if call('RuleImportAsset::canView') %}
-            <li class="step">
-                <a class="btn flex-column" href="{{ 'RuleImportAsset'|itemtype_search_path }}">
-                    <div class="d-flex align-items-center">
-                        <i class="{{ 'RuleImportAsset'|itemtype_icon }}"></i>
-                        <span>{{ __("Rules for import and link equipments") }}</span>
-                    </div>
-                    <div class="text-muted">
-                        {{ __("Match data with an existing asset, create a new asset, or deny the import") }}
-                    </div>
-                </a>
-            </li>
-            {% endif %}
+            {{ _self.rule_step(
+                'RuleImportAsset',
+                __("Rules for import and link equipments"),
+                __("Match data with an existing asset, create a new asset, or deny the import")
+            ) }}
 
-            {% if call('RuleDictionnaryDropdownCollection::canView') %}
-            <li class="step">
-                <a class="btn flex-column" href="{{ path('/front/dictionnary.php') }}">
-                    <div class="d-flex align-items-center">
-                        <i class="{{ 'RuleDictionnaryDropdownCollection'|itemtype_icon }}"></i>
-                        <span>{{ _n('Dictionary', 'Dictionaries', get_plural_number()) }}</span>
-                    </div>
-                    <div class="text-muted">
-                        {{ __("Normalize sub-data (like softwares, OS and models)") }}
-                    </div>
-                </a>
-            </li>
-            {% endif %}
+            {{ _self.rule_step(
+                'RuleDictionnaryDropdownCollection',
+                _n('Dictionary', 'Dictionaries', get_plural_number()),
+                __("Normalize sub-data (like softwares, OS and models)"),
+                path('/front/dictionnary.php')
+            ) }}
 
-            {% if call('RuleAsset::canView') %}
-            <li class="step">
-                <a class="btn flex-column" href="{{ 'RuleAsset'|itemtype_search_path }}">
-                    <div class="d-flex align-items-center">
-                        <i class="{{ 'RuleAsset'|itemtype_icon }}"></i>
-                        <span>{{ __("Business rules for assets") }}</span>
-                    </div>
-                    <div class="text-muted">
-                        {{ __("Alter asset fields based on their data") }}
-                    </div>
-                </a>
-            </li>
-            {% endif %}
+            {{ _self.rule_step(
+                'RuleAsset',
+                __("Business rules for assets"),
+                __("Alter asset fields based on their data")
+            ) }}
 
             <li class="end">
                 <i class="ti ti-circle-check me-1 fa-2x"></i>

--- a/templates/pages/admin/rules/index.html.twig
+++ b/templates/pages/admin/rules/index.html.twig
@@ -43,7 +43,9 @@
                 </div>
             </a>
         {% else %}
-            <div class="btn flex-column opacity-70" style="cursor: not-allowed;">
+            <div class="btn flex-column opacity-70" style="cursor: not-allowed;"
+                 data-bs-toggle="tooltip" data-bs-placement="top"
+                 title="{{ __('You do not have the required permissions') }}">
                 <div class="d-flex align-items-center">
                     <i class="{{ itemtype|itemtype_icon }}"></i>
                     <span>{{ title }}</span>


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !41547
- Hide inventory rules that the user does not have read access to in the same way as rules in the ‘Other rules’ category. 

## Screenshots (if appropriate):

Rights:
<img width="559" height="973" alt="image" src="https://github.com/user-attachments/assets/3e3edc9f-5c1f-4f6b-8864-cac6ec113354" />


View 
<img width="711" height="815" alt="image" src="https://github.com/user-attachments/assets/acd2ae9c-486d-489a-a9b3-374357f2ae5d" />



