### PR TITLE
Fix (Notepad) - Project notes displayed only with UPDATENOTE rights

### DIFF
--- a/src/Notepad.php
+++ b/src/Notepad.php
@@ -329,10 +329,11 @@ class Notepad extends CommonDBChild
         }
         $notes     = static::getAllForItem($item);
         $rand      = mt_rand();
+        $canread   = Session::haveRight($item::$rightname, READNOTE);
         $canedit   = Session::haveRight($item::$rightname, UPDATENOTE);
 
         if (
-            $canedit
+            $canread
             && !(!empty($withtemplate) && ($withtemplate == 2))
         ) {
             TemplateRenderer::getInstance()->display('components/notepad/form.html.twig', [
@@ -342,7 +343,6 @@ class Notepad extends CommonDBChild
                 'items_id'  => $item->getID(),
                 'notes'     => $notes,
                 'canedit'   => $canedit,
-                'candelete' => $canedit,
             ]);
         }
         return true;

--- a/src/Notepad.php
+++ b/src/Notepad.php
@@ -329,13 +329,9 @@ class Notepad extends CommonDBChild
         }
         $notes     = static::getAllForItem($item);
         $rand      = mt_rand();
-        $canread   = Session::haveRight($item::$rightname, READNOTE);
         $canedit   = Session::haveRight($item::$rightname, UPDATENOTE);
 
-        if (
-            $canread
-            && !(!empty($withtemplate) && ($withtemplate == 2))
-        ) {
+        if (!(!empty($withtemplate) && ($withtemplate == 2))) {
             TemplateRenderer::getInstance()->display('components/notepad/form.html.twig', [
                 'rand'      => $rand,
                 'url'       => Toolbox::getItemTypeFormURL('Notepad'),

--- a/templates/components/notepad/form.html.twig
+++ b/templates/components/notepad/form.html.twig
@@ -38,10 +38,14 @@
 } %}
 
 <div class="d-flex mb-3 justify-content-between align-items-center">
-    <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#new-note-form" aria-label="{{ _x('button', 'Add a note') }}">
-        <i class="ti ti-link"></i>
-        <span>{{ _x('button', 'Add a note') }}</span>
-    </button>
+    {% if canedit %}
+        <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#new-note-form" aria-label="{{ _x('button', 'Add a note') }}">
+            <i class="ti ti-link"></i>
+            <span>{{ _x('button', 'Add a note') }}</span>
+        </button>
+    {% else %}
+        <span></span>
+    {% endif %}
 
     {% if notes|length > 0 %}
         <small class="me-2">
@@ -60,53 +64,55 @@
     {% endif %}
 </div>
 
-<div class="my-3">
-    <div id="new-note-form" class="modal fade">
-        <div class="modal-dialog modal-xl">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h3 class="modal-title">
-                        <i class="ti ti-notes"></i>
-                        {{ __('Add a note') }}
-                    </h3>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                </div>
+{% if canedit %}
+    <div class="my-3">
+        <div id="new-note-form" class="modal fade">
+            <div class="modal-dialog modal-xl">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h3 class="modal-title">
+                            <i class="ti ti-notes"></i>
+                            {{ __('Add a note') }}
+                        </h3>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    </div>
 
-                <form action="{{ url }}" method="post" autocomplete="off" data-submit-once>
-                    <div class="modal-body">
-                        <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}" />
-                        <input type="hidden" name="itemtype" value="{{ itemtype }}" />
-                        <input type="hidden" name="items_id" value="{{ items_id }}" />
-                        {{ fields.textareaField(
-                            'content',
-                            '',
-                            __("Content"),
-                            fields_options|merge({
-                                enable_richtext: true,
-                                enable_fileupload: true,
-                            })
-                        ) }}
-
-                        {% if itemtype == "Entity" %}
-                            {{ fields.sliderField(
-                                'visible_from_ticket',
-                                false,
-                                __('Visible on tickets'),
-                                fields_options
+                    <form action="{{ url }}" method="post" autocomplete="off" data-submit-once>
+                        <div class="modal-body">
+                            <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}" />
+                            <input type="hidden" name="itemtype" value="{{ itemtype }}" />
+                            <input type="hidden" name="items_id" value="{{ items_id }}" />
+                            {{ fields.textareaField(
+                                'content',
+                                '',
+                                __("Content"),
+                                fields_options|merge({
+                                    enable_richtext: true,
+                                    enable_fileupload: true,
+                                })
                             ) }}
-                        {% endif %}
-                    </div>
 
-                    <div class="modal-footer">
-                        <button type="submit" value="Add" name="add" class="btn btn-primary">
-                            <span>{{ __('Add') }}</span>
-                        </button>
-                    </div>
-                </form>
+                            {% if itemtype == "Entity" %}
+                                {{ fields.sliderField(
+                                    'visible_from_ticket',
+                                    false,
+                                    __('Visible on tickets'),
+                                    fields_options
+                                ) }}
+                            {% endif %}
+                        </div>
+
+                        <div class="modal-footer">
+                            <button type="submit" value="Add" name="add" class="btn btn-primary">
+                                <span>{{ __('Add') }}</span>
+                            </button>
+                        </div>
+                    </form>
+                </div>
             </div>
         </div>
     </div>
-</div>
+{% endif %}
 
 <div class="accordion">
     {% for note in notes %}
@@ -148,32 +154,34 @@
                                 }, with_context = false) }}
                             </span>
 
