### PR TITLE
Fix: PREG_BACKTRACK_LIMIT_ERROR in RichText::loadImagesLazy()

### DIFF
--- a/src/Glpi/RichText/RichText.php
+++ b/src/Glpi/RichText/RichText.php
@@ -364,8 +364,15 @@ HTML;
     private static function loadImagesLazy(string $content): string
     {
         return preg_replace_callback(
-            '/<img([^>]+?)\s*\/?>/i',
-            fn($matches) => '<img' . $matches[1] . ' loading="lazy">',
+            '/<img\b((?>[^>]*))\s*\/?>/i',
+            static function (array $matches): string {
+                $attrs = $matches[1];
+                $attrs = rtrim($attrs, '/ \t\n\r\0\x0B');
+                if (preg_match('/\bloading\s*=/i', $attrs)) {
+                    return $matches[0];
+                }
+                return sprintf('<img%s loading="lazy">', $attrs);
+            },
             $content
         );
     }

--- a/tests/functional/Glpi/RichText/RichTextTest.php
+++ b/tests/functional/Glpi/RichText/RichTextTest.php
@@ -732,10 +732,11 @@ HTML,
 
         $result = $richtext->getEnhancedHtml($content, ['text_maxsize' => 0]);
 
+        ini_set('pcre.backtrack_limit', $save_pcre_backtrack_limit);
+
         $this->assertEquals(
             $expected_result,
             $result,
         );
-        ini_set('pcre.backtrack_limit', $save_pcre_backtrack_limit);
     }
 }

--- a/tests/functional/Glpi/RichText/RichTextTest.php
+++ b/tests/functional/Glpi/RichText/RichTextTest.php
@@ -729,6 +729,7 @@ HTML,
 
         $save_pcre_backtrack_limit = ini_get('pcre.backtrack_limit');
         ini_set('pcre.backtrack_limit', 100); // Lower limit to ensure the effectiveness of regex
+        $this->assertEquals(100, ini_get('pcre.backtrack_limit'));
 
         $result = $richtext->getEnhancedHtml($content, ['text_maxsize' => 0]);
 


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- Improvement of #22835

The PREG_BACKTRACK_LIMIT_ERROR error was present again.

Only by reducing the value of `pcre.backtrack_limit` was I able to reproduce the error and include it in tests.


## Screenshots (if appropriate):


