### PR TITLE
Fix(AuthLDAP): fix Insufficient access (50) with crt and key file

### DIFF
--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -2902,6 +2902,35 @@ TWIG, $twig_params);
         }
 
         $ldapuri = self::buildUri($host, (int) $port);
+
+        if (!empty($tls_certfile)) {
+            if (!Filesystem::isFilepathSafe($tls_certfile)) {
+                trigger_error("TLS certificate path is not safe.", E_USER_WARNING);
+            } elseif (!file_exists($tls_certfile)) {
+                trigger_error("TLS certificate path is not valid.", E_USER_WARNING);
+            } else {
+                try {
+                    @ldap_set_option(null, LDAP_OPT_X_TLS_CERTFILE, $tls_certfile);
+                } catch (LdapException $e) {
+                    trigger_error("Unable to set LDAP option `LDAP_OPT_X_TLS_CERTFILE`", E_USER_WARNING);
+                }
+            }
+        }
+
+        if (!empty($tls_keyfile)) {
+            if (!Filesystem::isFilepathSafe($tls_keyfile)) {
+                trigger_error("TLS key file path is not safe.", E_USER_WARNING);
+            } elseif (!file_exists($tls_keyfile)) {
+                trigger_error("TLS key file path is not valid.", E_USER_WARNING);
+            } else {
+                try {
+                    @ldap_set_option(null, LDAP_OPT_X_TLS_KEYFILE, $tls_keyfile);
+                } catch (LdapException $e) {
+                    trigger_error("Unable to set LDAP option `LDAP_OPT_X_TLS_KEYFILE`", E_USER_WARNING);
+                }
+            }
+        }
+
         $ds = @ldap_connect($ldapuri);
 
         if ($ds === false) {
@@ -2946,32 +2975,6 @@ TWIG, $twig_params);
             }
         }
 
-        if (!empty($tls_certfile)) {
-            if (!Filesystem::isFilepathSafe($tls_certfile)) {
-                trigger_error("TLS certificate path is not safe.", E_USER_WARNING);
-            } elseif (!file_exists($tls_certfile)) {
-                trigger_error("TLS certificate path is not valid.", E_USER_WARNING);
-            } else {
-                try {
-                    @ldap_set_option(null, LDAP_OPT_X_TLS_CERTFILE, $tls_certfile);
-                } catch (LdapException $e) {
-                    trigger_error("Unable to set LDAP option `LDAP_OPT_X_TLS_CERTFILE`", E_USER_WARNING);
-                }
-            }
-        }
-        if (!empty($tls_keyfile)) {
-            if (!Filesystem::isFilepathSafe($tls_keyfile)) {
-                trigger_error("TLS key file path is not safe.", E_USER_WARNING);
-            } elseif (!file_exists($tls_keyfile)) {
-                trigger_error("TLS key file path is not valid.", E_USER_WARNING);
-            } else {
-                try {
-                    @ldap_set_option(null, LDAP_OPT_X_TLS_KEYFILE, $tls_keyfile);
-                } catch (LdapException $e) {
-                    trigger_error("Unable to set LDAP option `LDAP_OPT_X_TLS_KEYFILE`", E_USER_WARNING);
-                }
-            }
-        }
         if (!empty($tls_version)) {
             $cipher_suite = 'NORMAL';
             foreach (self::TLS_VERSIONS as $tls_version_value) {

--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -2931,6 +2931,18 @@ TWIG, $twig_params);
             }
         }
 
+        if (!empty($tls_version)) {
+            $cipher_suite = 'NORMAL';
+            foreach (self::TLS_VERSIONS as $tls_version_value) {
+                $cipher_suite .= ($tls_version_value == $tls_version ? ':+' : ':!') . 'VERS-TLS' . $tls_version_value;
+            }
+            try {
+                @ldap_set_option(null, LDAP_OPT_X_TLS_CIPHER_SUITE, $cipher_suite);
+            } catch (LdapException $e) {
+                trigger_error("Unable to set LDAP option `LDAP_OPT_X_TLS_CIPHER_SUITE`", E_USER_WARNING);
+            }
+        }
+
         $ds = @ldap_connect($ldapuri);
 
         if ($ds === false) {
@@ -2975,17 +2987,7 @@ TWIG, $twig_params);
             }
         }
 
-        if (!empty($tls_version)) {
-            $cipher_suite = 'NORMAL';
-            foreach (self::TLS_VERSIONS as $tls_version_value) {
-                $cipher_suite .= ($tls_version_value == $tls_version ? ':+' : ':!') . 'VERS-TLS' . $tls_version_value;
-            }
-            try {
-                @ldap_set_option(null, LDAP_OPT_X_TLS_CIPHER_SUITE, $cipher_suite);
-            } catch (LdapException $e) {
-                trigger_error("Unable to set LDAP option `LDAP_OPT_X_TLS_CIPHER_SUITE`", E_USER_WARNING);
-            }
-        }
+
 
         // Only use STARTTLS if TLS is requested and the connection is not already using LDAPS
         // LDAPS (ldaps://) is already encrypted, so ldap_start_tls() should not be called


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !41555


## Fix intermittent "Insufficient Access (50)" by initializing LDAP TLS options before connection

### Description

This PR fixes a recurring issue where `ldap_search` returns an **LDAP_INSUFFICIENT_ACCESS (50)** error when using LDAPS (especially with Google Secure LDAP), even if the bind was successful.

The issue is particularly prevalent in multi-instance environments or high-concurrency web servers where the OpenLDAP library context is shared across multiple requests.

### Technical Analysis

In the current implementation, `ldap_connect()` is called before setting global TLS options (using `ldap_set_option` with a `null` handle).

According to OpenLDAP library behavior, TLS context initialization often "crystallizes" upon the first socket initialization. If the connection is initialized before the certificates (`LDAP_OPT_X_TLS_CERTFILE` and `LDAP_OPT_X_TLS_KEYFILE`) are globally defined, the library might attempt a handshake without the proper mTLS identity. This leads to intermittent failures where the library uses a stale or uninitialized global state for subsequent searches.

### Changes

* Moved the `ldap_set_option(null, ...)` calls for `LDAP_OPT_X_TLS_CERTFILE` and `LDAP_OPT_X_TLS_KEYFILE` before the `@ldap_connect($ldapuri)` call in `AuthLDAP::connectToServer`.
* This ensures that the OpenLDAP library is aware of the required client certificates at the very moment the connection object is created.


## Screenshots (if appropriate):