-                            <span>
-                                <button
-                                    class="btn btn-sm btn-ghost-danger delete-note"
-                                    name="purge"
-                                    type="submit"
-                                    value="1"
-                                    onclick="return confirm('{{ __('Confirm the final deletion?')|e('js') }}');"
-                                    data-id="{{ id }}"
-                                    aria-label="{{ __("Delete") }}"
-                                >
-                                    <i class="ti ti-trash"></i>
-                                    <span>{{ __('Delete') }}</span>
-                                </button>
+                            {% if canedit %}
+                                <span>
+                                    <button
+                                        class="btn btn-sm btn-ghost-danger delete-note"
+                                        name="purge"
+                                        type="submit"
+                                        value="1"
+                                        onclick="return confirm('{{ __('Confirm the final deletion?')|e('js') }}');"
+                                        data-id="{{ id }}"
+                                        aria-label="{{ __("Delete") }}"
+                                    >
+                                        <i class="ti ti-trash"></i>
+                                        <span>{{ __('Delete') }}</span>
+                                    </button>
 
-                                <button
-                                    class="btn btn-sm btn-ghost-secondary edit-note"
-                                    type="button"
-                                    data-id="{{ id }}"
-                                    data-bs-toggle="modal"
-                                    data-bs-target="#edit-{{ id }}"
-                                    aria-label="{{ __("Edit") }}"
-                                >
-                                    <i class="ti ti-edit"></i>
-                                    <span>{{ __('Edit') }}</span>
-                                </button>
-                            </span>
+                                    <button
+                                        class="btn btn-sm btn-ghost-secondary edit-note"
+                                        type="button"
+                                        data-id="{{ id }}"
+                                        data-bs-toggle="modal"
+                                        data-bs-target="#edit-{{ id }}"
+                                        aria-label="{{ __("Edit") }}"
+                                    >
+                                        <i class="ti ti-edit"></i>
+                                        <span>{{ __('Edit') }}</span>
+                                    </button>
+                                </span>
+                            {% endif %}
                         </div>
 
                         <div
@@ -258,70 +266,48 @@
 </div>
 
 <script>
