### PR TITLE
Use Exceptions on CommonDBTM CRUD flow

### DIFF
--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -39,6 +39,11 @@ use Glpi\DBAL\QueryFunction;
 use Glpi\DBAL\QueryParam;
 use Glpi\Debug\Profiler;
 use Glpi\Event;
+use Glpi\Exception\Crud\AddException;
+use Glpi\Exception\Crud\CloneException;
+use Glpi\Exception\Crud\DeleteException;
+use Glpi\Exception\Crud\PurgeException;
+use Glpi\Exception\Crud\UpdateException;
 use Glpi\Exception\Database\StatementException;
 use Glpi\Exception\Http\AccessDeniedHttpException;
 use Glpi\Exception\Http\NotFoundHttpException;
@@ -1292,7 +1297,7 @@ class CommonDBTM extends CommonGLPI
         global $CFG_GLPI, $DB;
 
         if ($DB->isReplica()) {
-            return false;
+            throw new AddException('Cannot add object in slave database');
         }
 
         // This means we are not adding a cloned object
@@ -1308,7 +1313,10 @@ class CommonDBTM extends CommonGLPI
             if (isset($input['id'])) {
                 $id_to_clone = $input['id'];
             }
-            if (isset($id_to_clone) && $this->getFromDB($id_to_clone)) {
+            if (isset($id_to_clone)) {
+                if ($this->getFromDB($id_to_clone)) {
+                    throw new CloneException('Unable to load item to clone #' . $id_to_clone);
+                }
                 if ($clone_id = $this->clone($input, $history)) {
                     $this->getFromDB($clone_id); // Load created items fields
                 }
@@ -1445,7 +1453,7 @@ class CommonDBTM extends CommonGLPI
             }
         }
 
