### PR TITLE
Add default permissions for all workflows

### DIFF
--- a/.github/workflows/audit_dependencies.yml
+++ b/.github/workflows/audit_dependencies.yml
@@ -1,5 +1,8 @@
 name: "Audit dependencies"
 
+permissions:
+  contents: read
+
 on:
   # Runs audit every monday
   schedule:

--- a/.github/workflows/audit_dependencies.yml
+++ b/.github/workflows/audit_dependencies.yml
@@ -1,7 +1,7 @@
 name: "Audit dependencies"
 
 permissions:
-  contents: read
+  contents: "read"
 
 on:
   # Runs audit every monday

--- a/.github/workflows/branch_build.yml
+++ b/.github/workflows/branch_build.yml
@@ -1,7 +1,7 @@
 name: "GLPI branch build"
 
 permissions:
-  contents: read
+  contents: "read"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/branch_build.yml
+++ b/.github/workflows/branch_build.yml
@@ -1,5 +1,8 @@
 name: "GLPI branch build"
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:
@@ -10,8 +13,6 @@ on:
 
 jobs:
   build:
-    permissions:
-      contents: "read"
     name: "Build GLPI"
     runs-on: "ubuntu-latest"
     services:

--- a/.github/workflows/bump_version_after_release.yml
+++ b/.github/workflows/bump_version_after_release.yml
@@ -1,5 +1,8 @@
 name: "Bump version after release"
 
+permissions:
+  contents: read
+
 on:
   release:
     types:

--- a/.github/workflows/bump_version_after_release.yml
+++ b/.github/workflows/bump_version_after_release.yml
@@ -1,7 +1,7 @@
 name: "Bump version after release"
 
 permissions:
-  contents: read
+  contents: "read"
 
 on:
   release:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: "GLPI CI"
 
 permissions:
-  contents: read
+  contents: "read"
 
 on:
   # Runs test suite when a new commit is pushed on "main" and "*/bugfixes" branches

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: "GLPI CI"
 
+permissions:
+  contents: read
+
 on:
   # Runs test suite when a new commit is pushed on "main" and "*/bugfixes" branches
   # and when a new tag is created
@@ -28,8 +31,6 @@ jobs:
   lint:
     # Do not run scheduled lint on tier repositories
     if: github.repository == 'glpi-project/glpi' || github.event_name != 'schedule'
-    permissions:
-      contents: "read"
     name: "Lint on PHP ${{ matrix.php-version }}"
     runs-on: "ubuntu-latest"
     strategy:
@@ -106,8 +107,6 @@ jobs:
   generate-tests-matrix:
     # Do not run scheduled tests on tier repositories
     if: github.repository == 'glpi-project/glpi' || github.event_name != 'schedule'
-    permissions:
-      contents: "read"
     name: "Generate tests matrix"
     runs-on: "ubuntu-latest"
     outputs:
@@ -141,8 +140,6 @@ jobs:
   tests:
     # Do not run scheduled tests on tier repositories
     if: github.repository == 'glpi-project/glpi' || github.event_name != 'schedule'
-    permissions:
-      contents: "read"
     name: "Test on PHP ${{ matrix.php-version }} using ${{ matrix.db-image }}"
     needs: "generate-tests-matrix"
     runs-on: "ubuntu-latest"

--- a/.github/workflows/close_stale_issues.yml
+++ b/.github/workflows/close_stale_issues.yml
@@ -1,7 +1,7 @@
 name: 'Close stale issues'
 
 permissions:
-  contents: read
+  contents: "read"
 
 on:
   schedule:

--- a/.github/workflows/close_stale_issues.yml
+++ b/.github/workflows/close_stale_issues.yml
@@ -1,4 +1,8 @@
 name: 'Close stale issues'
+
+permissions:
+  contents: read
+
 on:
   schedule:
     - cron: '0 8 * * *'

--- a/.github/workflows/coverage-schedule.yml
+++ b/.github/workflows/coverage-schedule.yml
@@ -1,7 +1,7 @@
 name: "Code coverage schedule"
 
 permissions:
-  contents: read
+  contents: "read"
 
 on:
   schedule:
@@ -9,8 +9,6 @@ on:
 
 jobs:
   run-coverage-workflow:
-    permissions:
-      contents: "read"
     name: "Run coverage workflow"
     uses: "glpi-project/glpi/.github/workflows/coverage.yml@main"
     with:

--- a/.github/workflows/coverage-schedule.yml
+++ b/.github/workflows/coverage-schedule.yml
@@ -1,5 +1,8 @@
 name: "Code coverage schedule"
 
+permissions:
+  contents: read
+
 on:
   schedule:
     - cron:  '0 0 * * *'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,7 +1,7 @@
 name: "GLPI test code coverage"
 
 permissions:
-  contents: read
+  contents: "read"
 
 on:
   # Enable execution from the "Code coverage schedule" workflow

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,5 +1,8 @@
 name: "GLPI test code coverage"
 
+permissions:
+  contents: read
+
 on:
   # Enable execution from the "Code coverage schedule" workflow
   workflow_call:
@@ -17,8 +20,6 @@ on:
 
 jobs:
   coverage:
-    permissions:
-      contents: "read"
     name: "Code coverage"
     runs-on: "ubuntu-latest"
     strategy:

--- a/.github/workflows/docker_releases.yml
+++ b/.github/workflows/docker_releases.yml
@@ -1,7 +1,7 @@
 name: "Trigger Docker releases"
 
 permissions:
-  contents: read
+  contents: "read"
 
 on:
   release:

--- a/.github/workflows/docker_releases.yml
+++ b/.github/workflows/docker_releases.yml
@@ -1,5 +1,8 @@
 name: "Trigger Docker releases"
 
+permissions:
+  contents: read
+
 on:
   release:
     types:
@@ -25,8 +28,6 @@ jobs:
 
   trigger-docker-releases:
     needs: [prepare]
-    permissions:
-      contents: "read"
     name: "Trigger Docker releases"
     uses: "glpi-project/docker-images/.github/workflows/glpi.yml@main"
     # Workflows that call reusable workflows in the same organization or enterprise

--- a/.github/workflows/label-commenter.yml
+++ b/.github/workflows/label-commenter.yml
@@ -1,5 +1,8 @@
 name: "Label commenter"
 
+permissions:
+  contents: read
+
 on:
   issues:
     types:

--- a/.github/workflows/label-commenter.yml
+++ b/.github/workflows/label-commenter.yml
@@ -1,7 +1,7 @@
 name: "Label commenter"
 
 permissions:
-  contents: read
+  contents: "read"
 
 on:
   issues:

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -1,7 +1,7 @@
 name: "GLPI nightly build"
 
 permissions:
-  contents: read
+  contents: "read"
 
 on:
   # Runs test suite every night

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -1,5 +1,8 @@
 name: "GLPI nightly build"
 
+permissions:
+  contents: read
+
 on:
   # Runs test suite every night
   schedule:


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

In #22660, a "prepare" job was added to the `Trigger Docker releases` workflow but its permissions has not been defined. Rather than defining default `content: read` permission at job level, I propose to move this at workflow leveln and just declare specific permissions at job level. I hop it will prevent to forgot specifying permissions in the future.