### PR TITLE
Fix (MailCollector) - Preserve image dimensions from collected emails in notifications

### DIFF
--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -50,6 +50,7 @@ use Safe\DateTime;
 
 use function Safe\preg_match;
 use function Safe\preg_match_all;
+use function Safe\preg_replace_callback;
 use function Safe\strtotime;
 
 /**

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -5371,7 +5371,28 @@ JAVASCRIPT;
                 // Set tag if image matches
                 foreach ($files as $data => $filename) {
                     if (preg_match("/" . preg_quote($data, '/') . "/i", $src_attr)) {
-                        $html = preg_replace("/<img[^>]*" . preg_quote($src_attr, '/') . "[^>]*>/s", "<p>" . htmlescape(Document::getImageTag($tags[$filename])) . "</p>", $html);
+                        $html = preg_replace_callback(
+                            "/<img[^>]*" . preg_quote($src_attr, '/') . "[^>]*>/s",
+                            function ($img_matches) use ($tags, $filename) {
+                                $img_tag = $img_matches[0];
+
+                                // Extract width attribute if present
+                                $width_attr = '';
+                                if (preg_match('/\bwidth\s*=\s*["\']?(\d+)["\']?/i', $img_tag, $w_matches)) {
+                                    $width_attr = ' width="' . (int) $w_matches[1] . '"';
+                                }
+
+                                // Extract height attribute if present
+                                $height_attr = '';
+                                if (preg_match('/\bheight\s*=\s*["\']?(\d+)["\']?/i', $img_tag, $h_matches)) {
+                                    $height_attr = ' height="' . (int) $h_matches[1] . '"';
+                                }
+
+                                // Return an img tag with the tag as id, preserving width/height
+                                return '<img id="' . htmlescape($tags[$filename]) . '"' . $width_attr . $height_attr . '>';
+                            },
+                            $html
+                        );
                     }
                 }
             }

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -50,7 +50,6 @@ use Safe\DateTime;
 
 use function Safe\preg_match;
 use function Safe\preg_match_all;
-use function Safe\preg_replace;
 use function Safe\strtotime;
 
 /**

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -2523,7 +2523,7 @@ class Toolbox
             $img_matches,
             PREG_PATTERN_ORDER
         );
-        if (isset($img_matches[1]) && count($img_matches[1]) > 0) {
+        if (count($img_matches[1]) > 0) {
             $all_tags = array_merge($all_tags, $img_matches[1]);
         }
 

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -2505,18 +2505,34 @@ class Toolbox
      */
     public static function getDocumentsFromTag(string $content_text): array
     {
+        $all_tags = [];
+
         preg_match_all(
             '/' . Document::getImageTag('(([a-z0-9]+|[\.\-]?)+)') . '/',
             $content_text,
             $matches,
             PREG_PATTERN_ORDER
         );
-        if (!isset($matches[1]) || count($matches[1]) == 0) {
+        if (isset($matches[1]) && count($matches[1]) > 0) {
+            $all_tags = array_merge($all_tags, $matches[1]);
+        }
+
+        preg_match_all(
+            '/<img[^>]+id=["\']([a-z0-9\.\-]+)["\'][^>]*>/i',
+            $content_text,
+            $img_matches,
+            PREG_PATTERN_ORDER
+        );
+        if (isset($img_matches[1]) && count($img_matches[1]) > 0) {
+            $all_tags = array_merge($all_tags, $img_matches[1]);
+        }
+
+        if (count($all_tags) === 0) {
             return [];
         }
 
         $document = new Document();
-        return $document->find(['tag' => array_unique($matches[1])]);
+        return $document->find(['tag' => array_unique($all_tags)]);
     }
 
     /**

--- a/tests/functional/TicketTest.php
+++ b/tests/functional/TicketTest.php
@@ -5021,11 +5021,11 @@ HTML,
                 ],
                 'expected' => <<<HTML
 Here is the screenshot:
-<p>#9faff0a6-f37490bd-60e2af9721f420.96500246#</p>
+<img id="9faff0a6-f37490bd-60e2af9721f420.96500246">
 blabla
 HTML,
             ];
-            // `img` of embedded image that has multiple attributes.
+            // `img` of embedded image that has multiple attributes including width/height.
             yield [
                 'content'  => <<<HTML
 Here is the screenshot:
@@ -5040,7 +5040,7 @@ HTML,
                 ],
                 'expected' => <<<HTML
 Here is the screenshot:
-<p>#9faff0a6-f37490bd-60e2af9721f420.96500246#</p>
+<img id="9faff0a6-f37490bd-60e2af9721f420.96500246" width="100" height="150">
 blabla
 HTML,
             ];
@@ -5062,7 +5062,7 @@ HTML,
                 'expected' => <<<HTML
 <img src={$quote_style}http://test.glpi-project.org/logo.png{$quote_style} />
 Here is the screenshot:
-<p>#3eaff0a6-f37490bd-60e2a59721f420.96500246#</p>
+<img id="3eaff0a6-f37490bd-60e2a59721f420.96500246">
 blabla
 HTML,
             ];


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !41570
- Here is a brief description of what this PR does

Fixes an issue where images from email signatures collected via MailCollector appear oversized in ticket notifications.

### Problem
When emails containing images with specific width/height attributes (e.g., email signatures) are collected by MailCollector and then notifications are sent, the images appear with their actual file dimensions instead of the intended display dimensions.

### Root Cause
The `Ticket::convertContentForTicket()` function was replacing `<img>` tags with simple text tags `#uuid#`, losing the original `width` and `height` attributes. When these tags were later converted back to images by `Toolbox::convertTagToImage()`, the code would use the actual file dimensions (e.g., 2200x961) instead of the intended display size (e.g., 173x158).

### Solution
- Modified `Ticket::convertContentForTicket()` to preserve width/height attributes by generating `<img id="uuid" width="X" height="Y">` instead of `<p>#uuid#</p>`
- Updated `Toolbox::getDocumentsFromTag()` to recognize both the legacy `#uuid#` format and the new `<img id="uuid">` format
- Updated corresponding tests to reflect the new behavior

## Screenshots (if appropriate):

Mail collected with a 2k image that has been resized to approximately -70% : 
<img width="696" height="587" alt="image" src="https://github.com/user-attachments/assets/f0fbfcb8-795a-428b-816c-e11e284c6ab5" />


Result of a ticket created from the collection without the patch: 
<img width="899" height="720" alt="image" src="https://github.com/user-attachments/assets/a684f128-4252-4358-b9f3-49743c813b0a" />

Result of a ticket created from the collection with the patch : 
<img width="894" height="499" alt="image" src="https://github.com/user-attachments/assets/eee4993a-133a-42de-93b8-b43ce6a1881c" />