-        return false;
+        throw new AddException('Cannot add item to database');
     }
 
     /**
@@ -1823,7 +1831,7 @@ class CommonDBTM extends CommonGLPI
             }
         }
 
-        return false;
+        throw new UpdateException('Cannot update item in database');
     }
 
 
@@ -2227,7 +2235,12 @@ class CommonDBTM extends CommonGLPI
                 return true;
             }
         }
-        return false;
+
+        if ($force) {
+            throw new PurgeException('Cannot purge item from database');
+        } else {
+            throw new DeleteException('Cannot delete item from database');
+        }
     }
 
 

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -1314,7 +1314,7 @@ class CommonDBTM extends CommonGLPI
                 $id_to_clone = $input['id'];
             }
             if (isset($id_to_clone)) {
-                if ($this->getFromDB($id_to_clone)) {
+                if (!$this->getFromDB($id_to_clone)) {
                     throw new CloneException('Unable to load item to clone #' . $id_to_clone);
                 }
                 if ($clone_id = $this->clone($input, $history)) {

--- a/src/Glpi/Exception/Crud/AddException.php
+++ b/src/Glpi/Exception/Crud/AddException.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Exception\Crud;
+
+class AddException extends CrudException {}

--- a/src/Glpi/Exception/Crud/CloneException.php
+++ b/src/Glpi/Exception/Crud/CloneException.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Exception\Crud;
+
+class CloneException extends CrudException {}

--- a/src/Glpi/Exception/Crud/CrudException.php
+++ b/src/Glpi/Exception/Crud/CrudException.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Exception\Crud;
+
+use Exception;
+
+class CrudException extends Exception {}

--- a/src/Glpi/Exception/Crud/DeleteException.php
+++ b/src/Glpi/Exception/Crud/DeleteException.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Exception\Crud;
+
+class DeleteException extends CrudException {}

--- a/src/Glpi/Exception/Crud/PurgeException.php
+++ b/src/Glpi/Exception/Crud/PurgeException.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Exception\Crud;
+
+class PurgeException extends DeleteException {}

--- a/src/Glpi/Exception/Crud/UpdateException.php
+++ b/src/Glpi/Exception/Crud/UpdateException.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Exception\Crud;
+
+class UpdateException extends CrudException {}

--- a/src/ProfileRight.php
+++ b/src/ProfileRight.php
@@ -37,6 +37,7 @@ use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryParam;
 use Glpi\DBAL\QuerySubQuery;
 use Glpi\Exception\Database\StatementException;
+use Glpi\Exception\Crud\CloneException;
 
 /**
  * Profile class
@@ -62,7 +63,7 @@ class ProfileRight extends CommonDBChild
         global $DB;
 
         if ($DB->isReplica()) {
-            return false;
+            throw new CloneException('Cannot clone item on a DB slave.');
         }
         $new_item = new static();
         $input = $this->fields;

--- a/src/ProfileRight.php
+++ b/src/ProfileRight.php
@@ -63,7 +63,7 @@ class ProfileRight extends CommonDBChild
         global $DB;
 
         if ($DB->isReplica()) {
-            throw new CloneException('Cannot clone item on a DB slave.');
+            throw new CloneException('Cannot clone item on a DB replica.');
         }
         $new_item = new static();
         $input = $this->fields;

--- a/tests/functional/CommonDBTMTest.php
+++ b/tests/functional/CommonDBTMTest.php
@@ -42,6 +42,8 @@ use Document_Item;
 use Entity;
 use FieldUnicity;
 use Glpi\Event;
+use Glpi\Exception\Crud\AddException;
+use Glpi\Exception\Crud\UpdateException;
 use Glpi\Exception\Http\AccessDeniedHttpException;
 use Glpi\Exception\Http\NotFoundHttpException;
 use Glpi\Exception\RedirectException;
@@ -1372,20 +1374,33 @@ class CommonDBTMTest extends DbTestCase
             ])
         );
 
-        $this->assertFalse($computer->update([
-            'id' => $computers_id2,
-            'uuid' => '76873749-0813-482f-ac20-eb7102ed3367',
-        ]));
+        $exception_thrown = false;
+        try {
+            $computer->update([
+                'id' => $computers_id2,
+                'uuid' => '76873749-0813-482f-ac20-eb7102ed3367',
+            ]);
+        } catch (UpdateException $e) {
+            $exception_thrown = true;
+            $this->assertSame('Cannot update item in database', $e->getMessage());
+        }
+        $this->assertTrue($exception_thrown);
 
         $err_msg = 'Impossible record for UUID = 76873749-0813-482f-ac20-eb7102ed3367<br>Other item exist<br>[<a href="/front/computer.form.php?id=' . $computers_id1 . '" data-bs-toggle="tooltip" data-bs-placement="bottom" title="testCheckUnicity01">testCheckUnicity01</a> - ID: ' . $computers_id1 . ' - Serial number:  - Entity: Root entity &gt; _test_root_entity]';
         $this->hasSessionMessages(ERROR, [$err_msg]);
 
-        $this->assertFalse($computer->add([
-            'name' => __FUNCTION__ . '03',
-            'entities_id' => getItemByTypeName('Entity', '_test_root_entity', true),
-            'uuid' => '76873749-0813-482f-ac20-eb7102ed3367',
-        ]));
-
+        $exception_thrown = false;
+        try {
+            $computer->add([
+                'name' => __FUNCTION__ . '03',
+                'entities_id' => getItemByTypeName('Entity', '_test_root_entity', true),
+                'uuid' => '76873749-0813-482f-ac20-eb7102ed3367',
+            ]);
+        } catch (AddException $e) {
+            $exception_thrown = true;
+            $this->assertSame('Cannot add item to database', $e->getMessage());
+        }
+        $this->assertTrue($exception_thrown);
         $this->hasSessionMessages(ERROR, [$err_msg]);
     }
 
@@ -1448,12 +1463,17 @@ class CommonDBTMTest extends DbTestCase
         $this->hasNoSessionMessages([ERROR]);
 
         //create computer with same name should not be possible (because of first computer)
-        $this->assertFalse(
+        $exception_thrown = false;
+        try {
             $computer->add([
                 'name' => __FUNCTION__ . '01',
                 'entities_id' => getItemByTypeName('Entity', '_test_root_entity', true),
-            ])
-        );
+            ]);
+        } catch (AddException $e) {
+            $exception_thrown = true;
+            $this->assertSame('Cannot add item to database', $e->getMessage());
+        }
+        $this->assertTrue($exception_thrown);
         $err_msg = 'Impossible record for Name = ' . __FUNCTION__ . '01<br>Other item exist<br>[<a href="/front/computer.form.php?id=' . $computers_id . '" data-bs-toggle="tooltip" data-bs-placement="bottom" title="' . __FUNCTION__ . '01">' . __FUNCTION__ . '01</a> - ID: ' . $computers_id . ' - Serial number:  - Entity: Root entity &gt; _test_root_entity]';
         $this->hasSessionMessages(ERROR, [$err_msg]);
 

--- a/tests/src/autoload/functions.php
+++ b/tests/src/autoload/functions.php
@@ -950,7 +950,15 @@ function loadDataset()
                     $item->update([$item::getIndexName() => $item->getID()] + $input);
                 } else {
                     // Not found, create it
-                    $item->add($input);
+                    try {
+                        $item->add($input);
+                    } catch (\Glpi\Exception\Crud\CloneException $e) {
+                        //a clone exception will be thrown because we provide explicit id at creation
+                        //FIXME: we should not provide hardcoded ids. Used in IMAP tests, maybe is there an alternative solution.
+                        if (!isset($input['id'])) {
+                            throw $e;
+                        }
+                    }
                 }
                 if (isset($input[$name_field])) {
                     $ids[$type][$input[$name_field]] = $item->getID(); // cache ID


### PR DESCRIPTION
Just a Quick'N'Dirty try for now.

This has been opened as PoC to begin the discussion; the base idea is to prevent silent fails of strange issues when a false is sometimes returned (and often not checked).

I've quickly discussed about that with Cédric, and he tells me it will throw an error instead of redirecting the user to a page with a comprehensible error message. This means I'll have to handle those Exceptions in controllers (OK, no problem) but also in all front files (that's not an interesting job, but I'm OK to do that for the need).

Of course, this PR still need work to be complete before making any change on front files (it will be done last); but I'd like to know if anyone has remarks about it before doing anything else.