-/**
- * Toggle all accordions in a notepad container with Bootstrap transitions
- *
- * @param {Element} element - The element that was clicked (button or link)
- */
-function toggleNotesAccordion(element) {
-    // Find the accordion container - it's the next sibling div after the modal div
-    const buttonsContainer = element.closest('.d-flex.mb-3');
-    const modalContainer = buttonsContainer.nextElementSibling;
-    const accordionContainer = modalContainer.nextElementSibling;
-
-    if (!accordionContainer || !accordionContainer.classList.contains('accordion')) {
-        console.warn('Accordion container not found');
-        return;
-    }
-
-    const accordionElements = accordionContainer.querySelectorAll('.accordion-collapse');
-    const elementText = element.querySelector('span');
-    const elementIcon = element.querySelector('i');
-    const isExpanding = elementText.textContent.includes(element.dataset.expandText);
-
-    // Use Bootstrap's native collapse methods for smooth transitions
-    accordionElements.forEach(function(accordion) {
-        try {
-            const bsCollapse = new bootstrap.Collapse(accordion, { toggle: false });
-
-            if (isExpanding) {
-                bsCollapse.show();
+$(function() {
+    /**
+     * Toggle all accordions in a notepad container with Bootstrap transitions
+     */
+    $('.toggle-all-notes').on('click', function(e) {
+        e.preventDefault();
+        
+        var $toggle = $(this);
+        var $accordion = $toggle.closest('.tab-pane').find('.accordion');
+        
+        if (!$accordion.length) {
+            console.warn('Accordion container not found');
+            return;
+        }
+        
+        var $text = $toggle.find('span');
+        var $icon = $toggle.find('i');
+        var expand_text = $toggle.data('expand-text');
+        var collapse_text = $toggle.data('collapse-text');
+        var expand_title = $toggle.data('expand-title');
+        var collapse_title = $toggle.data('collapse-title');
+        var is_expanding = $text.text().includes(expand_text);
+        
+        $accordion.find('.accordion-collapse').each(function() {
+            var collapse = bootstrap.Collapse.getOrCreateInstance(this, { toggle: false });
+            
+            if (is_expanding) {
+                collapse.show();
             } else {
-                bsCollapse.hide();
+                collapse.hide();
             }
-        } catch (error) {
-            console.error('Error with bootstrap.Collapse:', error);
+        });
+        
+        if (is_expanding) {
+            $text.text(collapse_text);
+            $toggle.attr('title', collapse_title);
+            $icon.attr('class', 'ti ti-eye');
+        } else {
+            $text.text(expand_text);
+            $toggle.attr('title', expand_title);
+            $icon.attr('class', 'ti ti-eye-off');
         }
     });
-
-    // Update element text and icon (if present)
-    if (isExpanding) {
-        elementText.textContent = element.dataset.collapseText;
-        element.title = element.dataset.collapseTitle;
-        if (elementIcon) {
-            elementIcon.className = 'ti ti-eye';
-        }
-    } else {
-        elementText.textContent = element.dataset.expandText;
-        element.title = element.dataset.expandTitle;
-        if (elementIcon) {
-            elementIcon.className = 'ti ti-eye-off';
-        }
-    }
-}
-
-// Event listener for toggle all notes button/link
-function setupToggleButton() {
-    const toggleButton = document.querySelector('.toggle-all-notes');
-
-    if (toggleButton && !toggleButton.hasAttribute('data-listener-added')) {
-        toggleButton.setAttribute('data-listener-added', 'true');
-        toggleButton.addEventListener('click', function(e) {
-            e.preventDefault();
-            toggleNotesAccordion(this);
-        });
-    }
-}
-
-setupToggleButton();
+});
 </script>

--- a/templates/components/notepad/form.html.twig
+++ b/templates/components/notepad/form.html.twig
@@ -265,8 +265,7 @@
     {% endfor %}
 </div>
 
-<script>
-$(function() {
+<script type="module">
     /**
      * Toggle all accordions in a notepad container with Bootstrap transitions
      */
@@ -309,5 +308,4 @@ $(function() {
             $icon.attr('class', 'ti ti-eye-off');
         }
     });
-});
 </script>

--- a/templates/components/notepad/form.html.twig
+++ b/templates/components/notepad/form.html.twig
@@ -272,15 +272,15 @@ $(function() {
      */
     $('.toggle-all-notes').on('click', function(e) {
         e.preventDefault();
-        
+
         var $toggle = $(this);
         var $accordion = $toggle.closest('.tab-pane').find('.accordion');
-        
+
         if (!$accordion.length) {
             console.warn('Accordion container not found');
             return;
         }
-        
+
         var $text = $toggle.find('span');
         var $icon = $toggle.find('i');
         var expand_text = $toggle.data('expand-text');
@@ -288,17 +288,17 @@ $(function() {
         var expand_title = $toggle.data('expand-title');
         var collapse_title = $toggle.data('collapse-title');
         var is_expanding = $text.text().includes(expand_text);
-        
+
         $accordion.find('.accordion-collapse').each(function() {
             var collapse = bootstrap.Collapse.getOrCreateInstance(this, { toggle: false });
-            
+
             if (is_expanding) {
                 collapse.show();
             } else {
                 collapse.hide();
             }
         });
-        
+
         if (is_expanding) {
             $text.text(collapse_text);
             $toggle.attr('title', collapse_title);

--- a/tests/functional/ProjectTest.php
+++ b/tests/functional/ProjectTest.php
@@ -38,7 +38,6 @@ use Glpi\Application\View\TemplateRenderer;
 use Glpi\Team\Team;
 use Glpi\Tests\DbTestCase;
 use Notepad;
-use Profile;
 use ProjectState;
 use ProjectTask;
 use ProjectTeam;
@@ -748,7 +747,7 @@ PLAINTEXT;
 
         $this->assertTrue($project->getFromDB($project->getID()));
         $this->assertTrue($project->canViewItem());
-        
+
         $notepad_test = new Notepad();
         $notepad_test->fields['itemtype'] = 'Project';
         $notepad_test->fields['items_id'] = $project->getID();
@@ -761,7 +760,7 @@ PLAINTEXT;
 
         $html = TemplateRenderer::getInstance()->render('components/notepad/form.html.twig', [
             'rand' => 12345,
-            'url' => \Notepad::getFormURL(),
+            'url' => Notepad::getFormURL(),
             'itemtype' => 'Project',
             'items_id' => $project->getID(),
             'notes' => $notes,
@@ -817,7 +816,7 @@ PLAINTEXT;
 
         $html = TemplateRenderer::getInstance()->render('components/notepad/form.html.twig', [
             'rand' => 12345,
-            'url' => \Notepad::getFormURL(),
+            'url' => Notepad::getFormURL(),
             'itemtype' => 'Project',
             'items_id' => $project->getID(),
             'notes' => $notes,
@@ -832,4 +831,3 @@ PLAINTEXT;
         $this->assertStringContainsString('class="btn btn-sm btn-ghost-secondary edit-note"', $html);
     }
 }
-


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !41491
- Here is a brief description of what this PR does

Fixes an issue where users with `READNOTE` permission (without `UPDATENOTE`) would see a blank page when accessing the Notes tab on projects.

### Changes
- **Notepad.php**: Fixed rights check to use `READNOTE` for viewing notes instead of UPDATE permissions
- **form.html.twig**: Refactored JavaScript accordion toggle to properly handle DOM structure when create modal is not rendered
- **ProjectTest.php**: Added tests to verify notepad display with different permission levels (read-only vs update rights)

### Root Cause
The notepad template assumed the presence of a creation modal in the DOM structure, causing JavaScript to fail when users lacked `UPDATENOTE` permission.

## Screenshots (if appropriate):

Before : 
<img width="1185" height="613" alt="image" src="https://github.com/user-attachments/assets/05688023-a634-4266-ae95-31f6e09ca86e" />


After without UPDATENOTE : 
<img width="939" height="619" alt="image" src="https://github.com/user-attachments/assets/39896755-74d2-442a-aaa2-67bdb8a01b2f" />


After with UPDATENOTE : 
<img width="939" height="619" alt="image" src="https://github.com/user-attachments/assets/0c452305-f0de-47f6-97b1-292c0218899f" />
