### PR TITLE
Fixed Cyrillic encoded attachments issue

### DIFF
--- a/src/MailCollector.php
+++ b/src/MailCollector.php
@@ -2433,9 +2433,17 @@ class MailCollector extends CommonDBTM
 
         $charset = $content_type->getParameter('charset');
 
-        // If charset is not specified, and not UTF-8, force fallback default encoding
+        // If charset is not specified, and not in $encodingsToCheck array, force fallback default encoding
         if ($charset === null) {
-            $charset = mb_check_encoding($contents, 'UTF-8') ? 'UTF-8' : 'ISO-8859-1';
+            $encodingsToCheck = ['UTF-8', 'Windows-1251'];
+            $charset = 'ISO-8859-1'; // set fallback encoding
+
+            foreach ($encodingsToCheck as $encoding) {
+                if (mb_check_encoding($contents, $encoding)) {
+                    $charset = $encoding;
+                    break;
+                }
+            }
         }
 
         if (strtoupper($charset) != 'UTF-8') {

--- a/src/MailCollector.php
+++ b/src/MailCollector.php
@@ -2435,7 +2435,7 @@ class MailCollector extends CommonDBTM
 
         // If charset is not specified, and not in $encodingsToCheck array, force fallback default encoding
         if ($charset === null) {
-            $encodingsToCheck = ['UTF-8', 'Windows-1251'];
+            $encodingsToCheck = ['UTF-8', 'ISO-8859-1', 'Windows-1251'];
             $charset = 'ISO-8859-1'; // set fallback encoding
 
             foreach ($encodingsToCheck as $encoding) {

--- a/tests/emails-tests/52-missing-charset-cyrillic.eml
+++ b/tests/emails-tests/52-missing-charset-cyrillic.eml
@@ -1,0 +1,13 @@
+From normal@glpi-project.org Mon Oct 21 10:00:00 2025
+From: normal@glpi-project.org
+To: unittests@glpi-project.org
+Subject: 47 - Missing charset parameter
+MIME-Version: 1.0
+Content-Type: text/plain
+Content-Transfer-Encoding: quoted-printable
+Date: Mon, 21 Oct 2025 10:00:00 +0000
+Message-ID: <missing-charset-test@example.org>
+
+ВНИМАНИЕ: Не переходите по ссылкам и не открывайте вложения pi=E8, если вы не просматриваете контент.
+
+

--- a/tests/imap/MailCollectorTest.php
+++ b/tests/imap/MailCollectorTest.php
@@ -889,6 +889,7 @@ class MailCollectorTest extends DbTestCase
                     '44 - Hebrew encoding issue',
                     '47 - Missing charset parameter',
                     '49 - Message with invalid CC email address',
+                    '52 - Missing charset parameter cyrillic',
                 ],
             ],
             // Mails having "normal" user as observer
@@ -916,6 +917,8 @@ Best regards,
 PLAINTEXT,
             // Email without charset parameter (47-missing-charset.eml) - tests ISO-8859-1 to UTF-8 fallback
             '47 - Missing charset parameter' => 'ATTENTION: Ne cliquez pas sur les liens ou n\'ouvrez pas les pièces jointes si vous n\'êtes pas sûr du contenu.',
+            // Email without charset parameter (cyrillic) (52-missing-charset-cyrillic.eml) - tests that cyrillic is decoded right
+            '52 - Missing charset parameter cyrillic' => 'ВНИМАНИЕ: Не переходите по ссылкам и не открывайте вложения pi=E8, если вы не просматриваете контент.',
             // HTML on multi-part email
             'Re: [GLPI #0038927] Update - Issues with new Windows 10 machine' => <<<HTML
 <p>This message have reply to header, requester should be get from this header.</p>


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

- It fixes #22997 
- Here is a brief description of what this PR does:
Changed MailCollector.php getDecodedContent method so that it checks for Windows-1251 encoding. It's easy to add new encodings to check if needed. Just add your encoding in $encodingsToCheck array



