### PR TITLE
Fix(AuthLDAP): fix Insufficient access (50) with crt and key file

### DIFF
--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -3108,6 +3108,26 @@ class AuthLDAP extends CommonDBTM
         bool $silent_bind_errors = false
     ) {
         $ldapuri = self::buildUri($host, (int) $port);
+
+        if (!empty($tls_certfile)) {
+            if (!Filesystem::isFilepathSafe($tls_certfile)) {
+                trigger_error("TLS certificate path is not safe.", E_USER_WARNING);
+            } elseif (!file_exists($tls_certfile)) {
+                trigger_error("TLS certificate path is not valid.", E_USER_WARNING);
+            } elseif (!@ldap_set_option(null, LDAP_OPT_X_TLS_CERTFILE, $tls_certfile)) {
+                trigger_error("Unable to set LDAP option `LDAP_OPT_X_TLS_CERTFILE`", E_USER_WARNING);
+            }
+        }
+        if (!empty($tls_keyfile)) {
+            if (!Filesystem::isFilepathSafe($tls_keyfile)) {
+                trigger_error("TLS key file path is not safe.", E_USER_WARNING);
+            } elseif (!file_exists($tls_keyfile)) {
+                trigger_error("TLS key file path is not valid.", E_USER_WARNING);
+            } elseif (!@ldap_set_option(null, LDAP_OPT_X_TLS_KEYFILE, $tls_keyfile)) {
+                trigger_error("Unable to set LDAP option `LDAP_OPT_X_TLS_KEYFILE`", E_USER_WARNING);
+            }
+        }
+
         $ds = @ldap_connect($ldapuri);
 
         if ($ds === false) {
@@ -3147,25 +3167,6 @@ class AuthLDAP extends CommonDBTM
                     ),
                     E_USER_WARNING
                 );
-            }
-        }
-
-        if (!empty($tls_certfile)) {
-            if (!Filesystem::isFilepathSafe($tls_certfile)) {
-                trigger_error("TLS certificate path is not safe.", E_USER_WARNING);
-            } elseif (!file_exists($tls_certfile)) {
-                trigger_error("TLS certificate path is not valid.", E_USER_WARNING);
-            } elseif (!@ldap_set_option(null, LDAP_OPT_X_TLS_CERTFILE, $tls_certfile)) {
-                trigger_error("Unable to set LDAP option `LDAP_OPT_X_TLS_CERTFILE`", E_USER_WARNING);
-            }
-        }
-        if (!empty($tls_keyfile)) {
-            if (!Filesystem::isFilepathSafe($tls_keyfile)) {
-                trigger_error("TLS key file path is not safe.", E_USER_WARNING);
-            } elseif (!file_exists($tls_keyfile)) {
-                trigger_error("TLS key file path is not valid.", E_USER_WARNING);
-            } elseif (!@ldap_set_option(null, LDAP_OPT_X_TLS_KEYFILE, $tls_keyfile)) {
-                trigger_error("Unable to set LDAP option `LDAP_OPT_X_TLS_KEYFILE`", E_USER_WARNING);
             }
         }
 


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

same as https://github.com/glpi-project/glpi/pull/23007

but for GLPI 10

## Reminder

This PR fixes a recurring issue where `ldap_search` returns an **LDAP_INSUFFICIENT_ACCESS (50)** error when using LDAPS (especially with Google Secure LDAP), even if the bind was successful.

The issue is particularly prevalent in multi-instance environments or high-concurrency web servers where the OpenLDAP library context is shared across multiple requests.

### Technical Analysis

In the current implementation, `ldap_connect()` is called before setting global TLS options (using `ldap_set_option` with a `null` handle).

According to OpenLDAP library behavior, TLS context initialization often "crystallizes" upon the first socket initialization. If the connection is initialized before the certificates (`LDAP_OPT_X_TLS_CERTFILE` and `LDAP_OPT_X_TLS_KEYFILE`) are globally defined, the library might attempt a handshake without the proper mTLS identity. This leads to intermittent failures where the library uses a stale or uninitialized global state for subsequent searches.

As describe from PHP doc

_All TLS options must be set globally before [ldap_connect()](https://www.php.net/manual/en/function.ldap-connect.php) for ldaps connection or for the connection before [ldap_start_tls()](https://www.php.net/manual/en/function.ldap-start-tls.php)._


### Changes

* Moved the `ldap_set_option(null, ...)` calls for `LDAP_OPT_X_TLS_CERTFILE` and `LDAP_OPT_X_TLS_KEYFILE` before the `@ldap_connect($ldapuri)` call in `AuthLDAP::connectToServer`.
* This ensures that the OpenLDAP library is aware of the required client certificates at the very moment the connection object is created.



## Screenshots (if appropriate):


