### PR TITLE
Disable paratests

### DIFF
--- a/.github/actions/test_tests-functional.sh
+++ b/.github/actions/test_tests-functional.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e -u -x -o pipefail
 
-vendor/bin/phpunit --group "single-thread" $@
+vendor/bin/phpunit $@

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,31 +206,31 @@ jobs:
         run: |
           .github/actions/init_initialize-9.5-db.sh
           docker compose exec -T app .github/actions/test_update-from-9.5.sh
-      - name: "Functional tests (phpunit)"
+      - name: "Functional tests"
         if: "${{ success() || failure() }}"
         run: |
           docker compose exec -T app .github/actions/test_tests-functional.sh
-      - name: "Clone databases"
-        if: "${{ success() || failure() }}"
-        run: |
-          docker compose exec -T db bash -c '
-            if command -v mariadb &> /dev/null; then
-              DB_CLIENT="mariadb"
-              DB_DUMP="mariadb-dump"
-            else
-              DB_CLIENT="mysql"
-              DB_DUMP="mysqldump"
-            fi
-            for i in 2 3 4; do
-              $DB_CLIENT -u root -e "CREATE DATABASE glpi_$i CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
-              $DB_DUMP -u root --single-transaction glpi | $DB_CLIENT -u root glpi_$i
-              echo "Database glpi_$i created and populated"
-            done
-          '
-      - name: "Functional tests (paratest)"
-        if: "${{ success() || failure() }}"
-        run: |
-          docker compose exec -T app .github/actions/test_tests-functional_parallel.sh
+      # - name: "Clone databases"
+      #   if: "${{ success() || failure() }}"
+      #   run: |
+      #     docker compose exec -T db bash -c '
+      #       if command -v mariadb &> /dev/null; then
+      #         DB_CLIENT="mariadb"
+      #         DB_DUMP="mariadb-dump"
+      #       else
+      #         DB_CLIENT="mysql"
+      #         DB_DUMP="mysqldump"
+      #       fi
+      #       for i in 2 3 4; do
+      #         $DB_CLIENT -u root -e "CREATE DATABASE glpi_$i CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
+      #         $DB_DUMP -u root --single-transaction glpi | $DB_CLIENT -u root glpi_$i
+      #         echo "Database glpi_$i created and populated"
+      #       done
+      #     '
+      # - name: "Functional tests (paratest)"
+      #   if: "${{ success() || failure() }}"
+      #   run: |
+      #     docker compose exec -T app .github/actions/test_tests-functional_parallel.sh
       - name: "Cache tests"
         if: "${{ success() || failure() }}"
         run: |


### PR DESCRIPTION
Temporarily disable paratest so I can look into the issues without impacting others PRs.

If the issues can be fixed without too much work, I'll re-enable it in another PR.
If it can't be fixed properly, I'll open a PR to clean up the related code and delete it for good.
